### PR TITLE
Allow using markdown files to be used for detailed descriptions of classes and groups.

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -423,7 +423,8 @@ be `.md` or `.markdown` (see
 \ref cfg_extension_mapping "EXTENSION_MAPPING" if your Markdown files have 
 a different extension, and use `md` as the name of the parser).
 Each file is converted to a page (see the \ref cmdpage "page" command for
-details). 
+details).
+Exception to this are Files that start with a doxygen command like `\@class` or `\@defgroup`.
 
 By default the name and title of the page are derived from the file name.
 If the file starts with a level 1 header however, it is used as the title

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2283,18 +2283,24 @@ void MarkdownFileParser::parseInput(const char *fileName,
   static QCString mdfileAsMainPage = Config_getString("USE_MDFILE_AS_MAINPAGE");
   if (id.isEmpty()) id = "md_"+baseName;
   if (title.isEmpty()) title = titleFn;
-  if (fn==mdfileAsMainPage)
+  
+  // Don't create a page if the file starts with a Doxygen command like "@class" or "@defgroup" as it probably won't be what the user wants.
+  if (docs[0] != '@' && docs[0] != '\\')
   {
-    docs.prepend("@mainpage\n");
+    if (fn==mdfileAsMainPage)
+    {
+      docs.prepend("@mainpage\n");
+    }
+    else if (id=="mainpage" || id=="index")
+    {
+      docs.prepend("@mainpage "+title+"\n");
+    }
+    else
+    {
+      docs.prepend("@page "+id+" "+title+"\n");
+    }
   }
-  else if (id=="mainpage" || id=="index")
-  {
-    docs.prepend("@mainpage "+title+"\n");
-  }
-  else
-  {
-    docs.prepend("@page "+id+" "+title+"\n");
-  }
+  
   int lineNr=1;
   int position=0;
 


### PR DESCRIPTION
This was possible before, however every markdown file also created a static page which kinda defeated the purpose.
