### PR TITLE
add config option NO_WARN_MISSING_PARAMDOC

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1165,6 +1165,15 @@ FILE_VERSION_INFO = "cleartool desc -fmt \%Vn"
 ]]>
       </docs>
     </option>
+    <option type='bool' id='NO_WARN_MISSING_PARAMDOC' defval='0'>
+      <docs>
+<![CDATA[
+ If \c NO_WARN_MISSING_PARAMS is set to \c YES, doxygen will not
+ print warnings if only some parameters are documented. If set to the default
+ value \c NO, those warnings will be printed
+]]>
+      </docs>
+    </option>
     <option type='bool' id='WARN_NO_PARAMDOC' defval='0'>
       <docs>
 <![CDATA[

--- a/src/configoptions.cpp
+++ b/src/configoptions.cpp
@@ -923,6 +923,15 @@ void addConfigOptions(Config *cfg)
              );
   //----
   cb = cfg->addBool(
+             "NO_WARN_MISSING_PARAMDOC",
+              "If NO_WARN_MISSING_PARAMS is set to YES, doxygen will not print warnings if\n"
+              "only some parameters are documented. If set to the default value NO, those\n"
+              "warnings will be printed\n"
+              "The default value is: NO.",
+              FALSE
+             );
+  //----
+  cb = cfg->addBool(
              "WARN_NO_PARAMDOC",
               "This WARN_NO_PARAMDOC option can be enabled to get warnings for functions that\n"
               "are documented, but have no documentation for their parameters or return\n"

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -412,7 +412,8 @@ static void checkArgumentName(const QCString &name,bool isParam)
  */
 static void checkUndocumentedParams()
 {
-  if (g_memberDef && g_hasParamCommand && Config_getBool("WARN_IF_DOC_ERROR"))
+  if (g_memberDef && g_hasParamCommand && Config_getBool("WARN_IF_DOC_ERROR") &&
+      !Config_getBool("NO_WARN_MISSING_PARAMDOC"))
   {
     ArgumentList *al=g_memberDef->isDocsForDefinition() ? 
       g_memberDef->argumentList() :


### PR DESCRIPTION
If \c NO_WARN_MISSING_PARAMS is set to YES, doxygen will not print warnings if only some parameters are documented. If set to the default value NO, those warnings will be printed.
