### PR TITLE
Small corrections for documentation

### DIFF
--- a/doc/config.doc
+++ b/doc/config.doc
@@ -998,7 +998,7 @@ The default value is: <code>NO</code>.
  option to \c NO.
 
 
-The default value is system dependent.
+The default value is: system dependent.
 
  \anchor cfg_hide_scope_names
 <dt>\c HIDE_SCOPE_NAMES <dd>

--- a/doc/doxywizard_usage.doc
+++ b/doc/doxywizard_usage.doc
@@ -18,7 +18,7 @@
 
 Doxywizard is a GUI front-end for configuring and running doxygen. 
 
-Note is is possible to start the doxywizard with as argument the configuration file to be used.
+Note it is possible to start the doxywizard with as argument the configuration file to be used.
 
 When you start doxywizard it will display the main window 
 (the actual look depends on the OS used).


### PR DESCRIPTION
Small typo corrected in doxywizard_usage.doc
Generated config.doc file in git is not identical to the generated one
