### PR TITLE
Small spelling correction

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9780,7 +9780,7 @@ static void usage(const char *name)
   msg("    RTF:        %s -w rtf styleSheetFile\n",name);
   msg("    HTML:       %s -w html headerFile footerFile styleSheetFile [configFile]\n",name);
   msg("    LaTeX:      %s -w latex headerFile footerFile styleSheetFile [configFile]\n\n",name);
-  msg("6) Use doxygen to generate an rtf extensions file\n");
+  msg("6) Use doxygen to generate a rtf extensions file\n");
   msg("    RTF:   %s -e rtf extensionsFile\n\n",name);
   msg("If -s is specified the comments of the configuration items in the config file will be omitted.\n");
   msg("If configName is omitted `Doxyfile' will be used as a default.\n\n");


### PR DESCRIPTION
to generate an rtf extensions file -> to generate a rtf extensions file
