### PR TITLE
Bug 706520 - Fortran: in body documentation lands on wrong place

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2109,7 +2109,7 @@ static void handleCommentBlock(const QCString &doc,bool brief)
   int lineNr = brief ? current->briefLine : current->docLine;
   while (parseCommentBlock(
 	g_thisParser,
-	docBlockInBody ? last_entry : current,
+	docBlockInBody ? subrCurrent.first() : current,
 	doc,        // text
 	yyFileName, // file
 	lineNr,


### PR DESCRIPTION
In some cases, in propriety code, with in body Fortran documentation doxygen crashed.
I REOPENED Bug_706520 for this
