### PR TITLE
Bug 707554 - When I use @INCLUDE DoxyWizard is closed

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -224,9 +224,13 @@ void MainWindow::updateConfigFileName(const QString &fileName)
 
 void MainWindow::loadConfigFromFile(const QString & fileName)
 {
-  m_expert->loadConfig(fileName);
-  m_wizard->refresh();
+  // save full path info of original file
+  QString absFileName = QFileInfo(fileName).absoluteFilePath();
+  // updates the current directory
   updateConfigFileName(fileName);
+  // open the specified configuration file
+  m_expert->loadConfig(absFileName);
+  m_wizard->refresh();
   updateLaunchButtonState();
   m_modified = false;
   updateTitle();


### PR DESCRIPTION
Current directory was not changed at the right time so the include files could not be found in the "current" directory (i.e. the directory where the Doxyfile resides too, as this directory is shown as the current directory in the doxywizard). This is also important when the doxywizard is started from a shortcut.
