### PR TITLE
make: add LEX_FLAGS as env variable

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9799,6 +9799,26 @@ static void usage(const char *name)
   msg("    RTF:   %s -e rtf extensionsFile\n\n",name);
   msg("If -s is specified the comments of the configuration items in the config file will be omitted.\n");
   msg("If configName is omitted `Doxyfile' will be used as a default.\n\n");
+  msg("Other parameters:\n");
+  msg("-m dump symbol map\n");
+  msg("-v print version string\n");
+  msg("-b output to wizard\n");
+  msg("-T activates output generation via Django like template\n");
+  msg("-d <level>  Enable a debug level, such as:\n");
+  msg("\tfindmembers\n");
+  msg("\tfunctions\n");
+  msg("\tvariables\n");
+  msg("\tpreprocessor\n");
+  msg("\tclasses\n");
+  msg("\tcommentcnv\n");
+  msg("\tcommentscan\n");
+  msg("\tvalidate\n");
+  msg("\tprinttree\n");
+  msg("\ttime\n");
+  msg("\textcmd\n");
+  msg("\tmarkdown\n");
+  msg("\tfilteroutput\n");
+  msg("\tlex\n");
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
LEX_FLAGS can be used to specify flex options,
such as -d to enable rule debugging.

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
