### PR TITLE
bug_647517  - make install prepends a slash to the installation path

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -81,21 +81,21 @@ DATE=$(shell date "+%B %Y")
 MAN1DIR = man/man1
 
 install: doxywizard_install doxysearch_install
-	$(INSTTOOL) -d $(DESTDIR)/$(INSTALL)/bin
-	$(INSTTOOL) -m 755 bin/doxygen        $(DESTDIR)/$(INSTALL)/bin
-	$(INSTTOOL) -d $(DESTDIR)/$(INSTALL)/$(MAN1DIR)
+	$(INSTTOOL) -d $(DESTDIR)$(INSTALL)/bin
+	$(INSTTOOL) -m 755 bin/doxygen        $(DESTDIR)$(INSTALL)/bin
+	$(INSTTOOL) -d $(DESTDIR)$(INSTALL)/$(MAN1DIR)
 	cat doc/doxygen.1    | sed -e "s/DATE/$(DATE)/g" -e "s/VERSION/$(VERSION)/g" > doxygen.1 
-	$(INSTTOOL) -m 644 doxygen.1 $(DESTDIR)/$(INSTALL)/$(MAN1DIR)/doxygen.1
+	$(INSTTOOL) -m 644 doxygen.1 $(DESTDIR)$(INSTALL)/$(MAN1DIR)/doxygen.1
 	rm doxygen.1
 
 install_docs: 
-	$(INSTTOOL) -d $(DESTDIR)/$(DOCDIR)
+	$(INSTTOOL) -d $(DESTDIR)$(DOCDIR)
 	$(MAKE) -C examples
 	$(MAKE) -C doc 
 	$(MAKE) -C latex 
-	$(INSTTOOL) -m 644 latex/doxygen_manual.pdf $(DESTDIR)/$(DOCDIR)
-	cp -r examples $(DESTDIR)/$(DOCDIR)
-	cp -r html $(DESTDIR)/$(DOCDIR)
+	$(INSTTOOL) -m 644 latex/doxygen_manual.pdf $(DESTDIR)$(DOCDIR)
+	cp -r examples $(DESTDIR)$(DOCDIR)
+	cp -r html $(DESTDIR)$(DOCDIR)
 
 docs: FORCE
 	cd examples ; $(MAKE)


### PR DESCRIPTION
Removed superfluous /
