### PR TITLE
Patch regarding generating the rules file for the windows build regardin...

### DIFF
--- a/configure
+++ b/configure
@@ -52,7 +52,6 @@ f_libclangstatic=NO
 # list will be in case as specified (f_langs) and in uppercase (f_ulangs) as used in the internal perl script
 #
 f_langs=`ls -1 src/translator_??.h | sed -e 's%src/translator_%%g' | sed -e 's/\.h//' | tr '\012' ',' | sed -e 's/,$//'`
-f_ulangs=`echo $f_langs | tr '[a-z]' '[A-Z]'`
 
 while test -n "$1";  do
   case $1 in
@@ -800,12 +799,6 @@ TMAKE_MOC = $QTDIR/bin/moc
 EOF
 fi
 
-if test "$f_english" = YES; then
-  cat >> .tmakeconfig <<EOF
-TMAKE_CXXFLAGS += -DENGLISH_ONLY
-EOF
-fi
-
 if test "$f_search" = YES; then
   cat >> .tmakeconfig <<EOF
 LIBS += -L$XAPIAN/lib
@@ -900,23 +893,18 @@ EOF
 done
 
 # - generating src/lang_cfg.h 
+# use consistent method on Linux and Windows
 
 if test -f "src/lang_cfg.h"; then
     chmod u+w src/lang_cfg.h   # make sure file can be overwritten
 fi
 echo "  Generating src/lang_cfg.h..."
-echo $f_langs | $f_perl -e '@l=split(/,/,<STDIN>); 
-        chomp @l; 
-	@allowed=(split(/,/,"'$f_ulangs'"));
-	foreach my $elem (@l){ 
-	     $elem =~ tr/a-z/A-Z/;
-	     $r=0;
-	     foreach my $tst (@allowed){
-		if ($tst eq $elem) { $r=1; last; } 		
-	     }	    
-	     if ($r!=1) { die "ERROR: Invalid language $elem was selected!\n"; } 
-	     print "#define LANG_$elem\n";
-        };' > ./src/lang_cfg.h   
+if test "$f_english" = YES; then
+   $f_python src/lang_cfg.py ENONLY > src/lang_cfg.h
+else
+   f_ulangs=`echo $f_langs | tr '[a-z,]' '[A-Z ]'`
+   $f_python src/lang_cfg.py $f_ulangs > src/lang_cfg.h
+fi
 
 if test -f "src/config.h"; then
     chmod u+w src/config.h

--- a/doc/maintainers.txt
+++ b/doc/maintainers.txt
@@ -134,7 +134,7 @@ Alexandr Chelpanov: cav at cryptopro dot ru
 TranslatorSerbian
 Dejan Milosavljevic: [unreachable] dmilos at email dot com
 
-TranslatorSerbianCyrilic
+TranslatorSerbianCyrillic
 Nedeljko Stefanovic: stenedjo at yahoo dot com
 
 TranslatorSlovak

--- a/src/config.xml
+++ b/src/config.xml
@@ -289,6 +289,7 @@ Go to the <a href="commands.html">next</a> section or return to the
       </docs>
       <value name='Afrikaans'/>
       <value name='Arabic'/>
+      <value name='Armenian'/>
       <value name='Brazilian'/>
       <value name='Catalan'/>
       <value name='Chinese'/>
@@ -297,28 +298,31 @@ Go to the <a href="commands.html">next</a> section or return to the
       <value name='Czech'/>
       <value name='Danish'/>
       <value name='Dutch'/>
-      <value name='English'/>
+      <value name='English' desc='(United States)'/>
       <value name='Esperanto'/>
-      <value name='Farsi'/>
+      <value name='Farsi' desc='(Persian)'/>
       <value name='Finnish'/>
       <value name='French'/>
       <value name='German'/>
       <value name='Greek'/>
       <value name='Hungarian'/>
+      <value name='Indonesian'/>
       <value name='Italian'/>
       <value name='Japanese'/>
-      <value name='Japanese-en'/>
+      <value name='Japanese-en' desc='(Japanese with English messages)'/>
       <value name='Korean'/>
-      <value name='Korean-en'/>
+      <value name='Korean-en' desc='(Korean with English messages)'/>
       <value name='Latvian'/>
-      <value name='Norwegian'/>
+      <value name='Lithuanian'/>
       <value name='Macedonian'/>
-      <value name='Persian'/>
+      <value name='Norwegian'/>
+      <value name='Persian' desc='(Farsi)'/>
       <value name='Polish'/>
       <value name='Portuguese'/>
       <value name='Romanian'/>
       <value name='Russian'/>
       <value name='Serbian'/>
+      <value name='Serbian-Cyrillic'/>
       <value name='Slovak'/>
       <value name='Slovene'/>
       <value name='Spanish'/>

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -406,7 +406,7 @@ void HtmlHelp::initialize()
   s_languageDict.insert("norwegian",   new QCString("0x814 Norwegian"));
   s_languageDict.insert("polish",      new QCString("0x415 Polish"));
   s_languageDict.insert("portuguese",  new QCString("0x816 Portuguese(Portugal)"));
-  s_languageDict.insert("brazil",      new QCString("0x416 Portuguese(Brazil)"));
+  s_languageDict.insert("brazilian",   new QCString("0x416 Portuguese(Brazil)"));
   s_languageDict.insert("russian",     new QCString("0x419 Russian"));
   s_languageDict.insert("spanish",     new QCString("0x40A Spanish(Traditional Sort)"));
   s_languageDict.insert("swedish",     new QCString("0x41D Swedish"));
@@ -433,6 +433,10 @@ void HtmlHelp::initialize()
   s_languageDict.insert("persian",     new QCString("0x429 Persian (Iran)"));
   s_languageDict.insert("arabic",      new QCString("0xC01 Arabic (Egypt)"));
   s_languageDict.insert("latvian",     new QCString("0x426 Latvian"));
+  s_languageDict.insert("macedonian",  new QCString("0x042f Macedonian (Former Yugoslav Republic of Macedonia)"));
+  s_languageDict.insert("armenian",    new QCString("0x42b Armenian"));
+  s_languageDict.insert("esperanto",   new QCString("0x48f Esperanto"));
+  s_languageDict.insert("serbian-cyrillic", new QCString("0xC1A Serbian (Serbia, Cyrillic)"));
 }
 
 

--- a/src/lang_cfg.py
+++ b/src/lang_cfg.py
@@ -1,0 +1,8 @@
+import sys
+
+if (len(sys.argv) > 0):
+    if (sys.argv[1] == "ENONLY"):
+        print "#define ENGLISH_ONLY"
+    else:
+        for x in xrange(1, len(sys.argv)):
+            print "#define LANG_%s"%(sys.argv[x])

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -354,9 +354,9 @@ bool setTranslator(const char *langName)
   }
 #endif
 #ifdef LANG_SC
-  else if (L_EQUAL("serbian-cyrilic"))
+  else if (L_EQUAL("serbian-cyrillic") || L_EQUAL("serbiancyr")) /* serbiancyr for consistency with older versions */
   {
-    theTranslator=new TranslatorSerbian;
+    theTranslator=new TranslatorSerbianCyrillic;
   }
 #endif
 #ifdef LANG_CA

--- a/src/languages.py
+++ b/src/languages.py
@@ -1,0 +1,106 @@
+#
+# This file is an aid to generated the Languages rules file.
+# usage:
+#   python languages.py > ..\winbuild\Languages.rules
+#
+import os
+import re
+
+files = [f for f in os.listdir('.') if re.match(r'translator_[a-z][a-z]\.h', f)]
+new_list = []
+for f in files:
+    new_list.append([f,(os.path.splitext(f)[0]).replace("translator_","").upper()])
+
+#
+# generating file is lang_cfg.py
+# the rules file has to output lang_cfg.h
+#
+print """\
+<?xml version="1.0" encoding="utf-8"?>
+<VisualStudioToolFile
+        Name="languages"
+        Version="8.00"
+        >
+        <Rules>
+                <CustomBuildRule
+                        Name="Languages"
+                        DisplayName="Settings"
+                        CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] &gt; $(InputDir)../src/$(InputName).h"
+                        Outputs="$(InputDir)../src/$(InputName).h"
+                        FileExtensions="*.py"
+                        AdditionalDependencies=""
+                        ExecutionDescription="Executing languages ..."
+                        ShowOnlyRuleProperties="false"
+                        >
+                        <Properties>
+                               <EnumProperty
+                                       Name="EnglishOnly"
+                                       DisplayName="Use English Only"
+                                       Description="Use English Only"
+                                       DefaultValue="0"
+                               >
+                                       <Values>
+                                               <EnumValue
+                                               Value="0"
+                                               Switch=""
+                                               DisplayName="Don't use English Only"
+                                               />
+                                               <EnumValue
+                                               Value="1"
+                                               Switch="ENONLY"
+                                               DisplayName="Use English Only"
+                                               />
+                                       </Values>
+                               </EnumProperty>
+"""
+#
+# generate loop, English is mandatory (so cannot be chosen)
+#
+for f in new_list:
+    if (f[1] != "EN"):
+        # search for the language description
+        fil = open(f[0], 'r')
+        tmp = ""
+        for line in fil:
+          if "idLanguage" in line:
+             tmp = line
+             if "}" in line:
+               break
+          elif (tmp != ""):
+             tmp += line
+             if "}" in line:
+               break
+    
+        tmp = tmp.replace("\n","")
+        l = re.sub('[^"]*"([^"]*)".*','\\1',tmp)
+        l1 = l.replace("-","")
+        # capatalize first letter
+        l = l.title()
+        print """\
+                                   <EnumProperty
+                                           Name="%s"
+                                           DisplayName="Use %s"
+                                           Description="Use %s"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use %s"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="%s"
+                                                   DisplayName="Use %s"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        """ % (l1, l, l, l, f[1], l)
+
+print """\
+                        </Properties>
+                </CustomBuildRule>
+        </Rules>
+</VisualStudioToolFile>
+"""

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -49,7 +49,7 @@ class TranslatorBrazilian : public TranslatorAdapter_1_8_0
      */
     virtual QCString idLanguage()
     {
-      return "brazil";
+      return "brazilian";
     }
 
     /*! Used to get the command(s) for the language support. This method

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -35,7 +35,7 @@
 #define TRANSLATOR_FA_H
 
 #define HtmlRightToLeft     QCString("<div dir=\"rtl\">")
-#define HtmlLeftToRight     QCString("<div dir=\"rtl\">")
+#define HtmlLeftToRight     QCString("<div dir=\"ltr\">")
 #define HtmlDivEnd          QCString("</div>")
 
 

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -16,7 +16,7 @@
  */
 // Тranslated by Slave Jovanovski <slavejovanovski@yahoo.com>
 //
-// The cyrilic strings were entered using Macedonian language support in
+// The cyrillic strings were entered using Macedonian language support in
 // Windows. The editor used was Eclipse 3.2. The file was saved in UTF-8.
 //
 // Updates:

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -40,7 +40,7 @@
  Translator class (by the local maintainer) when the localized
  translator is made up-to-date again.
 */
-class TranslatorSerbianCyrilic : public TranslatorAdapter_1_6_0
+class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
 {
   public:
 
@@ -53,7 +53,7 @@ class TranslatorSerbianCyrilic : public TranslatorAdapter_1_6_0
      * the identification used in language.cpp.
      */
     virtual QCString idLanguage()
-    { return "serbiancyr"; }
+    { return "serbian-cyrillic"; }
 
     /*! Used to get the LaTeX command(s) for the language support.
      *  This method should return string with commands that switch

--- a/winbuild/Doxygen.sln
+++ b/winbuild/Doxygen.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 10.00
-# Visual Studio 2008
+# Visual C++ Express 2008
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Doxygen", "Doxygen.vcproj", "{309C9A4A-94D2-4837-9A11-45B0A6CF35C3}"
 	ProjectSection(ProjectDependencies) = postProject
 		{B6BB4771-8A4E-4656-AC08-1EF8AC182F64} = {B6BB4771-8A4E-4656-AC08-1EF8AC182F64}
@@ -9,6 +9,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qtools", "qtools.vcproj", "{B6BB4771-8A4E-4656-AC08-1EF8AC182F64}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "doxywizard", "Doxywizard.vcproj", "{77C9C2D3-EA3F-3D59-8B4C-0ED852890172}"
+	ProjectSection(ProjectDependencies) = postProject
+		{309C9A4A-94D2-4837-9A11-45B0A6CF35C3} = {309C9A4A-94D2-4837-9A11-45B0A6CF35C3}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "doxysearch", "doxysearch.vcproj", "{F3F3408F-F6F7-46C7-BF1E-1FA056E0AE20}"
 EndProject

--- a/winbuild/Doxygen.vcproj
+++ b/winbuild/Doxygen.vcproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9,00"
+	Version="9.00"
 	Name="Doxygen"
 	ProjectGUID="{309C9A4A-94D2-4837-9A11-45B0A6CF35C3}"
 	RootNamespace="Doxygen"
@@ -31,6 +31,9 @@
 		<ToolFile
 			RelativePath=".\Gen_head.rules"
 		/>
+		<ToolFile
+			RelativePath=".\Languages.rules"
+		/>
 	</ToolFiles>
 	<Configurations>
 		<Configuration
@@ -42,27 +45,34 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
 			/>
 			<Tool
+				Name="Config_dw"
+			/>
+			<Tool
 				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="Lex"
-			/>
-			<Tool
-				Name="Settings"
-			/>
-			<Tool
-				Name="Version"
 			/>
 			<Tool
 				Name="Config"
 			/>
 			<Tool
-				Name="Genhead"
+				Name="Version"
+			/>
+			<Tool
+				Name="Settings"
+			/>
+			<Tool
+				Name="Gen_head"
+			/>
+			<Tool
+				Name="Languages"
+			/>
+			<Tool
+				Name="Lex"
 			/>
 			<Tool
 				Name="VCXMLDataGeneratorTool"
@@ -91,6 +101,7 @@
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Debug\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -111,9 +122,9 @@
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="Debug"
 				GenerateManifest="false"
-				IgnoreDefaultLibraryNames="libcmt.lib"
+				IgnoreDefaultLibraryNames="libcmtd.lib"
 				GenerateDebugInformation="true"
-				ProgramDatabaseFile=".\Debug/Doxygen.pdb"
+				ProgramDatabaseFile=".\Debug\$(TargetName).pdb"
 				SubSystem="1"
 				LargeAddressAware="2"
 				RandomizedBaseAddress="1"
@@ -145,117 +156,6 @@
 			/>
 		</Configuration>
 		<Configuration
-			Name="Debug|x64"
-			OutputDirectory="..\bin\Debug64"
-			IntermediateDirectory=".\Debug64"
-			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC60.vsprops"
-			UseOfMFC="0"
-			ATLMinimizesCRunTimeLibraryUsage="false"
-			CharacterSet="2"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="Lex"
-			/>
-			<Tool
-				Name="Settings"
-			/>
-			<Tool
-				Name="Version"
-			/>
-			<Tool
-				Name="Config"
-			/>
-			<Tool
-				Name="Genhead"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-				TargetEnvironment="3"
-				TypeLibraryName=".\Debug64\Doxygen.tlb"
-				HeaderFileName=""
-			/>
-			<Tool
-				Name="VCCLCompilerTool"
-				AdditionalOptions="/Zm200 /bigobj"
-				Optimization="0"
-				AdditionalIncludeDirectories="..\src,..\qtools,..\libpng,..\libmd5,."
-				PreprocessorDefinitions="_CONSOLE;WIN32;_DEBUG; _CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;LIBICONV_STATIC;CHARSET_STATIC"
-				MinimalRebuild="true"
-				BasicRuntimeChecks="3"
-				RuntimeLibrary="1"
-				PrecompiledHeaderFile=".\Debug64/Doxygen.pch"
-				AssemblerListingLocation=".\Debug64/"
-				ObjectFile=".\Debug64/"
-				ProgramDataBaseFileName=".\Debug64/"
-				WarningLevel="3"
-				SuppressStartupBanner="true"
-				DebugInformationFormat="3"
-			/>
-			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-				PreprocessorDefinitions="_DEBUG"
-				Culture="1033"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
-			<Tool
-				Name="VCLinkerTool"
-				AdditionalDependencies="qtools.lib ws2_32.lib iconv64.lib shell32.lib"
-				OutputFile="..\bin\Debug64\doxygen.exe"
-				LinkIncremental="2"
-				SuppressStartupBanner="true"
-				AdditionalLibraryDirectories="Debug64"
-				GenerateManifest="false"
-				GenerateDebugInformation="true"
-				ProgramDatabaseFile=".\Debug64/Doxygen.pdb"
-				SubSystem="1"
-				LargeAddressAware="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="17"
-			/>
-			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-				SuppressStartupBanner="true"
-				OutputFile=".\Debug64/Doxygen.bsc"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-			/>
-		</Configuration>
-		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="..\bin\Release"
 			IntermediateDirectory=".\Release"
@@ -264,27 +164,34 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
 			/>
 			<Tool
+				Name="Config_dw"
+			/>
+			<Tool
 				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="Lex"
-			/>
-			<Tool
-				Name="Settings"
-			/>
-			<Tool
-				Name="Version"
 			/>
 			<Tool
 				Name="Config"
 			/>
 			<Tool
-				Name="Genhead"
+				Name="Version"
+			/>
+			<Tool
+				Name="Settings"
+			/>
+			<Tool
+				Name="Gen_head"
+			/>
+			<Tool
+				Name="Languages"
+			/>
+			<Tool
+				Name="Lex"
 			/>
 			<Tool
 				Name="VCXMLDataGeneratorTool"
@@ -316,6 +223,7 @@
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Release\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -336,7 +244,7 @@
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="Release"
-				ProgramDatabaseFile=".\Release/Doxygen.pdb"
+				ProgramDatabaseFile=".\Release\$(TargetName).pdb"
 				SubSystem="1"
 				LargeAddressAware="2"
 				RandomizedBaseAddress="1"
@@ -368,14 +276,15 @@
 			/>
 		</Configuration>
 		<Configuration
-			Name="Release|x64"
-			OutputDirectory="..\bin\Release64"
-			IntermediateDirectory=".\Release64"
+			Name="Debug|x64"
+			OutputDirectory="..\bin\Debug64"
+			IntermediateDirectory=".\Debug64"
 			ConfigurationType="1"
 			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC60.vsprops"
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -396,7 +305,126 @@
 				Name="Config"
 			/>
 			<Tool
-				Name="Genhead"
+				Name="Gen_head"
+			/>
+			<Tool
+				Name="Languages"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				TargetEnvironment="3"
+				TypeLibraryName=".\Debug64\Doxygen.tlb"
+				HeaderFileName=""
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				AdditionalOptions="/Zm200 /bigobj"
+				Optimization="0"
+				AdditionalIncludeDirectories="..\src,..\qtools,..\libpng,..\libmd5,."
+				PreprocessorDefinitions="_CONSOLE;WIN32;_DEBUG; _CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;LIBICONV_STATIC;CHARSET_STATIC"
+				MinimalRebuild="true"
+				BasicRuntimeChecks="3"
+				RuntimeLibrary="1"
+				PrecompiledHeaderFile=".\Debug64/Doxygen.pch"
+				AssemblerListingLocation=".\Debug64/"
+				ObjectFile=".\Debug64/"
+				ProgramDataBaseFileName=".\Debug64/"
+				WarningLevel="3"
+				SuppressStartupBanner="true"
+				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Debug64\$(TargetName).pdb"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+				PreprocessorDefinitions="_DEBUG"
+				Culture="1033"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				AdditionalDependencies="qtools.lib ws2_32.lib iconv64.lib shell32.lib"
+				OutputFile="..\bin\Debug64\doxygen.exe"
+				LinkIncremental="2"
+				SuppressStartupBanner="true"
+				AdditionalLibraryDirectories="Debug64"
+				GenerateManifest="false"
+				GenerateDebugInformation="true"
+				ProgramDatabaseFile=".\Debug64\$(TargetName).pdb"
+				SubSystem="1"
+				LargeAddressAware="2"
+				RandomizedBaseAddress="1"
+				DataExecutionPrevention="0"
+				TargetMachine="17"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+				SuppressStartupBanner="true"
+				OutputFile=".\Debug64/Doxygen.bsc"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
+		<Configuration
+			Name="Release|x64"
+			OutputDirectory="..\bin\Release64"
+			IntermediateDirectory=".\Release64"
+			ConfigurationType="1"
+			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC60.vsprops"
+			UseOfMFC="0"
+			ATLMinimizesCRunTimeLibraryUsage="false"
+			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="Lex"
+			/>
+			<Tool
+				Name="Settings"
+			/>
+			<Tool
+				Name="Version"
+			/>
+			<Tool
+				Name="Config"
+			/>
+			<Tool
+				Name="Gen_head"
+			/>
+			<Tool
+				Name="Languages"
 			/>
 			<Tool
 				Name="VCXMLDataGeneratorTool"
@@ -429,6 +457,7 @@
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Release64\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -449,7 +478,7 @@
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="Release64"
-				ProgramDatabaseFile=".\Release64/Doxygen.pdb"
+				ProgramDatabaseFile=".\Release64\$(TargetName).pdb"
 				SubSystem="1"
 				LargeAddressAware="2"
 				RandomizedBaseAddress="1"
@@ -490,10 +519,6 @@
 			>
 			<File
 				RelativePath="..\src\arguments.cpp"
-				>
-			</File>
-			<File
-				RelativePath="..\src\constexp.cpp"
 				>
 			</File>
 			<File
@@ -545,6 +570,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\src\constexp.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\src\cppvalue.cpp"
 				>
 			</File>
@@ -574,6 +603,10 @@
 			</File>
 			<File
 				RelativePath="..\src\definition.cpp"
+				>
+			</File>
+			<File
+				RelativePath="..\src\dia.cpp"
 				>
 			</File>
 			<File
@@ -841,17 +874,17 @@
 				>
 			</File>
 			<File
-				RelativePath="..\src\textdocvisitor.h"
+				RelativePath="..\src\textdocvisitor.cpp"
 				>
 			</File>
 			<File
-				RelativePath="..\src\textdocvisitor.cpp"
+				RelativePath="..\src\textdocvisitor.h"
 				>
 			</File>
 			<File
 				RelativePath="..\src\tooltip.cpp"
 				>
-			</File>			
+			</File>
 			<File
 				RelativePath="..\src\util.cpp"
 				>
@@ -894,22 +927,22 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="Running bison on constexp.y"
-						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(InputDir)\..\src\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(InputDir)..\src\ce_parse.cpp&#x0D;&#x0A;del $(InputDir)..\src\ce_parse.c"
-						Outputs="$(InputDir)\..\src\ce_parse.cpp"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="VCCustomBuildTool"
-						Description="Running bison on constexp.y"
-						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(InputDir)\..\src\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(InputDir)..\src\ce_parse.cpp&#x0D;&#x0A;del $(InputDir)..\src\ce_parse.c"
+						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(InputDir)\..\src\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(InputDir)..\src\ce_parse.cpp&#x0D;&#x0A;del $(InputDir)..\src\ce_parse.c&#x0D;&#x0A;"
 						Outputs="$(InputDir)\..\src\ce_parse.cpp"
 					/>
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCustomBuildTool"
+						Description="Running bison on constexp.y"
+						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(InputDir)\..\src\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(InputDir)..\src\ce_parse.cpp&#x0D;&#x0A;del $(InputDir)..\src\ce_parse.c&#x0D;&#x0A;"
+						Outputs="$(InputDir)\..\src\ce_parse.cpp"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="VCCustomBuildTool"
@@ -938,22 +971,22 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="Running bison on vhdlparser.y"
-						CommandLine="bison -l -d -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.c&#x0D;&#x0A;bison -l -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.cpp&#x0D;&#x0A;del $(InputDir)\..\src\vhdlparser.c"
-						Outputs="$(InputDir)$(InputName).cpp"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="VCCustomBuildTool"
-						Description="Running bison on vhdlparser.y"
-						CommandLine="bison -l -d -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.c&#x0D;&#x0A;bison -l -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.cpp&#x0D;&#x0A;del $(InputDir)\..\src\vhdlparser.c"
+						CommandLine="bison -l -d -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.c&#x0D;&#x0A;bison -l -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.cpp&#x0D;&#x0A;del $(InputDir)\..\src\vhdlparser.c&#x0D;&#x0A;"
 						Outputs="$(InputDir)$(InputName).cpp"
 					/>
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCustomBuildTool"
+						Description="Running bison on vhdlparser.y"
+						CommandLine="bison -l -d -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.c&#x0D;&#x0A;bison -l -p vhdlscannerYY $(InputPath) -o $(InputDir)\..\src\vhdlparser.cpp&#x0D;&#x0A;del $(InputDir)\..\src\vhdlparser.c&#x0D;&#x0A;"
+						Outputs="$(InputDir)$(InputName).cpp"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="VCCustomBuildTool"
@@ -1022,7 +1055,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Lex"
@@ -1030,7 +1063,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Lex"
@@ -1058,7 +1091,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Lex"
@@ -1066,7 +1099,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Lex"
@@ -1110,7 +1143,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Lex"
@@ -1118,7 +1151,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Lex"
@@ -1146,7 +1179,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Lex"
@@ -1154,7 +1187,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Lex"
@@ -1182,7 +1215,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Lex"
@@ -1190,7 +1223,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Lex"
@@ -1209,13 +1242,51 @@
 		</Filter>
 		<Filter
 			Name="Python Files"
-			Filter="py"
 			>
+			<File
+				RelativePath="..\src\lang_cfg.py"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Languages"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Languages"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Languages"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Languages"
+					/>
+				</FileConfiguration>
+			</File>
 			<File
 				RelativePath="..\src\settings.py"
 				>
 				<FileConfiguration
-					Name="Debug|Win32"
+					Name="Debug|win32"
+					>
+					<Tool
+						Name="Settings"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|win32"
 					>
 					<Tool
 						Name="Settings"
@@ -1223,13 +1294,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug|x64"
-					>
-					<Tool
-						Name="Settings"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
 					>
 					<Tool
 						Name="Settings"
@@ -1247,7 +1311,14 @@
 				RelativePath="..\src\version.py"
 				>
 				<FileConfiguration
-					Name="Debug|Win32"
+					Name="Debug|win32"
+					>
+					<Tool
+						Name="Version"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|win32"
 					>
 					<Tool
 						Name="Version"
@@ -1255,13 +1326,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug|x64"
-					>
-					<Tool
-						Name="Version"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
 					>
 					<Tool
 						Name="Version"
@@ -1284,7 +1348,14 @@
 				RelativePath="..\src\config.xml"
 				>
 				<FileConfiguration
-					Name="Debug|Win32"
+					Name="Debug|win32"
+					>
+					<Tool
+						Name="Config"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|win32"
 					>
 					<Tool
 						Name="Config"
@@ -1292,13 +1363,6 @@
 				</FileConfiguration>
 				<FileConfiguration
 					Name="Debug|x64"
-					>
-					<Tool
-						Name="Config"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
 					>
 					<Tool
 						Name="Config"
@@ -1317,7 +1381,7 @@
 			Name="Generating header Files"
 			>
 			<File
-				RelativePath="..\src\index.xsd"
+				RelativePath="..\src\bib2xhtml.pl"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
@@ -1327,14 +1391,14 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Gen_head"
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Gen_head"
@@ -1359,13 +1423,6 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
 					Name="Release|Win32"
 					>
 					<Tool
@@ -1373,672 +1430,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\layout_default.xml"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
 					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\header.html"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\footer.html"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\search_functions.php"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\search_opensearch.php"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\search.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\search.css"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\extsearch.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\doxygen.css"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\doxygen.sty"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\navtree.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\resize.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\jquery_p1.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\jquery_p2.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\jquery_p3.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\jquery_ui.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\jquery_fx.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\jquery_pt.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\navtree.css"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\svgpan.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\src\dynsections.js"
-				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|x64"
-					>
-					<Tool
-						Name="Gen_head"
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
 					>
 					<Tool
 						Name="Gen_head"
@@ -2063,14 +1455,14 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Gen_head"
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Gen_head"
@@ -2085,10 +1477,17 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="..\src\bib2xhtml.pl"
+				RelativePath="..\src\doxygen.css"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="Gen_head"
@@ -2102,7 +1501,672 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\doxygen.sty"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
 					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\dynsections.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\extsearch.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\footer.html"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\header.html"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\index.xsd"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\jquery_fx.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\jquery_p1.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\jquery_p2.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\jquery_p3.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\jquery_pt.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\jquery_ui.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\layout_default.xml"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\navtree.css"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\navtree.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\resize.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\search.css"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\search.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\search_functions.php"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\search_opensearch.php"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="..\src\svgpan.js"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="Gen_head"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="Gen_head"
@@ -2215,6 +2279,10 @@
 			</File>
 			<File
 				RelativePath="..\src\definition.h"
+				>
+			</File>
+			<File
+				RelativePath="..\src\dia.h"
 				>
 			</File>
 			<File
@@ -2743,7 +2811,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Debug|x64"
+					Name="Release|Win32"
 					>
 					<Tool
 						Name="VCCustomBuildTool"
@@ -2753,7 +2821,7 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
-					Name="Release|Win32"
+					Name="Debug|x64"
 					>
 					<Tool
 						Name="VCCustomBuildTool"

--- a/winbuild/Doxywizard.vcproj
+++ b/winbuild/Doxywizard.vcproj
@@ -30,7 +30,8 @@
 		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="."
-			IntermediateDirectory="obj\"
+			IntermediateDirectory="Debug\"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			ConfigurationType="1"
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
@@ -72,7 +73,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="-Zm200 -w34100 -w34189 -Zm200 -w34100 -w34189 -w34100 -w34189"
 				Optimization="4"
-				AdditionalIncludeDirectories="&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include&quot;,&quot;..\addon\doxywizard&quot;,&quot;$(QT_DIR)\include\ActiveQt&quot;,&quot;..\addon\doxywizard\moc&quot;,&quot;..\addon\doxywizard&quot;,&quot;.&quot;,$(QT_DIR)\mkspecs\win32-msvc2005"
+				AdditionalIncludeDirectories="&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include&quot;,&quot;..\addon\doxywizard&quot;,&quot;$(QT_DIR)\include\ActiveQt&quot;,&quot;moc&quot;,&quot;..\addon\doxywizard&quot;,&quot;.&quot;,$(QT_DIR)\mkspecs\win32-msvc2005"
 				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,QT_LARGEFILE_SUPPORT,QT_NO_CAST_FROM_ASCII,QT_NO_CAST_TO_ASCII,QT_XML_LIB,QT_GUI_LIB,QT_CORE_LIB,QT_THREAD_SUPPORT"
 				GeneratePreprocessedFile="0"
 				ExceptionHandling="1"
@@ -80,12 +81,12 @@
 				BufferSecurityCheck="false"
 				TreatWChar_tAsBuiltInType="false"
 				RuntimeTypeInfo="true"
-				AssemblerListingLocation="obj\"
-				ObjectFile="obj\"
-				ProgramDataBaseFileName=".\"
+				AssemblerListingLocation="Debug\"
+				ObjectFile="Debug\"
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Debug\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -102,12 +103,12 @@
 				IgnoreImportLibrary="true"
 				AdditionalOptions="&quot;/MANIFESTDEPENDENCY:type=&apos;win32&apos; name=&apos;Microsoft.Windows.Common-Controls&apos; version=&apos;6.0.0.0&apos; publicKeyToken=&apos;6595b64144ccf1df&apos; language=&apos;*&apos; processorArchitecture=&apos;*&apos;&quot; &quot;/MANIFESTDEPENDENCY:type=&apos;win32&apos; name=&apos;Microsoft.Windows.Common-Controls&apos; version=&apos;6.0.0.0&apos; publicKeyToken=&apos;6595b64144ccf1df&apos; language=&apos;*&apos; processorArchitecture=&apos;*&apos;&quot;"
 				AdditionalDependencies="$(QT_DIR)\lib\qtmaind.lib $(QT_DIR)\lib\QtXmld.lib $(QT_DIR)\lib\QtGuid.lib $(QT_DIR)\lib\QtCored.lib kernel32.lib user32.lib shell32.lib uuid.lib ole32.lib advapi32.lib ws2_32.lib gdi32.lib comdlg32.lib oleaut32.lib imm32.lib winmm.lib winspool.lib msimg32.lib"
-				OutputFile="debug\doxywizard.exe"
+				OutputFile="..\bin\Debug\doxywizard.exe"
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="$(QT_DIR)\lib"
-				IgnoreDefaultLibraryNames="libcmt.lib"
+				IgnoreDefaultLibraryNames="libcmtd.lib"
 				GenerateDebugInformation="true"
-				ProgramDatabaseFile=""
+				ProgramDatabaseFile=".\Debug\$(TargetName).pdb"
 				SubSystem="2"
 				LargeAddressAware="2"
 				LinkTimeCodeGeneration="0"
@@ -140,6 +141,7 @@
 			Name="Release|Win32"
 			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
 			IntermediateDirectory="Release"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			ConfigurationType="1"
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
@@ -181,7 +183,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="-Zm200 -w34100 -w34189 -Zm200 -w34100 -w34189 -w34100 -w34189"
 				Optimization="2"
-				AdditionalIncludeDirectories="&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include&quot;,&quot;..\addon\doxywizard&quot;,&quot;$(QT_DIR)\include\ActiveQt&quot;,&quot;..\addon\doxywizard\moc&quot;,&quot;..\addon\doxywizard&quot;,&quot;.&quot;,$(QT_DIR)\mkspecs\win32-msvc2008"
+				AdditionalIncludeDirectories="&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtCore&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtGui&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include\QtXml&quot;,&quot;$(QT_DIR)\include&quot;,&quot;..\addon\doxywizard&quot;,&quot;$(QT_DIR)\include\ActiveQt&quot;,&quot;moc&quot;,&quot;..\addon\doxywizard&quot;,&quot;.&quot;,$(QT_DIR)\mkspecs\win32-msvc2008"
 				PreprocessorDefinitions="QT_NO_DEBUG,NDEBUG,_WINDOWS,UNICODE,WIN32,QT_LARGEFILE_SUPPORT,QT_NO_CAST_FROM_ASCII,QT_NO_CAST_TO_ASCII,QT_NO_DEBUG,QT_XML_LIB,QT_GUI_LIB,QT_CORE_LIB,QT_THREAD_SUPPORT,NDEBUG"
 				GeneratePreprocessedFile="0"
 				ExceptionHandling="1"
@@ -189,12 +191,12 @@
 				BufferSecurityCheck="false"
 				TreatWChar_tAsBuiltInType="false"
 				RuntimeTypeInfo="true"
-				AssemblerListingLocation="obj\"
-				ObjectFile="obj\"
-				ProgramDataBaseFileName=".\"
+				AssemblerListingLocation="Release\"
+				ObjectFile="Release\"
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="0"
+				ProgramDatabaseFileName=".\Release\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -211,14 +213,14 @@
 				IgnoreImportLibrary="true"
 				AdditionalOptions="&quot;/MANIFESTDEPENDENCY:type=&apos;win32&apos; name=&apos;Microsoft.Windows.Common-Controls&apos; version=&apos;6.0.0.0&apos; publicKeyToken=&apos;6595b64144ccf1df&apos; language=&apos;*&apos; processorArchitecture=&apos;*&apos;&quot; &quot;/MANIFESTDEPENDENCY:type=&apos;win32&apos; name=&apos;Microsoft.Windows.Common-Controls&apos; version=&apos;6.0.0.0&apos; publicKeyToken=&apos;6595b64144ccf1df&apos; language=&apos;*&apos; processorArchitecture=&apos;*&apos;&quot;"
 				AdditionalDependencies="$(QT_DIR)\lib\qtmain.lib $(QT_DIR)\lib\QtXml.lib $(QT_DIR)\lib\QtGui.lib $(QT_DIR)\lib\QtCore.lib kernel32.lib user32.lib shell32.lib uuid.lib ole32.lib advapi32.lib ws2_32.lib gdi32.lib comdlg32.lib oleaut32.lib imm32.lib winmm.lib winspool.lib msimg32.lib"
-				OutputFile="..\bin\doxywizard.exe"
+				OutputFile="..\bin\Release\doxywizard.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="$(QT_DIR)\lib"
+				IgnoreDefaultLibraryNames="libcmt.lib"
 				IgnoreAllDefaultLibraries="false"
-				IgnoreDefaultLibraryNames=""
 				GenerateDebugInformation="false"
-				ProgramDatabaseFile=""
+				ProgramDatabaseFile=".\Release\$(TargetName).pdb"
 				SubSystem="2"
 				LargeAddressAware="2"
 				LinkTimeCodeGeneration="0"
@@ -307,7 +309,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\doxywizard.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\doxywizard.h -o moc\moc_doxywizard.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\doxywizard.h -o moc\moc_doxywizard.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\doxywizard.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_doxywizard.cpp"
 					/>
@@ -318,7 +320,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\doxywizard.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\doxywizard.h -o moc\moc_doxywizard.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\doxywizard.h -o moc\moc_doxywizard.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\doxywizard.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_doxywizard.cpp"
 					/>
@@ -333,7 +335,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\expert.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\expert.h -o moc\moc_expert.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\expert.h -o moc\moc_expert.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\expert.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_expert.cpp"
 					/>
@@ -344,7 +346,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\expert.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\expert.h -o moc\moc_expert.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\expert.h -o moc\moc_expert.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\expert.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_expert.cpp"
 					/>
@@ -359,7 +361,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\helplabel.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\helplabel.h -o moc\moc_helplabel.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\helplabel.h -o moc\moc_helplabel.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\helplabel.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_helplabel.cpp"
 					/>
@@ -370,7 +372,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\helplabel.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\helplabel.h -o moc\moc_helplabel.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\helplabel.h -o moc\moc_helplabel.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\helplabel.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_helplabel.cpp"
 					/>
@@ -385,7 +387,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputbool.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputbool.h -o moc\moc_inputbool.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputbool.h -o moc\moc_inputbool.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputbool.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputbool.cpp"
 					/>
@@ -396,7 +398,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputbool.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputbool.h -o moc\moc_inputbool.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputbool.h -o moc\moc_inputbool.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputbool.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputbool.cpp"
 					/>
@@ -411,7 +413,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputint.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputint.h -o moc\moc_inputint.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputint.h -o moc\moc_inputint.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputint.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputint.cpp"
 					/>
@@ -422,7 +424,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputint.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputint.h -o moc\moc_inputint.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputint.h -o moc\moc_inputint.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputint.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputint.cpp"
 					/>
@@ -437,7 +439,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputstring.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstring.h -o moc\moc_inputstring.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstring.h -o moc\moc_inputstring.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputstring.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputstring.cpp"
 					/>
@@ -448,7 +450,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputstring.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstring.h -o moc\moc_inputstring.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstring.h -o moc\moc_inputstring.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputstring.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputstring.cpp"
 					/>
@@ -463,7 +465,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputstrlist.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstrlist.h -o moc\moc_inputstrlist.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstrlist.h -o moc\moc_inputstrlist.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputstrlist.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputstrlist.cpp"
 					/>
@@ -474,15 +476,11 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\inputstrlist.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstrlist.h -o moc\moc_inputstrlist.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\inputstrlist.h -o moc\moc_inputstrlist.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\inputstrlist.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_inputstrlist.cpp"
 					/>
 				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="..\addon\doxywizard\version.h"
-				>
 			</File>
 			<File
 				RelativePath="..\addon\doxywizard\wizard.h"
@@ -493,7 +491,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\wizard.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\wizard.h -o moc\moc_wizard.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\wizard.h -o moc\moc_wizard.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\wizard.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_wizard.cpp"
 					/>
@@ -504,7 +502,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="MOC ..\addon\doxywizard\wizard.h"
-						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;..\addon\doxywizard\moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\wizard.h -o moc\moc_wizard.cpp&#x0D;&#x0A;"
+						CommandLine="$(QT_DIR)\bin\moc.exe  -DUNICODE -DWIN32 -DQT_LARGEFILE_SUPPORT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_XML_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_THREAD_SUPPORT -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtCore&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtGui&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include\QtXml&quot; -I&quot;$(QT_DIR)\include&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;$(QT_DIR)\include\ActiveQt&quot; -I&quot;moc&quot; -I&quot;..\addon\doxywizard&quot; -I&quot;.&quot; -I$(QT_DIR)\mkspecs\win32-msvc2005 -D_MSC_VER=1400 -DWIN32 ..\addon\doxywizard\wizard.h -o moc\moc_wizard.cpp&#x0D;&#x0A;"
 						AdditionalDependencies="..\addon\doxywizard\wizard.h;$(QT_DIR)\bin\moc.exe"
 						Outputs="moc\moc_wizard.cpp"
 					/>
@@ -580,6 +578,20 @@
 				RelativePath="..\src\settings.py"
 				>
 				<FileConfiguration
+					Name="Debug|win32"
+					>
+					<Tool
+						Name="Settings"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|win32"
+					>
+					<Tool
+						Name="Settings"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
 					Name="Debug|x64"
 					>
 					<Tool
@@ -597,6 +609,34 @@
 			<File
 				RelativePath="..\src\version.py"
 				>
+				<FileConfiguration
+					Name="Debug|win32"
+					>
+					<Tool
+						Name="Version"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|win32"
+					>
+					<Tool
+						Name="Version"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="Version"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
+					>
+					<Tool
+						Name="Version"
+					/>
+				</FileConfiguration>
 			</File>
 		</Filter>
 		<Filter

--- a/winbuild/Languages.rules
+++ b/winbuild/Languages.rules
@@ -1,59 +1,862 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <VisualStudioToolFile
-	Name="settings"
-	Version="8.00"
-	>
-	<Rules>
-		<CustomBuildRule
-			Name="Settings"
-			DisplayName="Settings"
-			CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] [inputs]"
-			Outputs="$(InputDir)../src/$(InputName).h"
-			FileExtensions="*.py"
-			AdditionalDependencies="$(ProjectDir)..\src\configure"
-			ExecutionDescription="Executing Settings ..."
-			ShowOnlyRuleProperties="false"
-			>
-			<Properties>
-				<EnumProperty
-					Name="SqlLite3"
-					DisplayName="Use SqlLite3"
-					Description="Use SqlLite3"
-					DefaultValue="0"
-				>
-					<Values>
-						<EnumValue
-						Value="0"
-						Switch="NO"
-						DisplayName="Don't use SqlLite3"
-						/>
-						<EnumValue
-						Value="1"
-						Switch="YES"
-						DisplayName="Use SqlLite3"
-						/>
-					</Values>
-				</EnumProperty>
-				<EnumProperty
-					Name="CLANG"
-					DisplayName="Use CLANG"
-					Description="Use CLANG"
-					DefaultValue="0"
-				>
-					<Values>
-						<EnumValue
-						Value="0"
-						Switch="NO"
-						DisplayName="Don't use CLANG"
-						/>
-						<EnumValue
-						Value="1"
-						Switch="YES"
-						DisplayName="Use CLANG"
-						/>
-					</Values>
-				</EnumProperty>
-			</Properties>
-		</CustomBuildRule>
-	</Rules>
+        Name="languages"
+        Version="8.00"
+        >
+        <Rules>
+                <CustomBuildRule
+                        Name="Languages"
+                        DisplayName="Settings"
+                        CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] &gt; $(InputDir)../src/$(InputName).h"
+                        Outputs="$(InputDir)../src/$(InputName).h"
+                        FileExtensions="*.py"
+                        AdditionalDependencies=""
+                        ExecutionDescription="Executing languages ..."
+                        ShowOnlyRuleProperties="false"
+                        >
+                        <Properties>
+                               <EnumProperty
+                                       Name="EnglishOnlys"
+                                       DisplayName="Use English Only"
+                                       Description="Use English Only"
+                                       DefaultValue="0"
+                               >
+                                       <Values>
+                                               <EnumValue
+                                               Value="0"
+                                               Switch=""
+                                               DisplayName="Don't use English Only"
+                                               />
+                                               <EnumValue
+                                               Value="1"
+                                               Switch="ENONLY"
+                                               DisplayName="Use English Only"
+                                               />
+                                       </Values>
+                               </EnumProperty>
+
+                                   <EnumProperty
+                                           Name="armenian"
+                                           DisplayName="Use Armenian"
+                                           Description="Use Armenian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Armenian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="AM"
+                                                   DisplayName="Use Armenian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="arabic"
+                                           DisplayName="Use Arabic"
+                                           Description="Use Arabic"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Arabic"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="AR"
+                                                   DisplayName="Use Arabic"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="brazilian"
+                                           DisplayName="Use Brazilian"
+                                           Description="Use Brazilian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Brazilian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="BR"
+                                                   DisplayName="Use Brazilian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="catalan"
+                                           DisplayName="Use Catalan"
+                                           Description="Use Catalan"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Catalan"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="CA"
+                                                   DisplayName="Use Catalan"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="chinese"
+                                           DisplayName="Use Chinese"
+                                           Description="Use Chinese"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Chinese"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="CN"
+                                                   DisplayName="Use Chinese"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="czech"
+                                           DisplayName="Use Czech"
+                                           Description="Use Czech"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Czech"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="CZ"
+                                                   DisplayName="Use Czech"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="german"
+                                           DisplayName="Use German"
+                                           Description="Use German"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use German"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="DE"
+                                                   DisplayName="Use German"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="danish"
+                                           DisplayName="Use Danish"
+                                           Description="Use Danish"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Danish"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="DK"
+                                                   DisplayName="Use Danish"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="esperanto"
+                                           DisplayName="Use Esperanto"
+                                           Description="Use Esperanto"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Esperanto"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="EO"
+                                                   DisplayName="Use Esperanto"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="spanish"
+                                           DisplayName="Use Spanish"
+                                           Description="Use Spanish"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Spanish"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="ES"
+                                                   DisplayName="Use Spanish"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="persian"
+                                           DisplayName="Use Persian"
+                                           Description="Use Persian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Persian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="FA"
+                                                   DisplayName="Use Persian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="finnish"
+                                           DisplayName="Use Finnish"
+                                           Description="Use Finnish"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Finnish"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="FI"
+                                                   DisplayName="Use Finnish"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="french"
+                                           DisplayName="Use French"
+                                           Description="Use French"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use French"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="FR"
+                                                   DisplayName="Use French"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="greek"
+                                           DisplayName="Use Greek"
+                                           Description="Use Greek"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Greek"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="GR"
+                                                   DisplayName="Use Greek"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="croatian"
+                                           DisplayName="Use Croatian"
+                                           Description="Use Croatian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Croatian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="HR"
+                                                   DisplayName="Use Croatian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="hungarian"
+                                           DisplayName="Use Hungarian"
+                                           Description="Use Hungarian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Hungarian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="HU"
+                                                   DisplayName="Use Hungarian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="indonesian"
+                                           DisplayName="Use Indonesian"
+                                           Description="Use Indonesian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Indonesian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="ID"
+                                                   DisplayName="Use Indonesian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="italian"
+                                           DisplayName="Use Italian"
+                                           Description="Use Italian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Italian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="IT"
+                                                   DisplayName="Use Italian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="japaneseen"
+                                           DisplayName="Use Japanese-En"
+                                           Description="Use Japanese-En"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Japanese-En"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="JE"
+                                                   DisplayName="Use Japanese-En"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="japanese"
+                                           DisplayName="Use Japanese"
+                                           Description="Use Japanese"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Japanese"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="JP"
+                                                   DisplayName="Use Japanese"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="koreanen"
+                                           DisplayName="Use Korean-En"
+                                           Description="Use Korean-En"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Korean-En"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="KE"
+                                                   DisplayName="Use Korean-En"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="korean"
+                                           DisplayName="Use Korean"
+                                           Description="Use Korean"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Korean"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="KR"
+                                                   DisplayName="Use Korean"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="lithuanian"
+                                           DisplayName="Use Lithuanian"
+                                           Description="Use Lithuanian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Lithuanian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="LT"
+                                                   DisplayName="Use Lithuanian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="latvian"
+                                           DisplayName="Use Latvian"
+                                           Description="Use Latvian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Latvian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="LV"
+                                                   DisplayName="Use Latvian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="macedonian"
+                                           DisplayName="Use Macedonian"
+                                           Description="Use Macedonian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Macedonian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="MK"
+                                                   DisplayName="Use Macedonian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="dutch"
+                                           DisplayName="Use Dutch"
+                                           Description="Use Dutch"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Dutch"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="NL"
+                                                   DisplayName="Use Dutch"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="norwegian"
+                                           DisplayName="Use Norwegian"
+                                           Description="Use Norwegian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Norwegian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="NO"
+                                                   DisplayName="Use Norwegian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="polish"
+                                           DisplayName="Use Polish"
+                                           Description="Use Polish"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Polish"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="PL"
+                                                   DisplayName="Use Polish"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="portuguese"
+                                           DisplayName="Use Portuguese"
+                                           Description="Use Portuguese"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Portuguese"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="PT"
+                                                   DisplayName="Use Portuguese"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="romanian"
+                                           DisplayName="Use Romanian"
+                                           Description="Use Romanian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Romanian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="RO"
+                                                   DisplayName="Use Romanian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="russian"
+                                           DisplayName="Use Russian"
+                                           Description="Use Russian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Russian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="RU"
+                                                   DisplayName="Use Russian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="serbiancyrillic"
+                                           DisplayName="Use Serbian-Cyrillic"
+                                           Description="Use Serbian-Cyrillic"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Serbian-Cyrillic"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="SC"
+                                                   DisplayName="Use Serbian-Cyrillic"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="slovene"
+                                           DisplayName="Use Slovene"
+                                           Description="Use Slovene"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Slovene"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="SI"
+                                                   DisplayName="Use Slovene"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="slovak"
+                                           DisplayName="Use Slovak"
+                                           Description="Use Slovak"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Slovak"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="SK"
+                                                   DisplayName="Use Slovak"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="serbian"
+                                           DisplayName="Use Serbian"
+                                           Description="Use Serbian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Serbian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="SR"
+                                                   DisplayName="Use Serbian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="swedish"
+                                           DisplayName="Use Swedish"
+                                           Description="Use Swedish"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Swedish"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="SV"
+                                                   DisplayName="Use Swedish"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="turkish"
+                                           DisplayName="Use Turkish"
+                                           Description="Use Turkish"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Turkish"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="TR"
+                                                   DisplayName="Use Turkish"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="chinesetraditional"
+                                           DisplayName="Use Chinese-Traditional"
+                                           Description="Use Chinese-Traditional"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Chinese-Traditional"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="TW"
+                                                   DisplayName="Use Chinese-Traditional"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="ukrainian"
+                                           DisplayName="Use Ukrainian"
+                                           Description="Use Ukrainian"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Ukrainian"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="UA"
+                                                   DisplayName="Use Ukrainian"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="vietnamese"
+                                           DisplayName="Use Vietnamese"
+                                           Description="Use Vietnamese"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Vietnamese"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="VI"
+                                                   DisplayName="Use Vietnamese"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                                   <EnumProperty
+                                           Name="afrikaans"
+                                           DisplayName="Use Afrikaans"
+                                           Description="Use Afrikaans"
+                                           DefaultValue="1"
+                                   >
+                                           <Values>
+                                                   <EnumValue
+                                                   Value="0"
+                                                   Switch=""
+                                                   DisplayName="Don't use Afrikaans"
+                                                   />
+                                                   <EnumValue
+                                                   Value="1"
+                                                   Switch="ZA"
+                                                   DisplayName="Use Afrikaans"
+                                                   />
+                                           </Values>
+                                   </EnumProperty>
+        
+                        </Properties>
+                </CustomBuildRule>
+        </Rules>
 </VisualStudioToolFile>
+

--- a/winbuild/Settings.rules
+++ b/winbuild/Settings.rules
@@ -10,7 +10,7 @@
 			CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] [inputs]"
 			Outputs="$(InputDir)../src/$(InputName).h"
 			FileExtensions="*.py"
-			AdditionalDependencies="$(ProjectDir)..\src\configure"
+			AdditionalDependencies="$(ProjectDir)..\configure"
 			ExecutionDescription="Executing Settings ..."
 			ShowOnlyRuleProperties="false"
 			>

--- a/winbuild/Version.rules
+++ b/winbuild/Version.rules
@@ -8,9 +8,9 @@
 			Name="Version"
 			DisplayName="Version"
 			CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] [inputs]"
-			Outputs="$(InputDir)../src/$(InputName).cpp"
+			Outputs="$(InputDir)..\src\$(InputName).cpp"
 			FileExtensions="*.py"
-			AdditionalDependencies="$(ProjectDir)..\src\configure"
+			AdditionalDependencies="$(ProjectDir)..\configure"
 			ExecutionDescription="Executing Version ..."
 			ShowOnlyRuleProperties="false"
 			>

--- a/winbuild/doxyindexer.vcproj
+++ b/winbuild/doxyindexer.vcproj
@@ -25,6 +25,7 @@
 			IntermediateDirectory="$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -52,6 +53,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="4"
+				ProgramDatabaseFileName=".\Debug\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -65,7 +67,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="qtools.lib xapian.lib uuid.lib rpcrt4.lib ws2_32.lib"
-				OutputFile="..\bin\doxyindexer.exe"
+				OutputFile="..\bin\Debug\doxyindexer.exe"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories="&quot;$(XAPIAN_DIR)\Debug&quot;;Debug"
 				GenerateManifest="false"
@@ -104,6 +106,7 @@
 			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -132,6 +135,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Debug64\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -145,7 +149,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="qtools.lib xapian.lib uuid.lib rpcrt4.lib ws2_32.lib"
-				OutputFile="..\bin\doxyindexer.exe"
+				OutputFile="..\bin\Debug64\doxyindexer.exe"
 				LinkIncremental="2"
 				AdditionalLibraryDirectories="&quot;$(XAPIAN_DIR)\Debug64&quot;;Debug64"
 				GenerateDebugInformation="true"
@@ -181,6 +185,7 @@
 			IntermediateDirectory="$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			WholeProgramOptimization="1"
 			>
 			<Tool
@@ -209,6 +214,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Release\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -261,6 +267,7 @@
 			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			WholeProgramOptimization="1"
 			>
 			<Tool
@@ -290,6 +297,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Relase64\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"

--- a/winbuild/doxysearch.vcproj
+++ b/winbuild/doxysearch.vcproj
@@ -25,6 +25,7 @@
 			IntermediateDirectory="$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -52,6 +53,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="4"
+				ProgramDatabaseFileName=".\Debug\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -65,8 +67,8 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="xapian.lib uuid.lib rpcrt4.lib ws2_32.lib"
-				OutputFile="..\bin\doxysearch.cgi"
-				LinkIncremental="2"
+				OutputFile="..\bin\Debug\doxysearch.cgi"
+				LinkIncremental="1"
 				AdditionalLibraryDirectories="&quot;$(XAPIAN_DIR)\Debug&quot;"
 				GenerateDebugInformation="true"
 				ProgramDatabaseFile=".\Debug\$(TargetName).pdb"
@@ -101,6 +103,7 @@
 			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -129,6 +132,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Debug64\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -142,7 +146,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="xapian.lib uuid.lib rpcrt4.lib ws2_32.lib"
-				OutputFile="..\bin\doxysearch.cgi"
+				OutputFile="..\bin\Debug64\doxysearch.cgi"
 				LinkIncremental="2"
 				AdditionalLibraryDirectories="&quot;$(XAPIAN_DIR)\Debug64&quot;"
 				GenerateDebugInformation="true"
@@ -178,6 +182,7 @@
 			IntermediateDirectory="$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			WholeProgramOptimization="1"
 			>
 			<Tool
@@ -206,6 +211,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Release\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -257,6 +263,7 @@
 			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
 			ConfigurationType="1"
 			CharacterSet="1"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			WholeProgramOptimization="1"
 			>
 			<Tool
@@ -286,6 +293,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
+				ProgramDatabaseFileName=".\Release64\$(TargetName).pdb"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"

--- a/winbuild/iconv.vcproj
+++ b/winbuild/iconv.vcproj
@@ -25,6 +25,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -103,6 +104,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -257,6 +259,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -335,6 +338,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"

--- a/winbuild/qtools.vcproj
+++ b/winbuild/qtools.vcproj
@@ -26,6 +26,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -56,7 +57,7 @@
 				PrecompiledHeaderFile=".\Release/qtools.pch"
 				AssemblerListingLocation=".\Release/"
 				ObjectFile=".\Release/"
-				ProgramDataBaseFileName=".\Release/"
+				ProgramDatabaseFileName=".\Release\$(TargetName).pdb"
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"
@@ -104,6 +105,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -135,7 +137,7 @@
 				PrecompiledHeaderFile=".\Release64/qtools.pch"
 				AssemblerListingLocation=".\Release64/"
 				ObjectFile=".\Release64/"
-				ProgramDataBaseFileName=".\Release64/"
+				ProgramDatabaseFileName=".\Release64\$(TargetName).pdb"
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"
@@ -183,6 +185,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -211,7 +214,7 @@
 				PrecompiledHeaderFile=".\Debug/qtools.pch"
 				AssemblerListingLocation=".\Debug/"
 				ObjectFile=".\Debug/"
-				ProgramDataBaseFileName=".\Debug/"
+				ProgramDatabaseFileName=".\Debug\$(TargetName).pdb"
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"
@@ -259,6 +262,7 @@
 			UseOfMFC="0"
 			ATLMinimizesCRunTimeLibraryUsage="false"
 			CharacterSet="2"
+			BuildLogFile="$(IntDir)\$(TargetName)BuildLog.htm"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
@@ -288,7 +292,7 @@
 				PrecompiledHeaderFile=".\Debug64/qtools.pch"
 				AssemblerListingLocation=".\Debug64/"
 				ObjectFile=".\Debug64/"
-				ProgramDataBaseFileName=".\Debug64/"
+				ProgramDatabaseFileName=".\Debug64\$(TargetName).pdb"
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="3"


### PR DESCRIPTION
...g languages, some inconsistencies in the (windows) build system, corrections to some spelling.
- maintainers.txt
  Spelling correction
- config.xml
  Added missing languages
  Extended some descriptions
- htmlhelp.cpp
  Added missing languages
  Spelling corrections
- language.cpp
  Corrected call in respect to Serbian-Cyrillic
- translator_br.h
  Spelling correction
- translator_fa.h
  Corrected (not used) define in respect to LeftToRight
- translator_mk.h
  Spelling correction
- translator_sc.h
  Corrected in respect to consistency for Serbian-Cyrillic
- Doxygen.sln
  Added project dependency as otherwise there might be a problem with the generation of version.cpp
- Doxygen.vcproj
  Added rules for selecting languages to be used during translation
  Corrected some incorrect references / directories
  Corrected names of generated files / directories so they won't overwrite / conflict (especially during parallel builds)
  Corrected name of genhead <-> gen_head (consistency with rules file)
- Doxywizard.vcproj
  Corrected some incorrect references / directories
  Corrected names of generated files / directories so they won't overwrite / conflict (especially during parallel builds)
  Note place of resulting executable has hanged (more consistent now)
- Settings.rules
  Corrected place where configure file can be found
- Version.rules
  Corrected place where configure file can be found
- doxyindexer.vcproj
  Corrected some incorrect references / directories
  Corrected names of generated files / directories so they won't overwrite / conflict (especially during parallel builds)
- doxysearch.vcproj
  Corrected some incorrect references / directories
  Corrected names of generated files / directories so they won't overwrite / conflict (especially during parallel builds)
- iconv.vcproj
  Corrected some incorrect references / directories
  Corrected names of generated files / directories so they won't overwrite / conflict (especially during parallel builds)
- qtools.vcproj
  Corrected some incorrect references / directories
  Corrected names of generated files / directories so they won't overwrite / conflict (especially during parallel builds)
- lang_cfg.py
  Script to generate the file lang_cfg.h based on the specified languages in the windows GUI or in the configure script.
- languages.py
  Script to generate languages pane in the windows GUI
  This file has to be called outside visual studio as it generates the rules for the Languages pane in the GUI (command on src directory python languages.py > ..\winbuild\Languages.rules)
- Languages.rules
  Result file from language.py (old file was completely wrong and not used)
  This file has to be generated outside visual studio as it contains the rules for the Languages pane in the GUI
- configure
  Use lang_cfg.py script (consistency) instead of (internal) perl script.
