### PR TITLE
Build problem with unistd.h and Cygwin

### DIFF
--- a/src/libdoxygen.pro.in
+++ b/src/libdoxygen.pro.in
@@ -133,8 +133,6 @@ HEADERS      =	arguments.h \
 		tooltip.h \
 		translator.h \
 		translator_adapter.h \
-		types.h \
-		unistd.h \
 		util.h \
 		version.h \
 		vhdlcode.h \

--- a/winbuild/Doxygen.vcproj
+++ b/winbuild/Doxygen.vcproj
@@ -2798,7 +2798,7 @@
 				>
 			</File>
 			<File
-				RelativePath="..\src\unistd.h"
+				RelativePath="..\winbuild\unistd.h"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"


### PR DESCRIPTION
The standard g++ compiler under windows (win32-g++) has unistd.gh file; Microsoft windows does not have it, therfore it is better to use the winbuild directory in case of windows adn no dependency otherwise
