### PR TITLE
Doxysearch under Cygwin should not have extension cgi.exe but just .cgi

### DIFF
--- a/addon/doxysearch/doxysearch.pro.in
+++ b/addon/doxysearch/doxysearch.pro.in
@@ -1,5 +1,5 @@
 TEMPLATE     =	app.t
-CONFIG       =	console warn_on debug
+CONFIG       =	console warn_on debug cgi
 HEADERS      =	
 SOURCES      =	doxysearch.cpp
 LIBS        += -lxapian

--- a/tmake/lib/win32-g++/generic.t
+++ b/tmake/lib/win32-g++/generic.t
@@ -80,13 +80,17 @@
 	    $project{"TARGET_EXT"} = ".dll";
 	}
     } else {
-	Project('TMAKE_LFLAGS_CONSOLE_ANY = $$TMAKE_LFLAGS_CONSOLE');
-	Project('TMAKE_LFLAGS_WINDOWS_ANY = $$TMAKE_LFLAGS_WINDOWS');
-	if ( Project("TMAKE_APP_FLAG") ) {
-	    $project{"TARGET_EXT"} = ".exe";
-	} else {
-	    $project{"TARGET_EXT"} = ".a";
-	}
+        if ( Config("cgi") ) {
+	    Project('TMAKE_LFLAGS_CONSOLE_ANY = $$TMAKE_LFLAGS_CONSOLE');
+	    Project('TMAKE_LFLAGS_WINDOWS_ANY = $$TMAKE_LFLAGS_WINDOWS');
+	    $project{"TARGET_EXT"} = "";
+        } else {
+	    if ( Project("TMAKE_APP_FLAG") ) {
+	        $project{"TARGET_EXT"} = ".exe";
+	    } else {
+	        $project{"TARGET_EXT"} = ".a";
+	    }
+        }
     }
     if ( Config("windows") ) {
 	if ( Config("console") ) {


### PR DESCRIPTION
Doxysearch under Cygwin should not have extension cgi.exe but just .cgi
