### PR TITLE
Bug 711787 - Long initialization line in C stops doxygen

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -241,9 +241,12 @@ void replaceComment(int offset);
 
 %%
 
-<Scan>[^"'!\/\n\\#\\-]*           { /* eat anything that is not " / or \n */ 
-                                     copyToOutput(yytext,(int)yyleng); 
-				   }
+<Scan>[^"'!\/\n\\#\\-\\,]*           { /* eat anything that is not " / , or \n */ 
+                                       copyToOutput(yytext,(int)yyleng); 
+                                     }
+<Scan>[\\,]                          { /* eat , so we have a nice separator in long initialization lines */ 
+                                       copyToOutput(yytext,(int)yyleng); 
+                                     }
 <Scan>"\"\"\""!                     { /* start of python long comment */
                                      if (g_lang!=SrcLangExt_Python)
 				     {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3252,7 +3252,10 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					    *pCopyCurlyGString+=yytext; 
 					  }
                                         }
-<GCopyCurly>[^"'{}\/\n]+		{
+<GCopyCurly>[^"'{}\/\n,]+		{
+  					  *pCopyCurlyGString+=yytext;
+  					}
+<GCopyCurly>[,]+		        {
   					  *pCopyCurlyGString+=yytext;
   					}
 <GCopyCurly>"/"				{ *pCopyCurlyGString+=yytext; }


### PR DESCRIPTION
An extra "breakpoint" in the input string has been created in the form of a , (comma), so for initialization lines the line will be shorter and the , (comma) will be copied later on.
