### PR TITLE
Space missing in error message.

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9145,7 +9145,7 @@ static void copyExtraFiles(const QCString& filesOption,const QCString &outputOpt
       QFileInfo fi(fileName);
       if (!fi.exists()) 
       {
-        err("Extra file '%s' specified in" + filesOption + " does not exist!\n", fileName.data());
+        err("Extra file '%s' specified in " + filesOption + " does not exist!\n", fileName.data());
       }
       else
       {


### PR DESCRIPTION
the word 'in' and the vale of filesOption were concatenated
