### PR TITLE
Debug output for lexical analyzer

### DIFF
--- a/src/config.l
+++ b/src/config.l
@@ -33,6 +33,7 @@
 #include "version.h"
 #include "portable.h"
 #include "util.h"
+#include "message.h"
 
 #include "lang_cfg.h"
 #include "configoptions.h"
@@ -1686,8 +1687,12 @@ bool Config::parseString(const char *fn,const char *str)
 
 bool Config::parse(const char *fn)
 {
+  int retval;
   encoding = "UTF-8";
-  return parseString(fn,configFileToString(fn)); 
+  printlex(yy_flex_debug, TRUE, __FILE__, fn);
+  retval =  parseString(fn,configFileToString(fn)); 
+  printlex(yy_flex_debug, FALSE, __FILE__, fn);
+  return retval;
 }
 
 extern "C" { // some bogus code to keep the compiler happy

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -320,6 +320,9 @@ static int yyread(char *buf,int max_size)
 }
 
 //--------------------------------------------------------------------------
+#define REAL_YY_DECL int doctokenizerYYlex (void)
+#define YY_DECL static int local_doctokinizer(void)
+#define LOCAL_YY_DECL local_doctokinizer()
 
 %}
 
@@ -736,7 +739,7 @@ REFWORD   {LABELID}|{REFWORD2}|{REFWORD3}|{LNKWORD2}
                        }
 <St_CodeOpt>{BLANK}*"{"(".")?{LABELID}"}" {
                          g_token->name = yytext;
-                         int i=g_token->name.find('{');
+                         int i=g_token->name.find('{'); /* } to keep vi happy */
                          g_token->name = g_token->name.mid(i+1,g_token->name.length()-i-2);
                          BEGIN(St_Code);
                        }
@@ -1387,6 +1390,13 @@ void doctokenizerYYendAutoList()
   g_autoListLevel--;
 }
 
+REAL_YY_DECL
+{
+  printlex(yy_flex_debug, TRUE, __FILE__, g_fileName);
+  int retval = LOCAL_YY_DECL;
+  printlex(yy_flex_debug, FALSE, __FILE__, g_fileName);
+  return retval;
+}
 #if !defined(YY_FLEX_SUBMINOR_VERSION) 
 extern "C" { // some bogus code to keep the compiler happy
     void doctokenizerYYdummy() { yy_flex_realloc(0,0); }


### PR DESCRIPTION
The previous commit (pull request) was missing the debug output possibility for config.l and partial for doctokinizer.l.
The later is called on different places by means of the generic definition doctokinizerYYlex, which is declared by means of YY_DECL.
To be able to add the debug output the YY_DECL had to be redefined to be a new function and the new function, with the debug output possibility, has to be called through the original function name.
