### PR TITLE
Bug 715172 - Consistently document Fortran's equivalent function bodies

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -944,7 +944,7 @@ private                                 {
                                          }
 
                                          // TYPE_SPEC is for old function style function result
-                                         result = QCString(yytext).stripWhiteSpace();
+                                         result = QCString(yytext).stripWhiteSpace().lower();
                                          current->type = result;
                                          yy_push_state(SubprogPrefix);
                                        }


### PR DESCRIPTION
Although controversioal but for consistency converted type for fortran functions to lowercase
