### PR TITLE
Bug 668424 - HTML links in RTF output are broken

### DIFF
--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -325,7 +325,7 @@ void RTFDocVisitor::visit(DocURL *u)
   {
     m_t << "{\\field "
              "{\\*\\fldinst "
-               "{ HYPERLINK  \\\\l \"";
+               "{ HYPERLINK \"";
     if (u->isEmail()) m_t << "mailto:";
     m_t << u->url();
     m_t <<  "\" }"
@@ -1130,7 +1130,7 @@ void RTFDocVisitor::visitPre(DocHRef *href)
   {
     m_t << "{\\field "
              "{\\*\\fldinst "
-               "{ HYPERLINK  \\\\l \"" << href->url() << "\" "
+               "{ HYPERLINK \"" << href->url() << "\" "
                "}{}"
              "}"
              "{\\fldrslt "

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1049,7 +1049,7 @@ void RTFGenerator::startHtmlLink(const char *url)
 
   if (Config_getBool("RTF_HYPERLINKS"))
   {
-    t << "{\\field {\\*\\fldinst { HYPERLINK  \\\\l \"";
+    t << "{\\field {\\*\\fldinst { HYPERLINK \"";
     t << url;
     t << "\" }{}";
     t << "}{\\fldrslt {\\cs37\\ul\\cf2 ";


### PR DESCRIPTION
There are different types of hyperlinks: external and internal. The internal hyperlinks should have \\l behind the word HYPERLINK, the external shouldn't.
