### PR TITLE
Bug 719489 - Label "abstract" instead of "pure virtual" for Java language

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1355,7 +1355,14 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           if (!insidePHP) 
 					  {
 					    current->type += " abstract ";
-					    current->virt = Pure;
+					    if (!insideJava)
+					    {
+                                              current->virt = Pure;
+					    }
+					    else
+					    {
+                                              current->spec|=Entry::Abstract;
+					    }
 					  }
 					  else
 					  {


### PR DESCRIPTION
Proposed patch so the word abstract is recorded correctly in case of Java
