### PR TITLE
Report details about fork() failure in logs.

### DIFF
--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -84,7 +84,11 @@ int portable_system(const char *command,const char *args,bool commandHasConsole)
 #else  // Other Unices just use fork
 
   pid = fork();
-  if (pid==-1) return -1;
+  if (pid==-1)
+  {
+    perror("fork error");
+	  return -1;
+  }
   if (pid==0)
   {
     const char * argv[4];


### PR DESCRIPTION
When parsing a large codebase dot failed to start. Adding this line helped narrow down the issue. Increasing my VirtualBox VM RAM size worked around the issue. A proper fix would be to spawn separate processes without using fork() so they don't start with the giant address space used by the current process.
