### PR TITLE
doxygen version 1.8.5 throws many "Internal Inconsistency" errors when parsing .idl files

### DIFF
--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -891,7 +891,7 @@ void NamespaceSDict::writeDeclaration(OutputList &ol,const char *title,
       {
         if (nd->isConstantGroup())
         {
-          err("Internal inconsistency: constant group but not IDL?");
+          err("Internal inconsistency: constant group but not IDL?\n");
         }
         found=TRUE;
         break;
@@ -936,7 +936,7 @@ void NamespaceSDict::writeDeclaration(OutputList &ol,const char *title,
         }
         else
         {
-          err("Internal inconsistency: namespace in IDL not module or cg");
+          err("Internal inconsistency: namespace in IDL not module or cg\n");
         }
       }
       ol.insertMemberAlign();


### PR DESCRIPTION
A number of error messages lacked the '\n' character
