### PR TITLE
usage: make -d print dev doxygen options

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -21,6 +21,7 @@
 #include <qdict.h>
 
 #include "debug.h"
+#include "message.h"
 
 //------------------------------------------------------------------------
 
@@ -120,3 +121,14 @@ bool Debug::isFlagSet(DebugMask mask)
   return (curMask & mask)!=0;
 }
 
+void Debug::printFlags(void)
+{
+  int i;
+  for (i = 0; i < sizeof(s_labels)/sizeof(*s_labels); i++)
+  {
+     if (s_labels[i].name)
+     {
+        msg("\t%s\n",s_labels[i].name);
+     }
+  }
+}

--- a/src/debug.h
+++ b/src/debug.h
@@ -43,6 +43,7 @@ class Debug
     static int  setFlag(const char *label);
     static void clearFlag(const char *label);
     static bool isFlagSet(DebugMask mask);
+    static void printFlags(void);
     static void setPriority(int p);
     
   private:

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9775,25 +9775,12 @@ static void dumpSymbolMap()
 // print developer options of doxygen
 static void devUsage()
 {
-  msg("developer parameters:\n");
-  msg("-m dump symbol map\n");
-  msg("-b output to wizard\n");
-  msg("-T activates output generation via Django like template\n");
-  msg("-d <level>  Enable a debug level, such as:\n");
-  msg("\tfindmembers\n");
-  msg("\tfunctions\n");
-  msg("\tvariables\n");
-  msg("\tpreprocessor\n");
-  msg("\tclasses\n");
-  msg("\tcommentcnv\n");
-  msg("\tcommentscan\n");
-  msg("\tvalidate\n");
-  msg("\tprinttree\n");
-  msg("\ttime\n");
-  msg("\textcmd\n");
-  msg("\tmarkdown\n");
-  msg("\tfilteroutput\n");
-  msg("\tlex\n");
+  msg("Developer parameters:\n");
+  msg("  -m          dump symbol map\n");
+  msg("  -b          output to wizard\n");
+  msg("  -T          activates output generation via Django like template\n");
+  msg("  -d <level>  enable a debug level, such as (multiple invocations of -d are possible):\n");
+  Debug::printFlags();
 }
 
 


### PR DESCRIPTION
This is an extension / improvement to the pull request 67 from  groleo
- make printing of -d levels more flexible (when adding a new one this is now done automatically)
- layout of the message
