### PR TITLE
Bug 720691 - Code coloring in case of file without extension

### DIFF
--- a/src/parserintf.h
+++ b/src/parserintf.h
@@ -191,11 +191,11 @@ class ParserManager
       }
       else if (strlen(extension) == 0)
       {
-        ext = QCString(extension).lower();
+        ext = QCString(".no_extension");
       }
       else
       {
-        ext = QCString(".no_extension");
+        ext = QCString(extension).lower();
       }
       ParserInterface *intf = m_extensions.find(ext);
       if (intf==0 && ext.length()>4)


### PR DESCRIPTION
In case no extension is given or an empty extension the extension .no_extension is used (see also doxygen.cpp for its usage)
