### PR TITLE
Bug 436885 - c-source and h-source missing for latex

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -836,9 +836,9 @@ void FileDef::writeSource(OutputList &ol,bool sameTu,QStrList &filesInSameTu)
       getDirDef()->writeNavigationPath(ol);
       ol.endQuickIndices();
     }
-    startTitle(ol,getOutputFileBase());
+    startTitle(ol,getSourceFileBase());
     ol.parseText(name());
-    endTitle(ol,getOutputFileBase(),title);
+    endTitle(ol,getSourceFileBase(),title);
   }
   else
   {


### PR DESCRIPTION
Original title does not cover problem anymore. Problem has evolved to that when clicking on the name for the source file (in LaTeX) a jump to the beginning of the document was made. This problem is fixed with this patch.
