### PR TITLE
Bug 721302 - [Latex/PDF] Merging brief and detailed description in file section

### DIFF
--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -150,6 +150,7 @@ void DirDef::writeDetailedDescription(OutputList &ol,const QCString &title)
         // ol.newParagraph();  // FIXME:PARA
         ol.enableAll();
         ol.disableAllBut(OutputGenerator::Man);
+        ol.enable(OutputGenerator::Latex);
         ol.writeString("\n\n");
       ol.popGeneratorState();
     }

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -209,6 +209,7 @@ void FileDef::writeDetailedDescription(OutputList &ol,const QCString &title)
         // ol.newParagraph(); // FIXME:PARA
         ol.enableAll();
         ol.disableAllBut(OutputGenerator::Man);
+        ol.enable(OutputGenerator::Latex);
         ol.writeString("\n\n");
       ol.popGeneratorState();
     }

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -581,6 +581,7 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
       // ol.newParagraph(); // FIXME:PARA
       ol.enableAll();
       ol.disableAllBut(OutputGenerator::Man);
+      ol.enable(OutputGenerator::Latex);
       ol.writeString("\n\n");
       ol.popGeneratorState();
     }

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -280,6 +280,7 @@ void NamespaceDef::writeDetailedDescription(OutputList &ol,const QCString &title
         //ol.newParagraph(); // FIXME:PARA
         ol.enableAll();
         ol.disableAllBut(OutputGenerator::Man);
+        ol.enable(OutputGenerator::Latex);
         ol.writeString("\n\n");
       ol.popGeneratorState();
     }


### PR DESCRIPTION
Not only for Man pages the extra returns are necessary but also for LaTeX output.
The change in filedef.cpp is a direct consequence of t the bug report.
The groupdef.cpp has been tested on propriety code and the namespacedef.cpp and dirdef.cpp directly follow from code similarity.
