### PR TITLE
config knob to control what docs to generate

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1612,6 +1612,14 @@ to disable this feature.
 ]]>
       </docs>
     </option>
+    <option type='list' id='GENERATE_DOCS_FOR' format='string' defval='examples files pages groups classes namespaces directories'>
+      <docs>
+<![CDATA[
+In case of a source browser, certain docs are not needed.
+This tag lists the items for which docs will be generated.
+]]>
+      </docs>
+    </option>
   </group>
   <group name='HTML' docs='Configuration options related to the HTML output'>
     <option type='bool' id='GENERATE_HTML' defval='1'>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11303,10 +11303,14 @@ void generateOutput()
     }
     g_s.end();
   }
+  QStrList generateDocsFor = Config_getList("GENERATE_DOCS_FOR");
 
-  g_s.begin("Generating example documentation...\n");
-  generateExampleDocs();
-  g_s.end();
+  if (generateDocsFor.find("examples")!=-1)
+  {
+    g_s.begin("Generating example documentation...\n");
+    generateExampleDocs();
+    g_s.end();
+  }
 
   if (!Htags::useHtags)
   {
@@ -11315,25 +11319,40 @@ void generateOutput()
     g_s.end();
   }
 
-  g_s.begin("Generating file documentation...\n");
-  generateFileDocs();
-  g_s.end();
+  if (generateDocsFor.find("files")!=-1)
+  {
+    g_s.begin("Generating file documentation...\n");
+    generateFileDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating page documentation...\n");
-  generatePageDocs();
-  g_s.end();
+  if (generateDocsFor.find("pages")!=-1)
+  {
+    g_s.begin("Generating page documentation...\n");
+    generatePageDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating group documentation...\n");
-  generateGroupDocs();
-  g_s.end();
+  if (generateDocsFor.find("groups")!=-1)
+  {
+    g_s.begin("Generating group documentation...\n");
+    generateGroupDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating class documentation...\n");
-  generateClassDocs();
-  g_s.end();
+  if (generateDocsFor.find("classes")!=-1)
+  {
+    g_s.begin("Generating class documentation...\n");
+    generateClassDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating namespace index...\n");
-  generateNamespaceDocs();
-  g_s.end();
+  if (generateDocsFor.find("namespaces")!=-1)
+  {
+    g_s.begin("Generating namespace index...\n");
+    generateNamespaceDocs();
+    g_s.end();
+  }
 
   if (Config_getBool("GENERATE_LEGEND"))
   {
@@ -11342,9 +11361,12 @@ void generateOutput()
     g_s.end();
   }
 
-  g_s.begin("Generating directory documentation...\n");
-  generateDirDocs(*g_outputList);
-  g_s.end();
+  if (generateDocsFor.find("directories")!=-1)
+  {
+    g_s.begin("Generating directory documentation...\n");
+    generateDirDocs(*g_outputList);
+    g_s.end();
+  }
 
   if (Doxygen::formulaList->count()>0 && generateHtml
       && !Config_getBool("USE_MATHJAX"))

--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -812,7 +812,10 @@ void FTVHelp::generateLink(FTextStream &t,FTVNode *n)
 {
   //printf("FTVHelp::generateLink(ref=%s,file=%s,anchor=%s\n",
   //    n->ref.data(),n->file.data(),n->anchor.data());
-  if (n->file.isEmpty()) // no link
+  if (n->file.isEmpty() // no link
+  || (n->isDir && Config_getList("GENERATE_DOCS_FOR").find("directories")==-1)
+  || (!n->isDir &&  Config_getList("GENERATE_DOCS_FOR").find("files")==-1)
+  )
   {
     t << "<b>" << convertToHtml(n->name) << "</b>";
   }


### PR DESCRIPTION
The added config option, GENERATE_DOCS_FOR, lists the
stages we want to generate docs for.

It helps if you use doxygen as a source browser and want
a to have a quicker html output.

Tested on libdrm:
GENERATE_DOCS_FOR = default values
  Elapsed (wall clock) time (h:mm:ss or m:ss): 0:14.27
  9285 files in html dir

GENERATE_DOCS_FOR = <>
  Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.65
  717 files in html dir

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
