### PR TITLE
config: SOURCE_BROWSER_ONLY

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1468,6 +1468,16 @@ FILE_VERSION_INFO = "cleartool desc -fmt \%Vn"
 ]]>
       </docs>
     </option>
+    <option type='bool' id='SOURCE_BROWSER_ONLY' defval='0' depends='SOURCE_TOOLTIPS'>
+      <docs>
+<![CDATA[
+ If the \c SOURCE_BROWSER_ONLY is set to \c YES, then doxygen will skip
+ generating the documentation and diagrams, leaving only the highlighted
+ source files.
+ The highlighted sources will offer infos through SOURCE_TOOLTIPS
+]]>
+      </docs>
+    </option>
     <option type='bool' id='INLINE_SOURCES' defval='0'>
       <docs>
 <![CDATA[

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11303,10 +11303,14 @@ void generateOutput()
     }
     g_s.end();
   }
+  bool sourceBrowserOnly = Config_getBool("SOURCE_BROWSER_ONLY");
 
-  g_s.begin("Generating example documentation...\n");
-  generateExampleDocs();
-  g_s.end();
+  if (!sourceBrowserOnly)
+  {
+    g_s.begin("Generating example documentation...\n");
+    generateExampleDocs();
+    g_s.end();
+  }
 
   if (!Htags::useHtags)
   {
@@ -11315,25 +11319,40 @@ void generateOutput()
     g_s.end();
   }
 
-  g_s.begin("Generating file documentation...\n");
-  generateFileDocs();
-  g_s.end();
+  if (!sourceBrowserOnly)
+  {
+    g_s.begin("Generating file documentation...\n");
+    generateFileDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating page documentation...\n");
-  generatePageDocs();
-  g_s.end();
+  if (!sourceBrowserOnly)
+  {
+    g_s.begin("Generating page documentation...\n");
+    generatePageDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating group documentation...\n");
-  generateGroupDocs();
-  g_s.end();
+  if (!sourceBrowserOnly)
+  {
+    g_s.begin("Generating group documentation...\n");
+    generateGroupDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating class documentation...\n");
-  generateClassDocs();
-  g_s.end();
+  if (!sourceBrowserOnly)
+  {
+    g_s.begin("Generating class documentation...\n");
+    generateClassDocs();
+    g_s.end();
+  }
 
-  g_s.begin("Generating namespace index...\n");
-  generateNamespaceDocs();
-  g_s.end();
+  if (!sourceBrowserOnly)
+  {
+    g_s.begin("Generating namespace index...\n");
+    generateNamespaceDocs();
+    g_s.end();
+  }
 
   if (Config_getBool("GENERATE_LEGEND"))
   {
@@ -11342,9 +11361,12 @@ void generateOutput()
     g_s.end();
   }
 
-  g_s.begin("Generating directory documentation...\n");
-  generateDirDocs(*g_outputList);
-  g_s.end();
+  if (!sourceBrowserOnly)
+  {
+    g_s.begin("Generating directory documentation...\n");
+    generateDirDocs(*g_outputList);
+    g_s.end();
+  }
 
   if (Doxygen::formulaList->count()>0 && generateHtml
       && !Config_getBool("USE_MATHJAX"))

--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -812,7 +812,9 @@ void FTVHelp::generateLink(FTextStream &t,FTVNode *n)
 {
   //printf("FTVHelp::generateLink(ref=%s,file=%s,anchor=%s\n",
   //    n->ref.data(),n->file.data(),n->anchor.data());
-  if (n->file.isEmpty()) // no link
+  if (n->file.isEmpty() // no link
+  || Config_getBool("SOURCE_BROWSER_ONLY")
+  )
   {
     t << "<b>" << convertToHtml(n->name) << "</b>";
   }


### PR DESCRIPTION
When set to YES, the new config option,
will only generate the highlighted sources.
Information is provided through SOURCE_TOOLTIPS.

It helps if you only use doxygen as a source browser and want
a to have a quicker html output.
Also, so far, doxygen can either
a) generate the docs
b) a) + source browser
but no way of having only the source browser.

Tested on libdrm:
SOURCE_BROWSER_ONLY = NO
  Elapsed (wall clock) time (h:mm:ss or m:ss): 0:14.27
  9285 files in html dir

SOURCE_BROWSER_ONLY = YES
  Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.65
  717 files in html dir

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
