### PR TITLE
Enabling possibility to have { and } in (latex) index items

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2696,6 +2696,8 @@ class Receiver
 <hr>
 \section cmdfcurlyopen \\f{environment}{
 
+  \addindex \\f{
+
   Marks the start of a formula that is in a specific environment.
   \note The second \c { is optional and is only to help editors (such as \c Vim) to
   do proper syntax highlighting by making the number of opening and closing braces
@@ -2704,6 +2706,8 @@ class Receiver
 
 <hr>
 \section cmdfcurlyclose \\f}
+
+  \addindex \\f}
 
   Marks the end of a formula that is in a specific environment.
   \sa section \ref cmdfcurlyopen "\\f{" and section \ref formulas "formulas".
@@ -3030,7 +3034,7 @@ class Receiver
 \section cmdchardot \\.
 
   \addindex \\\.
-  This command writes a dot (\c .) to the output. This can be useful to 
+  This command writes a dot (`.`) to the output. This can be useful to 
   prevent ending a brief description when JAVADOC_AUTOBRIEF is enabled
   or to prevent starting a numbered list when the dot follows a number at
   the start of a line.
@@ -3038,7 +3042,7 @@ class Receiver
 <hr>
 \section cmddcolon \\::
 
-  \addindex \\\::
+  \addindex \\::
   This command writes a double colon (\c \::) to the output. This
   character sequence has to be escaped in some cases, because it is used
   to reference to documented entities.

--- a/doc/doxygen.sty
+++ b/doc/doxygen.sty
@@ -381,6 +381,8 @@
 }
 
 \newcommand{\doxyref}[3]{\textbf{#1} (\textnormal{#2}\,\pageref{#3})}
+\newcommand{\lcurly}{\{}
+\newcommand{\rcurly}{\}}
 \newenvironment{DoxyCompactList}
 {\begin{list}{}{
   \setlength{\leftmargin}{0.5cm}

--- a/src/doxygen.sty
+++ b/src/doxygen.sty
@@ -450,6 +450,10 @@
   \textbf{#1} (\textnormal{#2}\,\pageref{#3})%
 }
 
+% Used by @addindex
+\newcommand{\lcurly}{\{}
+\newcommand{\rcurly}{\}}
+
 % Used for syntax highlighting
 \definecolor{comment}{rgb}{0.5,0.0,0.0}
 \definecolor{keyword}{rgb}{0.0,0.5,0.0}

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -44,6 +44,9 @@ static QCString escapeLabelName(const char *s)
       case '%': result+="\\%"; break;
       case '|': result+="\\texttt{\"|}"; break;
       case '!': result+="\"!"; break;
+      case '{': result+="\\lcurly{}"; break;
+      case '}': result+="\\rcurly{}"; break;
+      case '~': result+="````~"; break; // to get it a bit better in index together with other special characters
       default: result+=c;
     }
   }
@@ -79,6 +82,8 @@ QCString LatexDocVisitor::escapeMakeIndexChars(const char *s)
       case '|': m_t << "\\texttt{\"|}"; break;
       case '[': m_t << "["; break;
       case ']': m_t << "]"; break;
+      case '{': m_t << "\\lcurly{}"; break;
+      case '}': m_t << "\\rcurly{}"; break;
       default:  str[0]=c; filter(str); break;
     }
   }

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1374,8 +1374,10 @@ void LatexGenerator::startMemberDoc(const char *clname,
     t << "}";
     if (clname)
     {
-      t << "!" << clname << "@{";
-      docify(clname);
+      t << "!";
+      escapeLabelName(clname);
+      t << "@{";
+      escapeMakeIndexChars(clname);
       t << "}"; 
     }
     t << "}" << endl;
@@ -2012,13 +2014,18 @@ void LatexGenerator::escapeLabelName(const char *s)
   {
     switch (c)
     {
+      case '|': t << "\\texttt{\"|}"; break;
+      case '!': t << "\"!"; break;
       case '%': t << "\\%";       break;
+      case '{': t << "\\lcurly{}"; break;
+      case '}': t << "\\rcurly{}"; break;
+      case '~': t << "````~"; break; // to get it a bit better in index together with other special characters
       // NOTE: adding a case here, means adding it to while below as well!
       default:  
         i=0;
         // collect as long string as possible, before handing it to docify
         result[i++]=c;
-        while ((c=*p) && c!='%')
+        while ((c=*p) && c!='|' && c!='!' && c!='%' && c!='{' && c!='}' && c!='~')
         {
           result[i++]=c;
           p++;
@@ -2041,16 +2048,20 @@ void LatexGenerator::escapeMakeIndexChars(const char *s)
   {
     switch (c)
     {
+      case '!': t << "\"!"; break;
       case '"': t << "\"\""; break;
       case '@': t << "\"@"; break;
+      case '|': t << "\\texttt{\"|}"; break;
       case '[': t << "["; break;
       case ']': t << "]"; break;
+      case '{': t << "\\lcurly{}"; break;
+      case '}': t << "\\rcurly{}"; break;
       // NOTE: adding a case here, means adding it to while below as well!
       default:  
         i=0;
         // collect as long string as possible, before handing it to docify
         result[i++]=c;
-        while ((c=*p) && c!='"' && c!='@' && c!='[' && c!=']')
+        while ((c=*p) && c!='"' && c!='@' && c!='[' && c!=']' && c!='!' && c!='{' && c!='}' && c!='|')
         {
           result[i++]=c;
           p++;


### PR DESCRIPTION
In the doxygen manual the index items for { and } were missing due to the missing support for the usage of { and } in parts of the code.
This patch fixes this problem by introducing 2 new latex commands. See also http://tex.stackexchange.com/questions/153291/index-unmatched-braces-in-latex
Further improvements in the index are:
- consistency in different places
- correction of index for ::
- placing ~ on a more logical place (together with other special characters, ~ is in the ASCII table after a-z whilst other characters are before this range)
