### PR TITLE
Missing &  and chars after " in tree of chm documentation

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -626,7 +626,7 @@ void HtmlHelp::addContentsItem(bool isDir,
   }
   int i; for (i=0;i<dc;i++) cts << "  ";
   cts << "<LI><OBJECT type=\"text/sitemap\">";
-  cts << "<param name=\"Name\" value=\"" << recode(name) << "\">";
+  cts << "<param name=\"Name\" value=\"" << recode(name).replace(QRegExp("&$"),"&amp;").replace(QRegExp("\""),"&quot;") << "\">";
   if (file)      // made file optional param - KPW
   {
     if (file && (file[0]=='!' || file[0]=='^')) // special markers for user defined URLs


### PR DESCRIPTION
In the chm-doxygen manual we see that for:
- the command & the & is missing
- commands containing a " all text is missing after this "
  These are known limitations of the chm format (see e.g. http://www.helpware.net/htmlhelp/hhwreadme.htm)

The problem with the & is that we cannot do a global replace as in the string there might be constructs like &...; , so only a & at the end of the text is replaced. Other places can easily be solved by the user by placing a space after the & sign (Note: &amp; in the original description is not, yet, possible as &amp; is not translated by doxygen)
The problem of the " is solved by replacing all occurrences by &quot;
