### PR TITLE
autolink: support explicit link to entities within current scope

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4436,7 +4436,8 @@ bool resolveRef(/* in */  const char *scName,
   QCString tsName = name;
   //bool memberScopeFirst = tsName.find('#')!=-1;
   QCString fullName = tsName;
-  if ((1 <= tsName.length()) && ('#' == tsName[0])) {
+  bool explicitLink = (1 <= tsName.length()) && ('#' == tsName[0]);
+  if (explicitLink) {
     // Do lookups on name following #, but isLowerCase(tsName) fails
     // so link to all-lower-case entity is still created.
     fullName = tsName.data() + 1;
@@ -4492,7 +4493,7 @@ bool resolveRef(/* in */  const char *scName,
       }
       return TRUE;
     }
-    else if (scName==fullName || (!inSeeBlock && scopePos==-1)) 
+    else if (scName==fullName || (!inSeeBlock && scopePos==-1 && !explicitLink)) 
       // nothing to link => output plain text
     {
       //printf("found scName=%s fullName=%s scName==fullName=%d "


### PR DESCRIPTION
This commit recognizes a prefixed hash (like #classname) as an explicit
link to a classname or other entity even when the name is entirely
lower-case, without also changing the references to be in global scope.

It does so by stripping a leading hash from the reference name prior to
substituting :: for hashes in the remainder.

Since (a) src/docparser:handleLinkedWord() will re-invoke resolveRef()
in global scope if the scoped lookup fails, and (b) resolveRef() checks
the unmodified name (which includes the hash) when checking for
all-lower-case strings that should not be links, this allows reference
to all-lower-case class names and other entities in the current
namespace without explicitly specifying the local namespace.
