### PR TITLE
Fix to VHDL scanner.

### DIFF
--- a/src/vhdlscanner.l
+++ b/src/vhdlscanner.l
@@ -543,7 +543,7 @@ BR                         [ \t\n\r]
 .	{ /* unknown characters */ }
 									
 
-<*>{BR}*"--!"[^{}\n]*[^\n]*\n/{B}*"--!" { // multi line comment
+<*>{B}*"--!"[^{}\n]*[^\n]*\n/{B}*"--!" { // multi line comment
   if (iDocLine==-1) iDocLine=yyLineNr;
   QCString qc(vhdlscannerYYtext);
   int len=qc.contains('\n')+yyLineNr-1;


### PR DESCRIPTION
The following code should produce two groups, each containing one page, within the same documentation scope,
currently it nests these groups and pages, resulting in incorrect documentation.

--! \defgroup group1 Group 1
--! {
--!   @brief Group 1
--! }

--! \ingroup group1
--! {
--! \page group1_page1 Page 1
--! \verbatim
--!  Some Page 1 text
--! \endverbatim
--! }

--! \defgroup group2 Group 2
--! {
--!   @brief Group 2
--! }

--! \ingroup group2
--! {
--! \page group2_page1 Page 1
--! \verbatim
--!  Some Page 1 text
--! \endverbatim
--! }

Similar C code to demonstrate the correct output.

//! \defgroup group1 Group 1
//! {
//!   @brief Group 1
//! }

//! \ingroup group1
//! {
//! \page group1_page1 Page 1
//! \verbatim
//!  Some Page 1 text
//! \endverbatim
//! }

//! \defgroup group2 Group 2
//! {
//!   @brief Group 2
//! }

//! \ingroup group2
//! {
//! \page group2_page1 Page 1
//! \verbatim
//!  Some Page 1 text
//! \endverbatim
//! }

Looks like the VHDL scanner is currently ignoring all blank lines between doxygen comment blocks, it probably shouldn't.
