### PR TITLE
Make sure all ids in g_linkRefs are lower case

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2101,7 +2101,7 @@ static QCString processBlocks(const QCString &s,int indent)
     {
       //printf("found link ref: id='%s' link='%s' title='%s'\n",
       //    id.data(),link.data(),title.data());
-      g_linkRefs.insert(id,new LinkRef(link,title));
+      g_linkRefs.insert(id.lower(),new LinkRef(link,title));
     }
     else
     {

--- a/testing/055/md_055_markdown.xml
+++ b/testing/055/md_055_markdown.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="md_055_markdown" kind="page">
+    <compoundname>md_055_markdown</compoundname>
+    <title>055_markdown</title>
+    <detaileddescription>
+      <para>// objective: test markdown parsing // check: md_055_markdown.xml</para>
+      <para>
+        <ulink url="http://example.com/inline">Inline link</ulink>
+      </para>
+      <para>
+        <ulink url="http://example.com/reference">Reference link</ulink>
+      </para>
+      <para>
+        <ulink url="http://example.com/last-line">Upper-cased reference link on last line</ulink>
+      </para>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/055_markdown.md
+++ b/testing/055_markdown.md
@@ -1,0 +1,12 @@
+// objective: test markdown parsing
+// check: md_055_markdown.xml
+
+[Inline link](http://example.com/inline)
+
+[Reference link][1]
+
+[1]: http://example.com/reference
+
+[Upper-cased reference link on last line][U]
+
+[U]: http://example.com/last-line


### PR DESCRIPTION
Ids created from the last line were not lower-cased, leading to the link
not being recognized.
