### PR TITLE
Error message is given for make distclean as generated_src is a directory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -45,6 +45,7 @@ distclean: clean
 	-rm -rf html
 	-rm -rf latex
 	-rm -rf man
+	-rm -rf docbook
 	-rm -rf perlmod
 	-rm -rf rtf
 	-rm -rf xml


### PR DESCRIPTION
generated_src is a directory and should be removed with the -rf flag.
Similar for other directories like bin, objects, lib, html latex, objects.
Directories man, rtf, perlmod, xml and docbook have been added for convenience (when testing with other documentation formats)
