### PR TITLE
Better message in case doxygen -u is used

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -493,13 +493,14 @@ class Config
      *  \returns TRUE if successful, or FALSE if the string could not be
      *  parsed.
      */ 
-    bool parseString(const char *fn,const char *str);
+    //bool parseString(const char *fn,const char *str);
+    bool parseString(const char *fn,const char *str,bool upd = FALSE);
 
     /*! Parse a configuration file with name \a fn.
      *  \returns TRUE if successful, FALSE if the file could not be 
      *  opened or read.
      */ 
-    bool parse(const char *fn);
+    bool parse(const char *fn,bool upd = FALSE);
 
     /*! Called from the constructor, will add doxygen's default options
      *  to the configuration object 

--- a/src/config.l
+++ b/src/config.l
@@ -435,6 +435,7 @@ static QCString          includeName;
 static QStrList          includePathList;
 static QStack<ConfigFileState> includeStack;  
 static int               includeDepth;
+static bool              config_upd = FALSE;
 
 static QCString     tabSizeString;
 static QCString     maxInitLinesString;
@@ -672,15 +673,31 @@ static void readIncludeFile(const char *incName)
 					         BEGIN(GetString);
 						 break;
 					       case ConfigOption::O_Obsolete:
-					         config_err("Warning: Tag `%s' at line %d of file %s has become obsolete.\n"
-						            "To avoid this warning please remove this line from your configuration "
-							    "file or upgrade it using \"doxygen -u\"\n", cmd.data(),yyLineNr,yyFileName.data()); 
+                                                 if (config_upd)
+                                                 {
+					           config_err("Warning: Tag `%s' at line %d of file `%s' has become obsolete.\n"
+						              "         This tag has been removed.\n", cmd.data(),yyLineNr,yyFileName.data());
+                                                 }
+                                                 else
+                                                 {
+					           config_err("Warning: Tag `%s' at line %d of file `%s' has become obsolete.\n"
+						              "         To avoid this warning please remove this line from your configuration "
+							      "file or upgrade it using \"doxygen -u\"\n", cmd.data(),yyLineNr,yyFileName.data()); 
+                                                 }
 					         BEGIN(SkipInvalid);
 						 break;
 					       case ConfigOption::O_Disabled:
-					         config_err("Warning: Tag `%s' at line %d of file %s belongs to an option that was not enabled at compile time.\n"
-						            "To avoid this warning please remove this line from your configuration "
-							    "file, upgrade it using \"doxygen -u\", or recompile doxygen with this feature enabled.\n", cmd.data(),yyLineNr,yyFileName.data()); 
+                                                 if (config_upd)
+                                                 {
+					           config_err("Warning: Tag `%s' at line %d of file `%s' belongs to an option that was not enabled at compile time.\n"
+						              "         This tag has been removed.\n", cmd.data(),yyLineNr,yyFileName.data());
+                                                 }
+                                                 else
+                                                 {
+					           config_err("Warning: Tag `%s' at line %d of file `%s' belongs to an option that was not enabled at compile time.\n"
+						              "         To avoid this warning please remove this line from your configuration "
+							    "file or upgrade it using \"doxygen -u\", or recompile doxygen with this feature enabled.\n", cmd.data(),yyLineNr,yyFileName.data()); 
+                                                 }
 					         BEGIN(SkipInvalid);
 						 break;
 					     }
@@ -1666,7 +1683,7 @@ static QCString configFileToString(const char *name)
   return "";
 }
 
-bool Config::parseString(const char *fn,const char *str)
+bool Config::parseString(const char *fn,const char *str,bool update)
 {
   config = Config::instance();
   inputString   = str;
@@ -1678,17 +1695,19 @@ bool Config::parseString(const char *fn,const char *str)
   includeDepth  = 0;
   configYYrestart( configYYin );
   BEGIN( Start );
+  config_upd = update;
   configYYlex();
+  config_upd = FALSE;
   inputString = 0;
   return TRUE;
 }
 
-bool Config::parse(const char *fn)
+bool Config::parse(const char *fn,bool update)
 {
   int retval;
   encoding = "UTF-8";
   printlex(yy_flex_debug, TRUE, __FILE__, fn);
-  retval =  parseString(fn,configFileToString(fn)); 
+  retval =  parseString(fn,configFileToString(fn), update); 
   printlex(yy_flex_debug, FALSE, __FILE__, fn);
   return retval;
 }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10349,7 +10349,7 @@ void readConfiguration(int argc, char **argv)
   }
 
 
-  if (!Config::instance()->parse(configName))
+  if (!Config::instance()->parse(configName,updateConfig))
   {
     err("could not open or read configuration file %s!\n",configName);
     cleanUpDoxygen();


### PR DESCRIPTION
In case of obsolete or not configured entries in the Doxyfile and the option -u is used a message like:

<pre>
  Warning: Tag `XML_DTD' at line 1821 of file Doxyfile has become obsolete.
  To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
</pre>

appears, but the item is removed from the Doxyfile.
This patch updates the message (and improves layout) to:

<pre>
  Warning: Tag `XML_DTD' at line 1821 of file \`Doxyfile' has become obsolete.
           This tag has been removed.
</pre>
