### PR TITLE
detect python2 as Python 2 binary

### DIFF
--- a/configure
+++ b/configure
@@ -596,7 +596,7 @@ fi
 
 printf "  Checking for python... "
 if test "$f_python" = NO; then
-  python_names="python"
+  python_names="python2 python"
   python_dirs="$bin_dirs /usr/bin /usr/local/bin /bin /sbin"
   python_prog=NO
   python_found=NO


### PR DESCRIPTION
On some distributions like Arch Linux
"python" is Python 3 and "python2" is Python version 2.

This change in `configure` tries "python2" first and uses it if available.
