### PR TITLE
Place where dot executable is found

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -167,7 +167,8 @@ static void createSVG()
     QRegExp ep("[\\s]");
     QCString vlargs="-Tsvg \""+ov+"\" "+dir ;
 
-    if (portable_system("dot",vlargs)!=0)
+    QCString dotExe   = Config_getString("DOT_PATH")+"dot";
+    if (portable_system(dotExe,vlargs)!=0)
     {
       err("could not create dot file");
     }
@@ -3884,8 +3885,9 @@ void FlowChart::createSVG()
   ov+="/flow_design.dot";
 
   QCString vlargs="-Tsvg "+ov+dir ;
+  QCString dotExe   = Config_getString("DOT_PATH")+"dot";
 
-  if (portable_system("dot",vlargs)!=0)
+  if (portable_system(dotExe,vlargs)!=0)
   {
     err("could not create dot file");
   }


### PR DESCRIPTION
In the current vhdl part of the code it is required that the dot executable is in the path. On in dot.cpp the possibility exists that the dot executable is found through the configuration setting DOT_PATH.
This patch makes this more consistent
