### PR TITLE
Superfluous backslash in documentation

### DIFF
--- a/doc/diagrams.doc
+++ b/doc/diagrams.doc
@@ -115,7 +115,7 @@
        edge of the arrow is labeled with the variable(s) responsible for the
        relation.
        Class \c A uses class \c B, if class \c A has a member variable \c m 
-       of type C, where B is a subtype of C (e.g. `C` could be `B`, `B*`, `T\<B\>*`). 
+       of type C, where B is a subtype of C (e.g. `C` could be `B`, `B*`, `T<B>*`). 
   </ul>
 
 


### PR DESCRIPTION
Some superfluous backslashes were found in the documentation (1.8.6 manual page 52, diagrams section)
