### PR TITLE
Command \< and \> are not properly shown in section headers (and consequently in index)

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6413,14 +6413,9 @@ void filterLatexString(FTextStream &t,const char *str,
                    break;
         case '-':  t << "-\\/";
                    break;
-        case '\\': if (*p=='<') 
-                   { t << "$<$"; p++; }
-                   else if (*p=='>')
-                   { t << "$>$"; p++; } 
-                   else  
-                   { t << "\\textbackslash{}"; }
+        case '\\': t << "\\textbackslash{}";
                    break;           
-        case '"':  { t << "\\char`\\\"{}"; }
+        case '"':  t << "\\char`\\\"{}";
                    break;
 
         default:   


### PR DESCRIPTION
In the pdf version of the doxygen manual (version 1.8.6) the commands \< and \> are shown as < and >
Tests (on the doxygen manual) revealed that the exception rules were nor required.
