### PR TITLE
Properly escape the XCODE path.

### DIFF
--- a/src/docsets.cpp
+++ b/src/docsets.cpp
@@ -72,7 +72,7 @@ void DocSets::initialize()
         "DOCSET_RESOURCES=$(DOCSET_CONTENTS)/Resources\n"
         "DOCSET_DOCUMENTS=$(DOCSET_RESOURCES)/Documents\n"
         "DESTDIR=~/Library/Developer/Shared/Documentation/DocSets\n"
-        "XCODE_INSTALL=$(shell xcode-select -print-path)\n"
+        "XCODE_INSTALL=\"$(shell xcode-select -print-path)\"\n"
         "\n"
         "all: docset\n"
         "\n"


### PR DESCRIPTION
This was causing problems on my system where Xcode is installed at /Applications/Xcode 5.0/
