### PR TITLE
Bug 724241 - Internal inconsistency: namespace in IDL

### DIFF
--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -68,6 +68,10 @@ NamespaceDef::NamespaceDef(const char *df,int dl,int dc,
   {
     m_type = CONSTANT_GROUP;
   }
+  else if (type && !strcmp("library", type))
+  {
+    m_type = LIBRARY;
+  }
   else
   {
     m_type = NAMESPACE;
@@ -1109,9 +1113,13 @@ QCString NamespaceDef::compoundTypeString() const
     {
       return "constants";
     }
+    else if (isLibrary())
+    {
+      return "library";
+    }
     else
     {
-      err("Internal inconsistency: namespace in IDL not module or constant group\n");
+      err("Internal inconsistency: namespace in IDL not module, library or constant group\n");
     }
   }
   return "";

--- a/src/namespacedef.h
+++ b/src/namespacedef.h
@@ -68,6 +68,7 @@ class NamespaceDef : public Definition
 
     bool isConstantGroup() const { return CONSTANT_GROUP == m_type; }
     bool isModule()        const { return MODULE == m_type; }
+    bool isLibrary() const { return LIBRARY == m_type; }
 
     bool isLinkableInProject() const;
     bool isLinkable() const;
@@ -132,7 +133,7 @@ class NamespaceDef : public Definition
     ClassSDict           *classSDict;
     NamespaceSDict       *namespaceSDict;
     bool                  m_subGrouping;
-    enum { NAMESPACE, MODULE, CONSTANT_GROUP } m_type;
+    enum { NAMESPACE, MODULE, CONSTANT_GROUP, LIBRARY } m_type;
     bool m_isPublished;
 };
 


### PR DESCRIPTION
Library was missing in the list of namespaces. In scanner.l constants, module and library are handled in the same way. In namespace.{h,cpp} only constants and module were handled, now also library is handled in a similar way.
