### PR TITLE
Limit number of dot threads

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3056,7 +3056,7 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
-    <option type='int' id='DOT_NUM_THREADS' defval='0' depends='HAVE_DOT'>
+    <option type='int' id='DOT_NUM_THREADS' minval='-100000' maxval='100000' defval='0' depends='HAVE_DOT'>
       <docs>
 <![CDATA[
  The \c DOT_NUM_THREADS specifies the number of \c dot invocations doxygen is 

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1230,7 +1230,15 @@ DotManager::DotManager() : m_dotMaps(1009)
   m_dotMaps.setAutoDelete(TRUE);
   m_queue = new DotRunnerQueue;
   int i;
-  int numThreads = QMIN(QThread::idealThreadCount()+1,Config_getInt("DOT_NUM_THREADS"));
+  int numThreads = Config_getInt("DOT_NUM_THREADS");
+  if (numThreads == 0)
+  {
+    numThreads = QMAX(2,QThread::idealThreadCount()+1);
+  }
+  else if (numThreads < 0)
+  {
+    numThreads = QMIN(QThread::idealThreadCount()+1, -numThreads);
+  }
   if (numThreads!=1)
   {
     if (numThreads==0) numThreads = QMAX(2,QThread::idealThreadCount()+1);


### PR DESCRIPTION
In case doxygen is run with DOT_NUM_THREADS = 0 the number of available processors + 1 is used for the number of threads. In case the number of threads is set to a value this value is used irrespective of the number of available processors.
With this patch the number of threads is limited to the number of available processors +1.
