### PR TITLE
Showing error message on windows in case of an error on startup

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -1,5 +1,4 @@
 #include <QtGui>
-#include <QImageReader>
 #include "doxywizard.h"
 #include "version.h"
 #include "expert.h"


### PR DESCRIPTION
In case, on windows, more than 1 argument is given doxywizard stops without showing a message even though a printf is present.
In this patch the message is show (for all platforms) by means of a message box, furthermore in case the argument --help is given the usage message is given in a message box.
