### PR TITLE
Extension in config.xml if type=string with format=image

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -323,6 +323,32 @@ static QString getDocsForNode(const QDomElement &child)
         }
       }
     }
+    else if (child.attribute(SA("format")) == SA("image"))
+    {
+      QString abspath = child.attribute(SA("abspath"));
+      if (defval != SA(""))
+      {
+        docs+=SA("<br/>");
+        if (abspath != SA("1"))
+        {
+          docs += SA(" The default image is: <code>") + defval + SA("</code>.");
+        }
+        else
+        {
+          docs += SA(" The default image (with absolute path) is: <code>") + defval + SA("</code>.");
+        }
+        docs += SA("<br/>");
+      }
+      else
+      {
+        if (abspath == SA("1"))
+        {
+          docs+=SA("<br/>");
+          docs += SA(" The image has to be specified with full path.");
+          docs += SA("<br/>");
+        }
+      }
+    }
     else // if (child.attribute(SA("format")) == SA("string"))
     {
       if (defval != SA(""))
@@ -476,6 +502,10 @@ QWidget *Expert::createTopicWidget(QDomElement &elem)
         else if (format==SA("file"))
         {
           mode = InputString::StringFile;
+        }
+        else if (format==SA("image"))
+        {
+          mode = InputString::StringImage;
         }
         else // format=="string"
         {

--- a/addon/doxywizard/inputstring.cpp
+++ b/addon/doxywizard/inputstring.cpp
@@ -44,6 +44,7 @@ InputString::InputString( QGridLayout *layout,int &row,
     layout->addWidget( m_com, row, 1, 1, 3, Qt::AlignLeft );
     m_le=0;
     m_br=0;
+    m_im=0;
     row++;
   }
   else
@@ -51,28 +52,39 @@ InputString::InputString( QGridLayout *layout,int &row,
     layout->addWidget( m_lab, row, 0 );
     m_le = new QLineEdit;
     m_le->setText( s );
+    m_im = 0;
     //layout->setColumnMinimumWidth(2,150);
-    if (m==StringFile || m==StringDir)
+    if (m==StringFile || m==StringDir || m==StringImage)
     {
       layout->addWidget( m_le, row, 1 );
       m_br = new QToolBar;
       m_br->setIconSize(QSize(24,24));
-      if (m==StringFile) 
+      if (m==StringFile || m==StringImage) 
       {
         QAction *file = m_br->addAction(QIcon(QString::fromAscii(":/images/file.png")),QString(),this,SLOT(browse()));
         file->setToolTip(tr("Browse to a file"));
+        layout->addWidget( m_br,row,2 );
+        if (m==StringImage) 
+        {
+          m_im = new QLabel;
+          m_im->setMinimumSize(1,55);
+          m_im->setAlignment(Qt::AlignLeft|Qt::AlignTop);
+          row++;
+          layout->addWidget( m_im,row,1 );
+        }
       }
       else 
       {
         QAction *dir = m_br->addAction(QIcon(QString::fromAscii(":/images/folder.png")),QString(),this,SLOT(browse()));
         dir->setToolTip(tr("Browse to a folder"));
+        layout->addWidget( m_br,row,2 );
       }
-      layout->addWidget( m_br,row,2 );
     }
     else
     {
       layout->addWidget( m_le, row, 1, 1, 2 );
       m_br=0;
+      m_im=0;
     }
     m_com=0;
     row++;
@@ -119,6 +131,33 @@ void InputString::updateDefault()
     {
       m_lab->setText(QString::fromAscii("<qt><font color='red'>")+m_id+QString::fromAscii("</font></qt>"));
     }
+    if (m_im)
+    {
+      if (m_str.isEmpty())
+      {
+        m_im->setText(tr("No Project logo selected."));
+      }
+      else
+      {
+        QFile Fout(m_str);
+        if(!Fout.exists()) 
+        {
+          m_im->setText(tr("Sorry, cannot find file(")+m_str+QString::fromAscii(");"));
+        }
+        else
+        {
+          QPixmap pm(m_str);
+          if (!pm.isNull())
+          {
+            m_im->setPixmap(pm.scaledToHeight(55,Qt::SmoothTransformation));
+          }
+          else
+          {
+            m_im->setText(tr("Sorry, no preview available (")+m_str+QString::fromAscii(");"));
+          }
+        }
+      }
+    }
     if (m_le && m_le->text()!=m_str) m_le->setText( m_str );
     emit changed();
   }
@@ -128,6 +167,7 @@ void InputString::setEnabled(bool state)
 {
   m_lab->setEnabled(state);
   if (m_le)  m_le->setEnabled(state);
+  if (m_im)  m_le->setEnabled(state);
   if (m_br)  m_br->setEnabled(state);
   if (m_com) m_com->setEnabled(state);
   updateDefault();
@@ -136,7 +176,7 @@ void InputString::setEnabled(bool state)
 void InputString::browse()
 {
   QString path = QFileInfo(MainWindow::instance().configFileName()).path();
-  if (m_sm==StringFile)
+  if (m_sm==StringFile || m_sm==StringImage)
   {
     QString fileName = QFileDialog::getOpenFileName(&MainWindow::instance(),
         tr("Select file"),path);

--- a/addon/doxywizard/inputstring.h
+++ b/addon/doxywizard/inputstring.h
@@ -35,7 +35,8 @@ class InputString : public QObject, public Input
     enum StringMode { StringFree=0, 
                       StringFile=1, 
                       StringDir=2, 
-                      StringFixed=3
+                      StringFixed=3,
+                      StringImage=4
                     };
 
     InputString( QGridLayout *layout,int &row,
@@ -77,6 +78,7 @@ class InputString : public QObject, public Input
     void updateDefault();
     QLabel       *m_lab;
     QLineEdit    *m_le;
+    QLabel       *m_im;
     QToolBar     *m_br;
     QComboBox    *m_com;
     QString       m_str;

--- a/addon/doxywizard/wizard.cpp
+++ b/addon/doxywizard/wizard.cpp
@@ -468,6 +468,7 @@ Step1::Step1(Wizard *wizard,const QHash<QString,Input*> &modelData) : m_wizard(w
   projVersion->setAlignment(Qt::AlignRight|Qt::AlignVCenter);
   // project icon
   QLabel *projLogo = new QLabel(this);
+  projLogo->setMinimumSize(1,55);
   projLogo->setText(tr("Project logo:"));
   projLogo->setAlignment(Qt::AlignRight|Qt::AlignVCenter);
 
@@ -564,21 +565,28 @@ void Step1::selectProjectIcon()
   QString path = QFileInfo(MainWindow::instance().configFileName()).path();
   QString iconName = QFileDialog::getOpenFileName(this,
                                     tr("Select project icon/image"),path);
-  QFile Fout(iconName);
-  if(!Fout.exists()) 
+  if (iconName.isEmpty())
   {
-    m_projIconLab->setText(tr("Sorry, cannot find file(")+iconName+QString::fromAscii(");"));
+    m_projIconLab->setText(tr("No Project logo selected."));
   }
   else
   {
-    QPixmap pm(iconName);
-    if (!pm.isNull())
+    QFile Fout(iconName);
+    if(!Fout.exists()) 
     {
-      m_projIconLab->setPixmap(pm.scaledToHeight(55,Qt::SmoothTransformation));
+      m_projIconLab->setText(tr("Sorry, cannot find file(")+iconName+QString::fromAscii(");"));
     }
     else
     {
-      m_projIconLab->setText(tr("Sorry, no preview available (")+iconName+QString::fromAscii(");"));
+      QPixmap pm(iconName);
+      if (!pm.isNull())
+      {
+        m_projIconLab->setPixmap(pm.scaledToHeight(55,Qt::SmoothTransformation));
+      }
+      else
+      {
+        m_projIconLab->setText(tr("Sorry, no preview available (")+iconName+QString::fromAscii(");"));
+      }
     }
   }
   updateStringOption(m_modelData,STR_PROJECT_LOGO,iconName);

--- a/src/config.h
+++ b/src/config.h
@@ -165,7 +165,7 @@ class ConfigEnum : public ConfigOption
 class ConfigString : public ConfigOption
 {
   public:
-    enum WidgetType { String, File, Dir };
+    enum WidgetType { String, File, Dir, Image };
     ConfigString(const char *name,const char *doc) 
       : ConfigOption(O_String)
     {

--- a/src/config.xml
+++ b/src/config.xml
@@ -247,7 +247,7 @@ Go to the <a href="commands.html">next</a> section or return to the
       </docs>
     </option>
 
-    <option type='string' id='PROJECT_LOGO' format='file' defval=''>
+    <option type='string' id='PROJECT_LOGO' format='image' defval=''>
       <docs>
 <![CDATA[
  With the \c PROJECT_LOGO tag one can specify an logo or icon that is 

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -201,6 +201,19 @@ def prepCDocs(node):
 				else:
 					if abspath == '1':
 						doc += "<br/>The file has to be specified with full path."
+			elif file =='image':
+				abspath = node.getAttribute('abspath')
+				if defval != '':
+					if abspath != '1':
+						doc += "<br/>The default image is: <code>%s</code>." % (
+							defval)
+					else:
+						doc += "<br/>%s: %s%s%s." % (
+							"The default image (with absolute path) is",
+							"<code>",defval,"</code>")
+				else:
+					if abspath == '1':
+						doc += "<br/>The image has to be specified with full path."
 			else: # format == 'string':
 				if defval != '':
 					doc += "<br/>The default value is: <code>%s</code>." % (
@@ -262,6 +275,8 @@ def parseOption(node):
 			print "  cs->setDefaultValue(\"%s\");" % (defval)
 		if format == 'file':
 			print "  cs->setWidgetType(ConfigString::File);"
+		elif format == 'image':
+			print "  cs->setWidgetType(ConfigString::Image);"
 		elif format == 'dir':
 			print "  cs->setWidgetType(ConfigString::Dir);"
 		if depends != '':
@@ -453,6 +468,21 @@ def parseOptionDoc(node, first):
 					if abspath == '1':
 						print ""
 						print "The file has to be specified with full path."
+			elif file =='image':
+				abspath = node.getAttribute('abspath')
+				if defval != '':
+					print ""
+					if abspath != '1':
+						print "The default image is: <code>%s</code>." % (
+							defval)
+					else:
+						print "%s: %s%s%s." % (
+							"The default image (with absolute path) is",
+							"<code>",defval,"</code>")
+				else:
+					if abspath == '1':
+						print ""
+						print "The image has to be specified with full path."
 			else: # format == 'string':
 				if defval != '':
 					print ""


### PR DESCRIPTION
In case of a project logo a preview is shown in the "wizard mode". In "expert mode" only the name is shown.
In this patch the config.xml the type=string possibilities are extended with format=image (config.xml, configgen.py, config.h).
The doxywizard has been extended so that in "expert mode" this type is supported and that a preview is given (expert.cpp, inputstring.cpp and inputstring.h), furthermore in wizard.cpp a minimum label size has been defined to prevent jumping of the items in case of switching between a message text and an icon.
