### PR TITLE
Bug 725516 - In case of sections with the same name they are not reported.

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -553,7 +553,7 @@ static void addXRefItem(const char *listName,const char *itemTitle,
     item->text += " <p>";
     if (Doxygen::markdownSupport)
     {
-      item->text += processMarkdown(yyFileName,current,outputXRef);
+      item->text += processMarkdown(yyFileName,yyLineNr,current,outputXRef);
     }
     else
     {
@@ -575,7 +575,7 @@ static void addXRefItem(const char *listName,const char *itemTitle,
     ASSERT(item!=0);
     if (Doxygen::markdownSupport)
     {
-      item->text = processMarkdown(yyFileName,current,outputXRef);
+      item->text = processMarkdown(yyFileName,yyLineNr,current,outputXRef);
     }
     else
     {
@@ -593,11 +593,26 @@ static void addXRefItem(const char *listName,const char *itemTitle,
     {
       docEntry->doc += cmdString;
     }
-    SectionInfo *si=new SectionInfo(listName,anchorLabel,
-	                            g_sectionTitle,SectionInfo::Anchor,
-                                    g_sectionLevel);
-    Doxygen::sectionDict->append(anchorLabel,si);
-    docEntry->anchors->append(si);
+    SectionInfo *si = Doxygen::sectionDict->find(anchorLabel);
+    if (si)
+    {
+      if (si->lineNr != -1)
+      {
+        warn(listName,yyLineNr,"multiple use of section label '%s', (first occurrence: %s, line %d)",anchorLabel,si->fileName.data(),si->lineNr);
+      }
+      else
+      {
+        warn(listName,yyLineNr,"multiple use of section label '%s', (first occurrence: %s)",anchorLabel,si->fileName.data());
+      }
+    }
+    else
+    {
+      si=new SectionInfo(listName,yyLineNr,anchorLabel,
+                         g_sectionTitle,SectionInfo::Anchor,
+                         g_sectionLevel);
+      Doxygen::sectionDict->append(anchorLabel,si);
+      docEntry->anchors->append(si);
+    }
   }
   outputXRef.resize(0);
 }
@@ -643,18 +658,32 @@ static SectionInfo::SectionType sectionLevelToType(int level)
 
 static void addSection()
 {
-  // create a new section element
-  g_sectionTitle+=yytext;
-  g_sectionTitle=g_sectionTitle.stripWhiteSpace();
-  SectionInfo *si = new SectionInfo(yyFileName,g_sectionLabel,
+  SectionInfo *si = Doxygen::sectionDict->find(g_sectionLabel);
+  if (si)
+  {
+    if (si->lineNr != -1)
+    {
+      warn(yyFileName,yyLineNr,"multiple use of section label '%s', (first occurrence: %s, line %d)",g_sectionLabel.data(),si->fileName.data(),si->lineNr);
+    }
+    else
+    {
+      warn(yyFileName,yyLineNr,"multiple use of section label '%s', (first occurrence: %s)",g_sectionLabel.data(),si->fileName.data());
+    }
+  }
+  else
+  {
+    // create a new section element
+    g_sectionTitle+=yytext;
+    g_sectionTitle=g_sectionTitle.stripWhiteSpace();
+    si = new SectionInfo(yyFileName,yyLineNr,g_sectionLabel,
                           g_sectionTitle,sectionLevelToType(g_sectionLevel),g_sectionLevel);
 
-  // add section to this entry
-  current->anchors->append(si);
+    // add section to this entry
+    current->anchors->append(si);
 
-  // add section to the global dictionary
-  Doxygen::sectionDict->append(g_sectionLabel,si);
-
+    // add section to the global dictionary
+    Doxygen::sectionDict->append(g_sectionLabel,si);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1701,9 +1730,24 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   /* ----- handle arguments of the anchor command ------- */
 
 <AnchorLabel>{LABELID}			{ // found argument
-                                          SectionInfo  *si = new SectionInfo(yyFileName,yytext,0,SectionInfo::Anchor,0);
-                                          Doxygen::sectionDict->append(yytext,si);
-  					  current->anchors->append(si);
+                                          SectionInfo *si = Doxygen::sectionDict->find(yytext);
+                                          if (si)
+                                          {
+                                            if (si->lineNr != -1)
+                                            {
+                                              warn(yyFileName,yyLineNr,"multiple use of section label '%s', (first occurrence: %s, line %d)",yytext,si->fileName.data(),si->lineNr);
+                                            }
+                                            else
+                                            {
+                                              warn(yyFileName,yyLineNr,"multiple use of section label '%s', (first occurrence: %s)",yytext,si->fileName.data());
+                                            }
+                                          }
+                                          else
+                                          {
+                                            si = new SectionInfo(yyFileName,yyLineNr,yytext,0,SectionInfo::Anchor,0);
+                                            Doxygen::sectionDict->append(yytext,si);
+  					    current->anchors->append(si);
+                                          }
 					  addOutput(yytext);
 					  BEGIN( Comment );
   					}
@@ -2876,9 +2920,9 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
 
   if (Doxygen::markdownSupport)
   {
-    current->brief      = processMarkdown(fileName,current,current->brief);
-    current->doc        = processMarkdown(fileName,current,current->doc);
-    current->inbodyDocs = processMarkdown(fileName,current,current->inbodyDocs);
+    current->brief      = processMarkdown(fileName,lineNr,current,current->brief);
+    current->doc        = processMarkdown(fileName,lineNr,current,current->doc);
+    current->inbodyDocs = processMarkdown(fileName,lineNr,current,current->inbodyDocs);
   }
 
   Debug::print(Debug::CommentScan,0,

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8643,15 +8643,30 @@ static void findMainPage(EntryNav *rootNav)
       Doxygen::mainPage->setShowToc(root->stat);
       addPageToContext(Doxygen::mainPage,rootNav);
           
-      // a page name is a label as well!
-      SectionInfo *si=new SectionInfo(
-          indexName,
+      SectionInfo *si = Doxygen::sectionDict->find(Doxygen::mainPage->name());
+      if (si)
+      {
+        if (si->lineNr != -1)
+        {
+          warn(root->fileName,root->startLine,"multiple use of section label '%s', (first occurrence: %s, line %d)",Doxygen::mainPage->name().data(),si->fileName.data(),si->lineNr);
+        }
+        else
+        {
+          warn(root->fileName,root->startLine,"multiple use of section label '%s', (first occurrence: %s)",Doxygen::mainPage->name().data(),si->fileName.data());
+        }
+      }
+      else
+      {
+        // a page name is a label as well! but should no be double either
+        si=new SectionInfo(
+          indexName, root->startLine,
           Doxygen::mainPage->name(),
           Doxygen::mainPage->title(),
           SectionInfo::Page,
           0); // level 0
-      Doxygen::sectionDict->append(indexName,si);
-      Doxygen::mainPage->addSectionsToDefinition(root->anchors);
+        Doxygen::sectionDict->append(indexName,si);
+        Doxygen::mainPage->addSectionsToDefinition(root->anchors);
+      }
     }
     else
     {

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -22,7 +22,7 @@
 class Entry;
 
 /** processes string \a s and converts markdown into doxygen/html commands. */
-QCString processMarkdown(const QCString &fileName,Entry *e,const QCString &s);
+QCString processMarkdown(const QCString &fileName,const int lineNr,Entry *e,const QCString &s);
 QCString markdownFileNameToId(const QCString &fileName);
 
 class MarkdownFileParser : public ParserInterface

--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -139,6 +139,7 @@ void marshalSectionInfoList(StorageIntf *s, QList<SectionInfo> *anchors)
       marshalQCString(s,si->ref);
       marshalInt(s,(int)si->type);
       marshalQCString(s,si->fileName);
+      marshalInt(s,si->lineNr);
       marshalInt(s,si->level);
     }
   }
@@ -546,8 +547,9 @@ QList<SectionInfo> *unmarshalSectionInfoList(StorageIntf *s)
     QCString ref   = unmarshalQCString(s);
     SectionInfo::SectionType type = (SectionInfo::SectionType)unmarshalInt(s);
     QCString fileName = unmarshalQCString(s);
+    int lineNr = unmarshalInt(s);
     int level = unmarshalInt(s);
-    result->append(new SectionInfo(fileName,label,title,type,level,ref));
+    result->append(new SectionInfo(fileName,lineNr,label,title,type,level,ref));
   }
   return result;
 }

--- a/src/section.h
+++ b/src/section.h
@@ -33,17 +33,23 @@ struct SectionInfo
                      Paragraph     = 4, 
                      Anchor        = 5 
                    };
-  SectionInfo(const char *f,const char *l,const char *t,
+  SectionInfo(const char *f,const int lin,const char *l,const char *t,
               SectionType st,int lev,const char *r=0) :
     label(l), title(t), type(st), ref(r), definition(0), 
-    fileName(f), generated(FALSE), level(lev)
+    fileName(f), generated(FALSE), level(lev), lineNr(lin)
   { 
   }
   SectionInfo(const SectionInfo &s)
   {
-    label=s.label.copy(); title=s.title.copy(); ref=s.ref.copy();
-    type =s.type; definition=s.definition;
-    fileName=s.fileName.copy(); generated=s.generated;
+    label=s.label.copy();
+    title=s.title.copy();
+    type =s.type;
+    ref=s.ref.copy();
+    definition=s.definition;
+    fileName=s.fileName.copy();
+    lineNr=s.lineNr;
+    generated=s.generated;
+    level=s.level;
   }
  ~SectionInfo() {}
   QCString label; 
@@ -52,6 +58,7 @@ struct SectionInfo
   QCString ref;
   Definition *definition;
   QCString fileName;
+  int lineNr;
   bool generated;
   int level;
 };

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -1120,7 +1120,7 @@ void TagFileParser::addDocAnchors(Entry *e,const TagAnchorInfoList &l)
     {
       //printf("New sectionInfo file=%s anchor=%s\n",
       //    ta->fileName.data(),ta->label.data());
-      SectionInfo *si=new SectionInfo(ta->fileName,ta->label,ta->title,
+      SectionInfo *si=new SectionInfo(ta->fileName,-1,ta->label,ta->title,
           SectionInfo::Anchor,0,m_tagName);
       Doxygen::sectionDict->append(ta->label,si);
       e->anchors->append(si);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6280,14 +6280,29 @@ PageDef *addRelatedPage(const char *name,const QCString &ptitle,
       {
         file=pd->getOutputFileBase();
       }
-      SectionInfo *si=new SectionInfo(
-          file,pd->name(),pd->title(),SectionInfo::Page,0,pd->getReference());
-      //printf("si->label=`%s' si->definition=%s si->fileName=`%s'\n",
-      //      si->label.data(),si->definition?si->definition->name().data():"<none>",
-      //      si->fileName.data());
-      //printf("  SectionInfo: sec=%p sec->fileName=%s\n",si,si->fileName.data());
-      //printf("Adding section key=%s si->fileName=%s\n",pageName.data(),si->fileName.data());
-      Doxygen::sectionDict->append(pd->name(),si);
+      SectionInfo *si = Doxygen::sectionDict->find(pd->name());
+      if (si)
+      {
+        if (si->lineNr != -1)
+        {
+          warn(file,-1,"multiple use of section label '%s', (first occurrence: %s, line %d)",pd->name().data(),si->fileName.data(),si->lineNr);
+        }
+        else
+        {
+          warn(file,-1,"multiple use of section label '%s', (first occurrence: %s)",pd->name().data(),si->fileName.data());
+        }
+      }
+      else
+      {
+        si=new SectionInfo(
+            file,-1,pd->name(),pd->title(),SectionInfo::Page,0,pd->getReference());
+        //printf("si->label=`%s' si->definition=%s si->fileName=`%s'\n",
+        //      si->label.data(),si->definition?si->definition->name().data():"<none>",
+        //      si->fileName.data());
+        //printf("  SectionInfo: sec=%p sec->fileName=%s\n",si,si->fileName.data());
+        //printf("Adding section key=%s si->fileName=%s\n",pageName.data(),si->fileName.data());
+        Doxygen::sectionDict->append(pd->name(),si);
+      }
     }
   }
   return pd;


### PR DESCRIPTION
In this patch it is checked if a section label has been used before and if so a warning is given with file name and line number (when possible) where the section label was used the first time.
Note in section.h the item level was not initialized in the past in case of a copy constructor.
