### PR TITLE
pass libclang header file location; add paths for Ubuntu's llvm-3.4

### DIFF
--- a/configure
+++ b/configure
@@ -554,8 +554,8 @@ fi
 
 if test "$f_libclang" = YES; then
   printf "  Checking for libclang ... "
-  libclang_hdr_dir="/usr/include /usr/local/include /opt/local/include"
-  libclang_lib_dir="/usr/lib /usr/local/lib /opt/local/lib"
+  libclang_hdr_dir="/usr/include /usr/local/include /opt/local/include /usr/lib/llvm-3.4/include"
+  libclang_lib_dir="/usr/lib /usr/local/lib /opt/local/lib /usr/lib/llvm-3.4/lib"
   if test "$f_libclangstatic" = NO; then
     libclang_lib_name="libclang.so libclang.dylib libclang.a libclang.dll.a"
   else
@@ -941,7 +941,7 @@ EOF
      #if test "$f_thread" = YES; then
      #  realopts="$realopts thread"
      #fi
-     cat $SRC .tmakeconfig | sed -e "s/\$extraopts/$realopts/g" -e "s;%%SQLITE3_INC%%;$sqlite3_hdr_dir;g" -e "s;%%SQLITE3_LIBS%%;$sqlite3_link;g" -e "s;%%LIBCLANG_LIBS%%;$libclang_link;g" >> $DST
+     cat $SRC .tmakeconfig | sed -e "s/\$extraopts/$realopts/g" -e "s;%%SQLITE3_INC%%;$sqlite3_hdr_dir;g" -e "s;%%SQLITE3_LIBS%%;$sqlite3_link;g" -e "s;%%LIBCLANG_LIBS%%;$libclang_link;g" -e "s;%%LIBCLANG_INC%%;$libclang_hdr;g" >> $DST
      echo "  Created $DST from $SRC..."
 done
 

--- a/src/libdoxygen.pro.in
+++ b/src/libdoxygen.pro.in
@@ -224,6 +224,7 @@ win32-g++:TMAKE_CXXFLAGS   += -fno-exceptions
 linux-g++:TMAKE_CXXFLAGS   += -fno-exceptions
 INCLUDEPATH                += ../generated_src/doxygen ../src ../qtools ../libmd5
 INCLUDEPATH                += %%SQLITE3_INC%%
+INCLUDEPATH		   += %%LIBCLANG_INC%%
 DEPENDPATH                 += ../generated_src/doxygen
 win32:INCLUDEPATH          += .
 DESTDIR                    =  ../lib


### PR DESCRIPTION
This is a partial fix for Bug 722445 - --with-clang does not find libclang on Debian systems
