### PR TITLE
Bug 643618 - Fortran: variable with name "type" confuses Doxygen

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -567,7 +567,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
  /*------- type definition  -------------------------------------------------------------------------------*/
 
-<Start,ModuleBody>^{BS}type/[^a-z0-9]    {
+<Start,ModuleBody>^{BS}type/[^a-z0-9_]   {
                                           if(YY_START == Start)
                                           {
                                             addModule(NULL); 


### PR DESCRIPTION
Most problems were solved in version 1.8.5 but the underscore character (_) had not been incorporated, this is done with this patch.
