### PR TITLE
Alternative way to get rules information from flex

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -190,13 +190,13 @@ could extract information from the XML output. Possible tools could be:
 Since doxygen uses a lot of \c flex code it is important to understand
 how \c flex works (for this one should read the man page) 
 and to understand what it is doing when \c flex is parsing some input. 
-Fortunately, when flex is used with the -d option it outputs what rules
+Fortunately, when flex is used with the `-d` option it outputs what rules
 matched. This makes it quite easy to follow what is going on for a 
 particular input fragment. 
 
 To make it easier to toggle debug information for a given flex file I
-wrote the following perl script, which automatically adds or removes -d
-from the correct line in the Makefile:
+wrote the following perl script, which automatically adds or removes `-d`
+from the correct line in the \c Makefile:
 
 \verbatim
 #!/usr/bin/perl 
@@ -236,6 +236,19 @@ $now = time;
 utime $now, $now, $file
 
 \endverbatim
+Another way to get rules matching / debugging information from the flex code is in the following way:
+\verbatim
+touch src/<flex code file>.l
+make LEX="flex -d"
+\endverbatim
+to remove the rules / debug information again:
+\verbatim
+touch src/<flex codefile>.l
+make
+\endverbatim
+
+Note that by running doxygen with `-d lex` you get information about which flex
+codefile is used.
 
 \htmlonly
 Return to the <a href="index.html">index</a>.


### PR DESCRIPTION
This patch describes an alternative way to get rules / debug information from flex files
