### PR TITLE
List only the project pages in "Related Pages"

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3173,9 +3173,10 @@ static void writePageIndex(OutputList &ol)
     PageDef *pd=0;
     for (pdi.toFirst();(pd=pdi.current());++pdi)
     {
-      if (pd->getOuterScope()==0 || 
-          pd->getOuterScope()->definitionType()!=Definition::TypePage
-         )  // not a sub page
+      if ((pd->getOuterScope()==0 ||
+          pd->getOuterScope()->definitionType()!=Definition::TypePage) && // not a sub page
+          !pd->isReference() // not an external page
+         )
       {
         writePages(pd,ftv);
       }


### PR DESCRIPTION
This avoids cluttering "Related Pages" with links to pages from external projects. This cause problem when generating doc for KDE frameworks. See for example: http://api.kde.org/frameworks-api/frameworks5-apidocs/threadweaver/html/pages.html
