### PR TITLE
Fix id parsing for atx markdown headers

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2184,7 +2184,6 @@ static QCString extractPageTitle(QCString &docs,QCString &id)
   {
     docs=docs.mid(end1);
   }
-  id = extractTitleId(title);
   //printf("extractPageTitle(title='%s' docs='%s' id='%s')\n",title.data(),docs.data(),id.data());
   return title;
 }


### PR DESCRIPTION
isAtxHeader() parses out the id and the title into the appropriate
variables.  The subsequent call to extractTitleId() would then have the
trimmed title (without the id ref) as input, and hence always set id to
be empty.
