### PR TITLE
Bug 726734 - alignment of blockquotes in pdf

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1469,13 +1469,13 @@ void LatexDocVisitor::visitPost(DocText *)
 void LatexDocVisitor::visitPre(DocHtmlBlockQuote *)
 {
   if (m_hide) return;
-  m_t << "\\begin{quotation}" << endl;
+  m_t << "\\begin{quote}" << endl;
 }
 
 void LatexDocVisitor::visitPost(DocHtmlBlockQuote *)
 {
   if (m_hide) return;
-  m_t << "\\end{quotation}" << endl;
+  m_t << "\\end{quote}" << endl;
 }
 
 void LatexDocVisitor::visitPre(DocVhdlFlow *)


### PR DESCRIPTION
The quote instead of quotation does align multi level block quotes
