### PR TITLE
Enable Previous and Next buttons in chm output file

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2029,7 +2029,8 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
 <![CDATA[
  The \c BINARY_TOC flag
  controls whether a binary table of contents is generated (\c YES) or a
- normal table of contents (\c NO) in the `.chm` file.
+ normal table of contents (\c NO) in the `.chm` file. Furthermore it enables
+ the `Previous` and `Next` buttons.
 ]]>
       </docs>
     </option>

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -495,9 +495,22 @@ void HtmlHelp::createProjectFile()
     //       the font-size one is not normally settable by the HTML Help Workshop
     //       utility but the way to set it is described here:
     //          http://support.microsoft.com/?scid=kb%3Ben-us%3B240062&x=17&y=18
-    t << "main=\"" << recode(Config_getString("PROJECT_NAME")) << "\",\"index.hhc\","
+    // NOTE: the 0x70387e number in addition to the above the Next and Prev button
+    //       are shown. They can only be shown in case of a binary toc.
+    //          dee http://www.mif2go.com/xhtml/htmlhelp_0016_943addingtabsandtoolbarbuttonstohtmlhelp.htm#Rz108x95873
+    //       Value has been taken from htmlhelp.h file of the HTML Help Workshop
+    if (Config_getBool("BINARY_TOC"))
+    {
+      t << "main=\"" << recode(Config_getString("PROJECT_NAME")) << "\",\"index.hhc\","
+         "\"index.hhk\",\"" << indexName << "\",\"" << 
+         indexName << "\",,,,,0x23520,,0x70387e,,,,,,,,0" << endl << endl;
+    }
+    else
+    {
+      t << "main=\"" << recode(Config_getString("PROJECT_NAME")) << "\",\"index.hhc\","
          "\"index.hhk\",\"" << indexName << "\",\"" << 
          indexName << "\",,,,,0x23520,,0x10387e,,,,,,,,0" << endl << endl;
+    }
     
     t << "[FILES]" << endl;
     char *s = indexFiles.first();
@@ -620,11 +633,14 @@ void HtmlHelp::addContentsItem(bool isDir,
                                Definition * /* def */)
 {
   // If we're using a binary toc then folders cannot have links. 
-  if(Config_getBool("BINARY_TOC") && isDir) 
-  {
-    file = 0;
-    anchor = 0;
-  }
+  // Tried this and I didn't see any problems, when not using
+  // the resetting of file and anchor the TOC works better
+  // (prev / next button)
+  //if(Config_getBool("BINARY_TOC") && isDir) 
+  //{
+    //file = 0;
+    //anchor = 0;
+  //}
   int i; for (i=0;i<dc;i++) cts << "  ";
   cts << "<LI><OBJECT type=\"text/sitemap\">";
   cts << "<param name=\"Name\" value=\"" << convertToHtml(recode(name),TRUE) << "\">";


### PR DESCRIPTION
Enables the Previous and Next buttons in case of a binary table of contents in the chm output file (binary toc is a requirement for the Previous and Next buttons).
