### PR TITLE
Chm don't add images multiple times

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -693,6 +693,6 @@ void HtmlHelp::addIndexItem(Definition *context,MemberDef *md,
 
 void HtmlHelp::addImageFile(const char *fileName)
 {
-  imageFiles.append(fileName);
+  if (!imageFiles.contains(fileName)) imageFiles.append(fileName);
 }
 


### PR DESCRIPTION
Don 't add image to list in case it is already present (happened for image extsearch_flow.png in the doxygen manual).
