### PR TITLE
Consistency of usage of the word LaTeX in the documentation

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -1797,7 +1797,7 @@ Commands to create links
   Adds a bibliographic reference in the text and in the list of bibliographic
   references. The \<label\> must be a valid BibTeX label that can be found 
   in one of the .bib files listed in \ref cfg_cite_bib_files "CITE_BIB_FILES".  
-  For the LaTeX output the formatting of the reference in the text can be 
+  For the \f$\mbox{\LaTeX}\f$ output the formatting of the reference in the text can be 
   configured with \ref cfg_latex_bib_style "LATEX_BIB_STYLE". For other
   output formats a fixed representation is used. Note that using this
   command requires the \c bibtex tool to be present in the search path.
@@ -2228,7 +2228,7 @@ Commands for displaying examples
 \section cmdlatexinclude \\latexinclude <file-name>
 
   \addindex \\latexinclude
-  This command includes the file \<file-name\> as is in the LaTeX documentation.
+  This command includes the file \<file-name\> as is in the \f$\mbox{\LaTeX}\f$ documentation.
   The command is equivalent to pasting the file in the documentation and
   placing \ref cmdlatexonly "\\latexonly" and \ref cmdendlatexonly "\\endlatexonly"
   commands around it.

--- a/doc/doxywizard_usage.doc
+++ b/doc/doxywizard_usage.doc
@@ -80,7 +80,7 @@ The latter does not affect the way doxygen parses your source code.
 \image latex doxywizard_page3.png "Wizard dialog: Output to produce" width=13cm
 
 You can select one or more of the output formats that doxygen should
-produce. For HTML and LaTeX there are additional options. 
+produce. For HTML and \f$\mbox{\LaTeX}\f$ there are additional options. 
 
 \image html doxywizard_page4.png "Wizard dialog: Diagrams to generate"
 \image latex doxywizard_page4.png "Wizard dialog: Diagrams to generate" width=13cm

--- a/doc/install.doc
+++ b/doc/install.doc
@@ -53,7 +53,7 @@ tools should be installed.
     This is needed to build the GUI front-end doxywizard. 
 <li>A \f$\mbox{\LaTeX}\f$ distribution: for instance
     <a href="http://www.tug.org/interest.html#free">TeX Live</a>
-    This is needed for generating LaTeX, Postscript, and PDF output.
+    This is needed for generating \f$\mbox{\LaTeX}\f$, Postscript, and PDF output.
 <li><a href="http://www.graphviz.org/">
     the Graph visualization toolkit version 1.8.10 or higher</a>
     Needed for the include dependency graphs, 
@@ -61,7 +61,7 @@ tools should be installed.
     If you compile graphviz yourself, make sure you do include
     freetype support (which requires the freetype library and header files), 
     otherwise the graphs will not render proper text labels.
-<li>For formulas or if you do not wish to use pdflatex, the ghostscript interpreter
+<li>For formulas or if you do not wish to use `pdflatex`, the ghostscript interpreter
     is needed. You can find it at 
     <a href="http://www.ghostscript.com/">www.ghostscript.com</a>.
 <li>In order to generate doxygen's own documentation, Python is needed, you
@@ -402,7 +402,7 @@ Compilation is now done by performing the following steps:
     the command-line (add them to the PATH environment variable if
     needed).
 
-    Notice: The use of LaTeX is optional and only needed for compilation
+    Notice: The use of \f$\mbox{\LaTeX}\f$ is optional and only needed for compilation
     of the documentation into PostScript or PDF. 
     It is \e not needed for compiling the doxygen's binaries. 
     
@@ -437,7 +437,7 @@ Compilation is now done by performing the following steps:
     The generated HTML docs are located in the <code>..\\html</code>
     subdirectory.
 
-    The sources for LaTeX documentation are located in the <code>..\\latex</code>
+    The sources for \f$\mbox{\LaTeX}\f$ documentation are located in the <code>..\\latex</code>
     subdirectory. From those sources, the DVI, PostScript, and PDF
     documentation can be generated. 
 </ol>
@@ -466,18 +466,18 @@ you need qhelpgenerator which is part of Qt.
 You can download Qt from <a href="http://qt-project.org/downloads">Qt Software Downloads</a>.
 
 In order to generate PDF output or use scientific formulas you will also need to
-install <a href="http://en.wikipedia.org/wiki/LaTeX">LaTeX</a> and 
+install <a href="http://en.wikipedia.org/wiki/LaTeX">\f$\mbox{\LaTeX}\f$</a> and 
 <a href="http://en.wikipedia.org/wiki/Ghostscript">Ghostscript</a>. 
 
-For LaTeX a number of distributions exists. Popular ones that should work with
+For \f$\mbox{\LaTeX}\f$ a number of distributions exists. Popular ones that should work with
 doxygen are <a href="http://www.miktex.org">MikTex</a> 
 and <a href="http://www.tug.org/protext/">proTeXt</a>.
 
 Ghostscript can be <a href="http://sourceforge.net/projects/ghostscript/">downloaded</a> 
 from Sourceforge.
 
-After installing LaTeX and Ghostscript you'll need to make sure the tools
-latex.exe, pdflatex.exe, and gswin32c.exe are present in the search path of a
+After installing \f$\mbox{\LaTeX}\f$ and Ghostscript you'll need to make sure the tools
+`latex.exe`, `pdflatex.exe`, and `gswin32c.exe` are present in the search path of a
 command box. Follow <a href="http://www.computerhope.com/issues/ch000549.htm">these</a>
 instructions if you are unsure and run the commands from a command box to verify it works.
 
@@ -493,7 +493,7 @@ There are a couple of tools you may want to install to use all of doxygen's
 features:
 
 <ul>
-<li>To generate LaTeX documentation or formulas in HTML you need the tools:
+<li>To generate \f$\mbox{\LaTeX}\f$ documentation or formulas in HTML you need the tools:
     <code>latex</code>, <code>dvips</code> and <code>gswin32</code>. 
     To get these working under Windows
     install the fpTeX distribution. You can find more info at:
@@ -504,7 +504,7 @@ features:
     Make sure the tools are available from a dos box, by adding the 
     directory they are in to the search path.
 
-    For your information, the LaTeX is freely available set of so
+    For your information, the \f$\mbox{\LaTeX}\f$ is freely available set of so
     called macros and styles on the top of the famous TeX program
     (by famous Donald Knuth) and the accompanied utilities (all
     available for free). It is used for high quality

--- a/doc/perlmod.doc
+++ b/doc/perlmod.doc
@@ -15,10 +15,10 @@ use.
 and could be changed in incompatible ways in future versions, although 
 this should not be very probable.  It is also lacking some features of 
 other Doxygen backends.  However, it can be already used to generate 
-useful output, as shown by the Perl Module-based LaTeX generator.
+useful output, as shown by the Perl Module-based \f$\mbox{\LaTeX}\f$ generator.
 
 <p>Please report any bugs or problems you find in the Perl Module 
-backend or the Perl Module-based LaTeX generator to the 
+backend or the Perl Module-based \f$\mbox{\LaTeX}\f$ generator to the 
 doxygen-develop mailing list.  Suggestions are welcome as well.
 
 \section using_perlmod_fmt Usage
@@ -49,7 +49,7 @@ file is intended to be included by your own Makefile.
 
 <p>To make use of the documentation stored in DoxyDocs.pm you can use
 one of the default Perl Module-based generators provided by Doxygen
-(at the moment this includes the Perl Module-based LaTeX generator,
+(at the moment this includes the Perl Module-based \f$\mbox{\LaTeX}\f$ generator,
 see \ref perlmod_latex "below") or write your own customized
 generator.  This should not be too hard if you have some knowledge of
 Perl and it's the main purpose of including the Perl Module backend in
@@ -58,7 +58,7 @@ to do this.
 
 \section perlmod_latex Using the LaTeX generator.
 
-<p>The Perl Module-based LaTeX generator is pretty experimental and
+<p>The Perl Module-based \f$\mbox{\LaTeX}\f$ generator is pretty experimental and
 incomplete at the moment, but you could find it useful nevertheless.
 It can generate documentation for functions, typedefs and variables
 within files and classes and can be customized quite a lot by
@@ -68,7 +68,7 @@ how to do this.
 <p>Setting the \ref cfg_perlmod_latex "PERLMOD_LATEX" tag to \c YES in the 
 \c Doxyfile enables the creation of some additional files in the `perlmod/` 
 subdirectory of your output directory.  These files contain the Perl 
-scripts and LaTeX code necessary to generate PDF and DVI output from 
+scripts and \f$\mbox{\LaTeX}\f$ code necessary to generate PDF and DVI output from 
 the Perl Module output, using `pdflatex` and `latex` respectively.  Rules 
 to automate the use of these files are also added to 
 `doxyrules.make` and the `Makefile`.
@@ -79,11 +79,11 @@ to automate the use of these files are also added to
 
 <li>`doxylatex.pl`: This Perl script uses `DoxyDocs.pm` and 
 DoxyModel.pm to generate `doxydocs.tex`, a TeX file containing 
-the documentation in a format that can be accessed by LaTeX code. This 
+the documentation in a format that can be accessed by \f$\mbox{\LaTeX}\f$ code. This 
 file is not directly LaTeXable.
 
 <li>`doxyformat.tex`: This file contains the \f$\mbox{\LaTeX}\f$ code that 
-transforms the documentation from doxydocs.tex into LaTeX text 
+transforms the documentation from doxydocs.tex into \f$\mbox{\LaTeX}\f$ text 
 suitable to be \f$\mbox{\LaTeX}\f$'ed and presented to the user.
 
 <li>`doxylatex-template.pl`:  This Perl script uses `DoxyModel.pm` 
@@ -100,7 +100,7 @@ rules added to `doxyrules.make`.
 
 \subsection pm_pdf_gen Creation of PDF and DVI output 
 
-<p>To try this you need to have installed LaTeX, PDFLaTeX and the 
+<p>To try this you need to have installed \c latex, \c pdflatex and the 
 packages used by `doxylatex.tex`.
 
 <ol>


### PR DESCRIPTION
The word LaTeX was used as just the word and on other places as \f$\mbox{\LaTeX}\f$
This has been made more consistent
Some names of executables etc. were not set in a 'code' font.
