### PR TITLE
Bug 678436 - Nested \if messes up list items

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1810,7 +1810,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 
   /* ----- handle arguments of if/ifnot commands ------- */
 
-<GuardParam>"("                         {
+<GuardParam>{B}*"("                         {
                                           g_guardExpr=yytext;
                                           g_roundCount=1;
                                           BEGIN(GuardExpr);


### PR DESCRIPTION
Blank spaces after an if statement have to be removed as well. Just enable them as part of the parameter of the conditional expression and remove them later on (to be safe not having them in the parser).
