### PR TITLE
Consistency of usage of the word LaTeX in the documentation

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -51,3 +51,5 @@ PDF_HYPERLINKS    = YES
 USE_PDFLATEX      = YES
 STRIP_CODE_COMMENTS = NO
 HTML_STYLESHEET   = doxygen_manual.css
+ALIASES           = LaTeX="\f$\mbox{\LaTeX}\f$"
+ALIASES          += TeX="\f$\mbox{\TeX}\f$"

--- a/doc/autolink.doc
+++ b/doc/autolink.doc
@@ -23,7 +23,7 @@
   Although doxygen also has a command to start such a section (See section
   \ref cmdsa "\\sa"), it does allow you to put these kind of links anywhere in the
   documentation. 
-  For \f$\mbox{\LaTeX}\f$ documentation a reference to the page number
+  For \LaTeX documentation a reference to the page number
   is written instead of a link. Furthermore, the index at the end of the 
   document can be used to quickly find the documentation of a member, class, 
   namespace or file.

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -632,7 +632,7 @@ Structural indicators
 
   If the \c \\mainpage command is placed in a comment block the
   block is used to customize the index page (in HTML) or
-  the first chapter (in \f$\mbox{\LaTeX}\f$).
+  the first chapter (in \LaTeX).
 
   The title argument is optional and replaces the default title that
   doxygen normally generates. If you do not want any title you can
@@ -763,7 +763,7 @@ Structural indicators
   Indicates that a comment block contains a piece of documentation that is
   not directly related to one specific class, file or member.
   The HTML generator creates a page containing the documentation. The
-  \f$\mbox{\LaTeX}\f$ generator
+  \LaTeX generator
   starts a new section in the chapter 'Page documentation'.
 
   \par Example:
@@ -1777,7 +1777,7 @@ Commands to create links
 \section cmdaddindex \\addindex (text)
 
   \addindex \\addindex
-  This command adds (text) to the \f$\mbox{\LaTeX}\f$ index.
+  This command adds (text) to the \LaTeX index.
 
 <hr>
 \section cmdanchor \\anchor <word>
@@ -1799,7 +1799,7 @@ Commands to create links
   Adds a bibliographic reference in the text and in the list of bibliographic
   references. The \<label\> must be a valid BibTeX label that can be found 
   in one of the .bib files listed in \ref cfg_cite_bib_files "CITE_BIB_FILES".  
-  For the LaTeX output the formatting of the reference in the text can be 
+  For the \LaTeX output the formatting of the reference in the text can be 
   configured with \ref cfg_latex_bib_style "LATEX_BIB_STYLE". For other
   output formats a fixed representation is used. Note that using this
   command requires the \c bibtex tool to be present in the search path.
@@ -1837,7 +1837,7 @@ Commands to create links
   the section. For a section or subsection the title of the section will be
   used as the text of the link. For an anchor the optional text between quotes
   will be used or \<name\> if no text is specified.
-  For \f$\mbox{\LaTeX}\f$ documentation the reference command will
+  For \LaTeX documentation the reference command will
   generate a section number for sections or the text followed by a
   page number if \<name\> refers to an anchor.
 
@@ -2230,7 +2230,7 @@ Commands for displaying examples
 \section cmdlatexinclude \\latexinclude <file-name>
 
   \addindex \\latexinclude
-  This command includes the file \<file-name\> as is in the LaTeX documentation.
+  This command includes the file \<file-name\> as is in the \LaTeX documentation.
   The command is equivalent to pasting the file in the documentation and
   placing \ref cmdlatexonly "\\latexonly" and \ref cmdendlatexonly "\\endlatexonly"
   commands around it.
@@ -2784,10 +2784,10 @@ class Receiver
 
   The fourth argument is also optional and can be used to specify the
   width or height of the image. This is only useful
-  for \f$\mbox{\LaTeX}\f$ output
+  for \LaTeX output
   (i.e. format=<code>latex</code>). The \c sizeindication can be
   either \c width or \c height. The size should be a valid
-  size specifier in \f$\mbox{\LaTeX}\f$ (for example <code>10cm</code> or
+  size specifier in \LaTeX (for example <code>10cm</code> or
   <code>6in</code> or a symbolic width like <code>\\textwidth</code>).
 
   Here is example of a comment block:
@@ -2807,7 +2807,7 @@ class Receiver
 \endverbatim
 
   \warning The image format for HTML is limited to what your
-           browser supports. For \f$\mbox{\LaTeX}\f$, the image format
+           browser supports. For \LaTeX, the image format
            must be Encapsulated PostScript (eps).
            <br><br>
            Doxygen does not check if the image is in the correct format.
@@ -2818,17 +2818,17 @@ class Receiver
 
   \addindex \\latexonly
   Starts a block of text that will be verbatim included in the
-  generated \f$\mbox{\LaTeX}\f$ documentation only. The block ends with a
+  generated \LaTeX documentation only. The block ends with a
   \ref cmdendlatexonly "\\endlatexonly" command.
 
-  This command can be used to include \f$\mbox{\LaTeX}\f$ code that is too
+  This command can be used to include \LaTeX code that is too
   complex for doxygen (i.e. images, formulas, special characters). You can
   use the \ref cmdhtmlonly "\\htmlonly" and \ref cmdendhtmlonly "\\endhtmlonly"
   pair to provide a proper HTML alternative.
 
   \b Note:
     environment variables (like \$(HOME) ) are resolved inside a
-    \f$\mbox{\LaTeX}\f$-only block.
+    \LaTeX-only block.
 
   \sa sections \ref cmdrtfonly "\\rtfonly",
                \ref cmdxmlonly "\\xmlonly",
@@ -2849,7 +2849,7 @@ class Receiver
   \ref cmdendhtmlonly "\\endhtmlonly" and
   \ref cmdlatexonly "\\latexonly" and
   \ref cmdendlatexonly "\\endlatexonly" pairs to provide proper
-  HTML and \f$\mbox{\LaTeX}\f$ alternatives.
+  HTML and \LaTeX alternatives.
 
   \sa sections \ref cmdhtmlonly "\\htmlonly",
                \ref cmdxmlonly "\\xmlonly",

--- a/doc/diagrams.doc
+++ b/doc/diagrams.doc
@@ -83,7 +83,7 @@
   <li> A <b>dotted dark green</b> arrow indicates private inheritance.
   </ul>
 
-  The elements in the class diagram in \f$\mbox{\LaTeX}\f$ have the 
+  The elements in the class diagram in \LaTeX have the 
   following meaning:
   <ul>
   <li> A \b white box indicates a class.

--- a/doc/doxygen_usage.doc
+++ b/doc/doxygen_usage.doc
@@ -71,7 +71,7 @@ doxygen -w html header.html footer.html stylesheet.css <config_file>
   a file named `Doxyfile` and process that. When this is also not found it
   will used the default settings.
 
-<li>For \f$\mbox{\LaTeX}\f$ output, you can generate the first and last part of \c refman.tex 
+<li>For \LaTeX output, you can generate the first and last part of \c refman.tex 
     (see \ref cfg_latex_header "LATEX_HEADER" and
      \ref cfg_latex_footer "LATEX_FOOTER") and the style sheet included
     by that header (normally <code>doxygen.sty</code>), using the following
@@ -79,7 +79,7 @@ doxygen -w html header.html footer.html stylesheet.css <config_file>
 \verbatim
 doxygen -w latex header.tex footer.tex doxygen.sty <config_file>
 \endverbatim
-If you need non-default options (for instance to use extra \f$\mbox{\LaTeX}\f$ packages) 
+If you need non-default options (for instance to use extra \LaTeX packages) 
 you need to make a config file with those options set correctly and then specify
 that config file after the generated files (make a backup of the configuration
 file first so you don't loose it in case you forget to specify one of the 

--- a/doc/doxywizard_usage.doc
+++ b/doc/doxywizard_usage.doc
@@ -80,7 +80,7 @@ The latter does not affect the way doxygen parses your source code.
 \image latex doxywizard_page3.png "Wizard dialog: Output to produce" width=13cm
 
 You can select one or more of the output formats that doxygen should
-produce. For HTML and LaTeX there are additional options. 
+produce. For HTML and \LaTeX there are additional options. 
 
 \image html doxywizard_page4.png "Wizard dialog: Diagrams to generate"
 \image latex doxywizard_page4.png "Wizard dialog: Diagrams to generate" width=13cm

--- a/doc/features.doc
+++ b/doc/features.doc
@@ -37,7 +37,7 @@
 <li>Comes with a GUI frontend (Doxywizard) to ease editing the options and 
     run doxygen. The GUI is available on Windows, Linux, and MacOSX.
 <li>Automatically generates class and collaboration diagrams in HTML (as clickable 
-    image maps) and \f$\mbox{\LaTeX}\f$ (as Encapsulated PostScript images).
+    image maps) and \LaTeX (as Encapsulated PostScript images).
 <li>Uses the `dot` tool of the Graphviz tool kit to generate
     include dependency graphs, collaboration diagrams, call graphs, directory structure
     graphs, and graphical class hierarchy graphs. 
@@ -49,12 +49,12 @@
 <li>Generates a list of all members of a class (including any inherited
     members) along with their protection level.
 <li>Outputs documentation in on-line format (XHTML and UNIX man page) and 
-    off-line format (\f$\mbox{\LaTeX}\f$ and RTF) simultaneously 
+    off-line format (\LaTeX and RTF) simultaneously 
     (any of these can be disabled if desired). All formats are optimized for 
     ease of reading. <br>
     Furthermore, compressed HTML can be generated from HTML output using 
     Microsoft's HTML Help Workshop (Windows only) and PDF can be generated 
-    from the \f$\mbox{\LaTeX}\f$ output.
+    from the \LaTeX output.
 <li>Support for various third party help formats including HTML Help,
     docsets, Qt-Help, and eclipse help.
 <li>Includes a full C preprocessor to allow proper parsing of conditional 
@@ -72,7 +72,7 @@
 <li>Includes an Javascript based live search feature to search for symbols
     as you type (for small to medium sized projects).
 <li>You can type normal HTML tags in your documentation. Doxygen will convert
-    them to their equivalent \f$\mbox{\LaTeX}\f$, RTF, and man-page 
+    them to their equivalent \LaTeX, RTF, and man-page 
     counterparts automatically.
 <li>Allows references to documentation generated for other (doxygen documented) 
     projects (or another part of the same project) in a location independent way.

--- a/doc/formulas.doc
+++ b/doc/formulas.doc
@@ -16,13 +16,13 @@
  */
 /*! \page formulas Including formulas 
 
-Doxygen allows you to put \f$\mbox{\LaTeX}\f$ formulas in the
-output (this works only for the HTML and \f$\mbox{\LaTeX}\f$ output, 
+Doxygen allows you to put \LaTeX formulas in the
+output (this works only for the HTML and \LaTeX output, 
 not for the RTF nor for the man page output). To be able to include 
 formulas (as images) in the HTML documentation, you will also need to 
 have the following tools installed
 <ul>
-<li>\c latex: the \f$\mbox{\LaTeX}\f$ compiler, needed to parse the formulas. 
+<li>\c latex: the \LaTeX compiler, needed to parse the formulas. 
     To test I have used the teTeX 1.0 distribution.
 <li>\c dvips: a tool to convert DVI files to PostScript files 
     I have used version 5.92b from Radical Eye software for testing.
@@ -76,7 +76,7 @@ There are three ways to include formulas in the documentation.
   \f]
 <li>Formulas or other latex elements that are not in a math 
     environment can be specified using \\f{environment}, where
-    \c environment is the name of the \f$\mbox{\LaTeX}\f$ environment, 
+    \c environment is the name of the \LaTeX environment, 
     the corresponding end command is \\f}. Here is an example for an 
     equation array
 \verbatim
@@ -96,7 +96,7 @@ There are three ways to include formulas in the documentation.
    \f}
 </ol>
 For the first two commands one should make sure formulas contain 
-valid commands in \f$\mbox{\LaTeX}\f$'s math-mode. For the third command
+valid commands in \LaTeX's math-mode. For the third command
 the section should contain valid command for the specific environment.
 
 \warning Currently, doxygen is not very fault tolerant in recovering 

--- a/doc/index.doc
+++ b/doc/index.doc
@@ -35,7 +35,7 @@ languages such as C, Objective-C, C#, PHP, Java, Python, IDL
 Doxygen can help you in three ways:
 <ol>
 <li> It can generate an on-line documentation browser (in HTML) and/or an 
-     off-line reference manual (in \f$\mbox{\LaTeX}\f$) from a set 
+     off-line reference manual (in \LaTeX) from a set 
      of documented source files. 
      There is also support for generating output in RTF (MS-Word), 
      PostScript, hyperlinked PDF, compressed HTML, and Unix man pages.

--- a/doc/install.doc
+++ b/doc/install.doc
@@ -51,9 +51,9 @@ tools should be installed.
     \addindex Qt
     version 4.3 or higher (but currently, Qt 5.x is not supported).
     This is needed to build the GUI front-end doxywizard. 
-<li>A \f$\mbox{\LaTeX}\f$ distribution: for instance
+<li>A \LaTeX distribution: for instance
     <a href="http://www.tug.org/interest.html#free">TeX Live</a>
-    This is needed for generating LaTeX, Postscript, and PDF output.
+    This is needed for generating \LaTeX, Postscript, and PDF output.
 <li><a href="http://www.graphviz.org/">
     the Graph visualization toolkit version 1.8.10 or higher</a>
     Needed for the include dependency graphs, 
@@ -61,7 +61,7 @@ tools should be installed.
     If you compile graphviz yourself, make sure you do include
     freetype support (which requires the freetype library and header files), 
     otherwise the graphs will not render proper text labels.
-<li>For formulas or if you do not wish to use pdflatex, the ghostscript interpreter
+<li>For formulas or if you do not wish to use `pdflatex, the ghostscript interpreter
     is needed. You can find it at 
     <a href="http://www.ghostscript.com/">www.ghostscript.com</a>.
 <li>In order to generate doxygen's own documentation, Python is needed, you
@@ -402,7 +402,7 @@ Compilation is now done by performing the following steps:
     the command-line (add them to the PATH environment variable if
     needed).
 
-    Notice: The use of LaTeX is optional and only needed for compilation
+    Notice: The use of \LaTeX is optional and only needed for compilation
     of the documentation into PostScript or PDF. 
     It is \e not needed for compiling the doxygen's binaries. 
     
@@ -437,7 +437,7 @@ Compilation is now done by performing the following steps:
     The generated HTML docs are located in the <code>..\\html</code>
     subdirectory.
 
-    The sources for LaTeX documentation are located in the <code>..\\latex</code>
+    The sources for \LaTeX documentation are located in the <code>..\\latex</code>
     subdirectory. From those sources, the DVI, PostScript, and PDF
     documentation can be generated. 
 </ol>
@@ -469,14 +469,14 @@ In order to generate PDF output or use scientific formulas you will also need to
 install <a href="http://en.wikipedia.org/wiki/LaTeX">LaTeX</a> and 
 <a href="http://en.wikipedia.org/wiki/Ghostscript">Ghostscript</a>. 
 
-For LaTeX a number of distributions exists. Popular ones that should work with
+For \LaTeX a number of distributions exists. Popular ones that should work with
 doxygen are <a href="http://www.miktex.org">MikTex</a> 
 and <a href="http://www.tug.org/protext/">proTeXt</a>.
 
 Ghostscript can be <a href="http://sourceforge.net/projects/ghostscript/">downloaded</a> 
 from Sourceforge.
 
-After installing LaTeX and Ghostscript you'll need to make sure the tools
+After installing \LaTeX and Ghostscript you'll need to make sure the tools
 latex.exe, pdflatex.exe, and gswin32c.exe are present in the search path of a
 command box. Follow <a href="http://www.computerhope.com/issues/ch000549.htm">these</a>
 instructions if you are unsure and run the commands from a command box to verify it works.
@@ -493,7 +493,7 @@ There are a couple of tools you may want to install to use all of doxygen's
 features:
 
 <ul>
-<li>To generate LaTeX documentation or formulas in HTML you need the tools:
+<li>To generate \LaTeX documentation or formulas in HTML you need the tools:
     <code>latex</code>, <code>dvips</code> and <code>gswin32</code>. 
     To get these working under Windows
     install the fpTeX distribution. You can find more info at:
@@ -504,8 +504,8 @@ features:
     Make sure the tools are available from a dos box, by adding the 
     directory they are in to the search path.
 
-    For your information, the LaTeX is freely available set of so
-    called macros and styles on the top of the famous TeX program
+    For your information, \LaTeX is a freely available set of so
+    called macros and styles on the top of the famous \TeX program
     (by famous Donald Knuth) and the accompanied utilities (all
     available for free). It is used for high quality
     typesetting. The result -- in the form of so called
@@ -515,7 +515,7 @@ features:
     to convert the <code>dvi</code> to the high quality PostScript
     (i.e. PostScript that can be processed by utilities like 
     <code>psnup</code>, <code>psbook</code>, <code>psselect</code>,
-    and others). The derived version of TeX (the pdfTeX) can be used
+    and others). The derived version of \TeX (the pdfTeX) can be used
     to produce PDF output instead of DVI, or the PDF can be produced
     from PostScript using the utility <code>ps2pdf</code>.
 

--- a/doc/language.tpl
+++ b/doc/language.tpl
@@ -98,7 +98,7 @@ Just follow the following steps:
      <ul>
      <li>  Enter them directly if your keyboard supports that. Recall that
            the text is expected to be saved using the UTF-8 encoding. Doxygen
-           will translate the characters to proper \f$\mbox{\LaTeX}\f$ and
+           will translate the characters to proper \LaTeX and
            leaves the HTML and man output in UTF-8.
      <li>  Use HTML codes like \c \&auml; for an \c a with an \c umlaut (i.e. \c &auml;).
            See the HTML specification for the codes.

--- a/doc/output.doc
+++ b/doc/output.doc
@@ -22,7 +22,7 @@ The following output formats are \e directly supported by doxygen:
 <dl>
 <dt><b>HTML</b>
 <dd>Generated if \ref cfg_generate_html "GENERATE_HTML" is set to \c YES in the configuration file.
-<dt>\f$\mbox{\LaTeX}\f$
+<dt>\LaTeX
 <dd>Generated if \ref cfg_generate_latex "GENERATE_LATEX" is set to \c YES in the configuration file.
 <dt><b>Man pages</b>
 <dd>Generated if \ref cfg_generate_man "GENERATE_MAN" is set to \c YES in the configuration file.
@@ -51,11 +51,11 @@ The following output formats are \e indirectly supported by doxygen:
 <dd>Compiled from HTML with a special index file that is generated when
     \ref cfg_generate_docset "GENERATE_DOCSET" is set to \c YES.
 <dt><b>PostScript</b>
-<dd>Generated from the \f$\mbox{\LaTeX}\f$ output by 
+<dd>Generated from the \LaTeX output by 
     running <code>make ps</code> in the output directory.
     For the best results \ref cfg_pdf_hyperlinks "PDF_HYPERLINKS" should be set to \c NO.
 <dt><b>PDF</b>\htmlonly &nbsp;&nbsp;&nbsp;\endhtmlonly
-<dd>Generated from the \f$\mbox{\LaTeX}\f$ output by
+<dd>Generated from the \LaTeX output by
     running <code>make pdf</code> in the output directory.
     To improve the PDF output, you typically would want to enable the use 
     of \c pdflatex by setting \ref cfg_use_pdflatex "USE_PDFLATEX" to \c YES in the 

--- a/doc/perlmod.doc
+++ b/doc/perlmod.doc
@@ -15,10 +15,10 @@ use.
 and could be changed in incompatible ways in future versions, although 
 this should not be very probable.  It is also lacking some features of 
 other Doxygen backends.  However, it can be already used to generate 
-useful output, as shown by the Perl Module-based LaTeX generator.
+useful output, as shown by the Perl Module-based \LaTeX generator.
 
 <p>Please report any bugs or problems you find in the Perl Module 
-backend or the Perl Module-based LaTeX generator to the 
+backend or the Perl Module-based \LaTeX generator to the 
 doxygen-develop mailing list.  Suggestions are welcome as well.
 
 \section using_perlmod_fmt Usage
@@ -49,26 +49,27 @@ file is intended to be included by your own Makefile.
 
 <p>To make use of the documentation stored in DoxyDocs.pm you can use
 one of the default Perl Module-based generators provided by Doxygen
-(at the moment this includes the Perl Module-based LaTeX generator,
+(at the moment this includes the Perl Module-based \LaTeX generator,
 see \ref perlmod_latex "below") or write your own customized
 generator.  This should not be too hard if you have some knowledge of
 Perl and it's the main purpose of including the Perl Module backend in
 Doxygen.  See \ref doxydocs_format "below" for details on how
 to do this.
 
+<-- want to use \LaTeX but not possible in headings -->
 \section perlmod_latex Using the LaTeX generator.
 
-<p>The Perl Module-based LaTeX generator is pretty experimental and
+<p>The Perl Module-based \LaTeX generator is pretty experimental and
 incomplete at the moment, but you could find it useful nevertheless.
 It can generate documentation for functions, typedefs and variables
 within files and classes and can be customized quite a lot by
-redefining TeX macros.  However, there is still no documentation on
+redefining \TeX macros.  However, there is still no documentation on
 how to do this.
 
 <p>Setting the \ref cfg_perlmod_latex "PERLMOD_LATEX" tag to \c YES in the 
 \c Doxyfile enables the creation of some additional files in the `perlmod/` 
 subdirectory of your output directory.  These files contain the Perl 
-scripts and LaTeX code necessary to generate PDF and DVI output from 
+scripts and \LaTeX code necessary to generate PDF and DVI output from 
 the Perl Module output, using `pdflatex` and `latex` respectively.  Rules 
 to automate the use of these files are also added to 
 `doxyrules.make` and the `Makefile`.
@@ -78,29 +79,29 @@ to automate the use of these files are also added to
 <ul>
 
 <li>`doxylatex.pl`: This Perl script uses `DoxyDocs.pm` and 
-DoxyModel.pm to generate `doxydocs.tex`, a TeX file containing 
-the documentation in a format that can be accessed by LaTeX code. This 
+DoxyModel.pm to generate `doxydocs.tex`, a \TeX file containing 
+the documentation in a format that can be accessed by \LaTeX code. This 
 file is not directly LaTeXable.
 
-<li>`doxyformat.tex`: This file contains the \f$\mbox{\LaTeX}\f$ code that 
-transforms the documentation from doxydocs.tex into LaTeX text 
-suitable to be \f$\mbox{\LaTeX}\f$'ed and presented to the user.
+<li>`doxyformat.tex`: This file contains the \LaTeX code that 
+transforms the documentation from doxydocs.tex into \LaTeX text 
+suitable to be \LaTeX'ed and presented to the user.
 
 <li>`doxylatex-template.pl`:  This Perl script uses `DoxyModel.pm` 
-to generate `doxytemplate.tex`, a \f$\mbox{\TeX}\f$ file defining default 
+to generate `doxytemplate.tex`, a \TeX file defining default 
 values for some macros.  doxytemplate.tex is included by 
 doxyformat.tex to avoid the need of explicitly defining some macros.
 
-<li>`doxylatex.tex`:  This is a very simple \f$\mbox{\LaTeX}\f$ document that 
+<li>`doxylatex.tex`:  This is a very simple \LaTeX document that 
 loads some packages and includes doxyformat.tex and doxydocs.tex. This 
-document is \f$\mbox{\LaTeX}\f$'ed to produce the PDF and DVI documentation by the 
+document is \LaTeX'ed to produce the PDF and DVI documentation by the 
 rules added to `doxyrules.make`.
 
 </ul>
 
 \subsection pm_pdf_gen Creation of PDF and DVI output 
 
-<p>To try this you need to have installed LaTeX, PDFLaTeX and the 
+<p>To try this you need to have installed `latex`, `pdflatex` and the 
 packages used by `doxylatex.tex`.
 
 <ol>

--- a/doc/starting.doc
+++ b/doc/starting.doc
@@ -165,7 +165,7 @@ doxygen <config-file>
 Depending on your settings doxygen will create \c html, \c rtf, 
 \c latex, \c xml, \c man, and/or docbook directories inside the output directory. 
 As the names suggest these directories contain the
-generated documentation in HTML, RTF, \f$\mbox{\LaTeX}\f$, XML,
+generated documentation in HTML, RTF, \LaTeX, XML,
 Unix-Man page, and DocBook format.
 
 The default output directory is the directory in which \c doxygen
@@ -193,8 +193,8 @@ require a browser that supports Dynamic HTML and Javascript enabled.
 
 \subsection latex_out LaTeX output
 \addindex LaTeX
-The generated \f$\mbox{\LaTeX}\f$ documentation must first be compiled by 
-a \f$\mbox{\LaTeX}\f$ compiler (I use a recent teTeX distribution for Linux
+The generated \LaTeX documentation must first be compiled by 
+a \LaTeX compiler (I use a recent teTeX distribution for Linux
 and MacOSX and MikTex for Windows). 
 To simplify the process of compiling the generated
 documentation, \c doxygen writes a \c Makefile into the \c latex directory
@@ -302,7 +302,7 @@ structural command; just putting a special documentation block in front or
 behind them will work fine. 
 
 The text inside a special documentation block is parsed
-before it is written to the HTML and/or \f$\mbox{\LaTeX}\f$ output files.
+before it is written to the HTML and/or \LaTeX output files.
 
 \addindex parsing
 During parsing the following steps take place:
@@ -323,7 +323,7 @@ During parsing the following steps take place:
   text. See section \ref autolink
   for more information on how the automatic link generation works.
 - HTML tags that are in the documentation are interpreted and converted 
-  to \f$\mbox{\LaTeX}\f$ equivalents for the \f$\mbox{\LaTeX}\f$ output. 
+  to \LaTeX equivalents for the \LaTeX output. 
   See section \ref htmlcmds for an overview of all supported HTML tags.
 
 \htmlonly


### PR DESCRIPTION
The word LaTeX was used as just the word and on other places as \f$\mbox{\LaTeX}\f$
This has been made more consistent by means of the definition of the Alia \LaTeX (similar for \TeX)
Some names of executables etc. were not set in a 'code' font.

This fix replaces the fix from feature/bug_docu_latex pull request 149
