### PR TITLE
Fix segfault on invalid bounding FIG when patching dot

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1102,7 +1102,7 @@ bool DotFilePatcher::run()
       }
       else // error invalid map id!
       {
-        err("Found invalid bounding FIG id in file %s!\n",mapId,m_patchFile.data());
+        err("Found invalid bounding FIG %d in file %s!\n",mapId,m_patchFile.data());
         t << line;
       }
     }


### PR DESCRIPTION
Got a segfault when running doxygen on the doxygen source code. 
