### PR TITLE
Bug 690999 - Add project name to xml output

### DIFF
--- a/src/compound.xsd
+++ b/src/compound.xsd
@@ -5,10 +5,20 @@
   <!-- Complex types -->
 
   <xsd:complexType name="DoxygenType">
-    <xsd:sequence maxOccurs="unbounded">
-      <xsd:element name="compounddef" type="compounddefType" minOccurs="0" />
+    <xsd:sequence>
+      <xsd:element name="project" type="ProjectType"/>
+      <xsd:element name="compounddef" type="compounddefType" maxOccurs="unbounded" minOccurs="0" />
     </xsd:sequence>
     <xsd:attribute name="version" type="DoxVersionNumber" use="required" />
+  </xsd:complexType>
+
+  <xsd:complexType name="ProjectType">
+    <xsd:sequence>
+    <xsd:element name="projectname" type="xsd:string"/>
+    <xsd:element name="projectnumber" type="xsd:string"/>
+    <xsd:element name="projectbrief" type="xsd:string"/>
+    <xsd:element name="projectlogo" type="xsd:string"/>
+    </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="compounddefType">

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9164,7 +9164,7 @@ static void copyStyleSheet()
   
 }
 
-static void copyLogo()
+static void copyLogo(const QCString& str)
 {
   QCString &projectLogo = Config_getString("PROJECT_LOGO");
   if (!projectLogo.isEmpty())
@@ -9177,7 +9177,7 @@ static void copyLogo()
     }
     else
     {
-      QCString destFileName = Config_getString("HTML_OUTPUT")+"/"+fi.fileName().data();
+      QCString destFileName = Config_getString(str)+"/"+fi.fileName().data();
       copyFile(projectLogo,destFileName);
       Doxygen::indexList->addImageFile(fi.fileName().data());
     }
@@ -11218,6 +11218,7 @@ void generateOutput()
 
   bool generateHtml  = Config_getBool("GENERATE_HTML");
   bool generateLatex = Config_getBool("GENERATE_LATEX");
+  bool generateXml   = Config_getBool("GENERATE_XML");
   bool generateMan   = Config_getBool("GENERATE_MAN");
   bool generateRtf   = Config_getBool("GENERATE_RTF");
 
@@ -11244,7 +11245,7 @@ void generateOutput()
 
     // copy static stuff
     copyStyleSheet();
-    copyLogo();
+    copyLogo("HTML_OUTPUT");
     copyExtraFiles("HTML_EXTRA_FILES","HTML_OUTPUT");
     FTVHelp::generateTreeViewImages();
   }
@@ -11255,6 +11256,10 @@ void generateOutput()
 
     // copy static stuff
     copyExtraFiles("LATEX_EXTRA_FILES","LATEX_OUTPUT");
+  }
+  if (generateXml)
+  {
+    copyLogo("XML_OUTPUT");
   }
   if (generateMan)
   {
@@ -11420,7 +11425,7 @@ void generateOutput()
       removeDoxFont(Config_getString("LATEX_OUTPUT"));
   }
 
-  if (Config_getBool("GENERATE_XML"))
+  if (generateXml)
   {
     g_s.begin("Generating XML output...\n");
     Doxygen::generatingXmlOutput=TRUE;

--- a/src/index.xsd
+++ b/src/index.xsd
@@ -4,9 +4,19 @@
 
   <xsd:complexType name="DoxygenType">
     <xsd:sequence>
+      <xsd:element name="project" type="ProjectType"/>
       <xsd:element name="compound" type="CompoundType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="version" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="ProjectType">
+    <xsd:sequence>
+    <xsd:element name="projectname" type="xsd:string"/>
+    <xsd:element name="projectnumber" type="xsd:string"/>
+    <xsd:element name="projectbrief" type="xsd:string"/>
+    <xsd:element name="projectlogo" type="xsd:string"/>
+    </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="CompoundType">

--- a/testing/001/indexpage.xml
+++ b/testing/001/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/002/indexpage.xml
+++ b/testing/002/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/003/indexpage.xml
+++ b/testing/003/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/004/indexpage.xml
+++ b/testing/004/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/005/indexpage.xml
+++ b/testing/005/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/006/indexpage.xml
+++ b/testing/006/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/007/indexpage.xml
+++ b/testing/007/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/008/008__brief_8c.xml
+++ b/testing/008/008__brief_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="008__brief_8c" kind="file">
     <compoundname>008_brief.c</compoundname>
     <briefdescription>

--- a/testing/009/bug.xml
+++ b/testing/009/bug.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="bug" kind="page">
     <compoundname>bug</compoundname>
     <title>Bug List</title>

--- a/testing/009/class_bug.xml
+++ b/testing/009/class_bug.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_bug" kind="class" prot="public">
     <compoundname>Bug</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_deprecated.xml
+++ b/testing/009/class_deprecated.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_deprecated" kind="class" prot="public">
     <compoundname>Deprecated</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_reminder.xml
+++ b/testing/009/class_reminder.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_reminder" kind="class" prot="public">
     <compoundname>Reminder</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_test.xml
+++ b/testing/009/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_todo.xml
+++ b/testing/009/class_todo.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_todo" kind="class" prot="public">
     <compoundname>Todo</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/deprecated.xml
+++ b/testing/009/deprecated.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="deprecated" kind="page">
     <compoundname>deprecated</compoundname>
     <title>Deprecated List</title>

--- a/testing/009/reminders.xml
+++ b/testing/009/reminders.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="reminders" kind="page">
     <compoundname>reminders</compoundname>
     <title>Reminders</title>

--- a/testing/009/test.xml
+++ b/testing/009/test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="test" kind="page">
     <compoundname>test</compoundname>
     <title>Test List</title>

--- a/testing/009/todo.xml
+++ b/testing/009/todo.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="todo" kind="page">
     <compoundname>todo</compoundname>
     <title>Todo List</title>

--- a/testing/010/indexpage.xml
+++ b/testing/010/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/011/category_integer_07_arithmetic_08.xml
+++ b/testing/011/category_integer_07_arithmetic_08.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="category_integer_07_arithmetic_08" kind="category" prot="public">
     <compoundname>Integer(Arithmetic)</compoundname>
     <sectiondef kind="public-func">

--- a/testing/011/interface_integer.xml
+++ b/testing/011/interface_integer.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="interface_integer" kind="class" prot="public">
     <compoundname>Integer</compoundname>
     <basecompoundref prot="public" virt="non-virtual">Object</basecompoundref>

--- a/testing/012/citelist.xml
+++ b/testing/012/citelist.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="citelist" kind="page">
     <compoundname>citelist</compoundname>
     <title>Bibliography</title>

--- a/testing/012/indexpage.xml
+++ b/testing/012/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/013/class_t1.xml
+++ b/testing/013/class_t1.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t1" kind="class" prot="public">
     <compoundname>T1</compoundname>
     <includes refid="013__class_8h" local="yes">inc/013_class.h</includes>

--- a/testing/013/class_t2.xml
+++ b/testing/013/class_t2.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t2" kind="class" prot="public">
     <compoundname>T2</compoundname>
     <includes refid="013__class_8h" local="no">013_class.h</includes>

--- a/testing/013/class_t3.xml
+++ b/testing/013/class_t3.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t3" kind="class" prot="public">
     <compoundname>T3</compoundname>
     <includes refid="013__class_8h" local="no">013_class.h</includes>

--- a/testing/013/class_t4.xml
+++ b/testing/013/class_t4.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t4" kind="class" prot="public">
     <compoundname>T4</compoundname>
     <includes refid="013__class_8h" local="yes">inc/013_class.h</includes>

--- a/testing/014/indexpage.xml
+++ b/testing/014/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/015/015__cond_8c.xml
+++ b/testing/015/015__cond_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="015__cond_8c" kind="file">
     <compoundname>015_cond.c</compoundname>
     <sectiondef kind="func">

--- a/testing/016/016__copydoc_8c.xml
+++ b/testing/016/016__copydoc_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="016__copydoc_8c" kind="file">
     <compoundname>016_copydoc.c</compoundname>
     <sectiondef kind="func">

--- a/testing/017/indexpage.xml
+++ b/testing/017/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/018/018__def_8c.xml
+++ b/testing/018/018__def_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="018__def_8c" kind="file">
     <compoundname>018_def.c</compoundname>
     <sectiondef kind="define">

--- a/testing/019/group__g1.xml
+++ b/testing/019/group__g1.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="group__g1" kind="group">
     <compoundname>g1</compoundname>
     <title>First Group</title>

--- a/testing/019/group__g2.xml
+++ b/testing/019/group__g2.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="group__g2" kind="group">
     <compoundname>g2</compoundname>
     <title>Second Group</title>

--- a/testing/019/group__g3.xml
+++ b/testing/019/group__g3.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="group__g3" kind="group">
     <compoundname>g3</compoundname>
     <title>Third Group</title>

--- a/testing/020/indexpage.xml
+++ b/testing/020/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/021/indexpage.xml
+++ b/testing/021/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/022/indexpage.xml
+++ b/testing/022/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/023/indexpage.xml
+++ b/testing/023/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/024/indexpage.xml
+++ b/testing/024/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/025/class_test.xml
+++ b/testing/025/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/025/example_test_8cpp-example.xml
+++ b/testing/025/example_test_8cpp-example.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="example_test_8cpp-example" kind="example">
     <compoundname>example_test.cpp</compoundname>
     <detaileddescription>

--- a/testing/026/class_test.xml
+++ b/testing/026/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" prot="public">
     <compoundname>Test</compoundname>
     <templateparamlist>

--- a/testing/027/struct_car.xml
+++ b/testing/027/struct_car.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_car" kind="struct" prot="public">
     <compoundname>Car</compoundname>
     <basecompoundref refid="struct_vehicle" prot="public" virt="non-virtual">Vehicle</basecompoundref>

--- a/testing/027/struct_object.xml
+++ b/testing/027/struct_object.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_object" kind="struct" prot="public">
     <compoundname>Object</compoundname>
     <derivedcompoundref refid="struct_vehicle" prot="public" virt="non-virtual">Vehicle</derivedcompoundref>

--- a/testing/027/struct_truck.xml
+++ b/testing/027/struct_truck.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_truck" kind="struct" prot="public">
     <compoundname>Truck</compoundname>
     <basecompoundref refid="struct_vehicle" prot="public" virt="non-virtual">Vehicle</basecompoundref>

--- a/testing/027/struct_vehicle.xml
+++ b/testing/027/struct_vehicle.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_vehicle" kind="struct" prot="public">
     <compoundname>Vehicle</compoundname>
     <basecompoundref refid="struct_object" prot="public" virt="non-virtual">Object</basecompoundref>

--- a/testing/028/indexpage.xml
+++ b/testing/028/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/029/029__hideinit_8c.xml
+++ b/testing/029/029__hideinit_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="029__hideinit_8c" kind="file">
     <compoundname>029_hideinit.c</compoundname>
     <sectiondef kind="var">

--- a/testing/030/indexpage.xml
+++ b/testing/030/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/031/indexpage.xml
+++ b/testing/031/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/032/indexpage.xml
+++ b/testing/032/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/033/indexpage.xml
+++ b/testing/033/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/034/indexpage.xml
+++ b/testing/034/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/035/035__invariant_8c.xml
+++ b/testing/035/035__invariant_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="035__invariant_8c" kind="file">
     <compoundname>035_invariant.c</compoundname>
     <sectiondef kind="func">

--- a/testing/036/036__link_8c.xml
+++ b/testing/036/036__link_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="036__link_8c" kind="file">
     <compoundname>036_link.c</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/037/class_receiver.xml
+++ b/testing/037/class_receiver.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_receiver" kind="class" prot="public">
     <compoundname>Receiver</compoundname>
     <sectiondef kind="public-func">

--- a/testing/037/class_sender.xml
+++ b/testing/037/class_sender.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_sender" kind="class" prot="public">
     <compoundname>Sender</compoundname>
     <sectiondef kind="public-func">

--- a/testing/038/indexpage.xml
+++ b/testing/038/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/039/class_test.xml
+++ b/testing/039/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="user-defined">

--- a/testing/040/namespace_n_s.xml
+++ b/testing/040/namespace_n_s.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="namespace_n_s" kind="namespace">
     <compoundname>NS</compoundname>
     <briefdescription>

--- a/testing/041/class_test.xml
+++ b/testing/041/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/042/namespaceorg_1_1doxygen_1_1_test.xml
+++ b/testing/042/namespaceorg_1_1doxygen_1_1_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="namespaceorg_1_1doxygen_1_1_test" kind="namespace">
     <compoundname>org::doxygen::Test</compoundname>
     <briefdescription>

--- a/testing/043/another.xml
+++ b/testing/043/another.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="another" kind="page">
     <compoundname>another</compoundname>
     <title>Another Page</title>

--- a/testing/043/mypage.xml
+++ b/testing/043/mypage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="mypage" kind="page">
     <compoundname>mypage</compoundname>
     <title>Page Title</title>

--- a/testing/044/struct_s.xml
+++ b/testing/044/struct_s.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_s" kind="struct" prot="public">
     <compoundname>S</compoundname>
     <includes refid="044__section_8h" local="no">044_section.h</includes>

--- a/testing/045/indexpage.xml
+++ b/testing/045/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/046/046__related_8cpp.xml
+++ b/testing/046/046__related_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="046__related_8cpp" kind="file">
     <compoundname>046_related.cpp</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/046/class_test.xml
+++ b/testing/046/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/047/047__return_8cpp.xml
+++ b/testing/047/047__return_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="047__return_8cpp" kind="file">
     <compoundname>047_return.cpp</compoundname>
     <sectiondef kind="func">

--- a/testing/048/048__showinit_8c.xml
+++ b/testing/048/048__showinit_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="048__showinit_8c" kind="file">
     <compoundname>048_showinit.c</compoundname>
     <sectiondef kind="var">

--- a/testing/049/indexpage.xml
+++ b/testing/049/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/050/indexpage.xml
+++ b/testing/050/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/051/indexpage.xml
+++ b/testing/051/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/052/indexpage.xml
+++ b/testing/052/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/053/indexpage.xml
+++ b/testing/053/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/054/054__parblock_8cpp.xml
+++ b/testing/054/054__parblock_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="054__parblock_8cpp" kind="file">
     <compoundname>054_parblock.cpp</compoundname>
     <sectiondef kind="func">

--- a/testing/055/md_055_markdown.xml
+++ b/testing/055/md_055_markdown.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="md_055_markdown" kind="page">
     <compoundname>md_055_markdown</compoundname>
     <title>055_markdown</title>

--- a/testing/056/indexpage.xml
+++ b/testing/056/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <project>
+    <projectname>My Project    </projectname>
+    <projectnumber/>
+    <projectbrief>    </projectbrief>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>


### PR DESCRIPTION
Adding the project\* elements to the the xml output.
- doxygen.cpp
  Extended logo copy function to be able to copy to a specified directory (instead of fixed directory specified by HTML_OUTPUT)  and copy logo in case of xml generation
- index.xsd
- compound.xsd
  Adjusting xsd file for new project elements
- xmlgen.cpp
  Added function to add project output and called it at the relevant places.
  Adjusted written xslt file to place the project only once in the result and be able to validate the result file against the general compound.xsd
  small layout correction for codeline
- testing
  Adjusted test output to new project elements
