### PR TITLE
Bug 692985 - Notes in xml output are not correctly separated

### DIFF
--- a/src/compound.xsd
+++ b/src/compound.xsd
@@ -473,7 +473,6 @@
       <xsd:element name="title" type="docTitleType" minOccurs="0" />
       <xsd:sequence minOccurs="0" maxOccurs="unbounded">
         <xsd:element name="para" type="docParaType" minOccurs="1" maxOccurs="unbounded" />
-        <xsd:element name="simplesectsep" type="docEmptyType" minOccurs="0"/>
       </xsd:sequence>
     </xsd:sequence>
     <xsd:attribute name="kind" type="DoxSimpleSectKind" />

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -337,9 +337,10 @@ void XmlDocVisitor::visit(DocIndexEntry *ie)
          "</indexentry>";
 }
 
-void XmlDocVisitor::visit(DocSimpleSectSep *)
+void XmlDocVisitor::visit(DocSimpleSectSep *dsss)
 {
-  m_t << "<simplesectsep/>";
+  visitPost((DocSimpleSect *)(dsss->parent()));
+  visitPre((DocSimpleSect *)(dsss->parent()));
 }
 
 void XmlDocVisitor::visit(DocCite *cite)


### PR DESCRIPTION
Replaced the simplesectsep element tag by a close and an open of a simplesect element tag
