### PR TITLE
Bug 623299 - Fortran: quotation after define causes error

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -173,6 +173,9 @@ static bool recognizeFixedForm(const char* contents, FortranFormat format)
         break;
       case ' ':
         break;
+      case '#':
+        skipLine=TRUE;
+        break;
       case '\000':
         return FALSE;
       case 'C':

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1333,6 +1333,9 @@ static bool recognizeFixedForm(const char* contents, FortranFormat format)
         break;
       case '\000':
         return FALSE;
+      case '#':
+        skipLine=TRUE;
+        break;
       case 'C':
       case 'c':
       case '*':


### PR DESCRIPTION
For the determination whether the file is free or fixed formatted code just see lines starting with # as comment lines
