### PR TITLE
Bug 728654 - configuration stops with settings.h missing

### DIFF
--- a/configure
+++ b/configure
@@ -51,7 +51,7 @@ f_libclangstatic=NO
 # first setup the list with availabe languages, so we cannot forget any
 # list will be in case as specified (f_langs) and in uppercase (f_ulangs) as used in the internal perl script
 #
-f_langs=`ls -1 src/translator_??.h | sed -e 's%src/translator_%%g' | sed -e 's/\.h//' | tr '\012' ',' | sed -e 's/,$//'`
+f_langs=`ls -1 src/translator_??.h | sed -e 's%src/translator_%%g' | sed -e 's/\.h//' | tr '\012' ','`
 
 while test -n "$1";  do
   case $1 in
@@ -708,13 +708,9 @@ fi
 
 # -----------------------------------------------------------------------------
 
-if ! test -d "generated_src/doxygen"; then
-  mkdir -p generated_src/doxygen
-fi
+mkdir -p generated_src/doxygen
 if test "$f_wizard" = YES; then
-  if ! test -d "generated_src/doxywizard"; then
-    mkdir -p generated_src/doxywizard
-  fi
+  mkdir -p generated_src/doxywizard
 fi
 
 #

--- a/src/lang_cfg.py
+++ b/src/lang_cfg.py
@@ -1,6 +1,6 @@
 import sys
 
-if (len(sys.argv) > 0):
+if (len(sys.argv) > 1):
     if (sys.argv[1] == "ENONLY"):
         print "#define ENGLISH_ONLY"
     else:


### PR DESCRIPTION
This bug fix fixes, in a general way, a number of issues encountered on Solaris
- configure
  - ! (exclamation mark) not recognized properly, but with mkdir -p no test is necessary (fix from Dimitri)
  - sed problem regarding removing last , (comma) in language list. Is automatically replaced in with a space when translating language names to upper case.
- lang_cfg.py
  - corrected check on number of arguments
