### PR TITLE
Bug 729236 - Added HIDE_COMPOUND_REFERENCE config option

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2050,9 +2050,16 @@ QCString ClassDef::title() const
   }
   else
   {
-    pageTitle = theTranslator->trCompoundReference(displayName(),
-              m_impl->compType == Interface && getLanguage()==SrcLangExt_ObjC ? Class : m_impl->compType,
-              m_impl->tempArgs != 0);
+    if (Config_getBool("HIDE_COMPOUND_REFERENCE"))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trCompoundReference(displayName(),
+                m_impl->compType == Interface && getLanguage()==SrcLangExt_ObjC ? Class : m_impl->compType,
+                m_impl->tempArgs != 0);
+    }
   }
   return pageTitle;
 }

--- a/src/config.xml
+++ b/src/config.xml
@@ -886,6 +886,15 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='bool' id='HIDE_COMPOUND_REFERENCE' defval='0'>
+      <docs>
+<![CDATA[
+ If the \c HIDE_COMPOUND_REFERENCE tag is set to \c NO (default) then
+ doxygen will append additional text to a page's title, such as Class Reference.
+ If set to \c YES the compound reference will be hidden. 
+]]>
+      </docs>
+    </option>
     <option type='bool' id='SHOW_INCLUDE_FILES' defval='1'>
       <docs>
 <![CDATA[


### PR DESCRIPTION
Added HIDE_COMPOUND_REFERENCE config option
- config.xml
  Added HIDE_COMPOUND_REFERENCE as a new bool config option.
- classref.cpp
  Use HIDE_COMPOUND_REFERENCE to determine whether trCompoundReference() is called
