### PR TITLE
Missing word after \n command in Doxygen rtf output, version 1.8.5 & up

### DIFF
--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -168,7 +168,7 @@ void RTFDocVisitor::visit(DocLineBreak *)
 {
   if (m_hide) return;
   DBG_RTF("{\\comment RTFDocVisitor::visit(DocLineBreak)}\n");
-  m_t << "\\par";
+  m_t << "\\par" << endl; 
   m_lastIsPara=TRUE;
 }
 


### PR DESCRIPTION
After a \par command no space or new line was present resulting in the joining of the \par with the first word after the \n.
Inserting an newline solves this problem
