### PR TITLE
Coded coloring of flow statements corrected (regression)

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -735,13 +735,13 @@ PREFIX    (RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,3}(RECURSIVE|I
                                         }
  /*-------- inner construct ---------------------------------------------------*/
  
-<Start>{COMMANDS}/[,( \t\n]             {  // highlight
+<Start>{COMMANDS}/{BS}[,( \t\n]         {  // highlight
    					  /* font class is defined e.g. in doxygen.css */
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  endFontClass();
 					}
-<Start>{FLOW}/[,( \t\n]                 {
+<Start>{FLOW}/{BS}[,( \t\n]               {
                                           if (g_isFixedForm)
                                           {
                                             if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;


### PR DESCRIPTION
Which patch 8e8c9a1 (dd. May 6) the rule:
<Start>{FLOW}/[,( \t\n].*
has been changed into"
<Start>{FLOW}/[,( \t\n]
(analogous: <Start>{COMMANDS}/[,( \t\n])
To overcome the warning: fortrancode.l:744: warning, dangerous trailing context.

The result is that the code coloring of (e.g.) the if statements in:
      subroutine test_on_if
        if (a == b) then
          c = d
        endif
        if(a == b) then
          c = d
        endif
      end subroutine
was removed, due to the fact that the rule: <Start>{ID}{BS}/"(" was used instead of the flow coloring rule.

This patch fixes the rules so the lines are colored again and there is no warning.
