### PR TITLE
Highlighting corrected for case statements without new line (regression)

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -751,7 +751,7 @@ PREFIX    (RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,3}(RECURSIVE|I
   					  codifyLines(yytext);
 					  endFontClass();
 					}
-<Start>^{BS}(CASE|CLASS|TYPE){BS_}(IS|DEFAULT) {
+<Start>{BS}(CASE|CLASS|TYPE){BS_}(IS|DEFAULT) {
                                           startFontClass("keywordflow");
                                           codifyLines(yytext);
                                           endFontClass();


### PR DESCRIPTION
Patch 8e8c9a1 introduced the incorrect requirement that FORTRAN case statements start on a new line. This patch fixes the relevant rule so that statements using semicolons are highlighted correctly.
