### PR TITLE
Fix unnecessary rules for FORTRAN user defined types

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -932,7 +932,7 @@ PREFIX    (RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,3}(RECURSIVE|I
 					  endFontClass();
   					}
 <Declaration>{ID}                       { // local var
-                                          if (g_currentMemberDef && !g_currentMemberDef->isFunction() && bracketCount==0)
+                                          if (g_currentMemberDef && g_currentMemberDef->isFunction() && bracketCount==0)
                                           {
                                             g_code->codify(yytext);
                                             addLocalVar(yytext);


### PR DESCRIPTION
This standardizes variable definitions using the "type", "class" and "procedure" keywords to be treated along with other variable definitions. This eliminates unnecessary matching constraints placed on these keywords  only.  @albert-github can you take a look at this and see if there are any cases I didn't think of? Thanks.

Also, moved "type" definition to its own rule to eliminate a "dangerous trailing context" warning.
