### PR TITLE
Bug 730418 - man page extension is incorrect

### DIFF
--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -56,7 +56,7 @@ static QCString getExtension()
         ext = ext.mid(1);
       }
     }
-    if (ext.at(0)<='0' || ext.at(0)>='9')
+    if (ext.at(0)<'0' || ext.at(0)>'9')
     {
       ext.prepend("3");
     }


### PR DESCRIPTION
Test in respect to handling extension was tone wit equal less than / greater than sign and should only be less than and greater than. Resulting in the fact that in case of a chosen extension starting with  .0 or .9 an 3 was pre-pended.
