### PR TITLE
make.bat: change current directory

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -249,6 +249,7 @@ static void writeMakeBat()
     t << mkidx_command << " refman.idx\n";
     t << "pdflatex refman\n";
     t << "cd /D %Dir_Old%\n";
+    t << "set Dir_Old=\n";
   }
 #endif
 }


### PR DESCRIPTION
First thing after calling make.bat: switch current directory to folder make.bat resides in.
Purpose: easy external call of make.bat.
/J.
