### PR TITLE
Removed not implemented HTML commands from documentation

### DIFF
--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -32,8 +32,6 @@ of a HTML tag are passed on to the HTML output only
 <li><tt>\</B\></tt>    Ends a <tt>\<B\></tt> section.
 <li><tt>\<BLOCKQUOTE\></tt> Starts a quotation block.
 <li><tt>\</BLOCKQUOTE\></tt> Ends the quotation block.
-<li><tt>\<BODY\></tt>  Does not generate any output.
-<li><tt>\</BODY\></tt> Does not generate any output.
 <li><tt>\<BR\></tt>    Forces a line break.
 <li><tt>\<CENTER\></tt> starts a section of centered text.
 <li><tt>\</CENTER\></tt> ends a section of centered text.
@@ -69,8 +67,6 @@ of a HTML tag are passed on to the HTML output only
 <li><tt>\<IMG\></tt>   This command is written with attributes to the HTML output only.
 <li><tt>\<LI\></tt>    Starts a new list item.
 <li><tt>\</LI\></tt>   Ends a list item.
-<li><tt>\<MULTICOL\></tt> ignored by doxygen.
-<li><tt>\</MUTLICOL\></tt> ignored by doxygen.
 <li><tt>\<OL\></tt>    Starts a numbered item list.
 <li><tt>\</OL\></tt>   Ends a numbered item list.
 <li><tt>\<P\></tt>     Starts a new paragraph.


### PR DESCRIPTION
This concerns the BODY and MULTICOL tags.
