### PR TITLE
\usepackage{fixltx2e} must come before use \usepackage{float}

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -290,6 +290,7 @@ static void writeDefaultHeaderPart1(FTextStream &t)
 
   // Load required packages
   t << "% Packages required by doxygen\n"
+       "\\usepackage{fixltx2e}\n" // for \textsubscript
        "\\usepackage{calc}\n"
        "\\usepackage{doxygen}\n"
        "\\usepackage{graphicx}\n"
@@ -297,7 +298,6 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\\usepackage{makeidx}\n"
        "\\usepackage{multicol}\n"
        "\\usepackage{multirow}\n"
-       "\\usepackage{fixltx2e}\n" // for \textsubscript
        "\\PassOptionsToPackage{warn}{textcomp}\n"
        "\\usepackage{textcomp}\n"
        "\\usepackage[nointegrals]{wasysym}\n"


### PR DESCRIPTION
The \usepackage{doxygen} statement adds float as a depenency.
If the order is wrong the latex generation fails with:
LaTeX Error: Unknown float option `H'
