### PR TITLE
Resolves the error of unbalanced tags opened/closed in docbook output

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1005,7 +1005,16 @@ void DocbookDocVisitor::visitPre(DocParamSect *s)
         break;
       }
     case DocParamSect::Exception:
-      m_t << "exception"; break;
+      {
+        m_t <<  endl;
+        m_t << "                <formalpara>" << endl;
+        m_t << "                    <title/>" << endl;
+        m_t << "                    <table frame=\"all\">" << endl;
+        m_t << "                        <title>Exceptions</title>" << endl;
+        m_t << "                        <tgroup cols=\"2\" align=\"left\" colsep=\"1\" rowsep=\"1\">" << endl;
+        m_t << "                        <tbody>" << endl;
+        break;
+      }
     case DocParamSect::TemplateParam:
       m_t << "templateparam"; break;
     default:


### PR DESCRIPTION
Resolves the error of unbalanced tags opened/closed in docbook output: parser error : Opening and ending tag mismatch: para line 358 and tbody

This occurs only when Exceptions are documented (in Java, maybe in other languages that have exceptions).

This error appears in any docbook output of a class with any method that throws an exception: simply xmllint all of the resulting docbook/class*xml files, you'll see they have unbalanced elements such as the example at top of para on the functions with exceptions.

The error may also occur with documented template parameters.

I'm not sure this matches the intended result, but this result no longer fails, and works well enough for me.

make test, Checking 1...58, 012_cite.dox fails due to missing bibtex (since I don't have latex, I don't have any ~tex executables.  Maybe you need latex for this).  This test also fails without my patch.  Otherwise, all tests still pass.
