### PR TITLE
Bug 589707 - Flex .rule file for Visual Studio build can't cope with spaces in filenames

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -17,7 +17,7 @@ all: language config.doc FORCE
 	export DOXYGEN_DOCDIR; \
         VERSION=$(VERSION) ; \
 	export VERSION; \
-	$(DOXYGEN)/bin/doxygen
+	"$(DOXYGEN)/bin/doxygen"
 	@rm -f ../latex/refman.tex
 	@cp doxygen_logo*.gif ../html
 	@cp Makefile.latex ../latex/Makefile

--- a/winbuild/Config.rules
+++ b/winbuild/Config.rules
@@ -7,7 +7,7 @@
 		<CustomBuildRule
 			Name="Config"
 			DisplayName="Config"
-			CommandLine="python $(ProjectDir)..\src\configgen.py -cpp [AllOptions] [AdditionalOptions] [inputs] &gt; $(IntDir)/$(InputName)options.cpp"
+			CommandLine="python &quot;$(ProjectDir)..\src\configgen.py&quot; -cpp [AllOptions] [AdditionalOptions] [inputs] &gt; $(IntDir)/$(InputName)options.cpp"
 			Outputs="$(IntDir)/$(InputName)options.cpp"
 			FileExtensions="*.xml"
 			AdditionalDependencies="$(ProjectDir)..\src\configgen.py"
@@ -18,7 +18,7 @@
 		<CustomBuildRule
 			Name="Config_dw"
 			DisplayName="Config"
-			CommandLine="python $(ProjectDir)..\src\configgen.py -wiz [AllOptions] [AdditionalOptions] [inputs]  &gt; $(IntDir)/$(InputName)doc.cpp"
+			CommandLine="python &quot;$(ProjectDir)..\src\configgen.py&quot; -wiz [AllOptions] [AdditionalOptions] [inputs]  &gt; $(IntDir)/$(InputName)doc.cpp"
 			Outputs="$(IntDir)/$(InputName)doc.cpp"
 			FileExtensions="*.xml"
 			AdditionalDependencies="$(ProjectDir)..\src\configgen.py"

--- a/winbuild/Doxygen.vcproj
+++ b/winbuild/Doxygen.vcproj
@@ -948,7 +948,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="Running bison on constexp.y"
-						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
+						CommandLine="bison -l -d -p ce_parseexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
 						Outputs="$(IntDir)\ce_parse.cpp"
 					/>
 				</FileConfiguration>
@@ -958,7 +958,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="Running bison on constexp.y"
-						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
+						CommandLine="bison -l -d -p ce_parseexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
 						Outputs="$(IntDir)\ce_parse.cpp"
 					/>
 				</FileConfiguration>
@@ -968,7 +968,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="Running bison on constexp.y"
-						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
+						CommandLine="bison -l -d -p ce_parseexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
 						Outputs="$(IntDir)\ce_parse.cpp"
 					/>
 				</FileConfiguration>
@@ -978,7 +978,7 @@
 					<Tool
 						Name="VCCustomBuildTool"
 						Description="Running bison on constexp.y"
-						CommandLine="bison -l -d -p ce_parseexpYY $(InputPath) -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY $(InputPath) -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
+						CommandLine="bison -l -d -p ce_parseexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.c&#x0D;&#x0A;bison -l -p constexpYY &quot;$(InputPath)&quot; -o $(IntDir)\ce_parse.cpp&#x0D;&#x0A;del $(IntDir)\ce_parse.c&#x0D;&#x0A;"
 						Outputs="$(IntDir)\ce_parse.cpp"
 					/>
 				</FileConfiguration>

--- a/winbuild/Gen_head.rules
+++ b/winbuild/Gen_head.rules
@@ -7,7 +7,7 @@
 		<CustomBuildRule
 			Name="Gen_head"
 			DisplayName="Gen_head"
-			CommandLine="python $(ProjectDir)..\src\to_c_cmd.py [AllOptions] [AdditionalOptions] [inputs] &lt; $(InputPath) &gt; $(IntDir)/$(InputName)$(InputExt).h"
+			CommandLine="python &quot;$(ProjectDir)..\src\to_c_cmd.py&quot; [AllOptions] [AdditionalOptions] [inputs] &lt; &quot;$(InputPath)&quot; &gt; $(IntDir)/$(InputName)$(InputExt).h"
 			Outputs="$(IntDir)/$(InputName)$(InputExt).h"
 			FileExtensions=".*"
 			AdditionalDependencies="$(ProjectDir)..\src\to_c_cmd.py"

--- a/winbuild/Languages.rules
+++ b/winbuild/Languages.rules
@@ -6,8 +6,8 @@
         <Rules>
                 <CustomBuildRule
                         Name="Languages"
-                        DisplayName="Settings"
-                        CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] &gt; $(IntDir)/$(InputName).h"
+                        DisplayName="Languages"
+                        CommandLine="python &quot;$(InputPath)&quot; [AllOptions] [AdditionalOptions] &gt; $(IntDir)/$(InputName).h"
                         Outputs="$(IntDir)/$(InputName).h"
                         FileExtensions="*.py"
                         AdditionalDependencies=""

--- a/winbuild/Lex.rules
+++ b/winbuild/Lex.rules
@@ -7,7 +7,7 @@
 		<CustomBuildRule
 			Name="Lex"
 			DisplayName="Lex"
-			CommandLine="flex [AllOptions] -t -P$(InputName)YY [AdditionalOptions] [inputs] | python $(ProjectDir)..\src\increasebuffer.py &gt; $(IntDir)/$(InputName).cpp"
+			CommandLine="flex [AllOptions] -t -P$(InputName)YY [AdditionalOptions] [inputs] | python &quot;$(ProjectDir)..\src\increasebuffer.py&quot; &gt; $(IntDir)/$(InputName).cpp"
 			Outputs="$(IntDir)/$(InputName).cpp"
 			FileExtensions="*.l"
 			AdditionalDependencies="$(ProjectDir)..\src\increasebuffer.py"

--- a/winbuild/Settings.rules
+++ b/winbuild/Settings.rules
@@ -7,7 +7,7 @@
 		<CustomBuildRule
 			Name="Settings"
 			DisplayName="Settings"
-			CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] $(IntDir)"
+			CommandLine="python &quot;$(InputPath)&quot; [AllOptions] [AdditionalOptions] $(IntDir)"
 			Outputs="$(IntDir)/$(InputName).h"
 			FileExtensions="*.py"
 			AdditionalDependencies="$(ProjectDir)..\configure"

--- a/winbuild/Unistd.rules
+++ b/winbuild/Unistd.rules
@@ -7,7 +7,7 @@
 		<CustomBuildRule
 			Name="Unistd"
 			DisplayName="Unistd"
-			CommandLine="python $(InputPath) [AllOptions] [AdditionalOptions] $(IntDir)"
+			CommandLine="python &quot;$(InputPath)&quot; [AllOptions] [AdditionalOptions] $(IntDir)"
 			Outputs="$(IntDir)/$(InputName).h"
 			FileExtensions="*.py"
 			ExecutionDescription="Executing Unistd ..."

--- a/winbuild/Version.rules
+++ b/winbuild/Version.rules
@@ -7,7 +7,7 @@
 		<CustomBuildRule
 			Name="Version"
 			DisplayName="Version"
-			CommandLine="python $(InputPath) $(IntDir)"
+			CommandLine="python &quot;$(InputPath)&quot; $(IntDir)"
 			Outputs="$(IntDir)\$(InputName).cpp"
 			FileExtensions="*.py"
 			AdditionalDependencies="$(ProjectDir)..\configure"

--- a/winbuild/moc.rules
+++ b/winbuild/moc.rules
@@ -7,7 +7,7 @@
 		<CustomBuildRule
 			Name="moc"
 			DisplayName="Moc"
-			CommandLine="$(QTDIR)/bin/moc.exe $(InputPath) -o moc_$(InputName).cpp"
+			CommandLine="$(QTDIR)/bin/moc.exe &quot;$(InputPath)&quot; -o moc_$(InputName).cpp"
 			Outputs="moc_$(InputName).cpp"
 			AdditionalDependencies="$(QTDIR)/bin/moc.exe"
 			FileExtensions="*.h"


### PR DESCRIPTION
Adjusted the rules files and where and the vcproj file so it can handle paths with spaces as well.
When generating the documentation (Cygwin) a small problem appeared in a Makefile when there is a space in the path, this is solved as well.
