### PR TITLE
Bug 702584 - \cite rejects valid BibTeX keys

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -58,6 +58,10 @@ static QCString getListOfBibFiles(const QCString &sep,bool namesOnly)
     {
       bibFile = bibFile.left(bibFile.length()-4);
     }
+    else
+    {
+      if (!namesOnly && bibFile.right(4)!=".bib") bibFile += ".bib";
+    }
     if ((i=bibFile.findRev('/'))!=-1) // strip path
     {
       bibFile = bibFile.mid(i+1);


### PR DESCRIPTION
According to the documentation the .bib is automatically added to the names in the CITE_BIB_FILES. In the example given with this bug this was not the case.
In case CITE_BIB_FILES was set to 'my.bib' it was working, but with only 'my' it wasn't.
