### PR TITLE
Bug 705503 - TCL: Documentation of oo::define is not working

### DIFF
--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -2195,15 +2195,62 @@ D
   }
   myEntryCl = tcl_entry_class(myName);
   myStr = (*tcl.list_commandwords.at(4)).utf8();
-  if (tcl.list_commandwords.count() > 5)
+  //
+  // special cases first
+  // oo::define classname method methodname args script
+  // oo::define classname constructor argList bodyScript
+  // oo::define classname destructor bodyScript
+  unsigned int n =tcl.list_commandwords.count();
+  if ((myStr == "method"      && n == 11) ||
+      (myStr == "constructor" && n == 9) ||
+      (myStr == "destructor"  && n == 7))
   {
-    for (uint i=5;i<tcl.list_commandwords.count();i++)
+    for (unsigned int i = 4; i < n-1; i++)
     {
-      myStr.append((*tcl.list_commandwords.at(i)).utf8());
+      tcl_codify_cmd("NULL",i);
     }
-    tcl.word_is=' ';
+    Entry *myEntry;
+    QCString myMethod;
+    tcl_name(myScan->ns,(*tcl.list_commandwords.at(n==11?6:4)).utf8(),myNs,myMethod);
+    // code snippet taken from tcl_command_METHOD()/tcl_command_CONSTRUCTOR
+    tcl.fn.remove(myMethod);
+    tcl.entry_current->section = Entry::FUNCTION_SEC;
+    tcl.entry_current->mtype = Method;
+    tcl.entry_current->name = myMethod;
+    tcl.entry_current->startLine = tcl.line_command;
+    tcl.entry_current->bodyLine = tcl.line_body0;
+    tcl.entry_current->endBodyLine = tcl.line_body1;
+    tcl_protection(tcl.entry_current);
+    if (n==11)
+    {
+      tcl_command_ARGLIST(*tcl.list_commandwords.at(8));
+    }
+    else if (n==9)
+    {
+      tcl_command_ARGLIST(*tcl.list_commandwords.at(6));
+    }
+    if (myEntryCl) myEntryCl->addSubEntry(tcl.entry_current);
+    tcl.fn.insert(myMethod,tcl.entry_current);
+    myEntry = tcl.entry_current;
+    myScan = tcl_scan_start('?',*tcl.list_commandwords.at(n-1),
+          myNs, myEntryCl, myEntry);
   }
-  myScan = tcl_scan_start(tcl.word_is,myStr,myName,myEntryCl,NULL);
+  else
+  {
+    // The general case
+    // Simply concat all arguments into a script.
+    // Note: all documentation collected just before the
+    // oo::define command is lost
+    if (tcl.list_commandwords.count() > 5)
+    {
+      for (uint i=5;i<tcl.list_commandwords.count();i++)
+      {
+        myStr.append((*tcl.list_commandwords.at(i)).utf8());
+      }
+      tcl.word_is=' ';
+    }
+    myScan = tcl_scan_start(tcl.word_is,myStr,myName,myEntryCl,NULL);
+  }
 }
 
 //! Handle \c variable statements.

--- a/testing/061/class_test.xml
+++ b/testing/061/class_test.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="class_test" kind="class" prot="public">
+    <compoundname>Test</compoundname>
+    <sectiondef kind="public-func">
+      <memberdef kind="function" id="class_test_1af863c78bca81b4e276dcbb30f12e8ec6" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type/>
+        <definition>Test::testmethod_one</definition>
+        <argsstring>args</argsstring>
+        <name>testmethod_one</name>
+        <briefdescription>
+          <para><ref refid="class_test" kindref="compound">Test</ref> method 1. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="061_bug_705503.tcl" bodystart="12" bodyend="12"/>
+      </memberdef>
+      <memberdef kind="function" id="class_test_1ac7148d2852b30d157e078fe0fe58a350" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type/>
+        <definition>Test::constructor</definition>
+        <argsstring>args</argsstring>
+        <name>constructor</name>
+        <briefdescription>
+          <para>Construction of class. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="061_bug_705503.tcl" bodystart="16" bodyend="16"/>
+      </memberdef>
+      <memberdef kind="function" id="class_test_1abdf3375950ec49e29f4bae947b7e3f26" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type/>
+        <definition>Test::testmethod_two</definition>
+        <argsstring>args</argsstring>
+        <name>testmethod_two</name>
+        <briefdescription>
+          <para><ref refid="class_test" kindref="compound">Test</ref> method 2. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="061_bug_705503.tcl" bodystart="19" bodyend="19"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>Testclass. </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="061_bug_705503.tcl" bodystart="10" bodyend="13"/>
+    <listofallmembers>
+      <member refid="class_test_1ac7148d2852b30d157e078fe0fe58a350" prot="public" virt="non-virtual">
+        <scope>Test</scope>
+        <name>constructor</name>
+      </member>
+      <member refid="class_test_1af863c78bca81b4e276dcbb30f12e8ec6" prot="public" virt="non-virtual">
+        <scope>Test</scope>
+        <name>testmethod_one</name>
+      </member>
+      <member refid="class_test_1abdf3375950ec49e29f4bae947b7e3f26" prot="public" virt="non-virtual">
+        <scope>Test</scope>
+        <name>testmethod_two</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/061_bug_705503.tcl
+++ b/testing/061_bug_705503.tcl
@@ -1,0 +1,19 @@
+#// objective: test for bug 705503 - TCL: Documentation of oo::define is not working
+#// check: class_test.xml
+#// config: EXTRACT_ALL = yes
+
+# taken from
+# https://bugzilla.gnome.org/show_bug.cgi?id=705503
+
+## @class Test
+# @brief Testclass
+oo::class create Test {
+	## @brief Test method 1.
+	method testmethod_one args {}
+}
+
+## @brief Construction of class
+oo::define Test constructor args {}
+
+## @brief Test method 2
+oo::define Test method testmethod_two args {}


### PR DESCRIPTION
This is a proposal. It solves the special case decribed in the bug report and also similar cases. However, I am not very familiar with tcloo and how such code is typically documented. Somebody should double check for side effects.
