### PR TITLE
Bug 155426 - filename extension wrong in Latex when image name contains a dot

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1092,7 +1092,9 @@ void LatexDocVisitor::visitPre(DocImage *img)
              "  \\mbox{";
     }
     QCString gfxName = img->name();
-    if (gfxName.right(4)==".eps" || gfxName.right(4)==".pdf")
+    QFileInfo gfx(gfxName);
+    QString completeSuffix(gfx.extension(TRUE));
+    if (completeSuffix=="eps" || completeSuffix=="pdf")
     {
       gfxName=gfxName.left(gfxName.length()-4);
     }


### PR DESCRIPTION
Only if the completeSuffix is eps or pdf strip it away, otherwise leave it.
Note: the version of Qt used uses the method extension, newer versions use the method completeSuffix
