### PR TITLE
Tcl: Bug 729092

### DIFF
--- a/testing/063/namespaceoo.xml
+++ b/testing/063/namespaceoo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespaceoo" kind="namespace">
+    <compoundname>oo</compoundname>
+    <innernamespace refid="namespaceoo_1_1define">oo::define</innernamespace>
+    <innernamespace refid="namespaceoo_1_1_helpers">oo::Helpers</innernamespace>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="[generated]" line="1" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/063/namespaceoo_1_1_helpers.xml
+++ b/testing/063/namespaceoo_1_1_helpers.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespaceoo_1_1_helpers" kind="namespace">
+    <compoundname>oo::Helpers</compoundname>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="namespaceoo_1_1_helpers_1a96c5b755588beb2e930cff23ce811d6c" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type/>
+        <definition>oo::Helpers::classvar</definition>
+        <argsstring>args</argsstring>
+        <name>classvar</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>Extension to TclOO to add static variables. Defines variables on the class instead of on the object. Can be used to enforce a limited number of instantiations. <simplesect kind="warning"><para>Do not modify! (unless you're waaay smarter than the writer of the below Tcl/Tk book). flynt2012tcl </para></simplesect>
+</para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="063_bug_729092.tcl" bodystart="40" bodyend="49"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="063_bug_729092.tcl" line="1" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/063/namespaceoo_1_1define.xml
+++ b/testing/063/namespaceoo_1_1define.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespaceoo_1_1define" kind="namespace">
+    <compoundname>oo::define</compoundname>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="namespaceoo_1_1define_1a89e7ea222a316f1926c1f9f30f2cc5c1" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type/>
+        <definition>oo::define::classmethod</definition>
+        <argsstring>name?args??body?</argsstring>
+        <name>classmethod</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>Extension to TclOO to add static methods. Defines the method on the class instead of on the object. Can be used for the creation of megawidgets using TclOO by overriding the unknown method to detect if the user is trying to instantiate a widget (because the method will be unknown and start with a dot). <simplesect kind="warning"><para>Do not modify! (unless you're waaay smarter than the writer of the below Tcl/Tk book). flynt2012tcl </para></simplesect>
+</para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="063_bug_729092.tcl" bodystart="21" bodyend="30"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="063_bug_729092.tcl" line="1" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/063_bug_729092.tcl
+++ b/testing/063_bug_729092.tcl
@@ -1,0 +1,49 @@
+#// objective: test for bug 729092 - TCL: Full documentation not shown for procs in namespaces.
+#// check: namespaceoo.xml
+#// check: namespaceoo_1_1_helpers.xml
+#// check: namespaceoo_1_1define.xml
+#// config: EXTRACT_ALL = yes
+#// config: GENERATE_HTML = yes
+
+# taken from
+# https://bugzilla.gnome.org/show_bug.cgi?id=729092
+
+##
+# Extension to TclOO to add static methods.
+# Defines the method on the class instead of on the object. Can be used for
+# the creation of megawidgets using TclOO by overriding the unknown method to
+# detect if the user is trying to instantiate a widget (because the method
+# will be unknown and start with a dot).
+# @warning Do not modify! (unless you're waaay smarter than the writer of the
+# below Tcl/Tk book).
+# @cite flynt2012tcl
+#
+proc ::oo::define::classmethod {name {args ""} {body ""}} {
+    # Create the method on the class if the caller gave arguments and body.
+    if {[llength [info level 0]] == 4} {
+        uplevel 1 [list self method $name $args $body]
+    }
+    # Get the name of the class being defined.
+    set cls [lindex [info level -1] 1]
+    # Make connection to private class "my" command by forwarding.
+    uplevel forward $name [info object namespace $cls]::my $name
+}
+
+##
+# Extension to TclOO to add static variables.
+# Defines variables on the class instead of on the object. Can be used to
+# enforce a limited number of instantiations.
+# @warning Do not modify! (unless you're waaay smarter than the writer of the
+# below Tcl/Tk book).
+# @cite flynt2012tcl
+#
+proc ::oo::Helpers::classvar {args} {
+    # Get reference to class's namespace.
+    set nsCl [info object namespace [uplevel 1 {self class}]]
+    set nsObj [uplevel 1 {namespace current}]
+    # Link variables into local (caller's) scope.
+    foreach v $args {
+        uplevel "my variable $v"
+        upvar #0 ${nsCl}::$v ${nsObj}::$v
+    }
+}


### PR DESCRIPTION
Looks ok for me under Windows.

Cannot reproduce the described behaviour. Neither with 1.8.4 nor with current tip.
I always get a detailed description and no 'More...' link.

There is no @brief tag in the example code.Even if I add a @brief tag then I will not see the decribed behaviour. 
