### PR TITLE
Bug 645165 - Last member of a group is not documented with "documentation after member" feature

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -203,6 +203,8 @@ documentation:
 \refitem cmdtilde \\~
 \refitem cmdlt \\\<
 \refitem cmdgt \\\>
+\refitem cmdgroupopen \\{
+\refitem cmdgroupclose \\}
 \refitem cmdhash \\\#
 \refitem cmdperc \\\%
 \refitem cmdquot \\\"
@@ -233,7 +235,7 @@ Structural indicators
   any of the commands.
 
   The title is optional, so this command can also be used to add a number of
-  entities to an existing group using \c \@{ and \c \@} like this:
+  entities to an existing group using \ref cmdgroupopen "\@{" and \ref cmdgroupclose "\@}" like this:
 
 \verbatim
   /*! \addtogroup mygrp
@@ -696,7 +698,8 @@ Structural indicators
   <code>//\@{ ... //\@}</code> block containing the
   members of the group.
 
-  See section \ref memgroup for an example.
+  \sa sections \ref cmdgroupopen "\@{" and \ref cmdgroupclose "\@}".
+  \sa \ref memgroup for an example.
 
 <hr>
 \section cmdnamespace \\namespace <name>
@@ -3036,6 +3039,26 @@ class Receiver
   \addindex \\\>
   This command writes the \c \> character to the output. This
   character has to be escaped because it has a special meaning in HTML.
+
+<hr>
+\section cmdgroupopen \\{
+
+  \addindex \\{
+  This command starts a grouping block in the documentation.
+  \note Due to the limited possibilities of detecting of continuation lines, it
+        is advised to to have a comment block with this comment as a separate
+        comment line and having it followed by a non doxygen comment line.
+  \sa section \ref cmdgroupclose "\\}" and section \ref grouping "grouping".
+
+<hr>
+\section cmdgroupclose \\}
+
+  \addindex \\}
+  This command ends a grouping block in the documentation.
+  \note Due to the limited possibilities of detecting of continuation lines, it
+        is advised to to have a comment block with this comment as a separate
+        comment line and having it preceded by a non doxygen comment line.<br>
+  \sa section \ref cmdgroupopen "\\{" and section \ref grouping "grouping".
 
 <hr>
 \section cmdperc \\\%

--- a/doc/grouping.doc
+++ b/doc/grouping.doc
@@ -42,8 +42,8 @@ a \ref cmdingroup "\\ingroup" command inside its documentation block.
 
 To avoid putting \ref cmdingroup "\\ingroup" commands in the documentation
 for each member you can also group members together by the 
-open marker <code>\@{</code> before the group and the 
-closing marker <code>\@}</code> after the group. The markers can 
+open marker \ref cmdgroupopen "\@{" before the group and the 
+closing marker \ref cmdgroupclose "\@}" after the group. The markers can 
 be put in the documentation of the group definition or in a separate 
 documentation block. 
 
@@ -76,7 +76,8 @@ or file, but only visible as part of a group).
 
 Doxygen will put members into the group whose definition has
 the highest "priority": e.g. An explicit \ref cmdingroup "\\ingroup" overrides 
-an implicit grouping definition via <code>\@{</code> <code>\@}</code>. 
+an implicit grouping definition via a block with \ref cmdgroupopen "\@{" and
+\ref cmdgroupclose "\@}".
 Conflicting grouping definitions with the same priority trigger a warning, 
 unless one definition was for a member without any explicit documentation. 
 


### PR DESCRIPTION
Due to the limited possibilities to detect continuation lines the commands \{ and \} have been documented together with a note about this limitation.
