### PR TITLE
Add USE_METHOD_NAME_FOR_ANCHORS.

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3361,6 +3361,16 @@ remove the intermediate dot files that are used to generate the various graphs.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='USE_METHOD_NAME_FOR_ANCHORS' defval='0'>
+      <docs>
+<![CDATA[
+If the \c USE_METHOD_NAME_FOR_ANCHORS tag is set to \c YES then anchor links (#)
+will use the method name rather than an md5 hash.
+Notice: this does not differentiate between identical method names in the
+same file.
+]]>
+      </docs>
+    </option>
 
     <option type='obsolete' id='USE_WINDOWS_ENCODING'/>
     <option type='obsolete' id='DETAILS_AT_TOP'/>

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3312,6 +3312,13 @@ static QCString escapeAnchor(const QCString &anchor)
 
 void MemberDef::setAnchor()
 {
+  if (Config_getBool("USE_METHOD_NAME_FOR_ANCHORS"))
+  {
+    // TODO: Handle conflicting anchors.
+    m_impl->anc = name();
+    return;
+  }
+
   QCString memAnchor = name();
   if (!m_impl->args.isEmpty()) memAnchor+=m_impl->args;
 


### PR DESCRIPTION
This new option makes it possible to choose to generate "nice" anchors.

This is off by default due to the fact that this does not handle cases of duplicate method names gracefully. If you have insight on a way to handle this sensibly I'd be happy to incorporate the changes.

This change is being used in production at nimbuskit.info. Example url: http://v2.nimbuskit.info/CDCDecoder.html#mergePolicy.
