### PR TITLE
Add HIDE_INHERITS_FROM.

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1213,7 +1213,7 @@ void ClassDef::writeInheritanceGraph(OutputList &ol)
     ol.disableAllBut(OutputGenerator::Man);
   }
 
-  if (m_impl->inherits && (count=m_impl->inherits->count())>0)
+  if (!Config_getBool("HIDE_INHERITS_FROM") && m_impl->inherits && (count=m_impl->inherits->count())>0)
   {
     ol.startParagraph();
     //parseText(ol,theTranslator->trInherits()+" ");

--- a/src/config.xml
+++ b/src/config.xml
@@ -3361,6 +3361,14 @@ remove the intermediate dot files that are used to generate the various graphs.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='HIDE_INHERITS_FROM' defval='0'>
+      <docs>
+<![CDATA[
+If the \c HIDE_INHERITS_FROM tag is set to \c YES then the "inherits from" text
+will not appear in class definitions.
+]]>
+      </docs>
+    </option>
 
     <option type='obsolete' id='USE_WINDOWS_ENCODING'/>
     <option type='obsolete' id='DETAILS_AT_TOP'/>


### PR DESCRIPTION
This new option makes it possible to specifically disable the "Inherits from" text that appears in class definitions.

This option is off by default.

This is being used at nimbuskit.info. For example: http://v2.nimbuskit.info/CURExpenseActor.html
