### PR TITLE
Add BREAD_CRUMB_TRAIL.

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3361,6 +3361,14 @@ remove the intermediate dot files that are used to generate the various graphs.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='BREAD_CRUMB_TRAIL' defval='0'>
+      <docs>
+<![CDATA[
+If the \c BREAD_CRUMB_TRAIL tag is set to \c YES then the complete bread crumb
+trail for a page will be displayed rather than just the root group.
+]]>
+      </docs>
+    </option>
 
     <option type='obsolete' id='USE_WINDOWS_ENCODING'/>
     <option type='obsolete' id='DETAILS_AT_TOP'/>


### PR DESCRIPTION
Add BREAD_CRUMB_TRAIL.

This feature enables recursive printing of the bread crumbs for any
page, rather than just printing the parent group.

This is being used at nimbuskit.info. Example: http://v2.nimbuskit.info/NimbusKitCoreDataCodingConfigurationOptions.html.

![screen shot 2014-07-19 at 1 53 56 pm](https://cloud.githubusercontent.com/assets/45670/3634047/8056e3a8-0f11-11e4-9f13-c08269ed3db7.png)
