### PR TITLE
Bug 733856 - segfault in QGListIterator while parsing fortran code

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1128,6 +1128,8 @@ PREFIX    (RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,3}(RECURSIVE|I
             }
                                           YY_FTN_RESET
   					}
+<*>^{BS}"type"{BS}"="                     { g_code->codify(yytext); }
+
 <*>.					{ 
   					  g_code->codify(yytext);
 					}

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -739,6 +739,7 @@ private                                 {
 {ID}	                               {
                                        }  
 ^{BS}"type"{BS_}"is"/{BS_}             { }
+^{BS}"type"{BS}"="                     { }
 }
 <AttributeList>{
 {COMMA}					{}


### PR DESCRIPTION
Problem with variables with the name type versus type definitions.
type followed by = is recognized as not being a type definition instead of the use of a variable.
