### PR TITLE
Messages truncated in warnings file

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -152,15 +152,15 @@ static void format_warn(const char *file,int line,const char *text)
 static void do_warn(const char *tag, const char *file, int line, const char *prefix, const char *fmt, va_list args)
 {
   if (!Config_getBool(tag)) return; // warning type disabled
-  char text[4096];
+  char text[40960];
   int l=0;
   if (prefix)
   {
     strcpy(text,prefix);
     l=strlen(prefix);
   }
-  vsnprintf(text+l, 4096-l, fmt, args);
-  text[4095]='\0';
+  vsnprintf(text+l, 40960-l, fmt, args);
+  text[40960-1]='\0';
   format_warn(file,line,text);
 }
 


### PR DESCRIPTION
The current limit for a message length in the messages file is 4095 characters. Most of the time this is more than sufficient, but in case of Fortran and a lot of arguments this might not be sufficient.
With Fortran the "data type" can be quite long as it can also includes words like: double precision, dimension, intent(inout) etc. When we have a lot of arguments and just one is described it also tries to write out the names of the non-described parameter/ arguments with the word parameter prepended resulting in an even longer line.

This patch increases the size of the buffer.
