### PR TITLE
Error linking 32-bit windows

### DIFF
--- a/winbuild/Doxygen.vcproj
+++ b/winbuild/Doxygen.vcproj
@@ -127,7 +127,7 @@
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="Debug"
 				GenerateManifest="false"
-				IgnoreDefaultLibraryNames="libcmtd.lib"
+				IgnoreDefaultLibraryNames="libcmtd.lib libcpmtd.lib libcmt.lib"
 				GenerateDebugInformation="true"
 				ProgramDatabaseFile=".\Debug\doxygen\$(TargetName).pdb"
 				SubSystem="1"


### PR DESCRIPTION
On Windows there were unresolved debug symbols resulting from libcpmtd. Adding this file to the ignore list solves the link issue. Remains:
LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library
even though libcmt is added.
