### PR TITLE
No warning in case cite definition is missing

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -235,7 +235,7 @@ void CiteDict::generatePage() const
   f.setName(citeListFile);
   if (!f.open(IO_ReadOnly)) 
   {
-    err("could not open file %s/citelist.doc for reading\n",outputDir.data());
+    err("could not open file %s for reading\n",citeListFile.data());
   }
   bool insideBib=FALSE;
   

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2465,7 +2465,7 @@ DocCite::DocCite(DocNode *parent,const QCString &target,const QCString &) //cont
   ASSERT(!target.isEmpty());
   m_relPath = g_relPath;
   CiteInfo *cite = Doxygen::citeDict->find(target);
-  if (numBibFiles>0 && cite) // ref to citation
+  if (numBibFiles>0 && cite && cite -> text) // ref to citation
   {
     m_text         = cite->text;
     if (m_text.isEmpty()) m_text = cite->label;


### PR DESCRIPTION
In case the \cite command is used but no entry for it is given in a bib file no warning is given as the CiteInfo entry is present with the right label, but the text item is empty and this is not tested.

(also corrected an error message on opening a file)
