### PR TITLE
Support multiple extra HTML stylesheets.

### DIFF
--- a/doc/customize.doc
+++ b/doc/customize.doc
@@ -110,8 +110,8 @@ This will create 3 files:
   link to www.doxygen.org and the body and html end tags.
 - customdoxygen.css is the default cascading style sheet
   used by doxygen. It is recommended only to look into this file and overrule
-  some settings you like by putting them in a separate stylesheet and
-  referencing that extra file 
+  some settings you like by putting them in a separate stylesheets and
+  referencing those extra files
   via \ref cfg_html_extra_stylesheet "HTML_EXTRA_STYLESHEET".
 
 You should edit these files and then reference them from the config file.

--- a/src/config.xml
+++ b/src/config.xml
@@ -1780,16 +1780,18 @@ doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFil
 ]]>
       </docs>
     </option>
-    <option type='string' id='HTML_EXTRA_STYLESHEET' format='file' defval='' depends='GENERATE_HTML'>
+    <option type='list' id='HTML_EXTRA_STYLESHEET' format='file' defval='' depends='GENERATE_HTML'>
       <docs>
 <![CDATA[
- The \c HTML_EXTRA_STYLESHEET tag can be used to specify an additional 
- user-defined cascading style sheet that is included after the standard 
+ The \c HTML_EXTRA_STYLESHEET tag can be used to specify additional 
+ user-defined cascading style sheets that are included after the standard 
  style sheets created by doxygen. Using this option one can overrule 
  certain style aspects. This is preferred over using \ref cfg_html_stylesheet "HTML_STYLESHEET" 
  since it does not replace the standard style sheet and is therefor more 
- robust against future updates. Doxygen will copy the style sheet file to 
+ robust against future updates. Doxygen will copy the style sheet files to 
  the output directory.
+ \note The order of the extra stylesheet files is of importance (e.g. the last
+ stylesheet in the list overrules the setting of the previous ones in the list).
 ]]>
       </docs>
       <docs doxywizard='0' doxyfile='0'>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9151,22 +9151,24 @@ static void copyStyleSheet()
       copyFile(htmlStyleSheet,destFileName);
     }
   }
-  QCString &htmlExtraStyleSheet = Config_getString("HTML_EXTRA_STYLESHEET");
-  if (!htmlExtraStyleSheet.isEmpty())
+  QStrList htmlExtraStyleSheet = Config_getList("HTML_EXTRA_STYLESHEET");
+  for (uint i=0; i<htmlExtraStyleSheet.count(); ++i)
   {
-    QFileInfo fi(htmlExtraStyleSheet);
-    if (!fi.exists())
+    QCString fileName(htmlExtraStyleSheet.at(i));
+    if (!fileName.isEmpty())
     {
-      err("Style sheet '%s' specified by HTML_EXTRA_STYLESHEET does not exist!\n",htmlExtraStyleSheet.data());
-      htmlExtraStyleSheet.resize(0); // revert to the default
-    }
-    else
-    {
-      QCString destFileName = Config_getString("HTML_OUTPUT")+"/"+fi.fileName().data();
-      copyFile(htmlExtraStyleSheet,destFileName);
+      QFileInfo fi(fileName);
+      if (!fi.exists())
+      {
+        err("Style sheet '%s' specified by HTML_EXTRA_STYLESHEET does not exist!\n",fileName.data());
+      }
+      else
+      {
+        QCString destFileName = Config_getString("HTML_OUTPUT")+"/"+fi.fileName().data();
+        copyFile(fileName, destFileName);
+      }
     }
   }
-  
 }
 
 static void copyLogo()

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1061,7 +1061,7 @@ static QCString substituteHtmlKeywords(const QCString &s,
 {
   // Build CSS/Javascript tags depending on treeview, search engine settings
   QCString cssFile;
-  QCString extraCssFile;
+  QStrList extraCssFile;
   QCString generatedBy;
   QCString treeViewCssJs;
   QCString searchCssJs;
@@ -1100,10 +1100,20 @@ static QCString substituteHtmlKeywords(const QCString &s,
       cssFile = "doxygen.css";
     }
   }
-  extraCssFile = Config_getString("HTML_EXTRA_STYLESHEET");
-  if (!extraCssFile.isEmpty())
+
+  extraCssText = "";
+  extraCssFile = Config_getList("HTML_EXTRA_STYLESHEET");
+  for (uint i=0; i<extraCssFile.count(); ++i)
   {
-    extraCssText = "<link href=\"$relpath^"+stripPath(extraCssFile)+"\" rel=\"stylesheet\" type=\"text/css\"/>\n";
+    QCString fileName(extraCssFile.at(i));
+    if (!fileName.isEmpty())
+    {
+      QFileInfo fi(fileName);
+      if (fi.exists())
+      {
+        extraCssText += "<link href=\"$relpath^"+stripPath(fileName)+"\" rel=\"stylesheet\" type=\"text/css\"/>\n";
+      }
+    }
   }
 
   if (timeStamp) 
@@ -1823,13 +1833,17 @@ void HtmlGenerator::writeStyleInfo(int part)
       }
       Doxygen::indexList->addStyleSheetFile(cssfi.fileName().utf8());
     }
-    static QCString extraCssFile = Config_getString("HTML_EXTRA_STYLESHEET");
-    if (!extraCssFile.isEmpty())
+    static QStrList extraCssFile = Config_getList("HTML_EXTRA_STYLESHEET");
+    for (uint i=0; i<extraCssFile.count(); ++i)
     {
-      QFileInfo fi(extraCssFile);
-      if (fi.exists())
+      QCString fileName(extraCssFile.at(i));
+      if (!fileName.isEmpty())
       {
-        Doxygen::indexList->addStyleSheetFile(fi.fileName().utf8());
+        QFileInfo fi(fileName);
+        if (fi.exists())
+        {
+          Doxygen::indexList->addStyleSheetFile(fi.fileName().utf8());
+        }
       }
     }
   }


### PR DESCRIPTION
In regular use it happens that it is more convenient to have multiple extra HTML stylesheets, e.g. in case of different levels of requirements: company, department, project
With this patch it is possible to specify multiple HTML stylesheets.
Note: for compatibility the configuration parameter HTML_EXTRA_STYLESHEET has not been renamed to HTM_EXTRA_STYLESHEETS.
