### PR TITLE
Create an easy possibility to take a snippet from the current file.

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2147,7 +2147,8 @@ Commands for displaying examples
  \addindex \\snippet
  Where the \ref cmdinclude "\\include" command can be used to include
  a complete file as source code, this command can be used to quote only
- a fragment of a source file.
+ a fragment of a source file. In case `this` is used as <file-name> the
+ current file is taken as file to take the snippet from.
 
  For example, the putting the following command in the documentation,
  references a snippet in file \c example.cpp residing in a subdirectory 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5218,6 +5218,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   QCString blockId;
   if (t==DocInclude::Snippet)
   {
+    if (fileName == "this") fileName=g_fileName;
     doctokenizerYYsetStateSnippet();
     tok=doctokenizerYYlex();
     doctokenizerYYsetStatePara();


### PR DESCRIPTION
In case the snippet of code is in the current file one has to specify the name of the file and also see to it that the file is reachable through the EXAMPLE_PATH.
A use case is the case of a list of initial values here it is quite often more convenient to have the values listed in a 'nice' list than direct in the definition line.
With this patch it is possible to specify the name of the file where the snippet resides as: this
