### PR TITLE
Remove extraneous 'README' to allow successful RPM creation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -112,7 +112,7 @@ DISTDIR = doxygen-`echo $(VERSION) | tr - _`
 dist: clean
 	rm -rf $(DISTDIR)
 	mkdir $(DISTDIR)
-	cp -a $(DISTFILES) README $(DISTDIR)
+	cp -a $(DISTFILES) $(DISTDIR)
 	find $(DISTDIR) \( -name ".svn" \) -print0 | xargs -0 rm -rf
 	tar zcvf $(DISTDIR).src.tar.gz $(DISTDIR)
 	rm -rf $(DISTDIR)


### PR DESCRIPTION
Building RPMs on RHEL 6.5 isn't successful due to a Makefile.in error: a nonexistent file is included in the `dist` make target. This pull request aims to fix the error.

The RPM builds successfully with this code modification in place. I've verified that the RPM then installs successfully on my RHEL 6.5 system.

This is seemingly related to [Bug 706813](https://bugzilla.gnome.org/show_bug.cgi?id=706813) in the Doxygen Bugzilla. Even so, the RPM cannot successfully be built on RHEL 6.5 without the code fix in this pull request.
