### PR TITLE
Bug 735745 - Spurious ASSERT message

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -4670,12 +4670,15 @@ int DocParamList::parse(const QCString &cmdName)
   DBG(("DocParamList::parse() start\n"));
   g_nodeStack.push(this);
   DocPara *par=0;
+  QCString saveCmdName = cmdName;
 
   int tok=doctokenizerYYlex();
   if (tok!=TK_WHITESPACE)
   {
     warn_doc_error(g_fileName,doctokenizerYYlineno,"expected whitespace after %s command",
         qPrint(cmdName));
+    retval=0;
+    goto endparamlist;
   }
   doctokenizerYYsetStateParam();
   tok=doctokenizerYYlex();
@@ -4715,7 +4718,13 @@ int DocParamList::parse(const QCString &cmdName)
     retval=0;
     goto endparamlist;
   }
-  ASSERT(tok==TK_WHITESPACE);
+  if (tok!=TK_WHITESPACE) /* premature end of comment block */
+  {
+    warn_doc_error(g_fileName,doctokenizerYYlineno,"unexpected token in comment block while parsing the "
+        "argument of command %s",qPrint(saveCmdName));
+    retval=0;
+    goto endparamlist;
+  }
 
   par = new DocPara(this);
   m_paragraphs.append(par);


### PR DESCRIPTION
The ASSERT message is replaced with a normal message.
The cmdName might be overwritten so we have to save the name cmdName first, also the first test should not try to read any further, but jump to the end as well )a push has already been performed so a pop etc. is necessary)
