### PR TITLE
Different latex problems

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -62,9 +62,14 @@ void CiteDict::writeLatexBibliography(FTextStream &t)
     unit = "chapter";
   t << "% Bibliography\n"
        "\\newpage\n"
-       "\\phantomsection\n"
-       "\\addcontentsline{toc}{" << unit << "}{" << theTranslator->trCiteReferences() << "}\n"
-       "\\bibliographystyle{" << style << "}\n"
+       "\\phantomsection\n";
+  bool pdfHyperlinks = Config_getBool("PDF_HYPERLINKS");
+  if (!pdfHyperlinks)
+  {
+    t << "\\clearemptydoublepage\n";
+    t << "\\addcontentsline{toc}{" << unit << "}{" << theTranslator->trCiteReferences() << "}\n";
+  }
+  t << "\\bibliographystyle{" << style << "}\n"
        "\\bibliography{";
   QStrList &citeDataList = Config_getList("CITE_BIB_FILES");
   QCString latexOutputDir = Config_getString("LATEX_OUTPUT")+"/";
@@ -87,8 +92,12 @@ void CiteDict::writeLatexBibliography(FTextStream &t)
     }
     bibdata = citeDataList.next();
   }
-  t << "}\n"
-       "\n";
+  t << "}\n";
+  if (pdfHyperlinks)
+  {
+    t << "\\addcontentsline{toc}{" << unit << "}{" << theTranslator->trCiteReferences() << "}\n";
+  }
+  t << "\n";
 }
 
 void CiteDict::insert(const char *label)

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -543,8 +543,10 @@ static void writeDefaultFooter(FTextStream &t)
   else
     unit = "chapter";
   t << "% Index\n"
+       "\\backmatter\n"
        "\\newpage\n"
        "\\phantomsection\n"
+       "\\clearemptydoublepage\n"
        "\\addcontentsline{toc}{" << unit << "}{" << theTranslator->trRTFGeneralIndex() << "}\n"
        "\\printindex\n"
        "\n"
@@ -1260,7 +1262,7 @@ void LatexGenerator::startTitleHead(const char *fileName)
   static bool usePDFLatex   = Config_getBool("USE_PDFLATEX");
   if (usePDFLatex && pdfHyperlinks && fileName)
   {
-    t << "\\hypertarget{" << stripPath(fileName) << "}{";
+    t << "\\hypertarget{" << stripPath(fileName) << "}{}";
   }
   if (Config_getBool("COMPACT_LATEX")) 
   {
@@ -1274,8 +1276,6 @@ void LatexGenerator::startTitleHead(const char *fileName)
 
 void LatexGenerator::endTitleHead(const char *fileName,const char *name)
 {
-  static bool pdfHyperlinks = Config_getBool("PDF_HYPERLINKS");
-  static bool usePDFLatex   = Config_getBool("USE_PDFLATEX");
   t << "}" << endl;
   if (name)
   {
@@ -1284,10 +1284,6 @@ void LatexGenerator::endTitleHead(const char *fileName,const char *name)
     t << "@{";
     escapeMakeIndexChars(name);
     t << "}}" << endl;
-  }
-  if (usePDFLatex && pdfHyperlinks && fileName)
-  {
-    t << "}" << endl;
   }
 }
 
@@ -1428,18 +1424,12 @@ void LatexGenerator::startDoxyAnchor(const char *fName,const char *,
     t << "\\hypertarget{";
     if (fName) t << stripPath(fName);
     if (anchor) t << "_" << anchor;
-    t << "}{";
+    t << "}{}";
   }
 }
 
 void LatexGenerator::endDoxyAnchor(const char *fName,const char *anchor)
 {
-  static bool pdfHyperlinks = Config_getBool("PDF_HYPERLINKS");
-  static bool usePDFLatex   = Config_getBool("USE_PDFLATEX");
-  if (usePDFLatex && pdfHyperlinks)
-  {
-    t << "}";
-  }
   t << "\\label{";
   if (fName) t << stripPath(fName);
   if (anchor) t << "_" << anchor;


### PR DESCRIPTION
- Bibliography refers to wrong page in the toc
  In case of LaTeX the reference in the toc tab to the Bibliography page is not correct.
  According to e.g. http://lookherefirst.wordpress.com/2008/10/05/add-the-bibliography-in-the-table-of-contents/
  when using the hyperref package the reference of the toc should be after the \bibliography entry.
  See to it that the Bibliography page starts at an odd page (like all other chapters)
- See to it that the Index page starts at an odd page (like all other chapters)
- Not all items are shown in the Index / Index generation crashes (Bug_733323) / Index is not shown
  The \hypertarget definition contains on 2 places the entire string (including section references and index references) in the caption part.
  In all other places the caption is empty and the caption part is not used (as a reference) in the \hyperlink command. The caption has been made empty/
