### PR TITLE
Bug 634763 - Fortran: external subroutine as dummy argument not recognized

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -258,11 +258,12 @@ CHAR      (CHARACTER{ARGS}?|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
 TYPE_SPEC (({NUM_TYPE}({BS}"*"{BS}[0-9]+)?)|({NUM_TYPE}{KIND})|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE{ARGS}|CLASS{ARGS}|PROCEDURE{ARGS}?)
 
 INTENT_SPEC intent{BS}"("{BS}(in|out|in{BS}out){BS}")"
-ATTR_SPEC (ALLOCATABLE|DIMENSION{ARGS}|EXTERNAL|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|NOPASS|PASS{ARGS}?|DEFERRED|NON_OVERRIDABLE)
+ATTR_SPEC (EXTERNAL|ALLOCATABLE|DIMENSION{ARGS}|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|NOPASS|PASS{ARGS}?|DEFERRED|NON_OVERRIDABLE)
 ACCESS_SPEC (PRIVATE|PUBLIC)
 LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
 /* Assume that attribute statements are almost the same as attributes. */
 ATTR_STMT {ATTR_SPEC}|DIMENSION|{ACCESS_SPEC}
+EXTERNAL_STMT (EXTERNAL)
 
 CONTAINS  CONTAINS
 PREFIX    (RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,3}(RECURSIVE|IMPURE|PURE|ELEMENTAL)?
@@ -726,6 +727,18 @@ private                                 {
 					  }
 					}
   */
+{EXTERNAL_STMT}/({BS}"::"|{BS_}{ID})   { 
+                                          /* external can be a "type" or an attribute */
+                                          if(YY_START == Start)
+                                          {
+                                            addModule(NULL); 
+                                            yy_push_state(ModuleBody); //anon program
+                                          }
+                                          QCString tmp = yytext;
+                                          currentModifiers |= tmp.stripWhiteSpace();
+					  argType = QCString(yytext).simplifyWhiteSpace().lower();
+					  yy_push_state(AttributeList);
+  				       }
 {ATTR_STMT}/{BS_}{ID}		       |
 {ATTR_STMT}/{BS}"::"                   { 
                                           /* attribute statement starts */
@@ -744,7 +757,7 @@ private                                 {
 <AttributeList>{
 {COMMA}					{}
 {BS}					{}
-{ATTR_SPEC}.				{ /* update current modifierswhen it is an ATTR_SPEC and not a variable name */
+{ATTR_SPEC}.				{ /* update current modifiers when it is an ATTR_SPEC and not a variable name */
             				  /* bug_625519 */
                                           QChar chr = yytext[(int)yyleng-1];
                                           if (chr.isLetter() || chr.isDigit() || (chr == '_'))
@@ -1723,8 +1736,11 @@ static QCString applyModifiers(QCString typeName, SymbolModifiers& mdfs)
   }
   if (mdfs.external) 
   {
-    if (!typeName.isEmpty()) typeName += ", ";
-    typeName += "external";
+    if (!typeName.contains("external"))
+    {
+      if (!typeName.isEmpty()) typeName += ", ";
+      typeName += "external";
+    }
   }
   if (mdfs.intrinsic) 
   {


### PR DESCRIPTION
Besides as as attribute the external can also be used as "type"
Previous commit (pull request 121) was reverted (pull request 122) due to warning message.
