### PR TITLE
Support charset option for PlantUML

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -79,6 +79,7 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
   pumlArgs+=" \"";
   pumlArgs+=baseName;
   pumlArgs+=".pu\" ";
+  pumlArgs+="-charset " + Config_getString("INPUT_ENCODING") + " ";
   int exitCode;
   //printf("*** running: %s %s outDir:%s %s\n",pumlExe.data(),pumlArgs.data(),outDir,outFile);
   msg("Running PlantUML on generated file %s.pu\n",baseName);


### PR DESCRIPTION
Use as charset for PlantUML the same character set as the INPUT_ENCODING of the input source
