### PR TITLE
Plantuml dependency on HAVE_DOT

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5584,7 +5584,11 @@ int DocPara::handleCommand(const QCString &cmdName)
         static QCString jarPath = Config_getString("PLANTUML_JAR_PATH");
         doctokenizerYYsetStatePlantUML();
         retval = doctokenizerYYlex();
-        if (jarPath.isEmpty())
+        if (!Config_getBool("HAVE_DOT"))
+        {
+          warn_doc_error(g_fileName,doctokenizerYYlineno,"ignoring startuml command because HAVE_DOT is not set");
+        }
+        else if (jarPath.isEmpty())
         {
           warn_doc_error(g_fileName,doctokenizerYYlineno,"ignoring startuml command because PLANTUML_JAR_PATH is not set");
         }


### PR DESCRIPTION
According to the documentation plantuml commands can only be used when PLANTUML_JAR_PATH is set, also that PLANTUML_JAR_PATH is depending on HAVE_DOT. The later was not enforced in the code.
