### PR TITLE
Fix bug with C++11 static_assert

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2444,7 +2444,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					}
 <StaticAssert>"("                       {
 					  lastSkipRoundContext = FindMembers;
-					  roundCount=1;
+					  roundCount=0;
                                           BEGIN(SkipRound);
                                         }
 <StaticAssert>{BN}+                     { lineCount(); }


### PR DESCRIPTION
When processing a C++11 static_assert, we wish to skip the arguments. However, the `roundCount` is set to 1 despite the fact that the `SkipRound` routine expects an initial value of 0. This causes the rest of the class to be skipped entirely.
