### PR TITLE
Package mathptmx gives discrepancy between pdf and HTML formulas

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -316,7 +316,6 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   // Define default fonts
   t << "% Font selection\n"
        "\\usepackage[T1]{fontenc}\n"
-       "\\usepackage{mathptmx}\n"
        "\\usepackage[scaled=.90]{helvet}\n"
        "\\usepackage{courier}\n"
        "\\usepackage{amssymb}\n"


### PR DESCRIPTION
When using the mathcal command in formulas the mathptmx package gives in the different output version different letters.
When the mathptmx, more exuberant,  type of fonts are to be used they can be added by means of the EXTRA_PACKAGES option.
