### PR TITLE
Generate error message in case bibtex generation fails

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -211,8 +211,15 @@ void CiteDict::generatePage() const
 
   // 5. run bib2xhtml perl script on the generated file which will insert the
   //    bibliography in citelist.doc
-  portable_system("perl","\""+bib2xhtmlFile+"\" "+bibOutputFiles+" \""+
-                         citeListFile+"\"");
+  int exitCode;
+  portable_sysTimerStop();
+  if ((exitCode=portable_system("perl","\""+bib2xhtmlFile+"\" "+bibOutputFiles+" \""+
+                         citeListFile+"\"")) != 0)
+  {
+    err("Problems running bibtex. Verify that the command 'perl --version' works from the command line. Exit code: %d\n",
+        exitCode);
+  }
+  portable_sysTimerStop();
 
   QDir::setCurrent(oldDir);
 


### PR DESCRIPTION
In case bibtex fails no message is given. When perl is missing the OS just emits an message. With this patch doxygen logs a message (analogous to other calls to portable_system)
