### PR TITLE
Empty entry in \tableofcontents in case e.g. section without description

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1618,7 +1618,7 @@ void Definition::writeToc(OutputList &ol)
       }
       cs[0]='0'+nextLevel;
       if (inLi[nextLevel]) ol.writeString("</li>\n");
-      ol.writeString("<li class=\"level"+QCString(cs)+"\"><a href=\"#"+si->label+"\">"+si->title+"</a>");
+      ol.writeString("<li class=\"level"+QCString(cs)+"\"><a href=\"#"+si->label+"\">"+(si->title.isEmpty()?si->label:si->title)+"</a>");
       inLi[nextLevel]=TRUE;
       level = nextLevel;
     }


### PR DESCRIPTION
In case a section, subsection etc just has a tag and not a description in the \tableofcontents there is nothing mentioned. With this patch the tag is used as description when no description is present, as is done on other places as well (consistency and no empty items in the \tableofcontents).
