### PR TITLE
Support the newpage command of PlantUML

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -263,10 +263,25 @@ void DocbookDocVisitor::visit(DocVerbatim *s)
         m_t << "        <title>" << shortName << "</title>" << endl;
         m_t << "        <mediaobject>" << endl;
         m_t << "            <imageobject>" << endl;
-        writePlantUMLFile(baseName);
+        writePlantUMLFile(baseName,TRUE);
         m_t << "            </imageobject>" << endl;
         m_t << "       </mediaobject>" << endl;
         m_t << "    </figure>" << endl;
+        // subsequent pages
+        int cnt_newpage = s->text().contains("newpage");
+        char strnum[5];
+        for (int i = 1; i <= cnt_newpage; i++)
+        {
+          sprintf(strnum,"_%03d",i);
+          m_t << "    <figure>" << endl;
+          m_t << "        <title>" << shortName << "</title>" << endl;
+          m_t << "        <mediaobject>" << endl;
+          m_t << "            <imageobject>" << endl;
+          writePlantUMLFile(baseName+strnum,FALSE);
+          m_t << "            </imageobject>" << endl;
+          m_t << "       </mediaobject>" << endl;
+          m_t << "    </figure>" << endl;
+        }
         m_t << "</para>" << endl;
       }
       break;
@@ -1219,7 +1234,7 @@ void DocbookDocVisitor::writeMscFile(const QCString &baseName)
   m_t << "</imagedata>" << endl;
 }
 
-void DocbookDocVisitor::writePlantUMLFile(const QCString &baseName)
+void DocbookDocVisitor::writePlantUMLFile(const QCString &baseName, const bool generate)
 {
   QCString shortName = baseName;
   int i;
@@ -1228,7 +1243,7 @@ void DocbookDocVisitor::writePlantUMLFile(const QCString &baseName)
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString("DOCBOOK_OUTPUT");
-  generatePlantUMLOutput(baseName,outDir,PUML_BITMAP);
+  if (generate) generatePlantUMLOutput(baseName,outDir,PUML_BITMAP);
   m_t << "                <imagedata";
   m_t << " width=\"50%\"";
   m_t << " align=\"center\" valign=\"middle\" scalefit=\"1\" fileref=\"" << shortName << ".png" << "\">";

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -156,7 +156,7 @@ class DocbookDocVisitor : public DocVisitor
     const QCString &height, bool hasCaption);
     void endDotFile(bool hasCaption);
     void writeDotFile(const QCString &fileName);
-    void writePlantUMLFile(const QCString &fileName);
+    void writePlantUMLFile(const QCString &fileName,const bool generate);
     //--------------------------------------
     // state variables
     //--------------------------------------

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -440,9 +440,20 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
 
         static QCString htmlOutput = Config_getString("HTML_OUTPUT");
         QCString baseName = writePlantUMLSource(htmlOutput,s->exampleFile(),s->text());
+        // base page
         m_t << "<div align=\"center\">" << endl;
-        writePlantUMLFile(baseName,s->relPath(),s->context());
+        writePlantUMLFile(baseName,s->relPath(),s->context(),TRUE);
         m_t << "</div>" << endl;
+        // subsequent pages
+        int cnt_newpage = s->text().contains("newpage");
+        char strnum[5];
+        for (int i = 1; i <= cnt_newpage; i++)
+        {
+          sprintf(strnum,"_%03d",i);
+          m_t << "<div align=\"center\">" << endl;
+          writePlantUMLFile(baseName+strnum,s->relPath(),s->context(),FALSE);
+          m_t << "</div>" << endl;
+        }
         forceStartParagraph(s);
       }
       break;
@@ -1991,7 +2002,8 @@ void HtmlDocVisitor::writeDiaFile(const QCString &fileName,
 
 void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName,
                                        const QCString &relPath,
-                                       const QCString &)
+                                       const QCString &,
+                                       const bool generate)
 {
   QCString baseName=fileName;
   int i;
@@ -2007,7 +2019,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName,
   static QCString imgExt = Config_getEnum("DOT_IMAGE_FORMAT");
   if (imgExt=="svg")
   {
-    generatePlantUMLOutput(fileName,outDir,PUML_SVG);
+    if (generate) generatePlantUMLOutput(fileName,outDir,PUML_SVG);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />" << endl;
     //m_t << "<p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p>";
     //m_t << "</iframe>" << endl;
@@ -2015,7 +2027,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName,
   }
   else
   {
-    generatePlantUMLOutput(fileName,outDir,PUML_BITMAP);
+    if (generate) generatePlantUMLOutput(fileName,outDir,PUML_BITMAP);
     m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />" << endl;
   }
 }

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -153,7 +153,7 @@ class HtmlDocVisitor : public DocVisitor
     void writeDotFile(const QCString &fileName,const QCString &relPath,const QCString &context);
     void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context);
     void writeDiaFile(const QCString &fileName,const QCString &relPath,const QCString &context);
-    void writePlantUMLFile(const QCString &fileName,const QCString &relPath,const QCString &context);
+    void writePlantUMLFile(const QCString &fileName,const QCString &relPath,const QCString &context,const bool generate = TRUE);
 
     void pushEnabled();
     void popEnabled();

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -327,9 +327,20 @@ void LatexDocVisitor::visit(DocVerbatim *s)
         QCString latexOutput = Config_getString("LATEX_OUTPUT");
         QCString baseName = writePlantUMLSource(latexOutput,s->exampleFile(),s->text());
 
+        // base page
         m_t << "\\begin{center}\n";
-        writePlantUMLFile(baseName);
+        writePlantUMLFile(baseName,TRUE);
         m_t << "\\end{center}\n";
+        // subsequent pages
+        int cnt_newpage = s->text().contains("newpage");
+        char strnum[5];
+        for (int i = 1; i <= cnt_newpage; i++)
+        {
+          sprintf(strnum,"_%03d",i);
+          m_t << "\\begin{center}\n";
+          writePlantUMLFile(baseName+strnum,FALSE);
+          m_t << "\\end{center}\n";
+        }
       }
       break;
   }
@@ -1846,7 +1857,7 @@ void LatexDocVisitor::writeDiaFile(const QCString &baseName)
   m_t << "\\end{DoxyImageNoCaption}\n";
 }
 
-void LatexDocVisitor::writePlantUMLFile(const QCString &baseName)
+void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, const bool generate)
 {
   QCString shortName = baseName;
   int i;
@@ -1855,7 +1866,7 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName)
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString("LATEX_OUTPUT");
-  generatePlantUMLOutput(baseName,outDir,PUML_EPS);
+  if (generate) generatePlantUMLOutput(baseName,outDir,PUML_EPS);
   m_t << "\n\\begin{DoxyImageNoCaption}"
          "  \\mbox{\\includegraphics";
   m_t << "{" << shortName << "}";

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -176,7 +176,7 @@ class LatexDocVisitor : public DocVisitor
                       const QCString &height, bool hasCaption);
     void endDiaFile(bool hasCaption);
     void writeDiaFile(const QCString &fileName);
-    void writePlantUMLFile(const QCString &fileName);
+    void writePlantUMLFile(const QCString &fileName,const bool generate = TRUE);
 
     void pushEnabled();
     void popEnabled();

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -326,8 +326,18 @@ void RTFDocVisitor::visit(DocVerbatim *s)
         QCString baseName = writePlantUMLSource(rtfOutput,s->exampleFile(),s->text());
 
         m_t << "\\par{\\qc "; // center picture
-        writePlantUMLFile(baseName);
+        writePlantUMLFile(baseName,TRUE);
         m_t << "} ";
+        // subsequent pages
+        int cnt_newpage = s->text().contains("newpage");
+        char strnum[5];
+        for (int i = 1; i <= cnt_newpage; i++)
+        {
+          sprintf(strnum,"_%03d",i);
+          m_t << "\\par{\\qc "; // center picture
+          writePlantUMLFile(baseName+strnum,FALSE);
+          m_t << "} ";
+        }
       }
       break;
   }
@@ -1717,7 +1727,7 @@ void RTFDocVisitor::writeDiaFile(const QCString &fileName)
   m_lastIsPara=TRUE;
 }
 
-void RTFDocVisitor::writePlantUMLFile(const QCString &fileName)
+void RTFDocVisitor::writePlantUMLFile(const QCString &fileName,const bool generate)
 {
   QCString baseName=fileName;
   int i;
@@ -1726,7 +1736,7 @@ void RTFDocVisitor::writePlantUMLFile(const QCString &fileName)
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString("RTF_OUTPUT");
-  generatePlantUMLOutput(fileName,outDir,PUML_BITMAP);
+  if (generate) generatePlantUMLOutput(fileName,outDir,PUML_BITMAP);
   if (!m_lastIsPara) m_t << "\\par" << endl;
   m_t << "{" << endl;
   m_t << rtf_Style_Reset;

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -155,7 +155,7 @@ class RTFDocVisitor : public DocVisitor
     void writeDotFile(const QCString &fileName);
     void writeMscFile(const QCString &fileName);
     void writeDiaFile(const QCString &fileName);
-    void writePlantUMLFile(const QCString &fileName);
+    void writePlantUMLFile(const QCString &fileName,const bool generate);
 
     //--------------------------------------
     // state variables


### PR DESCRIPTION
In case the PlantUML code contains the command "newpage" a new image is created for the PlantUML code following this command. This was not handled by doxygen, just the first image was displayed. With this patch all parts are added to doxygen generated documentation (as separate images).
