### PR TITLE
Last comment of \code{.f90} missing

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1136,6 +1136,17 @@ PREFIX    (RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,3}(RECURSIVE|I
 <*>{LOG_OPER}                           { // Fortran logical comparison keywords
                                           g_code->codify(yytext);
                                         }
+<*><<EOF>>                              {
+                                          if (YY_START == DocBlock) {
+                                            if (!Config_getBool("STRIP_CODE_COMMENTS"))
+                                            {
+                                              startFontClass("comment");
+                                              codifyLines(docBlock);
+                                              endFontClass();
+                                            }
+                                          }
+                                          yyterminate();
+                                        }
 %%
 
 /*@ ----------------------------------------------------------------------------


### PR DESCRIPTION
In case e.g. an number of Fortran variables are documented as an example in a \code block and the last line looks like:
INTEGER :: var !< documentation
The "!< documentation" is missing as the last block was not rendered.
Note: STRIP_CODE_COMMENTS has to be NO as otherwise the code comment will anyway, correctly,  be absent.
