### PR TITLE
Updated configuration script and libdoxygen.pro.in to use llvm-config

### DIFF
--- a/configure
+++ b/configure
@@ -554,8 +554,13 @@ fi
 
 if test "$f_libclang" = YES; then
   printf "  Checking for libclang ... "
-  libclang_hdr_dir="/usr/include /usr/local/include /opt/local/include"
-  libclang_lib_dir="/usr/lib /usr/local/lib /opt/local/lib /usr/lib64/llvm /usr/lib/llvm"
+  if llvm-config --version > /dev/null 2>&1; then
+    libclang_hdr_dir=$(llvm-config --includedir)
+    libclang_lib_dir=$(llvm-config --libdir)
+  else
+    libclang_hdr_dir="/usr/include /usr/local/include /opt/local/include"
+    libclang_lib_dir="/usr/lib /usr/local/lib /opt/local/lib /usr/lib64/llvm /usr/lib/llvm"
+  fi
   if test "$f_libclangstatic" = NO; then
     libclang_lib_name="libclang.so libclang.dylib libclang.a libclang.dll.a"
   else
@@ -952,7 +957,7 @@ EOF
      #if test "$f_thread" = YES; then
      #  realopts="$realopts thread"
      #fi
-     cat $SRC .tmakeconfig | sed -e "s/\$extraopts/$realopts/g" -e "s;%%SQLITE3_INC%%;$sqlite3_hdr_dir;g" -e "s;%%SQLITE3_LIBS%%;$sqlite3_link;g" -e "s;%%LIBCLANG_LIBS%%;$libclang_link;g" >> $DST
+     cat $SRC .tmakeconfig | sed -e "s/\$extraopts/$realopts/g" -e "s;%%SQLITE3_INC%%;$sqlite3_hdr_dir;g" -e "s;%%SQLITE3_LIBS%%;$sqlite3_link;g" -e "s;%%LIBCLANG_INC%%;$libclang_hdr_dir;g" -e "s;%%LIBCLANG_LIBS%%;$libclang_link;g" >> $DST
      echo "  Created $DST from $SRC..."
 done
 

--- a/src/libdoxygen.pro.in
+++ b/src/libdoxygen.pro.in
@@ -230,6 +230,7 @@ win32-g++:TMAKE_CXXFLAGS   += -fno-exceptions
 linux-g++:TMAKE_CXXFLAGS   += -fno-exceptions
 INCLUDEPATH                += ../generated_src/doxygen ../src ../qtools ../libmd5 ../vhdlparser
 INCLUDEPATH                += %%SQLITE3_INC%%
+INCLUDEPATH                += %%LIBCLANG_INC%%
 DEPENDPATH                 += ../generated_src/doxygen
 win32:INCLUDEPATH          += .
 DESTDIR                    =  ../lib


### PR DESCRIPTION
This is needed on platforms like ubuntu 14.04 where several version of
clang can be installed, and the version is included in the location. The
best way is to use the llvm-config if available
