### PR TITLE
Bug 738548 - latex: dead links to source code

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -327,6 +327,13 @@ void FileDef::writeDetailedDescription(OutputList &ol,const QCString &title)
     //printf("Writing source ref for file %s\n",name().data());
     if (Config_getBool("SOURCE_BROWSER")) 
     {
+      //if Latex enabled and LATEX_SOURCE_CODE isn't -> skip, bug_738548
+      ol.pushGeneratorState();
+      if (ol.isEnabled(OutputGenerator::Latex) && !Config_getBool("LATEX_SOURCE_CODE"))
+      { 
+        ol.disable(OutputGenerator::Latex);
+      }
+
       ol.startParagraph();
       QCString refText = theTranslator->trDefinedInSourceFile();
       int fileMarkerPos = refText.find("@0");
@@ -339,6 +346,8 @@ void FileDef::writeDetailedDescription(OutputList &ol,const QCString &title)
               refText.length()-fileMarkerPos-2)); // text right from marker 2
       }
       ol.endParagraph();
+      //Restore settings, bug_738548
+      ol.popGeneratorState();
     }
     ol.endTextBlock();
   }


### PR DESCRIPTION
For Latex an extra dependency exists. In case Latex is set and LATEX_SOURCE_CODE is not set the writing of the "Definition in file" section is disabled.
