### PR TITLE
Bug 738574 - &hellip; is replaced by \cdots rather than \dots in the LaTeX output

### DIFF
--- a/src/htmlentity.cpp
+++ b/src/htmlentity.cpp
@@ -193,7 +193,7 @@ static struct htmlEntityInfo
   { SYM(upsih),    "\xcf\x92",     "&upsih;",    "<upsih/>",             "&#978;",        "{$\\Upsilon$}",          NULL,     "\\u978?",     { NULL,         DocSymbol::Perl_unknown }},
   { SYM(piv),      "\xcf\x96",     "&piv;",      "<piv/>",               "&#982;",        "{$\\varpi$}",            NULL,     "\\u982?",     { NULL,         DocSymbol::Perl_unknown }},
   { SYM(bull),     "\xe2\x80\xa2", "&bull;",     "<bull/>",              "&#8226;",       "\\textbullet{}",         NULL,     "\\'95",       { NULL,         DocSymbol::Perl_unknown }},
-  { SYM(hellip),   "\xe2\x80\xa6", "&hellip;",   "<hellip/>",            "&#8230;",       "{$\\cdots$}",            NULL,     "\\'85",       { NULL,         DocSymbol::Perl_unknown }},
+  { SYM(hellip),   "\xe2\x80\xa6", "&hellip;",   "<hellip/>",            "&#8230;",       "{$\\dots$}",             NULL,     "\\'85",       { NULL,         DocSymbol::Perl_unknown }},
   { SYM(prime),    "\xe2\x80\xb2", "&prime;",    "<prime/>",             "&#8242;",       "'",                      NULL,     "\\u8242?",    { "\\\'",       DocSymbol::Perl_string  }},
   { SYM(Prime),    "\xe2\x80\xb3", "&Prime;",    "<Prime/>",             "&#8243;",       "''",                     NULL,     "\\u8243?",    { "\"",         DocSymbol::Perl_char    }},
   { SYM(oline),    "\xe2\x80\xbe", "&oline;",    "<oline/>",             "&#8254;",       "{$\\overline{\\,}$}",    NULL,     "\\u8254?",    { NULL,         DocSymbol::Perl_unknown }},


### PR DESCRIPTION
Changed the \cdots to \dots. Based on the bug report and on http://tex.stackexchange.com/questions/77737/dots-versus-ldots-is-there-a-difference
