### PR TITLE
Support dotfile files with same names from different directories

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1396,6 +1396,7 @@ void DocbookDocVisitor::startDotFile(const QCString &fileName,
     bool hasCaption
     )
 {
+  static int cntDotFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1407,6 +1408,12 @@ void DocbookDocVisitor::startDotFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("dot_");
+  //if (!inl)
+  //{
+    baseName += "_";
+    cntDotFile++;
+    baseName += QCString().setNum(cntDotFile);
+  //}
   QCString outDir = Config_getString("DOCBOOK_OUTPUT");
   QCString imgExt = Config_getEnum("DOT_IMAGE_FORMAT");
   writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP);

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -397,7 +397,7 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
 
         forceEndParagraph(s);
         m_t << "<div align=\"center\">" << endl;
-        writeDotFile(fileName,s->relPath(),s->context());
+        writeDotFile(fileName,s->relPath(),s->context(),TRUE);
         m_t << "</div>" << endl;
         forceStartParagraph(s);
 
@@ -1438,8 +1438,9 @@ void HtmlDocVisitor::visitPost(DocImage *img)
 void HtmlDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
+  forceEndParagraph(df);
   m_t << "<div class=\"dotgraph\">" << endl;
-  writeDotFile(df->file(),df->relPath(),df->context());
+  writeDotFile(df->file(),df->relPath(),df->context(),FALSE);
   if (df->hasCaption())
   { 
     m_t << "<div class=\"caption\">" << endl;
@@ -1454,6 +1455,7 @@ void HtmlDocVisitor::visitPost(DocDotFile *df)
     m_t << "</div>" << endl;
   }
   m_t << "</div>" << endl;
+  forceStartParagraph(df);
 }
 
 void HtmlDocVisitor::visitPre(DocMscFile *df)
@@ -1926,8 +1928,9 @@ void HtmlDocVisitor::popEnabled()
 }
 
 void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
-                                  const QCString &context)
+                                  const QCString &context,const bool inl)
 {
+  static int cntDotFile = 0;
   QCString baseName=fn;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1939,6 +1942,12 @@ void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
     baseName=baseName.left(i);
   }
   baseName.prepend("dot_");
+  if (!inl)
+  {
+    baseName += "_";
+    cntDotFile++;
+    baseName += QCString().setNum(cntDotFile);
+  }
   QCString outDir = Config_getString("HTML_OUTPUT");
   writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP);
   writeDotImageMapFromFile(m_t,fn,outDir,relPath,baseName,context);

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -150,7 +150,7 @@ class HtmlDocVisitor : public DocVisitor
                    const QCString &relPath,const QCString &anchor,
                    const QCString &tooltip = "");
     void endLink();
-    void writeDotFile(const QCString &fileName,const QCString &relPath,const QCString &context);
+    void writeDotFile(const QCString &fileName,const QCString &relPath,const QCString &context,const bool inl);
     void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context);
     void writeDiaFile(const QCString &fileName,const QCString &relPath,const QCString &context);
     void writePlantUMLFile(const QCString &fileName,const QCString &relPath,const QCString &context);

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -288,7 +288,7 @@ void LatexDocVisitor::visit(DocVerbatim *s)
         file.close();
 
         m_t << "\\begin{center}\n";
-        startDotFile(fileName,"","",FALSE);
+        startDotFile(fileName,"","",FALSE,TRUE);
         endDotFile(FALSE);
         m_t << "\\end{center}\n";
 
@@ -1163,7 +1163,7 @@ void LatexDocVisitor::visitPost(DocImage *img)
 void LatexDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
-  startDotFile(df->file(),df->width(),df->height(),df->hasCaption());
+  startDotFile(df->file(),df->width(),df->height(),df->hasCaption(),FALSE);
 }
 
 void LatexDocVisitor::visitPost(DocDotFile *df) 
@@ -1593,9 +1593,11 @@ void LatexDocVisitor::popEnabled()
 void LatexDocVisitor::startDotFile(const QCString &fileName,
                                    const QCString &width,
                                    const QCString &height,
-                                   bool hasCaption
+                                   bool hasCaption,
+                                   const bool inl
                                   )
 {
+  static int cntDotFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1607,6 +1609,12 @@ void LatexDocVisitor::startDotFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("dot_");
+  if (!inl)
+  {
+    baseName += "_";
+    cntDotFile++;
+    baseName += QCString().setNum(cntDotFile);
+  }
   QCString outDir = Config_getString("LATEX_OUTPUT");
   QCString name = fileName;
   writeDotGraphFromFile(name,outDir,baseName,GOF_EPS);

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -164,7 +164,7 @@ class LatexDocVisitor : public DocVisitor
                  const QCString &anchor);
     QCString escapeMakeIndexChars(const char *s);
     void startDotFile(const QCString &fileName,const QCString &width,
-                      const QCString &height, bool hasCaption);
+                      const QCString &height, bool hasCaption,const bool inl);
     void endDotFile(bool hasCaption);
 
     void startMscFile(const QCString &fileName,const QCString &width,

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -289,7 +289,7 @@ void RTFDocVisitor::visit(DocVerbatim *s)
         file.writeBlock( s->text(), s->text().length() );
         file.close();
         m_t << "\\par{\\qc "; // center picture
-        writeDotFile(fileName);
+        writeDotFile(fileName,TRUE);
         m_t << "} ";
         if (Config_getBool("DOT_CLEANUP")) file.remove();
       }
@@ -1050,7 +1050,7 @@ void RTFDocVisitor::visitPost(DocImage *)
 void RTFDocVisitor::visitPre(DocDotFile *df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocDotFile)}\n");
-  writeDotFile(df->file());
+  writeDotFile(df->file(),FALSE);
 
   // hide caption since it is not supported at the moment
   pushEnabled();
@@ -1657,8 +1657,9 @@ void RTFDocVisitor::popEnabled()
   delete v;
 }
 
-void RTFDocVisitor::writeDotFile(const QCString &fileName)
+void RTFDocVisitor::writeDotFile(const QCString &fileName,const bool inl)
 {
+  static int cntDotFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1666,6 +1667,12 @@ void RTFDocVisitor::writeDotFile(const QCString &fileName)
     baseName=baseName.right(baseName.length()-i-1);
   } 
   QCString outDir = Config_getString("RTF_OUTPUT");
+  if (!inl)
+  {
+    baseName += "_";
+    cntDotFile++;
+    baseName += QCString().setNum(cntDotFile);
+  }
   writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP);
   if (!m_lastIsPara) m_t << "\\par" << endl;
   m_t << "{" << endl;

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -152,7 +152,7 @@ class RTFDocVisitor : public DocVisitor
 
     void pushEnabled();
     void popEnabled();
-    void writeDotFile(const QCString &fileName);
+    void writeDotFile(const QCString &fileName,const bool inl);
     void writeMscFile(const QCString &fileName);
     void writeDiaFile(const QCString &fileName);
     void writePlantUMLFile(const QCString &fileName);


### PR DESCRIPTION
In case `\dotfile` is used with the name name but from a different directory the result is only 1 output file. This is corrected with this patch.
In the html version the warning in respect to systems without svg lead to problems (`<p> tag inside <p>` tag), this has been made consistent between `\dotfile` and `\dot ...\enddot`
