### PR TITLE
Support mscfile files with same names from different directories

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1241,6 +1241,7 @@ void DocbookDocVisitor::startMscFile(const QCString &fileName,
     bool hasCaption
     )
 {
+  static int cntMscFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1252,6 +1253,12 @@ void DocbookDocVisitor::startMscFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("msc_");
+  //if (!inl)
+  //{
+    baseName += "_";
+    cntMscFile++;
+    baseName += QCString().setNum(cntMscFile);
+  //}
   QCString outDir = Config_getString("DOCBOOK_OUTPUT");
   writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP);
   m_t << "<para>" << endl;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -428,7 +428,7 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
         file.close();
 
         m_t << "<div align=\"center\">" << endl;
-        writeMscFile(baseName+".msc",s->relPath(),s->context());
+        writeMscFile(baseName+".msc",s->relPath(),s->context(),TRUE);
         if (Config_getBool("DOT_CLEANUP")) file.remove();
         m_t << "</div>" << endl;
         forceStartParagraph(s);
@@ -1460,7 +1460,7 @@ void HtmlDocVisitor::visitPre(DocMscFile *df)
 {
   if (m_hide) return;
   m_t << "<div class=\"mscgraph\">" << endl;
-  writeMscFile(df->file(),df->relPath(),df->context());
+  writeMscFile(df->file(),df->relPath(),df->context(),FALSE);
   if (df->hasCaption())
   { 
     m_t << "<div class=\"caption\">" << endl;
@@ -1946,8 +1946,10 @@ void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
 
 void HtmlDocVisitor::writeMscFile(const QCString &fileName,
                                   const QCString &relPath,
-                                  const QCString &context)
+                                  const QCString &context,
+                                  const bool inl)
 {
+  static int cntMscFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1) // strip path
@@ -1959,6 +1961,12 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("msc_");
+  if (!inl)
+  {
+    baseName += "_";
+    cntMscFile++;
+    baseName += QCString().setNum(cntMscFile);
+  }
   QCString outDir = Config_getString("HTML_OUTPUT");
   QCString imgExt = Config_getEnum("DOT_IMAGE_FORMAT");
   MscOutputFormat mscFormat = MSC_BITMAP;

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -151,7 +151,7 @@ class HtmlDocVisitor : public DocVisitor
                    const QCString &tooltip = "");
     void endLink();
     void writeDotFile(const QCString &fileName,const QCString &relPath,const QCString &context);
-    void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context);
+    void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context, const bool inl);
     void writeDiaFile(const QCString &fileName,const QCString &relPath,const QCString &context);
     void writePlantUMLFile(const QCString &fileName,const QCString &relPath,const QCString &context);
 

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1669,6 +1669,7 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
                                    bool hasCaption
                                   )
 {
+  static int cntMscFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1680,6 +1681,12 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("msc_");
+  //if (!inl)
+  //{
+    baseName += "_";
+    cntMscFile++;
+    baseName += QCString().setNum(cntMscFile);
+  //}
 
   QCString outDir = Config_getString("LATEX_OUTPUT");
   writeMscGraphFromFile(fileName,outDir,baseName,MSC_EPS); 

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -149,8 +149,14 @@ void writeMscGraphFromFile(const char *inFile,const char *outDir,
     portable_sysTimerStop();
   }
 
-error:
   QDir::setCurrent(oldDir);
+  return;
+
+error:
+  err("Problems running mscgen: exit code=%d, command='%s', arguments='%s'\n",
+      exitCode,mscExe.data(),mscArgs.data());
+  QDir::setCurrent(oldDir);
+  return;
 }
 
 QCString getMscImageMapFromFile(const QCString& inFile, const QCString& outDir,

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -315,7 +315,7 @@ void RTFDocVisitor::visit(DocVerbatim *s)
         file.writeBlock( text, text.length() );
         file.close();
         m_t << "\\par{\\qc "; // center picture
-        writeMscFile(baseName);
+        writeMscFile(baseName,TRUE);
         m_t << "} ";
         if (Config_getBool("DOT_CLEANUP")) file.remove();
       }
@@ -1065,7 +1065,7 @@ void RTFDocVisitor::visitPost(DocDotFile *)
 void RTFDocVisitor::visitPre(DocMscFile *df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocMscFile)}\n");
-  writeMscFile(df->file());
+  writeMscFile(df->file(),FALSE);
 
   // hide caption since it is not supported at the moment
   pushEnabled();
@@ -1677,14 +1677,21 @@ void RTFDocVisitor::writeDotFile(const QCString &fileName)
   m_lastIsPara=TRUE;
 }
 
-void RTFDocVisitor::writeMscFile(const QCString &fileName)
+void RTFDocVisitor::writeMscFile(const QCString &fileName,const bool inl)
 {
+  static int cntMscFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
   {
     baseName=baseName.right(baseName.length()-i-1);
   } 
+  if (!inl)
+  {
+    baseName += "_";
+    cntMscFile++;
+    baseName += QCString().setNum(cntMscFile);
+  }
   QCString outDir = Config_getString("RTF_OUTPUT");
   writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP);
   if (!m_lastIsPara) m_t << "\\par" << endl;

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -153,7 +153,7 @@ class RTFDocVisitor : public DocVisitor
     void pushEnabled();
     void popEnabled();
     void writeDotFile(const QCString &fileName);
-    void writeMscFile(const QCString &fileName);
+    void writeMscFile(const QCString &fileName,const bool inl);
     void writeDiaFile(const QCString &fileName);
     void writePlantUMLFile(const QCString &fileName);
 


### PR DESCRIPTION
In case \mscfile is used with the name name but from a different directory the result is only 1 output file. This is corrected with this patch.
In case the mscgen command failed no error message was given, this is corrected as well.
