### PR TITLE
Support diafile files with same names from different directories

### DIFF
--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -81,8 +81,12 @@ void writeDiaGraphFromFile(const char *inFile,const char *outDir,
     }
     portable_sysTimerStop();
   }
+  QDir::setCurrent(oldDir);
+  return;
 
 error:
+  err("Problems running dia: exit code=%d, command='%s', arguments='%s'\n",
+      exitCode,diaExe.data(),diaArgs.data());
   QDir::setCurrent(oldDir);
 }
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1319,6 +1319,7 @@ void DocbookDocVisitor::startDiaFile(const QCString &fileName,
     bool hasCaption
     )
 {
+  static int cntDiaFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1330,6 +1331,12 @@ void DocbookDocVisitor::startDiaFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("dia_");
+  //if (!inl)
+  //{
+    baseName += "_";
+    cntDiaFile++;
+    baseName += QCString().setNum(cntDiaFile);
+  //}
   QCString outDir = Config_getString("DOCBOOK_OUTPUT");
   writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP);
   m_t << "<para>" << endl;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1972,6 +1972,7 @@ void HtmlDocVisitor::writeDiaFile(const QCString &fileName,
                                   const QCString &relPath,
                                   const QCString &)
 {
+  static int cntDiaFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1) // strip path
@@ -1983,6 +1984,12 @@ void HtmlDocVisitor::writeDiaFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("dia_");
+  //if (!inl)
+  //{
+    baseName += "_";
+    cntDiaFile++;
+    baseName += QCString().setNum(cntDiaFile);
+  //}
   QCString outDir = Config_getString("HTML_OUTPUT");
   writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP);
 

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1761,6 +1761,7 @@ void LatexDocVisitor::startDiaFile(const QCString &fileName,
                                    bool hasCaption
                                   )
 {
+  static int cntDiaFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
@@ -1772,6 +1773,12 @@ void LatexDocVisitor::startDiaFile(const QCString &fileName,
     baseName=baseName.left(i);
   }
   baseName.prepend("dia_");
+  //if (!inl)
+  //{
+    baseName += "_";
+    cntDiaFile++;
+    baseName += QCString().setNum(cntDiaFile);
+  //}
 
   QCString outDir = Config_getString("LATEX_OUTPUT");
   writeDiaGraphFromFile(fileName,outDir,baseName,DIA_EPS);

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1699,12 +1699,19 @@ void RTFDocVisitor::writeMscFile(const QCString &fileName)
 
 void RTFDocVisitor::writeDiaFile(const QCString &fileName)
 {
+  static int cntDiaFile = 0;
   QCString baseName=fileName;
   int i;
   if ((i=baseName.findRev('/'))!=-1)
   {
     baseName=baseName.right(baseName.length()-i-1);
   }
+  //if (!inl)
+  //{
+    baseName += "_";
+    cntDiaFile++;
+    baseName += QCString().setNum(cntDiaFile);
+  //}
   QCString outDir = Config_getString("RTF_OUTPUT");
   writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP);
   if (!m_lastIsPara) m_t << "\\par" << endl;


### PR DESCRIPTION
In case \diafile is used with the name name but from a different directory the result is only 1 output file. This is corrected with this patch.
In case the dia command failed no error message was given, this is corrected as well.
