### PR TITLE
Conditional section can give extra verbatim section

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -762,11 +762,11 @@ void replaceComment(int offset);
 <CComment,ReadLine>[\\@][\\@][~a-z_A-Z][a-z_A-Z0-9]*[ \t]* { // escaped command
 				     copyToOutput(yytext,(int)yyleng);
   				   }
-<CComment,ReadLine>[\\@]"cond"/[^a-z_A-Z0-9]	   { // conditional section
+<CComment,ReadLine>[ \t]*[\\@]"cond"/[^a-z_A-Z0-9]	   { // conditional section
   				     g_condCtx = YY_START; 
   				     BEGIN(CondLine);
   				   }
-<CComment,ReadLine>[\\@]"endcond"/[^a-z_A-Z0-9] { // end of conditional section
+<CComment,ReadLine>[ \t]*[\\@]"endcond"/[^a-z_A-Z0-9] { // end of conditional section
   				     bool oldSkip=g_skip;
   				     endCondSection();
 				     if (YY_START==CComment && oldSkip && !g_skip) 
@@ -809,7 +809,7 @@ void replaceComment(int offset);
                                      }
   				   }
 <CondLine>[ \t]*
-<CComment,ReadLine>[\\@]"cond"[ \t\r]*/\n |
+<CComment,ReadLine>[ \t]*[\\@]"cond"[ \t\r]*/\n |
 <CondLine>.			   { // forgot section id?
   				     if (YY_START!=CondLine) g_condCtx=YY_START;
   				     bool oldSkip=g_skip;


### PR DESCRIPTION
In Fortran when having code as shown below and setting `public` in the `ENABLED_SECTIONS` the result is that an extra verbatim section occurs before the `var_pub_2`.
This is due to the fact that in case of the `@cond` (and `@endcond)` the (white) space after `!>` is added in the comment converted "file" this extra space result in an extra verbatim section. By adding the space to the search pattern for `@cond` (and `@endcond`) this problem can be overcome.

===== code showing the problem =====
```
!> Docu of module
MODULE test_aa
!> @cond public
!> var public 1
CHARACTER(LEN=100), PARAMETER :: var_pub_1 = 'var_pub_1'
!> @endcond
!> @cond private
!> var private 1
CHARACTER(LEN=100), PARAMETER :: var_priv_1 = 'var_priv_1'
!> @endcond
!> @cond private
!> var private 2
CHARACTER(LEN=100), PARAMETER :: var_priv_2 = 'var_priv_2'
!> @endcond
!> @cond public
!> var public 2
CHARACTER(LEN=100), PARAMETER :: var_pub_2 = 'var_pub_2'
!> @endcond

END MODULE
```
