### PR TITLE
Support visible=no for main page tab.

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1104,7 +1104,7 @@ class LayoutParser : public QXmlDefaultHandler
         }
       }
       // create new item and make it the new root
-      m_rootNav = new LayoutNavEntry(m_rootNav,kind,kind==LayoutNavEntry::MainPage?TRUE:isVisible,baseFile,title,intro);
+      m_rootNav = new LayoutNavEntry(m_rootNav,kind,isVisible,baseFile,title,intro);
     }
 
     void endNavEntry()


### PR DESCRIPTION
Not sure why this was hard-coded in there, but I am using Doxygen to generate parts of a larger set of documentation, and the "main page" isn't Doxygen created (and the main Doxygen page is useless in this case).

I am not the only one who's had this issue: http://stackoverflow.com/questions/21182270/doxygenlayout-mainpage-visible-no-does-not-work

I think Doxygen should just do what the layout file says.  Alternatively, being able to specify a custom URL for the mainpage tab would also do.
