### PR TITLE
LaTeX problem with 2 consecutive single quotes

### DIFF
--- a/src/htmlentity.cpp
+++ b/src/htmlentity.cpp
@@ -298,7 +298,7 @@ static struct htmlEntityInfo
 
   // doxygen extension to the HTML4 table of HTML entities
   { SYM(tm),       "\xe2\x84\xa2", "&trade;",    "<trademark/>",         "&#8482;",       "\\texttrademark{}",      "(TM)",   "\\'99",       { "trademark",  DocSymbol::Perl_symbol  }},
-  { SYM(apos),     "'",            "'",          "'",                    "&apos;",        "'",                      "'",      "'",           { "\\\'",       DocSymbol::Perl_string  }},
+  { SYM(apos),     "'",            "'",          "'",                    "&apos;",        "\\textquotesingle{}",    "'",      "'",           { "\\\'",       DocSymbol::Perl_string  }},
 
   // doxygen commands represented as HTML entities
   { SYM(BSlash),   "\\",           "\\",         "\\",                   "\\",            "\\textbackslash{}",      "\\\\",   "\\\\",        { "\\\\",       DocSymbol::Perl_string  }},

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6500,6 +6500,8 @@ void filterLatexString(FTextStream &t,const char *str,
                    break;           
         case '"':  t << "\\char`\\\"{}";
                    break;
+        case '\'': t << "\\textquotesingle{}";
+                   break;
 
         default:   
                    //if (!insideTabbing && forceBreaks && c!=' ' && *p!=' ')


### PR DESCRIPTION
In LaTeX 2 consecutive single quotes are joined to 1 double quote. This leads in texts where 2 single quotes are intended to a strange view. An example is the initial value for variables. E.g. in Fortran: character(len=10) :: A = ''  (i.e an empty string which can either be defined as '' or as "") or in C: char *sq  = "''". In the source listings this is OK but in the description text it was not OK.
