### PR TITLE
Make number of Rerun loops to generate targets latex directory more flexible

### DIFF
--- a/doc/starting.doc
+++ b/doc/starting.doc
@@ -221,6 +221,15 @@ and \ref cfg_use_pdflatex "USE_PDFLATEX" tags to \c YES.
 In this case the \c Makefile will only contain a target to build 
 \c refman.pdf directly.
 
+
+\note In case you get at the end of the \c make process amessage like:
+`"LaTeX Warning: Label(s) may have changed. Rerun to get cross-references right."`
+this means that the default number of loops (default is 8) is insuffient. You can
+try to rerun with more loops. In case you want to rerun with e.g. 10 loops and
+you use `make.bat`  give the command `make 10`, in case you use `Makefile` you can
+give the command `make latex_count=10`.
+
+
 \subsection rtf_out RTF output
 \addindex RTF
 Doxygen combines the RTF output to a single file called refman.rtf. This

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -74,6 +74,7 @@ static void writeLatexMakefile()
   FTextStream t(&file);
   if (!Config_getBool("USE_PDFLATEX")) // use plain old latex
   {
+    t << "latex_count=8" << endl << endl;
     t << "all: refman.dvi" << endl
       << endl
       << "ps: refman.ps" << endl
@@ -103,12 +104,12 @@ static void writeLatexMakefile()
     }
     t << "\techo \"Rerunning latex....\"" << endl
       << "\t" << latex_command << " refman.tex" << endl
-      << "\tlatex_count=8 ; \\" << endl
-      << "\twhile egrep -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$latex_count -gt 0 ] ;\\" << endl
+      << "\tlocal_count=$(latex_count) ; \\" << endl
+      << "\twhile egrep -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$local_count -gt 0 ] ;\\" << endl
       << "\t    do \\" << endl
       << "\t      echo \"Rerunning latex....\" ;\\" << endl
       << "\t      " << latex_command << " refman.tex ;\\" << endl
-      << "\t      latex_count=`expr $$latex_count - 1` ;\\" << endl
+      << "\t      local_count=`expr $$local_count - 1` ;\\" << endl
       << "\t    done" << endl
       << "\t" << mkidx_command << " refman.idx" << endl
       << "\t" << latex_command << " refman.tex" << endl << endl
@@ -120,6 +121,7 @@ static void writeLatexMakefile()
   }
   else // use pdflatex for higher quality output
   {
+    t << "latex_count=8" << endl << endl;
     t << "all: refman.pdf" << endl << endl
       << "pdf: refman.pdf" << endl << endl;
     t << "refman.pdf: clean refman.tex" << endl;
@@ -131,12 +133,12 @@ static void writeLatexMakefile()
       t << "\tpdflatex refman" << endl;
     }
     t << "\tpdflatex refman" << endl
-      << "\tlatex_count=8 ; \\" << endl
-      << "\twhile egrep -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$latex_count -gt 0 ] ;\\" << endl
+      << "\tlocal_count=$(latex_count) ; \\" << endl
+      << "\twhile egrep -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$local_count -gt 0 ] ;\\" << endl
       << "\t    do \\" << endl
       << "\t      echo \"Rerunning latex....\" ;\\" << endl
       << "\t      pdflatex refman ;\\" << endl
-      << "\t      latex_count=`expr $$latex_count - 1` ;\\" << endl
+      << "\t      local_count=`expr $$local_count - 1` ;\\" << endl
       << "\t    done" << endl
       << "\t" << mkidx_command << " refman.idx" << endl
       << "\tpdflatex refman" << endl << endl;
@@ -178,7 +180,8 @@ static void writeMakeBat()
       t << latex_command << " refman.tex\n";
     }
     t << "setlocal enabledelayedexpansion\n";
-    t << "set count=8\n";
+    t << "set count=%1\n";
+    t << "if \"%1\"==\"\" set count=8\n";
     t << ":repeat\n";
     t << "set content=X\n";
     t << "for /F \"tokens=*\" %%T in ( 'findstr /C:\"Rerun LaTeX\" refman.log' ) do set content=\"%%~T\"\n";
@@ -210,7 +213,8 @@ static void writeMakeBat()
     t << "echo ----\n";
     t << "pdflatex refman\n\n";
     t << "setlocal enabledelayedexpansion\n";
-    t << "set count=8\n";
+    t << "set count=%1\n";
+    t << "if \"%1\"==\"\" set count=8\n";
     t << ":repeat\n";
     t << "set content=X\n";
     t << "for /F \"tokens=*\" %%T in ( 'findstr /C:\"Rerun LaTeX\" refman.log' ) do set content=\"%%~T\"\n";


### PR DESCRIPTION
Till now it was only possible to change the Makefile or the make.bat in case the default number of Rerun-loops was insufficient. With this patch the number of loops can also be specified from outside (e.g. make 8 when using make.bat or make latex_count=10  when using Makefile. Advantage is that this value can easier be applied in scripts / other Makefiles.
