### PR TITLE
Bug ?? for page numbers in the latex indices

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1065,7 +1065,7 @@ void LatexGenerator::endIndexItem(const char *ref,const char *fn)
 {
   if (!ref && fn)
   {
-    t << "}{\\pageref{" << fn << "}}{}" << endl;
+    t << "}{\\pageref{" << stripPath(fn) << "}}{}" << endl;
   }
 }
 


### PR DESCRIPTION
Due to the fact that the path was not stripped from the file name in case CREATE_SUBDIRS was set to YES there was a reference to a non existing page reference. In the corresponding hypertarget and label the path was already stripped.
