### PR TITLE
Fix bug: language switch command skipped when langauge id contains "-" letter

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1120,7 +1120,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 <Comment>{B}*("\\\\"|"@@")"f"[$\[{]	{ // escaped formula command
   					  addOutput(yytext);
   					}
-<Comment>{B}*{CMD}"~"[a-z_A-Z]*		{ // language switch command
+<Comment>{B}*{CMD}"~"[a-z_A-Z-]*		{ // language switch command
                                           QCString langId = QString(yytext).stripWhiteSpace().data()+2;
 			       	          if (!langId.isEmpty() &&
 					      qstricmp(Config_getEnum("OUTPUT_LANGUAGE"),langId)!=0)
@@ -2160,7 +2160,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 
   /* ----- handle language specific sections ------- */
 
-<SkipLang>[\\@]"~"[a-zA-Z]*        { /* language switch */
+<SkipLang>[\\@]"~"[a-zA-Z-]*        { /* language switch */
                                      QCString langId = &yytext[2];
 				     if (langId.isEmpty() ||
 					 qstricmp(Config_getEnum("OUTPUT_LANGUAGE"),langId)==0)

--- a/testing/065/indexpage.xml
+++ b/testing/065/indexpage.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="indexpage" kind="page">
+    <compoundname>index</compoundname>
+    <title>My Project</title>
+    <detaileddescription>
+      <para>これは日本語(en)です. Output for all languages. </para>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/065_tilde.dox
+++ b/testing/065_tilde.dox
@@ -1,0 +1,12 @@
+// objective: test \~ command with non default OUTPUT_LANGUAGE which contains '-' letter
+// check: indexpage.xml
+// config: OUTPUT_LANGUAGE = Japanese-en
+/** 
+\mainpage 
+\~english This is English.
+\~dutch Dit is Nederlands.
+\~japanese これは日本語です.
+\~japanese-en これは日本語(en)です.
+\~german Dies ist Deutsch.
+\~ Output for all languages.
+*/


### PR DESCRIPTION
This PR fixes language switch command "\~" issue:
Language switches with "Japanese-en", "Korean-en", and "Serbian-Cyrillic" are simply ignored.
Please see the test case "065" for detail.
