### PR TITLE
Extra empty line in source fragments

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -755,6 +755,7 @@ bool readCodeFragment(const char *fileName,
     {
       while ((c=fgetc(f))!='\n' && c!=EOF) /* skip */;
       lineNr++; 
+      if (found && c == '\n') c = '\0';
     }
     if (!feof(f))
     {
@@ -763,7 +764,7 @@ bool readCodeFragment(const char *fileName,
       while (lineNr<=endLine && !feof(f) && !found)
       {
         int pc=0;
-        while ((c=fgetc(f))!='{' && c!=':' && c!=EOF) 
+        while ((c=fgetc(f))!='{' && c!=':' && c!=EOF)  // } so vi matching brackets has no problem
         {
           //printf("parsing char `%c'\n",c);
           if (c=='\n') 
@@ -816,7 +817,7 @@ bool readCodeFragment(const char *fileName,
           result+=spaces;
         }
         // copy until end of line
-        result+=c;
+        if (c) result+=c;
         startLine=lineNr;
         if (c==':') 
         {


### PR DESCRIPTION
In case of a language that does not uses curly brackets to define blocks (such as Fortran) there was a newline character in the variable c and this was written in the "code fragment" buffer and subsequently written to the output resulting in and extra empty line on top. I languages using curly brackets this is later overwritten by the while loop searching for the open curly bracket.
