### PR TITLE
Bug 722940 - classes with same name in different namespace adding to same group

### DIFF
--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -151,13 +151,13 @@ bool GroupDef::addClass(const ClassDef *cd)
   static bool sortBriefDocs = Config_getBool("SORT_BRIEF_DOCS");
   if (cd->isHidden()) return FALSE;
   updateLanguage(cd);
-  if (classSDict->find(cd->qualifiedName())==0)
+  QCString qn = cd->name();
+  if (classSDict->find(qn)==0)
   {
-    QCString qn = cd->qualifiedName();
     //printf("--- addClass %s sort=%d\n",qn.data(),sortBriefDocs);
     if (sortBriefDocs)
     {
-      classSDict->inSort(cd->qualifiedName(),cd);
+      classSDict->inSort(qn,cd);
     }
     else
     {
@@ -180,13 +180,13 @@ bool GroupDef::addClass(const ClassDef *cd)
             j++;
           }
           //printf("Found scope at index %d\n",j);
-          classSDict->insertAt(j,cd->qualifiedName(),cd);
+          classSDict->insertAt(j,qn,cd);
           found=TRUE;
         }
       }
       if (!found) // no insertion point found -> just append
       {
-        classSDict->append(cd->qualifiedName(),cd);
+        classSDict->append(qn,cd);
       }
     }
     return TRUE;


### PR DESCRIPTION
If two classes with the same name, but in different namespaces (so different qualified names) were added to the same group, only one of them would end up in the group.
The problem is caused by qualifiedName of the class not containing the qualified name but the class name when a class is added to the group.
A workaround is to use the name attribute of the class, which does contain the qualified name.
