### PR TITLE
Add source code possibility for RTF output

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2686,6 +2686,16 @@ EXTRA_PACKAGES=times
 ]]>
       </docs>
     </option>
+    <option type='bool' id='RTF_SOURCE_CODE' defval='0' depends='GENERATE_RTF'>
+      <docs>
+<![CDATA[
+ If the \c RTF_SOURCE_CODE tag is set to \c YES then doxygen will include
+ source code with syntax highlighting in the RTF output.
+ <br>Note that which sources are shown also depends on other settings
+ such as \ref cfg_source_browser "SOURCE_BROWSER".
+]]>
+      </docs>
+    </option>
   </group>
   <group name='Man' docs='Configuration options related to the man page output'>
     <option type='bool' id='GENERATE_MAN' defval='0'>

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -911,6 +911,7 @@ QCString Definition::getSourceAnchor() const
 void Definition::writeSourceDef(OutputList &ol,const char *)
 {
   static bool latexSourceCode = Config_getBool("LATEX_SOURCE_CODE");
+  static bool rtfSourceCode = Config_getBool("RTF_SOURCE_CODE");
   ol.pushGeneratorState();
   //printf("Definition::writeSourceRef %d %p\n",bodyLine,bodyDef);
   QCString fn = getSourceFileBase();
@@ -930,13 +931,16 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
         // write text left from linePos marker
         ol.parseText(refText.left(lineMarkerPos)); 
         ol.pushGeneratorState();
-        ol.disable(OutputGenerator::RTF); 
         ol.disable(OutputGenerator::Man); 
         if (!latexSourceCode)
         {
           ol.disable(OutputGenerator::Latex);
         }
-        // write line link (HTML, LaTeX optionally)
+        if (!rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
+        }
+        // write line link (HTML, LaTeX optionally, RTF optionally)
         ol.writeObjectLink(0,fn,anchorStr,lineStr);
         ol.enableAll();
         ol.disable(OutputGenerator::Html);
@@ -944,7 +948,11 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
         {
           ol.disable(OutputGenerator::Latex);
         }
-        // write normal text (Man/RTF, Latex optionally)
+        if (rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
+        }
+        // write normal text (Man, Latex optionally, RTF optionally)
         ol.docify(lineStr);
         ol.popGeneratorState();
         
@@ -953,13 +961,16 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
               fileMarkerPos-lineMarkerPos-2));
 
         ol.pushGeneratorState();
-        ol.disable(OutputGenerator::RTF); 
         ol.disable(OutputGenerator::Man); 
         if (!latexSourceCode)
         {
           ol.disable(OutputGenerator::Latex);
         }
-        // write file link (HTML, LaTeX optionally)
+        if (!rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
+        }
+        // write file link (HTML, LaTeX optionally, RTF optionally)
         ol.writeObjectLink(0,fn,0,m_impl->body->fileDef->name());
         ol.enableAll();
         ol.disable(OutputGenerator::Html);
@@ -967,7 +978,11 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
         {
           ol.disable(OutputGenerator::Latex);
         }
-        // write normal text (Man/RTF, Latex optionally)
+        if (rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
+        }
+        // write normal text (Man, Latex optionally, RTF optionally)
         ol.docify(m_impl->body->fileDef->name());
         ol.popGeneratorState();
         
@@ -980,11 +995,14 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
         // write text left from file marker
         ol.parseText(refText.left(fileMarkerPos)); 
         ol.pushGeneratorState();
-        ol.disable(OutputGenerator::RTF); 
         ol.disable(OutputGenerator::Man); 
         if (!latexSourceCode)
         {
           ol.disable(OutputGenerator::Latex);
+        }
+        if (!rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
         }
         // write file link (HTML only)
         ol.writeObjectLink(0,fn,0,m_impl->body->fileDef->name());
@@ -994,7 +1012,11 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
         {
           ol.disable(OutputGenerator::Latex);
         }
-        // write normal text (Latex/Man only)
+        if (rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
+        }
+        // write normal text (RTF/Latex/Man only)
         ol.docify(m_impl->body->fileDef->name());
         ol.popGeneratorState();
         
@@ -1003,11 +1025,14 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
               lineMarkerPos-fileMarkerPos-2)); 
 
         ol.pushGeneratorState();
-        ol.disable(OutputGenerator::RTF); 
         ol.disable(OutputGenerator::Man); 
         if (!latexSourceCode)
         {
           ol.disable(OutputGenerator::Latex);
+        }
+        if (!rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
         }
         ol.disableAllBut(OutputGenerator::Html); 
         // write line link (HTML only)
@@ -1017,6 +1042,10 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
         if (latexSourceCode) 
         {
           ol.disable(OutputGenerator::Latex);
+        }
+        if (rtfSourceCode)
+        {
+          ol.disable(OutputGenerator::RTF);
         }
         // write normal text (Latex/Man only)
         ol.docify(lineStr);
@@ -1107,6 +1136,7 @@ void Definition::_writeSourceRefList(OutputList &ol,const char *scopeName,
     const QCString &text,MemberSDict *members,bool /*funcOnly*/)
 {
   static bool latexSourceCode = Config_getBool("LATEX_SOURCE_CODE"); 
+  static bool rtfSourceCode   = Config_getBool("RTF_SOURCE_CODE");
   static bool sourceBrowser   = Config_getBool("SOURCE_BROWSER");
   static bool refLinkSource   = Config_getBool("REFERENCES_LINK_SOURCE");
   ol.pushGeneratorState();
@@ -1159,11 +1189,14 @@ void Definition::_writeSourceRefList(OutputList &ol,const char *scopeName,
           ol.pushGeneratorState();
           //ol.disableAllBut(OutputGenerator::Html);
 
-          ol.disable(OutputGenerator::RTF); 
           ol.disable(OutputGenerator::Man); 
           if (!latexSourceCode)
           {
             ol.disable(OutputGenerator::Latex);
+          }
+          if (!rtfSourceCode)
+          {
+            ol.disable(OutputGenerator::RTF);
           }
           const int maxLineNrStr = 10;
           char anchorStr[maxLineNrStr];
@@ -1179,6 +1212,10 @@ void Definition::_writeSourceRefList(OutputList &ol,const char *scopeName,
           {
             ol.disable(OutputGenerator::Latex);
           }
+          if (!rtfSourceCode)
+          {
+            ol.disable(OutputGenerator::RTF);
+          }
           ol.docify(name);
           ol.popGeneratorState();
         }
@@ -1187,11 +1224,14 @@ void Definition::_writeSourceRefList(OutputList &ol,const char *scopeName,
           // for HTML write a real link
           ol.pushGeneratorState();
           //ol.disableAllBut(OutputGenerator::Html); 
-          ol.disable(OutputGenerator::RTF); 
           ol.disable(OutputGenerator::Man); 
           if (!latexSourceCode)
           {
             ol.disable(OutputGenerator::Latex);
+          }
+          if (!rtfSourceCode)
+          {
+            ol.disable(OutputGenerator::RTF);
           }
 
           ol.writeObjectLink(md->getReference(),
@@ -1205,6 +1245,10 @@ void Definition::_writeSourceRefList(OutputList &ol,const char *scopeName,
           if (latexSourceCode)
           {
             ol.disable(OutputGenerator::Latex);
+          }
+          if (rtfSourceCode)
+          {
+            ol.disable(OutputGenerator::RTF);
           }
           ol.docify(name);
           ol.popGeneratorState();

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -333,6 +333,10 @@ void FileDef::writeDetailedDescription(OutputList &ol,const QCString &title)
       { 
         ol.disable(OutputGenerator::Latex);
       }
+      if (ol.isEnabled(OutputGenerator::RTF) && !Config_getBool("RTF_SOURCE_CODE"))
+      { 
+        ol.disable(OutputGenerator::RTF);
+      }
 
       ol.startParagraph();
       QCString refText = theTranslator->trDefinedInSourceFile();
@@ -910,6 +914,7 @@ void FileDef::writeSource(OutputList &ol,bool sameTu,QStrList &filesInSameTu)
   static bool generateTreeView  = Config_getBool("GENERATE_TREEVIEW");
   static bool filterSourceFiles = Config_getBool("FILTER_SOURCE_FILES");
   static bool latexSourceCode   = Config_getBool("LATEX_SOURCE_CODE");
+  static bool rtfSourceCode     = Config_getBool("RTF_SOURCE_CODE");
   DevNullCodeDocInterface devNullIntf;
   QCString title = m_docname;
   if (!m_fileVersion.isEmpty())
@@ -918,8 +923,8 @@ void FileDef::writeSource(OutputList &ol,bool sameTu,QStrList &filesInSameTu)
   }
   QCString pageTitle = theTranslator->trSourceFile(title);
   ol.disable(OutputGenerator::Man);
-  ol.disable(OutputGenerator::RTF);
   if (!latexSourceCode) ol.disable(OutputGenerator::Latex);
+  if (!rtfSourceCode) ol.disable(OutputGenerator::RTF);
 
   bool isDocFile = isDocumentationFile();
   bool genSourceFile = !isDocFile && generateSourceFile();
@@ -951,10 +956,12 @@ void FileDef::writeSource(OutputList &ol,bool sameTu,QStrList &filesInSameTu)
   if (isLinkable())
   {
     if (latexSourceCode) ol.disable(OutputGenerator::Latex);
+    if (rtfSourceCode) ol.disable(OutputGenerator::RTF);
     ol.startTextLink(getOutputFileBase(),0);
     ol.parseText(theTranslator->trGotoDocumentation());
     ol.endTextLink();
     if (latexSourceCode) ol.enable(OutputGenerator::Latex);
+    if (rtfSourceCode) ol.enable(OutputGenerator::RTF);
   }
 
   (void)sameTu;

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -66,6 +66,7 @@ RTFGenerator::RTFGenerator() : OutputGenerator()
   m_bstartedBody = FALSE;
   m_omitParagraph = FALSE;
   m_numCols = 0;
+  m_prettyCode=Config_getBool("RTF_SOURCE_CODE");
 }
 
 RTFGenerator::~RTFGenerator()
@@ -539,6 +540,8 @@ void RTFGenerator::endIndexSection(IndexSections is)
 {
   bool fortranOpt = Config_getBool("OPTIMIZE_FOR_FORTRAN");
   bool vhdlOpt    = Config_getBool("OPTIMIZE_OUTPUT_VHDL");  
+  static bool sourceBrowser = Config_getBool("SOURCE_BROWSER");
+
   switch (is)
   {
     case isTitlePageStart:
@@ -810,6 +813,11 @@ void RTFGenerator::endIndexSection(IndexSections is)
                 t << "{\\field\\fldedit{\\*\\fldinst INCLUDETEXT \"";
                 t << fd->getOutputFileBase();
                 t << ".rtf\" \\\\*MERGEFORMAT}{\\fldrslt includedstuff}}\n";
+                if (sourceBrowser && m_prettyCode && fd->generateSourceFile())
+                {
+                  t << "\\par " << rtf_Style_Reset << endl;
+                  t << "{\\field\\fldedit{\\*\\fldinst INCLUDETEXT \"" << fd->getSourceFileBase() << ".rtf\" \\\\*MERGEFORMAT}{\\fldrslt includedstuff}}\n";
+                }
                 isFirst=FALSE;
               }
               else
@@ -819,6 +827,11 @@ void RTFGenerator::endIndexSection(IndexSections is)
                 t << "{\\field\\fldedit{\\*\\fldinst INCLUDETEXT \"";
                 t << fd->getOutputFileBase();
                 t << ".rtf\" \\\\*MERGEFORMAT}{\\fldrslt includedstuff}}\n";
+                if (sourceBrowser && m_prettyCode && fd->generateSourceFile())
+                {
+                  t << "\\par " << rtf_Style_Reset << endl;
+                  t << "{\\field\\fldedit{\\*\\fldinst INCLUDETEXT \"" << fd->getSourceFileBase() << ".rtf\" \\\\*MERGEFORMAT}{\\fldrslt includedstuff}}\n";
+                }
               }
             }
           }

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -126,7 +126,7 @@ class RTFGenerator : public OutputGenerator
     void writeAnchor(const char *fileName,const char *name);
     void startCodeFragment();
     void endCodeFragment();
-    void writeLineNumber(const char *,const char *,const char *,int l) { t << l << " "; }
+    void writeLineNumber(const char *,const char *,const char *,int l) { t << QString("%1").arg(l,5) << " "; }
     void startCodeLine(bool) { col=0; }
     void endCodeLine() { lineBreak(); }
     void startEmphasis() { t << "{\\i ";  }
@@ -277,6 +277,7 @@ class RTFGenerator : public OutputGenerator
     void incrementIndentLevel();
     void decrementIndentLevel();
     int  col;
+    bool m_prettyCode;
 
     bool m_bstartedBody;  // has startbody been called yet?
     int  m_listLevel; // // RTF does not really have a addative indent...manually set list level.


### PR DESCRIPTION
Analogous to Latex and HTML output the possibility to have source code shown in RTF output is created.
Based on question: http://doxygen.10944.n7.nabble.com/RTF-lack-of-source-code-tc6936.html
