### PR TITLE
Fix potential null pointer dereference in src/context.cpp

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -5244,7 +5244,7 @@ class NestingNodeContext::Private : public PropertyMapper
     void addClasses(bool inherit, bool hideSuper)
     {
       ClassDef *cd = m_def->definitionType()==Definition::TypeClass ? (ClassDef*)m_def : 0;
-      if (inherit)
+      if (cd && inherit)
       {
         bool hasChildren = !cd->visited && !hideSuper && classHasVisibleChildren(cd);
         if (hasChildren)


### PR DESCRIPTION
This fixes Coverity Scan ID 85036 Explicit null dereferenced.

Best regards and many thanks 

Martin Ettl
