### PR TITLE
Remove unused local and static global variables

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -63,7 +63,6 @@ void CiteDict::writeLatexBibliography(FTextStream &t)
   t << "\\bibliographystyle{" << style << "}\n"
        "\\bibliography{";
   QStrList &citeDataList = Config_getList("CITE_BIB_FILES");
-  QCString latexOutputDir = Config_getString("LATEX_OUTPUT")+"/";
   int i = 0;
   const char *bibdata = citeDataList.first();
   while (bibdata)

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -4031,7 +4031,6 @@ int ClassDef::countMemberDeclarations(MemberListType lt,ClassDef *inheritedFrom,
     static bool inlineInheritedMembers = Config_getBool("INLINE_INHERITED_MEMB");
     if (!inlineInheritedMembers) // show inherited members as separate lists
     {
-      QPtrDict<void> visited(17);
       count+=countInheritedDecMembers(lt,inheritedFrom,invert,showAlways,visitedClasses);
     }
   }

--- a/src/code.l
+++ b/src/code.l
@@ -1236,7 +1236,6 @@ static void generateMemberLink(CodeOutputInterface &ol,const QCString &varName,
       {
 	int vi;
 	QCString vn=varName;
-	QCString scope;
 	if ((vi=vn.findRev("::"))!=-1 || (vi=vn.findRev('.'))!=-1)  // explicit scope A::b(), probably static member
 	{
 	  ClassDef *jcd = getClass(vn.left(vi));

--- a/src/config.l
+++ b/src/config.l
@@ -431,19 +431,11 @@ static bool             *b=0;
 static QStrList         *l=0;
 static int               lastState;
 static QCString          elemStr;
-static QCString          includeName;
 static QStrList          includePathList;
 static QStack<ConfigFileState> includeStack;  
 static int               includeDepth;
 static bool              config_upd = FALSE;
 
-static QCString     tabSizeString;
-static QCString     maxInitLinesString;
-static QCString     colsInAlphaIndexString;
-static QCString     enumValuesPerLineString;
-static QCString     treeViewWidthString;
-static QCString     maxDotGraphWidthString;
-static QCString     maxDotGraphHeightString;
 static QCString     encoding;
 
 static Config      *config;

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -45,7 +45,6 @@ static QCString      funcTempList;
 static QCString      type;
 static QCString      name;
 static QCString      args;
-static QCString      tmpType;
 static int          sharpCount;
 static bool         classTempListFound;
 static bool         funcTempListFound;

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -80,8 +80,6 @@ void DirDef::addFile(FileDef *fd)
 
 static QCString encodeDirName(const QCString &anchor)
 {
-  QCString result;
-
   // convert to md5 hash
   uchar md5_sig[16];
   QCString sigStr(33);
@@ -90,6 +88,7 @@ static QCString encodeDirName(const QCString &anchor)
   return sigStr;
 
   // old algorithm
+//  QCString result;
 
 //  int l = anchor.length(),i;
 //  for (i=0;i<l;i++)

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -589,11 +589,9 @@ static void generateDocbookForMember(MemberDef *md,FTextStream &t,Definition *de
       t << "_1" << md->anchor() << "\">" << convertToXML(md->name()) << "</link>";
       t << " (" << endl;
       ArgumentList *declAl = md->declArgumentList();
-      ArgumentList *defAl = md->argumentList();
       if (declAl && declAl->count()>0)
       {
         ArgumentListIterator declAli(*declAl);
-        ArgumentListIterator defAli(*defAl);
         Argument *a;
         int cnt=0;
         for (declAli.toFirst();(a=declAli.current());++declAli)
@@ -812,7 +810,7 @@ static void generateDocbookForMember(MemberDef *md,FTextStream &t,Definition *de
   }
 }
 
-static void generateDocbookSection(Definition *d,FTextStream &t,MemberList *ml,const char *kind,
+static void generateDocbookSection(Definition *d,FTextStream &t,MemberList *ml,const char *,
     bool detailed=0, const char *header=0,const char *documentation=0)
 {
   if (ml==0) return;
@@ -820,7 +818,6 @@ static void generateDocbookSection(Definition *d,FTextStream &t,MemberList *ml,c
   MemberDef *md;
   int count=0;
   int doc_count=0;
-  QCString compkind = kind;
   QCString title, desctitle;
 
   for (mli.toFirst();(md=mli.current());++mli) 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1326,7 +1326,6 @@ void DocbookDocVisitor::writeDotFile(const QCString &baseName, DocVerbatim *s)
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString("DOCBOOK_OUTPUT");
-  QCString imgExt = Config_getEnum("DOT_IMAGE_FORMAT");
   writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP);
   visitPreStart(m_t, s->hasCaption(), baseName + ".dot", s->width(),s->height());
   visitCaption(this, s->children());

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -844,7 +844,6 @@ static int handleStyleArgument(DocNode *parent,QList<DocNode> &children,
                                const QCString &cmdName)
 {
   DBG(("handleStyleArgument(%s)\n",qPrint(cmdName)));
-  QCString tokenName = g_token->name;
   int tok=doctokenizerYYlex();
   if (tok!=TK_WHITESPACE)
   {
@@ -1178,7 +1177,6 @@ static void handleParameterType(DocNode *parent,QList<DocNode> &children,const Q
 {
   QCString name = g_token->name;
   int p=0,i;
-  QCString type;
   while ((i=paramTypes.find('|',p))!=-1)
   {
     g_token->name = paramTypes.mid(p,i-p);
@@ -2137,7 +2135,6 @@ DocXRefItem::DocXRefItem(DocNode *parent,int id,const char *key) :
 
 bool DocXRefItem::parse()
 {
-  QCString listName;
   RefList *refList = Doxygen::xrefLists->find(m_key); 
   if (refList && 
       (
@@ -2571,7 +2568,6 @@ DocCite::DocCite(DocNode *parent,const QCString &target,const QCString &) //cont
 {
   static uint numBibFiles = Config_getList("CITE_BIB_FILES").count();
   m_parent = parent;
-  QCString anchor;
   //printf("DocCite::DocCite(target=%s)\n",target.data());
   ASSERT(!target.isEmpty());
   m_relPath = g_relPath;

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -156,8 +156,6 @@ static const char svgZoomFooter[] =
 
 //--------------------------------------------------------------------
 
-static const int maxCmdLine = 40960;
-
 /*! mapping from protection levels to color names */
 static const char *normalEdgeColorMap[] =
 {
@@ -3147,8 +3145,6 @@ QCString DotClassGraph::writeGraph(FTextStream &out,
     regenerate=TRUE;
     if (graphFormat==GOF_BITMAP) // run dot to create a bitmap image
     {
-      QCString dotArgs(maxCmdLine);
-
       DotRunner *dotRun = new DotRunner(absDotName,
                               d.absPath().data(),TRUE,absImgName);
       dotRun->addJob(imgExt,absImgName);
@@ -3506,7 +3502,6 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
     if (graphFormat==GOF_BITMAP)
     {
       // run dot to create a bitmap image
-      QCString dotArgs(maxCmdLine);
       DotRunner *dotRun = new DotRunner(absDotName,d.absPath().data(),TRUE,absImgName);
       dotRun->addJob(imgExt,absImgName);
       if (generateImageMap) dotRun->addJob(MAP_CMD,absMapName);
@@ -3819,7 +3814,6 @@ QCString DotCallGraph::writeGraph(FTextStream &out, GraphOutputFormat graphForma
     if (graphFormat==GOF_BITMAP)
     {
       // run dot to create a bitmap image
-      QCString dotArgs(maxCmdLine);
       DotRunner *dotRun = new DotRunner(absDotName,d.absPath().data(),TRUE,absImgName);
       dotRun->addJob(imgExt,absImgName);
       if (generateImageMap) dotRun->addJob(MAP_CMD,absMapName);
@@ -3984,7 +3978,6 @@ QCString DotDirDeps::writeGraph(FTextStream &out,
     if (graphFormat==GOF_BITMAP)
     {
       // run dot to create a bitmap image
-      QCString dotArgs(maxCmdLine);
       DotRunner *dotRun = new DotRunner(absDotName,d.absPath().data(),TRUE,absImgName);
       dotRun->addJob(imgExt,absImgName);
       if (generateImageMap) dotRun->addJob(MAP_CMD,absMapName);
@@ -4512,7 +4505,6 @@ QCString DotGroupCollaboration::writeGraph( FTextStream &t,
   QCString imgExt      = Config_getEnum("DOT_IMAGE_FORMAT");
   QCString baseName    = m_diskName;
   QCString imgName     = baseName+"."+imgExt;
-  QCString mapName     = baseName+".map";
   QCString absPath     = d.absPath().data();
   QCString absBaseName = absPath+"/"+baseName;
   QCString absDotName  = absBaseName+".dot";
@@ -4539,8 +4531,6 @@ QCString DotGroupCollaboration::writeGraph( FTextStream &t,
 
     if (graphFormat==GOF_BITMAP) // run dot to create a bitmap image
     {
-      QCString dotArgs(maxCmdLine);
-
       DotRunner *dotRun = new DotRunner(absDotName,d.absPath().data(),FALSE);
       dotRun->addJob(imgExt,absImgName);
       if (writeImageMap) dotRun->addJob(MAP_CMD,absMapName);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2458,7 +2458,6 @@ static MemberDef *addVariableToFile(
 
   // see if the function is inside a namespace
   NamespaceDef *nd = 0;
-  QCString nscope;
   if (!scope.isEmpty())
   {
     if (scope.find('@')!=-1) return 0; // anonymous scope!
@@ -5493,7 +5492,6 @@ static bool findGlobalMember(EntryNav *rootNav,
       {
         Debug::print(Debug::FindMembers,0,"4. Try to add member `%s' to scope `%s'\n",
             md->name().data(),namespaceName.data());
-        QCString nsName = nd ? nd->name().data() : "";
 
         NamespaceDef *rnd = 0;
         if (!namespaceName.isEmpty()) rnd = Doxygen::namespaceSDict->find(namespaceName);

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1296,7 +1296,6 @@ void FileDef::addIncludedUsingDirectives()
   visited=TRUE;
   //printf("( FileDef::addIncludedUsingDirectives for file %s\n",name().data());
 
-  NamespaceList nl;
   if (m_includeList) // file contains #includes
   {
     {
@@ -1542,7 +1541,6 @@ static Directory *findDirNode(Directory *root,const QCString &name)
 
 static void mergeFileDef(Directory *root,FileDef *fd)
 {
-  QCString rootPath = root->name();
   QCString filePath = fd->absFilePath();
   //printf("merging %s\n",filePath.data());
   Directory *dirNode = findDirNode(root,filePath);

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -165,7 +165,6 @@ static ScanVar          v_type       = V_IGNORE; // type of parsed variable
 static QList<Entry>     moduleProcedures; // list of all interfaces which contain unresolved 
                                           // module procedures
 static QCString         docBlock;
-static QCString         docBlockName;
 static bool             docBlockInBody = FALSE;
 static bool             docBlockJavaStyle;
 

--- a/src/htags.cpp
+++ b/src/htags.cpp
@@ -105,7 +105,6 @@ bool Htags::execute(const QCString &htmldir)
 bool Htags::loadFilemap(const QCString &htmlDir)
 {
   QCString fileMapName = htmlDir+"/HTML/FILEMAP";
-  QCString fileMap;
   QFileInfo fi(fileMapName);
   /*
    * Construct FILEMAP dictionary using QDict.

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1063,7 +1063,6 @@ void HtmlDocVisitor::visitPost(DocPara *p)
     }
   }
 
-  QCString context;
   // if the last element of a paragraph is something that should be outside of
   // the paragraph (<ul>,<dl>,<table>) then that will already have ended the 
   // paragraph and we don't need to do it here

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1601,7 +1601,6 @@ static void writeAnnotatedClassList(OutputList &ol)
     }
     if (cd->isLinkableInProject() && cd->templateMaster()==0)
     {
-      QCString type=cd->compoundTypeString();
       ol.startIndexKey();
       if (cd->getLanguage()==SrcLangExt_VHDL)
       {

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -107,7 +107,6 @@ ManGenerator::~ManGenerator()
 
 void ManGenerator::init()
 {
-  QCString ext = getExtension();
   QCString &manOutput = Config_getString("MAN_OUTPUT");
   
   QDir d(manOutput);

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -810,7 +810,6 @@ static int processLink(GrowBuf &out,const char *data,int,int size)
   {
     return 0;
   }
-  static QRegExp re("^[@\\]ref ");
   if (isToc) // special case for [TOC]
   {
     if (g_current) g_current->stat=TRUE;

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2553,7 +2553,6 @@ void MemberDef::writeDocumentation(MemberList *ml,OutputList &ol,
 
   QCString cname   = container->name();
   QCString cfname  = getOutputFileBase();
-  QCString cfiname = container->getOutputFileBase();
 
   // get member name
   QCString doxyName=name();

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -169,7 +169,6 @@ QCString getMscImageMapFromFile(const QCString& inFile, const QCString& outDir,
   QCString mscExe = Config_getString("MSCGEN_PATH")+"mscgen"+portable_commandExtension();
   QCString mscArgs = "-T ismap -i \"";
   mscArgs+=inFile;
-  QFileInfo fi(inFile);
   mscArgs+="\" -o \"";
   mscArgs+=outFile + "\"";
 
@@ -201,7 +200,6 @@ void writeMscImageMapFromFile(FTextStream &t,const QCString &inFile,
  			    )
 {
   QCString mapName = baseName+".map";
-  QCString mapFile = inFile+".map";
   t << "<img src=\"" << relPath << baseName << ".";
   switch (format)
   {

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1371,7 +1371,6 @@ void PerlModDocVisitor::visitPost(DocParBlock *)
 
 static void addTemplateArgumentList(ArgumentList *al,PerlModOutput &output,const char *)
 {
-  QCString indentStr;
   if (!al)
     return;
   output.openList("template_parameters");

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -194,7 +194,10 @@ uint portable_pid()
   return pid;
 }
 
-static char **last_environ;
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#else
+  static char **last_environ;
+#endif
 
 void portable_setenv(const char *name,const char *value)
 {

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -79,7 +79,6 @@ static int           g_paramParens;
 
 static bool          g_exampleBlock;
 static QCString      g_exampleName;
-static QCString      g_exampleFile;
 
 static QCString      g_type;
 static QCString      g_name;

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -83,7 +83,6 @@ static Specifier 	virt;
 
 static int              docBlockContext;
 static QCString         docBlock;
-static QCString         docBlockName;
 static bool             docBlockInBody;
 static bool             docBlockJavaStyle;
 static bool             docBrief;
@@ -97,7 +96,6 @@ static int              g_indent = 0;
 static int              g_curIndent = 0;
 
 static QDict<QCString>  g_packageNameCache(257);
-static QCString         g_packageScope;
 
 static char             g_atomStart;
 static char             g_atomEnd;
@@ -931,7 +929,6 @@ STARTDOCSYMS      "##"
     "="		        { // default value
                           // TODO: this rule is too simple, need to be able to
                           // match things like =")" as well!
-      			  QCString defVal=&yytext[1];
 			  g_defVal.resize(0);
 			  g_braceCount=0;
 			  BEGIN(FunctionParamDefVal);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -83,7 +83,6 @@ static int		roundCount   = 0 ;
 static int		curlyCount   = 0 ;
 static int		squareCount  = 0 ;
 static int              padCount     = 0 ;
-static QCString         slString;
 static Entry*		current_root = 0 ;
 static Entry*		global_root  = 0 ;
 static Entry*		current      = 0 ;
@@ -114,7 +113,6 @@ static QCString         aliasName;
 static QCString         baseName;
 static QCString*        specName;
 static QCString         formulaText;
-static QCString         formulaEnd;
 static bool             useOverrideCommands = FALSE;
 
 static SrcLangExt       language;
@@ -162,13 +160,7 @@ static bool             needsSemi;
 
 //static int              depthIf;
 static int  	        initBracketCount;
-static QCString         memberGroupRelates;
-static QCString         memberGroupInside;
-static QCString         xrefItemKey;
-static QCString         xrefItemTitle;
-static QCString         xrefListTitle;
 
-static QCString         g_skipBlockName;
 static QCString         oldStyleArgType;
 static QCString         docBackup;
 static QCString         briefBackup;

--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -310,7 +310,6 @@ void SearchIndex::write(const char *fileName)
   padding = size - padding;
 
   //int statsOffset = size;
-  QDictIterator<IndexWord> wdi(m_words);
   //IndexWord *iw;
   int *wordStatOffsets = new int[m_words.count()];
   
@@ -1077,7 +1076,6 @@ void writeJavascriptSearchIndex()
         for (li.toFirst();(dl=li.current());++li)
         {
           Definition *d = dl->getFirst();
-          QCString id = d->localName();
 
           if (!firstEntry)
           {

--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -1123,7 +1123,6 @@ D
 static tcl_scan *tcl_scan_start(char type, QString content, QCString ns, Entry *entry_cl, Entry *entry_fn)
 {
   tcl_scan *myScan=tcl.scan.at(0);
-  QCString myName;
 tcl_inf("line=%d type=%d '%s'\n",tcl.line_body0,type,content.ascii());
 
   myScan->line1=yylineno;
@@ -2298,7 +2297,7 @@ D
 static void tcl_command_ITCL_CLASS()
 {
 D
-  QCString myNs, myName, myStr;
+  QCString myNs, myName;
   Entry *myEntryCl;
   tcl_scan *myScan = tcl.scan.at(0);
 
@@ -2327,7 +2326,7 @@ D
 static void tcl_command_OO_CLASS()
 {
 D
-  QCString myNs, myName, myStr;
+  QCString myNs, myName;
   //Entry *myEntryNs;
   Entry *myEntryCl;
   tcl_scan *myScan = tcl.scan.at(0);

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -2998,7 +2998,6 @@ class TemplateNodeRange : public TemplateNodeCreator<TemplateNodeRange>
           {
             c->push();
             //int index = m_reversed ? list.count() : 0;
-            TemplateVariant v;
             const TemplateVariant *parentLoop = c->getRef("forloop");
             uint index = 0;
             int i = m_down ? e : s;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3317,7 +3317,7 @@ static QCString getCanonicalTypeForIdentifier(
 {
   if (count>10) return word; // oops recursion
 
-  QCString symName,scope,result,templSpec,tmpName;
+  QCString symName,result,templSpec,tmpName;
   //DefinitionList *defList=0;
   if (tSpec && !tSpec->isEmpty()) 
     templSpec = stripDeclKeywords(getCanonicalTemplateSpec(d,fs,*tSpec));
@@ -4110,8 +4110,6 @@ bool getDefs(const QCString &scName,
         continue;
 
       if (!args) break;
-
-      QCString className = mmd->getClassDef()->name();
 
       ArgumentList *mmdAl = mmd->argumentList();
       if (matchArguments2(mmd->getOuterScope(),mmd->getFileDef(),mmdAl,

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -68,7 +68,6 @@ static bool       g_startCode = FALSE;
 static QCString   g_PrevString;
 static QCString   g_CurrClass;
 static QDict<QCString>g_vhdlKeyDict;   
-static QCString   g_tempClass;
 static QCString   g_tempComp;
 static QCString   g_PortMapComp;
 static MemberDef *g_vhdlMember;
@@ -77,7 +76,6 @@ static QCString   g_FuncProto;
 //-----------------------------------------------------------
   
 static CodeOutputInterface * g_code;
-static QCString      g_curClassName;
 static QCString      g_parmType;
 static QCString      g_parmName;
 static const char *  g_inputString;     //!< the code fragment as text
@@ -90,9 +88,6 @@ static Definition   *g_searchCtx;
 static QCString      g_exampleName;
 static QCString      g_exampleFile;
 
-static QCString      g_type;
-static QCString      g_name;
-static QCString      g_args;
 static QCString      g_classScope;
    
 static QCString      g_CurrScope;
@@ -1055,7 +1050,6 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
 
 
 <ClassesName>{FUNCNAME} {
-                         QDict<QCString> mem;
                          appStringLower(g_PrevString,vhdlcodeYYtext);
                          g_CurrClass.resize(0);
                          g_CurrClass.append(vhdlcodeYYtext);

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -70,7 +70,6 @@ static QDict<QCString> g_vhdlKeyDict0(17,FALSE);
 static QDict<QCString> g_vhdlKeyDict1(17,FALSE);
 static QDict<QCString> g_vhdlKeyDict2(17,FALSE);
 static QDict<QCString> g_vhdlKeyDict3(17,FALSE);
-static QDict<QCString> g_xilinxUcfDict(17,FALSE);
 
 static void initUCF(Entry* root,const char* type,QCString &  qcs,int line,QCString & fileName,QCString & brief);
 static void writeUCFLink(const MemberDef* mdef,OutputList &ol);
@@ -170,7 +169,6 @@ static void createSVG()
     QCString dir="-o \""+ov+"/vhdl_design_overview.html\"";
     ov+="/vhdl_design.dot";
 
-    QRegExp ep("[\\s]");
     QCString vlargs="-Tsvg \""+ov+"\" "+dir ;
 
     if (portable_system("dot",vlargs)!=0)
@@ -200,7 +198,6 @@ void VhdlDocGen::writeOverview()
   QCString ov =Config_getString("HTML_OUTPUT");
   QCString fileName=ov+"/vhdl_design.dot";
   QFile f(fileName);
-  QStringList qli;
   FTextStream  t(&f);
 
   if (!f.open(IO_WriteOnly))
@@ -502,7 +499,6 @@ static QList<MemberDef>* getPorts(ClassDef *cd)
 
 static void writeTable(QList<MemberDef>* port,FTextStream & t)
 {
-  QCString space(" ");
   MemberDef *md;
   uint len=port->count();
 
@@ -712,7 +708,6 @@ ClassDef *VhdlDocGen::getClass(const char *name)
 ClassDef* VhdlDocGen::getPackageName(const QCString & name)
 {
   ClassDef* cd=0;
-  QStringList ql=QStringList::split(".",name,FALSE);
   cd=getClass(name);
 
   return cd;
@@ -1127,7 +1122,6 @@ ClassDef* VhdlDocGen::findArchitecture(const ClassDef *cd)
 void VhdlDocGen::writeVhdlLink(const ClassDef* ccd ,OutputList& ol,QCString& type,QCString& nn,QCString& behav)
 {
   if (ccd==0)  return;
-  QCString temp=ccd->getOutputFileBase();
   ol.startBold();
   ol.docify(type.data());
   ol.endBold();
@@ -1185,7 +1179,6 @@ void VhdlDocGen::parseFuncProto(const char* text,QList<Argument>& qlist,
 
   if ((end-index)>0)
   {
-    QCString tt=s1.mid(index,(end-index+1));
     temp=s1.mid(index+1,(end-index-1));
     //getFuncParams(qlist,temp);
   }
@@ -1820,8 +1813,6 @@ static void setGlobalType(MemberList *ml)
   MemberListIterator mmli(*ml);
   for ( ; (mdd=mmli.current()); ++mmli )
   {
-    QCString l=mdd->typeString();
-
     if (qstrcmp(mdd->argsString(),"package")==0)
     {
  	mdd->setMemberSpecifiers(VhdlDocGen::INSTANTIATION);
@@ -1982,10 +1973,7 @@ void VhdlDocGen::writeVHDLDeclaration(MemberDef* mdef,OutputList &ol,
     ClassDef *cd,NamespaceDef *nd,FileDef *fd,GroupDef *gd,
     bool /*inGroup*/)
 {
-  static QRegExp reg("[%]");
-
   Definition *d=0;
-
 
   ASSERT(cd!=0 || nd!=0 || fd!=0 || gd!=0 ||
       mdef->getMemberSpecifiers()==VhdlDocGen::LIBRARY ||
@@ -2661,7 +2649,6 @@ void VhdlDocGen::parseUCF(const char*  input,  Entry* entity,QCString fileName,b
 {
   QCString ucFile(input);
   int lineNo=0;
-  QCString newLine="\n";
   QCString comment("#!");
   QCString brief;
 
@@ -2717,7 +2704,6 @@ void VhdlDocGen::parseUCF(const char*  input,  Entry* entity,QCString fileName,b
 static void initUCF(Entry* root,const char*  type,QCString &  qcs,int line,QCString & fileName,QCString & brief)
 {
   if (qcs.isEmpty())return;
-  QRegExp sp("\\s");
   QRegExp reg("[\\s=]");
   QCString n;
   // bool bo=(qstricmp(type,qcs.data())==0);
@@ -2840,7 +2826,6 @@ QCString  VhdlDocGen::parseForConfig(QCString & entity,QCString & arch)
 {
   int index;
   QCString label;
-  QCString ent("entity");
   if (!entity.contains(":")) return "";
 
   QRegExp exp("[:()\\s]");
@@ -2930,7 +2915,7 @@ void assignBinding(VhdlConfNode * conf)
   QListIterator<Entry> eli(instList);
   Entry *cur=0;
   ClassDef *archClass=0,*entClass=0;
-  QCString archName,entityName;
+  QCString archName;
   QCString arcBind,entBind;
 
   bool others,all;
@@ -2995,7 +2980,7 @@ void assignBinding(VhdlConfNode * conf)
   {
     if (cur->exception.lower()==label || conf->isInlineConf)
     {
-      QCString sign,archy;
+      QCString archy;
 
       if (all || others)
       {
@@ -3997,7 +3982,6 @@ void FlowChart::writeShape(FTextStream &t,const FlowChart* fl)
   }
 
   t<<getNodeName(fl->id).data();
-  QCString q=getNodeType(fl->type);
 
 #ifdef DEBUGFLOW
   QCString qq(getNodeName(fl->id).data());
@@ -4053,7 +4037,6 @@ void FlowChart::writeShape(FTextStream &t,const FlowChart* fl)
   {
     if (fl->text.isEmpty()) return;
     bool var=(fl->type & FlowChart::VARIABLE_NO);
-    QCString repl("<BR ALIGN=\"LEFT\"/>");
     QCString q=fl->text;
 
     if (exit)

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -437,7 +437,6 @@ void VhdlParser::addCompInst(char *n, char* instName, char* comp,int iLine)
 void VhdlParser::addVhdlType(const char *n,int startLine,int section,
     uint64 spec,const char* args,const char* type,Protection prot)
 {
-  static QRegExp reg("[\\s]");
   QCString name(n);
   if (isFuncProcProced() || VhdlDocGen::getFlowMember())  return;
 
@@ -540,7 +539,6 @@ void VhdlParser::pushLabel( QCString &label,QCString & val)
 
  QCString  VhdlParser::popLabel(QCString & q)
 {
-  QCString u=q;
   int i=q.findRev("|");
   if (i<0) return "";
   q = q.left(i);
@@ -550,8 +548,7 @@ void VhdlParser::pushLabel( QCString &label,QCString & val)
 void VhdlParser::addConfigureNode(const char* a,const char*b, bool,bool isLeaf,bool inlineConf)
 {
   VhdlConfNode* co=0;
-  QCString ent,arch,lab;
-  QCString l=genLabels;
+  QCString ent;
   ent=a;
 
   if (b)
@@ -606,7 +603,6 @@ void VhdlParser::addProto(const char *s1,const char *s2,const char *s3,
     const char *s4,const char *s5,const char *s6)
 {
   (void)s5; // avoid unused warning
-  static QRegExp reg("[\\s]");
   QCString name=s2;
   QStringList ql=QStringList::split(",",name,FALSE);
 

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -44,8 +44,6 @@ static void visitPreStart(FTextStream &t, const char *cmd, const bool doCaption,
                           const QCString &name, bool writeType, DocImage::Type type, const QCString &width, 
                           const QCString &height)
 {
-  QCString tmpStr;
-
   t << "<" << cmd;
   if (writeType)
   {


### PR DESCRIPTION
Remove unused local and static global variables. Variables have been identified by Understand (version 758) from Scitools.