### PR TITLE
Consistency in handling HTML and LaTeX in respect to header and footer

### DIFF
--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -71,18 +71,21 @@ static int yyread(char *buf,int maxSize)
     }
 }
 
+static QString warning_str = QString::fromAscii("warning: ");
+static QString error_str = QString::fromAscii("error: ");
+
 void config_err(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  vfprintf(stderr, fmt, args);
+  vfprintf(stderr, qPrintable(error_str.append(QString::fromAscii(fmt))), args);
   va_end(args); 
 }
 void config_warn(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  vfprintf(stderr, fmt, args);
+  vfprintf(stderr, qPrintable(warning_str.append(QString::fromAscii(fmt))), args);
   va_end(args);
 }
 
@@ -111,7 +114,7 @@ static FILE *tryPath(const QString &path,const QString &fileName)
   {
     FILE *f = fopen(absName.toLocal8Bit(),"r");
     if (f==NULL)
-      config_err("Error: could not open file %s for reading\n",absName.toLatin1().data());
+      config_err("could not open file %s for reading\n",qPrintable(absName));
     else 
       return f;
   }
@@ -141,7 +144,7 @@ static void readIncludeFile(const QString &incName)
 {
   if (g_includeDepth==MAX_INCLUDE_DEPTH) 
   {
-    config_err("Error: maximum include depth (%d) reached, %s is not included. Aborting...\n",
+    config_err("maximum include depth (%d) reached, %s is not included. Aborting...\n",
 	MAX_INCLUDE_DEPTH,qPrintable(incName));
     exit(1);
   } 
@@ -162,7 +165,7 @@ static void readIncludeFile(const QString &incName)
     // For debugging
 #if SHOW_INCLUDES
     for (i=0;i<includeStack.count();i++) msg("  ");
-    msg("@INCLUDE = %s: parsing...\n",inc.toLatin1().data());
+    msg("@INCLUDE = %s: parsing...\n",qPrintable(inc));
 #endif
 
     // store the state of the old file 
@@ -180,7 +183,7 @@ static void readIncludeFile(const QString &incName)
   } 
   else
   {
-    config_err("Error: @INCLUDE = %s: not found!\n",inc.toLatin1().data());
+    config_err("@INCLUDE = %s: not found!\n",qPrintable(inc));
     exit(1);
   }
 }
@@ -210,7 +213,7 @@ static void readIncludeFile(const QString &incName)
 					   g_curOption = g_options->value(cmd);
 					   if (g_curOption==0) // oops not known
 					   {
-					     config_err("Warning: ignoring unsupported tag `%s' at line %d, file %s\n",
+					     config_warn("ignoring unsupported tag `%s' at line %d, file %s\n",
 						 qPrintable(cmd),yylineno,qPrintable(g_yyFileName)); 
 					     BEGIN(SkipInvalid);
 					   }
@@ -235,7 +238,7 @@ static void readIncludeFile(const QString &incName)
 					         BEGIN(GetString);
 						 break;
 					       case Input::Obsolete:
-					         config_err("Warning: Tag `%s' at line %d of file %s has become obsolete.\n"
+					         config_warn("Tag `%s' at line %d of file %s has become obsolete.\n"
 						            "To avoid this warning please update your configuration "
 							    "file using \"doxygen -u\"\n", qPrintable(cmd),
 							    yylineno,qPrintable(g_yyFileName)); 
@@ -249,7 +252,7 @@ static void readIncludeFile(const QString &incName)
 					  g_curOption = g_options->value(cmd);
 					  if (g_curOption==0) // oops not known
 					  {
-					    config_err("Warning: ignoring unsupported tag `%s' at line %d, file %s\n",
+					    config_warn("ignoring unsupported tag `%s' at line %d, file %s\n",
 						yytext,yylineno,qPrintable(g_yyFileName)); 
 					    BEGIN(SkipInvalid);
 					  }
@@ -265,12 +268,12 @@ static void readIncludeFile(const QString &incName)
 					      case Input::String:
 					      case Input::Int:
 					      case Input::Bool:
-					        config_err("Warning: operator += not supported for `%s'. Ignoring line at line %d, file %s\n",
+					        config_warn("operator += not supported for `%s'. Ignoring line at line %d, file %s\n",
 						    yytext,yylineno,qPrintable(g_yyFileName)); 
 					        BEGIN(SkipInvalid);
 						break;
 					      case Input::Obsolete:
-					         config_err("Warning: Tag `%s' at line %d of file %s has become obsolete.\n"
+					         config_warn("Tag `%s' at line %d of file %s has become obsolete.\n"
 						            "To avoid this warning please update your configuration "
 							    "file using \"doxygen -u\"\n", 
 							    qPrintable(cmd),yylineno,qPrintable(g_yyFileName)); 
@@ -307,12 +310,12 @@ static void readIncludeFile(const QString &incName)
 					  }
   					}
 
-<Start>[a-z_A-Z0-9]+			{ config_err("Warning: ignoring unknown tag `%s' at line %d, file %s\n",yytext,yylineno,qPrintable(g_yyFileName)); }
+<Start>[a-z_A-Z0-9]+			{ config_warn("ignoring unknown tag `%s' at line %d, file %s\n",yytext,yylineno,qPrintable(g_yyFileName)); }
 <GetString,SkipInvalid>\n	        { BEGIN(Start); }
 <GetStrList>\n				{ 
 					  if (!g_elemStr.isEmpty())
 					  {
-					    //printf("elemStr1=`%s'\n",elemStr.toLatin1().data());
+					    //printf("elemStr1=`%s'\n",qPrintable(elemStr));
 					    *g_arg = QVariant(g_arg->toStringList() << g_elemStr);
 					  }
 					  BEGIN(Start); 
@@ -320,7 +323,7 @@ static void readIncludeFile(const QString &incName)
 <GetStrList>[ \t]+			{
   				          if (!g_elemStr.isEmpty())
 					  {
-					    //printf("elemStr2=`%s'\n",elemStr.toLatin1().data());
+					    //printf("elemStr2=`%s'\n",qPrintable(elemStr));
   					    *g_arg = QVariant(g_arg->toStringList() << g_elemStr);
 					  }
 					  g_elemStr = QString();
@@ -336,7 +339,7 @@ static void readIncludeFile(const QString &incName)
 <GetQuotedString>"\""|"\n" 		{ 
                                           // we add a bogus space to signal that the string was quoted. This space will be stripped later on.
                                           g_tmpString+=" ";
-  					  //printf("Quoted String = `%s'\n",tmpString.toLatin1().data());
+  					  //printf("Quoted String = `%s'\n",qPrintable(tmpString));
   					  if (g_lastState==GetString)
 					  {
 					    *g_arg = g_codec->toUnicode(g_tmpString);
@@ -348,7 +351,7 @@ static void readIncludeFile(const QString &incName)
 					  }
 					  if (*yytext=='\n')
 					  {
-					    config_err("Warning: Missing end quote (\") on line %d, file %s\n",yylineno,
+					    config_warn("Missing end quote (\") on line %d, file %s\n",yylineno,
                                                 qPrintable(g_yyFileName));
 					  }
 					  BEGIN(g_lastState);
@@ -377,11 +380,11 @@ static void substEnvVarsInString(QString &s)
   if (s.isEmpty()) return;
   int p=0;
   int i,l;
-  //printf("substEnvVarInString(%s) start\n",s.toLatin1().data());
+  //printf("substEnvVarInString(%s) start\n",qPrintable(s));
   while ((i=re.indexIn(s,p))!=-1)
   {
     l = re.matchedLength();
-    //printf("Found environment var s.mid(%d,%d)=`%s'\n",i+2,l-3,s.mid(i+2,l-3).toLatin1().data());
+    //printf("Found environment var s.mid(%d,%d)=`%s'\n",i+2,l-3,qPrintable(s.mid(i+2,l-3)));
     QString env=g_codec->toUnicode(getenv(s.mid(i+2,l-3).toLatin1()));
     substEnvVarsInString(env); // recursively expand variables if needed.
     s = s.left(i)+env+s.right(s.length()-i-l);
@@ -389,7 +392,7 @@ static void substEnvVarsInString(QString &s)
   }
   s=s.trimmed(); // to strip the bogus space that was added when an argument
                          // has quotes
-  //printf("substEnvVarInString(%s) end\n",s.toLatin1().data());
+  //printf("substEnvVarInString(%s) end\n",qPrintable(s));
 }
 
 static void substEnvVarsInStrList(QStringList &sl)
@@ -404,7 +407,7 @@ static void substEnvVarsInStrList(QStringList &sl)
     // here we strip the quote again
     substEnvVarsInString(result);
 
-    //printf("Result %s was quoted=%d\n",result.toLatin1().data(),wasQuoted);
+    //printf("Result %s was quoted=%d\n",qPrintable(result),wasQuoted);
 
     if (!wasQuoted) /* as a result of the expansion, a single string
 		       may have expanded into a list, which we'll

--- a/src/config.l
+++ b/src/config.l
@@ -53,18 +53,21 @@
 #define Config_getEnum(val)    getEnum(__FILE__,__LINE__,val)
 #define Config_getBool(val)    getBool(__FILE__,__LINE__,val)
   
+static const char *warning_str = "warning: ";
+static const char *error_str = "error: ";
+
 void config_err(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  vfprintf(stderr, fmt, args);
+  vfprintf(stderr, (QCString(error_str) + fmt).data(), args);
   va_end(args); 
 }
 void config_warn(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  vfprintf(stderr, fmt, args);
+  vfprintf(stderr, (QCString(warning_str) + fmt).data(), args);
   va_end(args);
 }
 
@@ -181,7 +184,7 @@ void ConfigInt::convertStrToVal()
     int val = m_valueString.toInt(&ok);
     if (!ok || val<m_minVal || val>m_maxVal)
     {
-      config_warn("Warning: argument `%s' for option %s is not a valid number in the range [%d..%d]!\n"
+      config_warn("argument `%s' for option %s is not a valid number in the range [%d..%d]!\n"
                 "Using the default: %d!\n",m_valueString.data(),m_name.data(),m_minVal,m_maxVal,m_value);
     }
     else
@@ -206,7 +209,7 @@ void ConfigBool::convertStrToVal()
     }
     else
     {
-      config_warn("Warning: argument `%s' for option %s is not a valid boolean value\n"
+      config_warn("argument `%s' for option %s is not a valid boolean value\n"
                 "Using the default: %s!\n",m_valueString.data(),m_name.data(),m_value?"YES":"NO");
     }
   }
@@ -527,7 +530,7 @@ static FILE *tryPath(const char *path,const char *fileName)
   if (fi.exists() && fi.isFile())
   {
     FILE *f=portable_fopen(absName,"r");
-    if (!f) config_err("Error: could not open file %s for reading\n",absName.data());
+    if (!f) config_err("could not open file %s for reading\n",absName.data());
     return f;
   }
   return 0;
@@ -561,7 +564,7 @@ static FILE *findFile(const char *fileName)
 static void readIncludeFile(const char *incName)
 {
   if (includeDepth==MAX_INCLUDE_DEPTH) {
-    config_err("Error: maximum include depth (%d) reached, %s is not included. Aborting...\n",
+    config_err("maximum include depth (%d) reached, %s is not included. Aborting...\n",
 	MAX_INCLUDE_DEPTH,incName);
     exit(1);
   } 
@@ -601,7 +604,7 @@ static void readIncludeFile(const char *incName)
   } 
   else
   {
-    config_err("Error: @INCLUDE = %s: not found!\n",inc.data());
+    config_err("@INCLUDE = %s: not found!\n",inc.data());
     exit(1);
   }
 }
@@ -632,7 +635,7 @@ static void readIncludeFile(const char *incName)
 					   ConfigOption *option = config->get(cmd);
 					   if (option==0) // oops not known
 					   {
-					     config_err("Warning: ignoring unsupported tag `%s' at line %d, file %s\n",
+					     config_warn("ignoring unsupported tag `%s' at line %d, file %s\n",
 						 yytext,yyLineNr,yyFileName.data()); 
 					     BEGIN(SkipInvalid);
 					   }
@@ -675,12 +678,12 @@ static void readIncludeFile(const char *incName)
 					       case ConfigOption::O_Obsolete:
                                                  if (config_upd)
                                                  {
-					           config_err("Warning: Tag `%s' at line %d of file `%s' has become obsolete.\n"
+					           config_warn("Tag `%s' at line %d of file `%s' has become obsolete.\n"
 						              "         This tag has been removed.\n", cmd.data(),yyLineNr,yyFileName.data());
                                                  }
                                                  else
                                                  {
-					           config_err("Warning: Tag `%s' at line %d of file `%s' has become obsolete.\n"
+					           config_warn("Tag `%s' at line %d of file `%s' has become obsolete.\n"
 						              "         To avoid this warning please remove this line from your configuration "
 							      "file or upgrade it using \"doxygen -u\"\n", cmd.data(),yyLineNr,yyFileName.data()); 
                                                  }
@@ -689,12 +692,12 @@ static void readIncludeFile(const char *incName)
 					       case ConfigOption::O_Disabled:
                                                  if (config_upd)
                                                  {
-					           config_err("Warning: Tag `%s' at line %d of file `%s' belongs to an option that was not enabled at compile time.\n"
+					           config_warn("Tag `%s' at line %d of file `%s' belongs to an option that was not enabled at compile time.\n"
 						              "         This tag has been removed.\n", cmd.data(),yyLineNr,yyFileName.data());
                                                  }
                                                  else
                                                  {
-					           config_err("Warning: Tag `%s' at line %d of file `%s' belongs to an option that was not enabled at compile time.\n"
+					           config_warn("Tag `%s' at line %d of file `%s' belongs to an option that was not enabled at compile time.\n"
 						              "         To avoid this warning please remove this line from your configuration "
 							    "file or upgrade it using \"doxygen -u\", or recompile doxygen with this feature enabled.\n", cmd.data(),yyLineNr,yyFileName.data()); 
                                                  }
@@ -708,7 +711,7 @@ static void readIncludeFile(const char *incName)
 					  ConfigOption *option = config->get(cmd);
 					  if (option==0) // oops not known
 					  {
-					    config_err("Warning: ignoring unsupported tag `%s' at line %d, file %s\n",
+					    config_warn("ignoring unsupported tag `%s' at line %d, file %s\n",
 						yytext,yyLineNr,yyFileName.data()); 
 					    BEGIN(SkipInvalid);
 					  }
@@ -730,18 +733,18 @@ static void readIncludeFile(const char *incName)
 					      case ConfigOption::O_String:
 					      case ConfigOption::O_Int:
 					      case ConfigOption::O_Bool:
-					        config_err("Warning: operator += not supported for `%s'. Ignoring line at line %d, file %s\n",
+					        config_warn("operator += not supported for `%s'. Ignoring line at line %d, file %s\n",
 						    yytext,yyLineNr,yyFileName.data()); 
 					        BEGIN(SkipInvalid);
 						break;
 					       case ConfigOption::O_Obsolete:
-					         config_err("Warning: Tag `%s' at line %d of file %s has become obsolete.\n"
+					         config_warn("Tag `%s' at line %d of file %s has become obsolete.\n"
 						            "To avoid this warning please update your configuration "
 							    "file using \"doxygen -u\"\n", cmd.data(),yyLineNr,yyFileName.data()); 
 					         BEGIN(SkipInvalid);
 						 break;
 					       case ConfigOption::O_Disabled:
-					         config_err("Warning: Tag `%s' at line %d of file %s belongs to an option that was not enabled at compile time.\n"
+					         config_warn("Tag `%s' at line %d of file %s belongs to an option that was not enabled at compile time.\n"
 						            "To avoid this warning please remove this line from your configuration "
 							    "file, upgrade it using \"doxygen -u\", or recompile doxygen with this feature enabled.\n", cmd.data(),yyLineNr,yyFileName.data()); 
 					         BEGIN(SkipInvalid);
@@ -778,7 +781,7 @@ static void readIncludeFile(const char *incName)
 					  }
   					}
 
-<Start>[a-z_A-Z0-9]+			{ config_err("Warning: ignoring unknown tag `%s' at line %d, file %s\n",yytext,yyLineNr,yyFileName.data()); }
+<Start>[a-z_A-Z0-9]+			{ config_warn("ignoring unknown tag `%s' at line %d, file %s\n",yytext,yyLineNr,yyFileName.data()); }
 <GetString,GetBool,SkipInvalid>\n	{ yyLineNr++; BEGIN(Start); }
 <GetStrList>\n				{ 
   					  yyLineNr++; 
@@ -819,7 +822,7 @@ static void readIncludeFile(const char *incName)
 					  }
 					  if (*yytext=='\n')
 					  {
-					    config_err("Warning: Missing end quote (\") on line %d, file %s\n",yyLineNr,yyFileName.data());
+					    config_warn("Missing end quote (\") on line %d, file %s\n",yyLineNr,yyFileName.data());
 					    yyLineNr++;
 					  }
 					  BEGIN(lastState);
@@ -838,7 +841,7 @@ static void readIncludeFile(const char *incName)
 					  else 
 					  {
 					    *b=FALSE; 
-					    config_warn("Warning: Invalid value `%s' for "
+					    config_warn("Invalid value `%s' for "
 						 "boolean tag in line %d, file %s; use YES or NO\n",
 						 bs.data(),yyLineNr,yyFileName.data());
 					  }
@@ -1070,7 +1073,7 @@ void Config::checkFileName(const char *optionName)
   if ((val=="yes" || val=="true"  || val=="1" || val=="all") ||
       (val=="no"  || val=="false" || val=="0" || val=="none")) 
   {
-    config_err("Error: file name expected for option %s, got %s instead. Ignoring...\n",optionName,s.data());
+    config_err("file name expected for option %s, got %s instead. Ignoring...\n",optionName,s.data());
     s=""; // note tihe use of &s above: this will change the option value!
   }
 }
@@ -1091,15 +1094,15 @@ void Config::check()
   {
     if (warnFormat.find("$file")==-1)
     {
-      config_err("Warning: warning format does not contain a $file tag!\n");
+      config_warn("warning format does not contain a $file tag!\n");
     }
     if (warnFormat.find("$line")==-1)
     {
-      config_err("Warning: warning format does not contain a $line tag!\n");
+      config_warn("warning format does not contain a $line tag!\n");
     }
     if (warnFormat.find("$text")==-1)
     {
-      config_err("Warning: warning format foes not contain a $text tag!\n");
+      config_warn("warning format foes not contain a $text tag!\n");
     }
   }
 
@@ -1120,7 +1123,7 @@ void Config::check()
   if (paperType!="a4" && paperType!="a4wide" && paperType!="letter" && 
       paperType!="legal" && paperType!="executive")
   {
-    config_err("Error: Unknown page type specified\n");
+    config_err("Unknown page type specified\n");
   }
   
   QCString &outputLanguage=Config_getEnum("OUTPUT_LANGUAGE");
@@ -1160,7 +1163,7 @@ void Config::check()
     QFileInfo fi(headerFile);
     if (!fi.exists())
     {
-      config_err("Error: tag HTML_HEADER: header file `%s' "
+      config_err("tag HTML_HEADER: header file `%s' "
 	  "does not exist\n",headerFile.data());
       exit(1);
     }
@@ -1172,11 +1175,12 @@ void Config::check()
     QFileInfo fi(footerFile);
     if (!fi.exists())
     {
-      config_err("Error: tag HTML_FOOTER: footer file `%s' "
+      config_err("tag HTML_FOOTER: footer file `%s' "
 	  "does not exist\n",footerFile.data());
       exit(1);
     }
   }
+
   // Test to see if MathJax code file is valid
   if (Config_getBool("USE_MATHJAX"))
   {
@@ -1186,12 +1190,13 @@ void Config::check()
       QFileInfo fi(MathJaxCodefile);
       if (!fi.exists())
       {
-        config_err("Error: tag MATHJAX_CODEFILE file `%s' "
+        config_err("tag MATHJAX_CODEFILE file `%s' "
 	    "does not exist\n",MathJaxCodefile.data());
         exit(1);
       }
     }
   }
+
   // Test to see if LaTeX header is valid
   QCString &latexHeaderFile = Config_getString("LATEX_HEADER");
   if (!latexHeaderFile.isEmpty())
@@ -1199,18 +1204,31 @@ void Config::check()
     QFileInfo fi(latexHeaderFile);
     if (!fi.exists())
     {
-      config_err("Error: tag LATEX_HEADER: header file `%s' "
+      config_err("tag LATEX_HEADER: header file `%s' "
 	  "does not exist\n",latexHeaderFile.data());
       exit(1);
     }
   }
+  // Test to see if LaTeX footer is valid
+  QCString &latexFooterFile = Config_getString("LATEX_FOOTER");
+  if (!latexFooterFile.isEmpty())
+  {
+    QFileInfo fi(latexFooterFile);
+    if (!fi.exists())
+    {
+      config_err("tag LATEX_FOOTER: footer file `%s' "
+	  "does not exist\n",latexFooterFile.data());
+      exit(1);
+    }
+  }
+
   // check include path
   QStrList &includePath = Config_getList("INCLUDE_PATH");
   char *s=includePath.first();
   while (s)
   {
     QFileInfo fi(s);
-    if (!fi.exists()) config_err("Warning: tag INCLUDE_PATH: include path `%s' "
+    if (!fi.exists()) config_warn("tag INCLUDE_PATH: include path `%s' "
 	                  "does not exist\n",s);
     s=includePath.next();
   }
@@ -1226,7 +1244,7 @@ void Config::check()
     alias=alias.stripWhiteSpace();
     if (alias.find(re1)!=0 && alias.find(re2)!=0)
     {
-      config_err("Error: Illegal alias format `%s'. Use \"name=value\" or \"name(n)=value\", where n is the number of arguments\n",
+      config_err("Illegal alias format `%s'. Use \"name=value\" or \"name(n)=value\", where n is the number of arguments\n",
 	  alias.data());
     }
     s=aliasList.next();
@@ -1235,19 +1253,19 @@ void Config::check()
   // check if GENERATE_TREEVIEW and GENERATE_HTMLHELP are both enabled
   if (Config_getBool("GENERATE_TREEVIEW") && Config_getBool("GENERATE_HTMLHELP"))
   {
-    config_err("Error: When enabling GENERATE_HTMLHELP the tree view (GENERATE_TREEVIEW) should be disabled. I'll do it for you.\n");
+    config_err("When enabling GENERATE_HTMLHELP the tree view (GENERATE_TREEVIEW) should be disabled. I'll do it for you.\n");
     Config_getBool("GENERATE_TREEVIEW")=FALSE;
   }
   if (Config_getBool("SEARCHENGINE") && Config_getBool("GENERATE_HTMLHELP"))
   {
-    config_err("Error: When enabling GENERATE_HTMLHELP the search engine (SEARCHENGINE) should be disabled. I'll do it for you.\n");
+    config_err("When enabling GENERATE_HTMLHELP the search engine (SEARCHENGINE) should be disabled. I'll do it for you.\n");
     Config_getBool("SEARCHENGINE")=FALSE;
   }
 
   // check if SEPARATE_MEMBER_PAGES and INLINE_GROUPED_CLASSES are both enabled
   if (Config_getBool("SEPARATE_MEMBER_PAGES") && Config_getBool("INLINE_GROUPED_CLASSES"))
   {
-    config_err("Error: When enabling INLINE_GROUPED_CLASSES the SEPARATE_MEMBER_PAGES option should be disabled. I'll do it for you.\n");
+    config_err("When enabling INLINE_GROUPED_CLASSES the SEPARATE_MEMBER_PAGES option should be disabled. I'll do it for you.\n");
     Config_getBool("SEPARATE_MEMBER_PAGES")=FALSE;
   }
     
@@ -1267,7 +1285,7 @@ void Config::check()
   QCString &dotFontName=Config_getString("DOT_FONTNAME");
   if (dotFontName=="FreeSans" || dotFontName=="FreeSans.ttf")
   {
-    config_err("Warning: doxygen no longer ships with the FreeSans font.\n"
+    config_warn("doxygen no longer ships with the FreeSans font.\n"
                "You may want to clear or change DOT_FONTNAME.\n"
                "Otherwise you run the risk that the wrong font is being used for dot generated graphs.\n");
   }
@@ -1287,7 +1305,7 @@ void Config::check()
       QFileInfo dp(dotPath+"/dot"+portable_commandExtension());
       if (!dp.exists() || !dp.isFile())
       {
-	config_err("Warning: the dot tool could not be found at %s\n",dotPath.data());
+	config_warn("the dot tool could not be found at %s\n",dotPath.data());
 	dotPath="";
       }
       else
@@ -1312,7 +1330,7 @@ void Config::check()
     QFileInfo dp(mscgenPath+"/mscgen"+portable_commandExtension());
     if (!dp.exists() || !dp.isFile())
     {
-      config_err("Warning: the mscgen tool could not be found at %s\n",mscgenPath.data());
+      config_warn("the mscgen tool could not be found at %s\n",mscgenPath.data());
       mscgenPath="";
     }
     else
@@ -1367,7 +1385,7 @@ void Config::check()
     QFileInfo dp(diaPath+"/dia"+portable_commandExtension());
     if (!dp.exists() || !dp.isFile())
     {
-      config_err("Warning: dia could not be found at %s\n",diaPath.data());
+      config_warn("dia could not be found at %s\n",diaPath.data());
       diaPath="";
     }
     else
@@ -1399,7 +1417,7 @@ void Config::check()
       QFileInfo fi(s);
       if (!fi.exists())
       {
-	config_err("Warning: tag INPUT: input source `%s' does not exist\n",s);
+	config_warn("tag INPUT: input source `%s' does not exist\n",s);
       }
       s=inputSources.next();
     }
@@ -1490,14 +1508,14 @@ void Config::check()
       Config_getString("GENERATE_TAGFILE").isEmpty()
      )
   {
-    config_err("Warning: No output formats selected! Set at least one of the main GENERATE_* options to YES.\n");
+    config_warn("No output formats selected! Set at least one of the main GENERATE_* options to YES.\n");
   }
 
   // check HTMLHELP creation requirements
   if (!Config_getBool("GENERATE_HTML") && 
       Config_getBool("GENERATE_HTMLHELP"))
   {
-    config_err("Warning: GENERATE_HTMLHELP=YES requires GENERATE_HTML=YES.\n");
+    config_warn("GENERATE_HTMLHELP=YES requires GENERATE_HTML=YES.\n");
   }
 
   // check QHP creation requirements
@@ -1505,13 +1523,13 @@ void Config::check()
   {
     if (Config_getString("QHP_NAMESPACE").isEmpty())
     {
-      config_err("Error: GENERATE_QHP=YES requires QHP_NAMESPACE to be set. Using 'org.doxygen.doc' as default!.\n");
+      config_err("GENERATE_QHP=YES requires QHP_NAMESPACE to be set. Using 'org.doxygen.doc' as default!.\n");
       Config_getString("QHP_NAMESPACE")="org.doxygen.doc";
     }
 
     if (Config_getString("QHP_VIRTUAL_FOLDER").isEmpty())
     {
-      config_err("Error: GENERATE_QHP=YES requires QHP_VIRTUAL_FOLDER to be set. Using 'doc' as default!\n");
+      config_err("GENERATE_QHP=YES requires QHP_VIRTUAL_FOLDER to be set. Using 'doc' as default!\n");
       Config_getString("QHP_VIRTUAL_FOLDER")="doc";
     }
   }
@@ -1562,7 +1580,7 @@ void Config::check()
   if (!mathJaxFormat.isEmpty() && mathJaxFormat!="HTML-CSS" &&
        mathJaxFormat!="NativeMML" && mathJaxFormat!="SVG")
   {
-    config_err("Error: Unsupported value for MATHJAX_FORMAT: Should be one of HTML-CSS, NativeMML, or SVG\n");
+    config_err("Unsupported value for MATHJAX_FORMAT: Should be one of HTML-CSS, NativeMML, or SVG\n");
     Config_getEnum("MATHJAX_FORMAT")="HTML-CSS";
   }
 
@@ -1608,7 +1626,7 @@ void Config::check()
     if (!b6) s6="  EXTRACT_PACKAGE        = YES (was NO)\n"; else s6="";
 
 
-    config_err("Warning: enabling OPTIMIZE_OUTPUT_VHDL assumes the following settings:\n"
+    config_warn("enabling OPTIMIZE_OUTPUT_VHDL assumes the following settings:\n"
 	       "%s%s%s%s%s%s",s1,s2,s3,s4,s5,s6
 	      );
 
@@ -1665,7 +1683,7 @@ void Config::init()
       ConfigOption * opt = Config::instance()->get(depName);
       if (opt==0)
       {
-        config_err("Warning: Config option '%s' has invalid depends relation on unknown option '%s'\n",
+        config_warn("Config option '%s' has invalid depends relation on unknown option '%s'\n",
             option->name().data(),depName.data());
         exit(1);
       }
@@ -1712,7 +1730,7 @@ static QCString configFileToString(const char *name)
     QFileInfo fi(name);
     if (!fi.exists() || !fi.isFile())
     {
-      config_err("Error: file `%s' not found\n",name);
+      config_err("file `%s' not found\n",name);
       return "";
     }
     f.setName(name);
@@ -1733,7 +1751,7 @@ static QCString configFileToString(const char *name)
   }
   if (!fileOpened)  
   {
-    config_err("Error: cannot open file `%s' for reading\n",name);
+    config_err("cannot open file `%s' for reading\n",name);
   }
   return "";
 }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10323,16 +10323,19 @@ void readConfiguration(int argc, char **argv)
         }
         else if (qstricmp(formatName,"latex")==0)
         {
-          if (optind+4<argc) // use config file to get settings
+          if (optind+4<argc || QFileInfo("Doxyfile").exists())
           {
-            if (!Config::instance()->parse(argv[optind+4]))
+            QCString df = optind+4<argc ? argv[optind+4] : QCString("Doxyfile");
+            if (!Config::instance()->parse(df))
             {
               err("error opening or reading configuration file %s!\n",argv[optind+4]);
+              cleanUpDoxygen();
               exit(1);
             }
             Config::instance()->substituteEnvironmentVars();
             Config::instance()->convertStrToVal();
             Config_getString("LATEX_HEADER")="";
+            Config_getString("LATEX_FOOTER")="";
             Config::instance()->check();
           }
           else // use default config


### PR DESCRIPTION
There was a discrepancy in the handling of the header and footer files between HTML and LaTeX.
Also the wrong error / warning routine was called and the config_err and config_warn have been made more consistent with the messages(.cpp)