### PR TITLE
Fortran FUNCTION source code

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -982,6 +982,8 @@ private                                 {
                                          result=result.stripWhiteSpace();
                                          addSubprogram(result);
                                          BEGIN(Subprog);
+				         current->bodyLine = yyLineNr + lineCountPrepass + 1; // we have to be at the line after the definition and we have to take continuation lines into account.
+				         current->startLine = yyLineNr;
                                        }
 
 <Start,ModuleBody,SubprogBody,InterfaceBody,ModuleBodyContains,SubprogBodyContains>^{BS}({PREFIX}{BS_})?{SUBPROG}{BS_} {


### PR DESCRIPTION
In case of a Fortran FUNCTION there was a difference between the handling of the source code lines for functions with and without the RESULT clause. This has  been made uniform.