### PR TITLE
Remove redundant semicolon.

### DIFF
--- a/vhdlparser/VhdlParserTokenManager.cc
+++ b/vhdlparser/VhdlParserTokenManager.cc
@@ -3031,7 +3031,7 @@ int VhdlParserTokenManager::jjMoveNfa_0(int startState, int curPos){
       else if (curChar < 128)
       {
          unsigned long long l = 1ULL << (curChar & 077);
-         if (l == 1);
+         if (l == 1)
          do
          {
             switch(jjstateSet[--i])


### PR DESCRIPTION
This fixes Coverity ID: 85253 Stray semicolon
The misplaced semicolon is a common typo that can cause unexpected changes to the flow of control in the program that results in logical errors.