### PR TITLE
Fortran: warning message about not documented module member

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3203,7 +3203,13 @@ void MemberDef::warnIfUndocumented()
   if (cd)
     t="class", d=cd;
   else if (nd)
-    t="namespace", d=nd;
+  {
+    d=nd;
+    if (d->getLanguage() == SrcLangExt_Fortran)
+      t="module";
+    else
+      t="namespace";
+  }
   else if (gd)
     t="group", d=gd;
   else


### PR DESCRIPTION
When having a not documented MODULE member it is mentioned that a member in a 'namespace' is not documented. For Fortran this is a bit strange as Fortran does not know the term namespace, modules are handled as namespaces (in the pre 1.8.9 version a message was given about 'class', which is equally confusing).
This patch changes in this case 'namespace' to 'module'.