### PR TITLE
Bug 742445 - Wrong icons in TOC of CHM help

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -495,7 +495,11 @@ void Definition::addSectionsToIndex()
       }
       QCString title = si->title;
       if (title.isEmpty()) title = si->label;
-      Doxygen::indexList->addContentsItem(TRUE,title,
+      // determine if there is a next level inside this item
+      ++li;
+      bool isDir = ((li.current()) ? (int)(li.current()->type > nextLevel):FALSE);
+      --li;
+      Doxygen::indexList->addContentsItem(isDir,title,
                                          getReference(),
                                          getOutputFileBase(),
                                          si->label,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3116,14 +3116,14 @@ static void writePages(PageDef *pd,FTVHelp *ftv)
     {
       //printf("*** adding %s\n",pageTitle.data());
       ftv->addContentsItem(
-          hasSubPages,pageTitle,
+          hasSubPages || hasSections,pageTitle,
           pd->getReference(),pd->getOutputFileBase(),
           0,hasSubPages,TRUE,pd); 
     }
     if (addToIndex && pd!=Doxygen::mainPage)
     {
       Doxygen::indexList->addContentsItem(
-          hasSubPages,pageTitle,
+          hasSubPages || hasSections,pageTitle,
           pd->getReference(),pd->getOutputFileBase(),
           0,hasSubPages,TRUE);
     }


### PR DESCRIPTION
It was not checked if a page / section had subsections or not it was always assumed they were present (definition.cpp). For pages it was only checked if it had subpages and not section (index.cpp).