### PR TITLE
Enable relative paths referenced source files

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1743,6 +1743,15 @@ static int internalValidatingParseDoc(DocNode *parent,QList<DocNode> &children,
 
 static void readTextFileByName(const QCString &file,QCString &text)
 {
+  if (portable_isAbsolutePath(file.data()))
+  {
+    QFileInfo fi(file);
+    if (fi.exists())
+    {
+      text = fileToString(file,Config_getBool("FILTER_SOURCE_FILES"));
+      return;
+    }
+  }
   QStrList &examplePathList = Config_getList("EXAMPLE_PATH");
   char *s=examplePathList.first();
   while (s)


### PR DESCRIPTION
This is a regression on pull request 210: Create an easy possibility to take a snippet from the current file.
In case the source file, as referenced through 'this' in the snippet command, is in the current directory or in a subdirectory pull request worked fine, but as soon as the source file is in a directory referenced through ../... the parser returns an absolute path name instead of a relative path and file is not found, resulting in a warning plus empty snippet part.
We now check whether or not is an absolute file name in which case it is checked if the file is found or not and further handled.