### PR TITLE
Bug 739680 - Using HTML entities in PROJECT_NAME

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6483,7 +6483,7 @@ void filterLatexString(FTextStream &t,const char *str,
         case '&':  // possibility to have a special symbol
                    q = p;
                    cnt = 2; // we have to count & and ; as well
-                   while (*q && *q != ';')
+                   while ((*q >= 'a' && *q <= 'z') || (*q >= 'A' && *q <= 'Z') || (*q >= '0' && *q <= '9'))
                    {
                      cnt++;
                      q++;
@@ -6500,6 +6500,7 @@ void filterLatexString(FTextStream &t,const char *str,
                       else
                       {
                         t << HtmlEntityMapper::instance()->latex(res);
+                        q++;
                         p = q;
                       }
                    }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6452,6 +6452,8 @@ void filterLatexString(FTextStream &t,const char *str,
   //printf("filterLatexString(%s)\n",str);
   //if (strlen(str)<2) stackTrace();
   const unsigned char *p=(const unsigned char *)str;
+  const unsigned char *q;
+  int cnt;
   unsigned char c;
   unsigned char pc='\0';
   while (*p)
@@ -6478,7 +6480,34 @@ void filterLatexString(FTextStream &t,const char *str,
         case '$':  t << "\\$";           break;
         case '%':  t << "\\%";           break;
         case '^':  t << "$^\\wedge$";    break;
-        case '&':  t << "\\&";           break;
+        case '&':  // possibility to have a special symbol
+                   q = p;
+                   cnt = 2; // we have to count & and ; as well
+                   while (*q && *q != ';')
+                   {
+                     cnt++;
+                     q++;
+                   }
+                   if (*q == ';')
+                   {
+                      --p; // we need & as well
+                      DocSymbol::SymType res = HtmlEntityMapper::instance()->name2sym(QCString((char *)p).left(cnt));
+                      if (res == DocSymbol::Sym_Unknown)
+                      {
+                        p++;
+                        t << "\\&";
+                      }
+                      else
+                      {
+                        t << HtmlEntityMapper::instance()->latex(res);
+                        p = q;
+                      }
+                   }
+                   else
+                   {
+                     t << "\\&";
+                   }
+                   break;
         case '*':  t << "$\\ast$";       break;
         case '_':  if (!insideTabbing) t << "\\+";  
                    t << "\\_"; 


### PR DESCRIPTION
Implementation for LaTeX of special symbols by scanning string in case a & is found.