### PR TITLE
Bug 742899 - <CAPTION> inside <TABLE> no longer works for LaTex output

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -932,7 +932,7 @@ void LatexDocVisitor::visitPost(DocHtmlTable *t)
 void LatexDocVisitor::visitPre(DocHtmlCaption *c)
 {
   if (m_hide) return;
-  m_t << "\\end{" << getTableName(c->parent()) << "}\n\\centering\n\\caption{";
+  m_t << "\\end{" << getTableName(c->parent()->parent()) << "}\n\\centering\n\\caption{";
 }
 
 void LatexDocVisitor::visitPost(DocHtmlCaption *) 


### PR DESCRIPTION
This is a regression for bug: Bug 732768 - nested html tables cause pdflatex to hang (1.8.4 and 1.8.6).