### PR TITLE
Handle user comments in Doxyfile

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -69,7 +69,7 @@ class ConfigOption
     QCString dependsOn() const { return m_dependency; }
     void addDependency(const char *dep) { m_dependency = dep; }
     void setEncoding(const QCString &e) { m_encoding = e; }
-    void setUserComment(const QCString &u) { m_userComment = u; }
+    void setUserComment(const QCString &u) { m_userComment += u; }
 
   protected:
     virtual void writeTemplate(FTextStream &t,bool sl,bool upd) = 0;
@@ -507,11 +507,26 @@ class Config
      */
     void create();
 
+    /*! Append user start comment
+     */
+    void appendStartComment(const QCString &u)
+    {
+      m_startComment += u;
+    }
     /*! Append user comment
      */
     void appendUserComment(const QCString &u)
     {
       m_userComment += u;
+    }
+    /*! Take the user start comment and reset it internally
+     *  \returns user start comment
+     */
+    QCString takeStartComment()
+    {
+      QCString result=m_startComment;
+      m_startComment.resize(0);
+      return result.replace(QRegExp("\r"),"");
     }
     /*! Take the user comment and reset it internally
      *  \returns user comment
@@ -552,6 +567,7 @@ class Config
     QList<ConfigOption> *m_disabled;
     QDict<ConfigOption> *m_dict;
     static Config *m_instance;
+    QCString m_startComment;
     QCString m_userComment;
     bool m_initialized;
     QCString m_header;

--- a/src/config.l
+++ b/src/config.l
@@ -617,6 +617,13 @@ static void readIncludeFile(const char *incName)
 %%
 
 <*>\0x0d
+/*
+  <PreStart>"##".*"\n" { config->appendStartComment(yytext);}
+  <PreStart>. {
+              BEGIN(Start);
+              REJECT;
+            }
+*/
 <Start,GetString,GetStrList,GetBool,SkipInvalid>"##".*"\n" { config->appendUserComment(yytext);}
 <Start,GetString,GetStrList,GetBool,SkipInvalid>"#"	   { BEGIN(SkipComment); }
 <Start>[a-z_A-Z][a-z_A-Z0-9]*[ \t]*"="	 { QCString cmd=yytext;
@@ -851,6 +858,12 @@ static void readIncludeFile(const char *incName)
 
 void Config::writeTemplate(FTextStream &t,bool sl,bool upd)
 {
+  /* print first lines of user comment that were at the beginning of the file, might have special meaning for editors */
+  if (m_startComment)
+  {
+    t << takeStartComment();
+    t << "\n";
+  }
   t << "# Doxyfile " << versionString << endl << endl;
   if (!sl)
   {

--- a/src/config.l
+++ b/src/config.l
@@ -601,9 +601,9 @@ static void readIncludeFile(const char *incName)
 
 %}
 
-%option nounput
 %option noyywrap
 
+%x      PreStart
 %x      Start
 %x	SkipComment
 %x      SkipInvalid
@@ -617,13 +617,11 @@ static void readIncludeFile(const char *incName)
 %%
 
 <*>\0x0d
-/*
-  <PreStart>"##".*"\n" { config->appendStartComment(yytext);}
-  <PreStart>. {
+<PreStart>"##".*"\n" { config->appendStartComment(yytext);}
+<PreStart>. {
               BEGIN(Start);
-              REJECT;
+              unput(*yytext);
             }
-*/
 <Start,GetString,GetStrList,GetBool,SkipInvalid>"##".*"\n" { config->appendUserComment(yytext);}
 <Start,GetString,GetStrList,GetBool,SkipInvalid>"#"	   { BEGIN(SkipComment); }
 <Start>[a-z_A-Z][a-z_A-Z0-9]*[ \t]*"="	 { QCString cmd=yytext;
@@ -861,8 +859,7 @@ void Config::writeTemplate(FTextStream &t,bool sl,bool upd)
   /* print first lines of user comment that were at the beginning of the file, might have special meaning for editors */
   if (m_startComment)
   {
-    t << takeStartComment();
-    t << "\n";
+    t << takeStartComment() << endl; 
   }
   t << "# Doxyfile " << versionString << endl << endl;
   if (!sl)
@@ -1755,7 +1752,7 @@ bool Config::parseString(const char *fn,const char *str,bool update)
   includeStack.clear();
   includeDepth  = 0;
   configYYrestart( configYYin );
-  BEGIN( Start );
+  BEGIN( PreStart );
   config_upd = update;
   configYYlex();
   config_upd = FALSE;

--- a/src/config.xml
+++ b/src/config.xml
@@ -29,7 +29,9 @@ parsed by \c doxygen. The file may contain tabs and newlines for
 formatting purposes. The statements in the file are case-sensitive.
 Comments may be placed anywhere within the file (except within quotes).
 Comments beginning with two hash characters (\c \#\#) are kept when updating
-the configuration file and are placed in front of the TAG are in front of.
+the configuration file and are placed in front of the TAG they are in front of.
+Comments beginning with two hash characters (\c \#\#) at the beginning of the
+configuration file are also kept and placed at the beginning of the file.
 Comments beginning with two hash characters (\c \#\#) at the end of the
 configuration file are also kept and placed at the end of the file.
 Comments begin with the hash character (\c \#) and ends at the end of the line.


### PR DESCRIPTION
Based on the report of Peter D. Barnes in the doxygen forum (http://doxy...gen.10944.n7.nabble.com/doxygen-1-8-9-1-upgrade-errors-td6990.html)

All lines at the beginning of the file starting with ## are preserved at the beginning of the Doxyfile
Consecutive user comments (with +=) are now joined like the options are.