### PR TITLE
Bug 743358 - Wrong inheritance diagrams in html if INLINE_GROUPED_CLASSES is set to YES

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1356,7 +1356,7 @@ void HtmlGenerator::endClassDiagram(const ClassDiagram &d,
   startSectionContent(t,m_sectionCount);
   t << " <div class=\"center\">" << endl;
   t << "  <img src=\"";
-  t << relPath << fileName << ".png\" usemap=\"#";
+  t << relPath << name << ".png\" usemap=\"#";
   docify(name);
   t << "_map\" alt=\"\"/>" << endl;
   t << "  <map id=\"";
@@ -1365,7 +1365,7 @@ void HtmlGenerator::endClassDiagram(const ClassDiagram &d,
   docify(name);
   t << "_map\">" << endl;
 
-  d.writeImage(t,dir,relPath,fileName);
+  d.writeImage(t,dir,relPath,name);
   t << " </div>";
   endSectionContent(t);
   m_sectionCount++;

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1636,9 +1636,9 @@ void LatexGenerator::startClassDiagram()
 }
 
 void LatexGenerator::endClassDiagram(const ClassDiagram &d,
-                                       const char *fileName,const char *)
+                                       const char *,const char *name)
 {
-  d.writeFigure(t,dir,fileName);
+  d.writeFigure(t,dir,name);
 }
 
 

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1818,18 +1818,18 @@ void RTFGenerator::startClassDiagram()
 }
 
 void RTFGenerator::endClassDiagram(const ClassDiagram &d,
-    const char *fileName,const char *)
+    const char *fileName,const char *name)
 {
   newParagraph();
 
   // create a png file
-  d.writeImage(t,dir,relPath,fileName,FALSE);
+  d.writeImage(t,dir,relPath,name,FALSE);
 
   // display the file
   t << "{" << endl;
   t << rtf_Style_Reset << endl;
   t << "\\par\\pard \\qc {\\field\\flddirty {\\*\\fldinst INCLUDEPICTURE \"";
-  t << fileName << ".png\"";
+  t << name << ".png\"";
   t << " \\\\d \\\\*MERGEFORMAT}{\\fldrslt IMAGE}}\\par" << endl;
   t << "}" << endl;
 }


### PR DESCRIPTION
Changed fileName to name as the fileName is identical in case of INLINE_GROUPED_CLASSES and thus giving the same image (last) for all occurrences on the page.