### PR TITLE
increase the size of l when result is modified

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7676,8 +7676,12 @@ QCString externalRef(const QCString &relPath,const QCString &ref,bool href)
       if (!relPath.isEmpty() && l>0 && result.at(0)=='.')
       { // relative path -> prepend relPath.
         result.prepend(relPath);
+        l+=relPath.length();
       }
-      if (!href) result.prepend("doxygen=\""+ref+":");
+      if (!href){
+        result.prepend("doxygen=\""+ref+":");
+        l+=10+ref.length();
+      }
       if (l>0 && result.at(l-1)!='/') result+='/';
       if (!href) result.append("\" ");
     }


### PR DESCRIPTION
We were having an issue in thr search box when result was "../BGL", the "/" appended was missing and the link was incorrect.