### PR TITLE
hack: work around issue 737472

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -377,7 +377,7 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
                                         -1,    // endLine
                                         FALSE, // inlineFragment
                                         0,     // memberDef
-                                        TRUE,  // show line numbers
+                                        FALSE,  // show line numbers
                                         m_ctx  // search context
                                        );
       m_t << PREFRAG_END;


### PR DESCRIPTION
While I suspect this isn't the correct fix (which requires some sort of configuration option), [bug 737472](https://bugzilla.gnome.org/show_bug.cgi?id=737472) is a fairly big problem for the way I use Doxygen.  The issue report doesn't seem to get much visibility where it is so I'm hoping this might elevate its priority (and provide a workaround until the right fix can be developed).
