### PR TITLE
Adding commands \hidecallgraph and \hidecallergraph

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -49,8 +49,8 @@ documentation:
 \refitem cmdbrief \\brief
 \refitem cmdbug \\bug
 \refitem cmdc \\c
-\refitem cmdcallgraph \\callgraph
 \refitem cmdcallergraph \\callergraph
+\refitem cmdcallgraph \\callgraph
 \refitem cmdcategory \\category
 \refitem cmdcite \\cite
 \refitem cmdclass \\class
@@ -104,6 +104,8 @@ documentation:
 \refitem cmdfile \\file
 \refitem cmdfn \\fn
 \refitem cmdheaderfile \\headerfile
+\refitem cmdhidecallergraph \\hidecallergraph
+\refitem cmdhidecallgraph \\hidecallgraph
 \refitem cmdhideinitializer \\hideinitializer
 \refitem cmdhtmlinclude \\htmlinclude
 \refitem cmdhtmlonly \\htmlonly
@@ -273,7 +275,26 @@ Structural indicators
   \note The completeness (and correctness) of the call graph depends on the
   doxygen code parser which is not perfect.
 
-  \sa section \ref cmdcallergraph "\\callergraph".
+  \sa section \ref cmdcallergraph "\\callergraph",
+      section \ref cmdhidecallgraph "\\hidecallgraph",
+      section \ref cmdhidecallergraph "\\hidecallergraph" and
+      option \ref cfg_call_graph "CALL_GRAPH"
+
+<hr>
+\section cmdhidecallgraph \\hidecallgraph
+
+  \addindex \\hidecallgraph
+  When this command is put in a comment block of a function or method
+  and then doxygen will not generate a call graph for that function. The
+  call graph will not be generated regardless of the value of
+  \ref cfg_call_graph "CALL_GRAPH".
+  \note The completeness (and correctness) of the call graph depends on the
+  doxygen code parser which is not perfect.
+
+  \sa section \ref cmdcallergraph "\\callergraph",
+      section \ref cmdcallgraph "\\callgraph",
+      section \ref cmdhidecallergraph "\\hidecallergraph" and
+      option \ref cfg_call_graph "CALL_GRAPH"
 
 <hr>
 \section cmdcallergraph \\callergraph
@@ -287,7 +308,26 @@ Structural indicators
   \note The completeness (and correctness) of the caller graph depends on the
   doxygen code parser which is not perfect.
 
-  \sa section \ref cmdcallgraph "\\callgraph".
+  \sa section \ref cmdcallgraph "\\callgraph",
+      section \ref cmdhidecallgraph "\\hidecallgraph",
+      section \ref cmdhidecallergraph "\\hidecallergraph" and
+      option \ref cfg_caller_graph "CALLER_GRAPH"
+
+<hr>
+\section cmdhidecallergraph \\hidecallergraph
+
+  \addindex \\hidecallergraph
+  When this command is put in a comment block of a function or method
+  and then doxygen will not generate a caller graph for that function. The
+  caller graph will not be generated regardless of the value of
+  \ref cfg_caller_graph "CALLER_GRAPH".
+  \note The completeness (and correctness) of the caller graph depends on the
+  doxygen code parser which is not perfect.
+
+  \sa section \ref cmdcallergraph "\\callergraph",
+      section \ref cmdcallgraph "\\callgraph",
+      section \ref cmdhidecallgraph "\\hidecallgraph" and
+      option \ref cfg_caller_graph "CALLER_GRAPH"
 
 <hr>
 \section cmdcategory \\category <name> [<header-file>] [<header-name>]

--- a/doc/diagrams.doc
+++ b/doc/diagrams.doc
@@ -52,10 +52,14 @@
       </ul>
   <li>if \ref cfg_call_graph "CALL_GRAPH" is set to YES, a 
       graphical call graph is drawn for each function showing the 
-      functions that the function directly or indirectly calls.
+      functions that the function directly or indirectly calls
+      (see also section \ref cmdcallgraph "\\callgraph" and
+       section \ref cmdhidecallgraph "\\hidecallgraph").
   <li>if \ref cfg_caller_graph "CALLER_GRAPH" is set to YES, a 
       graphical caller graph is drawn for each function showing the 
-      functions that the function is directly or indirectly called by.
+      functions that the function is directly or indirectly called by
+      (see also section \ref cmdcallergraph "\\callergraph" and
+       section \ref cmdhidecallergraph "\\hidecallergraph").
   </ul>
 
   Using a \ref customize "layout file" you can determine which of the

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -101,7 +101,9 @@ static bool handleNoSubGrouping(const QCString &);
 static bool handleShowInitializer(const QCString &);
 static bool handleHideInitializer(const QCString &);
 static bool handleCallgraph(const QCString &);
+static bool handleHideCallgraph(const QCString &);
 static bool handleCallergraph(const QCString &);
+static bool handleHideCallergraph(const QCString &);
 static bool handleInternal(const QCString &);
 static bool handleLineBr(const QCString &);
 static bool handleStatic(const QCString &);
@@ -204,7 +206,9 @@ static DocCmdMap docCmdMap[] =
   { "showinitializer", &handleShowInitializer,  FALSE },
   { "hideinitializer", &handleHideInitializer,  FALSE },
   { "callgraph",       &handleCallgraph,        FALSE },
+  { "hidecallgraph",   &handleHideCallgraph,    FALSE },
   { "callergraph",     &handleCallergraph,      FALSE },
+  { "hidecallergraph", &handleHideCallergraph,  FALSE },
   { "internal",        &handleInternal,         TRUE  },
   { "_linebr",         &handleLineBr,           FALSE },
   { "static",          &handleStatic,           FALSE },
@@ -2689,9 +2693,21 @@ static bool handleCallgraph(const QCString &)
   return FALSE;
 }
 
+static bool handleHideCallgraph(const QCString &)
+{
+  current->callGraph = FALSE; // OFF
+  return FALSE;
+}
+
 static bool handleCallergraph(const QCString &)
 {
   current->callerGraph = TRUE; // ON
+  return FALSE;
+}
+
+static bool handleHideCallergraph(const QCString &)
+{
+  current->callerGraph = FALSE; // OFF
   return FALSE;
 }
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -3234,7 +3234,9 @@ to be found in the default search path.
  generate a call dependency graph for every global function or class method. 
  <br>Note that enabling this option will significantly increase the time of a run.
  So in most cases it will be better to enable call graphs for selected 
- functions only using the \ref cmdcallgraph "\\callgraph" command.
+ functions only using the \ref cmdcallgraph "\\callgraph" command. 
+ Disabling a call graph can be accomplished by means of the command 
+ \ref cmdhidecallgraph "\\hidecallgraph".
 ]]>
       </docs>
     </option>
@@ -3245,7 +3247,9 @@ to be found in the default search path.
  generate a caller dependency graph for every global function or class method. 
  <br>Note that enabling this option will significantly increase the time of a run.
  So in most cases it will be better to enable caller graphs for selected 
- functions only using the \ref cmdcallergraph "\\callergraph" command.
+ functions only using the \ref cmdcallergraph "\\callergraph" command. 
+ Disabling a caller graph can be accomplished by means of the command 
+ \ref cmdhidecallergraph "\\hidecallergraph".
 ]]>
       </docs>
     </option>

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -4056,8 +4056,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
     TemplateVariant hasCallGraph() const
     {
       static bool haveDot = Config_getBool("HAVE_DOT");
-      static bool callGraph = Config_getBool("CALL_GRAPH");
-      if ((callGraph || m_memberDef->hasCallGraph()) && haveDot &&
+      if (m_memberDef->hasCallGraph() && haveDot &&
           (m_memberDef->isFunction() || m_memberDef->isSlot() || m_memberDef->isSignal()))
       {
         DotCallGraph *cg = getCallGraph();
@@ -4096,8 +4095,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
     TemplateVariant hasCallerGraph() const
     {
       static bool haveDot = Config_getBool("HAVE_DOT");
-      static bool callerGraph = Config_getBool("CALLER_GRAPH");
-      if ((callerGraph || m_memberDef->hasCallerGraph()) && haveDot &&
+      if (m_memberDef->hasCallerGraph() && haveDot &&
           (m_memberDef->isFunction() || m_memberDef->isSlot() || m_memberDef->isSignal()))
       {
         DotCallGraph *cg = getCallerGraph();

--- a/src/dbusxmlscanner.cpp
+++ b/src/dbusxmlscanner.cpp
@@ -661,9 +661,6 @@ private:
         entry->startLine = lineNumber();
         entry->bodyLine = lineNumber();
 
-        entry->callGraph = false;
-        entry->callerGraph = false;
-
         initGroupInfo(entry);
 
         m_currentEntry = entry;

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -24,7 +24,7 @@
 #include "doxygen.h"
 #include "filestorage.h"
 #include "arguments.h"
-
+#include "config.h"
 //------------------------------------------------------------------
 
 #define HEADER ('D'<<24)+('O'<<16)+('X'<<8)+'!'
@@ -216,6 +216,8 @@ void Entry::addSubEntry(Entry *current)
 
 void Entry::reset()
 {
+  static bool entryCallGraph   = Config_getBool("CALL_GRAPH");
+  static bool entryCallerGraph = Config_getBool("CALLER_GRAPH");
   //printf("Entry::reset()\n");
   name.resize(0);
   type.resize(0);
@@ -245,8 +247,8 @@ void Entry::reset()
   bodyLine = -1;
   endBodyLine = -1;
   mGrpId = -1;
-  callGraph = FALSE;
-  callerGraph = FALSE;
+  callGraph   = entryCallGraph;
+  callerGraph = entryCallerGraph;
   section = EMPTY_SEC;
   mtype   = Method;
   virt    = Normal;

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2043,7 +2043,7 @@ void MemberDef::getLabels(QStrList &sl,Definition *container) const
 void MemberDef::_writeCallGraph(OutputList &ol)
 {
   // write call graph
-  if ((m_impl->hasCallGraph || Config_getBool("CALL_GRAPH"))
+  if (m_impl->hasCallGraph
       && (isFunction() || isSlot() || isSignal()) && Config_getBool("HAVE_DOT")
      )
   {
@@ -2068,7 +2068,7 @@ void MemberDef::_writeCallGraph(OutputList &ol)
 
 void MemberDef::_writeCallerGraph(OutputList &ol)
 {
-  if ((m_impl->hasCallerGraph || Config_getBool("CALLER_GRAPH"))
+  if (m_impl->hasCallerGraph
       && (isFunction() || isSlot() || isSignal()) && Config_getBool("HAVE_DOT")
      )
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8007,12 +8007,10 @@ void addDocCrossReference(MemberDef *src,MemberDef *dst)
 {
   static bool referencedByRelation = Config_getBool("REFERENCED_BY_RELATION");
   static bool referencesRelation   = Config_getBool("REFERENCES_RELATION");
-  static bool callerGraph          = Config_getBool("CALLER_GRAPH");
-  static bool callGraph            = Config_getBool("CALL_GRAPH");
 
   //printf("--> addDocCrossReference src=%s,dst=%s\n",src->name().data(),dst->name().data());
   if (dst->isTypedef() || dst->isEnumerate()) return; // don't add types
-  if ((referencedByRelation || callerGraph || dst->hasCallerGraph()) && 
+  if ((referencedByRelation || dst->hasCallerGraph()) && 
       src->showInCallGraph()
      )
   {
@@ -8028,7 +8026,7 @@ void addDocCrossReference(MemberDef *src,MemberDef *dst)
       mdDecl->addSourceReferencedBy(src);
     }
   }
-  if ((referencesRelation || callGraph || src->hasCallGraph()) && 
+  if ((referencesRelation || src->hasCallGraph()) && 
       src->showInCallGraph()
      )
   {

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -40,7 +40,7 @@ static int              yyLineNr      = 1;
 static int*             lineParse;
 static int              iDocLine      = -1;
 static QCString         inputString;
-static Entry            gBlock;
+static Entry*           gBlock        = 0;
 static Entry*           previous      = 0;
 //-------------------------------------------------------
 
@@ -102,38 +102,40 @@ Entry* getVhdlCompound()
 void startCodeBlock(int index)
 {
   int ll=strComment.length();
+  if (!gBlock) gBlock = new Entry;
   iCodeLen=inputString.findRev(strComment.data())+ll;
   // fprintf(stderr,"\n startin code..%d %d %d\n",iCodeLen,num_chars,ll);
-  gBlock.reset();
+  gBlock->reset();
   int len=strComment.length();
   QCString name=strComment.right(len-index);//
   name=VhdlDocGen::getIndexWord(name.data(),1);
   if (!name)
-    gBlock.name="misc"+ VhdlDocGen::getRecordNumber();
+    gBlock->name="misc"+ VhdlDocGen::getRecordNumber();
   else
-    gBlock.name=name;
+    gBlock->name=name;
 
-  gBlock.startLine=yyLineNr;
-  gBlock.bodyLine=yyLineNr;
+  gBlock->startLine=yyLineNr;
+  gBlock->bodyLine=yyLineNr;
 
   strComment=strComment.left(index);
   VhdlDocGen::prepareComment(strComment);
-  gBlock.brief+=strComment;
+  gBlock->brief+=strComment;
 }
 
 void makeInlineDoc(int endCode)
 {
   int len=endCode-iCodeLen;
+  if (!gBlock) gBlock = new Entry;
   QCString par=inputString.mid(iCodeLen,len);
   //fprintf(stderr,"\n inline code: \n<%s>",par.data());
-  gBlock.doc=par;
-  gBlock.inbodyDocs=par;
-  gBlock.section=Entry::VARIABLE_SEC;
-  gBlock.spec=VhdlDocGen::MISCELLANEOUS;
-  gBlock.fileName = yyFileName;
-  gBlock.endBodyLine=yyLineNr-1;
-  gBlock.lang=SrcLangExt_VHDL;
-  Entry *temp=new Entry(gBlock);
+  gBlock->doc=par;
+  gBlock->inbodyDocs=par;
+  gBlock->section=Entry::VARIABLE_SEC;
+  gBlock->spec=VhdlDocGen::MISCELLANEOUS;
+  gBlock->fileName = yyFileName;
+  gBlock->endBodyLine=yyLineNr-1;
+  gBlock->lang=SrcLangExt_VHDL;
+  Entry *temp=new Entry(*gBlock);
   Entry* compound=getVhdlCompound();
 
   if (compound)
@@ -146,7 +148,7 @@ void makeInlineDoc(int endCode)
     VhdlParser::current_root->addSubEntry(temp);
   }
   strComment.resize(0);
-  gBlock.reset();
+  gBlock->reset();
 }// makeInlineDoc
 
 


### PR DESCRIPTION
With the new commands \hidecallgraph and \hidecallergraph it is possible to suppress a call or caller graph even though the corresponding option CALL_GRAPH or CALLER_GRAPH is set.

commands.doc
config.xml
diagrams.doc
- updating documentation to support new commands

entry.cpp
- initialize callgraph and callergraph with the value from the config file

commentscan.l
- add handling for the new commands

context.cpp
memberdef.cpp
util.cpp
- getting the option for CALL_GRAPH and CALLER_GRAPH is not necessary anymore as it is incorporated in the initialization of an Entry item

dbusxmlscanner.cpp
- initialization is done in the Entry item

vhdljjparser.cpp
- gBlock was a static variable and therefore initialized before the doxygen main routine started. A Entry element sets now the default for callgraph and callergraph based on the config file and as the config file is not yet known at that moment the value for CALL_GRAPH and CALLER_GRAPH were set to False. By making a pointer of gBlock and doing an appropriate new Entry call this problem is overcome.