### PR TITLE
Better error message in case of IDL inconsistency

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -151,7 +151,7 @@ static void format_warn(const char *file,int line,const char *text)
 
 static void do_warn(const char *tag, const char *file, int line, const char *prefix, const char *fmt, va_list args)
 {
-  if (!Config_getBool(tag)) return; // warning type disabled
+  if (tag && !Config_getBool(tag)) return; // warning type disabled
   const int bufSize = 40960;
   char text[bufSize];
   int l=0;
@@ -213,6 +213,14 @@ void err(const char *fmt, ...)
   va_list args;
   va_start(args, fmt);
   vfprintf(warnFile, (QCString(error_str) + fmt).data(), args);
+  va_end(args); 
+}
+
+extern void err_full(const char *file,int line,const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  do_warn(NULL, file, line, error_str, fmt, args);
   va_end(args); 
 }
 

--- a/src/message.h
+++ b/src/message.h
@@ -29,6 +29,7 @@ extern void warn_undoc(const char *file,int line,const char *fmt, ...);
 extern void warn_doc_error(const char *file,int line,const char *fmt, ...);
 extern void warn_uncond(const char *fmt, ...);
 extern void err(const char *fmt, ...);
+extern void err_full(const char *file,int line,const char *fmt, ...);
 void initWarningFormat();
 
 extern void printlex(int dbg, bool enter, const char *lexName, const char *fileName);

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -1188,7 +1188,7 @@ QCString NamespaceDef::compoundTypeString() const
     }
     else
     {
-      err("Internal inconsistency: namespace in IDL not module, library or constant group\n");
+      err_full(getDefFileName(),getDefLine(),"Internal inconsistency: namespace in IDL not module, library or constant group");
     }
   }
   return "";


### PR DESCRIPTION
In case of an IDL internal doxygen inconsistency ("error: Internal inconsistency: namespace in IDL not module, library or constant group ", see forum report: http://doxygen.10944.n7.nabble.com/Internal-inconsistency-Which-file-td7057.html) it is hard to find out which file causes the problem.
In this case the comment block with @namespace was the "problem").

This patch solves this by adding the file and line number of the source file causing the problem.