### PR TITLE
 Bug 659590 - EXTRA_PACKAGES can't handle package options

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2492,10 +2492,19 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
       <docs>
 <![CDATA[
  The \c EXTRA_PACKAGES tag can be used to specify one or more \f$\mbox{\LaTeX}\f$ 
- package names that should be included in the \f$\mbox{\LaTeX}\f$ output.
- To get the times font for instance you can specify 
+ package names that should be included in the \f$\mbox{\LaTeX}\f$ output. The package
+ can be specified just by its name or with the correct syntax as to be used with the
+ \f$\mbox{\LaTeX}\f$ `\usepackage` command.
+
+ To get the `times` font for instance you can specify :
 \verbatim
-EXTRA_PACKAGES=times
+  EXTRA_PACKAGES=times
+or 
+  EXTRA_PACKAGES={times}
+\endverbatim
+ To use the option `intlimits` with the `amsmath` package you can specify:
+\verbatim
+   EXTRA_PACKAGES=[intlimits]{amsmath}
 \endverbatim
  If left blank no extra packages will be included.
 ]]>

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -421,7 +421,10 @@ static void writeDefaultHeaderPart1(FTextStream &t)
     const char *pkgName=extraPackages.first();
     while (pkgName)
     {
-      t << "\\usepackage{" << pkgName << "}\n";
+      if ((pkgName[0] == '[') || (pkgName[0] == '{'))
+        t << "\\usepackage" << pkgName << "\n";
+      else
+        t << "\\usepackage{" << pkgName << "}\n";
       pkgName=extraPackages.next();
     }
     t << "\n";


### PR DESCRIPTION
Create the possibility to specify options with the EXTRA_PACKAGES command.
It is possible to specify the package by just its name or in the syntax as required by the LaTeX \usepackage command ([\<package-option-list\>]{\<package-list\>}[\<version\>])