### PR TITLE
Bug 745481 - Doxygen generates bad "More..." file links for functions within a namespace

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1808,7 +1808,10 @@ void MemberDef::writeDeclaration(OutputList &ol,
         ol.disableAllBut(OutputGenerator::Html);
         //ol.endEmphasis();
         ol.docify(" ");
-        if (separateMemberPages || (m_impl->group!=0 && gd==0)) // forward link to the page or group
+        if (separateMemberPages ||
+            (m_impl->group!=0 && gd==0) ||
+            (m_impl->nspace!=0 && nd==0)
+           ) // forward link to the page or group or namespace
         {
           ol.startTextLink(getOutputFileBase(),anchor());
         }


### PR DESCRIPTION
Namespaces are recorded at separate pages as well. Condition should be extended for namespaces as well.