### PR TITLE
Internal doxygen docs gives: warning: Unsupported xml/html tag <...> found

### DIFF
--- a/src/arguments.h
+++ b/src/arguments.h
@@ -70,7 +70,7 @@ struct Argument
   QCString array;    /*!< Argument's array specifier (may be empty) */
   QCString defval;   /*!< Argument's default value (may be empty) */
   QCString docs;     /*!< Argument's documentation (may be empty) */
-  QCString typeConstraint;  /*!< Used for Java generics: <T extends C> */
+  QCString typeConstraint;  /*!< Used for Java generics: \<T extends C\> */
 };
 
 /*! \brief This class represents an function or template argument list. 

--- a/vhdlparser/TokenManager.h
+++ b/vhdlparser/TokenManager.h
@@ -16,7 +16,7 @@ namespace parser {
 class TokenManager {
 public:
   /** This gets the next token from the input stream.
-   *  A token of kind 0 (<EOF>) should be returned on EOF.
+   *  A token of kind 0 (\<EOF\>) should be returned on EOF.
    */
   virtual       ~TokenManager() { }
   virtual Token *getNextToken() = 0;


### PR DESCRIPTION
When generating the doxygen internal documentation we get the warning about Unsupported xml/html tag. This patch fixes this problem.
(TokenManager.h is said to be generated code but original source is not found).