### PR TITLE
Showing grey/gray in documentation

### DIFF
--- a/qtools/qfeatures.h
+++ b/qtools/qfeatures.h
@@ -378,7 +378,7 @@
 */
 //#define QT_NO_QWS_DEPTH_1
 /*!
-    4-bit greyscale
+    4-bit grayscale
 */
 //#define QT_NO_QWS_DEPTH_4
 /*!

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -1051,7 +1051,7 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
         "<li>%A filled black box represents the struct or class for which the "
         "graph is generated.\n"
         "<li>%A box with a black border denotes a documented struct or class.\n"
-        "<li>%A box with a grey border denotes an undocumented struct or class.\n"
+        "<li>%A box with a gray border denotes an undocumented struct or class.\n"
         "<li>%A box with a red border denotes a documented struct or class for"
         "which not all inheritance/containment relations are shown. %A graph is "
         "truncated if it does not fit within the specified boundaries.\n"

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -1022,7 +1022,7 @@ class TranslatorEnglish : public Translator
         "<li>%A filled gray box represents the struct or class for which the "
         "graph is generated.</li>\n"
         "<li>%A box with a black border denotes a documented struct or class.</li>\n"
-        "<li>%A box with a grey border denotes an undocumented struct or class.</li>\n"
+        "<li>%A box with a gray border denotes an undocumented struct or class.</li>\n"
         "<li>%A box with a red border denotes a documented struct or class for"
         "which not all inheritance/containment relations are shown. %A graph is "
         "truncated if it does not fit within the specified boundaries.</li>\n"

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -1022,7 +1022,7 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
         "<li>%A filled black box represents the struct or class for which the "
         "graph is generated.\n"
         "<li>%A box with a black border denotes a documented struct or class.\n"
-        "<li>%A box with a grey border denotes an undocumented struct or class.\n"
+        "<li>%A box with a gray border denotes an undocumented struct or class.\n"
         "<li>%A box with a red border denotes a documented struct or class for"
         "which not all inheritance/containment relations are shown. %A graph is "
         "truncated if it does not fit within the specified boundaries.\n"

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -1013,7 +1013,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
         "<li>%A filled black box represents the struct or class for which the "
         "graph is generated.\n"
         "<li>%A box with a black border denotes a documented struct or class.\n"
-        "<li>%A box with a grey border denotes an undocumented struct or class.\n"
+        "<li>%A box with a gray border denotes an undocumented struct or class.\n"
         "<li>%A box with a red border denotes a documented struct or class for"
         "which not all inheritance/containment relations are shown. %A graph is "
         "truncated if it does not fit within the specified boundaries.\n"

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -1028,7 +1028,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
         "<li>%A filled gray box represents the struct or class for which the "
         "graph is generated.</li>\n"
         "<li>%A box with a black border denotes a documented struct or class.</li>\n"
-        "<li>%A box with a grey border denotes an undocumented struct or class.</li>\n"
+        "<li>%A box with a gray border denotes an undocumented struct or class.</li>\n"
         "<li>%A box with a red border denotes a documented struct or class for"
         "which not all inheritance/containment relations are shown. %A graph is "
         "truncated if it does not fit within the specified boundaries.</li>\n"

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -691,7 +691,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
         "<li>%A filled black box represents the struct or class for which the "
         "graph is generated.\n"
         "<li>%A box with a black border denotes a documented struct or class.\n"
-        "<li>%A box with a grey border denotes an undocumented struct or class.\n"
+        "<li>%A box with a gray border denotes an undocumented struct or class.\n"
         "<li>%A box with a red border denotes a documented struct or class for\n"
         "which not all inheritance/containment relations are shown. %A graph is "
         "truncated if it does not fit within the specified boundaries."


### PR DESCRIPTION
The US-English spelling is gray where as the British-English spelling is grey. The doxygen documentation is in US-English spelling.
This patch corrects the wrong spelled, user visible, grey to gray.