### PR TITLE
Crash in case of non generic interface in Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -485,7 +485,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
 <InterfaceBody>^{BS}end{BS}interface({BS_}{ID})? {
                                           // end scope only if GENERIC interface
-                                          last_entry->parent()->endBodyLine = yyLineNr - 1;
+                                          if (ifType == IF_GENERIC)last_entry->parent()->endBodyLine = yyLineNr - 1;
                                           if (ifType == IF_GENERIC && !endScope(current_root))
                                             yyterminate();
 


### PR DESCRIPTION
In case of a non generic interface in Fortran it happened that  doxygen crashed due to the fact that the pointer for setting the endBodyLine does not exist. The line number is only defined for GENERIC interfaces and therefore it should not be set anyhow when ending a  non generic interface.