### PR TITLE
Warning message multiple mainpages

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8726,9 +8726,8 @@ static void findMainPage(EntryNav *rootNav)
     {
       Entry *root = rootNav->entry();
       warn(root->fileName,root->startLine,
-          "found more than one \\mainpage comment block! Skipping this "
-          "block."
-          );
+           "found more than one \\mainpage comment block! (first occurrence: %s, line %d), Skipping current block!",
+           Doxygen::mainPage->docFile().data(),Doxygen::mainPage->docLine());
     }
 
     rootNav->releaseEntry();


### PR DESCRIPTION
Based on the report in the doxygen forum (http://doxygen.10944.n7.nabble.com/WARNING-Found-more-than-one-mainpage-comment-block-td7092.html) about the hard to find multiple occurrences of a mainpage definition.
This patch also outputs the name (and approximate line) of the first found mainpage.