### PR TITLE
Bug 746576 - Warnings without filename

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -519,8 +519,8 @@ static void checkUndocumentedParams()
         }
         else
         {
-           warn_doc_error(g_memberDef->docFile(),
-                          g_memberDef->docLine(),
+           warn_doc_error(g_memberDef->getDefFileName(),
+                          g_memberDef->getDefLine(),
                           substitute(errMsg,"%","%%"));
         }
       }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2991,13 +2991,13 @@ void MemberDef::writeDocumentation(MemberList *ml,OutputList &ol,
   {
     if (!hasDocumentedParams())
     {
-      warn_doc_error(docFile(),docLine(),
+      warn_doc_error(getDefFileName(),getDefLine(),
           "parameters of member %s are not (all) documented",
           qPrint(qualifiedName()));
     }
     if (!hasDocumentedReturnType() && isFunction() && hasDocumentation())
     {
-      warn_doc_error(docFile(),docLine(),
+      warn_doc_error(getDefFileName(),getDefLine(),
           "return type of member %s is not documented",
           qPrint(qualifiedName()));
     }
@@ -3230,7 +3230,7 @@ void MemberDef::warnIfUndocumented()
       !isReference()
      )
   {
-    warn_undoc(getDefFileName(),getDefLine(),"Member %s%s (%s) of %s %s is not documented.",
+    warn_undoc(d->getDefFileName(),d->getDefLine(),"Member %s%s (%s) of %s %s is not documented.",
          qPrint(name()),qPrint(argsString()),qPrint(memberTypeName()),t,qPrint(d->name()));
   }
 }


### PR DESCRIPTION
In a number of instances we don't get the filename of where the error occurs but a name or even unknown between \<\

> e.g.
\<fie_p2\>:1: warning: parameters of member fie_p2 are not (all) documented
\<error\>:1: warning: parameters of member p1.error are not (all) documented
\<unknown\>:1: warning: Member fie_p3 (function) of class p3::int1_p3 is not documented.

This patch tries to overcome this problem by providing the right file:
.../p2.h:8: warning: parameters of member fie_p2 are not (all) documented
.../p1.py:7: warning: parameters of member p1.error are not (all) documented
.../p3.f90:3: warning: Member fie_p3 (function) of class p3::int1_p3 is not documented.