### PR TITLE
Bug 746614 - Bogus warning regarding nested comments

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1028,6 +1028,7 @@ void convertCppComments(BufStr *inBuf,BufStr *outBuf,const char *fileName)
         "Nesting level %d %s",g_nestingCount+1,tmp.data()); // add one for "normal" expected end of comment
   }
   g_commentStack.clear();
+  g_nestingCount = 0;
   if (Debug::isFlagSet(Debug::CommentCnv))
   {
     g_outBuf->at(g_outBuf->curPos())='\0';


### PR DESCRIPTION
In case the previous file gives a warning regarding the wrong used nested comments and the next file does not have any doxygen comment there is still the message that there is a nested comment but even without probable line numbers.
The variable counting the nested comment level was not reset, this has been corrected with this patch.