### PR TITLE
fix enum brief description in RTF output

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11672,7 +11672,7 @@ void generateOutput()
     QString oldDir = QDir::currentDirPath();
     QDir::setCurrent(Config_getString("HTML_OUTPUT"));
     portable_sysTimerStart();
-    if (portable_system(Config_getString("HHC_LOCATION"), "index.hhp", FALSE))
+	if (portable_system(Config_getString("HHC_LOCATION"), "index.hhp", Debug::isFlagSet(Debug::ExtCmd)))
     {
       err("failed to run html help compiler on index.hhp\n");
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4140,7 +4140,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const QList<LayoutNavEntry
         case LayoutNavEntry::Classes: 
           if (annotatedClasses>0 && addToIndex)
           {
-            Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,0,0); 
+            Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,"annotated",0); 
             Doxygen::indexList->incContentsDepth();
             needsClosing=TRUE;
           }

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -409,7 +409,6 @@ void MemberList::writePlainDeclarations(OutputList &ol,
               {
                 ol.endDoxyAnchor(md->getOutputFileBase(),md->anchor());
               }
-              ol.endMemberItem();
               if (!md->briefDescription().isEmpty() && Config_getBool("BRIEF_MEMBER_DESC"))
               {
                 DocRoot *rootNode = validatingParseDoc(
@@ -437,6 +436,7 @@ void MemberList::writePlainDeclarations(OutputList &ol,
                 delete rootNode;
               }
               ol.endMemberDeclaration(md->anchor(),inheritId);
+              ol.endMemberItem();
             }
             md->warnIfUndocumented();
             break;


### PR DESCRIPTION
87429a2609b822d2b08ec17fb2a20464a5043c9e bug: brief description of enum member is put at the beginning of the
next list item, instead of at the end of the current list item

![enum-rtf-bug](https://cloud.githubusercontent.com/assets/8069470/6831019/f0a983ec-d31d-11e4-8f5a-c5e7f848e9d9.png)

700a9ac3c177fdef25b9b00ed6bb5e0ea963d236 bug: when layout file hides Class List but Classes are still visible
the related TOC entry of Compiled HTML Help file does not link to any
page, so the annotated.html file is not reachable from the TOC tree even
though it still gets generated

4438e24b478de1fd97ccc81a3a9f7651124e1c63 new: added HHC.exe own output to the debug output when extcmd flag enabled, this may help debugging the source of errors