### PR TITLE
add support for github flavored fenced code blocks

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1366,7 +1366,9 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
   int startTildes=0;
   while (i<size && data[i]==' ') indent++,i++;
   if (indent>=refIndent+4) return FALSE; // part of code block
-  while (i<size && data[i]=='~') startTildes++,i++;
+  char tildaChar='~';
+  if (i<size && data[i]=='`') tildaChar='`';
+  while (i<size && data[i]==tildaChar) startTildes++,i++;
   if (startTildes<3) return FALSE; // not enough tildes
   if (i<size && data[i]=='{') i++; // skip over optional {
   int startLang=i;
@@ -1376,11 +1378,11 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
   start=i;
   while (i<size)
   {
-    if (data[i]=='~')
+    if (data[i]==tildaChar)
     {
       end=i-1;
       int endTildes=0;
-      while (i<size && data[i]=='~') endTildes++,i++; 
+      while (i<size && data[i]==tildaChar) endTildes++,i++;
       while (i<size && data[i]==' ') i++;
       if (i==size || data[i]=='\n') 
       {

--- a/src/pre.l
+++ b/src/pre.l
@@ -2465,6 +2465,19 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
                                             BEGIN(SkipVerbatim);
                                           }
                                         }
+<SkipCComment>"```"[~]*                 {
+                                          static bool markdownSupport = Config_getBool("MARKDOWN_SUPPORT");
+                                          if (!markdownSupport)
+                                          {
+                                            REJECT;
+                                          }
+                                          else
+                                          {
+  					    outputArray(yytext,(int)yyleng);
+                                            g_fenceSize=yyleng;
+                                            BEGIN(SkipVerbatim);
+                                          }
+                                        }
 <SkipCComment>[\\@][\\@]("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"docbookonly"|"rtfonly"|"manonly"|"dot"|"code"("{"[^}]*"}")?){BN}+ {
   					  outputArray(yytext,(int)yyleng);
   					  g_yyLineNr+=QCString(yytext).contains('\n');
@@ -2600,6 +2613,13 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 					  }
   					}
 <SkipVerbatim>"~~~"[~]*                 {
+  					  outputArray(yytext,(int)yyleng);
+                                          if (g_fenceSize==yyleng)
+                                          {
+                                            BEGIN(SkipCComment);
+                                          }
+                                        }
+<SkipVerbatim>"```"[~]*                 {
   					  outputArray(yytext,(int)yyleng);
                                           if (g_fenceSize==yyleng)
                                           {

--- a/src/pre.l
+++ b/src/pre.l
@@ -2465,7 +2465,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
                                             BEGIN(SkipVerbatim);
                                           }
                                         }
-<SkipCComment>"```"[~]*                 {
+<SkipCComment>"```"[`]*                 {
                                           static bool markdownSupport = Config_getBool("MARKDOWN_SUPPORT");
                                           if (!markdownSupport)
                                           {
@@ -2619,7 +2619,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
                                             BEGIN(SkipCComment);
                                           }
                                         }
-<SkipVerbatim>"```"[~]*                 {
+<SkipVerbatim>"```"[`]*                 {
   					  outputArray(yytext,(int)yyleng);
                                           if (g_fenceSize==yyleng)
                                           {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6271,7 +6271,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           g_nestedComment=FALSE;
                                           BEGIN(DocCopyBlock);
                                         }
-<DocBlock>"```"[~]*                     {
+<DocBlock>"```"[`]*                     {
                                           docBlock+=yytext;
                                           docBlockName="```";
                                           g_fencedSize=yyleng;
@@ -6396,7 +6396,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                             BEGIN(DocBlock);
                                           }
                                         }
-<DocCopyBlock>"```"[~]*                 {
+<DocCopyBlock>"```"[`]*                 {
                                           docBlock+=yytext;
                                           if (g_fencedSize==yyleng)
                                           {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6271,6 +6271,13 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           g_nestedComment=FALSE;
                                           BEGIN(DocCopyBlock);
                                         }
+<DocBlock>"```"[~]*                     {
+                                          docBlock+=yytext;
+                                          docBlockName="```";
+                                          g_fencedSize=yyleng;
+                                          g_nestedComment=FALSE;
+                                          BEGIN(DocCopyBlock);
+                                        }
 <DocBlock>{B}*"<code>"                  {
   					  if (insideCS)
 					  {
@@ -6383,6 +6390,13 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  }
   					}
 <DocCopyBlock>"~~~"[~]*                 {
+                                          docBlock+=yytext;
+                                          if (g_fencedSize==yyleng)
+                                          {
+                                            BEGIN(DocBlock);
+                                          }
+                                        }
+<DocCopyBlock>"```"[~]*                 {
                                           docBlock+=yytext;
                                           if (g_fencedSize==yyleng)
                                           {


### PR DESCRIPTION
Hi!
Here is PR with support for Gihub flavored Fenced Code Blocks with three backquotes characters.
I recently found that this syntax is not supported in doxygen, but all my markdown contains this kind of syntax.
The change is little: in function isFencedCodeBlock() we remember backqoute if fenced code block contains it and then reuse it in comparisons.
Also I changed pre.l and scanner.l to support this kind of fenced code block (I just copied stuff from ~~~ and changed it to ```).

I tested this functionality with compiling on Visual Studio 2008 and it works.

Will you accept this PR?
Thank you for great tool, best regards, Aleksei.