### PR TITLE
Fix for bug 748208 regression in parsing enums in bitfields

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5634,9 +5634,10 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  BEGIN( ClassVar );
 					}
 <ClassVar>":"				{ 
-					  if (current->section==Entry::ENUM_SEC) // enum E:2, see bug 313527, 
+					  if (current->section==Entry::ENUM_SEC || current->section==Entry::VARIABLE_SEC) // enum E:2, see bug 313527,
                                                                                  // or C++11 style enum: 'E : unsigned int {...}'
 					  {
+						current->section = Entry::ENUM_SEC;
 					    current->args.resize(0);
   					    BEGIN(EnumBaseType);
 					  }


### PR DESCRIPTION
Fixes [#748208](https://bugzilla.gnome.org/show_bug.cgi?id=748208) which is a regression of [#313527](https://bugzilla.gnome.org/show_bug.cgi?id=313527).

Enums within bitfields are not parsed properly. See bugzilla for test cases and failure examples.