### PR TITLE
Fixes bug 748214  - inline comments being mis-rendered at the end of comment blocks

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6214,7 +6214,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
  /* ---- Comments blocks ------ */
 
 <DocBlock>"*"*"*/"			{ // end of comment block
-  				          handleCommentBlock(docBlock.data(),FALSE);
+					  handleCommentBlock(docBlock.data(),current->brief.isEmpty());
 					  BEGIN(docBlockContext);
   					}
 <DocBlock>^{B}*"*"+/[^/]		{ 


### PR DESCRIPTION
Fixes [#748214](https://bugzilla.gnome.org/show_bug.cgi?id=748214) where inline comments at the end of comment blocks would loose their brief comments if they used the same comment syntax as the block closing tag did.

See bugzilla for test case.