### PR TITLE
Work around for bug 742452

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -322,6 +322,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
  /*-----------------------------------------------------------------------------------*/
 
+<Prepass>^{BS}("!".*)?\n		{ } // ignore comment line in prepass
 <*>^.*\n                                { // prepass: look for line continuations
   					  functionLine = FALSE;
 


### PR DESCRIPTION
This addresses bug 742452, where attributes after a blank line are ignored. For example, `dheat` (and everything that follows) would be lost here, as the comment line is treated as the end of the continuation:

```fortran
   TYPE physical_constants
      REAL :: & 
      capp   = 1004.64, &  !< air spec. heat (J/kg/K)
      hlf    = 0.334e6, &  !< latent heat of fusion
      ! Some comment
      dheat  = 21.5E-6, &  !< molecular diffusivity for heat
      ...
```

This fix throws away blank lines during the prepass phase. However, due to the way the continuation prepass is performed, comments are still lost, so it's not possible to have a documentation block occurring in a continuation.