### PR TITLE
Alignment of project name

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1108,6 +1108,11 @@ dl.section dd {
 	border: 0px none;
 }
  
+#projectalign
+{
+        vertical-align: middle;
+}
+
 #projectname
 {
 	font: 300% Tahoma, Arial,sans-serif;

--- a/templates/html/header.html
+++ b/templates/html/header.html
@@ -27,7 +27,7 @@ $extrastylesheet
   <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"/></td>
   <!--END PROJECT_LOGO-->
   <!--BEGIN PROJECT_NAME-->
-  <td style="padding-left: 0.5em;">
+  <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">$projectname
    <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->
    </div>


### PR DESCRIPTION
With this bug fix it is possible to align the project name to another place than the default place "middle" by means of adjusting the style sheet. Until now it was also possible but one had to create an own html header file as well.