### PR TITLE
drop #include <unistd.h>

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -14,7 +14,7 @@
  * input used in their production; they are not affected by this license.
  *
  */
-
+%option never-interactive
 %{
 
 /*
@@ -46,7 +46,7 @@
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
 
-#define YY_NEVER_INTERACTIVE 1
+#define YY_NO_UNISTD_H 1
 
 #define CLASSBLOCK (int *)4
 #define SCOPEBLOCK (int *)8

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -14,10 +14,8 @@
  * input used in their production; they are not affected by this license.
  *
  */
-
+%option never-interactive
 %{
-
-#define YY_NEVER_INTERACTIVE 1
 
   
 #include <stdio.h>
@@ -39,6 +37,7 @@
 #include <assert.h>
 
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 #define ADDCHAR(c)    g_outBuf->addChar(c)
 #define ADDARRAY(a,s) g_outBuf->addArray(a,s)

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -12,7 +12,8 @@
  * input used in their production; they are not affected by this license.
  *
  */
-  
+
+%option never-interactive
 %{
 
 /*
@@ -26,7 +27,6 @@
 #include <qarray.h>
 #include <qstack.h>
 #include <qregexp.h>
-#include <unistd.h>
 #include <qfile.h>
   
 #include "scanner.h"
@@ -49,6 +49,7 @@
 #include "formula.h"
 
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 // forward declarations
 static bool handleBrief(const QCString &);

--- a/src/config.l
+++ b/src/config.l
@@ -9,7 +9,7 @@
  * See the GNU General Public License for more details.
  *
  */
-
+%option never-interactive
 %{
 
 /*
@@ -45,6 +45,7 @@
 #undef Config_getBool
 
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 // use in-class definitions
 #define Config_getString(val)  getString(__FILE__,__LINE__,val)

--- a/src/constexp.l
+++ b/src/constexp.l
@@ -15,7 +15,7 @@
  * input used in their production; they are not affected by this license.
  *
  */
-
+%option never-interactive
 %{
 
 #include "constexp.h"  
@@ -23,8 +23,8 @@
 #include "ce_parse.h" // generated header file
 #include "message.h"
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
   
 QCString    g_strToken;  
 CPPValue    g_resultValue;

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -14,7 +14,7 @@
  * input used in their production; they are not affected by this license.
  *
  */
-
+%option never-interactive
 %{
 
 /*
@@ -30,6 +30,7 @@
 #include "message.h"
 
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
   
 /* -----------------------------------------------------------------
  *

--- a/src/defargs.l
+++ b/src/defargs.l
@@ -39,7 +39,7 @@
  *        type, and the matchArgumentList in util.cpp is be used to
  *        further determine the correct separation.
  */
-
+%option never-interactive
 %{
 
 /*
@@ -57,8 +57,8 @@
 #include "arguments.h"
 #include "message.h"
   
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
   
 /* -----------------------------------------------------------------
  *	state variables

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -16,7 +16,7 @@
  *
  */
 
-
+%option never-interactive
 %{
 
 #include <ctype.h>
@@ -37,8 +37,8 @@
 #include "doxygen.h"
 #include "portable.h"
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
   
 //--------------------------------------------------------------------------
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <qtextcodec.h>
-#include <unistd.h>
 #include <errno.h>
 #include <qptrdict.h>
 #include <qtextstream.h>

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -15,8 +15,6 @@
  */
 
 #include <stdlib.h>
-#include <unistd.h>
-
 #include <qfile.h>
 #include <qfileinfo.h>
 #include <qtextstream.h>

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -23,7 +23,7 @@
        - links to interface functions 
        - references to variables
 **/
-
+%option never-interactive
 %{
 
 /*
@@ -56,9 +56,9 @@
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_TOP_STATE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 /*
  * For fixed formatted code position 6 is of importance (continuation character).

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -37,7 +37,7 @@
  *
  * - Must track yyLineNr when using REJECT, unput() or similar commands.
  */
-
+%option never-interactive
 %{
 
 #include <stdio.h> 
@@ -48,7 +48,6 @@
 #include <qarray.h>
 #include <qstack.h>
 #include <qregexp.h>
-#include <unistd.h> 
 #include <qfile.h>
 #include <qmap.h>
   
@@ -69,8 +68,8 @@
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 enum ScanVar { V_IGNORE, V_VARIABLE, V_PARAMETER, V_RESULT};
 enum InterfaceType { IF_NONE, IF_SPECIFIC, IF_GENERIC, IF_ABSTRACT };

--- a/src/pre.l
+++ b/src/pre.l
@@ -14,7 +14,7 @@
  * input used in their production; they are not affected by this license.
  *
  */
-
+%option never-interactive
 %{
 
 /*
@@ -54,11 +54,11 @@
 #include "memberdef.h"
 #include "membername.h"
 
+#define YY_NO_UNISTD_H 1
+
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
-
-#define YY_NEVER_INTERACTIVE 1
 
 struct CondCtx
 {

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -21,7 +21,7 @@
  *  taught by Peter H. Froehlich <phf@acm.org>.
  */
 
-
+%option never-interactive
 %{
 
 #include <stdio.h>
@@ -48,8 +48,8 @@
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 static ClassSDict    g_codeClassSDict(17);
 static QCString      g_curClassName;

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -21,7 +21,7 @@
  *  taught by Peter H. Froehlich <phf@acm.org>.
  */
 
-
+%option never-interactive
 %{
 
 /*
@@ -35,7 +35,6 @@
 #include <qarray.h>
 #include <qstack.h>
 #include <qregexp.h>
-#include <unistd.h>
 #include <qfile.h>
 #include <qfileinfo.h>
   
@@ -55,8 +54,8 @@
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 /* -----------------------------------------------------------------
  *

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -14,7 +14,7 @@
  * input used in their production; they are not affected by this license.
  *
  */
-  
+%option never-interactive
 %{
 
 /*
@@ -28,7 +28,6 @@
 #include <qarray.h>
 #include <qstack.h>
 #include <qregexp.h>
-#include <unistd.h>
 #include <qfile.h>
   
 #include "scanner.h"
@@ -45,8 +44,8 @@
 
 #include "clangparser.h"
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 /* -----------------------------------------------------------------
  *

--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -14,12 +14,12 @@
  * input used in their production; they are not affected by this license.
  *
  */ 
+%option never-interactive
 %{
 #include <stdio.h> 
 #include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
-#include <unistd.h> 
 
 #include <qstring.h>
 #include <qstringlist.h>
@@ -51,8 +51,8 @@
 #include "namespacedef.h"
 #include "filedef.h"
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
 
 #define MAX_INCLUDE_DEPTH 10
 

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -17,7 +17,7 @@
  * written by M. Kreis
  * supports VHDL-87/93/2008
  ******************************************************************************/
-
+%option never-interactive
 %{
 
 /*
@@ -44,8 +44,8 @@
 #include "filedef.h"
 #include "tooltip.h"
 
-#define YY_NEVER_INTERACTIVE 1
 #define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
   
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x


### PR DESCRIPTION
the generated lexers are not interactive, so istty from unistd.h is thus not
needed.

Signed-off-by: Adrian Negreanu <adrian.m.negreanu@intel.com>