### PR TITLE
Add USE_READABLE_ANCHORS

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3436,6 +3436,14 @@ remove the intermediate dot files that are used to generate the various graphs.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='USE_READABLE_ANCHORS' defval='0'>
+      <docs>
+<![CDATA[
+ If the \c USE_READABLE_ANCHORS tag is set to \c YES then anchor links (#)
+ will incorporate the method name instead of only the md5 hash.
+]]>
+      </docs>
+    </option>
     <option type='obsolete' id='USE_WINDOWS_ENCODING'/>
     <option type='obsolete' id='DETAILS_AT_TOP'/>
     <option type='obsolete' id='QTHELP_FILE'/>


### PR DESCRIPTION
The anchors this option enables are (mostly) human readable.  These are useful to see where a link is going, especially if it is a bald link into the documentation, posted on an external site.  Also this anchor tends to be a bit shorter, which is visually nice.
In the situation that the structure of the documentation changes enough that both the previous md5 anchor and this new anchor are invalidated, the readable name gives a hint of what it had been pointing to, allowing for easier finding (aided by a search engine).

Note: this does add an aliasing warning due to the typecast; let me know if you would prefer I do something different there.