### PR TITLE
Problem running tests under Windows

### DIFF
--- a/testing/022_dot.cpp
+++ b/testing/022_dot.cpp
@@ -1,7 +1,7 @@
 // objective: test the \dot and \enddot commands
 // check: indexpage.xml
 // config: HAVE_DOT = YES
-// config: DOTFILE_DIRS = .
+// config: DOTFILE_DIRS = $INPUTDIR
 
 /*! class B */
 class B {};

--- a/testing/031_image.dox
+++ b/testing/031_image.dox
@@ -1,6 +1,6 @@
 // objective: test the \image command
 // check: indexpage.xml
-// config: IMAGE_PATH = .
+// config: IMAGE_PATH = $INPUTDIR
 /** \mainpage
  * Some text.
  * \image html sample.png

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -25,7 +25,7 @@ class Tester:
 		elif not os.path.isfile(expected_file):
 			return (True,'%s absent' % expected_file)
 		else:
-			diff = os.popen('diff -u %s %s' % (got_file,expected_file)).read()
+			diff = os.popen('diff -b -w -u %s %s' % (got_file,expected_file)).read()
 			if diff and not diff.startswith("No differences"):
 				return (True,'Difference between generated output and reference:\n%s' % diff)
 		return (False,'')
@@ -66,7 +66,11 @@ class Tester:
 			sys.exit(1)
 
 		# run doxygen
-		if os.system('%s %s/Doxyfile 2>/dev/null' % (self.args.doxygen,self.test_out))!=0:
+		if (sys.platform == 'win32'):
+			redir=' > nul:'             
+		else:
+			redir=' 2> /dev/null'             
+		if os.system('%s %s/Doxyfile %s' % (self.args.doxygen,self.test_out, redir))!=0:
 			print('Error: failed to run %s on %s/Doxyfile' % (self.args.doxygen,self.test_out));
 			sys.exit(1)
 


### PR DESCRIPTION
The redirection used in the runtests.py script was based on *nix type systems. Corrected for windows.
Windows has a different line ending than *nix, resulting in a problem with diff unless the options -b -w are used.
Some tests had as directory for some paths a directory . this has been corrected to $INPUTDIR