### PR TITLE
docparser: warn when finding a documented empty return type

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -611,7 +611,18 @@ static void detectNoDocumentedParams()
     {
       g_memberDef->setHasDocumentedReturnType(TRUE);
     }
-       
+    if ( // see if return type is documented in a function w/o return type
+        g_memberDef->hasDocumentedReturnType() &&
+        (returnType.isEmpty()              || // empty return type
+         returnType.find("void")!=-1       || // void return type
+         returnType.find("subroutine")!=-1 || // fortran subroutine
+         g_memberDef->isConstructor()      || // a constructor
+         g_memberDef->isDestructor()          // or destructor
+        )
+       )
+    {
+      warn_doc_error(g_fileName,doctokenizerYYlineno,"documented empty return type");
+    }
   }
 }
 


### PR DESCRIPTION
There is an example on pg24 of [1] where a libclang based comment parser
emits a warning for a documented empty type.

[1] "Parsing Documentation Comments in Clang" http://llvm.org/devmtg/2012-11/Gribenko_CommentParsing.pdf