### PR TITLE
Building doxygen pdf documentation under Windows

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -2,7 +2,19 @@ if (build_doc)
 
 find_program(EPSTOPDF NAMES epstopdf )
 find_program(SED NAMES sed )
-find_program(MAKE NAMES make gmake nmake )
+if (WIN32)
+    set(CMD1 cd ..\\latex)
+    set(MAKE "make.bat"  CACHE FILEPATH "Windows uses generated make.bat")
+    set(CMD2 make.bat > ..\\latex_out.txt )
+    set(CMD3 cd ..\\doc)
+    set(CMD4 ${CMAKE_COMMAND} -E copy make.bat ../latex/make.bat)
+else(WIN32)
+    find_program(MAKE NAMES make gmake nmake )
+    set(CMD1 )
+    set(CMD2 ${MAKE} -C ../latex > latex_out.txt)
+    set(CMD3 )
+    set(CMD4 )
+endif(WIN32)
 
 file(GLOB DOC_FILES "*")
 file(GLOB LANG_FILES "${CMAKE_SOURCE_DIR}/src/translator_??.h")
@@ -23,10 +35,13 @@ add_custom_target(docs
 	COMMAND ${CMAKE_COMMAND} -E copy doxygen_logo.gif ../html
 	COMMAND ${CMAKE_COMMAND} -E copy doxygen_logo_low.gif ../html
 	COMMAND ${CMAKE_COMMAND} -E copy Makefile.latex ../latex/Makefile
+        COMMAND ${CMD4}
 	COMMAND ${SED} -e "s/\$VERSION/${VERSION}/g" doxygen_manual.tex > ../latex/doxygen_manual.tex
 	COMMAND ${SED} -e "s/\$VERSION/${VERSION}/g" doxygen.sty > ../latex/doxygen.sty
 	COMMAND ${EPSTOPDF} doxygen_logo.eps --outfile=../latex/doxygen_logo.pdf
-        COMMAND ${MAKE} -C ../latex > latex_out.txt
+        COMMAND ${CMD1}
+        COMMAND ${CMD2}
+        COMMAND ${CMD3}
 	DEPENDS doxygen ${PROJECT_BINARY_DIR}/doc/language.doc config.doc
                 "${PROJECT_BINARY_DIR}/man/doxygen.1"
                 "${PROJECT_BINARY_DIR}/man/doxywizard.1"

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,30 @@
+set Dir_Old=%cd%
+cd /D %~dp0
+
+del /s /f *.ps *.dvi *.aux *.toc *.idx *.ind *.ilg *.log *.out *.brf *.blg *.bbl doxygen_manual.pdf
+
+pdflatex doxygen_manual
+echo ----
+makeindex doxygen_manual.idx
+echo ----
+pdflatex doxygen_manual
+
+setlocal enabledelayedexpansion
+set count=8
+:repeat
+set content=X
+for /F "tokens=*" %%T in ( 'findstr /C:"Rerun LaTeX" doxygen_manual.log' ) do set content="%%~T"
+if !content! == X for /F "tokens=*" %%T in ( 'findstr /C:"Rerun to get cross-references right" doxygen_manual.log' ) do set content="%%~T"
+if !content! == X goto :skip
+set /a count-=1
+if !count! EQU 0 goto :skip
+
+echo ----
+pdflatex doxygen_manual
+goto :repeat
+:skip
+endlocal
+makeindex doxygen_manual.idx
+pdflatex doxygen_manual
+cd /D %Dir_Old%
+set Dir_Old=


### PR DESCRIPTION
Under windows the file make.bat is used to create the documentation.
Also an adjusted make.bat is needed as not the default refman is used but doxygen_manual