### PR TITLE
Copy user EXTRA_FILES at the end to overrule files generated by default by doxygen

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11439,21 +11439,11 @@ void generateOutput()
     if (generateDocSet)      Doxygen::indexList->addIndex(new DocSets);
     Doxygen::indexList->initialize();
     HtmlGenerator::writeTabData();
-
-    // copy static stuff
-    copyStyleSheet();
-    copyLogo();
-    copyExtraFiles("HTML_EXTRA_FILES","HTML_OUTPUT");
-    FTVHelp::generateTreeViewImages();
   }
   if (generateLatex) 
   {
     g_outputList->add(new LatexGenerator);
     LatexGenerator::init();
-
-    copyLatexStyleSheet();
-    // copy static stuff
-    copyExtraFiles("LATEX_EXTRA_FILES","LATEX_OUTPUT");
   }
   if (generateMan)
   {
@@ -11673,6 +11663,20 @@ void generateOutput()
     g_s.begin("Running dot...\n");
     DotManager::instance()->run();
     g_s.end();
+  }
+
+  // copy static stuff
+  if (generateHtml)  
+  {
+    FTVHelp::generateTreeViewImages();
+    copyStyleSheet();
+    copyLogo();
+    copyExtraFiles("HTML_EXTRA_FILES","HTML_OUTPUT");
+  }
+  if (generateLatex) 
+  {
+    copyLatexStyleSheet();
+    copyExtraFiles("LATEX_EXTRA_FILES","LATEX_OUTPUT");
   }
 
   if (generateHtml &&


### PR DESCRIPTION
In case the user wants to overrule by means of a HTML_EXTRA_FILES or LATEX_EXTRA_FILES a default file from doxygen (e.g. a logo or arrowdown) this is not directly possible as the files are again overwritten by doxygen.
Placing the copy commands at the end and in this list the generateTreeViewImages before the the user files a user can overrule default doxygen files