### PR TITLE
doc: put man pages under share/man/man1

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -88,7 +88,7 @@ install(FILES
         "${PROJECT_BINARY_DIR}/man/doxywizard.1"
         "${PROJECT_BINARY_DIR}/man/doxysearch.1"
         "${PROJECT_BINARY_DIR}/man/doxyindexer.1"
-        DESTINATION man/man1
+        DESTINATION share/man/man1
 )
 
 install(FILES


### PR DESCRIPTION
I found this on the Linux From Scratch page:
     sed -i 's:man/man1:share/&:' ../doc/CMakeLists.txt

With this, the man pages are installed under ${PREFIX}/share/man/man1

http://www.linuxfromscratch.org/blfs/view/svn/general/doxygen.html