### PR TITLE
Spelling correction for error message with USE_HTAGS usage

### DIFF
--- a/src/htags.cpp
+++ b/src/htags.cpp
@@ -59,7 +59,7 @@ bool Htags::execute(const QCString &htmldir)
   }
   else
   {
-    err("If you use USE_HTAGS then INPUT should specific a single directory. \n");
+    err("If you use USE_HTAGS then INPUT should specify a single directory.\n");
     return FALSE;
   }
 

--- a/src/htags.cpp
+++ b/src/htags.cpp
@@ -59,7 +59,7 @@ bool Htags::execute(const QCString &htmldir)
   }
   else
   {
-    err("If you use USE_HTAGS then INPUT should specify a single directory.\n");
+    err("If you use USE_HTAGS then INPUT should specific a single directory. \n");
     return FALSE;
   }
 


### PR DESCRIPTION
Spelling correction for error message with USE_HTAGS usage