### PR TITLE
Fixes bug 485701: Angle brackets (< and >) not escaped in HTML formula alt text

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1902,6 +1902,8 @@ void HtmlDocVisitor::filterQuotedCdataAttr(const char* str)
     {
       case '&':  m_t << "&amp;"; break;
       case '"':  m_t << "&quot;"; break;
+      case '<':  m_t << "&lt;"; break;
+      case '>':  m_t << "&gt;"; break;
        // For SGML compliance, and given the SGML declaration for HTML syntax,
        // it's enough to replace these two, provided that the declaration
        // for the HTML version we generate (and as supported by the browser)

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1904,24 +1904,6 @@ void HtmlDocVisitor::filterQuotedCdataAttr(const char* str)
       case '"':  m_t << "&quot;"; break;
       case '<':  m_t << "&lt;"; break;
       case '>':  m_t << "&gt;"; break;
-       // For SGML compliance, and given the SGML declaration for HTML syntax,
-       // it's enough to replace these two, provided that the declaration
-       // for the HTML version we generate (and as supported by the browser)
-       // specifies that all the other symbols used in rawVal are
-       // within the right character class (i.e., they're not
-       // some multinational weird characters not in the BASESET).
-       // We assume that 1) the browser will support whatever is remaining
-       // in the formula and 2) the TeX formulae are generally governed
-       // by even stricter character restrictions so it should be enough.
-       //
-       // On some incompliant browsers, additional translation of
-       // '>' and '<' into "&gt;" and "&lt;", respectively, might be needed;
-       // but I'm unaware of particular modern (last 4 years) versions
-       // with such problems, so let's not do it for performance.
-       // Also, some brousers will (wrongly) not process the entity references
-       // inside the attribute value and show the &...; form instead,  
-       // so we won't create entites unless necessary to minimize clutter there.
-       // --vassilii 
       default:   m_t << c;
     }
   }


### PR DESCRIPTION
This pull request fixes bug reported in https://bugzilla.gnome.org/show_bug.cgi?id=485701