### PR TITLE
Bug 661814 - writeMemberNavIndex template calls static fixSpaces

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1952,11 +1952,6 @@ static void endQuickIndexItem(FTextStream &t,const char *l)
   t << "</li>\n";
 }
 
-static QCString fixSpaces(const QCString &s)
-{
-  return substitute(s," ","&#160;");
-}
-
 static bool quickLinkVisible(LayoutNavEntry::Kind kind)
 {
   static bool showFiles = Config_getBool("SHOW_FILES");

--- a/src/index.h
+++ b/src/index.h
@@ -284,5 +284,6 @@ void initNamespaceMemberIndices();
 void addClassMemberNameToIndex(MemberDef *md);
 void addFileMemberNameToIndex(MemberDef *md);
 void addNamespaceMemberNameToIndex(MemberDef *md);
+QCString fixSpaces(const QCString &s);
 
 #endif


### PR DESCRIPTION
Problem had already been, partly, solved seen the comment in index.cpp.
Removed double code (from htmlgen.cpp) and added prototype.