### PR TITLE
Bug 752658 - XML empty <argsstring/> in python

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -963,7 +963,9 @@ STARTDOCSYMS      "##"
 			    {
 			      current->argList->getLast()->defval=g_defVal.stripWhiteSpace();
 			    }
-       			    BEGIN(FunctionParams);
+			    if (*yytext == ')')
+			      current->args = argListToString(current->argList);
+			    BEGIN(FunctionParams);
 			  }
 			  else // continue
 			  {


### PR DESCRIPTION
Problem comes from the fact that the last argument has a default value and in this case the routine argListToString is mot called as it is done in case of ')' after an argument without default value (see section "FunctionParams").