### PR TITLE
Bug 752657 - XML not documenting a class in python

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1278,6 +1278,12 @@ STARTDOCSYMS      "##"
 			initTriSingleQuoteBlock();
 			BEGIN(TripleComment);
                       }
+   "'"	              {
+       			g_stringContext=YY_START;
+			current->initializer+="'";
+			g_copyString=&current->initializer;
+                        BEGIN( SingleQuoteString );
+                      }
    "\""	              {
        			g_stringContext=YY_START;
 			current->initializer+="\"";


### PR DESCRIPTION
Problem looks like to be the improper handling of strings in this case a single quote was not seen as the start of a string and thus the double quote was mistreated.