### PR TITLE
Add RPM build for Red Hat

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -84,6 +84,12 @@ elseif(UNIX)
       execute_process(COMMAND dpkg --print-architecture OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
       set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE})
 
+    elseif(distribution MATCHES "RedHat.*")
+      # extract the major version from RedHat full version (e.g. 6.7 --> 6)
+      execute_process(COMMAND lsb_release -sr COMMAND sed s/[.].*//  OUTPUT_VARIABLE redhat_version_major OUTPUT_STRIP_TRAILING_WHITESPACE)
+      set(CPACK_GENERATOR "RPM")
+      set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}.el${redhat_version_major}.${CPACK_RPM_PACKAGE_ARCHITECTURE})
+
     elseif(distribution MATCHES "openSUSE.*")
       set(CPACK_GENERATOR "RPM")
       set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${release}.${CPACK_RPM_PACKAGE_ARCHITECTURE})


### PR DESCRIPTION
Tested on RHEL6

Unfortunately, generation/install of documentation files (man pages) is failing (-Dbuild_doc=ON).
This issue is not related to this pull request.