### PR TITLE
Actually using value of GROUP_NESTED_COMPOUNDS option

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6749,7 +6749,7 @@ static void parseCompounds(Entry *rt)
 
       // deep copy group list from parent (see bug 727732)
       static bool autoGroupNested = Config_getBool("GROUP_NESTED_COMPOUNDS");
-      if (rt->groups && ce->section!=Entry::ENUM_SEC && !(ce->spec&Entry::Enum))
+      if (autoGroupNested && rt->groups && ce->section!=Entry::ENUM_SEC && !(ce->spec&Entry::Enum))
       {
         QListIterator<Grouping> gli(*rt->groups);
         Grouping *g;


### PR DESCRIPTION
New option "GROUP_NESTED_COMPOUNDS" have been added, but its value was not used.
Probably it should be checked before adding nested elements into group.