### PR TITLE
Bug 333106 - $line param

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -138,11 +138,11 @@ static void format_warn(const char *file,int line,const char *text)
               outputFormat,
               "$file",fileSubst
             ),
-            "$text",textSubst
+            "$line",lineSubst
           ),
-          "$line",lineSubst
+          "$version",versionSubst
         ),
-        "$version",versionSubst
+        "$text",textSubst
       )+'\n';
 
   // print resulting message


### PR DESCRIPTION
Due to the order of the substitutions the $line was also substituted in the text part. Now the text part is added at the end and the substitution does not take place.