### PR TITLE
Bug 648865 - PYTHON: stops processing the file after encountering \""""

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1384,11 +1384,14 @@ STARTDOCSYMS      "##"
 			    docBlock += yytext;
 			  }
       			}
-    [^"'\n \t]+          {
+    [^"'\n \t\\]+       {
 			  docBlock += yytext;
                         }
     \n			{
       			  incLineNr();
+			  docBlock += yytext;
+      			}
+    \\.		        { // espaced char
 			  docBlock += yytext;
       			}
     .			{


### PR DESCRIPTION
Proper handling of escaped character inside a triple quoted string (""" and ''')