### PR TITLE
Adds config options and support for running externa scripts on dot files before rendering them with graphwiz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .*sw?
 \#*
 .DS_Store
+.kdev4/*
+doxygen.kdev4
 
 *.rej
 *.orig

--- a/src/config.xml
+++ b/src/config.xml
@@ -3220,7 +3220,8 @@ to be found in the default search path.
     <option type='bool' id='INCLUDE_GRAPH_PREPROCESS' defval='NO' depends='HAVE_DOT'>
       <docs>
 <![CDATA[
- If yes, then run a script on Include Graph dot files before generating the images. 
+ If yes, then run a script on Include Graph and Included By dot files before 
+ generating the images. 
 ]]>
       </docs>
     </option>
@@ -3228,7 +3229,8 @@ to be found in the default search path.
     <option type='string' id='INCLUDE_GRAPH_PP_CMD' defval='' depends='HAVE_DOT'>
       <docs>
 <![CDATA[
- Executable script that should be run to preprocess Include Graph dot files.
+ Executable script that should be run to preprocess Include Graph and Included by 
+ Graph dot files.
 ]]>
       </docs>
     </option>
@@ -3242,22 +3244,6 @@ to be found in the default search path.
  tags are set to \c YES then doxygen will generate a graph for each documented file
  showing the direct and indirect include dependencies of the file with other
  documented files.
-]]>
-      </docs>
-    </option>
-    
-    <option type='bool' id='INCLUDED_BY_GRAPH_PREPROCESS' defval='NO' depends='HAVE_DOT'>
-      <docs>
-<![CDATA[
- If yes, then run a script on Included By Graph dot files before generating the images. 
-]]>
-      </docs>
-    </option>
-    
-    <option type='string' id='INCLUDED_BY_GRAPH_PP_CMD' defval='' depends='HAVE_DOT'>
-      <docs>
-<![CDATA[
- Executable script that should be run to preprocess Included By Graph dot files.
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -3216,6 +3216,24 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    
+    <option type='bool' id='INCLUDE_GRAPH_PREPROCESS' defval='NO' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ If yes, then run a script on Include Graph dot files before generating the images. 
+]]>
+      </docs>
+    </option>
+    
+    <option type='string' id='INCLUDE_GRAPH_PP_CMD' defval='' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ Executable script that should be run to preprocess Include Graph dot files.
+]]>
+      </docs>
+    </option>
+    
+    
     <option type='bool' id='INCLUDED_BY_GRAPH' defval='1' depends='HAVE_DOT'>
       <docs>
 <![CDATA[
@@ -3227,6 +3245,23 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    
+    <option type='bool' id='INCLUDED_BY_GRAPH_PREPROCESS' defval='NO' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ If yes, then run a script on Included By Graph dot files before generating the images. 
+]]>
+      </docs>
+    </option>
+    
+    <option type='string' id='INCLUDED_BY_GRAPH_PP_CMD' defval='' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ Executable script that should be run to preprocess Included By Graph dot files.
+]]>
+      </docs>
+    </option>
+    
     <option type='bool' id='CALL_GRAPH' defval='0' depends='HAVE_DOT'>
       <docs>
 <![CDATA[

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -3491,7 +3491,8 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
     err("Output dir %s does not exist!\n",path); exit(1);
   }
   static bool usePDFLatex = Config_getBool("USE_PDFLATEX");
-
+  static bool dotPreprocess = Config_getBool("INCLUDE_GRAPH_PREPROCESS");
+  
   QCString baseName=m_diskName;
   if (m_inverse) baseName+="_dep";
   baseName+="_incl";
@@ -3507,6 +3508,13 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
   QCString absEpsName  = absBaseName+".eps";
   QCString absImgName  = absBaseName+"."+imgExt;
 
+  QCString dotPPcmd;
+  QCString dotPPargs;
+  if (dotPreprocess){
+    dotPPcmd = Config_getString("INCLUDE_GRAPH_PP_CMD");
+    dotPPargs = absDotName;    
+  }
+  
   bool regenerate = FALSE;
   if (updateDotGraph(m_startNode,
                  DotNode::Dependency,
@@ -3529,7 +3537,9 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
       DotRunner *dotRun = new DotRunner(absDotName,d.absPath().data(),TRUE,absImgName);
       dotRun->addJob(imgExt,absImgName);
       if (generateImageMap) dotRun->addJob(MAP_CMD,absMapName);
-      //TODO Add Preprocess Here
+      if (dotPreprocess){
+        dotRun->addPreProcessing(dotPPcmd, dotPPargs);
+      }
       DotManager::instance()->addRun(dotRun);
     }
     else if (graphFormat==GOF_EPS)
@@ -3543,7 +3553,9 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
       {
         dotRun->addJob("ps",absEpsName);
       }
-      //TODO Add Preprocess Here
+      if (dotPreprocess){
+        dotRun->addPreProcessing(dotPPcmd, dotPPargs);
+      }
       DotManager::instance()->addRun(dotRun);
     }
   }

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -810,6 +810,12 @@ void DotRunner::addPostProcessing(const char *cmd,const char *args)
   m_postArgs = args;
 }
 
+void DotRunner::addPreProcessing(const char *cmd,const char *args)
+{
+  m_preCmd = cmd;
+  m_preArgs = args;
+}
+
 bool DotRunner::run()
 {
   int exitCode=0;
@@ -827,8 +833,17 @@ bool DotRunner::run()
   QCString imageName = m_imageName;
   QCString postCmd   = m_postCmd;
   QCString postArgs  = m_postArgs;
+  QCString preCmd   = m_preCmd;
+  QCString preArgs  = m_preArgs;
   bool checkResult   = m_checkResult;
   bool cleanUp       = m_cleanUp;
+  
+  if (!preCmd.isEmpty() && portable_system(preCmd,preArgs)!=0)
+  {
+    err("Problems running '%s' as a pre-processing step for dot output\n",m_preCmd.data());
+    return FALSE;
+  }
+  
   if (multiTargets)
   {
     dotArgs="\""+file+"\"";
@@ -3514,6 +3529,7 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
       DotRunner *dotRun = new DotRunner(absDotName,d.absPath().data(),TRUE,absImgName);
       dotRun->addJob(imgExt,absImgName);
       if (generateImageMap) dotRun->addJob(MAP_CMD,absMapName);
+      //TODO Add Preprocess Here
       DotManager::instance()->addRun(dotRun);
     }
     else if (graphFormat==GOF_EPS)
@@ -3527,6 +3543,7 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
       {
         dotRun->addJob("ps",absEpsName);
       }
+      //TODO Add Preprocess Here
       DotManager::instance()->addRun(dotRun);
     }
   }

--- a/src/dot.h
+++ b/src/dot.h
@@ -340,6 +340,11 @@ class DotRunner
     DotRunner(const QCString &file,const QCString &fontPath,bool checkResult,
         const QCString &imageName = QCString());
 
+    /** Adds external preprocessing to the dot file
+     *  before the standard run.
+     */
+    void addPreProcessing(const char *cmd,const char *args);
+    
     /** Adds an additional job to the run.
      *  Performing multiple jobs one file can be faster.
      */
@@ -357,6 +362,8 @@ class DotRunner
     QList<QCString> m_jobs;
     QCString m_postArgs;
     QCString m_postCmd;
+    QCString m_preArgs;
+    QCString m_preCmd;
     QCString m_file;
     QCString m_path;
     bool m_checkResult;


### PR DESCRIPTION
Auto-generated graphs tend to get somewhat messy because of common include files, which create a nest of edges in the graph which make it difficult to see the functionally useful dependency graph. One common example of this is stdint.h includes in embedded projects.

Such applications are probably highly specific, so adding it to the core of Doxygen is probably counterproductive. However, it would be nice to be able to process the doxygen generated .dot files before they are turned into images. Perhaps by means of some kind of plugin? If there were a hook to run a script on a file between the generation of .dot and .png or .svg, that would be sufficient in principle. It would be even better if the script could also somehow obtain contextual information about the graph, but that wouldn't be necessary to make such a hook useful for a large number of cases.

The changes proposed here add options to the config script, which is not a very nice thing. It forces
everyone to update their configuration files. I'm not sure how to get around that problem.

