### PR TITLE
Tooltip can still contain < and > signs

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -593,7 +593,7 @@ void HtmlCodeGenerator::writeTooltip(const char *id, const DocLinkInfo &docInfo,
   if (desc)
   {
     m_t << "<div class=\"ttdoc\">";
-    m_t << desc; // desc is already HTML escaped
+    docify(desc); // desc is already HTML escaped; but there are still < and > signs
     m_t << "</div>";
   }
   if (!defInfo.file.isEmpty())


### PR DESCRIPTION
< and > signs , when still present are converted so e.g. xhtml does not have a problem with it.