### PR TITLE
Adds config options and support for running external scripts on dot files before rendering them with graphviz

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3240,6 +3240,26 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    
+    <option type='bool' id='INCLUDE_GRAPH_PREPROCESS' defval='NO' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ If yes, then run a script on Include Graph and Included By dot files before 
+ generating the images. 
+]]>
+      </docs>
+    </option>
+    
+    <option type='string' id='INCLUDE_GRAPH_PP_CMD' defval='' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ Executable script that should be run to preprocess Include Graph and Included by 
+ Graph dot files.
+]]>
+      </docs>
+    </option>
+    
+    
     <option type='bool' id='INCLUDED_BY_GRAPH' defval='1' depends='HAVE_DOT'>
       <docs>
 <![CDATA[
@@ -3251,6 +3271,7 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    
     <option type='bool' id='CALL_GRAPH' defval='0' depends='HAVE_DOT'>
       <docs>
 <![CDATA[

--- a/src/dot.h
+++ b/src/dot.h
@@ -340,6 +340,11 @@ class DotRunner
     DotRunner(const QCString &file,const QCString &fontPath,bool checkResult,
         const QCString &imageName = QCString());
 
+    /** Adds external preprocessing to the dot file
+     *  before the standard run.
+     */
+    void addPreProcessing(const char *cmd,const char *args);
+    
     /** Adds an additional job to the run.
      *  Performing multiple jobs one file can be faster.
      */
@@ -357,6 +362,8 @@ class DotRunner
     QList<QCString> m_jobs;
     QCString m_postArgs;
     QCString m_postCmd;
+    QCString m_preArgs;
+    QCString m_preCmd;
     QCString m_file;
     QCString m_path;
     bool m_checkResult;


### PR DESCRIPTION
Auto-generated graphs tend to get somewhat messy because of common include files, which create a nest of edges in the graph which make it difficult to see the functionally useful dependency graph. One common example of this is stdint.h and similar standard includes in embedded projects.

Such applications are probably highly specific, so adding it to the core of Doxygen is probably counterproductive. However, it would be nice to be able to process the doxygen generated .dot files before they are turned into images. In principle, it should be sufficient If there were a hook to run a script on a file between :
   - the generation of the .dot file
   - and the generation of .png or .svg by graphviz
 
It would be even better if such an external script could also somehow obtain contextual information about the graph, but that wouldn't be necessary to make such a hook useful for a large number of cases.

See http://static.chintal.in/doxygen/simplify.html for a small example of the use case this change intends to make possible.

The changes proposed here add options to the config script, which may not be a very nice thing. I _think_ it forces everyone to update their configuration files. I'm not sure how to get around that problem.
