### PR TITLE
Bug 646002 - htmlonly content appears in generated XML output

### DIFF
--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -223,32 +223,14 @@ void XmlDocVisitor::visit(DocVerbatim *s)
       m_t << "</verbatim>"; 
       break;
     case DocVerbatim::HtmlOnly: 
-      m_t << "<htmlonly>";
-      filter(s->text());
-      m_t << "</htmlonly>";
-      break;
     case DocVerbatim::RtfOnly: 
-      m_t << "<rtfonly>";
-      filter(s->text());
-      m_t << "</rtfonly>";
-      break;
     case DocVerbatim::ManOnly: 
-      m_t << "<manonly>";
-      filter(s->text());
-      m_t << "</manonly>";
-      break;
     case DocVerbatim::LatexOnly: 
-      m_t << "<latexonly>";
-      filter(s->text());
-      m_t << "</latexonly>";
+    case DocVerbatim::DocbookOnly:
+      /* nothing */ 
       break;
     case DocVerbatim::XmlOnly: 
       m_t << s->text();
-      break;
-    case DocVerbatim::DocbookOnly:
-      m_t << "<docbookonly>";
-      filter(s->text());
-      m_t << "</docbookonly>";
       break;
     case DocVerbatim::Dot:
       visitPreStart(m_t, "dot", s->hasCaption(), this, s->children(), QCString(""), FALSE, DocImage::Html, s->width(), s->height());

--- a/testing/020/indexpage.xml
+++ b/testing/020/indexpage.xml
@@ -4,21 +4,9 @@
     <compoundname>index</compoundname>
     <title>My Project</title>
     <detaileddescription>
-      <para>Text. <htmlonly> 
-HTML
-</htmlonly> <htmlonly>
-HTML with block
-</htmlonly> <rtfonly> 
-RTF
-</rtfonly> <manonly> 
-Man
-</manonly> <latexonly> 
-LaTeX
-</latexonly>  
+      <para>Text. 
 XML
- <docbookonly> 
-DocBook
-</docbookonly> More text. </para>
+More text. </para>
     </detaileddescription>
   </compounddef>
 </doxygen>


### PR DESCRIPTION
All the @\*only comments appear in the xml document. In the other document formats only documentation of the relevant @\*only (in HTML only @htmlonly) appears.
This patch corrects this so only the @xmlonly documentation appears.