### PR TITLE
Make list of default extensions consistent with language mapping list

### DIFF
--- a/src/config.l
+++ b/src/config.l
@@ -1426,71 +1426,7 @@ void Config::check()
     }
   }
 
-  // add default pattern if needed
-  QStrList &filePatternList = Config_getList("FILE_PATTERNS");
-  if (filePatternList.isEmpty())
-  {
-    filePatternList.append("*.c");
-    filePatternList.append("*.cc"); 
-    filePatternList.append("*.cxx");
-    filePatternList.append("*.cpp");
-    filePatternList.append("*.c++");
-    //filePatternList.append("*.d");
-    filePatternList.append("*.java");
-    filePatternList.append("*.ii");
-    filePatternList.append("*.ixx");
-    filePatternList.append("*.ipp");
-    filePatternList.append("*.i++");
-    filePatternList.append("*.inl");
-    filePatternList.append("*.h");
-    filePatternList.append("*.hh");
-    filePatternList.append("*.hxx");
-    filePatternList.append("*.hpp");
-    filePatternList.append("*.h++");
-    filePatternList.append("*.idl");
-    filePatternList.append("*.odl");
-    filePatternList.append("*.cs");
-    filePatternList.append("*.php");
-    filePatternList.append("*.php3");
-    filePatternList.append("*.inc");
-    filePatternList.append("*.m");
-    filePatternList.append("*.mm");
-    filePatternList.append("*.dox");
-    filePatternList.append("*.py");
-    filePatternList.append("*.f90");
-    filePatternList.append("*.f");
-    filePatternList.append("*.for");
-    filePatternList.append("*.vhd");
-    filePatternList.append("*.vhdl");
-    filePatternList.append("*.tcl");
-    filePatternList.append("*.md");
-    filePatternList.append("*.markdown");
-    if (portable_fileSystemIsCaseSensitive())
-    {
-      // unix => case sensitive match => also include useful uppercase versions
-      filePatternList.append("*.C");
-      filePatternList.append("*.CC"); 
-      filePatternList.append("*.C++");
-      filePatternList.append("*.II");
-      filePatternList.append("*.I++");
-      filePatternList.append("*.H");
-      filePatternList.append("*.HH");
-      filePatternList.append("*.H++");
-      filePatternList.append("*.CS");
-      filePatternList.append("*.PHP");
-      filePatternList.append("*.PHP3");
-      filePatternList.append("*.M");
-      filePatternList.append("*.MM");
-      filePatternList.append("*.PY");
-      filePatternList.append("*.F90");
-      filePatternList.append("*.F");
-      filePatternList.append("*.VHD");
-      filePatternList.append("*.VHDL");
-      filePatternList.append("*.TCL");
-      filePatternList.append("*.MD");
-      filePatternList.append("*.MARKDOWN");
-    }
-  }
+  initFilePattern();
 
   // add default pattern if needed
   QStrList &examplePatternList = Config_getList("EXAMPLE_PATTERNS");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6854,6 +6854,7 @@ bool updateLanguageMapping(const QCString &extension,const QCString &language)
 
 void initDefaultExtensionMapping()
 {
+  // NOTE: when adding an extension, also add the extension in config.xml
   g_extLookup.setAutoDelete(TRUE);
   //                  extension      parser id
   updateLanguageMapping(".dox",      "c");
@@ -8418,4 +8419,24 @@ QCString getDotImageExtension(void)
   QCString imgExt      = Config_getEnum("DOT_IMAGE_FORMAT");
   imgExt = imgExt.replace( QRegExp(":.*"), "" );
   return imgExt;
+}
+
+
+void initFilePattern(void)
+{
+  // add default pattern if needed
+  QStrList &filePatternList = Config_getList("FILE_PATTERNS");
+  if (filePatternList.isEmpty())
+  {
+    QDictIterator<int> it( g_extLookup );
+    QCString pattern;
+    bool caseSens =  portable_fileSystemIsCaseSensitive();
+    for (;it.current();++it)
+    {
+      pattern = "*";
+      pattern += it.currentKey();
+      filePatternList.append(pattern.data());
+      if (caseSens) filePatternList.append(pattern.upper().data());
+    }
+  }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -464,6 +464,7 @@ void convertProtectionLevel(
                   );
 
 bool mainPageHasTitle();
+void initFilePattern(void);
 
 #endif
 


### PR DESCRIPTION
In the forum a discrepancy was noted between config.l and config.xml (http://doxygen.10944.n7.nabble.com/FILE-PATTERNS-one-custom-plus-all-defaults-td7308.html). The config.xml list was based on the function initDefaultExtensionMapping in util.cpp and the list in the function Config::check in config.l. Now both routines use the same list.