### PR TITLE
Stop when doxygen configuration file ("Doxyfile") cannot be read

### DIFF
--- a/src/config.l
+++ b/src/config.l
@@ -1756,6 +1756,7 @@ static QCString configFileToString(const char *name)
   if (!fileOpened)  
   {
     config_err("cannot open file `%s' for reading\n",name);
+    exit(1);
   }
   return "";
 }


### PR DESCRIPTION
When the configuration file cannot be read a default configuration is used ad as the error message "error: cannot open file `Doxyfile' for reading" is show at the top of the output this is easily overseen.
By stopping the doxygen process it is made clearer that there is an error.