### PR TITLE
Bug 753909 - Copy and paste of code fragment from CHM merges all pasted text into single line

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -653,7 +653,7 @@ void HtmlCodeGenerator::startCodeLine(bool hasLineNumbers)
 
 void HtmlCodeGenerator::endCodeLine() 
 { 
-  if (m_streamSet) m_t << "</div>\n";
+  if (m_streamSet) m_t << "</div>";
 }
 
 void HtmlCodeGenerator::startFontClass(const char *s) 

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -206,6 +206,11 @@ div.line {
 	transition-duration: 0.5s;
 }
 
+div.line:after {
+    content:"\000A";
+    white-space: pre;
+}
+
 div.line.glow {
 	background-color: cyan;
 	box-shadow: 0 0 10px cyan;


### PR DESCRIPTION
Complete code fragment was pasted in one line (chm, HTML OK), with the change in the ccs file this problem is overcome. Result was that between multiple code lines on the 2nd and following line a extra space appeared at the beginning of the line, this is overcome by placing all relevant div statements on one line.

(based a.o. on http://stackoverflow.com/questions/19099873/how-can-i-use-css-to-insert-a-line-break-after-but-not-before-an-element)