### PR TITLE
Better handling of implicit statement in source code browser

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -795,7 +795,7 @@ PREFIX    (RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,3}(RECURSIVE|I
   					  codifyLines(yytext);
 					  endFontClass();
 					}
-<Start>"implicit"{BS}"none"             { 
+<Start>"implicit"{BS}("none"|{TYPE_SPEC})  { 
   					  startFontClass("keywordtype"); 
   					  codifyLines(yytext);
 					  endFontClass();


### PR DESCRIPTION
When using e.g. IMPLICIT INTEGER only the IMPLICIT was seen as keyword and INTEGER was not seen as keyword. Now types are seen as keywords as well.