### PR TITLE
Small documentation corrections

### DIFF
--- a/doc/docblocks.doc
+++ b/doc/docblocks.doc
@@ -601,15 +601,15 @@ Markdown is designed to be very easy to read and write.
 It's formatting is inspired by plain text mail.
 Markdown works great for simple, generic formatting, like an introduction
 page for your project. Doxygen also supports reading of markdown files 
-directly. See \ref markdown "here" for more details regards Markdown support.
+directly. For more details see chapter \ref markdown.
 
 For programming language specific formatting doxygen has two
 forms of additional markup on top of Markdown formatting.
 
 1. <a href="http://en.wikipedia.org/wiki/Javadoc">Javadoc</a> like markup.
-   See \ref cmd_intro "here" for a complete overview of all commands supported by doxygen.
+   See \ref commands for a complete overview of all commands supported by doxygen.
 2. <a href="http://en.wikipedia.org/wiki/C_Sharp_(programming_language)#XML_documentation_system">XML</a> markup
-   as specified in the C# standard. See \ref xmlcmds "here" for the XML commands supported by doxygen.
+   as specified in the C# standard. See \ref xmlcmds for the XML commands supported by doxygen.
 
 If this is still not enough doxygen also supports a \ref htmlcmds "subset" of 
 the <a href="http://en.wikipedia.org/wiki/HTML">HTML</a> markup language.

--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -337,6 +337,8 @@ which will look as follows:
 | 10    | 10     | 10    |
 | 1000  | 1000   | 1000  |
 
+For more complex tables in doxygen please have a look at: \ref tables
+
 \subsection md_fenced Fenced Code Blocks
 
 Another feature defined by "Markdown Extra" is support for
@@ -437,7 +439,7 @@ details).
 By default the name and title of the page are derived from the file name.
 If the file starts with a level 1 header however, it is used as the title
 of the page. If you specify a label for the 
-header (as shown \ref md_header_id "here") doxygen will use that as the
+header (as shown in \ref md_header_id) doxygen will use that as the
 page name. 
 
 If the label is called `index` or `mainpage` doxygen will put the

--- a/doc/tables.doc
+++ b/doc/tables.doc
@@ -18,7 +18,7 @@
 
 Doxygen supports two ways to put tables in the documentation.
 
-The easiest is to use the Markdown format as shown @ref md_tables "here".
+The easiest is to use the Markdown format as shown in @ref markdown_extra section @ref md_tables.
 
 Although this format is easy to use and read, it is also rather limited.
 It supports only a simple grid of cells, while each cell is a
@@ -58,7 +58,7 @@ It has a caption, table heading, various row and column spans,
 a nested table as one of the cells, and a item list in another cell.
 
 Note that the end tags (like `</td>`) are left out in the example above.
-This is allowed, and in the HTML output doxygen will be add the end tags again.
+This is allowed, and in the HTML output doxygen will add the end tags again.
 
 The output will look as follows:
 


### PR DESCRIPTION
- syntax correction
- cross reference between HTML table and Markdown table
- removed reference through "here" (problematic in printed documentation, one does not know where to go).