### PR TITLE
Use STATIC libraries to prevent them being shared

### DIFF
--- a/libmd5/CMakeLists.txt
+++ b/libmd5/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(md5
+add_library(md5 STATIC
 md5.c
 )

--- a/qtools/CMakeLists.txt
+++ b/qtools/CMakeLists.txt
@@ -52,6 +52,6 @@ qwaitcondition_win32.cpp
 )
 endif()
 
-add_library(qtools
+add_library(qtools STATIC
 ${qtools_src}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,7 @@ FLEX_TARGET(config         config.l         ${GENERATED_SRC}/config.cpp         
 BISON_TARGET(vhdlparser    vhdlparser.y     ${GENERATED_SRC}/vhdlparser.cpp     COMPILE_FLAGS "-l -p vhdlscannerYY")
 BISON_TARGET(constexp      constexp.y       ${GENERATED_SRC}/ce_parse.cpp       COMPILE_FLAGS "-l -p constexpYY")
 
-add_library(doxycfg
+add_library(doxycfg STATIC
     ${GENERATED_SRC}/lang_cfg.h
     ${GENERATED_SRC}/config.cpp
     ${GENERATED_SRC}/configoptions.cpp
@@ -114,7 +114,7 @@ add_library(doxycfg
     portable_c.c
 )
 
-add_library(_doxygen
+add_library(_doxygen STATIC
     # custom generated files
     ${GENERATED_SRC}/lang_cfg.h
     ${GENERATED_SRC}/settings.h

--- a/vhdlparser/CMakeLists.txt
+++ b/vhdlparser/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/qtools)
-add_library(vhdlparser
+add_library(vhdlparser STATIC
 CharStream.cc
 ParseException.cc
 Token.cc


### PR DESCRIPTION
This can happen when user override definition of -DBUILD_SHARED_LIBS=ON.
Without this hard-enforce the libraries would be generated as shared
while never installed. Thus resulting in broken binaries.