### PR TITLE
Compilation error Windows (cannot allocate an array of constant size 0)

### DIFF
--- a/src/res2cc_cmd.py
+++ b/src/res2cc_cmd.py
@@ -37,7 +37,11 @@ class File(object):
 
 	def writeBytes(self,data,outputFile):
 		bytes_per_line=16
-		print("static const unsigned char %s_data[] = " % self.bareName,file=outputFile)
+                if (len(data) == 0 and  sys.platform == "win32"):
+                  print("static const unsigned char %s_data[1] = " % self.bareName,file=outputFile)
+                else:
+                  print("static const unsigned char %s_data[] = " % self.bareName,file=outputFile)
+
 		print("{",file=outputFile)
 		lines = [data[x:x+bytes_per_line] for x in range(0,len(data),bytes_per_line)]
 		linesAsString = ',\n  '.join([', '.join(['0x'+self.formatByte(byte) for byte in line]) for line in lines])


### PR DESCRIPTION
On windows with Visual Studio 2013 the following error is given (3 times):
Error    14    error C2466: cannot allocate an array of constant size 0    ...\generated_src\resources.cpp    28198    1    _doxygen
In this patch the size of the array declaration for windows is set to 1 in case there are no elements