### PR TITLE
RTF bugfix: Example section was merged with next function title

### DIFF
--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2697,6 +2697,7 @@ void RTFGenerator::startSimpleSect(SectionTypes,const char *file,const char *anc
 void RTFGenerator::endSimpleSect()
 {
   DBG_RTF(t << "{\\comment (endSimpleSect)}"    << endl)
+  m_omitParagraph = FALSE;
   newParagraph();
   decrementIndentLevel();
   m_omitParagraph = TRUE;


### PR DESCRIPTION
Example section lacked of new paragraph(\par) because
writeExample set m_omitParagraph = TRUE
When the output file was open in MS word, example file name was
followed by function title in the same line.