### PR TITLE
Fix hexChar for inputs 0 <= i < 10

### DIFF
--- a/vhdlparser/TokenMgrError.cc
+++ b/vhdlparser/TokenMgrError.cc
@@ -64,7 +64,7 @@ namespace parser {
 // i < 16 - guaranteed
 char hexChar(int i) {
   if (i < 10) {
-    return i - '0';
+    return i + '0';
   }
   return 'a' + (i - 10);
 }


### PR DESCRIPTION
hexchar returns invalid characters for inputs i < 10.