### PR TITLE
Problem with latex and bookmarks

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1567,7 +1567,7 @@ void LatexGenerator::startMemberDoc(const char *clname,
   t << "\\" << levelLab[level]; 
 
   t << "[{";
-  t << latexEscapeIndexChars(title,insideTabbing);
+  t << latexEscapeIndexChars(memname,insideTabbing);
   t << "}]";
   t << "{\\setlength{\\rightskip}{0pt plus 5cm}";
   disableLinks=TRUE;


### PR DESCRIPTION
Regression to the commit 02a0c353a8947290a3191aead59db08dc84766ce (Started with generating LateX output via the template engine) a lot of message like "removing `math shift' on input line" appeared.
The change also included a change (unintentionally ?) of the bookmarks in the treeview of the PDF document, so it shows the complete signature of a function.
The signature can also contain asterisks which are translated into $\ast\ resulting in the mentioned problem (see e.g. http://tex.stackexchange.com/questions/249107/how-to-use-texorpdfstring-characters-disappear) and the asterisks are not show either.
In principle this would be nice but has big disadvantages (long bookmarks) when there are a number of arguments with a function.

This patch reverts back to only showing the name of the function.