### PR TITLE
Bug 755786 - fatal: Cannot open 'graph_legend': No such file or direc…

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1737,7 +1737,8 @@ bool FileDef::isDocumentationFile() const
 void FileDef::acquireFileVersion()
 {
   QCString vercmd = Config_getString("FILE_VERSION_FILTER");
-  if (!vercmd.isEmpty() && !m_filePath.isEmpty() && m_filePath!="generated") 
+  if (!vercmd.isEmpty() && !m_filePath.isEmpty() &&
+      m_filePath!="generated" && m_filePath!="graph_legend")
   {
     msg("Version of %s : ",m_filePath.data());
     QCString cmd = vercmd+" \""+m_filePath+"\"";


### PR DESCRIPTION
…tory

For the graph_legend also a file definition is created although it is a generated file and therefore it should be excluded as well.
(Problem occurs with any command that is used in FILE_VERSION_FILTER)