### PR TITLE
Bug 755783 - RTF output has incomplete "References" and "Referenced by" sections

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1219,7 +1219,7 @@ void Definition::_writeSourceRefList(OutputList &ol,const char *scopeName,
           {
             ol.disable(OutputGenerator::Latex);
           }
-          if (!rtfSourceCode)
+          if (rtfSourceCode)
           {
             ol.disable(OutputGenerator::RTF);
           }


### PR DESCRIPTION
Test for rtfSourceCode was incorrect (see also latexSourceCode) resulting in no output or double output depending on the settig of RTF_SOURCE_CODE