### PR TITLE
Bug 629249 - Incorrect "References" and "Referenced by"

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2026,6 +2026,11 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <SkipCPP>"//"				{ 
   					  g_code->codify(yytext);
 					}
+<Body,FuncCall>"}"			{ 
+                                          g_theVarContext.popScope();
+					  g_yyColNr++;
+					  g_code->codify(yytext);
+					}
 <Body,FuncCall>"{"			{ 
                                           g_theVarContext.pushScope();
 


### PR DESCRIPTION
Discrepancy between number of push and pop calls (push was called with "{" but no pop with "}", in the later case the <*>. rule was used)