### PR TITLE
DO NOT hardcode x86-64 architecture.

### DIFF
--- a/addon/doxywizard/CMakeLists.txt
+++ b/addon/doxywizard/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories(
 set(GENERATED_SRC_WIZARD ${GENERATED_SRC}/doxywizard)
 file(MAKE_DIRECTORY ${GENERATED_SRC_WIZARD})
 
-add_definitions(-DQT_ARCH_X86_64 -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DUNICODE)
+add_definitions(-DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DUNICODE)
 if (NOT Qt5Core_FOUND)
   include(${QT_USE_FILE})
 endif()


### PR DESCRIPTION
doxygen built on most of architectures by pure luck and order of Qt5
qatomics_arch.h header where check for QT_ARCH_X86_64 was *after* most
of other architectures.

But not after AArch64 where it failed due to attempt of using x86-64
atomics code.

Signed-off-by: Marcin Juszkiewicz <mjuszkiewicz@redhat.com>