### PR TITLE
Fix typo in function name

### DIFF
--- a/doc/autolink.doc
+++ b/doc/autolink.doc
@@ -77,7 +77,7 @@
     'fun(const std::string&,bool)' or '()' to match any prototype.
   \par Note 2:
     Member function modifiers (like 'const' and 'volatile') 
-    are required to identify the target, i.e. 'func(int) const' and 'fun(int)'
+    are required to identify the target, i.e. 'func(int) const' and 'func(int)'
     target different member functions.
   \par Note 3: 
     For JavaDoc compatibility a \# may be used instead of a :: in 


### PR DESCRIPTION
As both declarations should only differ by cv-qualifiers.

Signed-off-by: Thomas Braun <thomas.braun@byte-physics.de>