### PR TITLE
Right alignment of  in page table of contents

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1205,7 +1205,7 @@ div.toc {
         border-radius: 7px 7px 7px 7px;
         float: right;
         height: auto;
-        margin: 0 20px 10px 10px;
+        margin: 0 8px 10px 10px;
         width: 200px;
 }
 


### PR DESCRIPTION
The in page table of contents (@tableofcontents) should be right aligned with other "box" elements like div.fragment and pre.fragment