### PR TITLE
Title in case of USE_MDFILE_AS_MAINPAGE

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2363,21 +2363,22 @@ void MarkdownFileParser::parseInput(const char *fileName,
   QCString fn      = QFileInfo(fileName).fileName().utf8();
   static QCString mdfileAsMainPage = Config_getString("USE_MDFILE_AS_MAINPAGE");
   if (id.isEmpty()) id = markdownFileNameToId(fileName);
-  if (title.isEmpty()) title = titleFn;
   if (!mdfileAsMainPage.isEmpty() &&
       (fn==mdfileAsMainPage || // name reference
        QFileInfo(fileName).absFilePath()==
        QFileInfo(mdfileAsMainPage).absFilePath()) // file reference with path
      )
   {
-    docs.prepend("@mainpage\n");
+    docs.prepend("@mainpage "+title+"\n");
   }
   else if (id=="mainpage" || id=="index")
   {
+    if (title.isEmpty()) title = titleFn;
     docs.prepend("@mainpage "+title+"\n");
   }
   else
   {
+    if (title.isEmpty()) title = titleFn;
     docs.prepend("@page "+id+" "+title+"\n");
   }
   int lineNr=1;


### PR DESCRIPTION
In case USE_MDFILE_AS_MAINPAGE is used the title in the HTML output is the project name followed by the word documentation and in the index of LATeX / rtf the value is "Main Page", this is even the case when a level 1 header is given. This is a bit contrary to the handling non main pages.
With this patch in case of USE_MDFILE_AS_MAINPAGE and a level 1 header in the beginning of the main page file this level 1 header is used title