### PR TITLE
Bug 757621 - unclosed tag, c# generics method with where

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2420,6 +2420,7 @@ void HtmlGenerator::endConstraintDocs()
 void HtmlGenerator::endConstraintList()
 {
   t << "</table>" << endl;
+  t << "</dd>" << endl;
   t << "</dl>" << endl;
   t << "</div>" << endl;
 }


### PR DESCRIPTION
In the routine the \<dd\> tag is used to do an indentation in the \<dl\> section, this \<dd\> was not closed in endConstraintList.
Problem existed from the beginning (version Release-1.5.2-20070719, commit 29a8f14)