### PR TITLE
Fortran module private variables and EXTRACT_PRIVATE = NO

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2591,7 +2591,7 @@ static MemberDef *addVariableToFile(
   MemberDef *md=new MemberDef(
       fileName,root->startLine,root->startColumn,
       root->type,name,root->args,0,
-      Public, Normal,root->stat,Member,
+      root->protection, Normal,root->stat,Member,
       mtype,root->tArgLists ? root->tArgLists->getLast() : 0,0);
   md->setTagInfo(rootNav->tagInfo());
   md->setMemberSpecifiers(root->spec);
@@ -7324,7 +7324,7 @@ static void addEnumValuesToEnums(EntryNav *rootNav)
                   MemberDef *fmd=new MemberDef(
                       fileName,root->startLine,root->startColumn,
                       root->type,root->name,root->args,0,
-                      Public, Normal,root->stat,Member,
+                      root->protection, Normal,root->stat,Member,
                       MemberType_EnumValue,0,0);
                   if      (md->getClassDef())     fmd->setMemberClass(md->getClassDef());
                   else if (md->getNamespaceDef()) fmd->setNamespace(md->getNamespaceDef());


### PR DESCRIPTION
From the message in the doxygen forum(http://doxygen.10944.n7.nabble.com/Fortan-problems-td7434.html and http://doxygen.10944.n7.nabble.com/Fortran-module-private-variables-and-EXTRACT-PRIVATE-NO-td7423.html)
B. If EXTRACT_PRIVATE = NO, module private functions are not listed (as expected) but module private variables are (bug!).
C. Implicit PRIVATE/PUBLIC/PROTECTED statements in a module work as expected but are not "appended" to function/variable documentation. This is only a nuisance.

Problem had a common cause, the protection was hard set to 'Public' instead of the read value (analogous to static)