### PR TITLE
Markdown with @cond and @endcond

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -781,6 +781,7 @@ void replaceComment(int offset);
 				       //printf("** Adding start of comment!\n");
 				       if (g_lang!=SrcLangExt_Python &&
 					   g_lang!=SrcLangExt_VHDL &&
+					   g_lang!=SrcLangExt_Markdown &&
 					   g_lang!=SrcLangExt_Fortran)
 				       {
  				         ADDCHAR('/');
@@ -800,6 +801,7 @@ void replaceComment(int offset);
     			             {
 				       if (g_lang!=SrcLangExt_Python &&
 					   g_lang!=SrcLangExt_VHDL &&
+					   g_lang!=SrcLangExt_Markdown &&
 					   g_lang!=SrcLangExt_Fortran)
 				       {
  				         ADDCHAR('*');


### PR DESCRIPTION
In case markdown files are processed and they contain @cond and @endcond these are replaced wit C-style end and begin comments (and code in between is correctly removed). The C-Style comments should not be placed as they are not understood in a markdown context (analogous to what happens in Fortram, Pythone etc.).
Note: in principle @cond should not be used as a markdown file is one "comment" block and thus @if should be used, though in any case no unwanted characters should be added.