### PR TITLE
Support flex-2.6.0

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -3700,7 +3700,7 @@ void codeFreeScanner()
 extern "C" { // some bogus code to keep the compiler happy
   void codeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif YY_FLEX_MINOR_VERSION<6 && YY_FLEX_SUBMINOR_VERSION<33
 #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
 #endif
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1128,7 +1128,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					      // but we need to know the position in the input buffer where this 
 					      // rule matched.
 					      // for flex 2.5.33+ we should use YY_CURRENT_BUFFER_LVALUE
-#if YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
+#if YY_FLEX_MINOR_VERSION>5 || YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
 					      inputPosition=prevPosition + (int)(yy_bp - YY_CURRENT_BUFFER_LVALUE->yy_ch_buf);
 #else
 					      inputPosition=prevPosition + (int)(yy_bp - yy_current_buffer->yy_ch_buf);
@@ -1190,7 +1190,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           g_memberGroupHeader.resize(0);
 					  parseMore=TRUE;
                                           needNewEntry = TRUE;
-#if YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
+#if YY_FLEX_MINOR_VERSION>5 || YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
 				          inputPosition=prevPosition + (int)(yy_bp - YY_CURRENT_BUFFER_LVALUE->yy_ch_buf) + strlen(yytext);
 #else
 				          inputPosition=prevPosition + (int)(yy_bp - yy_current_buffer->yy_ch_buf) + strlen(yytext);

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1306,7 +1306,7 @@ void parseFortranCode(CodeOutputInterface &od,const char *className,const QCStri
 extern "C" { // some bogus code to keep the compiler happy
   void fortrancodeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif YY_FLEX_MINOR_VERSION<6 && YY_FLEX_SUBMINOR_VERSION<33
 #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
 #else
 extern "C" { // some bogus code to keep the compiler happy

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1503,7 +1503,7 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
 extern "C" { // some bogus code to keep the compiler happy
   void pycodeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif YY_FLEX_MINOR_VERSION<6 && YY_FLEX_SUBMINOR_VERSION<33
 #error "You seem to be using a version of flex newer than 2.5.4. These are currently incompatible with 2.5.4, and do NOT work with doxygen! Please use version 2.5.4 or expect things to be parsed wrongly! A bug report has been submitted (#732132)."
 #endif
 

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1613,7 +1613,7 @@ void codeFreeVhdlScanner()
 extern "C" { // some bogus code to keep the compiler happy
   void vhdlcodeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif YY_FLEX_MINOR_VERSION<6 && YY_FLEX_SUBMINOR_VERSION<33
 #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
 #endif
 

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -407,7 +407,7 @@ void resetXmlCodeParserState()
 extern "C" { // some bogus code to keep the compiler happy
   void xmlcodeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif YY_FLEX_MINOR_VERSION<6 && YY_FLEX_SUBMINOR_VERSION<33
 #error "You seem to be using a version of flex newer than 2.5.4. These are currently incompatible with 2.5.4, and do NOT work with doxygen! Please use version 2.5.4 or expect things to be parsed wrongly! A bug report has been submitted (#732132)."
 #endif
 


### PR DESCRIPTION
The version checks only considered YY_FLEX_SUBMINOR_VERSION and did not
take YY_FLEX_MINOR_VERSION into account, which made them fail with
flex-2.6.0.

I've successfully tested this patch with flex-2.5.39 and 2.6.0. Additionally I generated apidocs for kdelibs with the latter without problems.