### PR TITLE
Bug 758132 - Brief description of non documented functions

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1849,7 +1849,7 @@ void ClassDef::writeDeclarationLink(OutputList &ol,bool &found,const char *heade
   //static bool fortranOpt = Config_getBool("OPTIMIZE_FOR_FORTRAN");
   //static bool vhdlOpt    = Config_getBool("OPTIMIZE_OUTPUT_VHDL");
   SrcLangExt lang = getLanguage();
-  if (visibleInParentsDeclList())
+  if (visibleInParentsDeclList() && hasDocumentation())
   {
     if (!found) // first class
     {

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -228,6 +228,7 @@ void DirDef::writeSubDirList(OutputList &ol)
     DirDef *dd;
     for (;(dd=it.current());++it)
     {
+      if (!dd->hasDocumentation()) continue;
       ol.startMemberDeclaration();
       ol.startMemberItem(dd->getOutputFileBase(),0);
       ol.parseText(theTranslator->trDir(FALSE,TRUE)+" ");
@@ -266,6 +267,7 @@ void DirDef::writeFileList(OutputList &ol)
     FileDef *fd;
     for (;(fd=it.current());++it)
     {
+      if (!fd->hasDocumentation()) continue;
       ol.startMemberDeclaration();
       ol.startMemberItem(fd->getOutputFileBase(),0);
       ol.docify(theTranslator->trFile(FALSE,TRUE)+" ");

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -824,6 +824,7 @@ void GroupDef::writeFiles(OutputList &ol,const QCString &title)
     FileDef *fd;
     for (;(fd=it.current());++it)
     {
+      if (!fd->hasDocumentation()) continue;
       ol.startMemberDeclaration();
       ol.startMemberItem(fd->getOutputFileBase(),0);
       ol.docify(theTranslator->trFile(FALSE,TRUE)+" ");
@@ -877,6 +878,7 @@ void GroupDef::writeNestedGroups(OutputList &ol,const QCString &title)
     {
       if (gd->isVisible())
       {
+        if (!gd->hasDocumentation()) continue;
         ol.startMemberDeclaration();
         ol.startMemberItem(gd->getOutputFileBase(),0);
         //ol.docify(theTranslator->trGroup(FALSE,TRUE));
@@ -910,6 +912,7 @@ void GroupDef::writeDirs(OutputList &ol,const QCString &title)
     DirDef *dd;
     for (;(dd=it.current());++it)
     {
+      if (!dd->hasDocumentation()) continue;
       ol.startMemberDeclaration();
       ol.startMemberItem(dd->getOutputFileBase(),0);
       ol.parseText(theTranslator->trDir(FALSE,TRUE));

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1422,6 +1422,7 @@ void MemberDef::writeDeclaration(OutputList &ol,
   Definition *d=0;
   ASSERT (cd!=0 || nd!=0 || fd!=0 || gd!=0); // member should belong to something
   if (cd) d=cd; else if (nd) d=nd; else if (fd) d=fd; else d=gd;
+  if (!hasDocumentation()) return;
 
   //_writeTagData(compoundType);
   _addToSearchIndex();

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -387,7 +387,8 @@ void MemberList::writePlainDeclarations(OutputList &ol,
             }
             // if this is an anonymous enum and there are variables of this
             // enum type (i.e. enumVars>0), then we do not show the enum here.
-            if (enumVars==0) // show enum here
+            if ((enumVars==0) // show enum here
+                && md->hasDocumentation())
             {
               //printf("Enum!!\n");
               if (first)

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -984,7 +984,7 @@ void NamespaceSDict::writeDeclaration(OutputList &ol,const char *title,
   ol.startMemberList();
   for (ni.toFirst();(nd=ni.current());++ni)
   {
-    if (nd->isLinkable())
+    if (nd->isLinkable() && nd->hasDocumentation())
     {
       SrcLangExt lang = nd->getLanguage();
       if (lang==SrcLangExt_IDL && (isConstantGroup != nd->isConstantGroup()))


### PR DESCRIPTION
In case a function or an other item is not documented and EXTRACT_ALL has not been specified it should not appear in the list with brief description of functions etc.
(This patch supersedes the patch as proposed in pull request 411 based on the comments from Dimitri van Heesch)