### PR TITLE
Fix computeCommonDirPrefix sometimes not finding the correct prefix

### DIFF
--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -836,6 +836,7 @@ static void computeCommonDirPrefix()
           else // dir is shorter than path -> take path of dir as new start
           {
             path=dir->name();
+            l=path.length();
             int i=path.findRev('/',l-2);
             if (i==-1) // no unique prefix -> stop
             {


### PR DESCRIPTION
The code in some cases would search backwards in a string starting from
an offset beyond the string's length. Adjust so that doesn't happen and
the code doesn't mistakenly assume there is no common dir prefix.

This bug has in some scenarios led to absolute paths being used for
dir_(md5).html links, making doxygen output needlessly depend on details
of build-time paths.