### PR TITLE
Bug 606104 - Deprecated list: Wrong prefix '<globalScope>::' for global functions

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -153,9 +153,12 @@ void RefList::generatePage()
     doc += "\n";
     if (item->scope)
     {
-      doc += "\\_setscope ";
-      doc += item->scope->name();
-      doc += " ";
+      if (item->scope->name() != "<globalScope>")
+      {
+        doc += "\\_setscope ";
+        doc += item->scope->name();
+        doc += " ";
+      }
     }
     doc += item->prefix;
     doc += " \\_internalref ";


### PR DESCRIPTION
The globalScope as shown in the output has no meaning and is confusing (and is also lacking the starting <).
This problem is a regression from: Bug 740218 - Full scope needed when making link inside cross-referenced section \[with test case\] (https://bugzilla.gnome.org/show_bug.cgi?id=740218)