### PR TITLE
doxyapp and CLANG linking

### DIFF
--- a/addon/doxyapp/CMakeLists.txt
+++ b/addon/doxyapp/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(
 	${CMAKE_SOURCE_DIR}/src
 	${CMAKE_SOURCE_DIR}/qtools
 	${ICONV_INCLUDE_DIR}
+	${CLANG_INCLUDEDIR}
 )
 
 add_executable(doxyapp
@@ -21,6 +22,7 @@ ${ICONV_LIBRARIES}
 ${CMAKE_THREAD_LIBS_INIT}
 ${SQLITE3_LIBRARIES}
 ${EXTRA_LIBS}
+${CLANG_LIBS}
 )
 
 install(TARGETS doxyapp DESTINATION bin)


### PR DESCRIPTION
In case CLANG is enabled for doxygen this library is also used for doxyapp, but the clang libraries were not included in the doxyapp CMake project.