### PR TITLE
Bug 578720 - [Python] Add pyw as a valid extension

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1325,6 +1325,7 @@ FILE_VERSION_INFO = "cleartool desc -fmt \%Vn"
       <value name='*.mm'/>
       <value name='*.dox'/>
       <value name='*.py'/>
+      <value name='*.pyw'/>
       <value name='*.f90'/>
       <value name='*.f'/>
       <value name='*.for'/>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7040,6 +7040,7 @@ void initDefaultExtensionMapping()
   updateLanguageMapping(".M",        "objective-c");
   updateLanguageMapping(".mm",       "objective-c");
   updateLanguageMapping(".py",       "python");
+  updateLanguageMapping(".pyw",      "python");
   updateLanguageMapping(".f",        "fortran");
   updateLanguageMapping(".for",      "fortran");
   updateLanguageMapping(".f90",      "fortran");


### PR DESCRIPTION
Added pyw as extension, based also on: https://docs.python.org/2/tutorial/appendix.html (15.1.2. Executable Python Scripts)