### PR TITLE
Bug 732356 - doxygen's \param command is confused by some python default values

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -980,7 +980,7 @@ STARTDOCSYMS      "##"
 			  }
 			  else // continue
 			  {
-			    g_braceCount--;
+			    if (*yytext == ')')g_braceCount--;
 			    g_defVal+=*yytext;
 			  }
        			}


### PR DESCRIPTION


Decrement brace count only in case of a ')' not in case of a ','