### PR TITLE
Bug 735152 - Python: Allow undocumented "cls" parameter for class methods

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -471,9 +471,9 @@ static void checkUndocumentedParams()
         if (lang==SrcLangExt_Fortran) argName = argName.lower();
         argName=argName.stripWhiteSpace();
         if (argName.right(3)=="...") argName=argName.left(argName.length()-3);
-        if (g_memberDef->getLanguage()==SrcLangExt_Python && argName=="self")
+        if (g_memberDef->getLanguage()==SrcLangExt_Python && (argName=="self" || argName=="cls"))
         { 
-          // allow undocumented self parameter for Python
+          // allow undocumented self / cls parameter for Python
         }
         else if (!argName.isEmpty() && g_paramsFound.find(argName)==0 && a->docs.isEmpty()) 
         {
@@ -494,9 +494,9 @@ static void checkUndocumentedParams()
           QCString argName = g_memberDef->isDefine() ? a->type : a->name;
           if (lang==SrcLangExt_Fortran) argName = argName.lower();
           argName=argName.stripWhiteSpace();
-          if (g_memberDef->getLanguage()==SrcLangExt_Python && argName=="self")
+          if (g_memberDef->getLanguage()==SrcLangExt_Python && (argName=="self" || argName=="cls"))
           { 
-            // allow undocumented self parameter for Python
+            // allow undocumented self / cls parameter for Python
           }
           else if (!argName.isEmpty() && g_paramsFound.find(argName)==0) 
           {
@@ -554,7 +554,7 @@ static void detectNoDocumentedParams()
         for (ali.toFirst();(a=ali.current()) && allDoc;++ali)
         {
           if (!a->name.isEmpty() && a->type!="void" &&
-              !(isPython && a->name=="self")
+              !(isPython && (a->name=="self" || a->name=="cls"))
              )
           {
             allDoc = !a->docs.isEmpty();
@@ -570,7 +570,7 @@ static void detectNoDocumentedParams()
           for (ali.toFirst();(a=ali.current()) && allDoc;++ali)
           {
             if (!a->name.isEmpty() && a->type!="void" &&
-                !(isPython && a->name=="self")
+                !(isPython && (a->name=="self" || a->name=="cls"))
                )
             {
               allDoc = !a->docs.isEmpty();

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -989,6 +989,14 @@ TARGET           ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBUT
 				        codify("self.");
 				        findMemberLink(*g_code,&yytext[5]);
 	                            }
+      "cls."{IDENTIFIER}/"("       {
+				        codify("cls.");
+				        findMemberLink(*g_code,&yytext[4]);
+	                            }
+      "cls."{IDENTIFIER}           {
+				        codify("cls.");
+				        findMemberLink(*g_code,&yytext[4]);
+	                            }
 }
 
 <ClassDec>{IDENTIFIER}              {

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -745,8 +745,26 @@ STARTDOCSYMS      "##"
 
 <SearchMemVars>{
     "self."{IDENTIFIER}/{B}"=" {
-                        DBG_CTX((stderr,"Found member variable %s in %s at %d\n",&yytext[5],current_root->name.data(),yyLineNr));
+                        DBG_CTX((stderr,"Found instance method variable %s in %s at %d\n",&yytext[5],current_root->name.data(),yyLineNr));
 			current->name=&yytext[5];
+			current->section=Entry::VARIABLE_SEC;
+			current->fileName  = yyFileName;
+			current->startLine = yyLineNr;
+			current->bodyLine  = yyLineNr;
+			current->type.resize(0);
+			if (current->name.at(0)=='_') // mark as private
+			{
+			  current->protection=Private;
+			}
+			else
+			{
+			  current->protection=Public;
+			}
+			newEntry();
+                      }
+    "cls."{IDENTIFIER}/{B}"=" {
+                        DBG_CTX((stderr,"Found class method variable %s in %s at %d\n",&yytext[4],current_root->name.data(),yyLineNr));
+			current->name=&yytext[4];
 			current->section=Entry::VARIABLE_SEC;
 			current->fileName  = yyFileName;
 			current->startLine = yyLineNr;


### PR DESCRIPTION
Made 'cls' parameter analogous to the 'self' parameter. See also https://www.python.org/dev/peps/pep-0008 (paragraph: Function and method arguments)