### PR TITLE
Performance patches

### DIFF
--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -20,7 +20,7 @@ static int g_dirCount=0;
 
 DirDef::DirDef(const char *path) : Definition(path,1,1,path), visited(FALSE)
 {
-  bool fullPathNames = Config_getBool("FULL_PATH_NAMES");
+  bool fullPathNames = Doxygen::fullPathNames;
   // get display name (stipping the paths mentioned in STRIP_FROM_PATH)
   // get short name (last part of path)
   m_shortName = path;
@@ -620,8 +620,10 @@ bool DirDef::depGraphIsTrivial() const
 int FilePairDict::compareValues(const FilePair *left,const FilePair *right) const
 {
   int orderHi = qstricmp(left->source()->name(),right->source()->name());
+  if (orderHi != 0)
+    return orderHi;
   int orderLo = qstricmp(left->destination()->name(),right->destination()->name());
-  return orderHi==0 ? orderLo : orderHi;
+  return orderLo;
 }
 
 //----------------------------------------------------------------------

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -628,10 +628,27 @@ int FilePairDict::compareValues(const FilePair *left,const FilePair *right) cons
 
 //----------------------------------------------------------------------
 
-UsedDir::UsedDir(DirDef *dir,bool inherited) :
-   m_dir(dir), m_filePairs(7), m_inherited(inherited)
+FilePair* FilePairList::find(const QCString &n)
 {
-  m_filePairs.setAutoDelete(TRUE);
+  std::map<QCString, FilePair>::iterator it = m_map.find(n);
+  if (it == m_map.end())
+    return NULL;
+  return &(*it).second;
+}
+
+void FilePairList::insert(const QCString str, FilePair pair)
+{
+  if (!m_map.insert(std::pair<QCString, FilePair>(str, pair)).second) {
+    printf("ERROR, duplicate in FilePairList::insert\n");
+    abort();
+  }
+}
+
+//----------------------------------------------------------------------
+
+UsedDir::UsedDir(DirDef *dir,bool inherited) :
+   m_dir(dir), m_inherited(inherited)
+{
 }
 
 UsedDir::~UsedDir()
@@ -641,8 +658,9 @@ UsedDir::~UsedDir()
 
 void UsedDir::addFileDep(FileDef *srcFd,FileDef *dstFd)
 {
-  m_filePairs.inSort(srcFd->getOutputFileBase()+dstFd->getOutputFileBase(),
-                     new FilePair(srcFd,dstFd));
+  m_filePairs.insert(
+    srcFd->getOutputFileBase()+dstFd->getOutputFileBase(),
+    FilePair(srcFd,dstFd));
 }
 
 FilePair *UsedDir::findFilePair(const char *name)
@@ -765,16 +783,16 @@ void DirRelation::writeDocumentation(OutputList &ol)
   ol.writeString("</th>");
   ol.writeString("</tr>");
 
-  SDict<FilePair>::Iterator fpi(m_dst->filePairs());
-  FilePair *fp;
-  for (fpi.toFirst();(fp=fpi.current());++fpi)
+  const std::map<const QCString, FilePair>& fpl = m_dst->filePairs().m_map;
+  for (std::map<QCString, FilePair>::const_iterator fpi = fpl.begin(); fpi != fpl.end(); ++fpi)
   {
+    const FilePair &fp = (*fpi).second;
     ol.writeString("<tr class=\"dirtab\">");
     ol.writeString("<td class=\"dirtab\">");
-    writePartialFilePath(ol,m_src,fp->source());
+    writePartialFilePath(ol,m_src,fp.source());
     ol.writeString("</td>");
     ol.writeString("<td class=\"dirtab\">");
-    writePartialFilePath(ol,m_dst->dir(),fp->destination());
+    writePartialFilePath(ol,m_dst->dir(),fp.destination());
     ol.writeString("</td>");
     ol.writeString("</tr>");
   }

--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -21,7 +21,9 @@
 #include "sortdict.h"
 #include "definition.h"
 
+#include <map>
 #include <qlist.h>
+#include <qcstring.h>
 
 class FileList;
 class ClassSDict;
@@ -127,6 +129,14 @@ class FilePairDict : public SDict<FilePair>
     int compareValues(const FilePair *item1,const FilePair *item2) const;
 };
 
+class FilePairList
+{
+  public:
+    FilePair* find(const QCString &n);
+    void insert(const QCString str, FilePair pair);
+    std::map<const QCString, FilePair> m_map;
+};
+
 /** Usage information of a directory. */
 class UsedDir
 {
@@ -135,13 +145,13 @@ class UsedDir
     virtual ~UsedDir();
     void addFileDep(FileDef *srcFd,FileDef *dstFd);
     FilePair *findFilePair(const char *name);
-    const FilePairDict &filePairs() const { return m_filePairs; }
+    const FilePairList &filePairs() const { return m_filePairs; }
     const DirDef *dir() const { return m_dir; }
     bool inherited() const { return m_inherited; }
 
   private:
     DirDef *m_dir;
-    FilePairDict m_filePairs;
+    FilePairList m_filePairs;
     bool m_inherited;
 };
 

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <qdir.h>
 #include <qfile.h>
@@ -418,10 +419,10 @@ inline int reNumberNode(int number, bool doReNumbering)
         ns = number * 3 / 2 + 5;
       }
       s_newNumber.resize(ns);
-      for (int i=s;i<ns;i++) // clear new part of the array
-      {
-        s_newNumber.at(i)=0;
-      }
+
+      // clear new part of the array
+      int *raw_array = s_newNumber.data();
+      memset(raw_array + s, 0, sizeof(int) * (ns - s));
     }
     int i = s_newNumber.at(number);
     if (i == 0) // not yet mapped

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -2628,7 +2628,7 @@ void DotClassGraph::addClass(ClassDef *cd,DotNode *n,int prot,
   else // new class
   {
     QCString displayName=className;
-    if (Config_getBool("HIDE_SCOPE_NAMES")) displayName=stripScope(displayName);
+    if (Doxygen::hideScopeNames) displayName=stripScope(displayName);
     QCString tmp_url;
     if (cd->isLinkable() && !cd->isHidden()) 
     {
@@ -3689,7 +3689,7 @@ void DotCallGraph::buildGraph(DotNode *n,MemberDef *md,int distance)
         else
         {
           QCString name;
-          if (Config_getBool("HIDE_SCOPE_NAMES"))
+          if (Doxygen::hideScopeNames)
           {
             name  = rmd->getOuterScope()==m_scope ? 
                     rmd->name() : rmd->qualifiedName();
@@ -3778,7 +3778,7 @@ DotCallGraph::DotCallGraph(MemberDef *md,bool inverse)
   uniqueId = md->getReference()+"$"+
              md->getOutputFileBase()+"#"+md->anchor();
   QCString name;
-  if (Config_getBool("HIDE_SCOPE_NAMES"))
+  if (Doxygen::hideScopeNames)
   {
     name = md->name();
   }

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -51,6 +51,7 @@
 #include "namespacedef.h"
 #include "memberdef.h"
 #include "membergroup.h"
+#include "growbuf.h"
 
 #define MAP_CMD "cmapx"
 
@@ -789,59 +790,89 @@ DotRunner::DotRunner(const QCString &file,const QCString &path,
   m_cleanUp      = dotCleanUp;
   m_multiTargets = dotMultiTargets;
   m_jobs.setAutoDelete(TRUE);
+  m_formats.setAutoDelete(TRUE);
+  m_outnames.setAutoDelete(TRUE);
+}
+
+bool DotRunner::compatibleWith(const DotRunner *other)
+{
+  // don't compare m_dotExe/m_multiTargets, always equal
+  // I thiiink m_path should always be the same? But I'm not sure.
+  if (strcmp(m_path.data(), other->m_path.data())) return false;
+  if (m_checkResult != other->m_checkResult) return false;
+  if (m_cleanUp != other->m_cleanUp) return false;
+
+  if (m_jobs.count() != other->m_jobs.count()) return false;
+  // This is inefficient, but the job list is always just 1 or 2
+  // long, so it doesn't matter.
+  for (int i=0; i<m_jobs.count(); i++) {
+    if (strcmp(m_formats.at(i)->data(), other->m_formats.at(i)->data()))
+      return false;
+  }
+
+  return true;
 }
 
 void DotRunner::addJob(const char *format,const char *output)
 {
   QCString args = QCString("-T")+format+" -o \""+output+"\"";
   m_jobs.append(new DotConstString(args));
+  m_formats.append(new DotConstString(format));
+  m_outnames.append(new DotConstString(output));
 }
 
-void DotRunner::addPostProcessing(const char *cmd,const char *args)
-{
-  m_postCmd.set(cmd);
-  m_postArgs.set(args);
-}
-
-bool DotRunner::run()
+bool DotRunner::run(std::list<DotRunner*> &slaves)
 {
   int exitCode=0;
 
-  QCString dotArgs;
-  QListIterator<DotConstString> li(m_jobs);
   DotConstString *s;
+  const char *dotArgsStr;
+  QCString dotArgs;
   if (m_multiTargets)
   {
-    dotArgs=QCString("\"")+m_file.data()+"\"";
+    // This should really be rewritten to use fork()+execlp() or so
+    // directly, but I have no idea what the windows equivalent is.
+    GrowBuf argsBuf;
+    argsBuf.addStr("-O \"");
+    argsBuf.addStr(m_file.data());
+    argsBuf.addStr("\"");
+    for (std::list<DotRunner*>::iterator it = slaves.begin(); it != slaves.end(); it++) {
+      argsBuf.addStr(" \"");
+      argsBuf.addStr((*it)->m_file.data());
+      argsBuf.addChar('"');
+    }
+    QListIterator<DotConstString> li(m_formats);
     for (li.toFirst();(s=li.current());++li)
     {
-      dotArgs+=' ';
-      dotArgs+=s->data();
+      argsBuf.addStr(" -T");
+      argsBuf.addStr(s->data());
     }
-    if ((exitCode=portable_system(m_dotExe.data(),dotArgs,FALSE))!=0)
+    dotArgsStr = argsBuf.get();
+    if ((exitCode=portable_system(m_dotExe.data(),dotArgsStr,FALSE))!=0)
     {
       goto error;
     }
   }
   else
   {
+    QListIterator<DotConstString> li(m_jobs);
+    assert(slaves.size() == 0);
     for (li.toFirst();(s=li.current());++li)
     {
       dotArgs=QCString("\"")+m_file.data()+"\" "+s->data();
-      if ((exitCode=portable_system(m_dotExe.data(),dotArgs,FALSE))!=0)
+      dotArgsStr = dotArgs.data();
+      if ((exitCode=portable_system(m_dotExe.data(),dotArgsStr,FALSE))!=0)
       {
         goto error;
       }
     }
   }
-  if (!m_postCmd.isEmpty() && portable_system(m_postCmd.data(),m_postArgs.data())!=0)
-  {
-    err("Problems running '%s' as a post-processing step for dot output\n",m_postCmd.data());
-    return FALSE;
-  }
   if (m_checkResult)
   {
     checkDotResult(m_imgExt.data(),m_imageName.data());
+    for (std::list<DotRunner*>::iterator it = slaves.begin(); it != slaves.end(); it++) {
+      checkDotResult((*it)->m_imgExt.data(),(*it)->m_imageName.data());
+    }
   }
   if (m_cleanUp) 
   {
@@ -849,11 +880,15 @@ bool DotRunner::run()
     //QDir(path).remove(file);
     m_cleanupItem.file.set(m_file.data());
     m_cleanupItem.path.set(m_path.data());
+    for (std::list<DotRunner*>::iterator it = slaves.begin(); it != slaves.end(); it++) {
+      (*it)->m_cleanupItem.file.set((*it)->m_file.data());
+      (*it)->m_cleanupItem.path.set((*it)->m_path.data());
+    }
   }
   return TRUE;
 error:
   err("Problems running dot: exit code=%d, command='%s', arguments='%s'\n",
-      exitCode,m_dotExe.data(),dotArgs.data());
+      exitCode,m_dotExe.data(),dotArgsStr);
   return FALSE;
 }
 
@@ -1151,15 +1186,26 @@ void DotRunnerQueue::enqueue(DotRunner *runner)
   m_bufferNotEmpty.wakeAll();
 }
 
-DotRunner *DotRunnerQueue::dequeue()
+#define DOT_RUNNER_MAX_SLAVES 300 // chosen arbitrarily
+
+DotRunner *DotRunnerQueue::dequeue(std::list<DotRunner*> &slaves)
 {
   QMutexLocker locker(&m_mutex);
+  assert(slaves.empty());
   while (m_queue.isEmpty())
   {
     // wait until something is added to the queue
     m_bufferNotEmpty.wait(&m_mutex);
   }
+  int len_before = m_queue.count();
   DotRunner *result = m_queue.dequeue();
+  if (result && result->hasMultiTargets()) {
+    while (slaves.size() < DOT_RUNNER_MAX_SLAVES && !m_queue.isEmpty()
+        && m_queue.head() != 0 && result->compatibleWith(m_queue.head())) {
+      slaves.push_back(m_queue.dequeue());
+    }
+  }
+  int len_after = m_queue.count();
   return result;
 }
 
@@ -1180,14 +1226,22 @@ DotWorkerThread::DotWorkerThread(DotRunnerQueue *queue)
 void DotWorkerThread::run()
 {
   DotRunner *runner;
-  while ((runner=m_queue->dequeue()))
+  std::list<DotRunner*> slaves;
+  while ((runner=m_queue->dequeue(slaves)))
   {
-    runner->run();
+    runner->run(slaves);
+
     const DotRunner::CleanupItem &cleanup = runner->cleanup();
     if (!cleanup.file.isEmpty())
-    {
       m_cleanupItems.append(new DotRunner::CleanupItem(cleanup));
+
+    for (std::list<DotRunner*>::iterator it = slaves.begin(); it != slaves.end(); it++) {
+      const DotRunner::CleanupItem &cleanup = (*it)->cleanup();
+      if (!cleanup.file.isEmpty())
+        m_cleanupItems.append(new DotRunner::CleanupItem(cleanup));
     }
+
+    slaves.clear();
   }
 }
 
@@ -1343,8 +1397,10 @@ bool DotManager::run()
   {
     for (li.toFirst();(dr=li.current());++li)
     {
+      // TODO make singlethreaded case fast, too
+      std::list<DotRunner*> slaves;
       msg("Running dot for graph %d/%d\n",prev,numDotRuns);
-      dr->run();
+      dr->run(slaves);
       prev++;
     }
   }
@@ -1358,18 +1414,13 @@ bool DotManager::run()
     while ((i=m_queue->count())>0)
     {
       i = numDotRuns - i;
-      while (i>=prev)
-      {
-        msg("Running dot for graph %d/%d\n",prev,numDotRuns);
-        prev++;
+      if (i > prev) {
+        msg("Running dot for graph %d/%d\n",i,numDotRuns);
+        prev = i;
       }
       portable_sleep(100);
     }
-    while ((int)numDotRuns>=prev)
-    {
-      msg("Running dot for graph %d/%d\n",prev,numDotRuns);
-      prev++;
-    }
+    msg("Dot runs finalizing\n");
     // signal the workers we are done
     for (i=0;i<(int)m_workers.count();i++)
     {
@@ -2264,7 +2315,7 @@ void DotGfxHierarchyTable::createGraph(DotNode *n,FTextStream &out,
   QCString imgFmt = Config_getEnum("DOT_IMAGE_FORMAT");
   baseName.sprintf("inherit_graph_%d",id);
   QCString imgName = baseName+"."+ imgExt;
-  QCString mapName = baseName+".map";
+  QCString mapName = baseName+".dot.cmapx";
   QCString absImgName = QCString(d.absPath().data())+"/"+imgName;
   QCString absMapName = QCString(d.absPath().data())+"/"+mapName;
   QCString absBaseName = QCString(d.absPath().data())+"/"+baseName;
@@ -3154,7 +3205,7 @@ QCString DotClassGraph::writeGraph(FTextStream &out,
   QCString imgFmt = Config_getEnum("DOT_IMAGE_FORMAT");
   QCString absBaseName = d.absPath().utf8()+"/"+baseName;
   QCString absDotName  = absBaseName+".dot";
-  QCString absMapName  = absBaseName+".map";
+  QCString absMapName  = absBaseName+".dot.cmapx";
   QCString absPdfName  = absBaseName+".pdf";
   QCString absEpsName  = absBaseName+".eps";
   QCString absImgName  = absBaseName+"."+imgExt;
@@ -3511,7 +3562,7 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
   QCString imgFmt = Config_getEnum("DOT_IMAGE_FORMAT");
   QCString absBaseName = d.absPath().utf8()+"/"+baseName;
   QCString absDotName  = absBaseName+".dot";
-  QCString absMapName  = absBaseName+".map";
+  QCString absMapName  = absBaseName+".dot.cmapx";
   QCString absPdfName  = absBaseName+".pdf";
   QCString absEpsName  = absBaseName+".eps";
   QCString absImgName  = absBaseName+"."+imgExt;
@@ -3593,7 +3644,7 @@ QCString DotInclDepGraph::writeGraph(FTextStream &out,
       out << "<div class=\"center\"><img src=\"" << relPath << baseName << "." << imgExt << "\" border=\"0\" usemap=\"#" << mapName << "\" alt=\"\"/>";
       out << "</div>" << endl;
 
-      QCString absMapName = absBaseName+".map";
+      QCString absMapName = absBaseName+".dot.cmapx";
       if (regenerate || !insertMapFile(out,absMapName,relPath,mapName))
       {
         int mapId = DotManager::instance()->addMap(fileName,absMapName,relPath,
@@ -3789,7 +3840,7 @@ QCString DotCallGraph::writeGraph(FTextStream &out, GraphOutputFormat graphForma
   QCString imgFmt = Config_getEnum("DOT_IMAGE_FORMAT");
   QCString absBaseName = d.absPath().utf8()+"/"+baseName;
   QCString absDotName  = absBaseName+".dot";
-  QCString absMapName  = absBaseName+".map";
+  QCString absMapName  = absBaseName+".dot.cmapx";
   QCString absPdfName  = absBaseName+".pdf";
   QCString absEpsName  = absBaseName+".eps";
   QCString absImgName  = absBaseName+"."+imgExt;
@@ -3946,7 +3997,7 @@ QCString DotDirDeps::writeGraph(FTextStream &out,
   QCString imgFmt = Config_getEnum("DOT_IMAGE_FORMAT");
   QCString absBaseName = d.absPath().utf8()+"/"+baseName;
   QCString absDotName  = absBaseName+".dot";
-  QCString absMapName  = absBaseName+".map";
+  QCString absMapName  = absBaseName+".dot.cmapx";
   QCString absPdfName  = absBaseName+".pdf";
   QCString absEpsName  = absBaseName+".eps";
   QCString absImgName  = absBaseName+"."+imgExt;
@@ -4178,7 +4229,9 @@ void writeDotGraphFromFile(const char *inFile,const char *outDir,
   }
 
   dotRun.preventCleanUp();
-  if (!dotRun.run())
+  // TODO does this need speedup?
+  std::list<DotRunner*> slaves;
+  if (!dotRun.run(slaves))
   {
      return;
   }
@@ -4211,7 +4264,7 @@ void writeDotImageMapFromFile(FTextStream &t,
     err("Output dir %s does not exist!\n",outDir.data()); exit(1);
   }
 
-  QCString mapName = baseName+".map";
+  QCString mapName = baseName+".dot.cmapx";
   QCString imgExt = getDotImageExtension();
   QCString imgFmt = Config_getEnum("DOT_IMAGE_FORMAT");
   QCString imgName = baseName+"."+imgExt;
@@ -4220,7 +4273,10 @@ void writeDotImageMapFromFile(FTextStream &t,
   DotRunner dotRun(inFile,d.absPath().data(),FALSE);
   dotRun.addJob(MAP_CMD,absOutFile);
   dotRun.preventCleanUp();
-  if (!dotRun.run())
+
+  // TODO does this need speedup?
+  std::list<DotRunner*> slaves;
+  if (!dotRun.run(slaves))
   {
     return;
   }
@@ -4516,7 +4572,7 @@ QCString DotGroupCollaboration::writeGraph( FTextStream &t,
   QCString absBaseName = absPath+"/"+baseName;
   QCString absDotName  = absBaseName+".dot";
   QCString absImgName  = absBaseName+"."+imgExt;
-  QCString absMapName  = absBaseName+".map";
+  QCString absMapName  = absBaseName+".dot.cmapx";
   QCString absPdfName  = absBaseName+".pdf";
   QCString absEpsName  = absBaseName+".eps";
   bool regenerate=FALSE;

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <map>
+
 #include <qdir.h>
 #include <qfile.h>
 #include <qqueue.h>
@@ -398,7 +400,7 @@ static bool convertMapFile(FTextStream &t,const char *mapName,
   return TRUE;
 }
 
-static QArray<int> s_newNumber;
+static std::map<int,int> s_newNumber;
 static int s_max_newNumber=0;
 
 inline int reNumberNode(int number, bool doReNumbering)
@@ -409,35 +411,18 @@ inline int reNumberNode(int number, bool doReNumbering)
   } 
   else 
   {
-    int s = s_newNumber.size();
-    if (number>=s) 
-    {
-      int ns=0;
-      ns = s * 3 / 2 + 5; // new size
-      if (number>=ns) // number still doesn't fit
-      {
-        ns = number * 3 / 2 + 5;
-      }
-      s_newNumber.resize(ns);
-
-      // clear new part of the array
-      int *raw_array = s_newNumber.data();
-      memset(raw_array + s, 0, sizeof(int) * (ns - s));
+    int& mapped = s_newNumber[number];
+    if (mapped == 0) {
+      mapped = ++s_max_newNumber; // start from 1
     }
-    int i = s_newNumber.at(number);
-    if (i == 0) // not yet mapped
-    {
-      i = ++s_max_newNumber; // start from 1
-      s_newNumber.at(number) = i;
-    }
-    return i;
+    return mapped;
   }
 }
 
 static void resetReNumbering() 
 {
   s_max_newNumber=0;
-  s_newNumber.resize(s_max_newNumber);
+  s_newNumber.clear();
 }
 
 static QCString g_dotFontPath;

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -4893,7 +4893,7 @@ void writeDotDirDepGraph(FTextStream &t,DirDef *dd,bool linkRelations)
             Doxygen::dirRelations.append(relationName,
                 new DirRelation(relationName,dir,udir));
           }
-          int nrefs = udir->filePairs().count();
+          int nrefs = udir->filePairs().m_map.size();
           t << "  " << dir->getOutputFileBase() << "->"
                     << usedDir->getOutputFileBase();
           t << " [headlabel=\"" << nrefs << "\", labeldistance=1.5";

--- a/src/dot.h
+++ b/src/dot.h
@@ -19,6 +19,8 @@
 #ifndef _DOT_H
 #define _DOT_H
 
+#include <list>
+
 #include <qlist.h>
 #include <qdict.h>
 #include <qwaitcondition.h>
@@ -369,20 +371,23 @@ class DotRunner
      */
     void addJob(const char *format,const char *output);
 
-    void addPostProcessing(const char *cmd,const char *args);
-
     void preventCleanUp() { m_cleanUp = FALSE; }
 
     /** Runs dot for all jobs added. */
-    bool run();
+    bool run(std::list<DotRunner*> &slaves);
     const CleanupItem &cleanup() const { return m_cleanupItem; }
+
+    bool compatibleWith(const DotRunner *other);
+
+    bool hasMultiTargets() { return m_multiTargets; }
 
   private:
     DotConstString m_dotExe;
     bool m_multiTargets;
     QList<DotConstString> m_jobs;
-    DotConstString m_postArgs;
-    DotConstString m_postCmd;
+    QList<DotConstString> m_formats;
+    QList<DotConstString> m_outnames;
+    /* input file path */
     DotConstString m_file;
     DotConstString m_path;
     bool m_checkResult;
@@ -428,7 +433,7 @@ class DotRunnerQueue
 {
   public:
     void enqueue(DotRunner *runner);
-    DotRunner *dequeue();
+    DotRunner *dequeue(std::list<DotRunner*> &slaves);
     uint count() const;
   private:
     QWaitCondition  m_bufferNotEmpty;

--- a/src/dot.h
+++ b/src/dot.h
@@ -233,11 +233,9 @@ class DotCallGraph
                         const char *path,const char *fileName,
                         const char *relPath,bool writeImageMap=TRUE,
                         int graphId=-1) const;
-    void buildGraph(DotNode *n,MemberDef *md,int distance);
+    void buildGraph(MemberDef *root_md);
     bool isTrivial() const;
     bool isTooBig() const;
-    void determineVisibleNodes(QList<DotNode> &queue, int &maxNodes);
-    void determineTruncatedNodes(QList<DotNode> &queue);
     
   private:
     DotNode        *m_startNode;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -170,6 +170,7 @@ QCString         Doxygen::spaces;
 bool             Doxygen::generatingXmlOutput = FALSE;
 bool             Doxygen::markdownSupport = TRUE;
 bool             Doxygen::fullPathNames;
+bool             Doxygen::hideScopeNames;
 GenericsSDict   *Doxygen::genericsDict;
 
 // locally accessible globals
@@ -10584,6 +10585,7 @@ void adjustConfiguration()
   Doxygen::spaces.at(tabSize)='\0';
 
   Doxygen::fullPathNames = Config_getBool("FULL_PATH_NAMES");
+  Doxygen::hideScopeNames = Config_getBool("HIDE_SCOPE_NAMES");
 }
 
 #ifdef HAS_SIGNALS

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -169,6 +169,7 @@ bool             Doxygen::userComments = FALSE;
 QCString         Doxygen::spaces;
 bool             Doxygen::generatingXmlOutput = FALSE;
 bool             Doxygen::markdownSupport = TRUE;
+bool             Doxygen::fullPathNames;
 GenericsSDict   *Doxygen::genericsDict;
 
 // locally accessible globals
@@ -10581,6 +10582,8 @@ void adjustConfiguration()
   Doxygen::spaces.resize(tabSize+1);
   int sp;for (sp=0;sp<tabSize;sp++) Doxygen::spaces.at(sp)=' ';
   Doxygen::spaces.at(tabSize)='\0';
+
+  Doxygen::fullPathNames = Config_getBool("FULL_PATH_NAMES");
 }
 
 #ifdef HAS_SIGNALS

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -153,6 +153,7 @@ class Doxygen
     static bool                      markdownSupport;
     static GenericsSDict            *genericsDict;
     static bool                      fullPathNames;
+    static bool                      hideScopeNames;
 };
 
 void initDoxygen();

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -152,6 +152,7 @@ class Doxygen
     static bool                      generatingXmlOutput;
     static bool                      markdownSupport;
     static GenericsSDict            *genericsDict;
+    static bool                      fullPathNames;
 };
 
 void initDoxygen();

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1190,12 +1190,12 @@ void FileDef::insertNamespace(NamespaceDef *nd)
   }
 }
 
-QCString FileDef::name() const 
+const QCString& FileDef::name() const
 { 
-  if (Config_getBool("FULL_PATH_NAMES")) 
-    return m_fileName; 
-  else 
-    return Definition::name(); 
+  if (Doxygen::fullPathNames)
+    return m_fileName;
+  else
+    return Definition::name();
 } 
 
 void FileDef::addSourceRef(int line,Definition *d,MemberDef *md)

--- a/src/filedef.h
+++ b/src/filedef.h
@@ -76,7 +76,7 @@ class FileDef : public Definition
     DefType definitionType() const { return TypeFile; }
 
     /*! Returns the unique file name (this may include part of the path). */
-    QCString name() const;
+    const QCString& name() const;
     QCString displayName(bool=TRUE) const { return name(); }
     QCString fileName() const { return m_fileName; }
     

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -729,7 +729,7 @@ static void writeDirHierarchy(OutputList &ol, FTVHelp* ftv,bool addToIndex)
     ol.pushGeneratorState(); 
     ol.disable(OutputGenerator::Html);
   }
-  static bool fullPathNames = Config_getBool("FULL_PATH_NAMES");
+  static bool fullPathNames = Doxygen::fullPathNames;
   startIndexHierarchy(ol,0);
   if (fullPathNames)
   {

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2062,7 +2062,6 @@ void MemberDef::_writeCallGraph(OutputList &ol)
     }
     else if (!callGraph.isTrivial())
     {
-      msg("Generating call graph for function %s\n",qPrint(qualifiedName()));
       ol.disable(OutputGenerator::Man);
       ol.startParagraph();
       ol.startCallGraph();
@@ -2087,7 +2086,6 @@ void MemberDef::_writeCallerGraph(OutputList &ol)
     }
     else if (!callerGraph.isTrivial() && !callerGraph.isTooBig())
     {
-      msg("Generating caller graph for function %s\n",qPrint(qualifiedName()));
       ol.disable(OutputGenerator::Man);
       ol.startParagraph();
       ol.startCallGraph();

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -156,7 +156,7 @@ error:
 QCString getMscImageMapFromFile(const QCString& inFile, const QCString& outDir,
                                 const QCString& relPath,const QCString& context)
 {
-  QCString outFile = inFile + ".map";
+  QCString outFile = inFile + ".dot.cmapx";
 
 
   //printf("*** running:getMscImageMapFromFile \n");
@@ -199,7 +199,7 @@ void writeMscImageMapFromFile(FTextStream &t,const QCString &inFile,
 			      MscOutputFormat format
  			    )
 {
-  QCString mapName = baseName+".map";
+  QCString mapName = baseName+".dot.cmapx";
   t << "<img src=\"" << relPath << baseName << ".";
   switch (format)
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5234,7 +5234,7 @@ static ssize_t escapeCharsInString(char *out, const char *name, bool allowDots, 
   char *out_start = out;
   #define ADDCHAR(x) ((*(out++) = (x)), used++)
   #define ADDTWO(a, b) (ADDCHAR(a), ADDCHAR(b))
-  #define ADDTHREE(a) (ADDCHAR('_'), ADDCHAR('0'), ADDCHAR(c))
+  #define ADDTHREE(a) (ADDCHAR('_'), ADDCHAR('0'), ADDCHAR(a))
   static bool caseSenseNames = Config_getBool("CASE_SENSE_NAMES");
   static bool allowUnicodeNames = Config_getBool("ALLOW_UNICODE_NAMES");
   char c;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8596,7 +8596,7 @@ QCString getDotImageExtension(void)
 {
   QCString imgExt      = Config_getEnum("DOT_IMAGE_FORMAT");
   imgExt = imgExt.replace( QRegExp(":.*"), "" );
-  return imgExt;
+  return QCString("dot.") + imgExt;
 }
 
 void initFilePattern(void)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1622,30 +1622,18 @@ ClassDef *getResolvedClass(Definition *scope,
 
 static bool findOperator(const QCString &s,int i)
 {
-  int b = s.findRev("operator",i);
-  if (b==-1) return FALSE; // not found
-  b+=8;
-  while (b<i) // check if there are only spaces in between 
-    // the operator and the >
-  {
-    if (!isspace((uchar)s.at(b))) return FALSE;
-    b++;
-  }
-  return TRUE;
+  while (i>0 && isspace((uchar)s.at(i-1))) i--;
+
+  return i>=8 && s.at(i-8)=='o' && s.at(i-7)=='p' && s.at(i-6)=='e' && s.at(i-5)=='r'
+    && s.at(i-4)=='a' && s.at(i-3)=='t' && s.at(i-2)=='o' && s.at(i-1)=='r';
 }
 
 static bool findOperator2(const QCString &s,int i)
 {
-  int b = s.findRev("operator",i);
-  if (b==-1) return FALSE; // not found
-  b+=8;
-  while (b<i) // check if there are only non-ascii
-              // characters in front of the operator
-  {
-    if (isId((uchar)s.at(b))) return FALSE;
-    b++;
-  }
-  return TRUE;
+  while (i>0 && !isId((uchar)s.at(i-1))) i--;
+
+  return i>=8 && s.at(i-8)=='o' && s.at(i-7)=='p' && s.at(i-6)=='e' && s.at(i-5)=='r'
+    && s.at(i-4)=='a' && s.at(i-3)=='t' && s.at(i-2)=='o' && s.at(i-1)=='r';
 }
 
 static const char constScope[]   = { 'c', 'o', 'n', 's', 't', ':' };


### PR DESCRIPTION
Hello!

I want to be able to run Doxygen on Linux kernel code parts, e.g. on all kernel code that is involved in the compilation of a specific device (determined using https://git.thejh.net/?p=cleanmysourcetree.git). In particular, I want big call/callee graphs (I'm testing with size limit 100 and no depth limit).

However, when I attempted that, it took pretty long. These patches reduce the required time on my system a lot.

I just re-ran my patched doxygen and the version of the master branch my patches are based on, built with "-ggdb -O3" (no LTO), with clean result directories to compare the times needed. Results:

patched:
```
$ time ~/gitty/3FOREIGN/doxygen/build/bin/doxygen
[...]
real	17m19.091s
user	64m6.501s
sys	1m3.239s
```

master:
```
$ date && sleep 1 && time ~/gitty/3FOREIGN/doxygen/build/bin/doxygen
Mi 30. Dez 21:22:03 CET 2015
[...]
Computing dependencies between directories... [last message visible at 21:51]
[around 21:54, it starts to generate call/callee graphs]
[at 22:23, after an hour, it's still generating call/callee graphs]
```

I'll tell you how long the master build took to complete when it's done. :D

Some of these changes are algorithmic and change the big-O complexity of the code, others are microoptimizations. If you don't want to merge some of the microoptimizations I did because they make the code look ugly, I can send a new pull request with just the important high-level stuff.

Note that two patches change the file naming scheme a bit and one requires a dot version that is from 2006 or newer if DOT_MULTI_TARGETS is turned on. Also, I have removed some of the logging calls to stdout, particularly the logging of all function names when generating call graphs.