### PR TITLE
Fortran inline source code and crash on Linux

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -686,9 +686,12 @@ private                                 {
                                            // in a scope of their own, even if multiple
                                            // are group in one INTERFACE/END INTERFACE block.
                                            //
-                                           last_entry->endBodyLine = yyLineNr - 1;
                                            if (ifType == IF_ABSTRACT || ifType == IF_SPECIFIC)
+                                           {
                                              endScope(current_root);
+                                             last_entry->endBodyLine = yyLineNr - 1;
+                                           }
+                                           current_root->endBodyLine = yyLineNr - 1;
 
 					   if (!endScope(current_root))
 					     yyterminate();


### PR DESCRIPTION
This patch fixes a problem on Linux where in a number of cases doxygen crashed when an unnamed interface existed and the routine itself was in the same source file.
Furthermore the end line of routines is set correctly so  inline source code in Fortran will be possible as well.