### PR TITLE
Latex page numbering

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -74,6 +74,7 @@
 \hbadness=750
 \tolerance=750
 \begin{document}
+\pagenumbering{alph}
 \begin{titlepage}
 \includegraphics[width=\textwidth]{doxygen_logo}
 \begin{center}
@@ -82,8 +83,8 @@ Written by Dimitri van Heesch\\[2ex]
 \copyright 1997-\thisyear
 \end{center}
 \end{titlepage}
-\pagenumbering{Roman}
 \clearemptydoublepage
+\pagenumbering{Roman}
 \tableofcontents
 \clearemptydoublepage
 \pagenumbering{arabic}

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -687,7 +687,7 @@ static void writeDefaultHeaderPart1(FTextStream &t)
       << "             pdfencoding=unicode\n"
       << "            }\n";
   }
-  t << "\\pagenumbering{roman}\n"
+  t << "\\pagenumbering{alph}\n"
        "\\begin{titlepage}\n"
        "\\vspace*{7cm}\n"
        "\\begin{center}%\n"
@@ -716,6 +716,7 @@ static void writeDefaultHeaderPart3(FTextStream &t)
   bool compactLatex = Config_getBool("COMPACT_LATEX");
   if (!compactLatex)
     t << "\\clearemptydoublepage\n";
+  t << "\\pagenumbering{roman}\n";
 
   // ToC
   t << "\\tableofcontents\n";


### PR DESCRIPTION
In the documentation generated by doxygen the table of contents does not start with page number i but with iii, by setting the pagenumbering}{roman} after the clearemptydoublepage titlepage this is corrected. In the beginning of the documentation we set the page numbering to "alph" so it won't interfere with the numbers in the table of contents and the real documentation.

For the doxygen manual similar reasoning is true, furthermore the table of contents was on the left side page (when printed double sided), yhis is corrected as well.