### PR TITLE
PDF generation stops when image with caption is included in a table.

### DIFF
--- a/doc/manual.sty
+++ b/doc/manual.sty
@@ -31,3 +31,10 @@
 \fancyfoot[CO]{\fancyplain{}{}}
 \fancyfoot[RO]{\fancyplain{}{}}
 
+% Define caption that is also suitable in a table
+\makeatletter
+\def\doxyfigcaption{%
+\refstepcounter{figure}%
+\@dblarg{\@caption{figure}}}
+\makeatother
+

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -947,7 +947,7 @@ void LatexDocVisitor::visitPre(DocHtmlTable *t)
   if (t->hasCaption())
   {
     DocHtmlCaption *c = t->caption();
-    m_t << "\\doxyfigcaption{";
+    m_t << "\\caption{";
     visitCaption(this, c->children());
     m_t << "}";
     m_t << "\\label{" << stripPath(c->file()) << "_" << c->anchor() << "}";

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -114,7 +114,7 @@ static void visitPreStart(FTextStream &t, const bool hasCaption, QCString name, 
 
     if (hasCaption)
     {
-      t << "\n\\caption{";
+      t << "\n\\doxyfigcaption{";
     }
 }
 
@@ -947,7 +947,7 @@ void LatexDocVisitor::visitPre(DocHtmlTable *t)
   if (t->hasCaption())
   {
     DocHtmlCaption *c = t->caption();
-    m_t << "\\caption{";
+    m_t << "\\doxyfigcaption{";
     visitCaption(this, c->children());
     m_t << "}";
     m_t << "\\label{" << stripPath(c->file()) << "_" << c->anchor() << "}";

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -475,3 +475,10 @@
 
 % Color used for table heading
 \newcommand{\tableheadbgcolor}{lightgray}%
+
+% Define caption that is also suitable in a table
+\makeatletter
+\def\doxyfigcaption{%
+\refstepcounter{figure}%
+\@dblarg{\@caption{figure}}}
+\makeatother


### PR DESCRIPTION
In case an image is included in a table and this image has a caption the generation of a PDF stops with the message:
! Misplaced \noalign.
\caption ->\noalign
                    \bgroup \@ifnextchar [{\egroup \LT@c@ption \@firstofone ...
l.45 \end{longtabu}

This problem has in general been described in: http://tex.stackexchange.com/questions/85919/adding-a-caption-to-a-graphic-inside-a-longtable

In this patch the suggestion from this reference is implemented by defining \doxyfigcaption and using this where  a caption is required.