### PR TITLE
Problem jumping to line number in source code due to wrong hypertarget name

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -199,7 +199,7 @@ void LatexCodeGenerator::writeLineNumber(const char *ref,const char *fileName,co
     {
       QCString lineAnchor;
       lineAnchor.sprintf("_l%05d",l);
-      lineAnchor.prepend(m_sourceFileName);
+      lineAnchor.prepend(stripExtensionGeneral(m_sourceFileName, ".tex"));
       //if (!m_prettyCode) return;
       if (usePDFLatex && pdfHyperlinks)
       {


### PR DESCRIPTION
When having a line like "Definition at line 30 of file test.cpp." in the LaTeX document with source code the test.cpp is linked to the file but the 30 isn't (in HTML it is).
Problem is that in the hypertarget the extension is still present. This patch corrects this.