### PR TITLE
Bug 760970 - CASE_SENSE_NAMES ignored

### DIFF
--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -34,8 +34,7 @@ PageDef::PageDef(const char *f,int l,const char *n,
   m_subPageDict = new PageSDict(7);
   m_pageScope = 0;
   m_nestingLevel = 0;
-  static bool shortNames = Config_getBool(SHORT_NAMES);
-  m_fileName = shortNames ? convertNameToFile(n) : QCString(n);
+  m_fileName = ::convertNameToFile(n,FALSE,TRUE);
   m_showToc = FALSE;
 }
 


### PR DESCRIPTION
In case SHORT_NAMES was not selected the page bane was used as fileName in its bare for, this is a regression of "Bug 755080 - xrefitem link to list incorrect when using SHORT_NAMES (https://bugzilla.gnome.org/show_bug.cgi?id=755080 https://github.com/doxygen/doxygen/commit/af5c5b37c5464afb6a2df71edf6f9e82ece75187)
(We use ::convertNameToFile to get the routine from util.cpp and not from definition)