### PR TITLE
Bug 504305 - FILTER_PATTERNS won't take command with arguments

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2366,6 +2366,12 @@ QCString getFileFilter(const char* name,bool isSourceCode)
   }
   else
   {
+    /* remove surrounding double quotes */
+    if ((filterName.right(1) == "\"") && (filterName.left(1) == "\""))
+    {
+       filterName.remove(filterName.length() - 1, 1);
+       filterName.remove(0, 1);
+    }
     return filterName;
   }
 }


### PR DESCRIPTION
INPUT_FILTER is a string so multiple values are read till the end of the line and quotes are automatically removed.  FILTER_PATTERNS and FILTER_SOURCE_PATTERNS are list of strings so with multiple arguments for one extension quotes are mandatory, but they were not removed.