### PR TITLE
Add an additional option for EXTRACT_ALL

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -770,6 +770,18 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+  </group>
+  <group name='Build' docs='Build related configuration options'>
+    <option type='bool' id='EXTRACT_ALL_NO_DETAILED_IF_EMPTY' defval='0'>
+      <docs>
+<![CDATA[
+ When the \c EXTRACT_ALL tag is set to \c YES and a member or class
+ as no documentation, no detailed section will be produced if
+ the \c EXTRACT_ALL_NO_DETAILED_IF_EMPTY tag is set to \c YES.
+ This tag has no effect if the \c EXTRACT_ALL tag is set to \c NO.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='EXTRACT_PRIVATE' defval='0'>
       <docs>
 <![CDATA[

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1861,6 +1861,7 @@ void MemberDef::writeDeclaration(OutputList &ol,
 bool MemberDef::isDetailedSectionLinkable() const
 {
   static bool extractAll        = Config_getBool(EXTRACT_ALL);
+  static bool xAllNoDetailedSec = Config_getBool(EXTRACT_ALL_NO_DETAILED_IF_EMPTY);
   static bool alwaysDetailedSec = Config_getBool(ALWAYS_DETAILED_SEC);
   static bool repeatBrief       = Config_getBool(REPEAT_BRIEF);
   static bool briefMemberDesc   = Config_getBool(BRIEF_MEMBER_DESC);
@@ -1870,7 +1871,7 @@ bool MemberDef::isDetailedSectionLinkable() const
   // the member has details documentation for any of the following reasons
   bool docFilter =
          // treat everything as documented
-         extractAll ||
+         (extractAll && !xAllNoDetailedSec)||
          // has detailed docs
          !documentation().isEmpty() ||
          // has inbody docs


### PR DESCRIPTION
When EXTRACT_ALL is set to YES, the detailed description for all members is always generated, even if empty. This PR introduces a new tag (`EXTRACT_ALL_NO_DETAILED_IF_EMPTY`) that allows to control that behavior. The default is such that the former behavior is the same as before the introduction of this option.
