### PR TITLE
Bug 763104 - hyperref link label drop underscores

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6737,6 +6737,7 @@ QCString latexEscapePDFString(const char *s)
       case '\\': t << "\\textbackslash{}"; break;
       case '{':  t << "\\{"; break;
       case '}':  t << "\\}"; break;
+      case '_':  t << "\\_"; break;
       default:
         t << c;
         break;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6738,6 +6738,8 @@ QCString latexEscapePDFString(const char *s)
       case '{':  t << "\\{"; break;
       case '}':  t << "\\}"; break;
       case '_':  t << "\\_"; break;
+      case '%':  t << "\\%"; break;
+      case '&':  t << "\\&"; break;
       default:
         t << c;
         break;


### PR DESCRIPTION
underscores were not escaped in the content for "PDF summary/index in the left tab"