### PR TITLE
mangen.h: remove italic in brief member descriptions

### DIFF
--- a/src/mangen.h
+++ b/src/mangen.h
@@ -160,8 +160,8 @@ class ManGenerator : public OutputGenerator
     void endCenter()          {}
     void startSmall()         {}
     void endSmall()           {}
-    void startMemberDescription(const char *,const char *) { t << "\n.RI \"\\fI"; firstCol=FALSE; }
-    void endMemberDescription()   { t << "\\fP\""; firstCol=FALSE; }
+    void startMemberDescription(const char *,const char *) { t << "\n.RI \""; firstCol=FALSE; }
+    void endMemberDescription()   { t << "\""; firstCol=FALSE; }
     void startMemberDeclaration() {} 
     void endMemberDeclaration(const char *,const char *) {}
     void writeInheritedSectionTitle(const char *,const char *,const char *,


### PR DESCRIPTION
nroff does not support italic text and replaces it with underlined text which
looks weird on the brief description text.