### PR TITLE
Bug 763720 - Exclusion of a new line at the end of source code file causing nesting of HTML code for function documentation

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -878,7 +878,7 @@ bool readCodeFragment(const char *fileName,
     }
   }
   result = transcodeCharacterStringToUTF8(result);
-  if (result.right(1) != "\n") result += "\n";
+  if (!result.isEmpty() && result.at(result.length()-1)!='\n') result += "\n";
   //fprintf(stderr,"readCodeFragement(%d-%d)=%s\n",startLine,endLine,result.data());
   return found;
 }

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -878,6 +878,7 @@ bool readCodeFragment(const char *fileName,
     }
   }
   result = transcodeCharacterStringToUTF8(result);
+  if (result.right(1) != "\n") result += "\n";
   //fprintf(stderr,"readCodeFragement(%d-%d)=%s\n",startLine,endLine,result.data());
   return found;
 }


### PR DESCRIPTION
In case a code fragment does not end with a newline add it explicitly, otherwise following descriptive element might get into the same box.