### PR TITLE
Assertion failure generation documentation

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1722,7 +1722,7 @@ QCString removeRedundantWhiteSpace(const QCString &s)
   char c;
   char pc=0;
   // skip leading whitespace
-  while (i<l && isspace(src[i]))
+  while (i<l && isspace((uchar)src[i]))
   {
     i++;
   }


### PR DESCRIPTION
In case of windows 64 bit the generation of the doxygen documentation results in a pop up screen with (most relevant information):
Debug Assertion Failed
File: f:\dd\vctools\crt\crtw32\convert\istype.c
Line: 68
Expression c >= -1 && c <= 255

Problem is that a value is fed to isspace that is not in the correct range and has to be converted to this range.