### PR TITLE
Fix STRIP_FROM_PATH when running from drive root

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1155,24 +1155,27 @@ static void cleanUpPaths(QStrList &str)
       char c;
       while ((c=*p))
       {
-	if (c=='\\') *p='/';
-	p++;
+        if (c=='\\') *p='/';
+        p++;
       }
     }
     QCString path = sfp;
     if ((path.at(0)!='/' && (path.length()<=2 || path.at(1)!=':')) ||
-	path.at(path.length()-1)!='/'
+         path.at(path.length()-1)!='/'
        )
     {
       QFileInfo fi(path);
       if (fi.exists() && fi.isDir())
       {
-	int i = str.at();
-	str.remove();
-	if (str.at()==i) // did not remove last item
-	  str.insert(i,fi.absFilePath().utf8()+"/");
-	else
-	  str.append(fi.absFilePath().utf8()+"/");
+        int i = str.at();
+        QString p = fi.absFilePath();
+        if (p.at(p.length()-1)!='/')
+          p.append('/');
+        str.remove();
+        if (str.at()==i) // did not remove last item
+          str.insert(i,p.utf8());
+        else
+          str.append(p.utf8());
       }
     }
     sfp = str.next();
@@ -1281,7 +1284,10 @@ void Config::checkAndCorrect()
   char *sfp = stripFromPath.first();
   if (sfp==0) // by default use the current path
   {
-    stripFromPath.append(QDir::currentDirPath().utf8()+"/");
+    QString p = QDir::currentDirPath();
+    if (p.at(p.length()-1)!='/')
+        p.append('/');
+    stripFromPath.append(p.utf8());
   }
   else
   {


### PR DESCRIPTION
When running doxygen from the drive root, the STRIP_FROM_PATH,
variable could get an extra slash. As a result no paths were
stripped. This fix makes sure that a duplicate slash is not added
both for the automatic generation, and when you specify a relative
path that maps to the drive root in the configuration.

Also change some tabs to spaces