### PR TITLE
Bug 764656 - generated xml has errors

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -808,7 +808,7 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
   {
     QCString bitfield = md->bitfieldString();
     if (bitfield.at(0)==':') bitfield=bitfield.mid(1);
-    t << "        <bitfield>" << bitfield << "</bitfield>" << endl;
+    t << "        <bitfield>" << convertToXML(bitfield) << "</bitfield>" << endl;
   }
   
   MemberDef *rmd = md->reimplements();


### PR DESCRIPTION
Value of \<float\> in bitfield was not escaped when writing to XML