### PR TITLE
Bug 764515 - doxygen crashes no resolved

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1977,6 +1977,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					    current->section=Entry::USINGDECL_SEC;
 					  }
 					  current_root->addSubEntry(current);
+                                          previous = current;
 					  current = new Entry ;
 					  initEntry();
 					  BEGIN(Using);


### PR DESCRIPTION
Crash occurred in the rule: \<UsingAlias\>.   due to the fact that the previous variable was not set by the rule \<JavaImport\>({ID}{BN}*"."{BN}*)+{ID}