### PR TITLE
Table of contents breaks when documentation spans multiple comment blocks with same @page

### DIFF
--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -308,6 +308,6 @@ void PageDef::setNestingLevel(int l)
 
 void PageDef::setShowToc(bool b)
 {
-  m_showToc = b;
+  m_showToc |= b;
 }
 


### PR DESCRIPTION
Based on the question in the doxygen users forum:
http://doxygen.10944.n7.nabble.com/Table-of-contents-breaks-when-documentation-spans-multiple-comment-blocks-with-same-page-td7571.html

Fixed by means of that when toc is set once for a page it remains set for that page, otherwise the last page has to have the @tableofcontents command (or all @page commands)