### PR TITLE
Document support for nested Compiled HTML Help indices.

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -1872,7 +1872,16 @@ Commands to create links
 \section cmdaddindex \\addindex (text)
 
   \addindex \\addindex
-  This command adds (text) to the \LaTeX index.
+  This command adds (text) to the \LaTeX or Compiled HTML Help index.
+
+  Doxygen Compiled HTML Help output provides support for nested indices by
+  assigning special meaning to question marks in index entries: The portion
+  before the first question mark is interpreted as a 1st-level entry, while
+  any remainder is interpreted as a 2nd-level entry, with the separating
+  question mark being discarded. Only two-level indices are supported in this
+  manner. If any 1st-level entry would be comprised of only a single 2nd-level
+  entry, it is rendered as a single-level entry, with the 2nd-leve portion
+  stripped.
 
 <hr>
 \section cmdanchor \\anchor <word>

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -141,14 +141,14 @@ static QCString field2URL(const IndexField *f,bool checkReversed)
 
 /*! Writes the sorted list of index items into a html like list.
  *
- *  An list of calls with <code>name = level1,level2</code> as follows:
+ *  An list of calls with <code>name = level1?level2</code> as follows:
  *  <pre>
- *    a1,b1
- *    a1,b2
- *    a2,b1
- *    a2,b2
+ *    a1?b1
+ *    a1?b2
+ *    a2?b1
+ *    a2?b2
  *    a3
- *    a4,b1
+ *    a4?b1
  *  </pre>
  *
  *  Will result in the following list:
@@ -195,9 +195,9 @@ void HtmlHelpIndex::writeFields(FTextStream &t)
       // Added this code so that an item with only one subitem is written
       // without any subitem.
       // For example:
-      //   a1, b1 -> will create only a1, not separate subitem for b1
-      //   a2, b2
-      //   a2, b3
+      //   a1?b1 -> will create only a1, not separate subitem for b1
+      //   a2?b2
+      //   a2?b3
       QCString nextLevel1;
       IndexField* fnext = ++ifli;
       if (fnext)


### PR DESCRIPTION
I couldn't find any mention of this topic in the docs, so I turned to the source code, to find that nested indices are indeed implemented in Compiled HTML Help output, but poorly documented even in the source code.