### PR TITLE
Fix uppercase letters B-Z being unnecessarily escaped in index HTML anchors

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -50,7 +50,7 @@ static QCString convertIndexWordToAnchor(const QString &word)
     while ((c = *str++))
     {
       if ((c >= 'a' && c <= 'z') || // ALPHA
-          (c >= 'A' && c <= 'A') || // ALPHA
+          (c >= 'A' && c <= 'Z') || // ALPHA
           (c >= '0' && c <= '9') || // DIGIT
           c == '-' ||
           c == '.' ||


### PR DESCRIPTION
The escaping mechanism to generate anchor names from index words erroneously escaped uppercase letters 'B' to 'Z' due to a broken range test.