### PR TITLE
Fix Windows build instructions.

### DIFF
--- a/doc/install.doc
+++ b/doc/install.doc
@@ -183,7 +183,7 @@ cd into the \c doxygen-x.y.z directory, create and cd to a build directory
 \verbatim
 mkdir build
 cd build
-cmake -G "Visual Studio 12 2013"
+cmake -G "Visual Studio 12 2013" ..
 \endverbatim
 
 Note that compiling Doxywizard currently requires Qt version 4


### PR DESCRIPTION
When following the current instructions to build Doxygen for Windows, CMake will not be able to find CMakeLists.txt.