### PR TITLE
Bug 765001 - Bad character escaping scheme in HTML anchor generation.

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -134,17 +134,8 @@ static QCString field2URL(const IndexField *f,bool checkReversed)
   QCString result = f->url + Doxygen::htmlFileExtension;
   if (!f->anchor.isEmpty() && (!checkReversed || f->reversed)) 
   {
-    result+="#";
     // HTML Help needs colons in link anchors to be escaped in the .hhk file.
-    int prev = 0;
-    int next;
-    while ((next=f->anchor.find(':', prev))!=-1)
-    {
-      result+=f->anchor.mid(prev,next-prev);
-      result+="%3A";
-      prev=next+1;
-    }
-    result+=f->anchor.mid(prev);
+    result+="#"+substitute(f->anchor,":","%3A");
   }
   return result;
 }

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -134,7 +134,17 @@ static QCString field2URL(const IndexField *f,bool checkReversed)
   QCString result = f->url + Doxygen::htmlFileExtension;
   if (!f->anchor.isEmpty() && (!checkReversed || f->reversed)) 
   {
-    result+="#"+f->anchor;  
+    result+="#";
+    // HTML Help needs colons in link anchors to be escaped in the .hhk file.
+    int prev = 0;
+    int next;
+    while ((next=f->anchor.find(':', prev))!=-1)
+    {
+      result+=f->anchor.mid(prev,next-prev);
+      result+="%3A";
+      prev=next+1;
+    }
+    result+=f->anchor.mid(prev);
   }
   return result;
 }


### PR DESCRIPTION
HTML Help requires colons in anchor names to be escaped as `%3A` in the .hhk file. This fix achieves exactly that.

The same file is changed as in #473, so whatever pull request is applied second may be reported as conflicting. Changes are to different parts of the file though, so merging should be straightforward.