### PR TITLE
Bug 751984 - Use UTC timezone when displaying QDateTimes parsed from SOURCE_DATE_EPOCH

### DIFF
--- a/qtools/qdatetime.cpp
+++ b/qtools/qdatetime.cpp
@@ -1158,6 +1158,29 @@ void QDateTime::setTime_t( uint secsSince1Jan1970UTC )
 
 
 /*!
+  Sets the UTC date and time given the number of seconds that have passed
+  since 00:00:00 on January 1, 1970, Coordinated Universal Time (UTC).
+
+  Note that Microsoft Windows supports only a limited range of values for
+  \a secsSince1Jan1970UTC.
+*/
+
+void QDateTime::setTimeUtc_t( uint secsSince1Jan1970UTC )
+{
+    time_t tmp = (time_t) secsSince1Jan1970UTC;
+    tm *tM = gmtime( &tmp );
+    if ( !tM ) {
+	    d.jd = QDate::greg2jul( 1970, 1, 1 );
+	    t.ds = 0;
+	    return;
+    }
+    d.jd = QDate::greg2jul( tM->tm_year + 1900, tM->tm_mon + 1, tM->tm_mday );
+    t.ds = MSECS_PER_HOUR*tM->tm_hour + MSECS_PER_MIN*tM->tm_min +
+	    1000*tM->tm_sec;
+}
+
+
+/*!
   Returns the datetime as a string.
 
   The string format is "Sat May 20 03:40:13 1998".

--- a/qtools/qdatetime.h
+++ b/qtools/qdatetime.h
@@ -173,6 +173,7 @@ public:
     void   setDate( const QDate &date ) { d=date; }
     void   setTime( const QTime &time ) { t=time; }
     void   setTime_t( uint secsSince1Jan1970UTC );
+    void   setTimeUtc_t( uint secsSince1Jan1970UTC );
 
     QString toString()	const;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2582,7 +2582,7 @@ QCString dateToString(bool includeTime)
     }
     else // all ok, replace current time with epoch value
     {
-      current.setTime_t((ulong)epoch); // TODO: add support for 64bit epoch value
+      current.setTimeUtc_t((ulong)epoch); // TODO: add support for 64bit epoch value
     }
   }
   return theTranslator->trDateTime(current.date().year(),


### PR DESCRIPTION
According to the `SOURCE_DATE_EPOCH` spec [1], "Formatting MUST be deferred until runtime if an end user should observe the value in their own locale or timezone."

However `setTime_t` uses `localtime`, so the output is in the timezone of the build machine running doxygen, and not the timezone of the reader consuming the final output.

To adhere to the spec, the easiest option is to add a `setTimeUtc_t` function that is the same as `setTime_t`, but only uses `gmtime` instead of first trying `localtime`.

[1] https://reproducible-builds.org/specs/source-date-epoch/