### PR TITLE
Disable selecting line number

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -232,6 +232,15 @@ span.lineno a:hover {
 	background-color: #C8C8C8;
 }
 
+.lineno {
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
 div.ah, span.ah {
 	background-color: black;
 	font-weight: bold;


### PR DESCRIPTION
Make the line number not selected by user. 

The user case is when you want to copy the raw source code content, you would not want to automatically select the line number.