### PR TITLE
Bug 766787 - HTML Tables with 10+ columns are broken for LaTeX based output

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -908,7 +908,7 @@ static void writeStartTableCommand(FTextStream &t,const DocNode *n,int cols)
   }
   else
   {
-    t << "\\tabulinesep=1mm\n\\begin{longtabu} spread 0pt [c]{*" << cols << "{|X[-1]}|}\n";
+    t << "\\tabulinesep=1mm\n\\begin{longtabu} spread 0pt [c]{*{" << cols << "}{|X[-1]}|}\n";
   }
   //return isNested ? "TabularNC" : "TabularC";
 }


### PR DESCRIPTION
Added {} around number of columns (was present for tabularx but not for longtabu tables)