### PR TITLE
Bug 767171 - ALIASES stop working after verbatim with formula and /** */

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -465,7 +465,7 @@ void replaceComment(int offset);
                                      }
                                      BEGIN(VerbatimCode);
   				   }
-<CComment,ReadLine>[\\@]("f$"|"f["|"f{"[a-z]*) {
+<CComment,ReadLine>[\\@]("f$"|"f["|"f{") {
                                      copyToOutput(yytext,(int)yyleng); 
 				     g_blockName=&yytext[1];
 				     if (g_blockName.at(1)=='[')
@@ -488,9 +488,9 @@ void replaceComment(int offset);
 <Scan>.                            { /* any ather character */
                                      copyToOutput(yytext,(int)yyleng); 
                                    }
-<Verbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"docbookonly"|"endrtfonly"|"endmanonly"|"f$"|"f]"|"f}") { /* end of verbatim block */
+<Verbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"f$"|"f]"|"f}") { /* end of verbatim block */
                                      copyToOutput(yytext,(int)yyleng);
-				     if (yytext[1]=='f') // end of formula
+				     if (&yytext[1]==g_blockName) // end of formula
 				     {
 				       BEGIN(g_lastCommentContext);
 				     }


### PR DESCRIPTION
A formula should not end a "verbatim" type of block. A  "verbatim" type of block should only stop at the corresponding end command.
In case of a formula with an environment (i.e. f{) the name of the environment can be parsed separately.

Corrected end condition for docbookonly.