### PR TITLE
Modified (readability) layout for member title in HTML and LaTex

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1551,10 +1551,14 @@ void HtmlGenerator::endMemberDocList()
   DBG_HTML(t << "<!-- endMemberDocList -->" << endl;)
 }
 
-void HtmlGenerator::startMemberDoc(const char *,const char *,const char *,const char *,bool) 
-{ 
+void HtmlGenerator::startMemberDoc( const char *clName, const char *memName,
+                                    const char *anchor, const char *title, bool showInline)
+{
   DBG_HTML(t << "<!-- startMemberDoc -->" << endl;)
- 
+  t << "\n<h2 class=\"memtitle\">" << title << " "
+    << "<a href=\"#" << anchor << "\" class=\"permantlink\"" "title=\"Permalink to this headline\">&#9854;</a>"
+    << "</h2>"
+    << endl;
   t << "\n<div class=\"memitem\">" << endl;
   t << "<div class=\"memproto\">" << endl;
 }

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -225,7 +225,7 @@ class HtmlGenerator : public OutputGenerator
     void endDescForItem()   { t << "</dd>\n"; }
     void lineBreak(const char *style);
     void writeChar(char c);
-    void startMemberDoc(const char *,const char *,const char *,const char *,bool);
+    void startMemberDoc(const char *clName, const char *memName, const char *anchor, const char *title, bool showInline);
     void endMemberDoc(bool); 
     void startDoxyAnchor(const char *fName,const char *manName,
                          const char *anchor,const char *name,

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1562,7 +1562,7 @@ void LatexGenerator::startMemberDoc(const char *clname,
   if (compactLatex) level++;
   t << "\\" << levelLab[level]; 
 
-  t << "[{";
+  t << "{";
   if (pdfHyperlinks)
   {
     t << "\\texorpdfstring{";
@@ -1572,9 +1572,9 @@ void LatexGenerator::startMemberDoc(const char *clname,
   {
     t << "}{" << latexEscapePDFString(title) << "}";
   }
-  t << "}]";
-  t << "{\\setlength{\\rightskip}{0pt plus 5cm}";
-  disableLinks=TRUE;
+  t << "}";
+  t << "\n{\\ttfamily ";
+  //disableLinks=TRUE;
 }
 
 void LatexGenerator::endMemberDoc(bool)
@@ -1588,10 +1588,6 @@ void LatexGenerator::startDoxyAnchor(const char *fName,const char *,
                                      const char *anchor, const char *,
                                      const char *)
 {
-}
-
-void LatexGenerator::endDoxyAnchor(const char *fName,const char *anchor)
-{
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   static bool usePDFLatex   = Config_getBool(USE_PDFLATEX);
   if (usePDFLatex && pdfHyperlinks)
@@ -1604,7 +1600,11 @@ void LatexGenerator::endDoxyAnchor(const char *fName,const char *anchor)
   t << "\\label{";
   if (fName) t << stripPath(fName);
   if (anchor) t << "_" << anchor;
-  t << "}" << endl;
+  t << "} " << endl;
+}
+
+void LatexGenerator::endDoxyAnchor(const char *fName,const char *anchor)
+{
 }
 
 void LatexGenerator::writeAnchor(const char *fName,const char *name)

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -293,7 +293,7 @@ class LatexGenerator : public OutputGenerator
     void endTextBlock(bool) {}
 
     void startMemberDocPrefixItem() {}
-    void endMemberDocPrefixItem() {}
+    void endMemberDocPrefixItem() { t << "\\\\" << endl; }
     void startMemberDocName(bool) {}
     void endMemberDocName() {}
     void startParameterType(bool,const char *);

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2608,7 +2608,7 @@ void MemberDef::writeDocumentation(MemberList *ml,OutputList &ol,
   }
   else if (isFunction())
   {
-    title+=argsString();
+    title += "()";
   }
   int i=0,l;
   static QRegExp r("@[0-9]+");

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -510,6 +510,24 @@ table.memberdecls {
 
 /* Styles for detailed member documentation */
 
+.memtitle {
+    padding: 8px;
+    border-top: 1px solid #A8B8D9;
+    border-left: 1px solid #A8B8D9;
+    border-right: 1px solid #A8B8D9;
+    border-top-right-radius: 4px;
+    border-top-left-radius: 4px;
+    margin-bottom: -5px;
+    background-image: url('nav_f.png');
+    background-repeat: repeat-x;
+    background-color: #E2E8F2;
+    float:left;
+    /* display: inline-block; */
+}
+.permantlink
+{
+
+}
 .memtemplate {
 	font-size: 80%;
 	color: ##60;
@@ -564,9 +582,11 @@ table.memberdecls {
         color: ##2b;
         font-weight: bold;
         text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+        /*
         background-image:url('nav_f.png');
         background-repeat:repeat-x;
-        background-color: ##E6;
+        */
+        background-color: #DDE3F0;
         /* opera specific markup */
         box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
         border-top-right-radius: 4px;

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -307,7 +307,7 @@
 
 % Used for parameters within a detailed function description
 \newenvironment{DoxyParamCaption}{%
-  \renewcommand{\item}[2][]{##1 {\em ##2}}%
+  \renewcommand{\item}[2][]{\\ \hspace*{2.0cm} ##1 {\em ##2}}% 
 }{%
 }
 


### PR DESCRIPTION
Output from Doxygen is great but visual impact for members heading is a bit complex in special case if member has a lot of params and returns complex/template type.

In order to improve overall readability for HTML and LaTeX/PDF, in this pull request:
 - we use shortest member name in member title heading
 - we have moved full member definition just below the heading
 - we have adapted HTML and LaTeX templates

Changes should not have any effects on RTF and Man generators

Below some screen shoot 

![html](https://cloud.githubusercontent.com/assets/15944968/16260697/d0b4ac22-3868-11e6-9cfe-fa284cb0ee66.png)

![pdf](https://cloud.githubusercontent.com/assets/15944968/16260705/d7ec44dc-3868-11e6-9027-242c55c65a97.png)
