### PR TITLE
Revert #291 since it is wrong solution

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -43,7 +43,7 @@ QCString writePlantUMLSource(const QCString &outDir,const QCString &fileName,con
   {
     err("Could not open file %s for writing\n",baseName.data());
   }
-  QCString text = "@startuml";
+  QCString text = "@startuml\n";
   text+=content;
   text+="@enduml\n";
   file.writeBlock( text, text.length() );


### PR DESCRIPTION
Friend of mine, @EVGVir, noticed strange behavior in doxygen with PlantUML. Turns out that it cannot work with new line after `@startuml`  with sub-tool which is strange.

#291 Supposed to fix the issue with PlantUML generation, but it is actually supposed to work as it was according to PlantUML website
See http://plantuml.com/salt.html for example HOW it supposed to work

First simple example:
```
@startuml
salt
{
  Just plain text
  [This is my button]
  ()  Unchecked radio
  (X) Checked radio
  []  Unchecked box
  [X] Checked box
  "Enter text here   "
  ^This is a droplist^
}
@enduml
```

@byzheng ping also