### PR TITLE
Add support to more fields in Perlmod

### DIFF
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -653,8 +653,8 @@ void PerlModDocVisitor::visit(DocVerbatim *s)
       m_output.add("<programlisting>");
       parseCode(m_ci,s->context(),s->text(),FALSE,0);
       m_output.add("</programlisting>");
-#endif
       return;
+#endif
     case DocVerbatim::Verbatim:  type = "preformatted"; break;
     case DocVerbatim::HtmlOnly:  type = "htmlonly";     break;
     case DocVerbatim::RtfOnly:   type = "rtfonly";      break;

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1269,17 +1269,43 @@ void PerlModDocVisitor::visitPre(DocParamList *pl)
   DocNode *param;
   for (li.toFirst();(param=li.current());++li)
   {
-    QCString s;
+    QCString name;
     if (param->kind()==DocNode::Kind_Word)
     {
-      s = ((DocWord*)param)->word(); 
+      name = ((DocWord*)param)->word();
     }
     else if (param->kind()==DocNode::Kind_LinkedWord)
     {
-      s = ((DocLinkedWord*)param)->word(); 
+      name = ((DocLinkedWord*)param)->word();
     }
+
+    QCString dir = "";
+    DocParamSect *sect = 0;
+    if (pl->parent()->kind()==DocNode::Kind_ParamSect)
+    {
+      sect=(DocParamSect*)pl->parent();
+    }
+    if (sect && sect->hasInOutSpecifier())
+    {
+      if (pl->direction()!=DocParamSect::Unspecified)
+      {
+        if (pl->direction()==DocParamSect::In)
+        {
+          dir = "in";
+        }
+        else if (pl->direction()==DocParamSect::Out)
+        {
+          dir = "out";
+        }
+        else if (pl->direction()==DocParamSect::InOut)
+        {
+          dir = "in,out";
+        }
+      }
+    }
+
     m_output.openHash()
-      .addFieldQuotedString("name", s)
+      .addFieldQuotedString("name", name).addFieldQuotedString("dir", dir)
       .closeHash();
   }
   m_output.closeList()

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -905,6 +905,7 @@ void PerlModDocVisitor::visitPre(DocSection *s)
 {
   QCString sect = QCString().sprintf("sect%d",s->level());
   openItem(sect);
+  m_output.addFieldQuotedString("title", s->title());
   openSubBlock("content");
 }
 

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -667,6 +667,14 @@ void PerlModDocVisitor::visit(DocVerbatim *s)
     case DocVerbatim::PlantUML:  type = "plantuml";     break;
   }
   openItem(type);
+  if (s->hasCaption())
+  {
+     openSubBlock("caption");
+     QListIterator<DocNode> cli(s->children());
+     DocNode *n;
+     for (cli.toFirst();(n=cli.current());++cli) n->accept(this);
+     closeSubBlock();
+  }
   m_output.addFieldQuotedString("content", s->text());
   closeItem();
 }


### PR DESCRIPTION
This pull request adds missing fields to the perlmod generator.

The following fields are added:

* Captions to verbatim blocks
* Allow verbatim block for code to be place on the output.
* Add title to sections
* Add parameter's in/out specification 