### PR TITLE
Fix SHOW_NAMESPACES=NO to correctly hide all namespaces

### DIFF
--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -1114,9 +1114,10 @@ bool NamespaceDef::isLinkableInProject() const
   int i = name().findRev("::");
   if (i==-1) i=0; else i+=2;
   static bool extractAnonNs = Config_getBool(EXTRACT_ANON_NSPACES);
+  static bool showNamespaces = Config_getBool(SHOW_NAMESPACES);
   if (extractAnonNs &&                             // extract anonymous ns
-      name().mid(i,20)=="anonymous_namespace{"     // correct prefix
-     )                                             // not disabled by config
+      name().mid(i,20)=="anonymous_namespace{" &&  // correct prefix
+      showNamespaces)                              // not disabled by config
   {
     return TRUE;
   }
@@ -1124,7 +1125,8 @@ bool NamespaceDef::isLinkableInProject() const
     (hasDocumentation() || getLanguage()==SrcLangExt_CSharp) &&  // documented
     !isReference() &&      // not an external reference
     !isHidden() &&         // not hidden
-    !isArtificial();       // or artificial
+    !isArtificial() &&     // or artificial
+    showNamespaces;        // not disabled by config
 }
 
 bool NamespaceDef::isLinkable() const


### PR DESCRIPTION
This change will exclude the generated namespace documentation from the resulting outputfiles.

Currently, even if this option is enabled the namespace documentation is included.
The generation of namespace indices is inhibited which also leads to an error when generating a LaTeX documentation (namespaces.tex not found), except when the indices are hidden (`LATEX_HIDE_INDICES=YES`).

This also fixes [Bug 728649](https://bugzilla.gnome.org/show_bug.cgi?id=728649).

The implementation is similar to [`FileDef::isLinkableInProject()`](https://github.com/doxygen/doxygen/blob/77c505b0445c74d1933edceb9a4d2f5fa972d581/src/filedef.cpp#L1888).
A minimal working example can be found in this [Gist](https://gist.github.com/tsparber/215e0829a155bc2174e3c1cabf9e2ed0).
