### PR TITLE
Fixes for handling of PUBLIC/PRIVATE in Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -264,7 +264,7 @@ ATTR_SPEC (EXTERNAL|ALLOCATABLE|DIMENSION{ARGS}|{INTENT_SPEC}|INTRINSIC|OPTIONAL
 ACCESS_SPEC (PRIVATE|PUBLIC)
 LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
 /* Assume that attribute statements are almost the same as attributes. */
-ATTR_STMT {ATTR_SPEC}|DIMENSION|{ACCESS_SPEC}
+ATTR_STMT {ATTR_SPEC}|DIMENSION
 EXTERNAL_STMT (EXTERNAL)
 
 CONTAINS  CONTAINS
@@ -563,10 +563,12 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
   /*------- access specification --------------------------------------------------------------------------*/
 
-<ModuleBody>private/{BS}(\n|"!")         { defaultProtection = Private;
+<ModuleBody,TypedefBody,TypedefBodyContains>private/{BS}(\n|"!") {
+                                           defaultProtection = Private;
                                            current->protection = defaultProtection ;
                                          }
-<ModuleBody>public/{BS}(\n|"!")          { defaultProtection = Public;
+<ModuleBody,TypedefBody,TypedefBodyContains>public/{BS}(\n|"!")  {
+                                           defaultProtection = Public;
                                            current->protection = defaultProtection ;
                                          }
 
@@ -580,8 +582,8 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                           }
 
                                           yy_push_state(Typedef);
-                                          current->protection = defaultProtection;
-                                          typeProtection = defaultProtection;
+                                          current->protection = Package; // invalid in Fortran, replaced below
+                                          typeProtection = Public;
                                           typeMode = true;
                                         }
 <Typedef>{
@@ -598,11 +600,9 @@ extends{ARGS}                           {
                                         }
 public                                  {
                                           current->protection = Public;
-                                          typeProtection = Public;
                                         }
 private                                 {
                                           current->protection = Private;
-                                          typeProtection = Private;
                                         }
 {LANGUAGE_BIND_SPEC}                    {
                                           /* ignored for now */
@@ -621,6 +621,20 @@ private                                 {
                                                || current_root->section == Entry::NAMESPACE_SEC))
                                           {
                                             current->name = current_root->name + "::" + current->name;
+                                          }
+
+                                          // set modifiers to allow adjusting public/private in surrounding module scope
+                                          if( current->protection == Package )
+                                          {
+                                            current->protection = defaultProtection;
+                                          }
+                                          else if( current->protection == Public )
+                                          {
+                                            modifiers[current_root][current->name.lower()] |= QCString("public");
+                                          }
+                                          else if( current->protection == Private )
+                                          {
+                                            modifiers[current_root][current->name.lower()] |= QCString("private");
                                           }
 
                                           addCurrentEntry(1);
@@ -803,9 +817,24 @@ private                                 {
                                           //cout << "5=========> got variable: " << argType << "::" << yytext << endl;
  					  /* work around for bug in QCString.replace (QCString works) */
 					  QCString name=yytext;
-                                          name = name.lower();
+            name = name.lower();
+            /* if variable/type/etc is part of a module, mod name is necessary for output */
+            // get surrounding state
+            int currentState = YY_START;
+            yy_pop_state();
+            int outerState = YY_START;
+            yy_push_state(currentState);
+            if( outerState == Start || outerState == ModuleBody )
+            {
+              if ((current_root) && 
+                  (current_root->section == Entry::CLASS_SEC
+                   || current_root->section == Entry::NAMESPACE_SEC))
+              {
+                name = current_root->name + "::" + name;
+              }
+            }
 					  /* remember attributes for the symbol */
-					  modifiers[current_root][name.lower()] |= currentModifiers;
+					  modifiers[current_root][name] |= currentModifiers;
 					  argName= name;
 
 					  v_type= V_IGNORE;
@@ -2052,7 +2081,7 @@ static bool endScope(Entry *scope, bool isGlobalRoot)
     Entry *ce;
     for (;(ce=eli.current());++eli) 
     {
-      if (ce->section != Entry::VARIABLE_SEC && ce->section != Entry::FUNCTION_SEC)
+      if (ce->section != Entry::VARIABLE_SEC && ce->section != Entry::FUNCTION_SEC && ce->section != Entry::CLASS_SEC )
         continue;
 
       //cout<<ce->name<<", "<<mdfsMap.contains(ce->name.lower())<<mdfsMap.count()<<endl;

--- a/testing/066/structmymodule_1_1t1.xml
+++ b/testing/066/structmymodule_1_1t1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="structmymodule_1_1t1" kind="type" language="Fortran" prot="public">
+    <compoundname>mymodule::t1</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="structmymodule_1_1t1_1a40dabbcb827e13ffbb38bb7e9e5957cc" prot="public" static="no" mutable="no">
+        <type>integer</type>
+        <definition>integer mymodule::t1::publicvariable</definition>
+        <argsstring/>
+        <name>publicvariable</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="066_public_type.F90" line="14" column="1" bodyfile="066_public_type.F90" bodystart="14" bodyend="14"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="066_public_type.F90" line="13" column="1" bodyfile="066_public_type.F90" bodystart="13" bodyend="15"/>
+    <listofallmembers>
+      <member refid="structmymodule_1_1t1_1a40dabbcb827e13ffbb38bb7e9e5957cc" prot="public" virt="non-virtual">
+        <scope>mymodule::t1</scope>
+        <name>publicvariable</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/066/structmymodule_1_1t2.xml
+++ b/testing/066/structmymodule_1_1t2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="structmymodule_1_1t2" kind="type" language="Fortran" prot="public">
+    <compoundname>mymodule::t2</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="structmymodule_1_1t2_1af907af6c7950c587a50eadd26987799a" prot="public" static="no" mutable="no">
+        <type>integer</type>
+        <definition>integer mymodule::t2::publicvariable</definition>
+        <argsstring/>
+        <name>publicvariable</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="066_public_type.F90" line="20" column="1" bodyfile="066_public_type.F90" bodystart="20" bodyend="20"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="066_public_type.F90" line="19" column="1" bodyfile="066_public_type.F90" bodystart="19" bodyend="22"/>
+    <listofallmembers>
+      <member refid="structmymodule_1_1t2_1af907af6c7950c587a50eadd26987799a" prot="public" virt="non-virtual">
+        <scope>mymodule::t2</scope>
+        <name>publicvariable</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/066/structmymodule_1_1t3.xml
+++ b/testing/066/structmymodule_1_1t3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="structmymodule_1_1t3" kind="type" language="Fortran" prot="public">
+    <compoundname>mymodule::t3</compoundname>
+    <sectiondef kind="private-attrib">
+      <memberdef kind="variable" id="structmymodule_1_1t3_1a8c70e7ad082657d4ddd9967c11ea5c68" prot="private" static="no" mutable="no">
+        <type>integer</type>
+        <definition>integer mymodule::t3::privatevariable</definition>
+        <argsstring/>
+        <name>privatevariable</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="066_public_type.F90" line="26" column="1" bodyfile="066_public_type.F90" bodystart="26" bodyend="26"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="066_public_type.F90" line="24" column="1" bodyfile="066_public_type.F90" bodystart="24" bodyend="27"/>
+    <listofallmembers>
+      <member refid="structmymodule_1_1t3_1a8c70e7ad082657d4ddd9967c11ea5c68" prot="private" virt="non-virtual">
+        <scope>mymodule::t3</scope>
+        <name>privatevariable</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/066_public_type.F90
+++ b/testing/066_public_type.F90
@@ -1,0 +1,29 @@
+!// objective: test visibility of types in modules
+!// check: structmymodule_1_1t1.xml
+!// check: structmymodule_1_1t2.xml
+!// check: structmymodule_1_1t3.xml
+!// config: OPTIMIZE_FOR_FORTRAN=YES
+
+module myModule
+  implicit none
+  private
+
+  public :: T3
+
+  type T1
+    integer :: publicVariable
+  end type T1
+
+  public :: T1
+
+  type, public :: T2
+    integer :: publicVariable
+  contains
+  end type
+
+  type T3
+    private
+    integer :: privateVariable
+  end type
+
+end module myModule


### PR DESCRIPTION
Before, access statements `public :: myType` in modules were ignored as
well as public/private access specifications in type definitions.

Also added a test case for this which assures the correct behavior for
some cases...