### PR TITLE
Include command show lines numbers (e.g. LaTeX)

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -431,7 +431,14 @@ void LatexDocVisitor::visit(DocInclude *inc)
                                            inc->text(),
                                            langExt,
                                            inc->isExample(),
-                                           inc->exampleFile(), &fd);
+                                           inc->exampleFile(),
+                                           &fd,   // fileDef,
+                                           -1,    // start line
+                                           -1,    // end line
+                                           FALSE, // inline fragment
+                                           0,     // memberDef
+                                           TRUE   // show line numbers
+					  );
          m_t << "\\end{DoxyCodeInclude}" << endl;
       }
       break;    
@@ -440,7 +447,14 @@ void LatexDocVisitor::visit(DocInclude *inc)
       Doxygen::parserManager->getParser(inc->extension())
                             ->parseCode(m_ci,inc->context(),
                                         inc->text(),langExt,inc->isExample(),
-                                        inc->exampleFile());
+                                        inc->exampleFile(),
+                                        0,     // fileDef
+                                        -1,    // startLine
+                                        -1,    // endLine
+                                        TRUE,  // inlineFragment
+                                        0,     // memberDef
+                                        FALSE
+			  		);
       m_t << "\\end{DoxyCodeInclude}\n";
       break;
     case DocInclude::DontInclude: 

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -237,7 +237,14 @@ void ManDocVisitor::visit(DocInclude *inc)
                                            inc->text(),
                                            langExt,
                                            inc->isExample(),
-                                           inc->exampleFile(), &fd);
+                                           inc->exampleFile(),
+                                           &fd,   // fileDef,
+                                           -1,    // start line
+                                           -1,    // end line
+                                           FALSE, // inline fragment
+                                           0,     // memberDef
+                                           TRUE
+					   );
          if (!m_firstCol) m_t << endl;
          m_t << ".fi" << endl;
          m_t << ".PP" << endl;
@@ -253,7 +260,14 @@ void ManDocVisitor::visit(DocInclude *inc)
                                         inc->text(),
                                         langExt,
                                         inc->isExample(),
-                                        inc->exampleFile());
+                                        inc->exampleFile(),
+                                        0,     // fileDef
+                                        -1,    // startLine
+                                        -1,    // endLine
+                                        TRUE,  // inlineFragment
+                                        0,     // memberDef
+                                        FALSE
+				       );
       if (!m_firstCol) m_t << endl;
       m_t << ".fi" << endl;
       m_t << ".PP" << endl;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -386,7 +386,14 @@ void RTFDocVisitor::visit(DocInclude *inc)
                                            inc->text(),
                                            langExt,
                                            inc->isExample(),
-                                           inc->exampleFile(), &fd);
+                                           inc->exampleFile(),
+                                           &fd,   // fileDef,
+                                           -1,    // start line
+                                           -1,    // end line
+                                           FALSE, // inline fragment
+                                           0,     // memberDef
+                                           TRUE   // show line numbers
+					   );
          m_t << "\\par";
          m_t << "}" << endl;
       }
@@ -398,7 +405,14 @@ void RTFDocVisitor::visit(DocInclude *inc)
       Doxygen::parserManager->getParser(inc->extension())
                             ->parseCode(m_ci,inc->context(),
                                         inc->text(),langExt,inc->isExample(),
-                                        inc->exampleFile());
+                                        inc->exampleFile(),
+                                        0,     // fileDef
+                                        -1,    // startLine
+                                        -1,    // endLine
+                                        TRUE,  // inlineFragment
+                                        0,     // memberDef
+                                        FALSE  // show line numbers
+				       );
       m_t << "\\par";
       m_t << "}" << endl;
       break;

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -272,7 +272,14 @@ void XmlDocVisitor::visit(DocInclude *inc)
                                            inc->text(),
                                            langExt,
                                            inc->isExample(),
-                                           inc->exampleFile(), &fd);
+                                           inc->exampleFile(),
+                                           &fd,   // fileDef,
+                                           -1,    // start line
+                                           -1,    // end line
+                                           FALSE, // inline fragment
+                                           0,     // memberDef
+                                           TRUE   // show line numbers
+					   );
          m_t << "</programlisting>"; 
       }
       break;    
@@ -283,7 +290,14 @@ void XmlDocVisitor::visit(DocInclude *inc)
                                         inc->text(),
                                         langExt,
                                         inc->isExample(),
-                                        inc->exampleFile());
+                                        inc->exampleFile(),
+                                        0,     // fileDef
+                                        -1,    // startLine
+                                        -1,    // endLine
+                                        TRUE,  // inlineFragment
+                                        0,     // memberDef
+                                        FALSE  // show line numbers
+				       );
       m_t << "</programlisting>"; 
       break;
     case DocInclude::DontInclude: 


### PR DESCRIPTION
Based on the report of Luis Vega (http://doxygen.10944.n7.nabble.com/include-inserts-line-numbers-for-LaTeX-PDF-output-td7683.html)
The default setting for parseCode calls was not consistent between the different output formats, resulting in wrong settings of default options (e.g. show line numbers).