### PR TITLE
Determination of end of parameter list

### DIFF
--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1142,6 +1142,10 @@ TARGET           ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBUT
                                          codify(yytext);
                                     }
 
+    "\n"                            {
+				         codifyLines(yytext);
+                                    }
+
     ":"                             {
 				      codify(yytext);
 


### PR DESCRIPTION
The determination of a parameter list should not stop at a newline character.