### PR TITLE
Warnings from CLANG compiler

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -359,6 +359,11 @@ void DocbookDocVisitor::visit(DocInclude *inc)
             );
       m_t << "</computeroutput></literallayout>";
       break;
+    case DocInclude::SnippetDoc: 
+    case DocInclude::IncludeDoc: 
+      err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+          "Please create a bug report\n",__FILE__);
+      break;
   }
 }
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1941,6 +1941,11 @@ void DocInclude::parse()
             m_blockId.data(),m_file.data(),count);
       }
       break;
+    case DocInclude::SnippetDoc: 
+    case DocInclude::IncludeDoc: 
+      err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+          "Please create a bug report\n",__FILE__);
+      break;
   }
 }
 

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -585,6 +585,11 @@ void HtmlDocVisitor::visit(DocInclude *inc)
          forceStartParagraph(inc);
       }
       break;
+    case DocInclude::SnippetDoc: 
+    case DocInclude::IncludeDoc: 
+      err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+          "Please create a bug report\n",__FILE__);
+      break;
   }
 }
 

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -483,6 +483,11 @@ void LatexDocVisitor::visit(DocInclude *inc)
          m_t << "\\end{DoxyCodeInclude}" << endl;
       }
       break;
+    case DocInclude::SnippetDoc: 
+    case DocInclude::IncludeDoc: 
+      err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+          "Please create a bug report\n",__FILE__);
+      break;
   }
 }
 

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -306,6 +306,11 @@ void ManDocVisitor::visit(DocInclude *inc)
       m_t << ".PP" << endl;
       m_firstCol=TRUE;
       break;
+    case DocInclude::SnippetDoc: 
+    case DocInclude::IncludeDoc: 
+      err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+          "Please create a bug report\n",__FILE__);
+      break;
   }
 }
 

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -716,6 +716,11 @@ void PerlModDocVisitor::visit(DocInclude *inc)
   case DocInclude::LatexInclude: type = "latexonly"; break;
   case DocInclude::VerbInclude:	type = "preformatted"; break;
   case DocInclude::Snippet: return;
+  case DocInclude::SnippetDoc: 
+  case DocInclude::IncludeDoc: 
+    err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+        "Please create a bug report\n",__FILE__);
+    break;
   }
   openItem(type);
   m_output.addFieldQuotedString("content", inc->text());

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -22,6 +22,7 @@
 #include <qglobal.h>
 #include "docvisitor.h"
 #include "htmlentity.h"
+#include "message.h"
 
 /*! Concrete visitor implementation for pretty printing */
 class PrintDocVisitor : public DocVisitor
@@ -170,6 +171,11 @@ class PrintDocVisitor : public DocVisitor
         case DocInclude::LatexInclude: printf("latexinclude"); break;
         case DocInclude::VerbInclude: printf("verbinclude"); break;
         case DocInclude::Snippet: printf("snippet"); break;
+        case DocInclude::SnippetDoc: 
+        case DocInclude::IncludeDoc: 
+          err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+              "Please create a bug report\n",__FILE__);
+          break;
       }
       printf("\"/>");
     }

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -444,6 +444,11 @@ void RTFDocVisitor::visit(DocInclude *inc)
                                        );
       m_t << "}";
       break;
+    case DocInclude::SnippetDoc: 
+    case DocInclude::IncludeDoc: 
+      err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+          "Please create a bug report\n",__FILE__);
+      break;
   }
   m_lastIsPara=TRUE;
 }

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -329,6 +329,11 @@ void XmlDocVisitor::visit(DocInclude *inc)
                                        );
       m_t << "</programlisting>"; 
       break;
+    case DocInclude::SnippetDoc: 
+    case DocInclude::IncludeDoc: 
+      err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"
+          "Please create a bug report\n",__FILE__);
+      break;
   }
 }
 


### PR DESCRIPTION
The CLANG compiler gave some warnings after pull request #503 ("Introducing commands includedoc and snippetdoc ") at places that are not / should not be reachable.