### PR TITLE
make compound.xsd deterministic again

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -374,6 +374,13 @@
  
   <xsd:group name="docTitleCmdGroup">
     <xsd:choice>
+      <xsd:group ref="docTitleCmdGroupWithoutImage"/>
+      <xsd:element name="image" type="docEmptyType" />
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:group name="docTitleCmdGroupWithoutImage">
+    <xsd:choice>
       <xsd:element name="ulink" type="docURLLink" />
       <xsd:element name="bold" type="docMarkupType" />
       <xsd:element name="emphasis" type="docMarkupType" />
@@ -402,7 +409,7 @@
 
   <xsd:group name="docCmdGroup">
     <xsd:choice>
-      <xsd:group ref="docTitleCmdGroup"/>
+      <xsd:group ref="docTitleCmdGroupWithoutImage"/>
       <xsd:element name="linebreak" type="docEmptyType" />
       <xsd:element name="hruler" type="docEmptyType" />
       <xsd:element name="preformatted" type="docMarkupType" />


### PR DESCRIPTION
Some validating XML parsers (e.g. the Qt5 one) complain about
ambiguity and duplicate elements in the compound.xsd.

For example:

    Error XSDError in file:xml/compound.xsd, at line 781, column 20:
      Complex type docCaptionType has non-deterministic content.
    Exception: XSD xml/compound.xsd is invalid

And after this is fixed:

    Error XSDError in file:xml/compound.xsd, at line 683, column 20:
      Complex type docParaType has duplicated element image in
      its content model.
    Exception: XSD xml/compound.xsd is invalid

The first is due to those elements being generated from a table where the
`bareName` is not unique. Resulting in a choice element of `docTitleCmdGroup`
containing the element `trademark` twice. This change filters
out the duplicates.

The second is due to the choice element of `docCmdGroup` referencing
`docTitleCmdGroup` - which defines element `image` - while also locally
defining the `image` element. This change remove the redundant local
definition.

I noticed this while using [doxy2man](https://github.com/gsauthof/doxy2man) which validates the xml generated by doxygen, by default.