### PR TITLE
Bug 766059 - DOT_PATH not expanded

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9987,6 +9987,8 @@ void initDoxygen()
   setlocale(LC_CTYPE,"C"); // to get isspace(0xA0)==0, needed for UTF-8
   setlocale(LC_NUMERIC,"C");
 
+  portable_correct_path();
+
   Doxygen::runningTime.start();
   initPreprocessor();
 
@@ -10067,7 +10069,6 @@ void initDoxygen()
   g_compoundKeywordDict.insert("union",(void *)8);
   g_compoundKeywordDict.insert("interface",(void *)8);
   g_compoundKeywordDict.insert("exception",(void *)8);
-
 }
 
 void cleanUpDoxygen()

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -448,4 +448,26 @@ bool portable_isAbsolutePath(const char *fileName)
   return false;
 }
 
-
+/**
+ * Correct a possible wrong PATH variable
+ *
+ * This routine was inspired by the cause for bug 766059 was that in the Windows path there were forward slahes.
+ */
+void portable_correct_path(void)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  const char *p = portable_getenv("PATH");
+  char *q = (char *)malloc(strlen(p) + 1);
+  strcpy(q, p);
+  bool found = false;
+  for (int i = 0 ; i < strlen(q); i++)
+  {
+    if (q[i] == '/')
+    {
+      q[i] = '\\';
+      found = true;
+    }
+  }
+  if (found) portable_setenv("PATH",q);
+#endif
+}

--- a/src/portable.h
+++ b/src/portable.h
@@ -35,6 +35,7 @@ void           portable_sysTimerStop();
 double         portable_getSysElapsedTime();
 void           portable_sleep(int ms);
 bool           portable_isAbsolutePath(const char *fileName);
+void           portable_correct_path(void);
 
 extern "C" {
   void *         portable_iconv_open(const char* tocode, const char* fromcode);


### PR DESCRIPTION
The original problem in this bug request was that forward slashes were used in the PATH instead of backslashes.
In the command shell this does not result in problems, but when calling a program from within doxygen this leads to the problem that the executable cannot be found.
In this patch the PATH variable is, just for the process, changed in such a way that ther are back slashes instead of forward slashes (Windows only, not on Cygwin).