### PR TITLE
Bug 770660 - Code snippet always shows line numbers from 1

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -179,6 +179,7 @@ documentation:
 \refitem cmdskipline \\skipline
 \refitem cmdsnippet \\snippet
 \refitem cmdsnippetdoc \\snippetdoc
+\refitem cmdsnippetlineno \\snippetlineno
 \refitem cmdstartuml \\startuml
 \refitem cmdstruct \\struct
 \refitem cmdsubpage \\subpage
@@ -2183,7 +2184,7 @@ Commands for displaying examples
   This command works the same way as \ref cmdinclude "\\include", but will add line
   numbers to the included file.
 
-  \sa section \ref cmdinclude "\\include".
+  \sa sections \ref cmdinclude "\\include" and \ref cmdsnippetlineno "\\snippetlineno".
 
 <hr>
 \section cmdincludedoc \\includedoc <file-name>
@@ -2303,7 +2304,16 @@ Commands for displaying examples
  see section \ref cmddontinclude "\\dontinclude" for an alternative way
  to include fragments of a source file that does not require markers.
 
- \sa section \ref cmdsnippetdoc "\\snippetdoc".
+ \sa section \ref cmdsnippetdoc "\\snippetdoc" and \ref cmdsnippetlineno "\\snippetlineno".
+<hr>
+\section cmdsnippetlineno \\snippetlineno <file-name> ( block_id )
+
+  \addindex \\snippetlineno
+  This command works the same way as \ref cmdsnippet "\\snippet", but will add line
+  numbers to the included snippet.
+
+  \sa sections \ref cmdsnippet "\\snippet" and \ref cmdincludelineno "\\includelineno".
+
 <hr>
 \section cmdsnippetdoc \\snippetdoc <file-name> ( block_id )
 
@@ -3212,9 +3222,8 @@ class Receiver
   \c \\verbatim command or the parser will get confused!
 
   \sa sections \ref cmdcode "\\code",
-               \ref cmdendverbatim "\\endverbatim",
-               \ref cmdverbinclude "\\verbinclude", and
-               \ref cmdverbincludedooc "\\verbincludedooc".
+               \ref cmdendverbatim "\\endverbatim" and
+               \ref cmdverbinclude "\\verbinclude".
 
 <hr>
 \section cmdxmlonly \\xmlonly

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -179,7 +179,6 @@ documentation:
 \refitem cmdskipline \\skipline
 \refitem cmdsnippet \\snippet
 \refitem cmdsnippetdoc \\snippetdoc
-\refitem cmdsnippetlineno \\snippetlineno
 \refitem cmdstartuml \\startuml
 \refitem cmdstruct \\struct
 \refitem cmdsubpage \\subpage
@@ -2184,7 +2183,7 @@ Commands for displaying examples
   This command works the same way as \ref cmdinclude "\\include", but will add line
   numbers to the included file.
 
-  \sa sections \ref cmdinclude "\\include" and \ref cmdsnippetlineno "\\snippetlineno".
+  \sa section \ref cmdinclude "\\include".
 
 <hr>
 \section cmdincludedoc \\includedoc <file-name>
@@ -2304,16 +2303,7 @@ Commands for displaying examples
  see section \ref cmddontinclude "\\dontinclude" for an alternative way
  to include fragments of a source file that does not require markers.
 
- \sa section \ref cmdsnippetdoc "\\snippetdoc" and \ref cmdsnippetlineno "\\snippetlineno".
-<hr>
-\section cmdsnippetlineno \\snippetlineno <file-name> ( block_id )
-
-  \addindex \\snippetlineno
-  This command works the same way as \ref cmdsnippet "\\snippet", but will add line
-  numbers to the included snippet.
-
-  \sa sections \ref cmdsnippet "\\snippet" and \ref cmdincludelineno "\\includelineno".
-
+ \sa section \ref cmdsnippetdoc "\\snippetdoc".
 <hr>
 \section cmdsnippetdoc \\snippetdoc <file-name> ( block_id )
 
@@ -3222,8 +3212,9 @@ class Receiver
   \c \\verbatim command or the parser will get confused!
 
   \sa sections \ref cmdcode "\\code",
-               \ref cmdendverbatim "\\endverbatim" and
-               \ref cmdverbinclude "\\verbinclude".
+               \ref cmdendverbatim "\\endverbatim",
+               \ref cmdverbinclude "\\verbinclude", and
+               \ref cmdverbincludedooc "\\verbincludedooc".
 
 <hr>
 \section cmdxmlonly \\xmlonly

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -89,7 +89,6 @@ CommandMap cmdMap[] =
   { "section",       CMD_SECTION },
   { "snippet",       CMD_SNIPPET },
   { "snippetdoc",    CMD_SNIPPETDOC },
-  { "snippetlineno", CMD_SNIPWITHLINES },
   { "subpage",       CMD_SUBPAGE },
   { "subsection",    CMD_SUBSECTION },
   { "subsubsection", CMD_SUBSUBSECTION },

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -89,6 +89,7 @@ CommandMap cmdMap[] =
   { "section",       CMD_SECTION },
   { "snippet",       CMD_SNIPPET },
   { "snippetdoc",    CMD_SNIPPETDOC },
+  { "snippetlineno", CMD_SNIPWITHLINES },
   { "subpage",       CMD_SUBPAGE },
   { "subsection",    CMD_SUBSECTION },
   { "subsubsection", CMD_SUBSUBSECTION },

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -135,7 +135,8 @@ enum CommandType
   CMD_PLUS         = 105,
   CMD_MINUS        = 106,
   CMD_INCLUDEDOC   = 107,
-  CMD_SNIPPETDOC   = 108
+  CMD_SNIPPETDOC   = 108,
+  CMD_SNIPWITHLINES= 109
 };
 
 enum HtmlTagType

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -135,8 +135,7 @@ enum CommandType
   CMD_PLUS         = 105,
   CMD_MINUS        = 106,
   CMD_INCLUDEDOC   = 107,
-  CMD_SNIPPETDOC   = 108,
-  CMD_SNIPWITHLINES= 109
+  CMD_SNIPPETDOC   = 108
 };
 
 enum HtmlTagType

--- a/src/code.l
+++ b/src/code.l
@@ -3659,16 +3659,15 @@ void parseCCode(CodeOutputInterface &od,const char *className,const QCString &s,
   g_searchCtx = searchCtx;
   g_collectXRefs = collectXRefs;
   g_inFunctionTryBlock = FALSE;
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = countLines();
 
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
-
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = g_yyLineNr + countLines() - 1;
 
   g_curlyCount    = 0;
   g_bodyCurlyCount    = 0;

--- a/src/code.l
+++ b/src/code.l
@@ -3659,15 +3659,16 @@ void parseCCode(CodeOutputInterface &od,const char *className,const QCString &s,
   g_searchCtx = searchCtx;
   g_collectXRefs = collectXRefs;
   g_inFunctionTryBlock = FALSE;
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = countLines();
 
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
+
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = g_yyLineNr + countLines() - 1;
 
   g_curlyCount    = 0;
   g_bodyCurlyCount    = 0;

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -359,6 +359,28 @@ void DocbookDocVisitor::visit(DocInclude *inc)
             );
       m_t << "</computeroutput></literallayout>";
       break;
+    case DocInclude::SnipWithLines:
+      {
+         QFileInfo cfi( inc->file() );
+         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+         m_t << "<literallayout><computeroutput>";
+         Doxygen::parserManager->getParser(inc->extension())
+                               ->parseCode(m_ci,
+                                           inc->context(),
+                                           extractBlock(inc->text(),inc->blockId()),
+                                           langExt,
+                                           inc->isExample(),
+                                           inc->exampleFile(), 
+                                           &fd,
+                                           lineBlock(inc->text(),inc->blockId()),
+                                           -1,    // endLine
+                                           FALSE, // inlineFragment
+                                           0,     // memberDef
+                                           TRUE   // show line number
+                                          );
+         m_t << "</computeroutput></literallayout>";
+      }
+      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -359,28 +359,6 @@ void DocbookDocVisitor::visit(DocInclude *inc)
             );
       m_t << "</computeroutput></literallayout>";
       break;
-    case DocInclude::SnipWithLines:
-      {
-         QFileInfo cfi( inc->file() );
-         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
-         m_t << "<literallayout><computeroutput>";
-         Doxygen::parserManager->getParser(inc->extension())
-                               ->parseCode(m_ci,
-                                           inc->context(),
-                                           extractBlock(inc->text(),inc->blockId()),
-                                           langExt,
-                                           inc->isExample(),
-                                           inc->exampleFile(), 
-                                           &fd,
-                                           lineBlock(inc->text(),inc->blockId()),
-                                           -1,    // endLine
-                                           FALSE, // inlineFragment
-                                           0,     // memberDef
-                                           TRUE   // show line number
-                                          );
-         m_t << "</computeroutput></literallayout>";
-      }
-      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1931,6 +1931,7 @@ void DocInclude::parse()
       readTextFileByName(m_file,m_text);
       break;
     case Snippet:
+    case SnipWithLines:
       readTextFileByName(m_file,m_text);
       // check here for the existence of the blockId inside the file, so we
       // only generate the warning once.
@@ -5174,7 +5175,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   }
   QCString fileName = g_token->name;
   QCString blockId;
-  if (t==DocInclude::Snippet || t==DocInclude::SnippetDoc)
+  if (t==DocInclude::Snippet || t==DocInclude::SnipWithLines || t==DocInclude::SnippetDoc)
   {
     if (fileName == "this") fileName=g_fileName;
     doctokenizerYYsetStateSnippet();
@@ -5700,6 +5701,9 @@ int DocPara::handleCommand(const QCString &cmdName)
       break;
     case CMD_SNIPPET:
       handleInclude(cmdName,DocInclude::Snippet);
+      break;
+    case CMD_SNIPWITHLINES:
+      handleInclude(cmdName,DocInclude::SnipWithLines);
       break;
     case CMD_INCLUDEDOC:
       handleInclude(cmdName,DocInclude::IncludeDoc);

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1931,7 +1931,6 @@ void DocInclude::parse()
       readTextFileByName(m_file,m_text);
       break;
     case Snippet:
-    case SnipWithLines:
       readTextFileByName(m_file,m_text);
       // check here for the existence of the blockId inside the file, so we
       // only generate the warning once.
@@ -5175,7 +5174,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   }
   QCString fileName = g_token->name;
   QCString blockId;
-  if (t==DocInclude::Snippet || t==DocInclude::SnipWithLines || t==DocInclude::SnippetDoc)
+  if (t==DocInclude::Snippet || t==DocInclude::SnippetDoc)
   {
     if (fileName == "this") fileName=g_fileName;
     doctokenizerYYsetStateSnippet();
@@ -5701,9 +5700,6 @@ int DocPara::handleCommand(const QCString &cmdName)
       break;
     case CMD_SNIPPET:
       handleInclude(cmdName,DocInclude::Snippet);
-      break;
-    case CMD_SNIPWITHLINES:
-      handleInclude(cmdName,DocInclude::SnipWithLines);
       break;
     case CMD_INCLUDEDOC:
       handleInclude(cmdName,DocInclude::IncludeDoc);

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -483,7 +483,8 @@ class DocVerbatim : public DocNode
 class DocInclude : public DocNode
 {
   public:
-  enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude, IncWithLines, Snippet , IncludeDoc, SnippetDoc};
+  enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude,
+	      IncWithLines, Snippet , IncludeDoc, SnippetDoc, SnipWithLines};
     DocInclude(DocNode *parent,const QCString &file,
                const QCString context, Type t,
                bool isExample,const QCString exampleFile,

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -483,8 +483,7 @@ class DocVerbatim : public DocNode
 class DocInclude : public DocNode
 {
   public:
-  enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude,
-	      IncWithLines, Snippet , IncludeDoc, SnippetDoc, SnipWithLines};
+  enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude, IncWithLines, Snippet , IncludeDoc, SnippetDoc};
     DocInclude(DocNode *parent,const QCString &file,
                const QCString context, Type t,
                bool isExample,const QCString exampleFile,

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1263,16 +1263,15 @@ void parseFortranCode(CodeOutputInterface &od,const char *className,const QCStri
   g_needsTermination = FALSE;
   g_searchCtx = searchCtx;
   g_collectXRefs = collectXRefs;
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = countLines();
+
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
-
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = g_yyLineNr + countLines() - 1;
-
 
   g_exampleBlock  = exBlock; 
   g_exampleName   = exName;

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1263,15 +1263,16 @@ void parseFortranCode(CodeOutputInterface &od,const char *className,const QCStri
   g_needsTermination = FALSE;
   g_searchCtx = searchCtx;
   g_collectXRefs = collectXRefs;
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = countLines();
-
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
+
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = g_yyLineNr + countLines() - 1;
+
 
   g_exampleBlock  = exBlock; 
   g_exampleName   = exName;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -578,31 +578,6 @@ void HtmlDocVisitor::visit(DocInclude *inc)
                                            -1,    // endLine
                                            TRUE,  // inlineFragment
                                            0,     // memberDef
-                                           FALSE, // show line number
-                                           m_ctx  // search context
-                                          );
-         m_t << PREFRAG_END;
-         forceStartParagraph(inc);
-      }
-      break;
-    case DocInclude::SnipWithLines:
-      {
-         forceEndParagraph(inc);
-         m_t << PREFRAG_START;
-         QFileInfo cfi( inc->file() );
-         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
-         Doxygen::parserManager->getParser(inc->extension())
-                               ->parseCode(m_ci,
-                                           inc->context(),
-                                           extractBlock(inc->text(),inc->blockId()),
-                                           langExt,
-                                           inc->isExample(),
-                                           inc->exampleFile(), 
-                                           &fd,
-                                           lineBlock(inc->text(),inc->blockId()),
-                                           -1,    // endLine
-                                           FALSE, // inlineFragment
-                                           0,     // memberDef
                                            TRUE,  // show line number
                                            m_ctx  // search context
                                           );

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -578,6 +578,31 @@ void HtmlDocVisitor::visit(DocInclude *inc)
                                            -1,    // endLine
                                            TRUE,  // inlineFragment
                                            0,     // memberDef
+                                           FALSE, // show line number
+                                           m_ctx  // search context
+                                          );
+         m_t << PREFRAG_END;
+         forceStartParagraph(inc);
+      }
+      break;
+    case DocInclude::SnipWithLines:
+      {
+         forceEndParagraph(inc);
+         m_t << PREFRAG_START;
+         QFileInfo cfi( inc->file() );
+         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+         Doxygen::parserManager->getParser(inc->extension())
+                               ->parseCode(m_ci,
+                                           inc->context(),
+                                           extractBlock(inc->text(),inc->blockId()),
+                                           langExt,
+                                           inc->isExample(),
+                                           inc->exampleFile(), 
+                                           &fd,
+                                           lineBlock(inc->text(),inc->blockId()),
+                                           -1,    // endLine
+                                           FALSE, // inlineFragment
+                                           0,     // memberDef
                                            TRUE,  // show line number
                                            m_ctx  // search context
                                           );

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -483,28 +483,6 @@ void LatexDocVisitor::visit(DocInclude *inc)
          m_t << "\\end{DoxyCodeInclude}" << endl;
       }
       break;
-    case DocInclude::SnipWithLines:
-      {
-         QFileInfo cfi( inc->file() );
-         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
-         m_t << "\n\\begin{DoxyCodeInclude}\n";
-         Doxygen::parserManager->getParser(inc->extension())
-                               ->parseCode(m_ci,
-                                           inc->context(),
-                                           extractBlock(inc->text(),inc->blockId()),
-                                           langExt,
-                                           inc->isExample(),
-                                           inc->exampleFile(), 
-                                           &fd,
-                                           lineBlock(inc->text(),inc->blockId()),
-                                           -1,    // endLine
-                                           FALSE, // inlineFragment
-                                           0,     // memberDef
-                                           TRUE   // show line number
-                                          );
-         m_t << "\\end{DoxyCodeInclude}" << endl;
-      }
-      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -483,6 +483,28 @@ void LatexDocVisitor::visit(DocInclude *inc)
          m_t << "\\end{DoxyCodeInclude}" << endl;
       }
       break;
+    case DocInclude::SnipWithLines:
+      {
+         QFileInfo cfi( inc->file() );
+         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+         m_t << "\n\\begin{DoxyCodeInclude}\n";
+         Doxygen::parserManager->getParser(inc->extension())
+                               ->parseCode(m_ci,
+                                           inc->context(),
+                                           extractBlock(inc->text(),inc->blockId()),
+                                           langExt,
+                                           inc->isExample(),
+                                           inc->exampleFile(), 
+                                           &fd,
+                                           lineBlock(inc->text(),inc->blockId()),
+                                           -1,    // endLine
+                                           FALSE, // inlineFragment
+                                           0,     // memberDef
+                                           TRUE   // show line number
+                                          );
+         m_t << "\\end{DoxyCodeInclude}" << endl;
+      }
+      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -306,6 +306,33 @@ void ManDocVisitor::visit(DocInclude *inc)
       m_t << ".PP" << endl;
       m_firstCol=TRUE;
       break;
+    case DocInclude::SnipWithLines:
+      {
+         if (!m_firstCol) m_t << endl;
+         m_t << ".PP" << endl;
+         m_t << ".nf" << endl;
+         QFileInfo cfi( inc->file() );
+         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+         Doxygen::parserManager->getParser(inc->extension())
+                               ->parseCode(m_ci,
+                                           inc->context(),
+                                           extractBlock(inc->text(),inc->blockId()),
+                                           langExt,
+                                           inc->isExample(),
+                                           inc->exampleFile(), 
+                                           &fd,
+                                           lineBlock(inc->text(),inc->blockId()),
+                                           -1,    // endLine
+                                           FALSE, // inlineFragment
+                                           0,     // memberDef
+                                           TRUE   // show line number
+                                          );
+         if (!m_firstCol) m_t << endl;
+         m_t << ".fi" << endl;
+         m_t << ".PP" << endl;
+         m_firstCol=TRUE;
+      }
+      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -306,33 +306,6 @@ void ManDocVisitor::visit(DocInclude *inc)
       m_t << ".PP" << endl;
       m_firstCol=TRUE;
       break;
-    case DocInclude::SnipWithLines:
-      {
-         if (!m_firstCol) m_t << endl;
-         m_t << ".PP" << endl;
-         m_t << ".nf" << endl;
-         QFileInfo cfi( inc->file() );
-         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
-         Doxygen::parserManager->getParser(inc->extension())
-                               ->parseCode(m_ci,
-                                           inc->context(),
-                                           extractBlock(inc->text(),inc->blockId()),
-                                           langExt,
-                                           inc->isExample(),
-                                           inc->exampleFile(), 
-                                           &fd,
-                                           lineBlock(inc->text(),inc->blockId()),
-                                           -1,    // endLine
-                                           FALSE, // inlineFragment
-                                           0,     // memberDef
-                                           TRUE   // show line number
-                                          );
-         if (!m_firstCol) m_t << endl;
-         m_t << ".fi" << endl;
-         m_t << ".PP" << endl;
-         m_firstCol=TRUE;
-      }
-      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -716,7 +716,6 @@ void PerlModDocVisitor::visit(DocInclude *inc)
   case DocInclude::LatexInclude: type = "latexonly"; break;
   case DocInclude::VerbInclude:	type = "preformatted"; break;
   case DocInclude::Snippet: return;
-  case DocInclude::SnipWithLines: return;
   case DocInclude::SnippetDoc: 
   case DocInclude::IncludeDoc: 
     err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -716,6 +716,7 @@ void PerlModDocVisitor::visit(DocInclude *inc)
   case DocInclude::LatexInclude: type = "latexonly"; break;
   case DocInclude::VerbInclude:	type = "preformatted"; break;
   case DocInclude::Snippet: return;
+  case DocInclude::SnipWithLines: return;
   case DocInclude::SnippetDoc: 
   case DocInclude::IncludeDoc: 
     err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -171,6 +171,7 @@ class PrintDocVisitor : public DocVisitor
         case DocInclude::LatexInclude: printf("latexinclude"); break;
         case DocInclude::VerbInclude: printf("verbinclude"); break;
         case DocInclude::Snippet: printf("snippet"); break;
+        case DocInclude::SnipWithLines: printf("snipwithlines"); break;
         case DocInclude::SnippetDoc: 
         case DocInclude::IncludeDoc: 
           err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -171,7 +171,6 @@ class PrintDocVisitor : public DocVisitor
         case DocInclude::LatexInclude: printf("latexinclude"); break;
         case DocInclude::VerbInclude: printf("verbinclude"); break;
         case DocInclude::Snippet: printf("snippet"); break;
-        case DocInclude::SnipWithLines: printf("snipwithlines"); break;
         case DocInclude::SnippetDoc: 
         case DocInclude::IncludeDoc: 
           err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1534,8 +1534,8 @@ static void adjustScopesAndSuites(unsigned indentLength)
 
 void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
                  const QCString &s,bool exBlock, const char *exName,
-		 FileDef *fd,int startLine,int endLine,bool /*inlineFragment*/,
-		 MemberDef *,bool,Definition *searchCtx,bool collectXRefs) 
+                 FileDef *fd,int startLine,int endLine,bool inlineFragment,
+                 MemberDef *,bool,Definition *searchCtx,bool collectXRefs) 
 {
 
   //printf("***parseCode()\n");
@@ -1551,22 +1551,22 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
   g_needsTermination = FALSE;
   g_searchCtx=searchCtx;
   g_collectXRefs=collectXRefs;
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = countLines();
-  
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = g_yyLineNr + countLines() - 1;
+  
   
   g_exampleBlock  = exBlock; 
   g_exampleName   = exName;
   g_sourceFileDef = fd;
 
   bool cleanupSourceDef = FALSE;
-  if (fd==0)
+  if (exBlock && fd==0)
   {
     // create a dummy filedef for the example
     g_sourceFileDef = new FileDef("",(exName?exName:"generated"));
@@ -1577,6 +1577,7 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
     setCurrentDoc("l00001");
   }
 
+  g_includeCodeFragment = inlineFragment;
   // Starts line 1 on the output  
   startCodeLine();
 

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1534,8 +1534,8 @@ static void adjustScopesAndSuites(unsigned indentLength)
 
 void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
                  const QCString &s,bool exBlock, const char *exName,
-                 FileDef *fd,int startLine,int endLine,bool inlineFragment,
-                 MemberDef *,bool,Definition *searchCtx,bool collectXRefs) 
+		 FileDef *fd,int startLine,int endLine,bool /*inlineFragment*/,
+		 MemberDef *,bool,Definition *searchCtx,bool collectXRefs) 
 {
 
   //printf("***parseCode()\n");
@@ -1551,22 +1551,22 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
   g_needsTermination = FALSE;
   g_searchCtx=searchCtx;
   g_collectXRefs=collectXRefs;
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = countLines();
+  
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = g_yyLineNr + countLines() - 1;
-  
   
   g_exampleBlock  = exBlock; 
   g_exampleName   = exName;
   g_sourceFileDef = fd;
 
   bool cleanupSourceDef = FALSE;
-  if (exBlock && fd==0)
+  if (fd==0)
   {
     // create a dummy filedef for the example
     g_sourceFileDef = new FileDef("",(exName?exName:"generated"));
@@ -1577,7 +1577,6 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
     setCurrentDoc("l00001");
   }
 
-  g_includeCodeFragment = inlineFragment;
   // Starts line 1 on the output  
   startCodeLine();
 

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -444,30 +444,6 @@ void RTFDocVisitor::visit(DocInclude *inc)
                                        );
       m_t << "}";
       break;
-    case DocInclude::SnipWithLines:
-      {
-         QFileInfo cfi( inc->file() );
-         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
-         m_t << "{" << endl;
-         if (!m_lastIsPara) m_t << "\\par" << endl;
-         m_t << rtf_Style_Reset << getStyle("CodeExample");
-         Doxygen::parserManager->getParser(inc->extension())
-                               ->parseCode(m_ci,
-                                           inc->context(),
-                                           extractBlock(inc->text(),inc->blockId()),
-                                           langExt,
-                                           inc->isExample(),
-                                           inc->exampleFile(), 
-                                           &fd,
-                                           lineBlock(inc->text(),inc->blockId()),
-                                           -1,    // endLine
-                                           FALSE, // inlineFragment
-                                           0,     // memberDef
-                                           TRUE   // show line number
-                                          );
-         m_t << "}";
-      }
-      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -444,6 +444,30 @@ void RTFDocVisitor::visit(DocInclude *inc)
                                        );
       m_t << "}";
       break;
+    case DocInclude::SnipWithLines:
+      {
+         QFileInfo cfi( inc->file() );
+         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+         m_t << "{" << endl;
+         if (!m_lastIsPara) m_t << "\\par" << endl;
+         m_t << rtf_Style_Reset << getStyle("CodeExample");
+         Doxygen::parserManager->getParser(inc->extension())
+                               ->parseCode(m_ci,
+                                           inc->context(),
+                                           extractBlock(inc->text(),inc->blockId()),
+                                           langExt,
+                                           inc->isExample(),
+                                           inc->exampleFile(), 
+                                           &fd,
+                                           lineBlock(inc->text(),inc->blockId()),
+                                           -1,    // endLine
+                                           FALSE, // inlineFragment
+                                           0,     // memberDef
+                                           TRUE   // show line number
+                                          );
+         m_t << "}";
+      }
+      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -85,6 +85,7 @@ static int           g_yyLineNr;        //!< current line number
 static bool          g_needsTermination;
 static Definition   *g_searchCtx;
 
+static bool          g_exampleBlock;
 static QCString      g_exampleName;
 static QCString      g_exampleFile;
 
@@ -1504,7 +1505,7 @@ void resetVhdlCodeParserState()
 }
 
 void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString &s, 
-                  bool /*exBlock*/, const char *exName,FileDef *fd,
+                  bool exBlock, const char *exName,FileDef *fd,
                   int startLine,int endLine,bool inlineFragment,
                   MemberDef *memberDef,bool,Definition *searchCtx,
                   bool /* collectXRefs */)
@@ -1527,23 +1528,24 @@ void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString 
   g_needsTermination = FALSE;
   g_searchCtx = searchCtx;
 
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = countLines();
-
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
 
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = g_yyLineNr + countLines() - 1;
+
 
   // g_theCallContext.clear();
   g_classScope    = className;
+  g_exampleBlock  = exBlock; 
   g_exampleName   = exName;
   g_sourceFileDef = fd;
   bool cleanupSourceDef = FALSE;
-  if (fd==0)
+  if (exBlock && fd==0)
   {
     // create a dummy filedef for the example
     g_sourceFileDef = new FileDef("",exName);

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -85,7 +85,6 @@ static int           g_yyLineNr;        //!< current line number
 static bool          g_needsTermination;
 static Definition   *g_searchCtx;
 
-static bool          g_exampleBlock;
 static QCString      g_exampleName;
 static QCString      g_exampleFile;
 
@@ -1505,7 +1504,7 @@ void resetVhdlCodeParserState()
 }
 
 void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString &s, 
-                  bool exBlock, const char *exName,FileDef *fd,
+                  bool /*exBlock*/, const char *exName,FileDef *fd,
                   int startLine,int endLine,bool inlineFragment,
                   MemberDef *memberDef,bool,Definition *searchCtx,
                   bool /* collectXRefs */)
@@ -1528,24 +1527,23 @@ void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString 
   g_needsTermination = FALSE;
   g_searchCtx = searchCtx;
 
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = countLines();
+
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
 
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = g_yyLineNr + countLines() - 1;
-
 
   // g_theCallContext.clear();
   g_classScope    = className;
-  g_exampleBlock  = exBlock; 
   g_exampleName   = exName;
   g_sourceFileDef = fd;
   bool cleanupSourceDef = FALSE;
-  if (exBlock && fd==0)
+  if (fd==0)
   {
     // create a dummy filedef for the example
     g_sourceFileDef = new FileDef("",exName);

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -49,6 +49,7 @@ static int           g_yyLineNr;        //!< current line number
 static bool          g_needsTermination;
 static Definition   *g_searchCtx;
 
+static bool          g_exampleBlock;
 static QCString      g_exampleName;
 static QCString      g_exampleFile;
 
@@ -323,12 +324,12 @@ void parseXmlCode(
     CodeOutputInterface &od,
     const char * /*className*/,
     const QCString &s,
-    bool /*exBlock*/,
+    bool exBlock,
     const char *exName,
     FileDef *fd,
     int startLine,
     int endLine,
-    bool /*inlineFragment*/,
+    bool inlineFragment,
     MemberDef *,
     bool,Definition *searchCtx,
     bool /*collectXRefs*/
@@ -345,22 +346,23 @@ void parseXmlCode(
   g_needsTermination = FALSE;
   g_searchCtx=searchCtx;
   
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = countLines();
-  
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
   
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = g_yyLineNr + countLines() - 1;
+  
+  g_exampleBlock  = exBlock; 
   g_exampleName   = exName;
   g_sourceFileDef = fd;
 
   bool cleanupSourceDef = FALSE;
   
-  if (fd==0)
+  if (exBlock && fd==0)
   {
     // create a dummy filedef for the example
     g_sourceFileDef = new FileDef("",(exName?exName:"generated"));
@@ -372,6 +374,7 @@ void parseXmlCode(
     setCurrentDoc("l00001");
   }
 
+  g_includeCodeFragment = inlineFragment;
   // Starts line 1 on the output  
   startCodeLine();
 

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -49,7 +49,6 @@ static int           g_yyLineNr;        //!< current line number
 static bool          g_needsTermination;
 static Definition   *g_searchCtx;
 
-static bool          g_exampleBlock;
 static QCString      g_exampleName;
 static QCString      g_exampleFile;
 
@@ -324,12 +323,12 @@ void parseXmlCode(
     CodeOutputInterface &od,
     const char * /*className*/,
     const QCString &s,
-    bool exBlock,
+    bool /*exBlock*/,
     const char *exName,
     FileDef *fd,
     int startLine,
     int endLine,
-    bool inlineFragment,
+    bool /*inlineFragment*/,
     MemberDef *,
     bool,Definition *searchCtx,
     bool /*collectXRefs*/
@@ -346,23 +345,22 @@ void parseXmlCode(
   g_needsTermination = FALSE;
   g_searchCtx=searchCtx;
   
+  if (endLine!=-1)
+    g_inputLines  = endLine+1;
+  else
+    g_inputLines  = countLines();
+  
   if (startLine!=-1)
     g_yyLineNr    = startLine;
   else
     g_yyLineNr    = 1;
   
-  if (endLine!=-1)
-    g_inputLines  = endLine+1;
-  else
-    g_inputLines  = g_yyLineNr + countLines() - 1;
-  
-  g_exampleBlock  = exBlock; 
   g_exampleName   = exName;
   g_sourceFileDef = fd;
 
   bool cleanupSourceDef = FALSE;
   
-  if (exBlock && fd==0)
+  if (fd==0)
   {
     // create a dummy filedef for the example
     g_sourceFileDef = new FileDef("",(exName?exName:"generated"));
@@ -374,7 +372,6 @@ void parseXmlCode(
     setCurrentDoc("l00001");
   }
 
-  g_includeCodeFragment = inlineFragment;
   // Starts line 1 on the output  
   startCodeLine();
 

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -329,6 +329,28 @@ void XmlDocVisitor::visit(DocInclude *inc)
                                        );
       m_t << "</programlisting>"; 
       break;
+    case DocInclude::SnipWithLines:
+      {
+         m_t << "<programlisting>";
+         QFileInfo cfi( inc->file() );
+         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+         Doxygen::parserManager->getParser(inc->extension())
+                               ->parseCode(m_ci,
+                                           inc->context(),
+                                           extractBlock(inc->text(),inc->blockId()),
+                                           langExt,
+                                           inc->isExample(),
+                                           inc->exampleFile(), 
+                                           &fd,
+                                           lineBlock(inc->text(),inc->blockId()),
+                                           -1,    // endLine
+                                           FALSE, // inlineFragment
+                                           0,     // memberDef
+                                           TRUE   // show line number
+                                          );
+         m_t << "</programlisting>"; 
+      }
+      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -329,28 +329,6 @@ void XmlDocVisitor::visit(DocInclude *inc)
                                        );
       m_t << "</programlisting>"; 
       break;
-    case DocInclude::SnipWithLines:
-      {
-         m_t << "<programlisting>";
-         QFileInfo cfi( inc->file() );
-         FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
-         Doxygen::parserManager->getParser(inc->extension())
-                               ->parseCode(m_ci,
-                                           inc->context(),
-                                           extractBlock(inc->text(),inc->blockId()),
-                                           langExt,
-                                           inc->isExample(),
-                                           inc->exampleFile(), 
-                                           &fd,
-                                           lineBlock(inc->text(),inc->blockId()),
-                                           -1,    // endLine
-                                           FALSE, // inlineFragment
-                                           0,     // memberDef
-                                           TRUE   // show line number
-                                          );
-         m_t << "</programlisting>"; 
-      }
-      break;
     case DocInclude::SnippetDoc: 
     case DocInclude::IncludeDoc: 
       err("Internal inconsistency: found switch SnippetDoc / IncludeDoc in file: %s"

--- a/testing/014/indexpage.xml
+++ b/testing/014/indexpage.xml
@@ -6,16 +6,16 @@
     <detaileddescription>
       <para>
         <programlisting>
-          <codeline lineno="1">
+          <codeline>
             <highlight class="comment">#<sp/>comment<sp/>in<sp/>Python</highlight>
             <highlight class="normal"/>
           </codeline>
-          <codeline lineno="2">
+          <codeline>
             <highlight class="normal"/>
             <highlight class="keyword">class<sp/></highlight>
             <highlight class="normal">Python:</highlight>
           </codeline>
-          <codeline lineno="3">
+          <codeline>
             <highlight class="normal">
               <sp/>
               <sp/>

--- a/testing/014/indexpage.xml
+++ b/testing/014/indexpage.xml
@@ -6,16 +6,16 @@
     <detaileddescription>
       <para>
         <programlisting>
-          <codeline>
+          <codeline lineno="1">
             <highlight class="comment">#<sp/>comment<sp/>in<sp/>Python</highlight>
             <highlight class="normal"/>
           </codeline>
-          <codeline>
+          <codeline lineno="2">
             <highlight class="normal"/>
             <highlight class="keyword">class<sp/></highlight>
             <highlight class="normal">Python:</highlight>
           </codeline>
-          <codeline>
+          <codeline lineno="3">
             <highlight class="normal">
               <sp/>
               <sp/>


### PR DESCRIPTION
This patch makes the handling of the \snippet and other commands consistent between the different languages (no line numbers anymore with python) and also introduces analogous to \includelineno  the command \snippetlineno.

Some non relevant changes:
- *code.l Calculation of the end line was incorrect, in case of a snippet the end line was the number of lines of the snippet and not reltive to the start line.
- *code.l made consistent over the different laguages, enabling exBlock and inlineFragment
- testing/indexpage.xml in test 14 the \snippet command was used with python and giving line numbers, linenumbers are now gone (consistency)