### PR TITLE
Option for PlantUML configuration file

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3414,6 +3414,14 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    <option type='string' id='PLANTUML_CFG_FILE' format='file' defval=''>
+      <docs>
+<![CDATA[
+ When using plantuml, the \c PLANTUML_CFG_FILE tag can be used to specify a configuration 
+ file for plantuml.
+]]>
+      </docs>
+    </option>
     <option type='list' id='PLANTUML_INCLUDE_PATH' format='dir' defval=''>
       <docs>
 <![CDATA[

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -54,6 +54,7 @@ QCString writePlantUMLSource(const QCString &outDir,const QCString &fileName,con
 void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutputFormat format)
 {
   static QCString plantumlJarPath = Config_getString(PLANTUML_JAR_PATH);
+  static QCString plantumlConfigFile = Config_getString(PLANTUML_CFG_FILE);
 
   QCString pumlExe = "java";
   QCString pumlArgs = "";
@@ -74,6 +75,12 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
   }
   if (pumlIncludePathList.first()) pumlArgs += "\" ";
   pumlArgs += "-Djava.awt.headless=true -jar \""+plantumlJarPath+"plantuml.jar\" ";
+  if (plantumlConfigFile != "")
+  {
+    pumlArgs += "-config \"";
+    pumlArgs += plantumlConfigFile;
+    pumlArgs += "\" ";
+  }
   pumlArgs+="-o \"";
   pumlArgs+=outDir;
   pumlArgs+="\" ";


### PR DESCRIPTION
Prior to version 1.8.8, I used PlantUML as described at http://plantuml.com/doxygen.html. Since PlantUML is directly supported by Doxygen, I did not find a way to specify a configuration file for all UML diagrams. That is why I created this patch.