### PR TITLE
Bug 771344 - Class name 'internal' breaks class hierarchy in C++

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5771,7 +5771,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <BasesProt>"virtual"{BN}+               { lineCount(); baseVirt = Virtual; }
 <BasesProt>"public"{BN}+                { lineCount(); baseProt = Public; }
 <BasesProt>"protected"{BN}+             { lineCount(); baseProt = Protected; }
-<BasesProt>"internal"{BN}+              { lineCount(); baseProt = Package; }
+<BasesProt>"internal"{BN}+              { if (!insideCli) REJECT ; lineCount(); baseProt = Package; }
 <BasesProt>"private"{BN}+               { lineCount(); baseProt = Private; }
 <BasesProt>{BN}				{ lineCount(); }
 <BasesProt>.				{ unput(*yytext); BEGIN(Bases); }


### PR DESCRIPTION
Analogous to the rule for:
    `<FindMembers>{B}*"internal"{BN}*":"{BN}*`
reject the "internal" keyword in case not in Cli