### PR TITLE
Fix for PlantUML configuration

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -75,7 +75,7 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
   }
   if (pumlIncludePathList.first()) pumlArgs += "\" ";
   pumlArgs += "-Djava.awt.headless=true -jar \""+plantumlJarPath+"plantuml.jar\" ";
-  if (plantumlConfigFile != "")
+  if (!plantumlConfigFile.isEmpty())
   {
     pumlArgs += "-config \"";
     pumlArgs += plantumlConfigFile;


### PR DESCRIPTION
Because of a bug I introduced earlier, one **always** has to configure a PlantUML configuration file if PlantUML is used. Sorry for that! This will be fixed with the commit in this pull request.