### PR TITLE
For manpages remove trailing dash when no brief description

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -954,9 +954,10 @@ void ClassDef::writeBriefDescription(OutputList &ol,bool exampleFlag)
   if (hasBriefDescription())
   {
     ol.startParagraph();
+    ol.pushGeneratorState();
     ol.disableAllBut(OutputGenerator::Man);
     ol.writeString(" - ");
-    ol.enableAll();
+    ol.popGeneratorState();
     ol.generateDoc(briefFile(),briefLine(),this,0,
                    briefDescription(),TRUE,FALSE,0,TRUE,FALSE);
     ol.pushGeneratorState();

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -954,6 +954,9 @@ void ClassDef::writeBriefDescription(OutputList &ol,bool exampleFlag)
   if (hasBriefDescription())
   {
     ol.startParagraph();
+    ol.disableAllBut(OutputGenerator::Man);
+    ol.writeString(" - ");
+    ol.enableAll();
     ol.generateDoc(briefFile(),briefLine(),this,0,
                    briefDescription(),TRUE,FALSE,0,TRUE,FALSE);
     ol.pushGeneratorState();

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -170,13 +170,16 @@ void DirDef::writeDetailedDescription(OutputList &ol,const QCString &title)
 
 void DirDef::writeBriefDescription(OutputList &ol)
 {
-  if (!briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
+  if (hasBriefDescription())
   {
     DocRoot *rootNode = validatingParseDoc(
          briefFile(),briefLine(),this,0,briefDescription(),TRUE,FALSE);
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.disableAllBut(OutputGenerator::Man);
+      ol.writeString(" - ");
+      ol.enableAll();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -177,9 +177,10 @@ void DirDef::writeBriefDescription(OutputList &ol)
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.pushGeneratorState();
       ol.disableAllBut(OutputGenerator::Man);
       ol.writeString(" - ");
-      ol.enableAll();
+      ol.popGeneratorState();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -373,9 +373,10 @@ void FileDef::writeBriefDescription(OutputList &ol)
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.pushGeneratorState();
       ol.disableAllBut(OutputGenerator::Man);
       ol.writeString(" - ");
-      ol.enableAll();
+      ol.popGeneratorState();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -365,7 +365,7 @@ void FileDef::writeDetailedDescription(OutputList &ol,const QCString &title)
 
 void FileDef::writeBriefDescription(OutputList &ol)
 {
-  if (!briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
+  if (hasBriefDescription())
   {
     DocRoot *rootNode = validatingParseDoc(briefFile(),briefLine(),this,0,
                        briefDescription(),TRUE,FALSE,0,TRUE,FALSE);
@@ -373,6 +373,9 @@ void FileDef::writeBriefDescription(OutputList &ol)
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.disableAllBut(OutputGenerator::Man);
+      ol.writeString(" - ");
+      ol.enableAll();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -711,8 +711,11 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
       || !documentation().isEmpty() || !inbodyDocumentation().isEmpty()
      )
   {
+    ol.pushGeneratorState();
+    ol.disableAllBut(OutputGenerator::Man); // always print title for man page
     if (pageDict->count()!=countMembers()) // not only pages -> classical layout
     {
+      ol.enableAll();
       ol.pushGeneratorState();
         ol.disable(OutputGenerator::Html);
         ol.writeRuler();
@@ -721,10 +724,11 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
         ol.disableAllBut(OutputGenerator::Html);
         ol.writeAnchor(0,"details");
       ol.popGeneratorState();
-      ol.startGroupHeader();
-      ol.parseText(title);
-      ol.endGroupHeader();
     }
+    ol.startGroupHeader();
+    ol.parseText(title);
+    ol.endGroupHeader();
+    ol.popGeneratorState();
 
     // repeat brief description
     if (!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF))
@@ -762,13 +766,16 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
 
 void GroupDef::writeBriefDescription(OutputList &ol)
 {
-  if (!briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
+  if (hasBriefDescription())
   {
     DocRoot *rootNode = validatingParseDoc(briefFile(),briefLine(),this,0,
                                 briefDescription(),TRUE,FALSE,0,TRUE,FALSE);
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.disableAllBut(OutputGenerator::Man);
+      ol.writeString(" - ");
+      ol.enableAll();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);
@@ -789,6 +796,7 @@ void GroupDef::writeBriefDescription(OutputList &ol)
     }
     delete rootNode;
   }
+  ol.writeSynopsis();
 }
 
 void GroupDef::writeGroupGraph(OutputList &ol)
@@ -1091,7 +1099,6 @@ void GroupDef::writeDocumentation(OutputList &ol)
   ol.pushGeneratorState();
   ol.disableAllBut(OutputGenerator::Man);
   ol.endTitleHead(getOutputFileBase(),name());
-  ol.parseText(title);
   ol.popGeneratorState();
   ol.endHeaderSection();
   ol.startContents();

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -712,10 +712,8 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
      )
   {
     ol.pushGeneratorState();
-    ol.disableAllBut(OutputGenerator::Man); // always print title for man page
     if (pageDict->count()!=countMembers()) // not only pages -> classical layout
     {
-      ol.enableAll();
       ol.pushGeneratorState();
         ol.disable(OutputGenerator::Html);
         ol.writeRuler();
@@ -724,6 +722,10 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
         ol.disableAllBut(OutputGenerator::Html);
         ol.writeAnchor(0,"details");
       ol.popGeneratorState();
+    }
+    else
+    {
+      ol.disableAllBut(OutputGenerator::Man); // always print title for man page
     }
     ol.startGroupHeader();
     ol.parseText(title);
@@ -773,9 +775,10 @@ void GroupDef::writeBriefDescription(OutputList &ol)
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.pushGeneratorState();
       ol.disableAllBut(OutputGenerator::Man);
       ol.writeString(" - ");
-      ol.enableAll();
+      ol.popGeneratorState();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -191,7 +191,7 @@ void ManGenerator::endTitleHead(const char *,const char *name)
   t << ".ad l" << endl;
   t << ".nh" << endl;
   t << ".SH NAME" << endl;
-  t << name << " \\- ";
+  t << name;
   firstCol=FALSE;
   paragraph=TRUE;
   inHeader=TRUE;

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -408,9 +408,10 @@ void NamespaceDef::writeBriefDescription(OutputList &ol)
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.pushGeneratorState();
       ol.disableAllBut(OutputGenerator::Man);
       ol.writeString(" - ");
-      ol.enableAll();
+      ol.popGeneratorState();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -408,6 +408,9 @@ void NamespaceDef::writeBriefDescription(OutputList &ol)
     if (rootNode && !rootNode->isEmpty())
     {
       ol.startParagraph();
+      ol.disableAllBut(OutputGenerator::Man);
+      ol.writeString(" - ");
+      ol.enableAll();
       ol.writeDoc(rootNode,this,0);
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::RTF);

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -232,16 +232,17 @@ void PageDef::writePageDocumentation(OutputList &ol)
   QCString docStr = documentation()+inbodyDocumentation();
   if (!docStr.isEmpty())
   {
+    ol.pushGeneratorState();
     ol.disableAllBut(OutputGenerator::Man);
     ol.writeString(" - ");
-    ol.enableAll();
+    ol.popGeneratorState();
   }
   ol.generateDoc(
       docFile(),           // fileName
       docLine(),           // startLine
       this,                // context
       0,                   // memberdef
-      docStr, // docStr
+      docStr,              // docStr
       TRUE,                // index words
       FALSE                // not an example
       );

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -229,12 +229,19 @@ void PageDef::writePageDocumentation(OutputList &ol)
   }
 
   ol.startTextBlock();
+  QCString docStr = documentation()+inbodyDocumentation();
+  if (!docStr.isEmpty())
+  {
+    ol.disableAllBut(OutputGenerator::Man);
+    ol.writeString(" - ");
+    ol.enableAll();
+  }
   ol.generateDoc(
       docFile(),           // fileName
       docLine(),           // startLine
       this,                // context
       0,                   // memberdef
-      documentation()+inbodyDocumentation(), // docStr
+      docStr, // docStr
       TRUE,                // index words
       FALSE                // not an example
       );


### PR DESCRIPTION
Currently, if a definition does not have a brief description then the manpage will show:

>NAME
>Definition -

The change will show the manpage as

>NAME
>Definition

Also cleaned up manpage output for a group. Currently it seems to duplicate both the definition name and the brief description, leading to a big mess in the NAME section.