### PR TITLE
Clear header/footer information in ConfigImpl for postProcess

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1763,10 +1763,10 @@ void Config::postProcess(bool clearHeaderAndFooter)
   // refers to the files that we are supposed to parse.
   if (clearHeaderAndFooter)
   {
-    Config_getString(HTML_HEADER)="";
-    Config_getString(HTML_FOOTER)="";
-    Config_getString(LATEX_HEADER)="";
-    Config_getString(LATEX_FOOTER)="";
+    ConfigImpl_getString("HTML_HEADER")="";
+    ConfigImpl_getString("HTML_FOOTER")="";
+    ConfigImpl_getString("LATEX_HEADER")="";
+    ConfigImpl_getString("LATEX_FOOTER")="";
   }
 }
 


### PR DESCRIPTION
As described in [bug 771606](https://bugzilla.gnome.org/show_bug.cgi?id=771606), if using a config file with HTML_HEADER specified, and the header file does not exist, then with the -w command, doxygen will stop with an error. This shouldn't happen because the header file will not be used.

It looks like postProcess is actually clearing the header/footer information to avoid this error, but I think it should be clearing the ConfigImpl values instead.