### PR TITLE
Fixed typedef and define strings for Spanish translation

### DIFF
--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -406,13 +406,13 @@ class TranslatorSpanish : public Translator
      *  list of defines
      */
     virtual QCString trDefines()
-    { return "'defines'"; }
+    { return "defines"; }
 
     /*! This is used in the documentation of a file as a header before the
      *  list of typedefs
      */
     virtual QCString trTypedefs()
-    { return "'typedefs'"; }
+    { return "typedefs"; }
 
     /*! This is used in the documentation of a file as a header before the
      *  list of enumerations


### PR DESCRIPTION
Fixed strings for trTypedefs() and trDefines() on Spanish translation header file. This fixes JavaScript errors when either typedefs or defines were documented.