### PR TITLE
Add support for more CSS and column/row spanning in markdown tables

### DIFF
--- a/doc/doxygen_manual.css
+++ b/doc/doxygen_manual.css
@@ -1503,3 +1503,83 @@ tr.heading h2 {
   }
 }
 
+
+/* @group Markdown */
+
+/*
+table.markdownTable {
+	border-collapse:collapse;
+        margin-top: 4px;
+        margin-bottom: 4px;
+}
+
+table.markdownTable td, table.markdownTable th {
+	border: 1px solid ##37;
+	padding: 3px 7px 2px;
+}
+
+table.markdownTableHead tr {
+}
+
+table.markdownTableBodyLeft td, table.markdownTable th {
+	border: 1px solid ##37;
+	padding: 3px 7px 2px;
+}
+
+th.markdownTableHeadLeft th.markdownTableHeadRight th.markdownTableHeadCenter th.markdownTableHeadNone {
+	background-color: ##47;
+	color: #FFFFFF;
+	font-size: 110%;
+	padding-bottom: 4px;
+	padding-top: 5px;
+}
+
+th.markdownTableHeadLeft {
+	text-align: left
+}
+
+th.markdownTableHeadRight {
+	text-align: right
+}
+
+th.markdownTableHeadCenter {
+	text-align: center
+}
+*/
+
+table.markdownTable {
+	border-collapse:collapse;
+        margin-top: 4px;
+        margin-bottom: 4px;
+}
+
+table.markdownTable td, table.markdownTable th {
+	border: 1px solid ##37;
+	padding: 3px 7px 2px;
+}
+
+table.markdownTable tr {
+}
+
+th.markdownTableHeadLeft, th.markdownTableHeadRight, th.markdownTableHeadCenter, th.markdownTableHeadNone {
+	background-color: #374F7F;
+	color: #FFFFFF;
+	font-size: 110%;
+	padding-bottom: 4px;
+	padding-top: 5px;
+}
+
+th.markdownTableHeadLeft, td.markdownTableBodyLeft {
+	text-align: left
+}
+
+th.markdownTableHeadRight, td.markdownTableBodyRight {
+	text-align: right
+}
+
+th.markdownTableHeadCenter, td.markdownTableBodyCenter {
+	text-align: center
+}
+
+
+/* @end */

--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -337,6 +337,40 @@ which will look as follows:
 | 10    | 10     | 10    |
 | 1000  | 1000   | 1000  |
 
+Additionally, column and row spans are supported.  Using a caret ("^")
+in a cell indicates that the cell above should span rows.  Sequences
+of carets may be used for any number of row spans.  For example:
+
+    | Right | Center | Left  |
+    | ----: | :----: | :---- |
+    | 10    | 10     | 10    |
+    | ^     | 1000   | 1000  |
+
+which will look as follows:
+
+| Right | Center | Left  |
+| ----: | :----: | :---- |
+| 10    | 10     | 10    |
+| ^     | 1000   | 1000  |
+
+Column spans are supported by means of directly adjacent vertical bars
+("|").  Each additional vertical bar indicates an additional column to
+be spanned.  To put it another way, a single vertical bar indicates a
+single column span, two vertical bars indicates a 2 columns span, and
+so on.  For example:
+
+    | Right | Center | Left  |
+    | ----: | :----: | :---- |
+    | 10    | 10     | 10    |
+    | 1000  |||
+
+which will look as follows:
+
+| Right | Center | Left  |
+| ----: | :----: | :---- |
+| 10    | 10     | 10    |
+| 1000  |||   
+
 For more complex tables in doxygen please have a look at: \ref tables
 
 \subsection md_fenced Fenced Code Blocks

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1511,3 +1511,82 @@ tr.heading h2 {
   }
 }
 
+/* @group Markdown */
+
+/*
+table.markdownTable {
+	border-collapse:collapse;
+        margin-top: 4px;
+        margin-bottom: 4px;
+}
+
+table.markdownTable td, table.markdownTable th {
+	border: 1px solid ##37;
+	padding: 3px 7px 2px;
+}
+
+table.markdownTableHead tr {
+}
+
+table.markdownTableBodyLeft td, table.markdownTable th {
+	border: 1px solid ##37;
+	padding: 3px 7px 2px;
+}
+
+th.markdownTableHeadLeft th.markdownTableHeadRight th.markdownTableHeadCenter th.markdownTableHeadNone {
+	background-color: ##47;
+	color: #FFFFFF;
+	font-size: 110%;
+	padding-bottom: 4px;
+	padding-top: 5px;
+}
+
+th.markdownTableHeadLeft {
+	text-align: left
+}
+
+th.markdownTableHeadRight {
+	text-align: right
+}
+
+th.markdownTableHeadCenter {
+	text-align: center
+}
+*/
+
+table.markdownTable {
+	border-collapse:collapse;
+        margin-top: 4px;
+        margin-bottom: 4px;
+}
+
+table.markdownTable td, table.markdownTable th {
+	border: 1px solid ##37;
+	padding: 3px 7px 2px;
+}
+
+table.markdownTable tr {
+}
+
+th.markdownTableHeadLeft, th.markdownTableHeadRight, th.markdownTableHeadCenter, th.markdownTableHeadNone {
+	background-color: #374F7F;
+	color: #FFFFFF;
+	font-size: 110%;
+	padding-bottom: 4px;
+	padding-top: 5px;
+}
+
+th.markdownTableHeadLeft, td.markdownTableBodyLeft {
+	text-align: left
+}
+
+th.markdownTableHeadRight, td.markdownTableBodyRight {
+	text-align: right
+}
+
+th.markdownTableHeadCenter, td.markdownTableBodyCenter {
+	text-align: center
+}
+
+
+/* @end */


### PR DESCRIPTION
Mirrored syntax of foswiki tables for column and row spanning (see markdown.doc changes).  Other behavior unchanged, however, alignment was changed to use CSS instead of text-align in the td element (which is deprecated in HTML5).