### PR TITLE
Add plantuml support to Qt compressed help file

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2082,7 +2082,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName,
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")
   {
-    generatePlantUMLOutput(fileName,outDir,PUML_SVG);
+    generatePlantUMLOutput(baseName,outDir,PUML_SVG);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />" << endl;
     //m_t << "<p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p>";
     //m_t << "</iframe>" << endl;
@@ -2090,7 +2090,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName,
   }
   else
   {
-    generatePlantUMLOutput(fileName,outDir,PUML_BITMAP);
+    generatePlantUMLOutput(baseName,outDir,PUML_BITMAP);
     m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />" << endl;
   }
 }

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -16,6 +16,8 @@
 #include "plantuml.h"
 #include "portable.h"
 #include "config.h"
+#include "doxygen.h"
+#include "index.h"
 #include "message.h"
 
 #include <qdir.h>
@@ -84,28 +86,30 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
   pumlArgs+="-o \"";
   pumlArgs+=outDir;
   pumlArgs+="\" ";
-  QCString extension;
+  QCString imgName = baseName;
   switch (format)
   {
     case PUML_BITMAP:
       pumlArgs+="-tpng";
-      extension=".png";
+      imgName+=".png";
       break;
     case PUML_EPS:
       pumlArgs+="-teps";
-      extension=".eps";
+      imgName+=".eps";
       break;
     case PUML_SVG:
       pumlArgs+="-tsvg";
-      extension=".svg";
+      imgName+=".svg";
       break;
   }
   pumlArgs+=" \"";
+  pumlArgs+=outDir;
+  pumlArgs+="/";
   pumlArgs+=baseName;
   pumlArgs+=".pu\" ";
   pumlArgs+="-charset UTF-8 ";
   int exitCode;
-  //printf("*** running: %s %s outDir:%s %s\n",pumlExe.data(),pumlArgs.data(),outDir,outFile);
+  //printf("*** running: %s %s outDir:%s %s\n",pumlExe.data(),pumlArgs.data(),outDir,baseName);
   msg("Running PlantUML on generated file %s.pu\n",baseName);
   portable_sysTimerStart();
   if ((exitCode=portable_system(pumlExe,pumlArgs,TRUE))!=0)
@@ -129,5 +133,6 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
     }
     portable_sysTimerStop();
   }
+  Doxygen::indexList->addImageFile(imgName);
 }
 


### PR DESCRIPTION
Plantuml generated diagrams will be included in the
index.qcp file which defines what files to include
in the Qt compressed help file. This means that
plantuml diagrams will work in the Qt creator help
viewer.

Signed-off-by: Anders Wallander <anders.wallander@volvocars.com>