### PR TITLE
Fix plantuml generation issue

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2082,7 +2082,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName,
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")
   {
-    generatePlantUMLOutput(baseName,outDir,PUML_SVG);
+    generatePlantUMLOutput(fileName,outDir,PUML_SVG);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />" << endl;
     //m_t << "<p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p>";
     //m_t << "</iframe>" << endl;
@@ -2090,7 +2090,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName,
   }
   else
   {
-    generatePlantUMLOutput(baseName,outDir,PUML_BITMAP);
+    generatePlantUMLOutput(fileName,outDir,PUML_BITMAP);
     m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />" << endl;
   }
 }

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -87,6 +87,13 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
   pumlArgs+=outDir;
   pumlArgs+="\" ";
   QCString imgName = baseName;
+  // The basename contains path, we need to strip the path from the filename in order
+  // to create the image file name which should be included in the index.qhp (Qt help index file).
+  int i;
+  if ((i=imgName.findRev('/'))!=-1) // strip path
+  {
+    imgName=imgName.right(imgName.length()-i-1);
+  }
   switch (format)
   {
     case PUML_BITMAP:
@@ -103,8 +110,6 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
       break;
   }
   pumlArgs+=" \"";
-  pumlArgs+=outDir;
-  pumlArgs+="/";
   pumlArgs+=baseName;
   pumlArgs+=".pu\" ";
   pumlArgs+="-charset UTF-8 ";


### PR DESCRIPTION
Commit 62f09103b77b9e5b4093d248563e2f9d76b65728 which
merged pull request 538 introduced a bug in the generation
of plantuml diagrams for other plantuml sources than the
htmldocvisitor. In the previous commit the baseName argument
was wrongly interpreted as file name without path. This
commit fix this issue so the behaviour should be the same
as before, while still also having the support for
PlantUML diagrams in Qt compressed help files.