### PR TITLE
Fixed a problem with GENERATE_QHP and c functions in OPTIMIZE_OUTPUT_FOR_C mode.

### DIFF
--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -245,7 +245,14 @@ void Qhp::addIndexItem(Definition *context,MemberDef *md,
 
     // <keyword name="foo" id="MyApplication::foo" ref="doc.html#foo"/>
     ref = makeRef(contRef, anchor);
-    QCString id = level1+"::"+level2;
+    QCString id;
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C) && (
+        level1.find(".c", level1.length() - 2, false) >= 0 ||
+        level1.find(".h", level1.length() - 2, false) >= 0 )) {
+        id = level2;
+    } else {
+        id = level1+"::"+level2;
+    }
     const char * attributes[] =
     {
       "name", level2,


### PR DESCRIPTION
When exporting the documentation for a c only project to qhp, the id for
a keyword gets for example id="test.c::my_function". With this id the
QTCreator did not find the corresponding documentation with F1. Without
'test.c::' everything works fine.