### PR TITLE
Fix: Add missing jquery.js, dynsections.js & optional svgpan.js to QCH file

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1026,6 +1026,13 @@ void HtmlGenerator::writeStyleInfo(int part)
         }
       }
     }
+
+    Doxygen::indexList->addStyleSheetFile("jquery.js");
+    Doxygen::indexList->addStyleSheetFile("dynsections.js");
+    if (Config_getBool(INTERACTIVE_SVG))
+    {
+      Doxygen::indexList->addStyleSheetFile("svgpan.js");
+    }
   }
 }
 


### PR DESCRIPTION
Fixes bug https://bugzilla.gnome.org/show_bug.cgi?id=773693 for me.

Unsure about the (ab)use of `Doxygen::indexList->addStyleSheetFile(...)`, picked up behaviour of [src/searchindex.cpp:1244](https://github.com/doxygen/doxygen/blob/master/src/searchindex.cpp#L1244) here. Perhaps a new specific `addJavaScriptFile(...)` would be better for semantic, though in the end it might just do the same.
While at it, also added similar logic for "svgpan.js".

There are more JavaScript files which would need some similar fixing in general. Ignored those in this patch to do one step after the other (also no clue about those and also no need so far when interested in QCH only, where search and other things are provided by the viewer app).
