### PR TITLE
Reverting pull request #537 until it will be fixed

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -37,7 +37,7 @@
 #include <qfileinfo.h>
 #include <qdict.h>
 #include <qvector.h>
-//#define USE_ORIGINAL_TABLES
+#define USE_ORIGINAL_TABLES
 
 #include "markdown.h"
 #include "growbuf.h"
@@ -1592,6 +1592,16 @@ static int writeTableBlock(GrowBuf &out,const char *data,int size)
 
   i = findTableColumns(data,size,start,end,columns);
   
+#ifdef USE_ORIGINAL_TABLES
+  out.addStr("<table>");
+
+  // write table header, in range [start..end]
+  out.addStr("<tr>");
+
+  int headerStart = start;
+  int headerEnd = end;
+#endif
+    
   // read cell alignments
   int ret = findTableColumns(data+i,size-i,start,end,cc);
   k=0;
@@ -1633,13 +1643,6 @@ static int writeTableBlock(GrowBuf &out,const char *data,int size)
   i+=ret;
 
 #ifdef USE_ORIGINAL_TABLES
-  out.addStr("<table>");
-
-  // write table header, in range [start..end]
-  out.addStr("<tr>");
-
-  int headerStart = start;
-  int headerEnd = end;
 
   int m=headerStart;
   for (k=0;k<columns;k++)


### PR DESCRIPTION
Unfortunately code to support column/row spanning in markdown tables
breaking latex/pdf generation in case of utf8 symbols in table headers (at least)

Attempt to define USE_ORIGINAL_TABLES did not help, as important part of the original code
was moved to the wrong place, so this patch reverts original tables code while
keeping span support in place for debugging/fixing. Just undefine USE_ORIGINAL_TABLES to
enable new code with span support.

More info:
commit which made the problem: 2c32f65c0e7207654644baf283e88b5e93a7d4ee
PR: #537 

Latex error:
```
! Argument of \UTFviii@two@octets has an extra }.
<inserted text>
                \par
l.129 \end{longtabu}

?
```
markdown to reproduce:
```
| Имя поля     | Значение            | Тип поля        | Пример                      |
|--------------|---------------------|-----------------|-----------------------------|
|  period_name |  Название периода   |  Cтрока         |"period_name" : "декабрь 2015" |
```

Possible cause: probably string manipulation works with bytes assuming ASCII, resulting in wrong UTF8 strings, wrong string length detection etc. For example with this correct markdown table new code resulted in SPAN cell generation, which is wrong in this case.