### PR TITLE
Fix: replace deprecated {\bf with \textbf{ in LaTeX generator

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -3813,7 +3813,7 @@ class TextGeneratorLatex : public TextGeneratorIntf
       }
       else
       {
-        m_ts << "{\\bf ";
+        m_ts << "\\textbf{ ";
         filterLatexString(m_ts,text);
         m_ts << "}";
       }

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1169,7 +1169,7 @@ void LatexDocVisitor::visitPre(DocHtmlCell *c)
   }
   if (c->isHeading())
   {
-    m_t << "{\\bf ";
+    m_t << "\\textbf{ ";
   }
   if (cs>1)
   {
@@ -1566,7 +1566,7 @@ void LatexDocVisitor::visitPre(DocXRefItem *x)
   }
   else
   {
-    m_t << "{\\bf ";
+    m_t << "\\textbf{ ";
   }
   m_insideItem=TRUE;
   filter(x->title());
@@ -1674,7 +1674,7 @@ void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const Q
   }
   else // external link
   {
-    m_t << "{\\bf ";
+    m_t << "\\textbf{ ";
   }
 }
 

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1379,7 +1379,7 @@ void LatexGenerator::startTextLink(const char *f,const char *anchor)
   }
   else
   {
-    t << "{\\bf ";
+    t << "\\textbf{ ";
   }
 }
 
@@ -1404,7 +1404,7 @@ void LatexGenerator::writeObjectLink(const char *ref, const char *f,
   }
   else
   {
-    t << "{\\bf ";
+    t << "\\textbf{ ";
     docify(text);
     t << "}";
   } 
@@ -1907,7 +1907,7 @@ void LatexGenerator::endMemberList()
 void LatexGenerator::startMemberGroupHeader(bool hasHeader)
 {
   if (hasHeader) t << "\\begin{Indent}";
-  t << "{\\bf ";
+  t << "\\textbf{ ";
   // changed back to rev 756 due to bug 660501
   //if (Config_getBool(COMPACT_LATEX)) 
   //{


### PR DESCRIPTION
The newest version of scrbook (from Ubuntu 16.10) otherwise bails out with
"scrbook Error: undefined old font command `\bf'"