### PR TITLE
fixed 2 compilation warnings:

### DIFF
--- a/vhdlparser/TokenMgrError.cc
+++ b/vhdlparser/TokenMgrError.cc
@@ -98,7 +98,7 @@ JAVACC_SIMPLE_STRING addUnicodeEscapes(JAVACC_STRING_TYPE str) {
         retval.append("\\\\");
         continue;
       default:
-        if (ch < 0xff) {
+        if ((unsigned char)ch < 0xff) {
           retval += ch;
           continue;
         }

--- a/vhdlparser/VhdlParserTokenManager.cc
+++ b/vhdlparser/VhdlParserTokenManager.cc
@@ -3029,7 +3029,7 @@ int VhdlParserTokenManager::jjMoveNfa_0(int startState, int curPos){
             }
          } while(i != startsAt);
       }
-      else if (curChar < 128)
+      else if ((unsigned char)curChar < 128)
       {
          unsigned long long l = 1ULL << (curChar & 077);
          (void)l;


### PR DESCRIPTION
```
vhdlparser/TokenMgrError.cc:101:16: warning: comparison of constant 255 with expression of type 'char' is always true
      [-Wtautological-constant-out-of-range-compare]
        if (ch < 0xff) {
            ~~ ^ ~~~~
```
```
vhdlparser/VhdlParserTokenManager.cc:3032:24: warning: comparison of constant 128 with expression of type 'char' is always true
      [-Wtautological-constant-out-of-range-compare]
      else if (curChar < 128)
               ~~~~~~~ ^ ~~~
```