### PR TITLE
Fix bug #774432: Autogrouped only one level of entities

### DIFF
--- a/src/commentscan.h
+++ b/src/commentscan.h
@@ -76,6 +76,9 @@ void groupEnterFile(const char *file,int line);
 void groupLeaveFile(const char *file,int line);
 void groupLeaveCompound(const char *file,int line,const char *name);
 void groupEnterCompound(const char *file,int line,const char *name);
+void groupPushAutoGroup();
+void groupPopAutoGroup();
+
 void openGroup(Entry *e,const char *file,int line);
 void closeGroup(Entry *,const char *file,int line,bool foundInline=FALSE);
 void initGroupInfo(Entry *e);

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -443,6 +443,9 @@ static QStack<Grouping> g_autoGroupStack;
 static int              g_memberGroupId = DOX_NOGROUP;
 static QCString         g_memberGroupHeader;
 static QCString         g_memberGroupDocs;
+
+static QStack<QCString> g_compoundAutoGroupNameStack;
+
 static QCString         g_memberGroupRelates;
 static QCString         g_compoundName;
 
@@ -3009,6 +3012,8 @@ void groupEnterFile(const char *fileName,int)
   g_autoGroupStack.clear();
   g_memberGroupId = DOX_NOGROUP;
   g_memberGroupDocs.resize(0);
+  g_compoundAutoGroupNameStack.setAutoDelete(TRUE);
+  g_compoundAutoGroupNameStack.clear();
   g_memberGroupRelates.resize(0);
   g_compoundName=fileName;
 }
@@ -3026,6 +3031,17 @@ void groupLeaveFile(const char *fileName,int line)
   {
     warn(fileName,line,"end of file while inside a group\n");
   }
+}
+
+void groupPushAutoGroup() {
+  if (!g_autoGroupStack.isEmpty())
+      g_compoundAutoGroupNameStack.push(new QCString(g_autoGroupStack.top()->groupname));
+  else
+      g_compoundAutoGroupNameStack.push(new QCString(""));
+}
+
+void groupPopAutoGroup() {
+   g_compoundAutoGroupNameStack.pop();
 }
 
 void groupEnterCompound(const char *fileName,int line,const char *name)
@@ -3047,10 +3063,10 @@ void groupEnterCompound(const char *fileName,int line,const char *name)
   {
     g_compoundName=fileName;
   }
-  //printf("groupEnterCompound(%s)\n",name);
+  //printf("groupEnterCompound(%s) within AutoGroup(%s)\n",name, g_compoundAutoGroupNameStack.top()->data());
 }
 
-void groupLeaveCompound(const char *,int,const char * /*name*/)
+void groupLeaveCompound(const char *fileName,int line,const char * name)
 {
   //printf("groupLeaveCompound(%s)\n",name);
   //if (g_memberGroupId!=DOX_NOGROUP)
@@ -3086,10 +3102,11 @@ static int findExistingGroup(int &groupId,const MemberGroupInfo *info)
 void openGroup(Entry *e,const char *,int)
 {
   //printf("==> openGroup(name=%s,sec=%x) g_autoGroupStack=%d\n",
-  //  	e->name.data(),e->section,g_autoGroupStack.count());
+  // 	e->name.data(),e->section,g_autoGroupStack.count());
   if (e->section==Entry::GROUPDOC_SEC) // auto group
   {
     g_autoGroupStack.push(new Grouping(e->name,e->groupingPri()));
+    
   }
   else // start of a member group
   {
@@ -3127,6 +3144,7 @@ void closeGroup(Entry *e,const char *fileName,int line,bool foundInline)
     g_memberGroupId=DOX_NOGROUP;
     g_memberGroupRelates.resize(0);
     g_memberGroupDocs.resize(0);
+  
     if (!foundInline) e->mGrpId=DOX_NOGROUP;
     //printf("new group id=%d\n",g_memberGroupId);
   }
@@ -3152,7 +3170,18 @@ void initGroupInfo(Entry *e)
     //printf("Appending group %s to %s: count=%d entry=%p\n",
     //	g_autoGroupStack.top()->groupname.data(),
     //	e->name.data(),e->groups->count(),e);
-    e->groups->append(new Grouping(*g_autoGroupStack.top()));
+    if (g_compoundAutoGroupNameStack.isEmpty() ||
+        *g_compoundAutoGroupNameStack.top() != g_autoGroupStack.top()->groupname) {
+      e->groups->append(new Grouping(*g_autoGroupStack.top()));
+      //printf("Appending group %s to %s: count=%d entry=%p\n",
+      //g_autoGroupStack.top()->groupname.data(),
+      //e->name.data(),e->groups->count(),e);
+    }
+    else {
+      // printf("Not appending group %s to %s since parent compound is already a member of the group: count=%d entry=%p\n",
+      // g_autoGroupStack.top()->groupname.data(),
+      // e->name.data(),e->groups->count(),e);
+    }
   }
 }
 

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1587,6 +1587,7 @@ static void parseCompounds(Entry *rt)
   //printf("parseCompounds(%s)\n",rt->name.data());
   EntryListIterator eli(*rt->children());
   Entry *ce;
+  groupPushAutoGroup();
   for (;(ce=eli.current());++eli)
   {
     if (!ce->program.isEmpty())
@@ -1627,6 +1628,7 @@ static void parseCompounds(Entry *rt)
     }
     parseCompounds(ce);
   }
+  groupPopAutoGroup();
 }
 
 //----------------------------------------------------------------------------

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6754,6 +6754,8 @@ static void parseCompounds(Entry *rt)
   //printf("parseCompounds(%s)\n",rt->name.data());
   EntryListIterator eli(*rt->children());
   Entry *ce;
+  groupPushAutoGroup();
+
   for (;(ce=eli.current());++eli)
   {
     if (!ce->program.isEmpty())
@@ -6786,8 +6788,8 @@ static void parseCompounds(Entry *rt)
 
       // deep copy group list from parent (see bug 727732)
       static bool autoGroupNested = Config_getBool(GROUP_NESTED_COMPOUNDS);
-      if (autoGroupNested && rt->groups && ce->section!=Entry::ENUM_SEC && !(ce->spec&Entry::Enum))
-      {
+      if (autoGroupNested && rt->groups && ce->section != Entry::ENUM_SEC &&
+          !(ce->spec & Entry::Enum)) {
         QListIterator<Grouping> gli(*rt->groups);
         Grouping *g;
         for (;(g=gli.current());++gli)
@@ -6866,6 +6868,8 @@ static void parseCompounds(Entry *rt)
     }
     parseCompounds(ce);
   }
+  groupPopAutoGroup();
+
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Preivously, compound entities autogrouped using `\{` and `\}` will have all
their descendents entities included in the group as well.  This makes the
generated module page very noisy. See the description of Bugzilla
#774432 for details.

This patch maintains a stack of QCString, corresponding to the name of
the autogroup for the compound entities currently being recursively
parsed. Then upon `initGroupInfo`, an autogroup is added to the entry's
list of groups only if the autogroup is different from its parent
compound entity's autogroup.