### PR TITLE
Better module pages: autogroup include only one level of entites (Fix Issue #774432)

### DIFF
--- a/src/commentscan.h
+++ b/src/commentscan.h
@@ -76,8 +76,8 @@ void groupEnterFile(const char *file,int line);
 void groupLeaveFile(const char *file,int line);
 void groupLeaveCompound(const char *file,int line,const char *name);
 void groupEnterCompound(const char *file,int line,const char *name);
-void groupPushAutoGroup();
-void groupPopAutoGroup();
+void groupPushAutoGroup(Entry *e);
+void groupPopAutoGroup(Entry *e);
 
 void openGroup(Entry *e,const char *file,int line);
 void closeGroup(Entry *,const char *file,int line,bool foundInline=FALSE);

--- a/src/commentscan.h
+++ b/src/commentscan.h
@@ -76,6 +76,9 @@ void groupEnterFile(const char *file,int line);
 void groupLeaveFile(const char *file,int line);
 void groupLeaveCompound(const char *file,int line,const char *name);
 void groupEnterCompound(const char *file,int line,const char *name);
+void groupPushAutoGroup();
+void groupPopAutoGroup();
+
 void openGroup(Entry *e,const char *file,int line);
 void closeGroup(Entry *,const char *file,int line,bool foundInline=FALSE);
 void initGroupInfo(Entry *e);

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -443,6 +443,9 @@ static QStack<Grouping> g_autoGroupStack;
 static int              g_memberGroupId = DOX_NOGROUP;
 static QCString         g_memberGroupHeader;
 static QCString         g_memberGroupDocs;
+
+static QStack<QCString> g_compoundAutoGroupNameStack;
+
 static QCString         g_memberGroupRelates;
 static QCString         g_compoundName;
 
@@ -3009,6 +3012,8 @@ void groupEnterFile(const char *fileName,int)
   g_autoGroupStack.clear();
   g_memberGroupId = DOX_NOGROUP;
   g_memberGroupDocs.resize(0);
+  g_compoundAutoGroupNameStack.setAutoDelete(TRUE);
+  g_compoundAutoGroupNameStack.clear();
   g_memberGroupRelates.resize(0);
   g_compoundName=fileName;
 }
@@ -3026,6 +3031,17 @@ void groupLeaveFile(const char *fileName,int line)
   {
     warn(fileName,line,"end of file while inside a group\n");
   }
+}
+
+void groupPushAutoGroup() {
+  if (!g_autoGroupStack.isEmpty())
+      g_compoundAutoGroupNameStack.push(new QCString(g_autoGroupStack.top()->groupname));
+  else
+      g_compoundAutoGroupNameStack.push(new QCString(""));
+}
+
+void groupPopAutoGroup() {
+   g_compoundAutoGroupNameStack.pop();
 }
 
 void groupEnterCompound(const char *fileName,int line,const char *name)
@@ -3047,10 +3063,10 @@ void groupEnterCompound(const char *fileName,int line,const char *name)
   {
     g_compoundName=fileName;
   }
-  //printf("groupEnterCompound(%s)\n",name);
+  //printf("groupEnterCompound(%s) within AutoGroup(%s)\n",name, g_compoundAutoGroupNameStack.top()->data());
 }
 
-void groupLeaveCompound(const char *,int,const char * /*name*/)
+void groupLeaveCompound(const char *fileName,int line,const char * name)
 {
   //printf("groupLeaveCompound(%s)\n",name);
   //if (g_memberGroupId!=DOX_NOGROUP)
@@ -3086,10 +3102,11 @@ static int findExistingGroup(int &groupId,const MemberGroupInfo *info)
 void openGroup(Entry *e,const char *,int)
 {
   //printf("==> openGroup(name=%s,sec=%x) g_autoGroupStack=%d\n",
-  //  	e->name.data(),e->section,g_autoGroupStack.count());
+  // 	e->name.data(),e->section,g_autoGroupStack.count());
   if (e->section==Entry::GROUPDOC_SEC) // auto group
   {
     g_autoGroupStack.push(new Grouping(e->name,e->groupingPri()));
+    
   }
   else // start of a member group
   {
@@ -3127,6 +3144,7 @@ void closeGroup(Entry *e,const char *fileName,int line,bool foundInline)
     g_memberGroupId=DOX_NOGROUP;
     g_memberGroupRelates.resize(0);
     g_memberGroupDocs.resize(0);
+  
     if (!foundInline) e->mGrpId=DOX_NOGROUP;
     //printf("new group id=%d\n",g_memberGroupId);
   }
@@ -3152,7 +3170,18 @@ void initGroupInfo(Entry *e)
     //printf("Appending group %s to %s: count=%d entry=%p\n",
     //	g_autoGroupStack.top()->groupname.data(),
     //	e->name.data(),e->groups->count(),e);
-    e->groups->append(new Grouping(*g_autoGroupStack.top()));
+    if (g_compoundAutoGroupNameStack.isEmpty() ||
+        *g_compoundAutoGroupNameStack.top() != g_autoGroupStack.top()->groupname) {
+      e->groups->append(new Grouping(*g_autoGroupStack.top()));
+      //printf("Appending group %s to %s: count=%d entry=%p\n",
+      //g_autoGroupStack.top()->groupname.data(),
+      //e->name.data(),e->groups->count(),e);
+    }
+    else {
+      // printf("Not appending group %s to %s since parent compound is already a member of the group: count=%d entry=%p\n",
+      // g_autoGroupStack.top()->groupname.data(),
+      // e->name.data(),e->groups->count(),e);
+    }
   }
 }
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3033,15 +3033,20 @@ void groupLeaveFile(const char *fileName,int line)
   }
 }
 
-void groupPushAutoGroup() {
-  if (!g_autoGroupStack.isEmpty())
-      g_compoundAutoGroupNameStack.push(new QCString(g_autoGroupStack.top()->groupname));
-  else
-      g_compoundAutoGroupNameStack.push(new QCString(""));
+void groupPushAutoGroup(Entry *e) {
+  if (e-> section != Entry::NAMESPACE_SEC && !e->autogroupName.isNull() && !e->autogroupName.isEmpty()) {
+    g_compoundAutoGroupNameStack.push(new QCString(e->autogroupName));
+    //printf("Push autogroup %s for entry %s\n", e->autogroupName.data(), e->name.data());
+  }
+  else {
+    //printf("Push autogroup %s for entry %s (Namespace or undefined autogroup)\n", e->autogroupName.data(), e->name.data());
+  }
 }
 
-void groupPopAutoGroup() {
-   g_compoundAutoGroupNameStack.pop();
+void groupPopAutoGroup(Entry *e) {
+  if (e-> section != Entry::NAMESPACE_SEC && !e->autogroupName.isNull() && !e->autogroupName.isEmpty())
+    g_compoundAutoGroupNameStack.pop();
+  //printf("Pop autogroup for entry %s\n", e->name.data());
 }
 
 void groupEnterCompound(const char *fileName,int line,const char *name)
@@ -3170,17 +3175,18 @@ void initGroupInfo(Entry *e)
     //printf("Appending group %s to %s: count=%d entry=%p\n",
     //	g_autoGroupStack.top()->groupname.data(),
     //	e->name.data(),e->groups->count(),e);
+    e->autogroupName = g_autoGroupStack.top()->groupname;
     if (g_compoundAutoGroupNameStack.isEmpty() ||
-        *g_compoundAutoGroupNameStack.top() != g_autoGroupStack.top()->groupname) {
+        *g_compoundAutoGroupNameStack.top() != e->autogroupName) {
       e->groups->append(new Grouping(*g_autoGroupStack.top()));
       //printf("Appending group %s to %s: count=%d entry=%p\n",
-      //g_autoGroupStack.top()->groupname.data(),
-      //e->name.data(),e->groups->count(),e);
+      //  g_autoGroupStack.top()->groupname.data(),
+      //  e->name.data(),e->groups->count(),e);
     }
     else {
-      // printf("Not appending group %s to %s since parent compound is already a member of the group: count=%d entry=%p\n",
-      // g_autoGroupStack.top()->groupname.data(),
-      // e->name.data(),e->groups->count(),e);
+      //printf("Not appending group %s to %s since parent compound is already a member of the group: count=%d entry=%p\n",
+      //  g_autoGroupStack.top()->groupname.data(),
+      //  e->name.data(),e->groups->count(),e);
     }
   }
 }

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -45,6 +45,7 @@ Entry::Entry()
   extends->setAutoDelete(TRUE);
   groups = new QList<Grouping>;
   groups->setAutoDelete(TRUE);
+  autogroupName = "";
   anchors = new QList<SectionInfo>; // Doxygen::sectionDict takes ownership of the items!
   argList = new ArgumentList;
   argList->setAutoDelete(TRUE);
@@ -110,6 +111,7 @@ Entry::Entry(const Entry &e)
   extends->setAutoDelete(TRUE);
   groups      = new QList<Grouping>;
   groups->setAutoDelete(TRUE);
+  autogroupName = e.autogroupName;
   anchors     = new QList<SectionInfo>;
   fileName    = e.fileName;
   startLine   = e.startLine;
@@ -162,6 +164,8 @@ Entry::Entry(const Entry &e)
   {
     groups->append(new Grouping(*g));
   }
+
+
   
   QListIterator<SectionInfo> sli2(*e.anchors);
   SectionInfo *s;
@@ -266,6 +270,7 @@ void Entry::reset()
   m_sublist->clear();
   extends->clear();
   groups->clear();
+  autogroupName.resize(0);
   anchors->clear();
   argList->clear();
   if (tagInfo)    { delete tagInfo; tagInfo=0; }

--- a/src/entry.h
+++ b/src/entry.h
@@ -278,6 +278,7 @@ class Entry
     int          mGrpId;      //!< member group id
     QList<BaseInfo> *extends; //!< list of base classes    
     QList<Grouping> *groups;  //!< list of groups this entry belongs to
+    QCString     autogroupName; //!< the name of the autogroup (defined via `\{` and `\}`) this entry belongs to
     QList<SectionInfo> *anchors; //!< list of anchors defined in this entry
     QCString	fileName;     //!< file this entry was extracted from
     int		startLine;    //!< start line of entry in the source

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1587,6 +1587,7 @@ static void parseCompounds(Entry *rt)
   //printf("parseCompounds(%s)\n",rt->name.data());
   EntryListIterator eli(*rt->children());
   Entry *ce;
+  groupPushAutoGroup();
   for (;(ce=eli.current());++eli)
   {
     if (!ce->program.isEmpty())
@@ -1627,6 +1628,7 @@ static void parseCompounds(Entry *rt)
     }
     parseCompounds(ce);
   }
+  groupPopAutoGroup();
 }
 
 //----------------------------------------------------------------------------

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1587,7 +1587,7 @@ static void parseCompounds(Entry *rt)
   //printf("parseCompounds(%s)\n",rt->name.data());
   EntryListIterator eli(*rt->children());
   Entry *ce;
-  groupPushAutoGroup();
+  groupPushAutoGroup(rt);
   for (;(ce=eli.current());++eli)
   {
     if (!ce->program.isEmpty())
@@ -1628,7 +1628,7 @@ static void parseCompounds(Entry *rt)
     }
     parseCompounds(ce);
   }
-  groupPopAutoGroup();
+  groupPopAutoGroup(rt);
 }
 
 //----------------------------------------------------------------------------

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6754,10 +6754,10 @@ static void parseCompounds(Entry *rt)
   //printf("parseCompounds(%s)\n",rt->name.data());
   EntryListIterator eli(*rt->children());
   Entry *ce;
-  groupPushAutoGroup();
 
   for (;(ce=eli.current());++eli)
   {
+    groupPushAutoGroup(ce);
     if (!ce->program.isEmpty())
     {
       //printf("-- %s ---------\n%s\n---------------\n",
@@ -6867,8 +6867,8 @@ static void parseCompounds(Entry *rt)
       //}
     }
     parseCompounds(ce);
+    groupPopAutoGroup(ce);
   }
-  groupPopAutoGroup();
 
 }
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6754,6 +6754,8 @@ static void parseCompounds(Entry *rt)
   //printf("parseCompounds(%s)\n",rt->name.data());
   EntryListIterator eli(*rt->children());
   Entry *ce;
+  groupPushAutoGroup();
+
   for (;(ce=eli.current());++eli)
   {
     if (!ce->program.isEmpty())
@@ -6786,8 +6788,8 @@ static void parseCompounds(Entry *rt)
 
       // deep copy group list from parent (see bug 727732)
       static bool autoGroupNested = Config_getBool(GROUP_NESTED_COMPOUNDS);
-      if (autoGroupNested && rt->groups && ce->section!=Entry::ENUM_SEC && !(ce->spec&Entry::Enum))
-      {
+      if (autoGroupNested && rt->groups && ce->section != Entry::ENUM_SEC &&
+          !(ce->spec & Entry::Enum)) {
         QListIterator<Grouping> gli(*rt->groups);
         Grouping *g;
         for (;(g=gli.current());++gli)
@@ -6866,6 +6868,8 @@ static void parseCompounds(Entry *rt)
     }
     parseCompounds(ce);
   }
+  groupPopAutoGroup();
+
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Preivously, compound entities autogrouped using `\{` and `\}` will have all their descendents entities included in the group as well. This makes the generated module page very noisy.

This patch maintains a stack of QCString, corresponding to the name of the autogroup for the compound entities currently being recursively parsed. Then upon `initGroupInfo`, an autogroup is added to the entry's list of groups only if the autogroup is different from its parent compound entity's autogroup.

Also, namespaces are ignored when deciding if an entry's parent is already included in the autogroup. This is a more correct behavior since namespaces are open and can be extended at other places. When a
namespace is included in an autogroup via `\{` and `\}`, it really the content of the namespace defined within those braces that should be included in the module page, and not the namespace itself, which can
contain other entities defined elsewhere.

For example, consider the following snippets

```cpp
/// \defgroup autogroup
/// \{
/// desc of x
namespace x {
    /// desc of y
    namespace y {
        /// desc of a
        struct a {
            /// desc of a::b
            struct b{};

            /// desc of a::c
            int c;
        };
    }
}
/// \}
```

Then the module page for `autogroup` will include `x`, `x::y`, `x::y::a`, but not `x::y::a::b` or `x::y::a::c`, whereas the default Doxygen behavior is to include the latter two member entities. If `a` is very complex, and there are a lot of other complex classes defined, then the module page of `autogroup` becomes super noisy, polluted by all the implementation details of classes in `x::y`.






