### PR TITLE
Bug 776791 - [1.8.13 Regression] Segfault building the breathe docs

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -620,7 +620,7 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
     if (md->isInline()) t << "yes"; else t << "no";
     t << "\"";
 
-    if (al->refQualifier!=RefQualifierNone)
+    if (al!=0 && al->refQualifier!=RefQualifierNone)
     {
       t << " refqual=\"";
       if (al->refQualifier==RefQualifierLValue) t << "lvalue"; else t << "rvalue";


### PR DESCRIPTION
Protected against NULL pointer of variable al