### PR TITLE
Bug 777266: Environment default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 /doxygen_docs
 /doxygen.tag
+
+build/*

--- a/src/config.xml
+++ b/src/config.xml
@@ -46,7 +46,9 @@ new values to the list. Values are sequences of non-blanks. If the value should
 contain one or more blanks it must be surrounded by quotes (<code>&quot;...&quot;</code>).
 Multiple lines can be concatenated by inserting a backslash (\c \\)
 as the last character of a line. Environment variables can be expanded 
-using the pattern <code>\$(ENV_VARIABLE_NAME)</code>.
+using the pattern <code>\$(ENV_VARIABLE_NAME)</code>. A default value if environment 
+variable is not present can be set using the pattern 
+<code>\$(ENV_VARIABLE_NAME:-DEFAULT_VALUE)</code>
 
 You can also include part of a configuration file from another configuration
 file using a <code>\@INCLUDE</code> tag as follows:

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -881,25 +881,38 @@ void ConfigImpl::convertStrToVal()
   }
 }
 
-static void substEnvVarsInString(QCString &s)
+static void substEnvVarsInString(QCString &string)
 {
-  static QRegExp re("\\$\\([a-z_A-Z0-9.-]+\\)");
-  static QRegExp re2("\\$\\([a-z_A-Z0-9.-]+\\([a-z_A-Z0-9.-]+\\)\\)"); // For e.g. PROGRAMFILES(X86)
-  if (s.isEmpty()) return;
-  int p=0;
-  int i,l;
-  //printf("substEnvVarInString(%s) start\n",s.data());
-  while ((i=re.match(s,p,&l))!=-1 || (i=re2.match(s,p,&l))!=-1)
+  static QRegExp reVar("[$][(][a-z_A-Z][a-z_A-Z0-9]*[):]"); // $(<name>[):]
+  static QRegExp reDefault("-[^)]*[)]"); // -<default>)
+
+  if (string.isEmpty()) return;
+
+  int parsePosition=0;
+  int varStart, varLength, defaultStart, defaultLength;
+  //printf("substEnvVarInString(%s) start\n",string.data());
+  while ((varStart=reVar.match(string,parsePosition,&varLength))!=-1)
   {
-    //printf("Found environment var s.mid(%d,%d)=`%s'\n",i+2,l-3,s.mid(i+2,l-3).data());
-    QCString env=portable_getenv(s.mid(i+2,l-3));
-    substEnvVarsInString(env); // recursively expand variables if needed.
-    s = s.left(i)+env+s.right(s.length()-i-l);
-    p=i+env.length(); // next time start at the end of the expanded string
+    parsePosition += varLength;
+
+    // Find default value
+    if(string[varLength-1] == ':' && (defaultStart=reDefault.match(string,parsePosition,&defaultLength)) == -1) { 
+      // No valid environment variable
+      continue;
+    }
+
+    //printf("Found environment var string.mid(%d,%d)=`%s'\n",varStart+2,varLength-3,string.mid(varStart+2,varLength-3).data());
+    QCString env=portable_getenv(string.mid(varStart+2,varLength-3));
+    //printf("%s=%s\n",string.mid(varStart+2,varLength-3).data(), env.data());
+    if(string[varLength-1] == ':' && env == NULL) {
+      env = string.mid(defaultStart+1,defaultLength-2);
+      substEnvVarsInString(env); // Replace vars in default string.
+    }
+    string = string.left(varStart)+env+string.right(string.length()-varStart-varLength-defaultLength);
+    //printf("String after environment variable substitution: %s\n", string.data());
   }
-  s=s.stripWhiteSpace(); // to strip the bogus space that was added when an argument
-                         // has quotes
-  //printf("substEnvVarInString(%s) end\n",s.data());
+  string=string.stripWhiteSpace(); // to strip the bogus space that was added when an argument has quotes
+  //printf("substEnvVarInString(%s) End\n",string.data());
 }
 
 static void substEnvVarsInStrList(QStrList &sl)

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -883,7 +883,8 @@ void ConfigImpl::convertStrToVal()
 
 static void substEnvVarsInString(QCString &string)
 {
-  static QRegExp reVar("[$][(][a-z_A-Z][a-z_A-Z0-9]*[):]"); // $(<name>[):]
+  static QRegExp reVar1("[$][(][a-z_A-Z0-9.-]+[):]"); // $(<name>[):]
+  static QRegExp reVar2("[$][(][a-z_A-Z0-9.-]+[(][a-z_A-Z0-9.-]+[)][):]"); // $(<namepart1>(<namepart2>)[):]
   static QRegExp reDefault("-[^)]*[)]"); // -<default>)
 
   if (string.isEmpty()) return;
@@ -891,7 +892,7 @@ static void substEnvVarsInString(QCString &string)
   int parsePosition=0;
   int varStart, varLength, defaultStart, defaultLength;
   //printf("substEnvVarInString(%s) start\n",string.data());
-  while ((varStart=reVar.match(string,parsePosition,&varLength))!=-1)
+  while ((varStart=reVar1.match(string,parsePosition,&varLength))!=-1 || (varStart=reVar2.match(string,parsePosition,&varLength))!=-1)
   {
     parsePosition += varLength;
 

--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -1,0 +1,2 @@
+html/
+test_output_*

--- a/testing/066/indexpage.xml
+++ b/testing/066/indexpage.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="indexpage" kind="page">
+    <compoundname>index</compoundname>
+    <title>defaultproject</title>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/066_env_var_default.dox
+++ b/testing/066_env_var_default.dox
@@ -1,0 +1,6 @@
+// objective: test environment variable default substitution
+// check: indexpage.xml
+// config: PROJECT_NAME = $(ENVVARNAME:-defaultproject)
+/** 
+ * \mainpage
+ */

--- a/testing/067/indexpage.xml
+++ b/testing/067/indexpage.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="indexpage" kind="page">
+    <compoundname>index</compoundname>
+    <title>complexproject</title>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/067_env_var_default_windows.dox
+++ b/testing/067_env_var_default_windows.dox
@@ -1,0 +1,6 @@
+// objective: test environment variable default substitution
+// check: indexpage.xml
+// config: PROJECT_NAME = $(VAR.X(6.4):-complexproject)
+/** 
+ * \mainpage
+ */

--- a/testing/068/indexpage.xml
+++ b/testing/068/indexpage.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="indexpage" kind="page">
+    <compoundname>index</compoundname>
+    <title>doxygen</title>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/068_env_var_sub.dox
+++ b/testing/068_env_var_sub.dox
@@ -1,0 +1,7 @@
+// objective: test environment variable default substitution
+// check: indexpage.xml
+// env: TITLEENV=doxygen
+// config: PROJECT_NAME = $(TITLEENV)
+/** 
+ * \mainpage
+ */

--- a/testing/069/indexpage.xml
+++ b/testing/069/indexpage.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="indexpage" kind="page">
+    <compoundname>index</compoundname>
+    <title>doxygen</title>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/069_env_var_sub_with_default.dox
+++ b/testing/069_env_var_sub_with_default.dox
@@ -1,0 +1,7 @@
+// objective: test environment variable default substitution
+// check: indexpage.xml
+// env: TITLEENV=doxygen
+// config: PROJECT_NAME = $(TITLEENV:-defaultproject)
+/** 
+ * \mainpage
+ */

--- a/testing/README.txt
+++ b/testing/README.txt
@@ -33,6 +33,8 @@ Where <identifier> can be one of:
              be compared against the reference.
 - config:    'argument' is a line that is added to the default Doxyfile used to
              run doxygen on the test file.
+- env:       'argument' is a line that which sets an environment variable
+             passed to Doxygen. (i.e. 'ENVVARNAME=envvarvalue')
 
 Example to run all tests:
     python runtest.py

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import argparse, glob, itertools, re, shutil, os, sys
 
 config_reg = re.compile('.*\/\/\s*(?P<name>\S+):\s*(?P<value>.*)$')
+env_reg = re.compile('(?P<key>\S*)=(?P<value>.*)')
 
 class Tester:
 	def __init__(self,args,test):
@@ -61,6 +62,17 @@ class Tester:
 		if 'check' not in self.config or not self.config['check']:
 			print('Test doesn\'t specify any files to check')
 			sys.exit(1)
+
+		if 'env' in self.config:
+			for env_line in self.config['env']:
+				env_var = env_reg.match(env_line)
+				if env_var:
+					env_key = env_var.group('key')
+					env_value = env_var.group('value')
+					os.environ[env_key] = env_value
+				else:
+					print('Invalid env option: ', env_line)
+					sys.exit(1)
 
 		# run doxygen
 		if (sys.platform == 'win32'):


### PR DESCRIPTION
Solution for https://bugzilla.gnome.org/show_bug.cgi?id=777266

Please tell me if you prefer patches at bugzilla.

Now we only try to replace valid variable names.
I also removed the support for variables named for e.g. PROGRAMFILES(X86). Had this a special meaning?

Do I need to write a test case for this? If yes can you point me to a similar test?

Thank you for reviewing this in advance.