### PR TITLE
Ported to Android

### DIFF
--- a/qtools/qthread_unix.cpp
+++ b/qtools/qthread_unix.cpp
@@ -76,14 +76,18 @@ QThreadPrivate::~QThreadPrivate()
 
 void *QThreadPrivate::start(void *arg)
 {
+#ifndef __ANDROID__
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+#endif
     pthread_cleanup_push(QThreadPrivate::finish, arg);
 
     QThread *thr = reinterpret_cast<QThread *>(arg);
 
     thr->started();
+#ifndef __ANDROID__
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
     pthread_testcancel();
+#endif
     thr->run();
 
     pthread_cleanup_pop(1);
@@ -132,7 +136,9 @@ void QThread::start()
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr,PTHREAD_CREATE_DETACHED);
+#ifndef __ANDROID__
     pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+#endif
     if (d->stackSize>0)
     {
 #if defined(_POSIX_THREAD_ATTR_STACKSIZE) && (_POSIX_THREAD_ATTR_STACKSIZE-0>0)
@@ -160,7 +166,7 @@ void QThread::start()
 void QThread::terminate()
 {
     QMutexLocker locker(&d->mutex);
-
+#ifndef __ANDROID__
     if (!d->thread_id) return;
 
     int code = pthread_cancel(d->thread_id);
@@ -172,6 +178,7 @@ void QThread::terminate()
     {
         d->terminated = TRUE;
     }
+#endif
 }
 
 void QThread::wait()


### PR DESCRIPTION
First of:
I'm aware that this is not the preferred way of handing in features/patches, but the mailing list seems a little quiet down for a discussion.

Anyway, porting was not that complex as Doxygen has no external dependencies and is pretty well written.
The only problems were a few threading functions found in [qthread_unix.cpp](https://github.com/doxygen/doxygen/blob/master/qtools/qthread_unix.cpp) which are missing on Android.
A little background;
To keep things small, the Google and the Android Team decided to omit some POSIX thread functions from their standard C library (called [Bionic](https://en.wikipedia.org/wiki/Bionic_(software))) like `pthread_cancel`, `pthread_testcancel` and a few others.

I tried (and failed) to develop and re-introduce these functions back into the bionic thread structure. But while doing so, I found out that the [QT Project](https://github.com/qt/qtbase) already solved this limitation in their `qthread_unix.cpp` by simply using some #ifdefs around the missing/offending functions:
Take a look at this and look for the `#if !defined(Q_OS_ANDROID)` macros
https://github.com/qt/qtbase/blob/dev/src/corelib/thread/qthread_unix.cpp

And sure enough, that's really all it takes to get it to build and work on Android.
I took these recommendations and applied them in a more portable fashion to my [qthread_unix.cpp](https://github.com/sgeto/doxygen/blob/master/qtools/qthread_unix.cpp) by using the de facto standard `__ANDROID__` preprocessor definition instead of their own (QT specific) `Q_OS_ANDROID` macro.

I ported this for use with one of the projects I'm currently maintaining, but I can imagine that this may be of use for others as well. 
I hope you like it.

![Screenshot](https://4.bp.blogspot.com/-YfFyI0FIJUA/WLosW6k42UI/AAAAAAAABxc/f4-xYg4UHCgjCgR2vbQsRpdU4ShR6jqUwCLcB/s1600/Screenshot_20170303-151445.png "Screenshot")