### PR TITLE
Fix C# property initializer parsing

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6198,6 +6198,14 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  }
   					}
 <CSAccessorDecl>"{"			{ curlyCount++; }
+<CSAccessorDecl>"}"{B}*"="		{
+					  // fall back to next rule if it's not the right bracket
+					  if (curlyCount != 0) REJECT;
+					  current->initializer = "=";
+					  current->endBodyLine=yyLineNr;
+					  lastInitializerContext = FindMembers;
+					  BEGIN(ReadInitializer);
+					}
 <CSAccessorDecl>"}"			{ 
                                           if (curlyCount) 
                                           {
@@ -6207,6 +6215,8 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  {
   					    mtype = Method;
                                             virt = Normal;
+					    // not really important, but while we are at it
+					    current->endBodyLine=yyLineNr;
                                             unput(';');
 					    BEGIN(FindMembers);
 					  }

--- a/testing/066/class_class1.xml
+++ b/testing/066/class_class1.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="class_class1" kind="class" language="C#" prot="public">
+    <compoundname>Class1</compoundname>
+    <sectiondef kind="property">
+      <memberdef kind="property" id="class_class1_1a6b0b2ab73516e37adb38b8ff33f97c40" prot="public" static="no" readable="no" writable="no" gettable="yes" privategettable="no" protectedgettable="no" settable="no" privatesettable="no" protectedsettable="no">
+        <type>int</type>
+        <definition>int Class1.Property1</definition>
+        <argsstring/>
+        <name>Property1</name>
+        <initializer>= 1</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="066_property_initializer.cs" line="5" column="1" bodyfile="066_property_initializer.cs" bodystart="5" bodyend="5"/>
+      </memberdef>
+      <memberdef kind="property" id="class_class1_1a0d5b843d48ebc2c078e003d6ff3a1610" prot="public" static="no" readable="no" writable="no" gettable="yes" privategettable="no" protectedgettable="no" settable="yes" privatesettable="no" protectedsettable="no">
+        <type>string</type>
+        <definition>string Class1.Property2</definition>
+        <argsstring/>
+        <name>Property2</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="066_property_initializer.cs" line="6" column="1" bodyfile="066_property_initializer.cs" bodystart="6" bodyend="6"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="066_property_initializer.cs" line="4" column="1" bodyfile="066_property_initializer.cs" bodystart="3" bodyend="7"/>
+    <listofallmembers>
+      <member refid="class_class1_1a6b0b2ab73516e37adb38b8ff33f97c40" prot="public" virt="non-virtual">
+        <scope>Class1</scope>
+        <name>Property1</name>
+      </member>
+      <member refid="class_class1_1a0d5b843d48ebc2c078e003d6ff3a1610" prot="public" virt="non-virtual">
+        <scope>Class1</scope>
+        <name>Property2</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/066_property_initializer.cs
+++ b/testing/066_property_initializer.cs
@@ -1,0 +1,7 @@
+// objective: C# property initializer
+// check: class_class1.xml
+class Class1
+{
+  public int Property1 { get; } = 1;
+  public string Property2 { get; set; }
+}


### PR DESCRIPTION
This commit fixes an issue with parsing of the following C# code:
``` csharp
int Property {get; set;} = 23;
```
The parser was ending the property at the closing bracket, which resulted in the initializer being assigned to the following property.