### PR TITLE
Add links behind nav entries "Namespaces" and "Files" (matching "Classes")

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4151,7 +4151,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const QList<LayoutNavEntry
         case LayoutNavEntry::Classes: 
           if (annotatedClasses>0 && addToIndex)
           {
-            Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,"annotated",0); 
+            Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,lne->baseFile(),0);
             Doxygen::indexList->incContentsDepth();
             needsClosing=TRUE;
           }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4122,7 +4122,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const QList<LayoutNavEntry
             {
               if (documentedNamespaces>0 && addToIndex)
               {
-                Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,0,0); 
+                Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,lne->baseFile(),0);
                 Doxygen::indexList->incContentsDepth();
                 needsClosing=TRUE;
               }
@@ -4189,7 +4189,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const QList<LayoutNavEntry
             {
               if (documentedHtmlFiles>0 && addToIndex)
               {
-                Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,0,0); 
+                Doxygen::indexList->addContentsItem(TRUE,lne->title(),0,lne->baseFile(),0);
                 Doxygen::indexList->incContentsDepth();
                 needsClosing=TRUE;
               }


### PR DESCRIPTION
When layout file has "namespacelist" and/or "filelist" set to visible=no,
the files "namespaces.html" resp. "files.html" are still generated,
but not reachable.

So same fix as done for "classlist" should be used,
cmp. 700a9ac3c177fdef25b9b00ed6bb5e0ea963d236

Also gives a consistent result & at least in generated QCH files fixes the error
message currently shown when clicking on "Namespaces" or "Files" section titles in the navigation tree.

Using lne->baseFile() and thus the string from the central db instead of using a hardcoded duplicated filename feels better, and thus first patch also adapts the code for "LayoutNavEntry::Classes".