### PR TITLE
Bug 783134 - LaTeX output for \tparam block fails to compile when it contains a \code block

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -35,6 +35,7 @@
 #include "plantuml.h"
 
 const int maxLevels=5;
+int usedTableLevels = 0;
 static const char *secLabels[maxLevels] = 
    { "section","subsection","subsubsection","paragraph","subparagraph" };
 
@@ -1391,6 +1392,7 @@ void LatexDocVisitor::visitPre(DocParamSect *s)
   if (m_hide) return;
   bool hasInOutSpecs = s->hasInOutSpecifier();
   bool hasTypeSpecs  = s->hasTypeSpecifier();
+  usedTableLevels++;
   switch(s->type())
   {
     case DocParamSect::Param:
@@ -1424,6 +1426,7 @@ void LatexDocVisitor::visitPre(DocParamSect *s)
 void LatexDocVisitor::visitPost(DocParamSect *s)
 {
   if (m_hide) return;
+  usedTableLevels--;
   switch(s->type())
   {
     case DocParamSect::Param:

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -24,6 +24,7 @@
 #include <qcstring.h>
 #include <qlist.h>
 //#include <qmap.h>
+extern int usedTableLevels;
 
 class FTextStream;
 class CodeOutputInterface;

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -92,7 +92,7 @@ void LatexCodeGenerator::codify(const char *str)
                    m_col+=spacesToNextTabStop;
                    p++;
                    break;
-        case '\n': m_t << '\n'; m_col=0; p++;
+        case '\n': (usedTableLevels>0) ? m_t << "\\newline\n" : m_t << '\n'; m_col=0; p++;
                    break;
         default:
                    i=0;
@@ -1843,11 +1843,13 @@ void LatexGenerator::writeNonBreakableSpace(int)
 
 void LatexGenerator::startDescTable(const char *title)
 {
+  usedTableLevels++;
   t << "\\begin{DoxyEnumFields}{" << title << "}" << endl;
 }
 
 void LatexGenerator::endDescTable()
 {
+  usedTableLevels--;
   t << "\\end{DoxyEnumFields}" << endl;
 }
 
@@ -2190,6 +2192,7 @@ void LatexGenerator::lineBreak(const char *)
 
 void LatexGenerator::startMemberDocSimple(bool isEnum)
 {
+  usedTableLevels++;
   if (isEnum)
   {
     t << "\\begin{DoxyEnumFields}{";
@@ -2205,6 +2208,7 @@ void LatexGenerator::startMemberDocSimple(bool isEnum)
 
 void LatexGenerator::endMemberDocSimple(bool isEnum)
 {
+  usedTableLevels--;
   if (isEnum)
   {
     t << "\\end{DoxyEnumFields}" << endl;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -47,6 +47,7 @@
 #include "searchindex.h"
 #include "doxygen.h"
 #include "textdocvisitor.h"
+#include "latexdocvisitor.h"
 #include "portable.h"
 #include "parserintf.h"
 #include "bufstr.h"
@@ -6655,6 +6656,12 @@ void filterLatexString(FTextStream &t,const char *str,
         case '{':  t << "\\{"; break;
         case '}':  t << "\\}"; break;
         case '_':  t << "\\_"; break;
+        case '&':  t << "\\&"; break;
+        case '%':  t << "\\%"; break;
+        case '#':  t << "\\#"; break;
+        case '$':  t << "\\$"; break;
+	case '^':  (usedTableLevels>0) ? t << "\\string^" : t << (char)c;    break;
+	case '~':  (usedTableLevels>0) ? t << "\\string~" : t << (char)c;    break;
         case ' ':  if (keepSpaces) t << "~"; else t << ' ';
                    break;
         default:


### PR DESCRIPTION
General problem regarding having a code / verbatim section inside a table.
Besides handling of the $ some other characters need special handling as well as the \n.