### PR TITLE
Bug 783768 - Add QHP_NO_CONSTRUCTOR_KEYWORDS option

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2171,6 +2171,15 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='QHP_NO_CONSTRUCTOR_KEYWORDS' defval='0' depends='GENERATE_QHP'>
+      <docs>
+<![CDATA[
+ If the \c QHP_NO_CONSTRUCTOR_KEYWORDS tag is set to \c YES then doxygen will not produce
+ keywords for constructor members, so they do not clash with keyword for the class itself.
+ If set to \c NO, constructor members will get keyword handling like any member.
+]]>
+      </docs>
+    </option>
     <option type='string' id='QHG_LOCATION' format='file' defval='' depends='GENERATE_QHP'>
       <docs>
 <![CDATA[

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -226,6 +226,7 @@ void Qhp::addIndexItem(Definition *context,MemberDef *md,
   if (md) // member
   {
     static bool separateMemberPages = Config_getBool(SEPARATE_MEMBER_PAGES);
+    static bool noConstructorKeywords = Config_getBool(QHP_NO_CONSTRUCTOR_KEYWORDS);
     if (context==0) // global member
     {
       if (md->getGroupDef())
@@ -234,6 +235,7 @@ void Qhp::addIndexItem(Definition *context,MemberDef *md,
         context = md->getFileDef();
     }
     if (context==0) return; // should not happen
+    if (md->isConstructor() && noConstructorKeywords) return;
     QCString cfname  = md->getOutputFileBase();
     QCString cfiname = context->getOutputFileBase();
     QCString level1  = context->name();


### PR DESCRIPTION
Allows to avoid clashes between keywords for classes themselves and
for their constructors methods

Not sure if this option should be limited to QCH generation alone and not be a generic option. Currently I only work with QCH generation, so cannot judge how useful this option would be for other output formats.

Fixes https://bugzilla.gnome.org/show_bug.cgi?id=783768