### PR TITLE
CMakeLists: Avoid MSVC iconv changes for MinGW builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,14 @@ if (${CMAKE_SYSTEM} MATCHES "Darwin")
 endif()
 
 if (WIN32)
-    if(NOT ICONV_DIR)
-      set(ICONV_DIR "${CMAKE_SOURCE_DIR}/winbuild")
+    if (NOT "${CMAKE_GENERATOR}" MATCHES ".*MinGW Makefiles.*")
+        if (NOT ICONV_DIR)
+          set(ICONV_DIR "${CMAKE_SOURCE_DIR}/winbuild")
+        endif()
+        set(CMAKE_REQUIRED_DEFINITIONS "-DLIBICONV_STATIC")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # needed for language.cpp on 64bit
+        add_definitions(-DLIBICONV_STATIC -D_CRT_SECURE_NO_WARNINGS)
     endif()
-    set(CMAKE_REQUIRED_DEFINITIONS "-DLIBICONV_STATIC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # needed for language.cpp on 64bit
-    add_definitions(-DLIBICONV_STATIC -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 if ("${CMAKE_GENERATOR}" MATCHES "Ninja") 


### PR DESCRIPTION
Change-Id: Ibad47399f87511f6d8ef7c2238c932377777a333
Signed-off-by: Adrian DC <radian.dc@gmail.com>