### PR TITLE
dot.cpp: Fix DotGfxHierarchyTable first class node loop

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -2477,7 +2477,7 @@ void DotGfxHierarchyTable::addClassList(ClassSDict *cl)
   }
 }
 
-DotGfxHierarchyTable::DotGfxHierarchyTable() : m_curNodeNumber(0)
+DotGfxHierarchyTable::DotGfxHierarchyTable() : m_curNodeNumber(1)
 {
   m_rootNodes = new QList<DotNode>;
   m_usedNodes = new QDict<DotNode>(1009); 


### PR DESCRIPTION
 * Upon 'inherits' diagram creation, the first element
    (alphabetically last parent name) would use a default
    node number 0, equal to the child element, and would
    result in a class looping on itself as parent

 * A simple test to confirm the issue can be done with the
    following lines in a test.h inside an empty project:

     // Test first class node loop
     class aChildClass : public zParentClass { };
     class bChildClass : public yParentClass { };

Change-Id: I7901e5e13d9564747d112e0b8c758d239d43a380
Signed-off-by: Adrian DC <radian.dc@gmail.com>