### PR TITLE
Fixup man page NAME section when page has title

### DIFF
--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -169,6 +169,11 @@ void PageDef::writeDocumentation(OutputList &ol)
   ol.endTitleHead(manPageName, manPageName);
   if (si)
   {
+    ol.pushGeneratorState();
+    ol.disableAllBut(OutputGenerator::Man);
+    ol.writeString(" - ");
+    ol.popGeneratorState();
+
     ol.generateDoc(docFile(),docLine(),this,0,si->title,TRUE,FALSE,0,TRUE,FALSE);
     ol.endSection(si->label,si->type);
   }
@@ -230,7 +235,7 @@ void PageDef::writePageDocumentation(OutputList &ol)
 
   ol.startTextBlock();
   QCString docStr = documentation()+inbodyDocumentation();
-  if (!docStr.isEmpty())
+  if (hasBriefDescription() && !Doxygen::sectionDict->find(name()))
   {
     ol.pushGeneratorState();
     ol.disableAllBut(OutputGenerator::Man);


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=784032

This fixes the incorrect manpage NAME section a page has a title. Also if a page has a title and a brief, then the output will be identical to v1.8.12(<pagename> - <title> <brief>)