### PR TITLE
Add variadic arguments support to @link and @ref, aka '...' arguments

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -360,8 +360,9 @@ SPCMD3    {CMD}form#[0-9]+
 SPCMD4    {CMD}"::"
 INOUT	  "inout"|"in"|"out"|("in"{BLANK}*","{BLANK}*"out")|("out"{BLANK}*","{BLANK}*"in")
 PARAMIO   {CMD}param{BLANK}*"["{BLANK}*{INOUT}{BLANK}*"]"
+VARARGS   "..."
 TEMPCHAR  [a-z_A-Z0-9.,: \t\*\&\(\)\[\]]
-FUNCCHAR  [a-z_A-Z0-9,:\<\> \t\^\*\&\[\]]
+FUNCCHAR  [a-z_A-Z0-9,:\<\> \t\^\*\&\[\]]|{VARARGS}
 FUNCPART  {FUNCCHAR}*("("{FUNCCHAR}*")"{FUNCCHAR}*)?
 SCOPESEP  "::"|"#"|"."
 TEMPLPART "<"{TEMPCHAR}*">"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4594,7 +4594,7 @@ bool resolveRef(/* in */  const char *scName,
   QCString fullName = substitute(tsName,"#","::");
   if (fullName.find("anonymous_namespace{")==-1)
   {
-    fullName = removeRedundantWhiteSpace(substitute(fullName,".","::"));
+    fullName = removeRedundantWhiteSpace(substitute(fullName,".","::",3));
   }
   else
   {
@@ -5186,8 +5186,11 @@ QCString showFileDefMatches(const FileNameDict *fnDict,const char *n)
 
 //----------------------------------------------------------------------
 
-/// substitute all occurrences of \a src in \a s by \a dst
-QCString substitute(const QCString &s,const QCString &src,const QCString &dst)
+/// substitute all occurrences of \a src in \a s by \a dst, but skip
+/// each consecutive sequence of \a src where the number consecutive
+/// \a src matches \a skip_seq; if \a skip_seq is negative, skip any
+/// number of consecutive \a src
+QCString substitute(const QCString &s,const QCString &src,const QCString &dst,int skip_seq)
 {
   if (s.isEmpty() || src.isEmpty()) return s;
   const char *p, *q;
@@ -5208,13 +5211,36 @@ QCString substitute(const QCString &s,const QCString &src,const QCString &dst)
   char *r;
   for (r=result.rawData(), p=s; (q=strstr(p,src))!=0; p=q+srcLen)
   {
-    int l = (int)(q-p);
+    // search a consecutive sequence of src
+    int seq = 0, skip = 0;
+    if (skip_seq)
+    {
+      for (const char *n=q+srcLen; qstrncmp(n,src,srcLen)==0; seq=1+skip, n+=srcLen)
+        ++skip; // number of consecutive src after the current one
+
+      // verify the allowed number of consecutive src to skip
+      if (skip_seq > 0 && skip_seq != seq)
+        seq = skip = 0;
+    }
+
+    // skip a consecutive sequence of src when necessary
+    int l = (int)((q + seq * srcLen)-p);
     memcpy(r,p,l);
     r+=l;
+
+    if (skip)
+    {
+      // skip only the consecutive src found after the current one
+      q += skip * srcLen;
+      // the next loop will skip the current src, aka (p=q+srcLen)
+      continue;
+    }
+
     if (dst) memcpy(r,dst,dstLen);
     r+=dstLen;
   }
   qstrcpy(r,p);
+  result.resize(strlen(result.data())+1);
   //printf("substitute(%s,%s,%s)->%s\n",s,src,dst,result.data());
   return result;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4767,7 +4767,7 @@ QCString linkToText(SrcLangExt lang,const char *link,bool isFileName)
     // replace # by ::
     result=substitute(result,"#","::");
     // replace . by ::
-    if (!isFileName && result.find('<')==-1) result=substitute(result,".","::");
+    if (!isFileName && result.find('<')==-1) result=substitute(result,".","::",3);
     // strip leading :: prefix if present
     if (result.at(0)==':' && result.at(1)==':')
     {

--- a/src/util.h
+++ b/src/util.h
@@ -193,7 +193,7 @@ void mergeArguments(ArgumentList *,ArgumentList *,bool forceNameOverwrite=FALSE)
 
 QCString substituteClassNames(const QCString &s);
 
-QCString substitute(const QCString &s,const QCString &src,const QCString &dst);
+QCString substitute(const QCString &s,const QCString &src,const QCString &dst,int skip_seq = 0);
 
 QCString clearBlock(const char *s,const char *begin,const char *end);
 

--- a/testing/067/067__link__varargs_8cpp.xml
+++ b/testing/067/067__link__varargs_8cpp.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="067__link__varargs_8cpp" kind="file" language="C++">
+    <compoundname>067_link_varargs.cpp</compoundname>
+    <innerclass refid="class_test" prot="public">Test</innerclass>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="067__link__varargs_8cpp_1affb6da6cff1b57cdf8efc0123dceac9b" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A function </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="067_link_varargs.cpp" line="11" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="067__link__varargs_8cpp_1a106e01084409028d1b41f5ad83fb82c1" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p,...)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>...</type>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>Overloaded function taking variadic arguments </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="067_link_varargs.cpp" line="15" column="1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+      <para>See <ref refid="067__link__varargs_8cpp_1a106e01084409028d1b41f5ad83fb82c1" kindref="member">the function</ref> for more info. See the <ref refid="class_test" kindref="compound">test</ref> class. </para>
+    </detaileddescription>
+    <location file="067_link_varargs.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/067_link_varargs.cpp
+++ b/testing/067_link_varargs.cpp
@@ -1,0 +1,20 @@
+// objective: test \link command with function variadic arguments '...'
+// check: 067__link__varargs_8cpp.xml
+
+/** \file
+ *  See \link func(int,...) the function\endlink for more info.
+ *  See the \link Test test\endlink class.
+ */
+
+/** A function
+ */
+void func(int p);
+
+/** Overloaded function taking variadic arguments
+ */
+void func(int p, ...);
+
+/** A test */
+class Test
+{
+};

--- a/testing/068/068__ref__varargs_8cpp.xml
+++ b/testing/068/068__ref__varargs_8cpp.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="068__ref__varargs_8cpp" kind="file" language="C++">
+    <compoundname>068_ref_varargs.cpp</compoundname>
+    <innerclass refid="class_test" prot="public">Test</innerclass>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="068__ref__varargs_8cpp_1affb6da6cff1b57cdf8efc0123dceac9b" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A function </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="068_ref_varargs.cpp" line="11" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="068__ref__varargs_8cpp_1a106e01084409028d1b41f5ad83fb82c1" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p,...)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>...</type>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>Overloaded function taking variadic arguments </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="068_ref_varargs.cpp" line="15" column="1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+      <para>See <ref refid="068__ref__varargs_8cpp_1a106e01084409028d1b41f5ad83fb82c1" kindref="member">the function</ref> for more info. See the <ref refid="class_test" kindref="compound">test</ref> class. </para>
+    </detaileddescription>
+    <location file="068_ref_varargs.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/068_ref_varargs.cpp
+++ b/testing/068_ref_varargs.cpp
@@ -1,0 +1,20 @@
+// objective: test \ref command with function variadic arguments '...'
+// check: 068__ref__varargs_8cpp.xml
+
+/** \file
+ *  See \ref func(int,...) "the function" for more info.
+ *  See the \ref Test "test" class.
+ */
+
+/** A function
+ */
+void func(int p);
+
+/** Overloaded function taking variadic arguments
+ */
+void func(int p, ...);
+
+/** A test */
+class Test
+{
+};

--- a/testing/069/069__link__variadic__template_8cpp.xml
+++ b/testing/069/069__link__variadic__template_8cpp.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="069__link__variadic__template_8cpp" kind="file" language="C++">
+    <compoundname>069_link_variadic_template.cpp</compoundname>
+    <innerclass refid="class_test" prot="public">Test</innerclass>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1affb6da6cff1b57cdf8efc0123dceac9b" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A function </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="40" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1aa7e4936a17759246bce60256cf224e16" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args &amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args &amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="45" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1ad6fc2d2a6cb8980f3e0eaacbd2ae41fe" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args &amp;&amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args &amp;&amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="50" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args &amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args &amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="55" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1aed64c596fea5f4f5e719006539922f7c" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args &amp;&amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args &amp;&amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="60" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1a0ad18d95a1dc2dbacee657c43f719187" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args *... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args *...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="65" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1a2331eedd0a1db9da5de0ad0faef78a4e" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args **... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args **...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="70" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1a72bd94e61df947347f98a2a6214e9342" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args *... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args *...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="75" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1a0bd03c39aa36ae51d2b8d87e04cf7eab" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args **... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args **...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="80" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="069__link__variadic__template_8cpp_1abb1e0338f72ae46a1240ada65d6a397c" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="069_link_variadic_template.cpp" line="85" column="1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+      <para>
+        <simplesect kind="attention">
+          <para>
+            <parblock>
+              <para>At the time of writing, the part between &lt;&gt; is totally ignored: func&lt;Args...&gt;(Args... args) is interpreted as func(Args... args).</para>
+              <para>Beware that a function parameter with either a &amp; or * operator, e.g. 'const Args&amp;... args', requires \link and \ref to specify such parameter as verbatim, i.e. 'const Args&amp;... args'. At the time of writing, the form func(const Args&amp;...) will fail, unless the function parameter was declared just as 'const Args&amp;...'. </para>
+            </parblock>
+          </para>
+        </simplesect>
+      </para>
+      <para>
+        <ref refid="class_test_1a64d85df31d518e39726467315a9b05e3" kindref="member">variadic template method</ref>
+      </para>
+      <para>Links to the variadic template function overloads: <itemizedlist><listitem><para><ref refid="069__link__variadic__template_8cpp_1aa7e4936a17759246bce60256cf224e16" kindref="member">First overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1ad6fc2d2a6cb8980f3e0eaacbd2ae41fe" kindref="member">Second overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" kindref="member">Third overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1aed64c596fea5f4f5e719006539922f7c" kindref="member">Fourth overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1a0ad18d95a1dc2dbacee657c43f719187" kindref="member">Fifth overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1a2331eedd0a1db9da5de0ad0faef78a4e" kindref="member">Sixth overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1a72bd94e61df947347f98a2a6214e9342" kindref="member">Seventh overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1a0bd03c39aa36ae51d2b8d87e04cf7eab" kindref="member">Eighth overload</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1abb1e0338f72ae46a1240ada65d6a397c" kindref="member">Ninth overload</ref></para></listitem></itemizedlist>
+The followings are interpreted the same: <itemizedlist><listitem><para><ref refid="069__link__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" kindref="member">without template argument</ref></para></listitem><listitem><para><ref refid="069__link__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" kindref="member">with template argument</ref></para></listitem></itemizedlist>
+See the <ref refid="class_test" kindref="compound">test</ref> class. </para>
+    </detaileddescription>
+    <location file="069_link_variadic_template.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/069_link_variadic_template.cpp
+++ b/testing/069_link_variadic_template.cpp
@@ -1,0 +1,95 @@
+// objective: test \link command with a variadic template function
+// check: 069__link__variadic__template_8cpp.xml
+
+/** \file
+ *
+ *  @attention
+ *  @parblock
+ *  At the time of writing, the part between \<\> is totally ignored:
+ *  %func<Args...>(Args... args) is interpreted as %func(Args... args).
+ *
+ *  Beware that a function parameter with either a \& or \* operator,
+ *  e.g. 'const Args&... args', requires \\link and \\ref to specify
+ *  such parameter as verbatim, i.e. 'const Args&... args'.  At the
+ *  time of writing, the form %func(const Args&...) will fail, unless
+ *  the function parameter was declared just as 'const Args&...'.
+ *  @endparblock
+ *
+ *  \link Test::func(int,Args...)const variadic template method\endlink
+ *
+ *  Links to the variadic template function overloads:
+ *    @li \link func(int,Args&... args) First overload\endlink
+ *    @li \link func(int,Args&&... args) Second overload\endlink
+ *    @li \link func(int,const Args&... args) Third overload\endlink
+ *    @li \link func(int,const Args&&... args) Fourth overload\endlink
+ *    @li \link func(int,Args*... args) Fifth overload\endlink
+ *    @li \link func(int,Args**... args) Sixth overload\endlink
+ *    @li \link func(int,const Args*... args) Seventh overload\endlink
+ *    @li \link func(int,const Args**... args) Eighth overload\endlink
+ *    @li \link func(int,Args...) Ninth overload\endlink
+ *
+ *  The followings are interpreted the same:
+ *    @li \link func(int,const Args&... args) without template argument\endlink
+ *    @li \link func<Args...>(int,const Args&... args) with template argument\endlink
+ *
+ *  See the \link Test test\endlink class.
+ */
+
+/** A function
+ */
+void func(int p);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args&&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args&&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args*... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args**... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args*... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args**... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args... args);
+
+/** A test */
+class Test
+{
+ public:
+  /** A variadic template method
+   */
+  template <typename... Args>
+  void func(int p, Args... args) const;
+};

--- a/testing/070/070__ref__variadic__template_8cpp.xml
+++ b/testing/070/070__ref__variadic__template_8cpp.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="070__ref__variadic__template_8cpp" kind="file" language="C++">
+    <compoundname>070_ref_variadic_template.cpp</compoundname>
+    <innerclass refid="class_test" prot="public">Test</innerclass>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1affb6da6cff1b57cdf8efc0123dceac9b" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A function </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="40" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1aa7e4936a17759246bce60256cf224e16" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args &amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args &amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="45" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1ad6fc2d2a6cb8980f3e0eaacbd2ae41fe" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args &amp;&amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args &amp;&amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="50" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args &amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args &amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="55" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1aed64c596fea5f4f5e719006539922f7c" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args &amp;&amp;... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args &amp;&amp;...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="60" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1a0ad18d95a1dc2dbacee657c43f719187" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args *... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args *...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="65" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1a2331eedd0a1db9da5de0ad0faef78a4e" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args **... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args **...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="70" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1a72bd94e61df947347f98a2a6214e9342" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args *... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args *...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="75" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1a0bd03c39aa36ae51d2b8d87e04cf7eab" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, const Args **... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>const Args **...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="80" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="070__ref__variadic__template_8cpp_1abb1e0338f72ae46a1240ada65d6a397c" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <templateparamlist>
+          <param>
+            <type>typename...</type>
+            <declname>Args</declname>
+            <defname>Args</defname>
+          </param>
+        </templateparamlist>
+        <type>void</type>
+        <definition>void func</definition>
+        <argsstring>(int p, Args... args)</argsstring>
+        <name>func</name>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <param>
+          <type>Args...</type>
+          <declname>args</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A variadic template function overload </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="070_ref_variadic_template.cpp" line="85" column="1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+      <para>
+        <simplesect kind="attention">
+          <para>
+            <parblock>
+              <para>At the time of writing, the part between &lt;&gt; is totally ignored: func&lt;Args...&gt;(Args... args) is interpreted as func(Args... args).</para>
+              <para>Beware that a function parameter with either a &amp; or * operator, e.g. 'const Args&amp;... args', requires \link and \ref to specify such parameter as verbatim, i.e. 'const Args&amp;... args'. At the time of writing, the form func(const Args&amp;...) will fail, unless the function parameter was declared just as 'const Args&amp;...'. </para>
+            </parblock>
+          </para>
+        </simplesect>
+      </para>
+      <para>
+        <ref refid="class_test_1a64d85df31d518e39726467315a9b05e3" kindref="member">variadic template method</ref>
+      </para>
+      <para>References to the variadic template function overloads: <itemizedlist><listitem><para><ref refid="070__ref__variadic__template_8cpp_1aa7e4936a17759246bce60256cf224e16" kindref="member">First overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1ad6fc2d2a6cb8980f3e0eaacbd2ae41fe" kindref="member">Second overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" kindref="member">Third overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1aed64c596fea5f4f5e719006539922f7c" kindref="member">Fourth overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1a0ad18d95a1dc2dbacee657c43f719187" kindref="member">Fifth overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1a2331eedd0a1db9da5de0ad0faef78a4e" kindref="member">Sixth overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1a72bd94e61df947347f98a2a6214e9342" kindref="member">Seventh overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1a0bd03c39aa36ae51d2b8d87e04cf7eab" kindref="member">Eighth overload</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1abb1e0338f72ae46a1240ada65d6a397c" kindref="member">Ninth overload</ref></para></listitem></itemizedlist>
+The followings are interpreted the same: <itemizedlist><listitem><para><ref refid="070__ref__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" kindref="member">without template argument</ref></para></listitem><listitem><para><ref refid="070__ref__variadic__template_8cpp_1a708a5bf22646ed7233fe61b83182811a" kindref="member">with template argument</ref></para></listitem></itemizedlist>
+See the <ref refid="class_test" kindref="compound">test</ref> class. </para>
+    </detaileddescription>
+    <location file="070_ref_variadic_template.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/070_ref_variadic_template.cpp
+++ b/testing/070_ref_variadic_template.cpp
@@ -1,0 +1,95 @@
+// objective: test \ref command with a variadic template function
+// check: 070__ref__variadic__template_8cpp.xml
+
+/** \file
+ *
+ *  @attention
+ *  @parblock
+ *  At the time of writing, the part between \<\> is totally ignored:
+ *  %func<Args...>(Args... args) is interpreted as %func(Args... args).
+ *
+ *  Beware that a function parameter with either a \& or \* operator,
+ *  e.g. 'const Args&... args', requires \\link and \\ref to specify
+ *  such parameter as verbatim, i.e. 'const Args&... args'.  At the
+ *  time of writing, the form %func(const Args&...) will fail, unless
+ *  the function parameter was declared just as 'const Args&...'.
+ *  @endparblock
+ *
+ *  \ref Test::func(int,Args...)const "variadic template method"
+ *
+ *  References to the variadic template function overloads:
+ *    @li \ref func(int,Args&... args) "First overload"
+ *    @li \ref func(int,Args&&... args) "Second overload"
+ *    @li \ref func(int,const Args&... args) "Third overload"
+ *    @li \ref func(int,const Args&&... args) "Fourth overload"
+ *    @li \ref func(int,Args*... args) "Fifth overload"
+ *    @li \ref func(int,Args**... args) "Sixth overload"
+ *    @li \ref func(int,const Args*... args) "Seventh overload"
+ *    @li \ref func(int,const Args**... args) "Eighth overload"
+ *    @li \ref func(int,Args...) "Ninth overload"
+ *
+ *  The followings are interpreted the same:
+ *    @li \ref func(int,const Args&... args) "without template argument"
+ *    @li \ref func<Args...>(int,const Args&... args) "with template argument"
+ *
+ *  See the \ref Test "test" class.
+ */
+
+/** A function
+ */
+void func(int p);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args&&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args&&... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args*... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args**... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args*... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, const Args**... args);
+
+/** A variadic template function overload
+ */
+template <typename... Args>
+void func(int p, Args... args);
+
+/** A test */
+class Test
+{
+ public:
+  /** A variadic template method
+   */
+  template <typename... Args>
+  void func(int p, Args... args) const;
+};


### PR DESCRIPTION
Hi,

While commenting some code, I could not find a way to make `@link` and `@ref` to accept variadic arguments, aka '...'. Is there any way to do it without modifying the code?

Example:
`/// {@link func(int,...)}`
`void func(int i, ...);`

This pull request is my attempt to address the problem. There are also some regression tests.

Please, feel free to give me some feedback!

Thanks!