### PR TITLE
Call endMemberItem consistently.

### DIFF
--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -426,6 +426,7 @@ void MemberList::writePlainDeclarations(OutputList &ol,
               {
                 ol.endDoxyAnchor(md->getOutputFileBase(),md->anchor());
               }
+              ol.endMemberItem();
               if (!md->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
               {
                 DocRoot *rootNode = validatingParseDoc(
@@ -452,7 +453,6 @@ void MemberList::writePlainDeclarations(OutputList &ol,
                 }
                 delete rootNode;
               }
-              ol.endMemberItem();
               ol.endMemberDeclaration(md->anchor(),inheritId);
             }
             md->warnIfUndocumented();


### PR DESCRIPTION
When generating man pages, enums erroneously output their description
on the same line as the definition, with a trailing '"'. This is due to
endMemberItem being called after the member description is emitted, rather
than before, as it is elsewhere.

This patch moves the call to the same place where it is called elsewhere.

Bad output:
enum foo { FOO = 0 } Description. "

Good output:
enum foo { FOO = 0 }
	Description.


Signed-off-by: Alastair D'Silva <alastair@d-silva.org>