### PR TITLE
preprocess all Fortran files

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2618,8 +2618,9 @@ void FortranLanguageScanner::parseCode(CodeOutputInterface & codeOutIntf,
 
 bool FortranLanguageScanner::needsPreprocessing(const QCString &extension)
 {
-  return extension!=extension.lower(); // use preprocessor only for upper case extensions
+  return true;  // use preprocessor for all extensions!
 }
+
 void FortranLanguageScanner::resetCodeParserState()
 {
   ::resetFortranCodeParserState();


### PR DESCRIPTION
Currently doxygen only preprocesses Fortran files with upper-case file extensions (such as .F and .F90). This seems reasonable, since most Fortran compilers also stick to the convention of preprocessing only upper-case files.

However, basically all compilers have command-line flags for running the preprocessor also on lower-case files (such as .f and .f90). I don't see such a possibility for doxygen, therefore this commit is the only reasonable way I found to have doxygen preprocess .f90 files.