### PR TITLE
Bug 786409 - parsing error in Fortran file with preprocessing

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1984,6 +1984,11 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
   					  g_defArgsStr+=*yytext;
   					  BEGIN(ReadString);
   					}
+<FindDefineArgs>'                       {
+                                          if (getLanguageFromFileName(g_yyFileName)!=SrcLangExt_Fortran) REJECT;
+                                          g_defArgsStr+=*yytext;
+                                          BEGIN(ReadString);
+                                        }
 <FindDefineArgs>\n			{
                                           g_defArgsStr+=' ';
   					  g_yyLineNr++;
@@ -2014,6 +2019,12 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
   					  g_defArgsStr+=*yytext;
 					  BEGIN(FindDefineArgs);
   					}
+<ReadString>"'"                         {
+                                          if (getLanguageFromFileName(g_yyFileName)!=SrcLangExt_Fortran) REJECT;
+                                          g_defArgsStr+=*yytext;
+                                          BEGIN(FindDefineArgs);
+                                        }
+
 <ReadString>"//"|"/*"			{
   					  g_defArgsStr+=yytext;
   					}


### PR DESCRIPTION
Problem with ' (single quote) in Fortran. A string in Fortran can be between single or double quotes.