### PR TITLE
Bug 786409 - parsing error in Fortran file with preprocessing

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2902,7 +2902,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
                                           }
   					}
 <*>"//"[/]?				{
-                                          if (YY_START==SkipVerbatim || YY_START==SkipCond)
+                                          if (YY_START==SkipVerbatim || YY_START==SkipCond || getLanguageFromFileName(g_yyFileName)==SrcLangExt_Fortran)
                                           {
                                             REJECT;
                                           }


### PR DESCRIPTION
the // is in Fortran the indication for string concatenation and not for comment and should thus be ignored during, Fortran, preprocessing