### PR TITLE
Add language type attribute to programlisting tag

### DIFF
--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -211,7 +211,7 @@ void XmlDocVisitor::visit(DocVerbatim *s)
   switch(s->type())
   {
     case DocVerbatim::Code: // fall though
-      m_t << "<programlisting lang=\"" << lang << "\">"; 
+      m_t << "<programlisting language=\"" << lang << "\">"; 
       Doxygen::parserManager->getParser(lang)
                             ->parseCode(m_ci,s->context(),s->text(),langExt,
                                         s->isExample(),s->exampleFile());

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -211,7 +211,7 @@ void XmlDocVisitor::visit(DocVerbatim *s)
   switch(s->type())
   {
     case DocVerbatim::Code: // fall though
-      m_t << "<programlisting>"; 
+      m_t << "<programlisting lang=\"" << lang << "\">"; 
       Doxygen::parserManager->getParser(lang)
                             ->parseCode(m_ci,s->context(),s->text(),langExt,
                                         s->isExample(),s->exampleFile());

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -264,6 +264,7 @@
     <xsd:sequence>
       <xsd:element name="codeline" type="codelineType" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
+    <xsd:attribute name="language" type="xsd:string" use="optional"/>
   </xsd:complexType>
 
   <xsd:complexType name="codelineType">

--- a/testing/014/indexpage.xml
+++ b/testing/014/indexpage.xml
@@ -5,7 +5,7 @@
     <title>My Project</title>
     <detaileddescription>
       <para>
-        <programlisting>
+        <programlisting language=".py">
           <codeline>
             <highlight class="comment">#<sp/>comment<sp/>in<sp/>Python</highlight>
             <highlight class="normal"/>
@@ -25,7 +25,7 @@
         </programlisting>
       </para>
       <para>
-        <programlisting>
+        <programlisting language=".cpp">
           <codeline>
             <highlight class="comment">//<sp/>comment<sp/>in<sp/>a<sp/>code<sp/>block</highlight>
             <highlight class="normal"/>


### PR DESCRIPTION
The current programlisting tag doesn't have any attribute to indicate
the code's language. This makes code highlighting customization
difficult.

For example, the current doxygen generated document doesn't hightlight
javascript code block. If one wants to customize the code block by
parsing the xml files and uses 3rd party syntax highlighter, there is
no way to tell from the xml file what language the code snippet is
using.

This change introduces an attribute "lang" to the programlisting tag.