### PR TITLE
Bug 776870 - XML Parsing Error for operator<< methods when outputing to XHTML

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1589,8 +1589,8 @@ void HtmlGenerator::startMemberDoc( const char *clName, const char *memName,
 {
   DBG_HTML(t << "<!-- startMemberDoc -->" << endl;)
   t << "\n<h2 class=\"memtitle\">"
-    << "<span class=\"permalink\"><a href=\"#" << anchor << "\">&#9670;&nbsp;</a></span>"
-    << title;
+    << "<span class=\"permalink\"><a href=\"#" << anchor << "\">&#9670;&nbsp;</a></span>";
+  docify(title);
   if (memTotal>1)
   {
     t << " <span class=\"overload\">[" << memCount << "/" << memTotal <<"]</span>";


### PR DESCRIPTION
The < sign in the title has to be escaped, especially in case of xhtml.

NOTE: this bugfix also requires pull request #594 in case #586 has been incorporated.