### PR TITLE
Use -fvisibility=hidden with GCC/Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ if (WIN32)
     endif()
 endif()
 
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 if ("${CMAKE_GENERATOR}" MATCHES "Ninja") 
   set(LEX_FLAGS )
   set(YACC_FLAGS )


### PR DESCRIPTION
Allows us to hide all the internal symbols from the final binary.
As a result it becomes ~10% smaller.

Signed-off-by: Emil Velikov <emil.l.velikov@gmail.com>