### PR TITLE
Bug 778730 - doxygen build fails

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -3804,13 +3804,13 @@ class TextGeneratorLatex : public TextGeneratorIntf
       static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
       if (!ref && pdfHyperlinks)
       {
-        m_ts << "\\hyperlink{";
+        m_ts << "\\mbox{\\hyperlink{";
         if (f) m_ts << stripPath(f);
         if (f && anchor) m_ts << "_";
         if (anchor) m_ts << anchor;
         m_ts << "}{";
         filterLatexString(m_ts,text);
-        m_ts << "}";
+        m_ts << "}}";
       }
       else
       {

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1344,7 +1344,7 @@ void LatexDocVisitor::visitPost(DocRef *ref)
   }
   else
   {
-    if (!ref->file().isEmpty()) endLink(ref->ref(),ref->file(),ref->anchor());
+    if (!ref->file().isEmpty()) endLink(ref->ref(),ref->file(),ref->anchor(),ref->refToTable());
   }
 }
 
@@ -1355,7 +1355,7 @@ void LatexDocVisitor::visitPre(DocSecRefItem *ref)
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (pdfHyperlinks)
   {
-    m_t << "\\hyperlink{" << ref->file() << "_" << ref->anchor() << "}{" ;
+    m_t << "\\mbox{\\hyperlink{" << ref->file() << "_" << ref->anchor() << "}{" ;
   }
 }
 
@@ -1365,7 +1365,7 @@ void LatexDocVisitor::visitPost(DocSecRefItem *ref)
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (pdfHyperlinks)
   {
-    m_t << "}";
+    m_t << "}}";
   }
   m_t << "}{\\ref{" << ref->file() << "_" << ref->anchor() << "}}{}" << endl;
 }
@@ -1553,6 +1553,7 @@ void LatexDocVisitor::visitPost(DocParamList *pl)
 
 void LatexDocVisitor::visitPre(DocXRefItem *x)
 {
+  static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (m_hide) return;
   if (x->title().isEmpty()) return;
   m_t << "\\begin{DoxyRefDesc}{";
@@ -1560,9 +1561,9 @@ void LatexDocVisitor::visitPre(DocXRefItem *x)
   m_t << "}" << endl;
   bool anonymousEnum = x->file()=="@";
   m_t << "\\item[";
-  if (Config_getBool(PDF_HYPERLINKS) && !anonymousEnum)
+  if (pdfHyperlinks && !anonymousEnum)
   {
-    m_t << "\\hyperlink{" << stripPath(x->file()) << "_" << x->anchor() << "}{";
+    m_t << "\\mbox{\\hyperlink{" << stripPath(x->file()) << "_" << x->anchor() << "}{";
   }
   else
   {
@@ -1571,6 +1572,10 @@ void LatexDocVisitor::visitPre(DocXRefItem *x)
   m_insideItem=TRUE;
   filter(x->title());
   m_insideItem=FALSE;
+  if (pdfHyperlinks && !anonymousEnum)
+  {
+    m_t << "}";
+  }
   m_t << "}]";
 }
 
@@ -1657,7 +1662,7 @@ void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const Q
     }
     else
     {
-      m_t << "\\hyperlink{";
+      m_t << "\\mbox{\\hyperlink{";
     }
     if (!file.isEmpty()) m_t << stripPath(file);
     if (!file.isEmpty() && !anchor.isEmpty()) m_t << "_";
@@ -1678,7 +1683,7 @@ void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const Q
   }
 }
 
-void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCString &anchor)
+void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable)
 {
   m_t << "}";
   static bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
@@ -1689,6 +1694,13 @@ void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCS
     m_t << "}{" << file;
     if (!file.isEmpty() && !anchor.isEmpty()) m_t << "_";
     m_t << anchor << "}";
+  }
+  if (ref.isEmpty() && pdfHyperLinks) // internal PDF link
+  {
+    if (!refToTable)
+    {
+      m_t << "}";
+    }
   }
 }
 

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -161,7 +161,7 @@ class LatexDocVisitor : public DocVisitor
     void startLink(const QCString &ref,const QCString &file,
                    const QCString &anchor,bool refToTable=FALSE);
     void endLink(const QCString &ref,const QCString &file,
-                 const QCString &anchor);
+                 const QCString &anchor,bool refToTable=FALSE);
     QCString escapeMakeIndexChars(const char *s);
     void startDotFile(const QCString &fileName,const QCString &width,
                       const QCString &height, bool hasCaption);

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -171,13 +171,13 @@ void LatexCodeGenerator::writeCodeLink(const char *ref,const char *f,
   }
   if (!ref && usePDFLatex && pdfHyperlinks)
   {
-    m_t << "\\hyperlink{";
+    m_t << "\\mbox{\\hyperlink{";
     if (f) m_t << stripPath(f);
     if (f && anchor) m_t << "_"; 
     if (anchor) m_t << anchor; 
     m_t << "}{";
     codify(name);
-    m_t << "}";
+    m_t << "}}";
   }
   else
   {
@@ -1370,9 +1370,10 @@ void LatexGenerator::endIndexValue(const char *name,bool /*hasBrief*/)
 
 void LatexGenerator::startTextLink(const char *f,const char *anchor)
 {
-  if (!disableLinks && Config_getBool(PDF_HYPERLINKS))
+  static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+  if (!disableLinks && pdfHyperlinks)
   {
-    t << "\\hyperlink{";
+    t << "\\mbox{\\hyperlink{";
     if (f) t << stripPath(f);
     if (anchor) t << "_" << anchor; 
     t << "}{";
@@ -1385,6 +1386,11 @@ void LatexGenerator::startTextLink(const char *f,const char *anchor)
 
 void LatexGenerator::endTextLink()
 {
+  static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+  if (!disableLinks && pdfHyperlinks)
+  {
+    t << "}";
+  }
   t << "}";
 }
 
@@ -1394,13 +1400,13 @@ void LatexGenerator::writeObjectLink(const char *ref, const char *f,
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (!disableLinks && !ref && pdfHyperlinks)
   {
-    t << "\\hyperlink{";
+    t << "\\mbox{\\hyperlink{";
     if (f) t << stripPath(f);
     if (f && anchor) t << "_"; 
     if (anchor) t << anchor; 
     t << "}{";
     docify(text);
-    t << "}";
+    t << "}}";
   }
   else
   {


### PR DESCRIPTION
When a hyperlink splits across a page boundary it can come to the problem of "\pdfendlink ended up in different nesting level than \pdfstartlink".
To overcome this problem the \hyperlink is packed into a "\mbox" construct (as suffested e.g. in https://tex.stackexchange.com/questions/1522/pdfendlink-ended-up-in-different-nesting-level-than-pdfstartlink)