### PR TITLE
Physical newlines in ALIASES configuration tags.

### DIFF
--- a/doc/custcmd.doc
+++ b/doc/custcmd.doc
@@ -40,7 +40,9 @@ The simplest form of an alias is a simple substitution of the form
  put the command `\sideeffect` (or `@sideeffect`) in the documentation, which 
  will result in a user-defined paragraph with heading <b>Side Effects:</b>.
 
-Note that you can put `\n`'s in the value part of an alias to insert newlines.
+Note that you can put `\n`'s in the value part of an alias to insert newlines
+(in the resulting output). You can put `^^` in the value part of an alias to
+insert a newline as if a physical newline was in the original file.
 
 Also note that you can redefine existing special commands if you wish.
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -532,7 +532,10 @@ Go to the <a href="commands.html">next</a> section or return to the
  will allow you to
  put the command \c \\sideeffect (or \c \@sideeffect) in the documentation, which 
  will result in a user-defined paragraph with heading "Side Effects:".
- You can put \ref cmdn "\\n"'s in the value part of an alias to insert newlines.
+ You can put \ref cmdn "\\n"'s in the value part of an alias to insert newlines
+ (in the resulting output).
+ You can put `^^` in the value part of an alias to insert a newline as if 
+ a physical newline was in the original file.
 ]]>
       </docs>
     </option>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9826,6 +9826,16 @@ static void escapeAliases()
     }
     newValue+=value.mid(p,value.length()-p);
     *s=newValue;
+    p = 0;
+    newValue = "";
+    while ((in=value.find("^^",p))!=-1)
+    {
+      newValue+=value.mid(p,in-p);
+      newValue+="\n";
+      p=in+2;
+    }
+    newValue+=value.mid(p,value.length()-p);
+    *s=newValue;
     //printf("Alias %s has value %s\n",adi.currentKey().data(),s->data());
   }
 }


### PR DESCRIPTION
Some commands read input till the end of the physical line. In case these commands are used in an alias the rest of the line is lost / gives not the required results.
This patch creates the possibility to have physical newlines in ALIASES.
See also: https://stackoverflow.com/questions/46050789/doxygen-alias-with-multiple-commands