### PR TITLE
Mark JS as freely available (regression 2)

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -315,7 +315,7 @@ static QCString substituteHtmlKeywords(const QCString &s,
       if (disableIndex || !Config_getBool(HTML_DYNAMIC_MENUS))
       {
         searchCssJs += "<script type=\"text/javascript\">\n"
-					"/* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&amp;dn=gpl-2.0.txt GPL-v2 */\n";
+					"/* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&amp;dn=gpl-2.0.txt GPL-v2 */\n"
 				"  $(document).ready(function() { init_search(); });\n"
 					"/* @license-end */\n"
 					"</script>";


### PR DESCRIPTION
result of extra ';' was that part of the html file was not written and thus no correct end of script and thus garbled output.
(problem was missed at first regression fix)