### PR TITLE
Bug 557094 - Wrong spacing in function names with french language (latex output)

### DIFF
--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -131,7 +131,8 @@ class TranslatorFrench : public Translator
      */
        virtual QCString latexLanguageSupportCommand()
       {
-         return "\\usepackage[french]{babel}\n";
+         return "\\usepackage[french]{babel}\n"
+		"\\NoAutoSpaceBeforeFDP\n";
       }
 
     // --- Language translation methods -------------------


### PR DESCRIPTION
Removed superfluous space in case of French as output language