### PR TITLE
Fix https://bugzilla.gnome.org/show_bug.cgi?id=782583.

### DIFF
--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -174,8 +174,11 @@ void PageDef::writeDocumentation(OutputList &ol)
     ol.writeString(" - ");
     ol.popGeneratorState();
 
-    ol.generateDoc(docFile(),docLine(),this,0,si->title,TRUE,FALSE,0,TRUE,FALSE);
-    ol.endSection(si->label,si->type);
+    if (si->title != manPageName)
+    {
+      ol.generateDoc(docFile(),docLine(),this,0,si->title,TRUE,FALSE,0,TRUE,FALSE);
+      ol.endSection(si->label,si->type);
+    }
   }
   ol.popGeneratorState();
   //2.}


### PR DESCRIPTION
Don't write both page name and title to NAME section of man page, if they are the same.

The rationale is as follows. Both the man page file name (which comes from the `name` argument of the \page command) and the entry in the tree view index of the HTML version (which comes from the `title` argument) should be the name of the command being documented, e.g. toktx. Currently this results in

```
NAME
    toktx - toktx Brief description from first line of text after \page
```

Ater this change you'll get

```
NAME
    toktx - Brief ...
```