### PR TITLE
SHOW_USED_FILES_SRC to exclude source files displayed

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -800,7 +800,7 @@ void ClassDef::findSectionsInDocumentation()
 // add a file name to the used files set
 void ClassDef::insertUsedFile(FileDef *fd)
 {
-  if (fd==0) return;
+  if (fd == 0 || (!Config_getBool(SHOW_USED_FILES_SRC) && fd->isSource())) return;
   if (m_impl->files.find(fd)==-1) m_impl->files.append(fd);
   if (m_impl->templateInstances)
   {

--- a/src/config.xml
+++ b/src/config.xml
@@ -1090,6 +1090,18 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+	<option type='bool' id='SHOW_USED_FILES_SRC' defval='1'>
+      <docs>
+<![CDATA[
+ Set the \c SHOW_USED_FILES_SRC tag to \c NO to omit the listing of source files
+ at the bottom of the documentation of classes and structs. If set to \c YES
+ the list will mention the source files that were used to generate the documentation 
+ along with the header files in the used files section. 
+ This option requires SHOW_USED_FILES to be set to YES.
+ The default value is : YES.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='SHOW_FILES' defval='1'>
       <docs>
 <![CDATA[


### PR DESCRIPTION
SHOW_USED_FILES usually lists source and header files (for C++) but this is not always desired because implementation details may not be of interest in a code documentation (this is what we need here at work for our code docs).
    
Introducing SHOW_USED_FILES_SRC configuration option allows to exclude source files from being listed if it is set to NO. By default it is set to YES which resembles the way it was before (i.e. both source and header files are displayed) to remain compatible with old configurations.