### PR TITLE
Suppresses warning for XML <see langword="..."/>

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -6122,9 +6122,20 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
             }
           }
         }
+        else if (findAttribute(tagHtmlAttribs,"langword",&cref)) // <see langword="..."/> or <see langworld="..."></see>
+        {
+            doctokenizerYYsetStatePara();
+            DocLink *lnk = new DocLink(this,cref);
+            m_children.append(lnk);
+            QCString leftOver = lnk->parse(FALSE,TRUE);
+            if (!leftOver.isEmpty())
+            {
+              m_children.append(new DocWord(this,leftOver));
+            }
+        }
         else
         {
-          warn_doc_error(g_fileName,doctokenizerYYlineno,"Missing 'cref' attribute from <see> tag.");
+          warn_doc_error(g_fileName,doctokenizerYYlineno,"Missing 'cref' or 'langword' attribute from <see> tag.");
         }
       }
       break;


### PR DESCRIPTION
`<see langword="..."/>` is a valid C# doc comment but triggers warnings. This is preventing me from using WARN_AS_ERROR. I'm open to suggestions for actually highlighting the langword, as all I have done here is suppress it.