### PR TITLE
fix impossible range checks for chars

### DIFF
--- a/vhdlparser/TokenMgrError.cc
+++ b/vhdlparser/TokenMgrError.cc
@@ -101,7 +101,7 @@ JAVACC_SIMPLE_STRING addUnicodeEscapes(JAVACC_STRING_TYPE str) {
         retval.append("\\\\");
         continue;
       default:
-        if (ch < 0xff) {
+        if (static_cast<unsigned char>(ch) < 0xff) {
           retval += ch;
           continue;
         }

--- a/vhdlparser/VhdlParserTokenManager.cc
+++ b/vhdlparser/VhdlParserTokenManager.cc
@@ -3036,7 +3036,7 @@ int VhdlParserTokenManager::jjMoveNfa_0(int startState, int curPos){
             }
          } while(i != startsAt);
       }
-      else if (curChar < 128)
+      else if (static_cast<unsigned char>(curChar) < 128)
       {
          unsigned long long l = 1ULL << (curChar & 077);
          (void)l;


### PR DESCRIPTION
The default type for char is a signed char on most platforms, which is limited to -128..127, so these checks are always true. Explicitely cast to unsigned char to make the checks work as intended.

Spotted by the Clang in TravisCI builds.