### PR TITLE
Provide dot path to plantuml

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -57,6 +57,7 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
 {
   static QCString plantumlJarPath = Config_getString(PLANTUML_JAR_PATH);
   static QCString plantumlConfigFile = Config_getString(PLANTUML_CFG_FILE);
+  static QCString dotPath = Config_getString(DOT_PATH);
 
   QCString pumlExe = "java";
   QCString pumlArgs = "";
@@ -82,6 +83,12 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
     pumlArgs += "-config \"";
     pumlArgs += plantumlConfigFile;
     pumlArgs += "\" ";
+  }
+  if (Config_getBool(HAVE_DOT) && !dotPath.isEmpty())
+  {
+    pumlArgs += "-graphvizdot \"";
+    pumlArgs += dotPath;
+    pumlArgs += "dot\" ";
   }
   pumlArgs+="-o \"";
   pumlArgs+=outDir;


### PR DESCRIPTION
If `HAVE_DOT = YES` and `DOT_PATH` is configured, pass the path to the dot executable to plantuml with the `-graphvizdot` option.

Rationale is that plantuml does not look for dot on the path, but assumes dot is at `/usr/bin/dot`. The changes allow dot to be in a non-standard location which is configured in the `Doxyfile`.