### PR TITLE
Provide template parameters also for type aliases in the XML output

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -789,10 +789,7 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
       md->memberType()!=MemberType_Enumeration
      )
   {
-    if (md->memberType()!=MemberType_Typedef)
-    {
-      writeMemberTemplateLists(md,t);
-    }
+    writeMemberTemplateLists(md,t);
     QCString typeStr = md->typeString(); //replaceAnonymousScopes(md->typeString());
     stripQualifiers(typeStr);
     t << "        <type>";

--- a/testing/067/067__using_8cpp.xml
+++ b/testing/067/067__using_8cpp.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="067__using_8cpp" kind="file" language="C++">
+    <compoundname>067_using.cpp</compoundname>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="067__using_8cpp_1a1b01c504448c96cd2191a5184dd31acf" prot="public" static="no">
+        <templateparamlist>
+          <param>
+            <type>class T</type>
+          </param>
+        </templateparamlist>
+        <type>std::vector&lt; T &gt;</type>
+        <definition>using Vec =  std::vector&lt;T&gt;</definition>
+        <argsstring/>
+        <name>Vec</name>
+        <briefdescription>
+          <para>A vector. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="067_using.cpp" line="7" column="1" bodyfile="067_using.cpp" bodystart="7" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="067_using.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/067_using.cpp
+++ b/testing/067_using.cpp
@@ -1,0 +1,7 @@
+// objective: test template parameters for a type alias
+// check: 067__using_8cpp.xml
+
+/** \file */
+
+/** @brief A vector */
+template<class T> using Vec = std::vector<T>;


### PR DESCRIPTION
This is a simple one.

Until now, probably due to C++03 assumptions, typedefs and type aliases skipped printing of the template parameter specifications to the XML output. That's now fixed, so the following type alias will properly contain `<templateparamlist>` in the XML output:

```cpp
template<class T> using Vec = std::vector<T>;
```

Added also a test case that verifies this.

Thanks again and sorry for the loads of patches recently :)