### PR TITLE
Full support for strong and typed enums in the XML output

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -802,6 +802,13 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
     t << "        <argsstring>" << convertToXML(md->argsString()) << "</argsstring>" << endl;
   }
 
+  if (md->memberType() == MemberType_Enumeration)
+  {
+    t << "        <type>";
+    linkifyText(TextGeneratorXMLImpl(t),def,md->getBodyDef(),md,md->enumBaseType());
+    t << "</type>" << endl;
+  }
+
   t << "        <name>" << convertToXML(md->name()) << "</name>" << endl;
   
   if (md->memberType() == MemberType_Property)

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -668,6 +668,13 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
     t << "\"";
   }
 
+  if (md->memberType() == MemberType_Enumeration)
+  {
+    t << " strong=\"";
+    if (md->isStrong()) t << "yes"; else t << "no";
+    t << "\"";
+  }
+
   if (md->memberType() == MemberType_Variable)
   {
     //ArgumentList *al = md->argumentList();

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -146,6 +146,7 @@
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="prot" type="DoxProtectionKind" />
     <xsd:attribute name="static" type="DoxBool" />
+    <xsd:attribute name="strong" type="DoxBool" use="optional"/>
     <xsd:attribute name="const" type="DoxBool" use="optional"/>
     <xsd:attribute name="explicit" type="DoxBool" use="optional"/>
     <xsd:attribute name="inline" type="DoxBool" use="optional"/>

--- a/testing/018/018__def_8c.xml
+++ b/testing/018/018__def_8c.xml
@@ -17,7 +17,7 @@
       </memberdef>
     </sectiondef>
     <sectiondef kind="enum">
-      <memberdef kind="enum" id="018__def_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no">
+      <memberdef kind="enum" id="018__def_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
         <type/>
         <name>E</name>
         <enumvalue id="018__def_8c_1aa57b8491d1d8fc1014dd54bcf83b130aab1710e6a49014ba389d57c8753c530f4" prot="public">

--- a/testing/018/018__def_8c.xml
+++ b/testing/018/018__def_8c.xml
@@ -18,6 +18,7 @@
     </sectiondef>
     <sectiondef kind="enum">
       <memberdef kind="enum" id="018__def_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no">
+        <type/>
         <name>E</name>
         <enumvalue id="018__def_8c_1aa57b8491d1d8fc1014dd54bcf83b130aab1710e6a49014ba389d57c8753c530f4" prot="public">
           <name>E1</name>

--- a/testing/068/068__typed__enum_8cpp.xml
+++ b/testing/068/068__typed__enum_8cpp.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="068__typed__enum_8cpp" kind="file" language="C++">
+    <compoundname>068_typed_enum.cpp</compoundname>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="068__typed__enum_8cpp_1aa72902e6181db009a6a84502f81612c2" prot="public" static="no">
+        <type>unsigned short</type>
+        <name>E</name>
+        <briefdescription>
+          <para>A strongly-typed enum. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="068_typed_enum.cpp" line="7" column="1" bodyfile="068_typed_enum.cpp" bodystart="7" bodyend="7"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="068_typed_enum.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/068/068__typed__enum_8cpp.xml
+++ b/testing/068/068__typed__enum_8cpp.xml
@@ -3,7 +3,7 @@
   <compounddef id="068__typed__enum_8cpp" kind="file" language="C++">
     <compoundname>068_typed_enum.cpp</compoundname>
     <sectiondef kind="enum">
-      <memberdef kind="enum" id="068__typed__enum_8cpp_1aa72902e6181db009a6a84502f81612c2" prot="public" static="no">
+      <memberdef kind="enum" id="068__typed__enum_8cpp_1aa72902e6181db009a6a84502f81612c2" prot="public" static="no" strong="yes">
         <type>unsigned short</type>
         <name>E</name>
         <briefdescription>

--- a/testing/068_typed_enum.cpp
+++ b/testing/068_typed_enum.cpp
@@ -1,0 +1,7 @@
+// objective: test underlying type and strongness for an enum
+// check: 068__typed__enum_8cpp.xml
+
+/** \file */
+
+/** @brief A strongly-typed enum */
+enum class E: unsigned short {};


### PR DESCRIPTION
The `<type>` element (used for function return type and variable type) is now reused also for underlying enum type. C++03-style enum types that don't have the underlying type specified have the `<type>` tag as well, but empty to indicate that the underlying type is unspecified.

Besides that, there's a new boolean `strong` attribute on the `<memberdef>` element that defines whether the enum is a classic or a strong one.

Added a new test and updated the existing ones to verify all cases.