### PR TITLE
Fix not initialized pointer when parser is starting on a new file.

### DIFF
--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -196,6 +196,7 @@ void VHDLLanguageScanner::parseInput(const char *fileName,const char *fileBuf,En
   VhdlParser::lastEntity=0;
   VhdlParser::currentCompound=0;
   VhdlParser::lastEntity=0;
+  oldEntry = 0;
   VhdlParser::current=new Entry();
   VhdlParser::initEntry(VhdlParser::current);
   groupEnterFile(fileName,yyLineNr);


### PR DESCRIPTION
The pointer oldEntry holds the last value of VhdlParser::current and is
compared to detect comment blocks that belong together. This could lead to
false positives when a new file is parsed and the new entry in
VhdlParser::current has by chance the same pointer value as the old entry.
Doxygen warning like "warning: Found unknown command `\brief'" are the
consequence that leads to concatenated brief and detailed description in
the resulting output.