### PR TITLE
Properly copy images for the XML output

### DIFF
--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -770,17 +770,22 @@ void XmlDocVisitor::visitPre(DocImage *img)
   visitPreStart(m_t, "image", FALSE, this, img->children(), baseName, TRUE, img->type(), img->width(), img->height());
 
   // copy the image to the output dir
-  QFile inImage(img->name());
-  QFile outImage(Config_getString(XML_OUTPUT)+"/"+baseName.data());
-  if (inImage.open(IO_ReadOnly))
+  FileDef *fd;
+  bool ambig;
+  if ((fd=findFileDef(Doxygen::imageNameDict,img->name(),ambig)))
   {
-    if (outImage.open(IO_WriteOnly))
+    QFile inImage(fd->absFilePath());
+    QFile outImage(Config_getString(XML_OUTPUT)+"/"+baseName.data());
+    if (inImage.open(IO_ReadOnly))
     {
-      char *buffer = new char[inImage.size()];
-      inImage.readBlock(buffer,inImage.size());
-      outImage.writeBlock(buffer,inImage.size());
-      outImage.flush();
-      delete[] buffer;
+      if (outImage.open(IO_WriteOnly))
+      {
+        char *buffer = new char[inImage.size()];
+        inImage.readBlock(buffer,inImage.size());
+        outImage.writeBlock(buffer,inImage.size());
+        outImage.flush();
+        delete[] buffer;
+      }
     }
   }
 }


### PR DESCRIPTION
Use the exact same mechanism that is used for the HTML/LaTeX/... output, which is in `findAndCopyImage()` in `docparser.cpp`, because that one works, unlike the method here. 

Note: I'm not sure why that function doesn't handle XML as well, so maybe there could be a different solution than this. Also not sure how to integrate this into the automated tests.

Thanks in advance.