### PR TITLE
Changed the navtree collapsed list icon to be more symmetric to the expanded list icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ There are three mailing lists:
 Source Code
 ----------------------------------
 In May 2013, Doxygen moved from 
-subversion to git hosted at github
+subversion to git hosted at GitHub
 * https://github.com/doxygen/doxygen
 
 Enjoy,

--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -257,7 +257,7 @@ void FTVHelp::generateIndent(FTextStream &t, FTVNode *n,bool opened)
   while (p) { indent++; p=p->parent; }
   if (n->isDir)
   {
-    QCString dir = opened ? "&#9660;" : "&#9658;";
+    QCString dir = opened ? "&#9660;" : "&#9654;";
     t << "<span style=\"width:" << (indent*16) << "px;display:inline-block;\">&#160;</span>"
       << "<span id=\"arr_" << generateIndentLabel(n,0) << "\" class=\"arrow\" ";
     t << "onclick=\"toggleFolder('" << generateIndentLabel(n,0) << "')\"";

--- a/templates/html/dynsections.js
+++ b/templates/html/dynsections.js
@@ -60,7 +60,7 @@ function toggleLevel(level)
       $(this).show();
     } else if (l==level+1) {
       i.removeClass('iconfclosed iconfopen').addClass('iconfclosed');
-      a.html('&#9658;');
+      a.html('&#9654;');
       $(this).show();
     } else {
       $(this).hide();
@@ -87,7 +87,7 @@ function toggleFolder(id)
     // replace down arrow by right arrow for current row
     var currentRowSpans = currentRow.find("span");
     currentRowSpans.filter(".iconfopen").removeClass("iconfopen").addClass("iconfclosed");
-    currentRowSpans.filter(".arrow").html('&#9658;');
+    currentRowSpans.filter(".arrow").html('&#9654;');
     rows.filter("[id^=row_"+id+"]").hide(); // hide all children
   } else { // we are SHOWING
     // replace right arrow by down arrow for current row
@@ -97,7 +97,7 @@ function toggleFolder(id)
     // replace down arrows by right arrows for child rows
     var childRowsSpans = childRows.find("span");
     childRowsSpans.filter(".iconfopen").removeClass("iconfopen").addClass("iconfclosed");
-    childRowsSpans.filter(".arrow").html('&#9658;');
+    childRowsSpans.filter(".arrow").html('&#9654;');
     childRows.show(); //show all children
   }
   updateStripes();

--- a/templates/html/htmldirtree.tpl
+++ b/templates/html/htmldirtree.tpl
@@ -20,7 +20,7 @@
   {% else %}
     <span style="width:{{ (node.level)*16 }}px;display:inline-block;">&#160;</span>
     <span id="arr_{{ node.id }}" class="arrow" onclick="toggleFolder('{{ node.id}}')">
-       {%if node.level+1<tree.preferredDepth %}&#9660;{% else %}&#9658;{% endif %}
+       {%if node.level+1<tree.preferredDepth %}&#9660;{% else %}&#9654;{% endif %}
     </span>
   {% endif %}
   {% if node.namespace %}

--- a/templates/html/navtree.js
+++ b/templates/html/navtree.js
@@ -23,7 +23,7 @@
  */
 var navTreeSubIndices = new Array();
 var arrowDown = '&#9660;';
-var arrowRight = '&#9658;';
+var arrowRight = '&#9654;';
 
 function getData(varName)
 {


### PR DESCRIPTION
1. The right arrow symbol, `►` (Unicode `&#9658;` "BLACK RIGHT-POINTING POINTER"), used in the navtree to show that a list item is collapsed is thinner at the base and not symmetric to the down arrow symbol, `▼` (Unicode `&#9660;` "BLACK DOWN-POINTING TRIANGLE"), which makes it look a little weird.

    The new symbol, `▶` (Unicode `&#9654;` "BLACK RIGHT-POINTING TRIANGLE"), is symmetric to the down arrow symbol. Here's how it looks in the rendered docs (the one beside "constructors" is how it currently looks, and the one beside "functions" is how it's going to look with the changes):
    
   ![screenshot-2017-12-22 bigint bigint class reference](https://user-images.githubusercontent.com/11466676/34281569-9bde341e-e6e5-11e7-8dad-3bdbeacb2b33.png)


1. Made a small typo fix to README.md: changed `github` to `GitHub`.