### PR TITLE
Fix the perl script of doc/arch.doc to toggle debug information for a given flex file

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -237,7 +237,7 @@ else {
 
 # touch the file
 $now = time;
-utime $now, $now, $file
+utime $now, $now, $file;
 \endverbatim
 Another way to get rules matching / debugging information
 from the \c flex code is setting LEX_FLAGS with \c make (`make LEX_FLAGS=-d`).

--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -220,11 +220,11 @@ if (open(F,"<src/CMakeFiles/_doxygen.dir/build.make.old")) {
   }
   print "Processing build.make...\n";
   while (<F>) {
-    if ( s/flex \$\(LEX_FLAGS\) -P${file}YY/flex \$(LEX_FLAGS) -d -P${file}YY/ ) {
-      print "Enabling debug info for $file.l\n";
-    }
-    elsif ( s/flex \$\(LEX_FLAGS\) -d -P${file}YY/flex \$(LEX_FLAGS) -P${file}YY/ ) {
+    if ( s/flex \$\(LEX_FLAGS\) -d(.*) ${file}.l/flex \$(LEX_FLAGS)$1 ${file}.l/ ) {
       print "Disabling debug info for $file\n";
+    }
+    elsif ( s/flex \$\(LEX_FLAGS\)(.*) ${file}.l$/flex \$(LEX_FLAGS) -d$1 ${file}.l/ ) {
+      print "Enabling debug info for $file.l\n";
     }
     print G "$_";
   }

--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -209,12 +209,12 @@ if (!-e "../src/${file}.l")
   exit 1;
 }
 system("touch ../src/${file}.l");
-unless (rename "src/CMakeFiles/_doxygen.dir/build.make","src/CMakefiles/_doxygen.dir/build.make.old") {
+unless (rename "src/CMakeFiles/_doxygen.dir/build.make","src/CMakeFiles/_doxygen.dir/build.make.old") {
   print STDERR "Error: cannot rename src/CMakeFiles/_doxygen.dir/build.make!\n";
   exit 1;
 }
 if (open(F,"<src/CMakeFiles/_doxygen.dir/build.make.old")) {
-  unless (open(G,">src/CMakefiles/_doxygen.dir/build.make")) {
+  unless (open(G,">src/CMakeFiles/_doxygen.dir/build.make")) {
     print STDERR "Error: opening file build.make for writing\n";
     exit 1;
   }

--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -205,7 +205,7 @@ $file = shift @ARGV;
 print "Toggle debugging mode for $file\n";
 if (!-e "../src/${file}.l")
 {
-  print STDERR "Error: file ../src/${file}.l does not exist!";
+  print STDERR "Error: file ../src/${file}.l does not exist!\n";
   exit 1;
 }
 system("touch ../src/${file}.l");


### PR DESCRIPTION
Found some typos:
- 'CMakefiles' where the 'f' is lowercase instead than uppercase.
- A missing '\n' characater.
- A missing ';' at end of line.

Also the perl regexp to toggle the flex debug flag in build.make searches the non existing string '-P${file}YY'.