### PR TITLE
Add warning suppression pattern

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1201,6 +1201,13 @@ FILE_VERSION_INFO = "cleartool desc -fmt \%Vn"
 ]]>
       </docs>
     </option>
+    <option type='list' id='SUPPRESS_WARNINGS_ON_PATTERNS'>
+      <docs>
+<![CDATA[
+Suppress all warnings (\c WARNINGS , \c WARN_IF_UNDOCUMENTED , \c WARN_IF_DOC_ERROR , \c WARN_NO_PARAMDOC) from files that match one of the given patterns.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='WARN_IF_UNDOCUMENTED' defval='1'>
       <docs>
 <![CDATA[

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <qdatetime.h>
+#include <qfileinfo.h>
 #include "config.h"
 #include "util.h"
 #include "debug.h"
@@ -184,18 +185,23 @@ void warn(const char *file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  do_warn(Config_getBool(WARNINGS), file, line, warning_str, fmt, args);
+  do_warn(Config_getBool(WARNINGS)
+          && !patternMatch(QFileInfo(file), &Config_getList(SUPPRESS_WARNINGS_ON_PATTERNS)),
+          file, line, warning_str, fmt, args);
   va_end(args);
 }
 
 void va_warn(const char *file,int line,const char *fmt,va_list args)
 {
-  do_warn(Config_getBool(WARNINGS), file, line, warning_str, fmt, args);
+  do_warn(Config_getBool(WARNINGS)
+          && !patternMatch(QFileInfo(file), &Config_getList(SUPPRESS_WARNINGS_ON_PATTERNS)),
+          file, line, warning_str, fmt, args);
 }
 
 void warn_simple(const char *file,int line,const char *text)
 {
-  if (!Config_getBool(WARNINGS)) return; // warning type disabled
+  if (!Config_getBool(WARNINGS)
+      || patternMatch(QFileInfo(file), &Config_getList(SUPPRESS_WARNINGS_ON_PATTERNS))) return; // warning type disabled
   format_warn(file,line,QCString(warning_str) + text);
 }
 
@@ -203,7 +209,9 @@ void warn_undoc(const char *file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  do_warn(Config_getBool(WARN_IF_UNDOCUMENTED), file, line, warning_str, fmt, args);
+  do_warn(Config_getBool(WARN_IF_UNDOCUMENTED)
+          && !patternMatch(QFileInfo(file), &Config_getList(SUPPRESS_WARNINGS_ON_PATTERNS)),
+          file, line, warning_str, fmt, args);
   va_end(args);
 }
 
@@ -211,7 +219,9 @@ void warn_doc_error(const char *file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  do_warn(Config_getBool(WARN_IF_DOC_ERROR), file, line, warning_str, fmt, args);
+  do_warn(Config_getBool(WARN_IF_DOC_ERROR)
+          && !patternMatch(QFileInfo(file), &Config_getList(SUPPRESS_WARNINGS_ON_PATTERNS)),
+          file, line, warning_str, fmt, args);
   va_end(args);
 }
 


### PR DESCRIPTION
The motivation for this is stated in https://stackoverflow.com/questions/47876081/disable-warnings-from-tags-files

This is a first try. Currently the balance between writing the code and having performance is less on the performance side: Each warning checks against the pattern list. For large lists and many warnings, this is unfeasible.

A better approach would be to set a per file flag whether to output warnings and to avoid calling the warn functions on them altogether. This should reduce the number of useless patternMatch calls drastically.

For the time being, not using the feature does not seem to cost much:
Parsing my project which adds Qt's `.tags` resulted in following (average of 3) numbers
- Vanilla Doxygen (no suppression pattern support): 4.8s, 1443 warnings
- 0 Suppression Patterns : 4.6s, 1443 warnings
- 1 Suppression Pattern (*.tags): 4.8s, 325 warnings
- 2 Suppression Patterns(*.tags nomatch): 4.5s, 325 warnings
- 3 Suppression Patterns (*.tags nomatch dummy-pattern): 4.8s, 325 warnings

These limited performance tests are inconclusive about the impact of the change. Can you recommend some larger projects to test this with?