### PR TITLE
XML output: avoid warnings with scoped enum values in anonymous namespaces

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -954,11 +954,11 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
       MemberDef *emd;
       for (emli.toFirst();(emd=emli.current());++emli)
       {
-        ti << "    <member refid=\"" << memberOutputFileBase(emd) 
-           << "_1" << emd->anchor() << "\" kind=\"enumvalue\"><name>" 
+        ti << "    <member refid=\"" << memberOutputFileBase(md)
+           << "_1" << emd->anchor() << "\" kind=\"enumvalue\"><name>"
            << convertToXML(emd->name()) << "</name></member>" << endl;
 
-        t << "        <enumvalue id=\"" << memberOutputFileBase(emd) << "_1" 
+        t << "        <enumvalue id=\"" << memberOutputFileBase(md) << "_1"
           << emd->anchor() << "\" prot=\"";
         switch (emd->protection())
         {

--- a/testing/071/namespace_a_namespace_1_1_0D0.xml
+++ b/testing/071/namespace_a_namespace_1_1_0D0.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespace_a_namespace_1_1_0D0" kind="namespace" language="C++">
+    <compoundname>ANamespace::@0</compoundname>
+      <sectiondef kind="enum">
+      <memberdef kind="enum" id="071__enum__in__anon__ns_8cpp_1a96ab6574751fdf6a53ceec8a3896c45d" prot="public" static="no" strong="yes">
+        <type/>
+        <name>Boolean</name>
+        <enumvalue id="071__enum__in__anon__ns_8cpp_1a96ab6574751fdf6a53ceec8a3896c45daf8320b26d30ab433c5a54546d21f414c" prot="public">
+          <name>False</name>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="071__enum__in__anon__ns_8cpp_1a96ab6574751fdf6a53ceec8a3896c45daf827cf462f62848df37c5e1e94a4da74" prot="public">
+          <name>True</name>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="071__enum__in__anon__ns_8cpp_1a96ab6574751fdf6a53ceec8a3896c45da2767828026039e8ba7b38973cbb701f2" prot="public">
+          <name>FileNotFound</name>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="071_enum_in_anon_ns.cpp" line="6" column="1" bodyfile="071_enum_in_anon_ns.cpp" bodystart="6" bodyend="10"/>
+      </memberdef>
+      </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="071_enum_in_anon_ns.cpp" line="4" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/071_enum_in_anon_ns.cpp
+++ b/testing/071_enum_in_anon_ns.cpp
@@ -1,0 +1,12 @@
+// objective: test that enum values in anonymous namespaces produce no warning
+// check: namespace_a_namespace_1_1_0D0.xml
+
+namespace ANamespace { namespace {
+
+enum class Boolean {
+    False,
+    True,
+    FileNotFound
+};
+
+}}


### PR DESCRIPTION
When a C++11 `enum class` was present in an anonymous namespace (usually in *.cpp files), the XML output was emitting warnings similar to the following:

> Internal inconsistency: member False does not belong to any container!

And the XML output was rendering bogus IDs for enum values starting with `dummy_`, such as:

    dummy_1a96ab6574751fdf6a53ceec8a3896c45daf8320b26d30ab433c5a54546d21f414c

The fix is to call `memberOutputFileBase()` on the enumeration itself and not on the enum value, that way it provides correct file base that corresponds to file base of the enumeration. There's also a new test that checks this.

**Note:** this assumes that enum values are rendered to the same output file as enums themselves. In my experience that was always the case and there's no broken test after this change, so I hope I didn't break anything. Tell me if you'd like to fix this in a different way.

Btw., thanks a lot for releasing 1.8.14! :)