### PR TITLE
Make dot failure a fatal error

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1143,6 +1143,12 @@ uint DotRunnerQueue::count() const
   return m_queue.count();
 }
 
+void DotRunnerQueue::doExit(QCString msg)
+{
+  err(msg);
+  exit(1);
+}
+
 //--------------------------------------------------------------------
 
 DotWorkerThread::DotWorkerThread(DotRunnerQueue *queue)
@@ -1156,7 +1162,10 @@ void DotWorkerThread::run()
   DotRunner *runner;
   while ((runner=m_queue->dequeue()))
   {
-    runner->run();
+    bool success = runner->run();
+    if(!success){
+      m_queue->doExit("Running dot for graph failed\n");
+    }
     const DotRunner::CleanupItem &cleanup = runner->cleanup();
     if (!cleanup.file.isEmpty())
     {
@@ -1318,7 +1327,11 @@ bool DotManager::run()
     for (li.toFirst();(dr=li.current());++li)
     {
       msg("Running dot for graph %d/%d\n",prev,numDotRuns);
-      dr->run();
+      bool success = dr->run();
+      if(!success){
+        err("Running dot for graph failed\n");
+        exit(1);
+      }
       prev++;
     }
   }

--- a/src/dot.h
+++ b/src/dot.h
@@ -440,6 +440,7 @@ class DotRunnerQueue
     void enqueue(DotRunner *runner);
     DotRunner *dequeue();
     uint count() const;
+    void doExit(QCString msg);
   private:
     QWaitCondition  m_bufferNotEmpty;
     QQueue<DotRunner> m_queue;


### PR DESCRIPTION
Currently if dot fails to run for any reason, doxygen will carry on and appear to complete. The error message will likey be lost in the scrollback.

Make it so that uf dot fails to run then give a message and exit.

In the multithreaded case pass we need to exit from the main thread, so
add a DotRunnerQueue::doExit() that can be called from the worked thread.

