### PR TITLE
Bug 793052 - C#: Incorrect parsing of property definitions containing  "//" symbols in one line with "}

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -755,6 +755,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 %x	CopyHereDocEnd
 %x	RawString
 %x	RawGString
+%x	CSString
 
 %x      IDLAttribute
 %x      IDLProp
@@ -6235,8 +6236,14 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <CSAccessorDecl>"add"			{ if (curlyCount==0) current->spec |= Entry::Addable;   }
 <CSAccessorDecl>"remove"		{ if (curlyCount==0) current->spec |= Entry::Removable; }
 <CSAccessorDecl>"raise"			{ if (curlyCount==0) current->spec |= Entry::Raisable;  }
-<CSAccessorDecl>.			{}
+<CSAccessorDecl>"\""			{ BEGIN(CSString);}
+<CSAccessorDecl>"."			{}
 <CSAccessorDecl>\n			{ lineCount(); }
+<CSString>"\""				{ BEGIN(CSAccessorDecl);}
+<CSString>"//"				{} /* Otherwise the rule <*>"//" will kick in */
+<CSString>"/*"				{} /* Otherwise the rule <*>"/*" will kick in */
+<CSString>\n				{ lineCount(); }
+<CSString>"."				{}
 
 
 


### PR DESCRIPTION
The handling of comment signs inside a string for property definitions has been corrected, by defining parsing rules for these cases so that not the default comment handler will be used (i.e. remove the part behind the comment sign).