### PR TITLE
Bug 792935 - error: Could not open file .../doc/html/functions_ .html for writing

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1638,10 +1638,15 @@ static void writeAnnotatedClassList(OutputList &ol)
   ol.endIndexList();
 }
 
+inline bool isId1(int c)
+{
+  return (c<127 && c>31); // printable ASCII character
+}
+
 static QCString letterToLabel(uint startLetter)
 {
   char s[11]; // max 0x12345678 + '\0'
-  if (isId(startLetter)) // printable ASCII character
+  if (isId1(startLetter)) // printable ASCII character
   {
     s[0]=(char)startLetter;
     s[1]=0;


### PR DESCRIPTION
Labels are used internally in pages but also for filenames and not all file systems can cope with all characters, so only ASCII printable characters are left untouched.