### PR TITLE
Bug 792415 - Blank rows on class page when using external tag file

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -302,6 +302,10 @@ void FTVHelp::generateLink(FTextStream &t,FTVNode *n)
       else
         t << "\" target=\"_self\">";
     }
+    else
+    {
+      t << ">";
+    }
     t << convertToHtml(n->name);
     t << "</a>";
     if (!n->ref.isEmpty())


### PR DESCRIPTION
Regression on: Bug 743367 - Duplicate attribute (target="_top" target="_top") generated in .SVG files
Added missing closing >.