### PR TITLE
Bug 792727 - unescaped double quote in searchdata.js breaks search box functionality

### DIFF
--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -1180,6 +1180,7 @@ void writeJavascriptSearchIndex()
           SearchIndexList *sl;
           for (it.toFirst();(sl=it.current());++it) // for each letter
           {
+            if ( sl->letter() == '"' ) t << QString( QChar( '\\' ) ).utf8();
             t << QString( QChar( sl->letter() ) ).utf8();
           }
           t << "\"";


### PR DESCRIPTION
Escaped the double quote.