### PR TITLE
Added "label" option for latex images so it is possible to create latex references to them.

### DIFF
--- a/src/docparser.h
+++ b/src/docparser.h
@@ -507,11 +507,13 @@ class DocVerbatim : public DocNode
     bool hasCaption() const      { return !m_children.isEmpty(); }
     QCString width() const       { return m_width; }
     QCString height() const      { return m_height; }
+    QCString label() const       { return m_label; }
     const QList<DocNode> &children() const { return m_children; }
     QList<DocNode> &children()   { return m_children; }
     void setText(const QCString &t)   { m_text=t;   }
     void setWidth(const QCString &w)  { m_width=w;  }
     void setHeight(const QCString &h) { m_height=h; }
+    void setLabel(const QCString &l) { m_label=l; }
 
   private:
     QCString  m_context;
@@ -524,6 +526,7 @@ class DocVerbatim : public DocNode
     bool      m_isBlock;
     QCString  m_width;
     QCString  m_height;
+    QCString  m_label;
     QList<DocNode> m_children;
 };
 
@@ -746,6 +749,7 @@ class DocImage : public CompAccept<DocImage>
     QCString height() const     { return m_height; }
     QCString relPath() const    { return m_relPath; }
     QCString url() const        { return m_url; }
+    QCString label() const      { return m_label; }
     const HtmlAttribList &attribs() const { return m_attribs; }
     void parse();
 
@@ -757,6 +761,7 @@ class DocImage : public CompAccept<DocImage>
     QCString  m_height;
     QCString  m_relPath;
     QCString  m_url;
+    QCString  m_label;
 };
 
 /** Node representing a dot file */
@@ -773,6 +778,8 @@ class DocDotFile : public CompAccept<DocDotFile>
     QCString width() const      { return m_width; }
     QCString height() const     { return m_height; }
     QCString context() const    { return m_context; }
+    QCString label() const      { return m_label; }
+
   private:
     QCString  m_name;
     QCString  m_file;
@@ -780,6 +787,7 @@ class DocDotFile : public CompAccept<DocDotFile>
     QCString  m_width;
     QCString  m_height;
     QCString  m_context;
+    QCString  m_label;
 };
 
 /** Node representing a msc file */
@@ -796,6 +804,7 @@ class DocMscFile : public CompAccept<DocMscFile>
     QCString width() const     { return m_width; }
     QCString height() const    { return m_height; }
     QCString context() const   { return m_context; }
+    QCString label() const      { return m_label; }
   private:
     QCString  m_name;
     QCString  m_file;
@@ -803,6 +812,7 @@ class DocMscFile : public CompAccept<DocMscFile>
     QCString  m_width;
     QCString  m_height;
     QCString  m_context;
+    QCString  m_label;
 };
 
 /** Node representing a dia file */
@@ -819,6 +829,8 @@ class DocDiaFile : public CompAccept<DocDiaFile>
     QCString width() const     { return m_width; }
     QCString height() const    { return m_height; }
     QCString context() const   { return m_context; }
+    QCString label() const      { return m_label; }
+
   private:
     QCString  m_name;
     QCString  m_file;
@@ -826,6 +838,7 @@ class DocDiaFile : public CompAccept<DocDiaFile>
     QCString  m_width;
     QCString  m_height;
     QCString  m_context;
+    QCString  m_label;
 };
 
 /** Node representing a VHDL flow chart */

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -87,18 +87,23 @@ static void visitPreStart(FTextStream &t, const bool hasCaption, QCString name, 
     }
 
     t << "{" << name << "}";
-
+    
     if (hasCaption)
     {
       t << "\n\\doxyfigcaption{";
     }
 }
 
-
-
-static void visitPostEnd(FTextStream &t, const bool hasCaption)
+static void visitLabel(FTextStream &t, QCString label)
 {
     t << "}\n"; // end mbox or caption
+    if (!label.isEmpty())
+        t << "\\label{" << label << "}\n";
+}
+
+static void visitPostEnd(FTextStream &t, const bool hasCaption, QCString label)
+{
+    visitLabel(t, label);
     if (hasCaption)
     {
       t << "\\end{DoxyImage}\n";
@@ -333,9 +338,9 @@ void LatexDocVisitor::visit(DocVerbatim *s)
           file.writeBlock( s->text(), s->text().length() );
           file.close();
 
-          startDotFile(fileName,s->width(),s->height(),s->hasCaption());
+          startDotFile(fileName,s->width(),s->height(), s->hasCaption());
           visitCaption(this, s->children());
-          endDotFile(s->hasCaption());
+          endDotFile(s->hasCaption(), s->label());
 
           if (Config_getBool(DOT_CLEANUP)) file.remove();
         }
@@ -1265,7 +1270,7 @@ void LatexDocVisitor::visitPost(DocImage *img)
   if (img->type()==DocImage::Latex)
   {
     if (m_hide) return;
-    visitPostEnd(m_t,img->hasCaption());
+    visitPostEnd(m_t,img->hasCaption(), img->label());
   }
   else // other format
   {
@@ -1282,7 +1287,7 @@ void LatexDocVisitor::visitPre(DocDotFile *df)
 void LatexDocVisitor::visitPost(DocDotFile *df) 
 {
   if (m_hide) return;
-  endDotFile(df->hasCaption());
+  endDotFile(df->hasCaption(),df->label());
 }
 void LatexDocVisitor::visitPre(DocMscFile *df)
 {
@@ -1293,7 +1298,7 @@ void LatexDocVisitor::visitPre(DocMscFile *df)
 void LatexDocVisitor::visitPost(DocMscFile *df) 
 {
   if (m_hide) return;
-  endMscFile(df->hasCaption());
+  endMscFile(df->hasCaption(),df->label());
 }
 
 void LatexDocVisitor::visitPre(DocDiaFile *df)
@@ -1305,7 +1310,7 @@ void LatexDocVisitor::visitPre(DocDiaFile *df)
 void LatexDocVisitor::visitPost(DocDiaFile *df)
 {
   if (m_hide) return;
-  endDiaFile(df->hasCaption());
+  endDiaFile(df->hasCaption(),df->label());
 }
 void LatexDocVisitor::visitPre(DocLink *lnk)
 {
@@ -1742,10 +1747,10 @@ void LatexDocVisitor::startDotFile(const QCString &fileName,
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
-void LatexDocVisitor::endDotFile(bool hasCaption)
+void LatexDocVisitor::endDotFile(bool hasCaption,QCString label)
 {
   if (m_hide) return;
-  visitPostEnd(m_t,hasCaption);
+  visitPostEnd(m_t,hasCaption,label);
 }
 
 void LatexDocVisitor::startMscFile(const QCString &fileName,
@@ -1771,10 +1776,10 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
-void LatexDocVisitor::endMscFile(bool hasCaption)
+void LatexDocVisitor::endMscFile(bool hasCaption,QCString label)
 {
   if (m_hide) return;
-  visitPostEnd(m_t,hasCaption);
+  visitPostEnd(m_t,hasCaption,label);
 }
 
 
@@ -1790,7 +1795,7 @@ void LatexDocVisitor::writeMscFile(const QCString &baseName, DocVerbatim *s)
   writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS);
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(),s->height());
   visitCaption(this, s->children());
-  visitPostEnd(m_t, s->hasCaption());
+  visitPostEnd(m_t, s->hasCaption(),s->label());
 }
 
 
@@ -1817,10 +1822,10 @@ void LatexDocVisitor::startDiaFile(const QCString &fileName,
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
-void LatexDocVisitor::endDiaFile(bool hasCaption)
+void LatexDocVisitor::endDiaFile(bool hasCaption,QCString label)
 {
   if (m_hide) return;
-  visitPostEnd(m_t,hasCaption);
+  visitPostEnd(m_t,hasCaption,label);
 }
 
 
@@ -1836,7 +1841,7 @@ void LatexDocVisitor::writeDiaFile(const QCString &baseName, DocVerbatim *s)
   writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DIA_EPS);
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(), s->height());
   visitCaption(this, s->children());
-  visitPostEnd(m_t, s->hasCaption());
+  visitPostEnd(m_t, s->hasCaption(),s->label());
 }
 
 void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, DocVerbatim *s)
@@ -1851,6 +1856,6 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, DocVerbatim *s
   generatePlantUMLOutput(baseName,outDir,PUML_EPS);
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(), s->height());
   visitCaption(this, s->children());
-  visitPostEnd(m_t, s->hasCaption());
+  visitPostEnd(m_t, s->hasCaption(),s->label());
 }
 

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -164,16 +164,16 @@ class LatexDocVisitor : public DocVisitor
     QCString escapeMakeIndexChars(const char *s);
     void startDotFile(const QCString &fileName,const QCString &width,
                       const QCString &height, bool hasCaption);
-    void endDotFile(bool hasCaption);
+    void endDotFile(bool hasCaption, QCString label);
 
     void startMscFile(const QCString &fileName,const QCString &width,
                       const QCString &height, bool hasCaption);
-    void endMscFile(bool hasCaption);
+    void endMscFile(bool hasCaption, QCString label);
     void writeMscFile(const QCString &fileName, DocVerbatim *s);
 
     void startDiaFile(const QCString &fileName,const QCString &width,
                       const QCString &height, bool hasCaption);
-    void endDiaFile(bool hasCaption);
+    void endDiaFile(bool hasCaption, QCString label);
     void writeDiaFile(const QCString &fileName, DocVerbatim *s);
     void writePlantUMLFile(const QCString &fileName, DocVerbatim *s);
 


### PR DESCRIPTION
Added a property "label" for Latex images and dot/msc files so you can set a label
> \image latex figure.eps "Caption" width=0.7\textwidth label=figA 

and refer to the figure in the documentation like this:

> As seen in figure \latexonly \ref{figA} \endlatexonly ...
