### PR TITLE
Make it possible to list namespace members in file scope for XML output

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2881,6 +2881,15 @@ or
 ]]>
       </docs>
     </option>
+    <option type='bool' id='XML_NAMESPACE_MEMBERS_IN_FILE_SCOPE' defval='0' depends='GENERATE_XML'>
+      <docs>
+<![CDATA[
+ If the \c XML_NAMESPACE_MEMBERS_IN_FILE_SCOPE tag is set to \c YES, doxygen
+ will include namespace members in file scope as well, matching the HTML
+ output.
+]]>
+      </docs>
+    </option>
   </group>
   <group name='Docbook' docs='Configuration options related to the DOCBOOK output'>
     <option type='bool' id='GENERATE_DOCBOOK' defval='0'>

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -1052,7 +1052,7 @@ static void generateXMLSection(Definition *d,FTextStream &ti,FTextStream &t,
   {
     // namespace members are also inserted in the file scope, but 
     // to prevent this duplication in the XML output, we filter those here.
-    if (d->definitionType()!=Definition::TypeFile || md->getNamespaceDef()==0)
+    if ((Config_getBool(XML_NAMESPACE_MEMBERS_IN_FILE_SCOPE) || d->definitionType()!=Definition::TypeFile) || md->getNamespaceDef()==0)
     {
       count++;
     }
@@ -1074,7 +1074,7 @@ static void generateXMLSection(Definition *d,FTextStream &ti,FTextStream &t,
   {
     // namespace members are also inserted in the file scope, but 
     // to prevent this duplication in the XML output, we filter those here.
-    if (d->definitionType()!=Definition::TypeFile || md->getNamespaceDef()==0)
+    if ((Config_getBool(XML_NAMESPACE_MEMBERS_IN_FILE_SCOPE) || d->definitionType()!=Definition::TypeFile) || md->getNamespaceDef()==0)
     {
       generateXMLForMember(md,ti,t,d);
     }

--- a/testing/072/072__no__xml__namespace__members__in__file__scope_8h.xml
+++ b/testing/072/072__no__xml__namespace__members__in__file__scope_8h.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="072__no__xml__namespace__members__in__file__scope_8h" kind="file" language="C++">
+    <compoundname>072_no_xml_namespace_members_in_file_scope.h</compoundname>
+    <innernamespace refid="namespace_namespace">Namespace</innernamespace>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="072_no_xml_namespace_members_in_file_scope.h"/>
+  </compounddef>
+</doxygen>

--- a/testing/072_no_xml_namespace_members_in_file_scope.h
+++ b/testing/072_no_xml_namespace_members_in_file_scope.h
@@ -1,0 +1,16 @@
+// objective: test that namespace members are not put to file docs by default
+// check: 072__no__xml__namespace__members__in__file__scope_8h.xml
+
+namespace Namespace {
+
+/**
+@brief A function
+
+Detailed documentation.
+*/
+void foo();
+
+/** @brief An enum */
+enum class Enum {};
+
+}

--- a/testing/073/073__xml__namespace__members__in__file__scope_8h.xml
+++ b/testing/073/073__xml__namespace__members__in__file__scope_8h.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="073__xml__namespace__members__in__file__scope_8h" kind="file" language="C++">
+    <compoundname>073_xml_namespace_members_in_file_scope.h</compoundname>
+    <innernamespace refid="namespace_namespace">Namespace</innernamespace>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="073__xml__namespace__members__in__file__scope_8h_1add172b93283b1ab7612c3ca6cc5dcfea" prot="public" static="no" strong="yes">
+        <type/>
+        <name>Enum</name>
+        <briefdescription>
+          <para>An enum. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="073_xml_namespace_members_in_file_scope.h" line="15" column="1" bodyfile="073_xml_namespace_members_in_file_scope.h" bodystart="15" bodyend="15"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="073__xml__namespace__members__in__file__scope_8h_1a0f1fe1a972c7c4196988a1bdde63ec77" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void Namespace::foo</definition>
+        <argsstring>()</argsstring>
+        <name>foo</name>
+        <briefdescription>
+          <para>A function. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>Detailed documentation. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="073_xml_namespace_members_in_file_scope.h" line="12" column="1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="073_xml_namespace_members_in_file_scope.h"/>
+  </compounddef>
+</doxygen>

--- a/testing/073_xml_namespace_members_in_file_scope.h
+++ b/testing/073_xml_namespace_members_in_file_scope.h
@@ -1,0 +1,17 @@
+// objective: test that namespace members are put to file docs when enabled
+// check: 073__xml__namespace__members__in__file__scope_8h.xml
+// config: XML_NAMESPACE_MEMBERS_IN_FILE_SCOPE = YES
+
+namespace Namespace {
+
+/**
+@brief A function
+
+Detailed documentation.
+*/
+void foo();
+
+/** @brief An enum */
+enum class Enum {};
+
+}


### PR DESCRIPTION
For better consistency with the HTML output, where each file documentation lists (and links to) all members of given namespace. This also makes it possible to be consistent with the HTML output in case a namespace is not documented and thus all its member detailed docs should be put into corresponding file docs instead.

In order to be backwards compatible and avoid breaking stuff for existing users of the XML output, this is controlled by a new `XML_NAMESPACE_MEMBERS_IN_FILE_SCOPE` configuration option that defaults
to `NO`.

Note that this, unlike the HTML output, will put the whole detailed docs into the file scope instead of just listing them. It's up to the user of the XML output to filter and deduplicate this information. It can be done for example by comparing member ID prefixes with compound ID -- íf different, the detailed docs are already somewhere else.

Cc: @Leandros