### PR TITLE
Consistency for "group" commands

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1517,14 +1517,16 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  if (*yytext=='\n') yyLineNr++;
 					  BEGIN( Comment );
   					}
+<GroupDocArg1>.				{ // ignore other stuff
+  					}
 <GroupDocArg2>"\\"{B}*"\n"		{ // line continuation
   					  yyLineNr++; 
 					  addOutput('\n');
                                         }
-<GroupDocArg2>[^\n\\\*]+		{ // title (stored in type)
+<GroupDocArg2>[^\n\*]+			{ // title (stored in type)
 					  current->type += yytext;
 					  current->type = current->type.stripWhiteSpace();
-  					}
+                                        }
 <GroupDocArg2>{DOCNL}			{
                                           if ( current->groupDocType==Entry::GROUPDOC_NORMAL &&
                                                current->type.isEmpty() 


### PR DESCRIPTION
When a non-recognized character appears in a group-command id this is echoed to the console as the default (lex-)rule will be used.
This patch ignores these characters, furthermore in case of a \ in the description this is shown in the output as well.