### PR TITLE
Bug 683564 - Value from enumeration followed with semicolon is not present in java docs

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3639,7 +3639,10 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					      current->fileName   = yyFileName;
 					      current->startLine  = yyLineNr;
 					      current->startColumn = yyColNr;
-					      current->type       = "@"; // enum marker
+					      if (!(current_root->spec&Entry::Enum))
+					      {
+					        current->type       = "@"; // enum marker
+					      }
 					      current->args       = current->args.simplifyWhiteSpace();
 					      current->name       = current->name.stripWhiteSpace();
 					      current->section    = Entry::VARIABLE_SEC;


### PR DESCRIPTION
For java the type should not be reset to "@", see also rule  \<FindFields\>","