### PR TITLE
Ignore build* directories and not just build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 
 /doxygen_docs
 /doxygen.tag
-/build
+/build*


### PR DESCRIPTION
in case of parallel build directories is is better to ignore the build* directories