### PR TITLE
Consistent warning messages

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1860,10 +1860,10 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  addOutput(*yytext);
   					}
 <FormatBlock><<EOF>>			{
-                                          QCString endTag = "@end"+blockName;
+                                          QCString endTag = "end"+blockName;
                                           if (blockName=="startuml") endTag="enduml";
                                           warn(yyFileName,yyLineNr,
-	                                    "reached end of comment while inside a @%s block; check for missing @%s tag!",
+	                                    "reached end of comment while inside a \\%s block; check for missing \\%s tag!",
 	                                    blockName.data(),endTag.data()
 	                                  );				
 					  yyterminate();
@@ -1944,7 +1944,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  if (guards.isEmpty())
 					  {
 					    warn(yyFileName,yyLineNr,
-						"found @endif without matching start command");
+						"found \\endif without matching start command");
 					  }
 					  else
 					  {
@@ -1962,7 +1962,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  if (guards.isEmpty())
 					  {
 					    warn(yyFileName,yyLineNr,
-						"found @else without matching start command");
+						"found \\else without matching start command");
 					  }
 					  else
 					  {
@@ -1979,7 +1979,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  if (guards.isEmpty())
 					  {
 					    warn(yyFileName,yyLineNr,
-						"found @elseif without matching start command");
+						"found \\elseif without matching start command");
 					  }
 					  else
 					  {


### PR DESCRIPTION
Remove second @ from warning message and replace all @ with \ in warnings for comments in comment scanner.
Error showed up in (Lapack v3.8.0):
  .../lapack/BLAS/SRC/sdsdot.f:25: warning: reached end of comment while inside a @verbatim block; check for missing @@endverbatim tag!