### PR TITLE
Bug 793644 - Long functionnames with links are not split in latex output when the line is to short.

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -655,7 +655,8 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   // End of preamble, now comes the document contents
   t << "%===== C O N T E N T S =====\n"
        "\n"
-       "\\begin{document}\n";
+       "\\begin{document}\n"
+       "\\sloppy\n";
   if (theTranslator->idLanguage()=="greek")
     t << "\\selectlanguage{greek}\n";
   t << "\n";


### PR DESCRIPTION
Regression on Bug 778730 - doxygen build fails
Stakexchange TEX article: When I prevent hyphenation using an \mbox, the box gets pushed into the right margin (https://tex.stackexchange.com/questions/53364/when-i-prevent-hyphenation-using-an-mbox-the-box-gets-pushed-into-the-right-ma)

Implemented \sloppy preventing the overflow.