### PR TITLE
Bug 611240 - C# keywords 'get' and 'set' are highlighted as reserved words in C++ documentation source browser.

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -116,6 +116,7 @@ static int           g_memCallContext;
 static int	     g_lastCContext;
 static int           g_skipInlineInitContext;
 
+static bool          g_insideCpp;
 static bool          g_insideObjC;
 static bool          g_insideJava;
 static bool          g_insideCS;
@@ -2415,6 +2416,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  g_prefixed_with_this_keyword = TRUE;
                                         }
 <Body>{KEYWORD}/([^a-z_A-Z0-9]) 	{
+                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  if (QCString(yytext)=="typedef")
@@ -2425,11 +2427,13 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  endFontClass();
   					}
 <Body>{KEYWORD}/{B}* 			{
+                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  endFontClass();
   					}
 <Body>{KEYWORD}/{BN}*"(" 		{
+                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  endFontClass();
@@ -2984,6 +2988,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <MemberCall2,FuncCall>{KEYWORD}/([^a-z_A-Z0-9]) {
 					  //addParmType();
 					  //g_parmName=yytext; 
+                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  g_code->codify(yytext);
 					  endFontClass();
@@ -3742,6 +3747,7 @@ void parseCCode(CodeOutputInterface &od,const char *className,const QCString &s,
   g_insideJava = lang==SrcLangExt_Java;
   g_insideCS   = lang==SrcLangExt_CSharp;
   g_insidePHP  = lang==SrcLangExt_PHP;
+  g_insideCpp  = lang==SrcLangExt_Cpp;
   if (g_sourceFileDef) 
   {
     setCurrentDoc("l00001");


### PR DESCRIPTION
In case of Cpp don't  see 'get' and 'set' as keywords, but in case the keyword rule is used REJECT the rule and give other rules a chance (e.g. the function rule).