### PR TITLE
Bug 792122 - XHTML pages are broken several ways

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -563,14 +563,7 @@ static void addXRefItem(const char *listName,const char *itemTitle,
     RefItem *item = refList->getRefItem(lii->itemId);
     ASSERT(item!=0);
     item->text += " <p>";
-    if (Doxygen::markdownSupport)
-    {
-      item->text += processMarkdown(yyFileName,yyLineNr,current,outputXRef);
-    }
-    else
-    {
-      item->text += outputXRef;
-    }
+    item->text += outputXRef;
     //printf("%s: text +=%s\n",listName,item->text.data());
   }
   else // new item
@@ -585,14 +578,7 @@ static void addXRefItem(const char *listName,const char *itemTitle,
     sprintf(anchorLabel,"_%s%06d",listName,itemId);
     RefItem *item = refList->getRefItem(itemId);
     ASSERT(item!=0);
-    if (Doxygen::markdownSupport)
-    {
-      item->text = processMarkdown(yyFileName,yyLineNr,current,outputXRef);
-    }
-    else
-    {
-      item->text = outputXRef;
-    }
+    item->text = outputXRef;
     item->listAnchor = anchorLabel;
     docEntry->addSpecialListItem(listName,itemId);
     QCString cmdString;
@@ -2943,7 +2929,19 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
   langParser     = parser;
   current        = curEntry;
   if (comment.isEmpty()) return FALSE; // avoid empty strings
-  inputString    = comment;
+  if (Doxygen::markdownSupport)
+  {
+    inputString      = processMarkdown(fileName,lineNr,NULL,comment);
+    QString qq(inputString);
+    while (qq.startsWith(" ")) qq = qq.mid(1);
+    while (qq.startsWith("\n")) qq = qq.mid(1);
+    if (qq.startsWith("<br>")) qq = qq.mid(4);
+    inputString = QCString(qq.data());
+  }
+  else
+  {
+    inputString    = comment;
+  }
   inputString.append(" ");
   inputPosition  = position;
   yyLineNr       = lineNr;
@@ -2970,7 +2968,7 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
   }
 
   Debug::print(Debug::CommentScan,0,"-----------\nCommentScanner: %s:%d\n"
-               "input=[\n%s]\n",qPrint(fileName),lineNr,qPrint(comment)
+               "input=[\n%s]\n",qPrint(fileName),lineNr,qPrint(inputString)
               );
   
   commentscanYYrestart( commentscanYYin );
@@ -3008,15 +3006,9 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
     openGroup(current,yyFileName,yyLineNr);
   }
 
-  if (Doxygen::markdownSupport)
-  {
-    current->brief      = processMarkdown(fileName,lineNr,current,current->brief);
-    current->doc        = processMarkdown(fileName,lineNr,current,current->doc);
-    current->inbodyDocs = processMarkdown(fileName,lineNr,current,current->inbodyDocs);
-  }
-
-  Debug::print(Debug::CommentScan,0,
-               "brief=[line=%d\n%s]\ndocs=[line=%d\n%s]\ninbody=[line=%d\n%s]\n===========\n",
+  Debug::print(Debug::CommentScan,0,"-----------\nCommentScanner: %s:%d\noutput=[\n"
+               "brief=[line=%d\n%s]\ndocs=[line=%d\n%s]\ninbody=[line=%d\n%s]\n]\n===========\n",
+               qPrint(fileName),lineNr,
 	       current->briefLine,qPrint(current->brief),
                current->docLine,qPrint(current->doc),
                current->inbodyLine,qPrint(current->inbodyDocs)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10965,7 +10965,7 @@ void parseInput()
 
 
   /**************************************************************************
-   *            Check/create output directorties                            *
+   *            Check/create output directories                             *
    **************************************************************************/
 
   QCString htmlOutput;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -483,6 +483,8 @@ static int processNmdash(GrowBuf &out,const char *data,int off,int size)
   {
     count++;
   }
+  if (count==2 && off>=2 && qstrncmp(data-2,"<!",2)==0) return 0; // start HTML comment
+  if (count==2 && (data[2]=='>')) return 0; // end HTML comment
   if (count==2 && (off<8 || qstrncmp(data-8,"operator",8)!=0)) // -- => ndash
   {
     out.addStr("&ndash;");
@@ -2548,7 +2550,7 @@ QCString processMarkdown(const QCString &fileName,const int lineNr,Entry *e,cons
   // finally process the inline markup (links, emphasis and code spans)
   processInline(out,s,s.length());
   out.addChar(0);
-  Debug::print(Debug::Markdown,0,"======== Markdown =========\n---- input ------- \n%s\n---- output -----\n%s\n---------\n",qPrint(input),qPrint(out.get()));
+  Debug::print(Debug::Markdown,0,"======== Markdown =========\n---- input ------- \n%s\n---- output -----\n%s\n=========\n",qPrint(input),qPrint(out.get()));
   return out.get();
 }
 

--- a/testing/054/054__parblock_8cpp.xml
+++ b/testing/054/054__parblock_8cpp.xml
@@ -80,6 +80,96 @@
                 <parameterdescription>
                   <para>
                     <parblock>
+                      <para>First paragraph of the param description.</para>
+                      <para>Second paragraph of the param description. </para>
+                    </parblock>
+                  </para>
+                </parameterdescription>
+              </parameteritem>
+            </parameterlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="054_parblock.cpp" line="33" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="054__parblock_8cpp_1a5cded03ec9e6fd626da35ab05f624f39" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void function_2</definition>
+        <argsstring>(int client, int *resource, int parblock, int *test, int p)</argsstring>
+        <name>function_2</name>
+        <param>
+          <type>int</type>
+          <declname>client</declname>
+        </param>
+        <param>
+          <type>int *</type>
+          <declname>resource</declname>
+        </param>
+        <param>
+          <type>int</type>
+          <declname>parblock</declname>
+        </param>
+        <param>
+          <type>int *</type>
+          <declname>test</declname>
+        </param>
+        <param>
+          <type>int</type>
+          <declname>p</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>call by target-specific code to manage resources required by the client.</para>
+          <para>
+            <parameterlist kind="param">
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="in">client</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>ID of client requesting resource. </para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="out">resource</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>Requested resource </para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="in">parblock</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>
+                    <parblock>
+                      <para>This is a test for the @parblock command.</para>
+                      <para>A list if values for the parblock param:<itemizedlist><listitem><para>Item 1. This is short one-line description.</para></listitem><listitem><para>Item 2. This is a long bullet item; sometimes they wrap on multiple lines like this one.</para></listitem></itemizedlist>
+</para>
+                      <para>This is the second paragraph description for the @parblock parameter. Always end the text inside the @parblock command with an @endparblock command. </para>
+                    </parblock>
+                  </para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="out">test</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>This is a test parameter for this function to see if it is included in the parameter table </para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="in">p</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>
+                    <parblock>
                       <para>First paragraph of the param description. <verbatim>                  Second paragraph of the param description.
 </verbatim> </para>
                     </parblock>
@@ -91,7 +181,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="054_parblock.cpp" line="32" column="1"/>
+        <location file="054_parblock.cpp" line="60" column="1"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/054_parblock.cpp
+++ b/testing/054_parblock.cpp
@@ -24,9 +24,37 @@
                        @endparblock
  @param[out] test      This is a test parameter for this function to see if
                        it is included in the parameter table
+ @param[in]  p
+         @parblock First paragraph of the param description.
+
+         Second paragraph of the param description.
+         @endparblock
+ */
+void function(int client,int *resource,int parblock,int *test,int p);
+/**
+ call by target-specific code to manage resources required by the client.
+
+ @param[in]  client    ID of client requesting resource.
+ @param[out] resource  Requested resource
+ @param[in]  parblock  @parblock This is a test for the \@parblock
+                       command.
+
+                       A list if values for the parblock param:
+                       - Item 1. This is short one-line description.
+                       - Item 2. This is a long bullet item;
+                         sometimes they wrap on multiple lines like this
+                         one.
+
+                       This is the second paragraph description for the
+                       \@parblock parameter. Always end the text inside
+                       the \@parblock command with an \@endparblock
+                       command.
+                       @endparblock
+ @param[out] test      This is a test parameter for this function to see if
+                       it is included in the parameter table
  @param[in]  p         @parblock First paragraph of the param description.
 
                        Second paragraph of the param description.
-                       @endparblock
+ @endparblock
  */
-void function(int client,int *resource,int parblock,int *test,int p);
+void function_2(int client,int *resource,int parblock,int *test,int p);


### PR DESCRIPTION
The Markdown processing was done after the normal tag processing and splitting the comment in brief, doc, inline. This resulted in that sectioning parts (i.e. e.g. ==== conversion to \<h1> ) remained in the brief description whilst similar constructs with HTML commands landed in the doc (details) description. By performing the markdown on the entire comment block this problem has been overcome.

commentscan.l
- change moment of calling markdown processing
- skip start spaces and subsequent empty lines in markdown processed code
- small debug correction

markdown.cpp
- don't convert the dashes in \<!--  and --> (HTML type comment)
- small debug correction

054 test
- update of example for compatibility and adding part about none code result.

doxygen.cpp
- small textual comment correction