### PR TITLE
Bug 778012 - Python List as Default Parameter not parsed correctly

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -109,7 +109,7 @@ static QCString         g_packageName;
 
 //static bool             g_hideClassDocs;
 
-static QCString         g_defVal;
+static QGString         g_defVal;
 static int              g_braceCount;
 
 static bool             g_lexInit = FALSE;
@@ -993,34 +993,48 @@ STARTDOCSYMS      "##"
 }
 
 <FunctionParamDefVal>{
-     "("		{ // internal opening brace
+     "["		| 
+     "("		{ // internal opening brace, assumption is that we have correct code so braces do match
        			  g_braceCount++;
 			  g_defVal+=*yytext;
        			}
      ","		| 
+     "]"		| 
      ")"		{
        			  if (g_braceCount==0)  // end of default argument
 			  {
 			    if (current->argList->getLast())
 			    {
-			      current->argList->getLast()->defval=g_defVal.stripWhiteSpace();
+			      current->argList->getLast()->defval=QCString(g_defVal.data()).stripWhiteSpace();
 			    }
-			    if (*yytext == ')')
+			    if (*yytext != ',')
 			      current->args = argListToString(current->argList);
 			    BEGIN(FunctionParams);
 			  }
 			  else // continue
 			  {
-			    if (*yytext == ')')g_braceCount--;
+			    if (*yytext != ',')g_braceCount--;
 			    g_defVal+=*yytext;
 			  }
        			}
-     .			{
-			    g_defVal+=*yytext;
-       			}
+     "'"                {
+                          g_defVal+=*yytext;
+                          g_copyString=&g_defVal;
+                          g_stringContext=FunctionParamDefVal;
+                          BEGIN( SingleQuoteString );
+                        }
+     "\""               {
+                          g_defVal+=*yytext;
+                          g_copyString=&g_defVal;
+                          g_stringContext=FunctionParamDefVal;
+                          BEGIN( DoubleQuoteString );
+                        }
      \n                 {
        			    g_defVal+=*yytext;
 			    incLineNr();
+       			}
+     .			{
+			    g_defVal+=*yytext;
        			}
 }
 


### PR DESCRIPTION
Added handling of square brackets, single quoted strings and double quoted strings (could contain comma's as well) to default values of arguments.