### PR TITLE
Bug 777746 - Build of PDF with LaTEX breaks

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -13,6 +13,7 @@
 \RequirePackage{tabu}
 \RequirePackage{tabularx}
 \RequirePackage{multirow}
+\RequirePackage{environ}
 
 %---------- Internal commands used in this style file ----------------
 
@@ -376,14 +377,18 @@
 }
 
 % Used for member lists
-\newenvironment{DoxyCompactItemize}{%
-  \begin{itemize}%
-    \setlength{\itemsep}{-3pt}%
-    \setlength{\parsep}{0pt}%
-    \setlength{\topsep}{0pt}%
-    \setlength{\partopsep}{0pt}%
-}{%
-  \end{itemize}%
+\NewEnviron{DoxyCompactItemize}{
+    \ifx\BODY\empty%
+      % Do nothing
+    \else%
+      \begin{itemize}%
+            \setlength{\itemsep}{-3pt}%
+            \setlength{\parsep}{0pt}%
+            \setlength{\topsep}{0pt}%
+            \setlength{\partopsep}{0pt}%
+            {\BODY}%
+        \end{itemize}%
+    \fi%
 }
 
 % Used for member descriptions


### PR DESCRIPTION
This pull request fixes situation with many breaks during latex build.
```
! LaTeX Error: Something's wrong--perhaps a missing \item.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.5 \end{DoxyCompactItemize}
```

This caused by itemize environment requires non empty list.
I'll replace definition of `DoxyCompactItemize` within `NewEnviron` instead of `newenvironment`. This allows to access body of environment tag and check for emptiness.

I replaced