### PR TITLE
Correcting "Definition at line @0 of file @1."

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1034,15 +1034,15 @@ void Definition::writeSourceDef(OutputList &ol,const char *)
 
         ol.pushGeneratorState();
         ol.disable(OutputGenerator::Man); 
-        if (!latexSourceCode)
-        {
-          ol.disable(OutputGenerator::Latex);
-        }
-        if (!rtfSourceCode)
-        {
-          ol.disable(OutputGenerator::RTF);
-        }
         ol.disableAllBut(OutputGenerator::Html); 
+        if (latexSourceCode)
+        {
+          ol.enable(OutputGenerator::Latex);
+        }
+        if (rtfSourceCode)
+        {
+          ol.enable(OutputGenerator::RTF);
+        }
         // write line link (HTML only)
         ol.writeObjectLink(0,fn,anchorStr,lineStr);
         ol.enableAll();


### PR DESCRIPTION
In the LaTeX and RTF documentation where the filename should be presented before the linenumber (e.g. Chinese, Japanese) in the sentence "Definition at line @0 of file @1." neither was shown, the HTML version was correct.