### PR TITLE
Bug 303020 - Missing warning of undocumented member in member group

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3212,7 +3212,10 @@ QCString MemberDef::memberTypeName() const
 
 void MemberDef::warnIfUndocumented()
 {
-  if (m_impl->memberGroup) return;
+  /*
+   *  Removed bug_303020:
+   *  if (m_impl->memberGroup) return;
+   */
   ClassDef     *cd = getClassDef();
   NamespaceDef *nd = getNamespaceDef();
   FileDef      *fd = getFileDef();


### PR DESCRIPTION
Removed restrictions that functions / variables / enums ... in a \name command were excluded from the test.
(Note: In case of functions the arguments were tested or presence).