### PR TITLE
Consistency of Index name in LaTeX output

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -748,7 +748,7 @@ static void writeDefaultFooter(FTextStream &t)
   t << "\\newpage\n"
        "\\phantomsection\n"
        "\\clearemptydoublepage\n"
-       "\\addcontentsline{toc}{" << unit << "}{" << theTranslator->trRTFGeneralIndex() << "}\n"
+       "\\addcontentsline{toc}{" << unit << "}{\\indexname}\n"
        "\\printindex\n"
        "\n"
        "\\end{document}\n";


### PR DESCRIPTION
The name of the index is used on a number of places, in the Contents and the Bookmarks the name as used in the \addcontentsline is used and in the chapter with the index the name as specified in the \indexname is used.
The \indexname is set by the language package and the name in the \addcontentsline the name as used in the doxygen translator is used, this can lead to inconsistencies (e.g. Slovak language Register versus Index).
The approach has be made uniform here by using \indexname on bot places.