### PR TITLE
Generating doxygen documentation on Windows (with MikTex)

### DIFF
--- a/examples/include.cpp
+++ b/examples/include.cpp
@@ -8,7 +8,7 @@ class Include_Test
     void example();
 };
 
-/*! \page example
+/*! \page pag_example
  *  \dontinclude include_test.cpp
  *  Our main function starts like this:
  *  \skip main


### PR DESCRIPTION
The current version of MikTex gives the error message:

> Appendix Z.
> (../html/examples/include/latex/refman_doc.tex ("C:\Program Files\MiKTeX 2.9\te
> x\latex\alertmessage\example.tex"
> 
> ! LaTeX Error: Can be used only in preamble.

This is due to a ```\page``` command with the name 'example', renaming the page solves this issue.