### PR TITLE
Include "empty" directories documenting themselves.

### DIFF
--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -930,14 +930,14 @@ void buildDirectories()
     for (;(fd=fni.current());++fni)
     {
       //printf("buildDirectories %s\n",fd->name().data());
-      if (fd->getReference().isEmpty() && !fd->isDocumentationFile())
+      if (fd->getReference().isEmpty())
       {
         DirDef *dir;
         if ((dir=Doxygen::directories->find(fd->getPath()))==0) // new directory
         {
           dir = DirDef::mergeDirectoryInTree(fd->getPath());
         }
-        if (dir) dir->addFile(fd);
+        if (dir && !fd->isDocumentationFile()) dir->addFile(fd);
       }
       else
       {


### PR DESCRIPTION
Non-code directories can now be documented via a `.dox` (or similar) file in the directory itself.

Previously, directories would only be included in the documentation (e.g. "File list" tree or modules' "Directories" section) if they contained any _code_ input files (as opposed to _documentation_ input files, e.g. `.dox` or `.md` files), preventing the use of `.dox` files to document otherwise empty or non-code directories in a repository.

With this pull request, directories are instead included if they contain _any_ input files, provided at least one of them is a code file _or_ the directory is documented using a corresponding `\dir` special command. (The `\dir` command may reside anywhere, but the primary use case is for it to reside in a `.dox` file in the directory itself.)

The exact mechanism is that `buildDirectories()` will now add the directory of _any_ input file to the tree, regardless of code vs. documentation status. (Note that this also adds _undocumented_ documentation-only directories, which need to be filtered out further downstream, but such mechanisms seem to already be in place.)