### PR TITLE
Wrong determination of begin / end tag of formula in markdown.

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -240,7 +240,7 @@ static QCString isBlockCommand(const char *data,int offset,int size)
     {
       return "f]";
     }
-    else if (data[end]=='}')
+    else if (data[end]=='{')
     {
       return "f}";
     }


### PR DESCRIPTION
The begin tag for a formula during markdown checking was not determined correctly and thus the end tag was not set and the formula code was interpreted which should not be the case (especially in case of labels with '_' in it were miss interpreted .