### PR TITLE
Bug 768240 - Make maxLineLen of latex output configurable

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -526,7 +526,19 @@ void LatexDocVisitor::visit(DocIncOperator *op)
 void LatexDocVisitor::visit(DocFormula *f)
 {
   if (m_hide) return;
-  m_t << f->text();
+  const char *p=f->text();
+  char c;
+  if (p)
+  {
+    while ((c=*p++))
+    {
+      switch (c)
+      {
+        case '\'': m_t << "\\text{'}"; break;
+        default:  m_t << c; break;
+      }
+    }
+  }
 }
 
 void LatexDocVisitor::visit(DocIndexEntry *i)
@@ -927,7 +939,7 @@ static void writeStartTableCommand(FTextStream &t,const DocNode *n,int cols)
   }
   else
   {
-    t << "\\tabulinesep=1mm\n\\begin{longtabu} spread 0pt [c]{*{" << cols << "}{|X[-1]}|}\n";
+    t << "\\tabulinesep=1mm\n\\begin{longtabu}spread 0pt [c]{*{" << cols << "}{|X[-1]}|}\n";
   }
   //return isNested ? "TabularNC" : "TabularC";
 }

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -38,6 +38,7 @@
 #include "filename.h"
 #include "resourcemgr.h"
 
+static bool DoxyCodeOpen = FALSE;
 //-------------------------------
 
 LatexCodeGenerator::LatexCodeGenerator(FTextStream &t,const QCString &relPath,const QCString &sourceFileName)
@@ -77,8 +78,8 @@ void LatexCodeGenerator::codify(const char *str)
     //char cs[5];
     int spacesToNextTabStop;
     static int tabSize = Config_getInt(TAB_SIZE);
-    const int maxLineLen = 108;
-    QCString result(4*maxLineLen+1); // worst case for 1 line of 4-byte chars
+    static char *result = NULL;
+    static int lresult = 0;
     int i;
     while ((c=*p))
     {
@@ -86,9 +87,17 @@ void LatexCodeGenerator::codify(const char *str)
       {
         case 0x0c: p++;  // remove ^L
                    break;
+        case ' ':  m_t <<" ";
+                   m_col++;
+                   p++;
+                   break;
+        case '^':  m_t <<"\\string^";
+                   m_col++;
+                   p++;
+                   break;
         case '\t': spacesToNextTabStop =
                          tabSize - (m_col%tabSize);
-                   m_t << Doxygen::spaces.left(spacesToNextTabStop);
+                   for (i = 0; i < spacesToNextTabStop; i++) m_t <<" ";
                    m_col+=spacesToNextTabStop;
                    p++;
                    break;
@@ -100,6 +109,11 @@ void LatexCodeGenerator::codify(const char *str)
 #undef  COPYCHAR
 // helper macro to copy a single utf8 character, dealing with multibyte chars.
 #define COPYCHAR() do {                                           \
+                     if (lresult < (i + 5))                       \
+                     {                                            \
+                       lresult += 512;                            \
+                       result = (char *)realloc(result, lresult); \
+                     }                                            \
                      result[i++]=c; p++;                          \
                      if (c<0) /* multibyte utf-8 character */     \
                      {                                            \
@@ -116,30 +130,16 @@ void LatexCodeGenerator::codify(const char *str)
                          result[i++]=*p++;                        \
                        }                                          \
                      }                                            \
-                     m_col++;                                       \
+                     m_col++;                                     \
                    } while(0)
 
-                   // gather characters until we find whitespace or are at
-                   // the end of a line
+                   // gather characters until we find whitespace or another special character
                    COPYCHAR();
-                   if (m_col>=maxLineLen) // force line break
+                   while ((c=*p) &&
+                          c!=0x0c && c!='\t' && c!='\n' && c!=' ' && c!='^'
+                         )
                    {
-                     m_t << "\n      ";
-                     m_col=0;
-                   }
-                   else // copy more characters
-                   {
-                     while (m_col<maxLineLen && (c=*p) &&
-                            c!=0x0c && c!='\t' && c!='\n' && c!=' '
-                           )
-                     {
-                       COPYCHAR();
-                     }
-                     if (m_col>=maxLineLen) // force line break
-                     {
-                       m_t << "\n      ";
-                       m_col=0;
-                     }
+                     COPYCHAR();
                    }
                    result[i]=0; // add terminator
                    //if (m_prettyCode)
@@ -190,6 +190,11 @@ void LatexCodeGenerator::writeLineNumber(const char *ref,const char *fileName,co
 {
   static bool usePDFLatex = Config_getBool(USE_PDFLATEX);
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+  if (!DoxyCodeOpen)
+  {
+    m_t << "\\DoxyCodeLine{";
+    DoxyCodeOpen = TRUE;
+  }
   if (m_prettyCode)
   {
     QCString lineNumber;
@@ -223,10 +228,20 @@ void LatexCodeGenerator::writeLineNumber(const char *ref,const char *fileName,co
 void LatexCodeGenerator::startCodeLine(bool)
 {
   m_col=0;
+  if (!DoxyCodeOpen)
+  {
+    m_t << "\\DoxyCodeLine{";
+    DoxyCodeOpen = TRUE;
+  }
 }
 
 void LatexCodeGenerator::endCodeLine()
 {
+  if (DoxyCodeOpen)
+  {
+    m_t << "}";
+    DoxyCodeOpen = FALSE;
+  }
   codify("\n");
 }
 
@@ -472,8 +487,7 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   t << "% Packages required by doxygen\n"
        "\\usepackage{fixltx2e}\n" // for \textsubscript
        "\\usepackage{calc}\n"
-       "\\usepackage{doxygen}\n"
-       "\\usepackage[export]{adjustbox} % also loads graphicx\n";
+       "\\usepackage{doxygen}\n";
   QStrList extraLatexStyle = Config_getList(LATEX_EXTRA_STYLESHEET);
   for (uint i=0; i<extraLatexStyle.count(); ++i)
   {
@@ -503,7 +517,6 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\\PassOptionsToPackage{warn}{textcomp}\n"
        "\\usepackage{textcomp}\n"
        "\\usepackage[nointegrals]{wasysym}\n"
-       "\\usepackage[table]{xcolor}\n"
        "\n";
 
   // Language support
@@ -625,13 +638,42 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (pdfHyperlinks)
   {
+    unsigned char minus[4]; // Superscript minus
+    char *pminus = (char *)minus;
+    unsigned char sup2[3]; // Superscript two
+    char *psup2 = (char *)sup2;
+    unsigned char sup3[3];
+    char *psup3 = (char *)sup3; // Superscript three
+    minus[0]= 0xE2;
+    minus[1]= 0x81;
+    minus[2]= 0xBB;
+    minus[3]= 0;
+    sup2[0]= 0xC2;
+    sup2[1]= 0xB2;
+    sup2[2]= 0;
+    sup3[0]= 0xC2;
+    sup3[1]= 0xB3;
+    sup3[2]= 0;
+
     t << "% Hyperlinks (required, but should be loaded last)\n"
-         "\\usepackage{ifpdf}\n"
          "\\ifpdf\n"
          "  \\usepackage[pdftex,pagebackref=true]{hyperref}\n"
          "\\else\n"
          "  \\usepackage[ps2pdf,pagebackref=true]{hyperref}\n"
          "\\fi\n"
+	 "\\ifpdf\n"
+         "  \\DeclareUnicodeCharacter{207B}{${}^{-}$}% Superscript minus\n"
+         "  \\DeclareUnicodeCharacter{C2B2}{${}^{2}$}% Superscript two\n"
+         "  \\DeclareUnicodeCharacter{C2B3}{${}^{3}$}% Superscript three\n"
+         "\\else\n"
+         "  \\catcode`\\" << pminus << "=13% Superscript minus\n"
+         "  \\def" << pminus << "{${}^{-}$}\n"
+         "  \\catcode`\\" << psup2 << "=13% Superscript two\n"
+         "  \\def" << psup2 << "{${}^{2}$}\n"
+         "  \\catcode`\\"<<psup3<<"=13% Superscript three\n"
+         "  \\def"<<psup3<<"{${}^{3}$}\n"
+         "\\fi\n"
+         "\n"
          "\\hypersetup{%\n"
          "  colorlinks=true,%\n"
          "  linkcolor=blue,%\n"

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -14,6 +14,12 @@
 \RequirePackage{fancyvrb}
 \RequirePackage{tabularx}
 \RequirePackage{multirow}
+\RequirePackage{hanging}
+\RequirePackage{ifpdf}
+\RequirePackage{adjustbox}
+\RequirePackage{amssymb}
+\RequirePackage{stackengine}
+
 
 %---------- Internal commands used in this style file ----------------
 
@@ -78,16 +84,48 @@
   \end{alltt}%
   \normalsize%
 }
+% Necessary for redefining not defined charcaters, i.e. "Replacement Character" in tex output.
+\newlength{\CodeWidthChar}
+\newlength{\CodeHeightChar}
+% Necessary for hanging indent
+\newlength{\DoxyCodeWidth}
+
+\newcommand\DoxyCodeLine[1]{\hangpara{\DoxyCodeWidth}{1}{#1}\par}
+
+\newcommand\NiceSpace{%
+     \discretionary{}{\kern\fontdimen2\font}{\kern\fontdimen2\font}%
+}
 
 % Used by @code ... @endcode
 \newenvironment{DoxyCode}{%
   \par%
   \scriptsize%
-  \begin{alltt}%
+  \normalfont\ttfamily%
+  \rightskip0pt plus 1fil%
+  \settowidth{\DoxyCodeWidth}{000000}%
+  \settowidth{\CodeWidthChar}{?}%
+  \settoheight{\CodeHeightChar}{?}%
+  \setlength{\parskip}{0ex plus 0ex minus 0ex}%
+  {\lccode`~32 \lowercase{\global\let~}\NiceSpace}\obeyspaces%
+
 }{%
-  \end{alltt}%
+  \normalfont%
   \normalsize%
 }
+
+% Redefining not defined charcaters, i.e. "Replacement Character" in tex output.
+\def\ucr{\adjustbox{width=\CodeWidthChar,height=\CodeHeightChar}{\stackinset{c}{}{c}{-.2pt}{%
+   \textcolor{white}{\sffamily\bfseries\small ?}}{%
+   \rotatebox{45}{$\blacksquare$}}}}
+
+% Choosing right setup for "Replacement character"
+\ifpdf
+  \RequirePackage[utf8]{inputenc}
+  \DeclareUnicodeCharacter{FFFD}{\ucr}
+\else
+  \catcode`\�=13
+  \def�{\ucr}
+\fi
 
 % Used by @example, @include, @includelineno and @dontinclude
 \newenvironment{DoxyCodeInclude}{%
@@ -274,10 +312,10 @@
     \tabulinesep=1mm%
     \par%
     \ifthenelse{\equal{#1}{}}%
-      {\begin{longtabu*} spread 0pt [l]{|X[-1,l]|X[-1,l]|}}% name + description
+      {\begin{longtabu*}spread 0pt [l]{|X[-1,l]|X[-1,l]|}}% name + description
     {\ifthenelse{\equal{#1}{1}}%
-      {\begin{longtabu*} spread 0pt [l]{|X[-1,l]|X[-1,l]|X[-1,l]|}}% in/out + name + desc
-      {\begin{longtabu*} spread 0pt [l]{|X[-1,l]|X[-1,l]|X[-1,l]|X[-1,l]|}}% in/out + type + name + desc
+      {\begin{longtabu*}spread 0pt [l]{|X[-1,l]|X[-1,l]|X[-1,l]|}}% in/out + name + desc
+      {\begin{longtabu*}spread 0pt [l]{|X[-1,l]|X[-1,l]|X[-1,l]|X[-1,l]|}}% in/out + type + name + desc
     }
     \multicolumn{2}{l}{\hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #2}\\[1ex]%
     \hline%
@@ -294,7 +332,7 @@
 \newenvironment{DoxyFields}[1]{%
     \tabulinesep=1mm%
     \par%
-    \begin{longtabu*} spread 0pt [l]{|X[-1,r]|X[-1,l]|X[-1,l]|}%
+    \begin{longtabu*}spread 0pt [l]{|X[-1,r]|X[-1,l]|X[-1,l]|}%
     \multicolumn{3}{l}{\hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1}\\[1ex]%
     \hline%
     \endfirsthead%
@@ -310,7 +348,7 @@
 \newenvironment{DoxyEnumFields}[1]{%
     \tabulinesep=1mm%
     \par%
-    \begin{longtabu*} spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
+    \begin{longtabu*}spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
     \multicolumn{2}{l}{\hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1}\\[1ex]%
     \hline%
     \endfirsthead%
@@ -332,7 +370,7 @@
 \newenvironment{DoxyRetVals}[1]{%
     \tabulinesep=1mm%
     \par%
-    \begin{longtabu*} spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
+    \begin{longtabu*}spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
     \multicolumn{2}{l}{\hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1}\\[1ex]%
     \hline%
     \endfirsthead%
@@ -348,7 +386,7 @@
 \newenvironment{DoxyExceptions}[1]{%
     \tabulinesep=1mm%
     \par%
-    \begin{longtabu*} spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
+    \begin{longtabu*}spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
     \multicolumn{2}{l}{\hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1}\\[1ex]%
     \hline%
     \endfirsthead%
@@ -364,7 +402,7 @@
 \newenvironment{DoxyTemplParams}[1]{%
     \tabulinesep=1mm%
     \par%
-    \begin{longtabu*} spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
+    \begin{longtabu*}spread 0pt [l]{|X[-1,r]|X[-1,l]|}%
     \multicolumn{2}{l}{\hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1}\\[1ex]%
     \hline%
     \endfirsthead%
@@ -440,11 +478,11 @@
 \newcommand{\PBS}[1]{\let\temp=\\#1\let\\=\temp}%
 \newenvironment{TabularC}[1]%
 {\tabulinesep=1mm
-\begin{longtabu*} spread 0pt [c]{*#1{|X[-1]}|}}%
+\begin{longtabu*}spread 0pt [c]{*#1{|X[-1]}|}}%
 {\end{longtabu*}\par}%
 
 \newenvironment{TabularNC}[1]%
-{\begin{tabu} spread 0pt [l]{*#1{|X[-1]}|}}%
+{\begin{tabu}spread 0pt [l]{*#1{|X[-1]}|}}%
 {\end{tabu}\par}%
 
 % Used for member group headers


### PR DESCRIPTION
Removing the automatic line breaking after 108 characters (also didn't work properly with e.g. executive paper size).
Due to new implementation some character encodings had to be changed as well as well as handling of the single quote in formulas.