### PR TITLE
Problem with TEST_FLAGS when using cmake for Ninja

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,7 +119,7 @@ FLEX_TARGET(xmlcode        xmlcode.l        ${GENERATED_SRC}/xmlcode.cpp        
 FLEX_TARGET(sqlcode        sqlcode.l        ${GENERATED_SRC}/sqlcode.cpp        COMPILE_FLAGS "${LEX_FLAGS}")
 FLEX_TARGET(configimpl     configimpl.l     ${GENERATED_SRC}/configimpl.cpp     COMPILE_FLAGS "${LEX_FLAGS}")
 
-BISON_TARGET(constexp      constexp.y       ${GENERATED_SRC}/ce_parse.cpp       COMPILE_FLAGS ${YACC_FLAGS})
+BISON_TARGET(constexp      constexp.y       ${GENERATED_SRC}/ce_parse.cpp       COMPILE_FLAGS "${YACC_FLAGS}")
 
 add_library(doxycfg STATIC
     ${GENERATED_SRC}/lang_cfg.h

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,9 +1,18 @@
-add_custom_target(tests
-         COMMENT "Running doxygen tests..."
-	 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py $(TEST_FLAGS) --doxygen ${PROJECT_BINARY_DIR}/bin/doxygen --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
-         DEPENDS doxygen
-)
-add_test(NAME suite
-	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py $(TEST_FLAGS) --doxygen $<TARGET_FILE:doxygen> --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
-)
+if (CMAKE_GENERATOR MATCHES "Ninja")
+        add_custom_target(tests
+	        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py --doxygen ${PROJECT_BINARY_DIR}/bin/doxygen --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+                DEPENDS doxygen
+        )
+        add_test(NAME suite
+	        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py --doxygen $<TARGET_FILE:doxygen> --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+        )
+else ()
+        add_custom_target(tests
+	        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py $(TEST_FLAGS) --doxygen ${PROJECT_BINARY_DIR}/bin/doxygen --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+                DEPENDS doxygen
+        )
+        add_test(NAME suite
+	        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py $(TEST_FLAGS) --doxygen $<TARGET_FILE:doxygen> --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+        )
+endif ()
 


### PR DESCRIPTION
The command sequence:
`    cmake -G Ninja -D CMAKE_BUILD_TYPE=Release ..`
`    cmake --build . -- -j 3 -v || echo error && cd .. && exit 1`
results in the error message:
`    ninja: error: build.ninja:2384: bad $-escape (literal $ must be written as $$)`

In respect to `LEX_FLAGS` and `YACC_FLAGS` (the later still required some quotes), similar problems appeared in the past and this was solved by setting the (local) `LEX_FLAGS` and `YACC_FLAGS` to the empty string. A similar solution didn't work directly for the `TEST_FLAGS` so here the code has been duplicated once with the flags and once (for Ninja) without the flags.