### PR TITLE
Problem with \cond in normal comment of test 015

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1068,7 +1068,7 @@ void convertCppComments(BufStr *inBuf,BufStr *outBuf,const char *fileName)
   {
     CondCtx *ctx = g_condStack.pop();
     QCString sectionInfo = " ";
-    if (ctx->sectionId!=" ") sectionInfo.sprintf(" with label %s ",ctx->sectionId.data()); 
+    if (ctx->sectionId!=" ") sectionInfo.sprintf(" with label '%s' ",ctx->sectionId.stripWhiteSpace().data());
     warn(g_fileName,ctx->lineNr,"Conditional section%sdoes not have "
 	"a corresponding \\endcond command within this file.",sectionInfo.data());
   }

--- a/src/pre.l
+++ b/src/pre.l
@@ -3195,7 +3195,7 @@ void preprocessFile(const char *fileName,BufStr &input,BufStr &output)
   {
     CondCtx *ctx = g_condStack.pop();
     QCString sectionInfo = " ";
-    if (ctx->sectionId!=" ") sectionInfo.sprintf(" with label %s ",ctx->sectionId.data()); 
+    if (ctx->sectionId!=" ") sectionInfo.sprintf(" with label '%s' ",ctx->sectionId.stripWhiteSpace().data());
     warn(fileName,ctx->lineNr,"Conditional section%sdoes not have "
 	"a corresponding \\endcond command within this file.",sectionInfo.data());
     delete ctx;

--- a/testing/015/015__cond_8c.xml
+++ b/testing/015/015__cond_8c.xml
@@ -11,15 +11,17 @@
         <briefdescription>
         </briefdescription>
         <detaileddescription>
+          <para>Function to be shown. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="015_cond.c" line="20" column="1" bodyfile="015_cond.c" bodystart="20" bodyend="22"/>
+        <location file="015_cond.c" line="21" column="1" bodyfile="015_cond.c" bodystart="21" bodyend="23"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
     </briefdescription>
     <detaileddescription>
+      <para>Text <emphasis>argument</emphasis> more text. </para>
     </detaileddescription>
     <location file="015_cond.c"/>
   </compounddef>

--- a/testing/015_cond.c
+++ b/testing/015_cond.c
@@ -1,4 +1,4 @@
-// objective: test the \cond command
+// objective: test the `cond` command
 // check: 015__cond_8c.xml
 // config: ENABLED_SECTIONS = COND_ENABLED
 
@@ -17,12 +17,14 @@ void func();
 /// \endcond
 
 /// \cond COND_ENABLED
+/// Function to be shown.
 void cond_enabled()
 {
 }
 /// \endcond
 
 /** \cond COND_DISABLED */
+    Function not to be shown.
 void cond_disabled()
 {
 }


### PR DESCRIPTION
In the \cond is also recognized in non-doxygen comment.
- As a work around the \ has been removed
- in case of e.g. pdf the enabled function is not shown as it does not have a doxygen comment
- test file output update due to change in input code.
- pre.l and commentcnv.l. better error message i.e. showing better the used condition