### PR TITLE
Making the 'tex' part of \makeindex available to the user

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2548,6 +2548,20 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 <![CDATA[
  The \c MAKEINDEX_CMD_NAME tag can be used to specify the command name to 
  generate index for \f$\mbox{\LaTeX}\f$.
+
+ @note This tag is used in the `Makefile` / `make.bat`.
+ \sa  \ref cfg_latex_makeindex_cmd "LATEX_MAKEINDEX_CMD" for the part in the generated output file (`.tex`).
+]]>
+      </docs>
+    </option>
+    <option type='string' id='LATEX_MAKEINDEX_CMD' defval='\makeindex' depends='GENERATE_LATEX'>
+      <docs>
+<![CDATA[
+ The \c LATEX_MAKEINDEX_CMD tag can be used to specify the command name to 
+ generate index for \f$\mbox{\LaTeX}\f$.
+
+ @note This tag is used in the generated output file (`.tex`).
+ \sa  \ref cfg_makeindex_cmd_name "MAKEINDEX_CMD_NAME" for the part in the `Makefile` / `make.bat`.
 ]]>
       </docs>
     </option>

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -272,7 +272,7 @@ def parseOption(node):
 				print("              \"%s\"" % (line))
 		print("             );")
 		if defval != '':
-			print("  cs->setDefaultValue(\"%s\");" % (defval))
+			print("  cs->setDefaultValue(\"%s\");" % (defval.replace('\\','\\\\')))
 		if format == 'file':
 			print("  cs->setWidgetType(ConfigString::File);")
 		elif format == 'image':
@@ -529,7 +529,7 @@ def parseOptionDoc(node, first):
 				if defval != '':
 					print("")
 					print("The default value is: <code>%s</code>." % (
-						defval))
+						defval.replace('\\','\\\\')))
 			print("")
 		# depends handling
 		if (node.hasAttribute('depends')):

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -628,9 +628,21 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\\usepackage{natbib}\n"
        "\\usepackage[titles]{tocloft}\n"
        "\\setcounter{tocdepth}{3}\n"
-       "\\setcounter{secnumdepth}{5}\n"
-       "\\makeindex\n"
-       "\n";
+       "\\setcounter{secnumdepth}{5}\n";
+
+  QCString latex_mkidx_command = Config_getString(LATEX_MAKEINDEX_CMD);
+  if (!latex_mkidx_command.isEmpty())
+  {
+    if (latex_mkidx_command[0] == '\\')
+      t << latex_mkidx_command << "\n";
+    else
+      t << '\\' << latex_mkidx_command << "\n";
+  }
+  else
+  {
+    t << "\\makeindex\n";
+  }
+  t << "\n";
 
   writeExtraLatexPackages(t);
 


### PR DESCRIPTION
In case we need to use another 'makeindex' command in the Makefile / make.bat we can use the configuration tag MAKEINDEX_CMD_NAME
When we want to have another index we can use e.g. EXTRA_PACKAGES = [nottoc]tocbibind
but in those cases  the \makeindex command is still the same but should be \makeindex[intoc]. By means of the new configuration tag LATEX_MAKEINDEX_CMD this discrepancy has been solved.
Due to the default value some small changes in the configuration parser were necessary as well.

(based on the stack question https://stackoverflow.com/questions/44394311/add-index-to-toc-with-doxygen).