### PR TITLE
Bug 678684 - Not warning of undocumented function parameters

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1244,6 +1244,8 @@ FILE_VERSION_INFO = "cleartool desc -fmt \%Vn"
  or return value. If set to \c NO, doxygen will only warn about
  wrong or incomplete parameter documentation, but not about the absence of
  documentation.
+ If \ref cfg_extract_all "EXTRACT_ALL" is set to \c YES then this flag will
+ automatically be disabled.
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
Noted in documentation that parameter has no effect in case of EXTRACT_ALL.