### PR TITLE
Cannot properly jump from brief to detailed function description in python

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2576,7 +2576,7 @@ void MemberDef::writeDocumentation(MemberList *ml,
     else if (getFileDef())      { scopeName=getFileDef()->displayName();      scopedContainer=getFileDef(); }
     ciname = ((GroupDef *)container)->groupTitle();
   }
-  else if (container->definitionType()==TypeFile && getNamespaceDef())
+  else if (container->definitionType()==TypeFile && getNamespaceDef() && lang != SrcLangExt_Python)
   { // member is in a namespace, but is written as part of the file documentation
     // as well, so we need to make sure its label is unique.
     memAnchor.prepend("file_");


### PR DESCRIPTION
In case a plain python function (i.e. not in a class or similar) the reference in the brief description to the detailed description points to nowhere as the anchor at the detailed description has file_ in front of it.
The file_ is required for namespaces as mentioned in the code:

>       // member is in a namespace, but is written as part of the file documentation
>       // as well, so we need to make sure its label is unique.

tests, on a python project, gave that this doesn't happen and that in case of just files a wrong member reference is given in.

Based on: Generating Python Documentation with doxygen produces broken links to functions (https://stackoverflow.com/questions/50217315/generating-python-documentation-with-doxygen-produces-broken-links-to-functions#50217315)