### PR TITLE
Bug 727103 - Misparsed comments leading to missing call graph

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -3573,6 +3573,9 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					    endFontClass();
 					  }
 					}
+<SkipComment>[^\*\n]+                   {
+                                          g_code->codify(yytext);
+                                        }
 <*>"/*"					{ 
 					  startFontClass("comment");
   					  g_code->codify(yytext);


### PR DESCRIPTION
Handling comment block in scanner.l and code.l in an analogous way.
The problem is caused by a non terminated comment bock in a comment block.
It is strongly advised not to use comment blocks inside other comment blocks and otherwise fix the message.