### PR TITLE
Problem with TEST_FLAGS when using CMake for Visual Studio

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,7 +119,7 @@ FLEX_TARGET(xmlcode        xmlcode.l        ${GENERATED_SRC}/xmlcode.cpp        
 FLEX_TARGET(sqlcode        sqlcode.l        ${GENERATED_SRC}/sqlcode.cpp        COMPILE_FLAGS "${LEX_FLAGS}")
 FLEX_TARGET(configimpl     configimpl.l     ${GENERATED_SRC}/configimpl.cpp     COMPILE_FLAGS "${LEX_FLAGS}")
 
-BISON_TARGET(constexp      constexp.y       ${GENERATED_SRC}/ce_parse.cpp       COMPILE_FLAGS ${YACC_FLAGS})
+BISON_TARGET(constexp      constexp.y       ${GENERATED_SRC}/ce_parse.cpp       COMPILE_FLAGS "${YACC_FLAGS}")
 
 add_library(doxycfg STATIC
     ${GENERATED_SRC}/lang_cfg.h

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_custom_target(tests
          COMMENT "Running doxygen tests..."
-	 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py $(TEST_FLAGS) --doxygen ${PROJECT_BINARY_DIR}/bin/doxygen --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+	 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py --doxygen ${PROJECT_BINARY_DIR}/bin/doxygen --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
          DEPENDS doxygen
 )
 add_test(NAME suite
-	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py $(TEST_FLAGS) --doxygen $<TARGET_FILE:doxygen> --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testing/runtests.py --doxygen $<TARGET_FILE:doxygen> --inputdir ${CMAKE_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
 )
 

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -293,7 +293,8 @@ def main():
 		action="store_true")
 	parser.add_argument('--keep',help='keep result directories',
 		action="store_true")
-	args = parser.parse_args()
+	test_flags = os.getenv('TEST_FLAGS', default='').split()
+	args = parser.parse_args(test_flags + sys.argv[1:])
 
 	# sanity check
 	if (not args.xml) and (not args.pdf) and (not args.xhtml):


### PR DESCRIPTION
I tried to run the tests on Windows using ctest (and the custom `tests` target), and got the following output:
```
    Start 1: suite
1/1 Test #1: suite ............................***Failed    0.10 sec
usage: runtests.py [-h] [--updateref] [--doxygen [DOXYGEN]]
                   [--xmllint [XMLLINT]] [--id IDS [IDS ...]] [--all]
                   [--inputdir [INPUTDIR]] [--outputdir [OUTPUTDIR]]
                   [--noredir] [--xml] [--xhtml] [--pdf] [--keep]
runtests.py: error: unrecognized arguments: $(TEST_FLAGS)


0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.10 sec

The following tests FAILED:
          1 - suite (Failed)
Errors while running CTest
```
I went through #712 which solves this problem for Ninja.
I'm trying to solve it for _all_ generators by moving the logic for `TEST_FLAGS` to `runtests.py`.