### PR TITLE
Bug 796094 - Backslashes in default values confuse the parser (and cause params to be ignored)

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1782,7 +1782,7 @@ QCString removeRedundantWhiteSpace(const QCString &s)
               pc = c;
               i++;
               c = src[i];
-              *dst+=c;
+              *dst++=c;
             }
             else if (c=='"')
             {


### PR DESCRIPTION
Corrected assignment / counting.