### PR TITLE
Bug 796086 - Adjacent xrefitems always added to first list present on page

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -548,7 +548,7 @@ static void addXRefItem(const char *listName,const char *itemTitle,
   if (docEntry->sli)
   {
     QListIterator<ListItemInfo> slii(*docEntry->sli);
-    for (slii.toFirst();(lii=slii.current());++slii)
+    for (slii.toLast();(lii=slii.current());--slii)
     {
       if (qstrcmp(lii->type,listName)==0) 
       {


### PR DESCRIPTION
Better to search backward then forward to find related item.