### PR TITLE
Numbers overlap the titles in TOC of PDF

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -694,6 +694,9 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   t << "\\usepackage{caption}\n"
     << "\\captionsetup{labelsep=space,justification=centering,font={bf},singlelinecheck=off,skip=4pt,position=top}\n\n";
 
+  // prevent numbers overlap the titles in toc
+  t << "\\renewcommand{\\numberline}[1]{#1~}\n";
+
   // End of preamble, now comes the document contents
   t << "%===== C O N T E N T S =====\n"
        "\n"


### PR DESCRIPTION
With a lot of paragraphs / nesting levels in the TOC it happens that the paragraph number flows into paragraph title in the toc, this patch overcomes this problem.
See also https://en.wikibooks.org/wiki/LaTeX/Tables_of_Contents_and_Lists_of_Figures#Numbers_overlap_the_titles