### PR TITLE
Bug 746419 - \todo at end of C# XML comment breaks following todo's

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1046,10 +1046,13 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           addOutput(yytext);
   					}
 <Comment>"</summary>"	                { // start of a .NET XML style detailed description
+					  setOutput(OutputBrief);
                                           addOutput(yytext);
 					  setOutput(OutputDoc);
   					}
 <Comment>"</remarks>"			{ // end of a brief or detailed description
+                                          
+					  setOutput(OutputDoc);
                                           addOutput(yytext);
   					}
 <Comment>"<"{CAPTION}{ATTR}">"          {


### PR DESCRIPTION
In case of \</summary\> or \</remarks\> to be sure to switch back to the right scope