### PR TITLE
Bug 759063 - Macros (@test, @todo, etc) used with PHP namespaces causes illegal command warning

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -21,6 +21,7 @@
 #include "util.h"
 #include "ftextstream.h"
 #include "definition.h"
+#include <qregexp.h>
 
 /*! Create a list of items that are cross referenced with documentation blocks
  *  @param listName String representing the name of the list.
@@ -164,7 +165,7 @@ void RefList::generatePage()
     doc += " \\_internalref ";
     doc += item->name;
     doc += " \"";
-    doc += item->title;
+    doc += item->title.replace(QRegExp("\\"),"\\\\");
     doc += "\" ";
     // write declaration in case a function with arguments
     if (!item->args.isEmpty()) 


### PR DESCRIPTION
Illegal command is in case cause by the fact that the namespace-name and class-name are "concatenated" by means of a '\\' in the title of the, internal, xreflist.
This patch fixes this by doubling the backslash.