### PR TITLE
Bug 663297 - @todo in @param leads to strange confusing message

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -582,7 +582,7 @@ static void addXRefItem(const char *listName,const char *itemTitle,
     item->listAnchor = anchorLabel;
     docEntry->addSpecialListItem(listName,itemId);
     QCString cmdString;
-    cmdString.sprintf("\\xrefitem %s %d.",listName,itemId);
+    cmdString.sprintf(" \\xrefitem %s %d.",listName,itemId);
     if (inBody)
     {
       docEntry->inbodyDocs += cmdString;
@@ -1086,7 +1086,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  BEGIN(HtmlComment);
 					}
 <Comment>{B}*{CMD}"endinternal"{B}*	{
-                                          addOutput("\\endinternal "); 
+                                          addOutput(" \\endinternal "); 
                                           if (!inInternalDocs)
   					    warn(yyFileName,yyLineNr,
                                                "found \\endinternal without matching \\internal"
@@ -1704,7 +1704,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 
   /* ----- handle arguments of the section/subsection/.. commands ------- */
 
-<SectionLabel>{LABELID}			{ // first argyment
+<SectionLabel>{LABELID}			{ // first argument
   					  g_sectionLabel=yytext;
                                           addOutput(yytext);
 					  g_sectionTitle.resize(0);
@@ -2038,7 +2038,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					  }
   					}
 <SkipInternal>[@\\]"endinternal"[ \t]*  {
-                                          addOutput("\\endinternal "); 
+                                          addOutput(" \\endinternal "); 
 					  BEGIN(Comment);
 					}
 <SkipInternal>[^ \\@\n]+		{ // skip non-special characters
@@ -2209,7 +2209,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 
   /* ----- handle arguments of the cite command ------- */
 
-<CiteLabel>{CITEID}			{ // found argyment
+<CiteLabel>{CITEID}			{ // found argument
   					  addCite();
                                           addOutput(yytext);
 					  BEGIN(Comment);
@@ -2770,7 +2770,7 @@ static bool handleInternal(const QCString &)
   else
   {
     // re-enabled for bug640828
-    addOutput("\\internal "); 
+    addOutput(" \\internal "); 
     inInternalDocs = TRUE;
   }
   return FALSE;


### PR DESCRIPTION
With the 1.8.14 version the message was:
`warning: unexpected token in comment block while parsing the argument of command param`
this is due to the fact that the @todo command is replaced by a \\xrefitem command but it was joined directly with the parameter name, adding a space, in the code, solves the problem.
In case there was another word (or doxygen command) in front of it the problem does not occur as it \\xrefitem is not joined with the parameter name.
Similar problem occurred with the \\endinternal (\internal) command.