### PR TITLE
Bug 760661 - \internal stops all parsing if used inside a section

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2038,7 +2038,6 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					  }
   					}
 <SkipInternal>[@\\]"endinternal"[ \t]*  {
-                                          addOutput("\\endinternal "); 
 					  BEGIN(Comment);
 					}
 <SkipInternal>[^ \\@\n]+		{ // skip non-special characters


### PR DESCRIPTION
In case of state `SkipInternal` the `\endinternal` should not be written as the `\internal` isn't written either.