### PR TITLE
 GNOME Bugzilla migration to GitLab 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The latest binaries and source of Doxygen can be downloaded from:
 Developers
 ---------
 * Build Status: <a href="https://travis-ci.org/doxygen/doxygen"><img src="https://secure.travis-ci.org/doxygen/doxygen.png?branch=master"/></a>
-
+test
 * Coverity Scan Build Status: <a href="https://scan.coverity.com/projects/2860"> <img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/2860/badge.svg"/> </a>
 
 * Doxygen's Doxygen Documentation: <a href="https://codedocs.xyz/doxygen/doxygen/"><img src="https://codedocs.xyz/doxygen/doxygen.svg"/></a>


### PR DESCRIPTION
Hi,

I tried to contact you over your mailing list a month ago, but seems my email was never reached. I also tried to ask in the doxygen freenode irc, and nothing either. So I'm hoping this MR will do.

GNOME has been moving from Bugzilla to gitlab.gnome.org over the last few months.  More info in the [mass migration plan](https://mail.gnome.org/archives/desktop-devel-list/2018-March/msg00023.html). We are targeting 1st July for making Bugzilla read only.

Doxygen is a bit special since the code is hosted in GitHub but the issues are in Bugzilla. What would be the best option for Doxygen? Moving the code to gitlab.gnome.org is a perfectly viable option.