### PR TITLE
Bug 792122 - XHTML pages are broken several ways (Regression #674)

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -844,7 +844,7 @@ static int processLink(GrowBuf &out,const char *data,int,int size)
   }
   if (isToc) // special case for [TOC]
   {
-    if (g_current) g_current->stat=TRUE;
+    out.addStr("@tableofcontents");
   }
   else if (isImageLink) 
   {


### PR DESCRIPTION
The markdown processing of [TOC] was not performed anymore, at the moment of processing there was no g_current.
Adding @tableofcontents to the stream (like with images) solves this problem.