### PR TITLE
Enable in page table of contents for LaTeX

### DIFF
--- a/doc/autolink.doc
+++ b/doc/autolink.doc
@@ -16,7 +16,7 @@
  */
 /*! \page autolink Automatic link generation
 
-  \tableofcontents
+  \tableofcontents{html,latex}
 
   Most documentation systems have special `see also' sections where links
   to other pieces of documentation can be inserted.

--- a/doc/changelog.doc
+++ b/doc/changelog.doc
@@ -1,5 +1,5 @@
 /** \page changelog Changelog
-\tableofcontents
+\tableofcontents{html,latex}
 \section log_1_8 1.8 Series
 
 \subsection log_1_8_14 Release 1.8.14

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2016,15 +2016,19 @@ Make sure you have first read \ref intro "the introduction".
 \endverbatim
 
 <hr>
-\section cmdtableofcontents \\tableofcontents['{'[option][,option]*'}']
+\section cmdtableofcontents \\tableofcontents['{'[option[:level]][,option[:level]]*'}']
 
   \addindex \\tableofcontents
   Creates a table of contents at the top of a page, listing all
-  sections and subsections in the page. The option can be `HTML` or `LaTeX`.
-  In case no option is specified \c \\tableofcontents acts as if just the
-  option `HTML` was specified. In case of multiple \c \\tableofcontents
-  commands in a page the option(s) will be used additional to the already
-  specified option(s).
+  sections and subsections in the page. The `option` can be `HTML` or `LaTeX`
+  or `XML`. When a `level` is specified this means the maximum nesting level
+  that is shown. The value of `level` should be in the range 1..5, values outside
+  this range are considered to be 5. In case no `level` is specified `level` is
+  set to 5 (show all)
+  In case no `option. is specified \c \\tableofcontents acts as if just the
+  `option` `HTML` was specified. In case of multiple \c \\tableofcontents
+  commands in a page the `option`(s) will be used additional to the already
+  specified `option`(s), but only the last `level` of an `option` is valid.
 
   \warning This command only works inside related page documentation and
            \e not in other documentation blocks and only has effect in the

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2016,15 +2016,19 @@ Make sure you have first read \ref intro "the introduction".
 \endverbatim
 
 <hr>
-\section cmdtableofcontents \\tableofcontents
+\section cmdtableofcontents \\tableofcontents['{'[option][,option]*'}']
 
   \addindex \\tableofcontents
   Creates a table of contents at the top of a page, listing all
-  sections and subsections in the page. 
+  sections and subsections in the page. The option can be `HTML` or `LaTeX`.
+  In case no option is specified \c \\tableofcontents acts as if just the
+  option `HTML` was specified. In case of multiple \c \\tableofcontents
+  commands in a page the option(s) will be used additional to the already
+  specified option(s).
 
   \warning This command only works inside related page documentation and
            \e not in other documentation blocks and only has effect in the
-           HTML output!
+           the specified output!
 
 <hr>
 \section cmdsection \\section <section-name> (section title)

--- a/doc/custcmd.doc
+++ b/doc/custcmd.doc
@@ -16,7 +16,7 @@
  */
 /*! \page custcmd Custom Commands
 
-\tableofcontents
+\tableofcontents{html,latex}
 
 Doxygen provides a large number of \ref commands "special commands", 
 \ref xmlcmds "XML commands", and \ref htmlcmds "HTML commands".

--- a/doc/customize.doc
+++ b/doc/customize.doc
@@ -16,7 +16,7 @@
  */
 /*! \page customize Customizing the output
 
-\tableofcontents
+\tableofcontents{html,latex}
 
 Doxygen provides various levels of customization. 
 The section \ref minor_tweaks "Minor Tweaks" discusses what to 

--- a/doc/docblocks.doc
+++ b/doc/docblocks.doc
@@ -15,7 +15,7 @@
  *
  */
 /*! \page docblocks Documenting the code
-\tableofcontents
+\tableofcontents{html,latex}
 
 This chapter covers two topics:
 1. How to put comments in your code such that doxygen incorporates them in

--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -70,9 +70,13 @@
 \hfuzz=15pt
 \setlength{\emergencystretch}{15pt}
 \setlength{\parindent}{0pt}
-\setlength{\parskip}{0.2cm}
+\newcommand{\doxynormalparskip}{\setlength{\parskip}{0.2cm}}
+\newcommand{\doxytocparskip}{\setlength{\parskip}{0.2cm}}
+\doxynormalparskip
 \hbadness=750
 \tolerance=750
+\usepackage{etoc}
+\etocsettocstyle{\doxytocparskip}{\doxynormalparskip}
 \begin{document}
 \pagenumbering{alph}
 \begin{titlepage}
@@ -85,6 +89,7 @@ Written by Dimitri van Heesch\\[2ex]
 \end{titlepage}
 \clearemptydoublepage
 \pagenumbering{Roman}
+\chapter*{Contents}
 \tableofcontents
 \clearemptydoublepage
 \pagenumbering{arabic}

--- a/doc/faq.doc
+++ b/doc/faq.doc
@@ -16,7 +16,7 @@
  */
 /*! \page faq Frequently Asked Questions
 
-\tableofcontents
+\tableofcontents{html,latex}
 
 
 \section faq_index How to get information on the index page in HTML?

--- a/doc/install.doc
+++ b/doc/install.doc
@@ -17,7 +17,7 @@
 /*! \page install Installation
 
 \addindex installation
-\tableofcontents
+\tableofcontents{html,latex}
 
 First go to the 
 <a href="http://www.doxygen.org/download.html">download</a> page

--- a/doc/starting.doc
+++ b/doc/starting.doc
@@ -15,7 +15,7 @@
  *
  */
 /*! \page starting Getting started
-\tableofcontents
+\tableofcontents{html,latex}
 
 The executable \c doxygen is the main program that parses the sources and 
 generates the documentation. See section \ref doxygen_usage for more

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1094,7 +1094,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                               );
                                           inInternalDocs = FALSE;
   					}
-<Comment>{B}*{CMD}[a-z_A-Z]+"{"[a-zA-Z_,\. ]*"}"{B}*  |
+<Comment>{B}*{CMD}[a-z_A-Z]+"{"[a-zA-Z_,:0-9\. ]*"}"{B}*  |
 <Comment>{B}*{CMD}[a-z_A-Z]+{B}*	{ // potentially interesting command
                                           // the {B}* in the front was added for bug620924
                                           QCString fullMatch = QCString(yytext);
@@ -2858,14 +2858,48 @@ static bool handleToc(const QCString &, const QCString &opt)
     for ( it = optList.begin(); it != optList.end(); ++it )
     {
       QString opt = (*it).stripWhiteSpace().lower();
+      char dum;
+      int level = 5;
+      int i = opt.find(':');
+      if (i>0)  // found ':' but not on position 0 what would mean just a level
+      {
+        if (sscanf(opt.right(opt.length() - i - 1).data(),"%d%c",&level,&dum) != 1)
+        {
+          warn(yyFileName,yyLineNr,"Unknown option:level specified with \\tableofcontents: `%s'", (*it).stripWhiteSpace().data());
+          opt = "";
+        }
+        else
+        {
+          level = (level > 5 ? 5 : level);
+          level = (level <= 0 ? 5 : level);
+          opt = opt.left(i).stripWhiteSpace();
+        }
+      }
       if (!opt.isEmpty())
       {
-        if (opt == "html") current->localToc |= Definition::Html;
-        else if (opt == "latex") current->localToc |= Definition::Latex;
+        if (opt == "html")
+        {
+          current->localToc |= (1 << Definition::Html);
+          current->localTocLevel[Definition::Html] = level;
+        }
+        else if (opt == "latex")
+        {
+          current->localToc |= (1 << Definition::Latex);
+          current->localTocLevel[Definition::Latex] = level;
+        }
+        else if (opt == "xml")
+        {
+          current->localToc |= (1 << Definition::Xml);
+          current->localTocLevel[Definition::Xml] = level;
+        }
         else warn(yyFileName,yyLineNr,"Unknown option specified with \\tableofcontents: `%s'", (*it).stripWhiteSpace().data());
       }
     }
-    if (current->localToc == Definition::None) current->localToc |= Definition::Html;
+    if (current->localToc == Definition::None)
+    {
+      current->localToc |= (1 << Definition::Html);
+      current->localTocLevel[Definition::Html] = 5;
+    }
   }
   return FALSE;
 }

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -30,6 +30,7 @@
 #include <qstack.h>
 #include <qregexp.h>
 #include <qfile.h>
+#include <qstringlist.h>
   
 #include "scanner.h"
 #include "entry.h"
@@ -54,81 +55,81 @@
 #define YY_NO_UNISTD_H 1
 
 // forward declarations
-static bool handleBrief(const QCString &);
-static bool handleFn(const QCString &);
-static bool handleDef(const QCString &);
-static bool handleOverload(const QCString &);
-static bool handleEnum(const QCString &);
-static bool handleDefGroup(const QCString &);
-static bool handleAddToGroup(const QCString &);
-static bool handleWeakGroup(const QCString &);
-static bool handleNamespace(const QCString &);
-static bool handlePackage(const QCString &);
-static bool handleClass(const QCString &);
-static bool handleHeaderFile(const QCString &);
-static bool handleProtocol(const QCString &);
-static bool handleCategory(const QCString &);
-static bool handleUnion(const QCString &);
-static bool handleStruct(const QCString &);
-static bool handleInterface(const QCString &);
-static bool handleIdlException(const QCString &);
-static bool handlePage(const QCString &);
-static bool handleMainpage(const QCString &);
-static bool handleFile(const QCString &);
-static bool handleDir(const QCString &);
-static bool handleExample(const QCString &);
-static bool handleDetails(const QCString &);
-static bool handleName(const QCString &);
-static bool handleTodo(const QCString &);
-static bool handleTest(const QCString &);
-static bool handleBug(const QCString &);
-static bool handleSubpage(const QCString &s);
-static bool handleDeprecated(const QCString &);
-static bool handleXRefItem(const QCString &);
-static bool handleRelated(const QCString &);
-static bool handleRelatedAlso(const QCString &);
-static bool handleMemberOf(const QCString &);
-static bool handleRefItem(const QCString &);
-static bool handleSection(const QCString &);
-static bool handleAnchor(const QCString &);
-static bool handleCite(const QCString &);
-static bool handleFormatBlock(const QCString &);
-static bool handleAddIndex(const QCString &);
-static bool handleIf(const QCString &);
-static bool handleIfNot(const QCString &);
-static bool handleElseIf(const QCString &);
-static bool handleElse(const QCString &);
-static bool handleEndIf(const QCString &);
-static bool handleIngroup(const QCString &);
-static bool handleNoSubGrouping(const QCString &);
-static bool handleShowInitializer(const QCString &);
-static bool handleHideInitializer(const QCString &);
-static bool handleCallgraph(const QCString &);
-static bool handleHideCallgraph(const QCString &);
-static bool handleCallergraph(const QCString &);
-static bool handleHideCallergraph(const QCString &);
-static bool handleInternal(const QCString &);
-static bool handleLineBr(const QCString &);
-static bool handleStatic(const QCString &);
-static bool handlePure(const QCString &);
-static bool handlePrivate(const QCString &);
-static bool handlePrivateSection(const QCString &);
-static bool handleProtected(const QCString &);
-static bool handleProtectedSection(const QCString &);
-static bool handlePublic(const QCString &s);
-static bool handlePublicSection(const QCString &s);
-static bool handleToc(const QCString &s);
-static bool handleInherit(const QCString &);
-static bool handleExtends(const QCString &);
-static bool handleCopyDoc(const QCString &);
-static bool handleCopyBrief(const QCString &);
-static bool handleCopyDetails(const QCString &);
-static bool handleParBlock(const QCString &);
-static bool handleEndParBlock(const QCString &);
-static bool handleParam(const QCString &);
-static bool handleRetval(const QCString &);
+static bool handleBrief(const QCString &, const QCString &);
+static bool handleFn(const QCString &, const QCString &);
+static bool handleDef(const QCString &, const QCString &);
+static bool handleOverload(const QCString &, const QCString &);
+static bool handleEnum(const QCString &, const QCString &);
+static bool handleDefGroup(const QCString &, const QCString &);
+static bool handleAddToGroup(const QCString &, const QCString &);
+static bool handleWeakGroup(const QCString &, const QCString &);
+static bool handleNamespace(const QCString &, const QCString &);
+static bool handlePackage(const QCString &, const QCString &);
+static bool handleClass(const QCString &, const QCString &);
+static bool handleHeaderFile(const QCString &, const QCString &);
+static bool handleProtocol(const QCString &, const QCString &);
+static bool handleCategory(const QCString &, const QCString &);
+static bool handleUnion(const QCString &, const QCString &);
+static bool handleStruct(const QCString &, const QCString &);
+static bool handleInterface(const QCString &, const QCString &);
+static bool handleIdlException(const QCString &, const QCString &);
+static bool handlePage(const QCString &, const QCString &);
+static bool handleMainpage(const QCString &, const QCString &);
+static bool handleFile(const QCString &, const QCString &);
+static bool handleDir(const QCString &, const QCString &);
+static bool handleExample(const QCString &, const QCString &);
+static bool handleDetails(const QCString &, const QCString &);
+static bool handleName(const QCString &, const QCString &);
+static bool handleTodo(const QCString &, const QCString &);
+static bool handleTest(const QCString &, const QCString &);
+static bool handleBug(const QCString &, const QCString &);
+static bool handleSubpage(const QCString &s, const QCString &);
+static bool handleDeprecated(const QCString &, const QCString &);
+static bool handleXRefItem(const QCString &, const QCString &);
+static bool handleRelated(const QCString &, const QCString &);
+static bool handleRelatedAlso(const QCString &, const QCString &);
+static bool handleMemberOf(const QCString &, const QCString &);
+static bool handleRefItem(const QCString &, const QCString &);
+static bool handleSection(const QCString &, const QCString &);
+static bool handleAnchor(const QCString &, const QCString &);
+static bool handleCite(const QCString &, const QCString &);
+static bool handleFormatBlock(const QCString &, const QCString &);
+static bool handleAddIndex(const QCString &, const QCString &);
+static bool handleIf(const QCString &, const QCString &);
+static bool handleIfNot(const QCString &, const QCString &);
+static bool handleElseIf(const QCString &, const QCString &);
+static bool handleElse(const QCString &, const QCString &);
+static bool handleEndIf(const QCString &, const QCString &);
+static bool handleIngroup(const QCString &, const QCString &);
+static bool handleNoSubGrouping(const QCString &, const QCString &);
+static bool handleShowInitializer(const QCString &, const QCString &);
+static bool handleHideInitializer(const QCString &, const QCString &);
+static bool handleCallgraph(const QCString &, const QCString &);
+static bool handleHideCallgraph(const QCString &, const QCString &);
+static bool handleCallergraph(const QCString &, const QCString &);
+static bool handleHideCallergraph(const QCString &, const QCString &);
+static bool handleInternal(const QCString &, const QCString &);
+static bool handleLineBr(const QCString &, const QCString &);
+static bool handleStatic(const QCString &, const QCString &);
+static bool handlePure(const QCString &, const QCString &);
+static bool handlePrivate(const QCString &, const QCString &);
+static bool handlePrivateSection(const QCString &, const QCString &);
+static bool handleProtected(const QCString &, const QCString &);
+static bool handleProtectedSection(const QCString &, const QCString &);
+static bool handlePublic(const QCString &s, const QCString &);
+static bool handlePublicSection(const QCString &s, const QCString &);
+static bool handleToc(const QCString &s, const QCString &);
+static bool handleInherit(const QCString &, const QCString &);
+static bool handleExtends(const QCString &, const QCString &);
+static bool handleCopyDoc(const QCString &, const QCString &);
+static bool handleCopyBrief(const QCString &, const QCString &);
+static bool handleCopyDetails(const QCString &, const QCString &);
+static bool handleParBlock(const QCString &, const QCString &);
+static bool handleEndParBlock(const QCString &, const QCString &);
+static bool handleParam(const QCString &, const QCString &);
+static bool handleRetval(const QCString &, const QCString &);
 
-typedef bool (*DocCmdFunc)(const QCString &name);
+typedef bool (*DocCmdFunc)(const QCString &name, const QCString &opt);
 
 struct DocCmdMap
 {
@@ -1093,9 +1094,22 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                               );
                                           inInternalDocs = FALSE;
   					}
+<Comment>{B}*{CMD}[a-z_A-Z]+"{"[a-zA-Z_,\. ]*"}"{B}*  |
 <Comment>{B}*{CMD}[a-z_A-Z]+{B}*	{ // potentially interesting command
                                           // the {B}* in the front was added for bug620924
-  					  QCString cmdName = QCString(yytext).stripWhiteSpace().data()+1;
+                                          QCString fullMatch = QCString(yytext);
+                                          int idx = fullMatch.find('{');
+                                          QCString cmdName;
+                                          QCString optName;
+                                          if (idx == -1)
+                                          {
+                                            cmdName = QCString(yytext).stripWhiteSpace().data()+1; // to remove {CMD}
+                                          }
+                                          else
+                                          {
+                                            cmdName = fullMatch.left(idx).stripWhiteSpace().data()+1; // to remove {CMD}
+                                            optName = fullMatch.right(fullMatch.length() - idx).stripWhiteSpace().data();
+                                          }
 					  DocCmdMapper::Cmd *cmdPtr = DocCmdMapper::map(cmdName);
 					  if (cmdPtr) // special action is required
 					  {
@@ -1109,7 +1123,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					      setOutput(OutputDoc);
 					    }
                                             //if (i>0) addOutput(QCString(yytext).left(i)); // removed for bug 689341
-					    if (cmdPtr->func && cmdPtr->func(cmdName))
+					    if (cmdPtr->func && cmdPtr->func(cmdName, optName))
 					    {
 					      // implicit split of the comment block into two
 					      // entries. Restart the next block at the start
@@ -2255,14 +2269,14 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 
 //----------------------------------------------------------------------------
 
-static bool handleBrief(const QCString &)
+static bool handleBrief(const QCString &, const QCString &)
 {
   //printf("handleBrief\n");
   setOutput(OutputBrief);
   return FALSE;
 }
 
-static bool handleFn(const QCString &)
+static bool handleFn(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::MEMBERDOC_SEC);
   functionProto.resize(0);
@@ -2271,7 +2285,7 @@ static bool handleFn(const QCString &)
   return stop;
 }
 
-static bool handleDef(const QCString &)
+static bool handleDef(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::DEFINEDOC_SEC);
   functionProto.resize(0);
@@ -2279,21 +2293,21 @@ static bool handleDef(const QCString &)
   return stop;
 }
 
-static bool handleOverload(const QCString &)
+static bool handleOverload(const QCString &, const QCString &)
 {
   functionProto.resize(0);
   BEGIN(OverloadParam);
   return FALSE;
 }
 
-static bool handleEnum(const QCString &)
+static bool handleEnum(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::ENUMDOC_SEC);
   BEGIN(EnumDocArg1);
   return stop;
 }
 
-static bool handleDefGroup(const QCString &)
+static bool handleDefGroup(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::GROUPDOC_SEC);
   current->groupDocType = Entry::GROUPDOC_NORMAL;
@@ -2301,7 +2315,7 @@ static bool handleDefGroup(const QCString &)
   return stop;
 }
 
-static bool handleAddToGroup(const QCString &)
+static bool handleAddToGroup(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::GROUPDOC_SEC);
   current->groupDocType = Entry::GROUPDOC_ADD;
@@ -2309,7 +2323,7 @@ static bool handleAddToGroup(const QCString &)
   return stop;
 }
 
-static bool handleWeakGroup(const QCString &)
+static bool handleWeakGroup(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::GROUPDOC_SEC);
   current->groupDocType = Entry::GROUPDOC_WEAK;
@@ -2317,83 +2331,83 @@ static bool handleWeakGroup(const QCString &)
   return stop;
 }
 
-static bool handleNamespace(const QCString &)
+static bool handleNamespace(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::NAMESPACEDOC_SEC);
   BEGIN( NameSpaceDocArg1 );
   return stop;
 }
 
-static bool handlePackage(const QCString &)
+static bool handlePackage(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::PACKAGEDOC_SEC);
   BEGIN( PackageDocArg1 );
   return stop;
 }
 
-static bool handleClass(const QCString &)
+static bool handleClass(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::CLASSDOC_SEC);
   BEGIN( ClassDocArg1 ); 
   return stop;
 }
 
-static bool handleHeaderFile(const QCString &)
+static bool handleHeaderFile(const QCString &, const QCString &)
 {
   BEGIN( ClassDocArg2 );
   return FALSE;
 }
 
-static bool handleProtocol(const QCString &)
+static bool handleProtocol(const QCString &, const QCString &)
 { // Obj-C protocol
   bool stop=makeStructuralIndicator(Entry::PROTOCOLDOC_SEC);
   BEGIN( ClassDocArg1 ); 
   return stop;
 }
 
-static bool handleCategory(const QCString &)
+static bool handleCategory(const QCString &, const QCString &)
 { // Obj-C category
   bool stop=makeStructuralIndicator(Entry::CATEGORYDOC_SEC);
   BEGIN( CategoryDocArg1 ); 
   return stop;
 }
 
-static bool handleUnion(const QCString &)
+static bool handleUnion(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::UNIONDOC_SEC);
   BEGIN( ClassDocArg1 ); 
   return stop;
 }
 
-static bool handleStruct(const QCString &)
+static bool handleStruct(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::STRUCTDOC_SEC);
   BEGIN( ClassDocArg1 ); 
   return stop;
 }
 
-static bool handleInterface(const QCString &)
+static bool handleInterface(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::INTERFACEDOC_SEC);
   BEGIN( ClassDocArg1 ); 
   return stop;
 }
 
-static bool handleIdlException(const QCString &)
+static bool handleIdlException(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::EXCEPTIONDOC_SEC);
   BEGIN( ClassDocArg1 ); 
   return stop;
 }
 
-static bool handlePage(const QCString &)
+static bool handlePage(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::PAGEDOC_SEC);
   BEGIN( PageDocArg1 );
   return stop;
 }
 
-static bool handleMainpage(const QCString &)
+static bool handleMainpage(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::MAINPAGEDOC_SEC);
   if (!stop) 
@@ -2404,7 +2418,7 @@ static bool handleMainpage(const QCString &)
   return stop;
 }
 
-static bool handleFile(const QCString &)
+static bool handleFile(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::FILEDOC_SEC);
   if (!stop) 
@@ -2415,7 +2429,7 @@ static bool handleFile(const QCString &)
   return stop;
 }
 
-static bool handleParam(const QCString &)
+static bool handleParam(const QCString &, const QCString &)
 {
   // we need process param and retval arguments to escape leading underscores in case of
   // markdown processing, see bug775493
@@ -2424,14 +2438,14 @@ static bool handleParam(const QCString &)
   return FALSE;
 }
 
-static bool handleRetval(const QCString &)
+static bool handleRetval(const QCString &, const QCString &)
 {
   addOutput("@retval ");
   BEGIN( ParamArg1 );
   return FALSE;
 }
 
-static bool handleDir(const QCString &)
+static bool handleDir(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::DIRDOC_SEC);
   if (!stop) current->name = yyFileName;
@@ -2439,7 +2453,7 @@ static bool handleDir(const QCString &)
   return stop;
 }
 
-static bool handleExample(const QCString &)
+static bool handleExample(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::EXAMPLE_SEC);
   if (!stop) current->name = yyFileName;
@@ -2447,7 +2461,7 @@ static bool handleExample(const QCString &)
   return stop;
 }
 
-static bool handleDetails(const QCString &)
+static bool handleDetails(const QCString &, const QCString &)
 {
   if (inContext!=OutputBrief)
   {
@@ -2458,7 +2472,7 @@ static bool handleDetails(const QCString &)
   return FALSE;
 }
 
-static bool handleName(const QCString &)
+static bool handleName(const QCString &, const QCString &)
 {
   bool stop=makeStructuralIndicator(Entry::MEMBERGRP_SEC);
   if (!stop)
@@ -2473,7 +2487,7 @@ static bool handleName(const QCString &)
   return stop;
 }
 
-static bool handleTodo(const QCString &)
+static bool handleTodo(const QCString &, const QCString &)
 {
   newXRefKind = XRef_Todo;
   setOutput(OutputXRef);
@@ -2481,7 +2495,7 @@ static bool handleTodo(const QCString &)
   return FALSE;
 }
 
-static bool handleTest(const QCString &)
+static bool handleTest(const QCString &, const QCString &)
 {
   newXRefKind = XRef_Test;
   setOutput(OutputXRef);
@@ -2489,7 +2503,7 @@ static bool handleTest(const QCString &)
   return FALSE;
 }
 
-static bool handleBug(const QCString &)
+static bool handleBug(const QCString &, const QCString &)
 {
   newXRefKind = XRef_Bug;
   setOutput(OutputXRef);
@@ -2497,7 +2511,7 @@ static bool handleBug(const QCString &)
   return FALSE;
 }
 
-static bool handleDeprecated(const QCString &)
+static bool handleDeprecated(const QCString &, const QCString &)
 {
   newXRefKind = XRef_Deprecated;
   setOutput(OutputXRef);
@@ -2505,14 +2519,14 @@ static bool handleDeprecated(const QCString &)
   return FALSE;
 }
 
-static bool handleXRefItem(const QCString &)
+static bool handleXRefItem(const QCString &, const QCString &)
 {
   newXRefKind = XRef_Item;
   BEGIN(XRefItemParam1);
   return FALSE;
 }
 
-static bool handleParBlock(const QCString &)
+static bool handleParBlock(const QCString &, const QCString &)
 {
   if (g_insideParBlock)
   {
@@ -2529,7 +2543,7 @@ static bool handleParBlock(const QCString &)
   return FALSE;
 }
 
-static bool handleEndParBlock(const QCString &)
+static bool handleEndParBlock(const QCString &, const QCString &)
 {
   if (!g_insideParBlock)
   {
@@ -2542,34 +2556,34 @@ static bool handleEndParBlock(const QCString &)
   return FALSE;
 }
 
-static bool handleRelated(const QCString &)
+static bool handleRelated(const QCString &, const QCString &)
 {
   BEGIN(RelatesParam1);
   return FALSE;
 }
 
-static bool handleRelatedAlso(const QCString &)
+static bool handleRelatedAlso(const QCString &, const QCString &)
 {
   current->relatesType = Duplicate;
   BEGIN(RelatesParam1);
   return FALSE;
 }
 
-static bool handleMemberOf(const QCString &)
+static bool handleMemberOf(const QCString &, const QCString &)
 {
   current->relatesType = MemberOf;
   BEGIN(RelatesParam1);
   return FALSE;
 }
 
-static bool handleRefItem(const QCString &)
+static bool handleRefItem(const QCString &, const QCString &)
 {
   addOutput("@refitem ");
   BEGIN(LineParam);
   return FALSE;
 }
 
-static bool handleSection(const QCString &s)
+static bool handleSection(const QCString &s, const QCString &)
 {
   setOutput(OutputDoc);
   addOutput("@"+s+" ");
@@ -2581,7 +2595,7 @@ static bool handleSection(const QCString &s)
   return FALSE;
 }
 
-static bool handleSubpage(const QCString &s)
+static bool handleSubpage(const QCString &s, const QCString &)
 {
   if (current->section!=Entry::EMPTY_SEC && 
       current->section!=Entry::PAGEDOC_SEC &&
@@ -2601,14 +2615,14 @@ static bool handleSubpage(const QCString &s)
   return FALSE;
 }
 
-static bool handleAnchor(const QCString &s)
+static bool handleAnchor(const QCString &s, const QCString &)
 {
   addOutput("@"+s+" ");
   BEGIN(AnchorLabel);
   return FALSE;
 }
 
-static bool handleCite(const QCString &s)
+static bool handleCite(const QCString &s, const QCString &)
 {
   if (!g_spaceBeforeCmd.isEmpty()) 
   {
@@ -2620,24 +2634,24 @@ static bool handleCite(const QCString &s)
   return FALSE;
 }
 
-static bool handleFormatBlock(const QCString &s)
+static bool handleFormatBlock(const QCString &s, const QCString &opt)
 {
-  addOutput("@"+s+" ");
-  //printf("handleFormatBlock(%s)\n",s.data());
+  addOutput("@"+s+" "+opt);
+  //printf("handleFormatBlock(%s) with option(%s)\n",s.data(),opt.data());
   blockName=s;
   g_commentCount=0;
   BEGIN(FormatBlock);
   return FALSE;
 }
 
-static bool handleAddIndex(const QCString &)
+static bool handleAddIndex(const QCString &, const QCString &)
 {
   addOutput("@addindex ");
   BEGIN(LineParam);
   return FALSE;
 }
 
-static bool handleIf(const QCString &)
+static bool handleIf(const QCString &, const QCString &)
 {
   enabledSectionFound=FALSE;
   guardType = Guard_If;
@@ -2646,7 +2660,7 @@ static bool handleIf(const QCString &)
   return FALSE;
 }
 
-static bool handleIfNot(const QCString &)
+static bool handleIfNot(const QCString &, const QCString &)
 {
   enabledSectionFound=FALSE;
   guardType = Guard_IfNot;
@@ -2655,7 +2669,7 @@ static bool handleIfNot(const QCString &)
   return FALSE;
 }
 
-static bool handleElseIf(const QCString &)
+static bool handleElseIf(const QCString &, const QCString &)
 {
   if (guards.isEmpty())
   {
@@ -2670,7 +2684,7 @@ static bool handleElseIf(const QCString &)
   return FALSE;
 }
 
-static bool handleElse(const QCString &)
+static bool handleElse(const QCString &, const QCString &)
 {
   if (guards.isEmpty())
   {
@@ -2684,7 +2698,7 @@ static bool handleElse(const QCString &)
   return FALSE;
 }
 
-static bool handleEndIf(const QCString &)
+static bool handleEndIf(const QCString &, const QCString &)
 {
   if (guards.isEmpty())
   {
@@ -2705,56 +2719,56 @@ static bool handleEndIf(const QCString &)
   return FALSE;
 }
 
-static bool handleIngroup(const QCString &)
+static bool handleIngroup(const QCString &, const QCString &)
 {
   inGroupParamFound=FALSE;
   BEGIN( InGroupParam );
   return FALSE;
 }
 
-static bool handleNoSubGrouping(const QCString &)
+static bool handleNoSubGrouping(const QCString &, const QCString &)
 {
   current->subGrouping = FALSE; 
   return FALSE;
 }
 
-static bool handleShowInitializer(const QCString &)
+static bool handleShowInitializer(const QCString &, const QCString &)
 {
   current->initLines = 100000; // ON
   return FALSE;
 }
 
-static bool handleHideInitializer(const QCString &)
+static bool handleHideInitializer(const QCString &, const QCString &)
 {
   current->initLines = 0; // OFF
   return FALSE;
 }
 
-static bool handleCallgraph(const QCString &)
+static bool handleCallgraph(const QCString &, const QCString &)
 {
   current->callGraph = TRUE; // ON
   return FALSE;
 }
 
-static bool handleHideCallgraph(const QCString &)
+static bool handleHideCallgraph(const QCString &, const QCString &)
 {
   current->callGraph = FALSE; // OFF
   return FALSE;
 }
 
-static bool handleCallergraph(const QCString &)
+static bool handleCallergraph(const QCString &, const QCString &)
 {
   current->callerGraph = TRUE; // ON
   return FALSE;
 }
 
-static bool handleHideCallergraph(const QCString &)
+static bool handleHideCallergraph(const QCString &, const QCString &)
 {
   current->callerGraph = FALSE; // OFF
   return FALSE;
 }
 
-static bool handleInternal(const QCString &)
+static bool handleInternal(const QCString &, const QCString &)
 {
   if (!Config_getBool(INTERNAL_DOCS))
   {
@@ -2776,85 +2790,99 @@ static bool handleInternal(const QCString &)
   return FALSE;
 }
 
-static bool handleLineBr(const QCString &)
+static bool handleLineBr(const QCString &, const QCString &)
 {
   addOutput('\n');
   return FALSE;
 }
 
-static bool handleStatic(const QCString &)
+static bool handleStatic(const QCString &, const QCString &)
 {
   endBrief();
   current->stat = TRUE; 
   return FALSE;
 }
 
-static bool handlePure(const QCString &)
+static bool handlePure(const QCString &, const QCString &)
 {
   endBrief();
   current->virt = Pure; 
   return FALSE;
 }
 
-static bool handlePrivate(const QCString &)
+static bool handlePrivate(const QCString &, const QCString &)
 {
   current->protection = Private;
   return FALSE;
 }
 
-static bool handlePrivateSection(const QCString &)
+static bool handlePrivateSection(const QCString &, const QCString &)
 {
   current->protection = protection = Private;
   return FALSE;
 }
 
-static bool handleProtected(const QCString &)
+static bool handleProtected(const QCString &, const QCString &)
 {
   current->protection = Protected;
   return FALSE;
 }
 
-static bool handleProtectedSection(const QCString &)
+static bool handleProtectedSection(const QCString &, const QCString &)
 {
   current->protection = protection = Protected ;
   return FALSE;
 }
 
-static bool handlePublic(const QCString &)
+static bool handlePublic(const QCString &, const QCString &)
 {
   current->protection = Public;
   return FALSE;
 }
 
-static bool handlePublicSection(const QCString &)
+static bool handlePublicSection(const QCString &, const QCString &)
 {
   current->protection = protection = Public;
   return FALSE;
 }
 
-static bool handleToc(const QCString &)
+static bool handleToc(const QCString &, const QCString &opt)
 {
   if (current->section==Entry::PAGEDOC_SEC || 
       current->section==Entry::MAINPAGEDOC_SEC)
   {
-    current->stat=TRUE;  // we 'abuse' stat to pass whether or the TOC is enabled
+    QString optName = opt.stripWhiteSpace(); // to be sure
+    optName = optName.left(optName.length() - 1).right(optName.length() - 2);
+    QStringList optList=QStringList::split(",",optName,FALSE);
+    QStringList::Iterator it;
+    for ( it = optList.begin(); it != optList.end(); ++it )
+    {
+      QString opt = (*it).stripWhiteSpace().lower();
+      if (!opt.isEmpty())
+      {
+        if (opt == "html") current->localToc |= Definition::Html;
+        else if (opt == "latex") current->localToc |= Definition::Latex;
+        else warn(yyFileName,yyLineNr,"Unknown option specified with \\tableofcontents: `%s'", (*it).stripWhiteSpace().data());
+      }
+    }
+    if (current->localToc == Definition::None) current->localToc |= Definition::Html;
   }
   return FALSE;
 }
 
-static bool handleInherit(const QCString &)
+static bool handleInherit(const QCString &, const QCString &)
 {
   BEGIN(InheritParam);
   return FALSE;
 }
 
-static bool handleExtends(const QCString &)
+static bool handleExtends(const QCString &, const QCString &)
 {
   BEGIN(ExtendsParam);
   return FALSE;
 }
 
-static bool handleCopyBrief(const QCString &)
+static bool handleCopyBrief(const QCString &, const QCString &)
 {
   if (current->brief.isEmpty() && current->doc.isEmpty())
   { // if we don't have a brief or detailed description yet,
@@ -2871,7 +2899,7 @@ static bool handleCopyBrief(const QCString &)
   return FALSE;
 }
 
-static bool handleCopyDetails(const QCString &)
+static bool handleCopyDetails(const QCString &, const QCString &)
 {
   setOutput(OutputDoc);
   if (!g_spaceBeforeCmd.isEmpty()) 
@@ -2883,7 +2911,7 @@ static bool handleCopyDetails(const QCString &)
   return FALSE;
 }
 
-static bool handleCopyDoc(const QCString &)
+static bool handleCopyDoc(const QCString &, const QCString &)
 {
   setOutput(OutputBrief);
   if (!g_spaceBeforeCmd.isEmpty()) 

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1613,10 +1613,12 @@ void Definition::writeNavigationPath(OutputList &ol) const
 }
 
 // TODO: move to htmlgen
-void Definition::writeToc(OutputList &ol)
+void Definition::writeToc(OutputList &ol, int localToc)
 {
   SectionDict *sectionDict = m_impl->sectionDict;
   if (sectionDict==0) return;
+  if (localToc & Definition::Html)
+  {
   ol.pushGeneratorState();
   ol.disableAllBut(OutputGenerator::Html);
   ol.writeString("<div class=\"toc\">");
@@ -1675,6 +1677,15 @@ void Definition::writeToc(OutputList &ol)
   ol.writeString("</ul>\n");
   ol.writeString("</div>\n");
   ol.popGeneratorState();
+  }
+
+  if (localToc & Definition::Latex)
+  {
+  ol.pushGeneratorState();
+  ol.disableAllBut(OutputGenerator::Latex);
+  ol.writeString("\\localtableofcontents\n");
+  ol.popGeneratorState();
+  }
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/definition.h
+++ b/src/definition.h
@@ -283,7 +283,7 @@ class Definition : public DefinitionIntf
     QCString id() const;
 
     /** returns the section dictionary, only of importance for pagedef */
-    SectionDict * Definition::getSectionDict(void);
+    SectionDict * getSectionDict(void);
 
     //-----------------------------------------------------------------------------------
     // ----  setters -----

--- a/src/definition.h
+++ b/src/definition.h
@@ -98,9 +98,11 @@ class Definition : public DefinitionIntf
     };
 
     enum outputLocalTocType {
-	    None          = 0,
-	    Html          = 0x01,
-            Latex         = 0x02
+      None                   = 0, // absolute value
+      Html                   = 0, // index / also to be used as (1 << Definition::Html)
+      Latex                  = 1, // ...
+      Xml                    = 2, // ...
+      numOutputLocalTocType  = 3  // number of outputLocalTocType
     };
     /*! Create a new definition */
     Definition(
@@ -280,6 +282,9 @@ class Definition : public DefinitionIntf
 
     QCString id() const;
 
+    /** returns the section dictionary, only of importance for pagedef */
+    SectionDict * Definition::getSectionDict(void);
+
     //-----------------------------------------------------------------------------------
     // ----  setters -----
     //-----------------------------------------------------------------------------------
@@ -351,7 +356,7 @@ class Definition : public DefinitionIntf
     void setLocalName(const QCString name);
 
     void addSectionsToIndex();
-    void writeToc(OutputList &ol, int localToc);
+    void writeToc(OutputList &ol, int localToc, int *localTocLevel);
 
     void setCookie(Cookie *cookie) { delete m_cookie; m_cookie = cookie; }
     Cookie *cookie() const { return m_cookie; }

--- a/src/definition.h
+++ b/src/definition.h
@@ -97,6 +97,11 @@ class Definition : public DefinitionIntf
       virtual ~Cookie() {}
     };
 
+    enum outputLocalTocType {
+	    None          = 0,
+	    Html          = 0x01,
+            Latex         = 0x02
+    };
     /*! Create a new definition */
     Definition(
         const char *defFileName,int defLine,int defColumn,
@@ -346,7 +351,7 @@ class Definition : public DefinitionIntf
     void setLocalName(const QCString name);
 
     void addSectionsToIndex();
-    void writeToc(OutputList &ol);
+    void writeToc(OutputList &ol, int localToc);
 
     void setCookie(Cookie *cookie) { delete m_cookie; m_cookie = cookie; }
     Cookie *cookie() const { return m_cookie; }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -605,7 +605,7 @@ static void addRelatedPage(EntryNav *rootNav)
   {
     pd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
     pd->addSectionsToDefinition(root->anchors);
-    pd->setShowToc(root->localToc);
+    pd->setShowToc(root->localToc, root->localTocLevel);
     addPageToContext(pd,rootNav);
   }
 }
@@ -8712,7 +8712,7 @@ static void findMainPage(EntryNav *rootNav)
       //setFileNameForSections(root->anchors,"index",Doxygen::mainPage);
       Doxygen::mainPage->setBriefDescription(root->brief,root->briefFile,root->briefLine);
       Doxygen::mainPage->setFileName(indexName);
-      Doxygen::mainPage->setShowToc(root->localToc);
+      Doxygen::mainPage->setShowToc(root->localToc, root->localTocLevel);
       addPageToContext(Doxygen::mainPage,rootNav);
 
       SectionInfo *si = Doxygen::sectionDict->find(Doxygen::mainPage->name());

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -605,7 +605,7 @@ static void addRelatedPage(EntryNav *rootNav)
   {
     pd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
     pd->addSectionsToDefinition(root->anchors);
-    pd->setShowToc(root->stat);
+    pd->setShowToc(root->localToc);
     addPageToContext(pd,rootNav);
   }
 }
@@ -8712,7 +8712,7 @@ static void findMainPage(EntryNav *rootNav)
       //setFileNameForSections(root->anchors,"index",Doxygen::mainPage);
       Doxygen::mainPage->setBriefDescription(root->brief,root->briefFile,root->briefLine);
       Doxygen::mainPage->setFileName(indexName);
-      Doxygen::mainPage->setShowToc(root->stat);
+      Doxygen::mainPage->setShowToc(root->localToc);
       addPageToContext(Doxygen::mainPage,rootNav);
 
       SectionInfo *si = Doxygen::sectionDict->find(Doxygen::mainPage->name());

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -74,6 +74,10 @@ Entry::Entry(const Entry &e)
   initLines   = e.initLines;
   stat        = e.stat;
   localToc    = e.localToc;
+  for (int i = 0; i < sizeof(localTocLevel) / sizeof(*localTocLevel) ; i++)
+  {
+    localTocLevel[i] = e.localTocLevel[i];
+  }
   explicitExternal = e.explicitExternal;
   proto       = e.proto;
   subGrouping = e.subGrouping;
@@ -255,6 +259,10 @@ void Entry::reset()
   virt    = Normal;
   stat    = FALSE;
   localToc = Definition::None;
+  for (int i = 0; i < sizeof(localTocLevel) / sizeof(*localTocLevel) ; i++)
+  {
+    localTocLevel[i] = 0;
+  }
   proto   = FALSE;
   explicitExternal = FALSE;
   spec  = 0;

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -73,6 +73,7 @@ Entry::Entry(const Entry &e)
   spec        = e.spec;
   initLines   = e.initLines;
   stat        = e.stat;
+  localToc    = e.localToc;
   explicitExternal = e.explicitExternal;
   proto       = e.proto;
   subGrouping = e.subGrouping;
@@ -253,6 +254,7 @@ void Entry::reset()
   mtype   = Method;
   virt    = Normal;
   stat    = FALSE;
+  localToc = Definition::None;
   proto   = FALSE;
   explicitExternal = FALSE;
   spec  = 0;

--- a/src/entry.h
+++ b/src/entry.h
@@ -288,6 +288,7 @@ class Entry
     bool        artificial;   //!< Artificially introduced item
     GroupDocType groupDocType;
     QCString    id;           //!< libclang id
+    int         localToc;     //!< types of local TOC, command \tableofcontents
 
 
     static int  num;          //!< counts the total number of entries

--- a/src/entry.h
+++ b/src/entry.h
@@ -289,6 +289,7 @@ class Entry
     GroupDocType groupDocType;
     QCString    id;           //!< libclang id
     int         localToc;     //!< types of local TOC, command \tableofcontents
+    int         localTocLevel[3];//!< depth of local TOC, command \tableofcontents
 
 
     static int  num;          //!< counts the total number of entries

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3885,7 +3885,7 @@ static void writeIndex(OutputList &ol)
     Doxygen::insideMainPage=TRUE;
     if (Doxygen::mainPage->showToc() && Doxygen::mainPage->hasSections())
     {
-      Doxygen::mainPage->writeToc(ol);
+      Doxygen::mainPage->writeToc(ol,Doxygen::mainPage->showToc());
     }
 
     ol.startTextBlock();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3885,7 +3885,7 @@ static void writeIndex(OutputList &ol)
     Doxygen::insideMainPage=TRUE;
     if (Doxygen::mainPage->showToc() && Doxygen::mainPage->hasSections())
     {
-      Doxygen::mainPage->writeToc(ol,Doxygen::mainPage->showToc());
+      Doxygen::mainPage->writeToc(ol,Doxygen::mainPage->showToc(),Doxygen::mainPage->showTocLevel());
     }
 
     ol.startTextBlock();

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -566,7 +566,9 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\\hbadness=750\n"
        "\\setlength{\\emergencystretch}{15pt}\n"
        "\\setlength{\\parindent}{0cm}\n"
-       "\\setlength{\\parskip}{3ex plus 2ex minus 2ex}\n";
+       "\\newcommand{\\doxynormalparskip}{\\setlength{\\parskip}{3ex plus 2ex minus 2ex}}\n"
+       "\\newcommand{\\doxytocparskip}{\\setlength{\\parskip}{1ex plus 0ex minus 0ex}}\n"
+       "\\doxynormalparskip\n";
   // Redefine paragraph/subparagraph environments, using sectsty fonts
   t << "\\makeatletter\n"
        "\\renewcommand{\\paragraph}{%\n"
@@ -693,6 +695,10 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   // caption style definition
   t << "\\usepackage{caption}\n"
     << "\\captionsetup{labelsep=space,justification=centering,font={bf},singlelinecheck=off,skip=4pt,position=top}\n\n";
+
+  // in page table of contents
+  t << "\\usepackage{etoc}\n"
+       "\\etocsettocstyle{\\doxytocparskip}{\\doxynormalparskip}\n";
 
   // End of preamble, now comes the document contents
   t << "%===== C O N T E N T S =====\n"

--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -355,6 +355,7 @@ void marshalEntry(StorageIntf *s,Entry *e)
   marshalUInt64(s,e->spec);
   marshalInt(s,e->initLines);
   marshalBool(s,e->stat);
+  marshalInt(s,e->localToc);
   marshalBool(s,e->explicitExternal);
   marshalBool(s,e->proto);
   marshalBool(s,e->subGrouping);
@@ -737,6 +738,7 @@ Entry * unmarshalEntry(StorageIntf *s)
   e->spec             = unmarshalUInt64(s);
   e->initLines        = unmarshalInt(s);
   e->stat             = unmarshalBool(s);
+  e->localToc         = unmarshalInt(s);
   e->explicitExternal = unmarshalBool(s);
   e->proto            = unmarshalBool(s);
   e->subGrouping      = unmarshalBool(s);

--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -356,6 +356,10 @@ void marshalEntry(StorageIntf *s,Entry *e)
   marshalInt(s,e->initLines);
   marshalBool(s,e->stat);
   marshalInt(s,e->localToc);
+  for (int i = 0; i < sizeof(e->localTocLevel) / sizeof(*(e->localTocLevel)) ; i++)
+  {
+    marshalInt(s,e->localTocLevel[i]);
+  }
   marshalBool(s,e->explicitExternal);
   marshalBool(s,e->proto);
   marshalBool(s,e->subGrouping);
@@ -739,6 +743,10 @@ Entry * unmarshalEntry(StorageIntf *s)
   e->initLines        = unmarshalInt(s);
   e->stat             = unmarshalBool(s);
   e->localToc         = unmarshalInt(s);
+  for (int i = 0; i < sizeof(e->localTocLevel) / sizeof(*(e->localTocLevel)) ; i++)
+  {
+    e->localTocLevel[i] = unmarshalInt(s);
+  }
   e->explicitExternal = unmarshalBool(s);
   e->proto            = unmarshalBool(s);
   e->subGrouping      = unmarshalBool(s);

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -35,7 +35,7 @@ PageDef::PageDef(const char *f,int l,const char *n,
   m_pageScope = 0;
   m_nestingLevel = 0;
   m_fileName = ::convertNameToFile(n,FALSE,TRUE);
-  m_showToc = FALSE;
+  m_showToc = Definition::None;
 }
 
 PageDef::~PageDef()
@@ -209,7 +209,7 @@ void PageDef::writeDocumentation(OutputList &ol)
 
   if (m_showToc && hasSections())
   {
-    writeToc(ol);
+    writeToc(ol, m_showToc);
   }
 
   writePageDocumentation(ol);
@@ -326,7 +326,7 @@ void PageDef::setNestingLevel(int l)
   m_nestingLevel = l;
 }
 
-void PageDef::setShowToc(bool b)
+void PageDef::setShowToc(int b)
 {
   m_showToc |= b;
 }

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -36,6 +36,10 @@ PageDef::PageDef(const char *f,int l,const char *n,
   m_nestingLevel = 0;
   m_fileName = ::convertNameToFile(n,FALSE,TRUE);
   m_showToc = Definition::None;
+  for (int i = 0; i < sizeof(m_localTocLevel) / sizeof(*m_localTocLevel) ; i++)
+  {
+    m_localTocLevel[i] = 0;
+  }
 }
 
 PageDef::~PageDef()
@@ -209,7 +213,7 @@ void PageDef::writeDocumentation(OutputList &ol)
 
   if (m_showToc && hasSections())
   {
-    writeToc(ol, m_showToc);
+    writeToc(ol, m_showToc, m_localTocLevel);
   }
 
   writePageDocumentation(ol);
@@ -326,8 +330,11 @@ void PageDef::setNestingLevel(int l)
   m_nestingLevel = l;
 }
 
-void PageDef::setShowToc(int b)
+void PageDef::setShowToc(int localToc, int *localTocLevel)
 {
-  m_showToc |= b;
+  m_showToc |= localToc;
+  for (int i = 0; i < sizeof(m_localTocLevel) / sizeof(*m_localTocLevel) ; i++)
+  {
+    m_localTocLevel[i] += localTocLevel[i];
+  }
 }
-

--- a/src/pagedef.h
+++ b/src/pagedef.h
@@ -34,7 +34,7 @@ class PageDef : public Definition
 
     // setters
     void setFileName(const char *name);
-    void setShowToc(int b);
+    void setShowToc(int localToc, int *localTocLevel);
 
     // getters
     DefType definitionType() const { return TypePage; }
@@ -60,6 +60,8 @@ class PageDef : public Definition
     bool hasSubPages() const;
     bool hasParentPage() const;
     int showToc() const { return m_showToc; }
+    int *showTocLevel() { return m_localTocLevel; }
+    static bool isLocalToc(int localToc, int tocType) { return(localToc & (1 << tocType)); }
     void setPageScope(Definition *d){ m_pageScope = d; }
     Definition *getPageScope() const { return m_pageScope; }
     QCString displayName(bool=TRUE) const { return !m_title.isEmpty() ? m_title : Definition::name(); }
@@ -76,6 +78,7 @@ class PageDef : public Definition
     Definition *m_pageScope;
     int m_nestingLevel;
     int m_showToc;
+    int m_localTocLevel[numOutputLocalTocType];
 };
 
 class PageSDict : public SDict<PageDef>

--- a/src/pagedef.h
+++ b/src/pagedef.h
@@ -34,7 +34,7 @@ class PageDef : public Definition
 
     // setters
     void setFileName(const char *name);
-    void setShowToc(bool b);
+    void setShowToc(int b);
 
     // getters
     DefType definitionType() const { return TypePage; }
@@ -59,7 +59,7 @@ class PageDef : public Definition
     bool documentedPage() const;
     bool hasSubPages() const;
     bool hasParentPage() const;
-    bool showToc() const { return m_showToc; }
+    int showToc() const { return m_showToc; }
     void setPageScope(Definition *d){ m_pageScope = d; }
     Definition *getPageScope() const { return m_pageScope; }
     QCString displayName(bool=TRUE) const { return !m_title.isEmpty() ? m_title : Definition::name(); }
@@ -75,7 +75,7 @@ class PageDef : public Definition
     PageSDict *m_subPageDict;                 // list of pages in the group
     Definition *m_pageScope;
     int m_nestingLevel;
-    bool m_showToc;
+    int m_showToc;
 };
 
 class PageSDict : public SDict<PageDef>

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -29,7 +29,7 @@
       <xsd:element name="innergroup" type="refType" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="templateparamlist" type="templateparamlistType" minOccurs="0" />
       <xsd:element name="sectiondef" type="sectiondefType" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="tableofcontents" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="tableofcontents" type="tableofcontentsType" minOccurs="0" maxOccurs="1" />
       <xsd:element name="briefdescription" type="descriptionType" minOccurs="0" />
       <xsd:element name="detaileddescription" type="descriptionType" minOccurs="0" />
       <xsd:element name="inheritancegraph" type="graphType" minOccurs="0" />
@@ -878,6 +878,20 @@
       <xsd:enumeration value="unretained"/>
     </xsd:restriction>
   </xsd:simpleType>
+
+  <xsd:complexType name="tableofcontentsType">
+    <xsd:sequence>
+      <xsd:element name="tocsect" type="tableofcontentsKindType" minOccurs="1" maxOccurs="unbounded" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="tableofcontentsKindType">
+    <xsd:sequence>
+      <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="reference" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+      <xsd:element name="tableofcontents" type="tableofcontentsType" minOccurs="0" maxOccurs="unbounded" />
+    </xsd:sequence>
+  </xsd:complexType>
 
 </xsd:schema>
 

--- a/testing/043/mypage.xml
+++ b/testing/043/mypage.xml
@@ -4,7 +4,34 @@
     <compoundname>mypage</compoundname>
     <title>Page Title</title>
     <innerpage refid="another">Another Page</innerpage>
-    <tableofcontents/>
+    <tableofcontents>
+      <tocsect>
+        <name>Section Title.</name>
+        <reference>mypage_1mysect</reference>
+        <tableofcontents>
+          <tocsect>
+            <name>Subsection Title.</name>
+            <reference>mypage_1mysubsect</reference>
+            <tableofcontents>
+              <tocsect>
+                <name>Subsubsection Title.</name>
+                <reference>mypage_1mysubsubsect</reference>
+                <tableofcontents>
+                  <tocsect>
+                    <name>Paragraph Title.</name>
+                    <reference>mypage_1mypara</reference>
+                  </tocsect>
+                </tableofcontents>
+              </tocsect>
+            </tableofcontents>
+          </tocsect>
+        </tableofcontents>
+      </tocsect>
+      <tocsect>
+        <name>Another Section Title.</name>
+        <reference>mypage_1mysect2</reference>
+      </tocsect>
+    </tableofcontents>
     <briefdescription>
       <para>Page brief description. </para>
     </briefdescription>

--- a/testing/043_page.dox
+++ b/testing/043_page.dox
@@ -4,7 +4,7 @@
 /** \page mypage Page Title
  *  \brief Page brief description.
  *
- *  @tableofcontents
+ *  @tableofcontents{xml,html,latex}
  *
  *  Text at page level. See \ref mysect for more.
  *  \section mysect Section Title.


### PR DESCRIPTION
currently the \\tableofcontents command is only supported for HTML.
In this patch:
- enable in page table of contents for LaTeX: \\tableofcontents['{'[option[:level]][,option[:level]]*'}']
     where option can be 'HTML',  'LaTeX' or 'XML'
- add the possibility to have maximum levels in the in page table of contents (possible per output type and per in page table of contents. Default is show all)

(side effect: possibility to have options with, nearly, all commands.)