### PR TITLE
Small problems when having code in LaTeX output

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -69,8 +69,10 @@ void FormulaList::generateBitmaps(const char *path)
     FTextStream t(&f);
     if (Config_getBool(LATEX_BATCHMODE)) t << "\\batchmode" << endl;
     t << "\\documentclass{article}" << endl;
+    t << "\\usepackage{ifthen}" << endl;
     t << "\\usepackage{epsfig}" << endl; // for those who want to include images
     writeExtraLatexPackages(t);
+    writeLatexSpecialFormulaChars(t);
     t << "\\pagestyle{empty}" << endl; 
     t << "\\begin{document}" << endl;
     int page=0;

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -181,7 +181,7 @@ void LatexCodeGenerator::writeCodeLink(const char *ref,const char *f,
   }
   else
   {
-    m_t << name;
+    codify(name);
   }
   m_col+=l;
 }
@@ -633,45 +633,17 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\n";
 
   writeExtraLatexPackages(t);
+  writeLatexSpecialFormulaChars(t);
 
   // Hyperlinks
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (pdfHyperlinks)
   {
-    unsigned char minus[4]; // Superscript minus
-    char *pminus = (char *)minus;
-    unsigned char sup2[3]; // Superscript two
-    char *psup2 = (char *)sup2;
-    unsigned char sup3[3];
-    char *psup3 = (char *)sup3; // Superscript three
-    minus[0]= 0xE2;
-    minus[1]= 0x81;
-    minus[2]= 0xBB;
-    minus[3]= 0;
-    sup2[0]= 0xC2;
-    sup2[1]= 0xB2;
-    sup2[2]= 0;
-    sup3[0]= 0xC2;
-    sup3[1]= 0xB3;
-    sup3[2]= 0;
-
     t << "% Hyperlinks (required, but should be loaded last)\n"
          "\\ifpdf\n"
          "  \\usepackage[pdftex,pagebackref=true]{hyperref}\n"
          "\\else\n"
          "  \\usepackage[ps2pdf,pagebackref=true]{hyperref}\n"
-         "\\fi\n"
-	 "\\ifpdf\n"
-         "  \\DeclareUnicodeCharacter{207B}{${}^{-}$}% Superscript minus\n"
-         "  \\DeclareUnicodeCharacter{C2B2}{${}^{2}$}% Superscript two\n"
-         "  \\DeclareUnicodeCharacter{C2B3}{${}^{3}$}% Superscript three\n"
-         "\\else\n"
-         "  \\catcode`\\" << pminus << "=13% Superscript minus\n"
-         "  \\def" << pminus << "{${}^{-}$}\n"
-         "  \\catcode`\\" << psup2 << "=13% Superscript two\n"
-         "  \\def" << psup2 << "{${}^{2}$}\n"
-         "  \\catcode`\\"<<psup3<<"=13% Superscript three\n"
-         "  \\def"<<psup3<<"{${}^{3}$}\n"
          "\\fi\n"
          "\n"
          "\\hypersetup{%\n"
@@ -2209,6 +2181,11 @@ void LatexGenerator::startCodeFragment()
 
 void LatexGenerator::endCodeFragment()
 {
+  if (DoxyCodeOpen)
+  {
+    t << "}\n";
+    DoxyCodeOpen = FALSE;
+  }
   t << "\\end{DoxyCode}\n";
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8833,6 +8833,41 @@ void writeExtraLatexPackages(FTextStream &t)
   }
 }
 
+void writeLatexSpecialFormulaChars(FTextStream &t)
+{
+    unsigned char minus[4]; // Superscript minus
+    char *pminus = (char *)minus;
+    unsigned char sup2[3]; // Superscript two
+    char *psup2 = (char *)sup2;
+    unsigned char sup3[3];
+    char *psup3 = (char *)sup3; // Superscript three
+    minus[0]= 0xE2;
+    minus[1]= 0x81;
+    minus[2]= 0xBB;
+    minus[3]= 0;
+    sup2[0]= 0xC2;
+    sup2[1]= 0xB2;
+    sup2[2]= 0;
+    sup3[0]= 0xC2;
+    sup3[1]= 0xB3;
+    sup3[2]= 0;
+
+    t << "\\ifthenelse{\\isundefined{\\DeclareUnicodeCharacter}}{%\n"
+         "  \\catcode`\\" << pminus << "=13% Superscript minus\n"
+         "  \\def" << pminus << "{${}^{-}$}\n"
+         "  \\catcode`\\" << psup2 << "=13% Superscript two\n"
+         "  \\def" << psup2 << "{${}^{2}$}\n"
+         "  \\catcode`\\"<<psup3<<"=13% Superscript three\n"
+         "  \\def"<<psup3<<"{${}^{3}$}\n"
+         "}{%\n"
+         "  \\DeclareUnicodeCharacter{207B}{${}^{-}$}% Superscript minus\n"
+         "  \\DeclareUnicodeCharacter{C2B2}{${}^{2}$}% Superscript two\n"
+         "  \\DeclareUnicodeCharacter{C2B3}{${}^{3}$}% Superscript three\n"
+         "  \\DeclareUnicodeCharacter{2212}{-}% Just a minus sign\n"
+         "}\n"
+         "\n";
+}
+
 //------------------------------------------------------
 
 static int g_usedTableLevels = 0;

--- a/src/util.h
+++ b/src/util.h
@@ -477,6 +477,7 @@ void convertProtectionLevel(
 bool mainPageHasTitle();
 bool openOutputFile(const char *outFile,QFile &f);
 void writeExtraLatexPackages(FTextStream &t);
+void writeLatexSpecialFormulaChars(FTextStream &t);
 
 int usedTableLevels();
 void incUsedTableLevels();

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -113,19 +113,19 @@
   \normalsize%
 }
 
-% Redefining not defined charcaters, i.e. "Replacement Character" in tex output.
+% Redefining not defined characters, i.e. "Replacement Character" in tex output.
 \def\ucr{\adjustbox{width=\CodeWidthChar,height=\CodeHeightChar}{\stackinset{c}{}{c}{-.2pt}{%
    \textcolor{white}{\sffamily\bfseries\small ?}}{%
    \rotatebox{45}{$\blacksquare$}}}}
 
 % Choosing right setup for "Replacement character"
-\ifpdf
-  \RequirePackage[utf8]{inputenc}
-  \DeclareUnicodeCharacter{FFFD}{\ucr}
-\else
+\ifthenelse{\isundefined{\DeclareUnicodeCharacter}}{%
   \catcode`\�=13
   \def�{\ucr}
-\fi
+}{%
+  \RequirePackage[utf8]{inputenc}
+  \DeclareUnicodeCharacter{FFFD}{\ucr}
+}
 
 % Used by @example, @include, @includelineno and @dontinclude
 \newenvironment{DoxyCodeInclude}{%


### PR DESCRIPTION
- in formulas it is also possible to have special characters
- adding special character '-' for U+2212
- making special characters more system independent (plain latex was not handled) and should be independent of hyperlink setting
- without hyperlinks the name of normally linked names with underscore kept e.g. their underscores instead of escaping it
- be sure that on the end of a code section the previous line is properly 'closed'.