### PR TITLE
Include header for CompilationDatabase

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -4,6 +4,7 @@
 
 #if USE_LIBCLANG
 #include <clang-c/Index.h>
+#include "clang/Tooling/CompilationDatabase.h"
 #include "clang/Tooling/Tooling.h"
 #include <qfileinfo.h>
 #include <stdlib.h>


### PR DESCRIPTION
It seems that clang 7 no longer include the compilation database header in the general `Tooling.h` file. Instead, it uses a forward declaration in `Tooling.h`. This causes compilation errors for Doxygen when using clang.