### PR TITLE
Problem with code inside a Doxy table in LaTeX

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -18,6 +18,7 @@
 #include "htmlattrib.h"
 #include <qfileinfo.h> 
 #include "latexdocvisitor.h"
+#include "latexgen.h"
 #include "docparser.h"
 #include "language.h"
 #include "doxygen.h"
@@ -291,10 +292,12 @@ void LatexDocVisitor::visit(DocVerbatim *s)
   {
     case DocVerbatim::Code: 
       {
-        m_t << "\n\\begin{DoxyCode}\n";
+        m_t << "\n\\begin{DoxyCode}{" << usedTableLevels() << "}\n";
+	LatexCodeGenerator::setDoxyCodeOpen(TRUE);
         Doxygen::parserManager->getParser(lang)
                               ->parseCode(m_ci,s->context(),s->text(),langExt,
                                           s->isExample(),s->exampleFile());
+	LatexCodeGenerator::setDoxyCodeOpen(FALSE);
         m_t << "\\end{DoxyCode}\n";
       }
       break;
@@ -399,7 +402,8 @@ void LatexDocVisitor::visit(DocInclude *inc)
   {
     case DocInclude::IncWithLines:
       { 
-         m_t << "\n\\begin{DoxyCodeInclude}\n";
+         m_t << "\n\\begin{DoxyCodeInclude}{" << usedTableLevels() << "}\n";
+	 LatexCodeGenerator::setDoxyCodeOpen(TRUE);
          QFileInfo cfi( inc->file() );
          FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
          Doxygen::parserManager->getParser(inc->extension())
@@ -415,11 +419,13 @@ void LatexDocVisitor::visit(DocInclude *inc)
                                            0,     // memberDef
                                            TRUE   // show line numbers
 					  );
+	 LatexCodeGenerator::setDoxyCodeOpen(FALSE);
          m_t << "\\end{DoxyCodeInclude}" << endl;
       }
       break;    
     case DocInclude::Include: 
-      m_t << "\n\\begin{DoxyCodeInclude}\n";
+      m_t << "\n\\begin{DoxyCodeInclude}{" << usedTableLevels() << "}\n";
+      LatexCodeGenerator::setDoxyCodeOpen(TRUE);
       Doxygen::parserManager->getParser(inc->extension())
                             ->parseCode(m_ci,inc->context(),
                                         inc->text(),langExt,inc->isExample(),
@@ -431,6 +437,7 @@ void LatexDocVisitor::visit(DocInclude *inc)
                                         0,     // memberDef
                                         FALSE
 			  		);
+      LatexCodeGenerator::setDoxyCodeOpen(FALSE);
       m_t << "\\end{DoxyCodeInclude}\n";
       break;
     case DocInclude::DontInclude: 
@@ -447,7 +454,8 @@ void LatexDocVisitor::visit(DocInclude *inc)
       break;
     case DocInclude::Snippet:
       {
-         m_t << "\n\\begin{DoxyCodeInclude}\n";
+         m_t << "\n\\begin{DoxyCodeInclude}{" << usedTableLevels() << "}\n";
+         LatexCodeGenerator::setDoxyCodeOpen(TRUE);
          Doxygen::parserManager->getParser(inc->extension())
                                ->parseCode(m_ci,
                                            inc->context(),
@@ -456,6 +464,7 @@ void LatexDocVisitor::visit(DocInclude *inc)
                                            inc->isExample(),
                                            inc->exampleFile()
                                           );
+         LatexCodeGenerator::setDoxyCodeOpen(FALSE);
          m_t << "\\end{DoxyCodeInclude}" << endl;
       }
       break;
@@ -463,7 +472,8 @@ void LatexDocVisitor::visit(DocInclude *inc)
       {
          QFileInfo cfi( inc->file() );
          FileDef fd( cfi.dirPath().utf8(), cfi.fileName().utf8() );
-         m_t << "\n\\begin{DoxyCodeInclude}\n";
+         m_t << "\n\\begin{DoxyCodeInclude}{" << usedTableLevels() << "}\n";
+         LatexCodeGenerator::setDoxyCodeOpen(TRUE);
          Doxygen::parserManager->getParser(inc->extension())
                                ->parseCode(m_ci,
                                            inc->context(),
@@ -478,6 +488,7 @@ void LatexDocVisitor::visit(DocInclude *inc)
                                            0,     // memberDef
                                            TRUE   // show line number
                                           );
+         LatexCodeGenerator::setDoxyCodeOpen(FALSE);
          m_t << "\\end{DoxyCodeInclude}" << endl;
       }
       break;
@@ -495,7 +506,8 @@ void LatexDocVisitor::visit(DocIncOperator *op)
   //    op->type(),op->isFirst(),op->isLast(),op->text().data());
   if (op->isFirst()) 
   {
-    if (!m_hide) m_t << "\n\\begin{DoxyCodeInclude}\n";
+    if (!m_hide) m_t << "\n\\begin{DoxyCodeInclude}{" << usedTableLevels() << "}\n";
+    LatexCodeGenerator::setDoxyCodeOpen(TRUE);
     pushEnabled();
     m_hide = TRUE;
   }
@@ -515,6 +527,7 @@ void LatexDocVisitor::visit(DocIncOperator *op)
   if (op->isLast())  
   {
     popEnabled();
+    LatexCodeGenerator::setDoxyCodeOpen(FALSE);
     if (!m_hide) m_t << "\n\\end{DoxyCodeInclude}\n";
   }
   else

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -51,6 +51,7 @@ class LatexCodeGenerator : public CodeOutputInterface
     void writeCodeAnchor(const char *) {}
     void setCurrentDoc(Definition *,const char *,bool) {}
     void addWord(const char *,bool) {}
+    static void setDoxyCodeOpen(bool val);
 
   private:
     void _writeCodeLink(const char *className,

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -97,7 +97,7 @@
 }
 
 % Used by @code ... @endcode
-\newenvironment{DoxyCode}{%
+\newenvironment{DoxyCode}[1]{%
   \par%
   \scriptsize%
   \normalfont\ttfamily%
@@ -106,7 +106,13 @@
   \settowidth{\CodeWidthChar}{?}%
   \settoheight{\CodeHeightChar}{?}%
   \setlength{\parskip}{0ex plus 0ex minus 0ex}%
-  {\lccode`~32 \lowercase{\global\let~}\NiceSpace}\obeyspaces%
+  \ifthenelse{\equal{#1}{0}}
+  {
+    {\lccode`~32 \lowercase{\global\let~}\NiceSpace}\obeyspaces%
+  }
+  {
+    {\lccode`~32 \lowercase{\global\let~}}\obeyspaces%
+  }
 
 }{%
   \normalfont%
@@ -128,8 +134,8 @@
 \fi
 
 % Used by @example, @include, @includelineno and @dontinclude
-\newenvironment{DoxyCodeInclude}{%
-  \DoxyCode%
+\newenvironment{DoxyCodeInclude}[1]{%
+	\DoxyCode{#1}%
 }{%
   \endDoxyCode%
 }


### PR DESCRIPTION
When code is used inside a problem occurs with \discretionary
- Inside a table \discretionary is disabled when code is used.
- \newline should not be appended to a code line (is already implicitly done by the command).