### PR TITLE
Bug 796355 - LaTeX: Class scrbook Error: undefined old font command `\tt'

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -218,7 +218,7 @@ void LatexDocVisitor::visit(DocURL *u)
     if (u->isEmail()) m_t << "mailto:";
     m_t << u->url() << "}";
   }
-  m_t << "{\\tt ";
+  m_t << "\\texttt{ ";
   filter(u->url());
   m_t << "}";
 }
@@ -1232,7 +1232,7 @@ void LatexDocVisitor::visitPre(DocHRef *href)
     m_t << href->url();
     m_t << "}";
   }
-  m_t << "{\\tt ";
+  m_t << "\\texttt{ ";
 }
 
 void LatexDocVisitor::visitPost(DocHRef *) 
@@ -1479,7 +1479,7 @@ void LatexDocVisitor::visitPre(DocParamList *pl)
   {
     if (pl->direction()!=DocParamSect::Unspecified)
     {
-      m_t << "\\mbox{\\tt ";
+      m_t << "\\mbox{\\texttt{ ";
       if (pl->direction()==DocParamSect::In)
       {
         m_t << "in";
@@ -1492,7 +1492,7 @@ void LatexDocVisitor::visitPre(DocParamList *pl)
       {
         m_t << "in,out";
       }
-      m_t << "} ";
+      m_t << "}} ";
     }
     if (useTable) m_t << " & ";
   }

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1373,7 +1373,7 @@ void LatexGenerator::startHtmlLink(const char *url)
     t << url;
     t << "}";
   }
-  t << "{\\tt ";
+  t << "\\texttt{ ";
 }
 
 void LatexGenerator::endHtmlLink()
@@ -1389,7 +1389,7 @@ void LatexGenerator::endHtmlLink()
 //    t << url;
 //    t << "}";
 //  }
-//  t << "{\\tt "; 
+//  t << "\\texttt{ ";
 //  docify(url);
 //  t << "}";
 //}
@@ -1397,7 +1397,7 @@ void LatexGenerator::endHtmlLink()
 void LatexGenerator::writeStartAnnoItem(const char *,const char *,
                                         const char *path,const char *name)
 {
-  t << "\\item\\contentsline{section}{\\bf ";
+  t << "\\item\\contentsline{section}\\textbf{ ";
   if (path) docify(path);
   docify(name); 
   t << "} ";
@@ -1432,7 +1432,7 @@ void LatexGenerator::endIndexValue(const char *name,bool /*hasBrief*/)
 //void LatexGenerator::writeClassLink(const char *,const char *,
 //                                    const char *,const char *name)
 //{
-//  t << "{\\bf ";
+//  t << "\\textbf{ ";
 //  docify(name);
 //  t << "}"; 
 //}


### PR DESCRIPTION
- Replaced \tt by \texttt
- Replaced the left over \bf by \textbf
and taking care that { } still match.