### PR TITLE
Bug 774597 - Title in rtf file is incorrect when overridden by user in extension file

### DIFF
--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -602,7 +602,7 @@ void RTFGenerator::endIndexSection(IndexSections is)
         t << rtf_Style_Reset << rtf_Style["Title"]->reference << endl; // set to title style
         if (rtf_title)
           // User has overridden document title in extensions file
-          t << "{\\field\\fldedit {\\*\\fldinst " << rtf_title << " \\\\*MERGEFORMAT}{\\fldrslt " << rtf_title << "}}\\par" << endl;
+          t << "{\\field\\fldedit {\\*\\fldinst TITLE \\\\*MERGEFORMAT}{\\fldrslt " << rtf_title << "}}\\par" << endl;
         else
         {
           DocText *root = validatingParseText(projectName);


### PR DESCRIPTION
Corrected title in case of extension file used.