### PR TITLE
Bug 782754 - rtf generation

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1935,21 +1935,7 @@ void ClassDef::writeDeclarationLink(OutputList &ol,bool &found,const char *heade
       if (rootNode && !rootNode->isEmpty())
       {
         ol.startMemberDescription(anchor());
-
-        ol.pushGeneratorState();
-        ol.disableAll();
-        ol.enable(OutputGenerator::RTF);
-        ol.writeString("{");
-        ol.popGeneratorState();
-
         ol.writeDoc(rootNode,this,0);
-
-        ol.pushGeneratorState();
-        ol.disableAll();
-        ol.enable(OutputGenerator::RTF);
-        ol.writeString("\\par}");
-        ol.popGeneratorState();
-
         if (isLinkableInProject())
         {
           writeMoreLink(ol,anchor());

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1639,11 +1639,11 @@ void RTFGenerator::endMemberDescription()
 {
   DBG_RTF(t << "{\\comment (endMemberDescription)}"    << endl)
   endEmphasis();
-  newParagraph();
+  //newParagraph();
   decrementIndentLevel();
-  //t << "\\par";
+  t << "\\par";
   t << "}" << endl;
-  //m_omitParagraph = TRUE;
+  m_omitParagraph = TRUE;
 }
 
 void RTFGenerator::startDescList(SectionTypes)


### PR DESCRIPTION
Looks like problem has been introduced with the fix for bug 445105 (release 1.5.3), in this case the \par is necessary.
The fix for bug 784281 (pull request #596) is related to this problem and the fix here is not necessary with this fix.
Bug 741547 - RTF: list of classes in Namespace Documentation not separated CRLF is also related to this problem.
Bug 595357 - wrong line breaks in rtf output format is also related to this problem.
Related to bug 778525, here 2 problems occur and the mangling is solved with this patch.