### PR TITLE
Bug 792918 - incorrect parsing of markdown table

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1590,15 +1590,15 @@ static int writeTableBlock(GrowBuf &out,const char *data,int size)
   int columns,start,end,cc;
 
   i = findTableColumns(data,size,start,end,columns);
-  
+
+  int headerStart = start;
+  int headerEnd = end;
+
 #ifdef USE_ORIGINAL_TABLES
   out.addStr("<table>");
 
   // write table header, in range [start..end]
   out.addStr("<tr>");
-
-  int headerStart = start;
-  int headerEnd = end;
 #endif
     
   // read cell alignments
@@ -1711,9 +1711,6 @@ static int writeTableBlock(GrowBuf &out,const char *data,int size)
   // allows us to handle row spanning.
   QVector<QVector<TableCell> > tableContents;
   tableContents.setAutoDelete(TRUE);
-
-  int headerStart = start;
-  int headerEnd = end;
 
   int m=headerStart;
   QVector<TableCell> *headerContents = new QVector<TableCell>(columns);


### PR DESCRIPTION
Problem due to the fact that for the display of the header line the size of the separator line was used. The headerStart and headerEnd have to be set before the next call to 'findTableColumns'

Related to:
- pull request #537 Add support for more CSS and column/row spanning in markdown tables
- pull request #542 Reverting pull request #537 until it will be fixed
- commit on 16/09/2017: New table features mentioned in the documentation were not enabled.