### PR TITLE
Doxygen manual doesn't have lines around markdown tables / cells.

### DIFF
--- a/doc/doxygen_manual.css
+++ b/doc/doxygen_manual.css
@@ -1554,7 +1554,7 @@ table.markdownTable {
 }
 
 table.markdownTable td, table.markdownTable th {
-	border: 1px solid ##37;
+	border: 1px solid #2D4068;
 	padding: 3px 7px 2px;
 }
 


### PR DESCRIPTION
In the chapter about markdown tables the tables lack the lines around the table and between the cells.
Reason is a wrong color in the doxygen_manual.css (taken value from the standard doxygen.css).

Regression on pull request #537