### PR TITLE
Problems and some enhancements for LaTeX tables

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -3505,14 +3505,34 @@ DocHtmlCell::Alignment DocHtmlCell::alignment() const
 {
   HtmlAttribList attrs = attribs();
   uint i;
-  for (i=0; i<attrs.count(); ++i) 
+  for (i=0; i<attrs.count(); ++i)
   {
     if (attrs.at(i)->name.lower()=="align")
     {
-      if (attrs.at(i)->value.lower()=="center") 
+      if (attrs.at(i)->value.lower()=="center")
         return Center;
-      else if (attrs.at(i)->value.lower()=="right") 
+      else if (attrs.at(i)->value.lower()=="right")
         return Right;
+      else return Left;
+    }
+    else if (attrs.at(i)->name.lower()=="class")
+    {
+      if (attrs.at(i)->value.lower()=="markdowntableheadcenter")
+        return Center;
+      else if (attrs.at(i)->value.lower()=="markdowntableheadright")
+        return Right;
+      else if (attrs.at(i)->value.lower()=="markdowntableheadleft")
+        return Left;
+      else if (attrs.at(i)->value.lower()=="markdowntableheadnone")
+        return Center;
+      else if (attrs.at(i)->value.lower()=="markdowntablebodycenter")
+        return Center;
+      else if (attrs.at(i)->value.lower()=="markdowntablebodyright")
+        return Right;
+      else if (attrs.at(i)->value.lower()=="markdowntablebodyleft")
+        return Left;
+      else if (attrs.at(i)->value.lower()=="markdowntablebodynone")
+        return Left;
       else return Left;
     }
   }


### PR DESCRIPTION
- Possibility to honor also the cell alignment when using Markdown tables for other formats (markdown.cpp, latexdocvisitor.cpp, lines: 1146, 1157, 1173)

latexdocvisitor.cpp:
- Possibility to nest tables to a further level when using LaTeX. It was only possible till level 2 (i.e. a longtabu followed buy a tabularx table). By placing tabularx in an extra set of brackets this is fixed (lines 938 and 951)
- tablarx environment cannot handle the headers as used for the longtabu table. A header line is in case of tabularx implemented by mimicking the header line.
  - longtabu needs multiple times the header line (first and following), tabularx we only need 1 (line 998)
  - no longtabu special headers (line 1092)
- tabularx cannot handle rowcolor, coloring done only with columncolor(line 1024, 1134, 1188)
- no necessity for longtabu to define column with for spanned columns / rows(line 1048, 1134, 1171)