### PR TITLE
Bug 782082 - Czech/Slovak language documentation with tables from LaTeX to PDF is not possible

### DIFF
--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -96,7 +96,13 @@ class TranslatorCzech : public Translator
     virtual QCString latexLanguageSupportCommand()
     {
       return "\\usepackage[T2A]{fontenc}\n"
-             "\\usepackage[czech]{babel}\n";
+             "\\usepackage[czech]{babel}\n"
+             "\\usepackage{regexpatch}\n"
+             "\\makeatletter\n"
+             "% Change the `-` delimiter to an active character\n"
+             "\\xpatchparametertext\\@@@cmidrule{-}{\\cA-}{}{}\n"
+             "\\xpatchparametertext\\@cline{-}{\\cA-}{}{}\n"
+             "\\makeatother\n";
     }
 
     // --- Language translation methods -------------------

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -41,8 +41,14 @@ class TranslatorSlovak : public Translator
     { return "slovak"; }
 
     virtual QCString latexLanguageSupportCommand()
-    { return "\\usepackage[slovak]{babel}\n"; }
-
+    { return "\\usepackage[slovak]{babel}\n"
+             "\\usepackage{regexpatch}\n"
+             "\\makeatletter\n"
+             "% Change the `-` delimiter to an active character\n"
+             "\\xpatchparametertext\\@@@cmidrule{-}{\\cA-}{}{}\n"
+             "\\xpatchparametertext\\@cline{-}{\\cA-}{}{}\n"
+             "\\makeatother\n";
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */


### PR DESCRIPTION
Added commands as indicated to overrule \cline and \cmidrule due to problems with `-`