### PR TITLE
Drop down lists in menu bar missing

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -167,6 +167,14 @@ ul {
   overflow: hidden; /*Fixed: list item bullets overlap floating elements*/
 }
 
+#side-nav ul {
+  overflow: visible; /* reset ul rule for scroll bar in GENERATE_TREEVIEW window */
+}
+
+#main-nav ul {
+  overflow: visible; /* reset ul rule for the navigation bar drop down lists */
+}
+
 .fragment {
   text-align: left;
   direction: ltr;


### PR DESCRIPTION
As a result of pull request #636 the drop down lists in the main bar don't work anymore, furthermore the treeview is lacking the scrollbar when a text is to long (text is not shown.