### PR TITLE
Bug 796494 - Collapsed treeview arrow displays as emoji in Microsoft Edge

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -257,7 +257,7 @@ void FTVHelp::generateIndent(FTextStream &t, FTVNode *n,bool opened)
   while (p) { indent++; p=p->parent; }
   if (n->isDir)
   {
-    QCString dir = opened ? "&#9660;" : "&#9654;";
+    QCString dir = opened ? "&#9660;" : "&#9658;";
     t << "<span style=\"width:" << (indent*16) << "px;display:inline-block;\">&#160;</span>"
       << "<span id=\"arr_" << generateIndentLabel(n,0) << "\" class=\"arrow\" ";
     t << "onclick=\"toggleFolder('" << generateIndentLabel(n,0) << "')\"";

--- a/templates/html/dynsections.js
+++ b/templates/html/dynsections.js
@@ -60,7 +60,7 @@ function toggleLevel(level)
       $(this).show();
     } else if (l==level+1) {
       i.removeClass('iconfclosed iconfopen').addClass('iconfclosed');
-      a.html('&#9654;');
+      a.html('&#9658;');
       $(this).show();
     } else {
       $(this).hide();
@@ -87,7 +87,7 @@ function toggleFolder(id)
     // replace down arrow by right arrow for current row
     var currentRowSpans = currentRow.find("span");
     currentRowSpans.filter(".iconfopen").removeClass("iconfopen").addClass("iconfclosed");
-    currentRowSpans.filter(".arrow").html('&#9654;');
+    currentRowSpans.filter(".arrow").html('&#9658;');
     rows.filter("[id^=row_"+id+"]").hide(); // hide all children
   } else { // we are SHOWING
     // replace right arrow by down arrow for current row
@@ -97,7 +97,7 @@ function toggleFolder(id)
     // replace down arrows by right arrows for child rows
     var childRowsSpans = childRows.find("span");
     childRowsSpans.filter(".iconfopen").removeClass("iconfopen").addClass("iconfclosed");
-    childRowsSpans.filter(".arrow").html('&#9654;');
+    childRowsSpans.filter(".arrow").html('&#9658;');
     childRows.show(); //show all children
   }
   updateStripes();

--- a/templates/html/htmldirtree.tpl
+++ b/templates/html/htmldirtree.tpl
@@ -20,7 +20,7 @@
   {% else %}
     <span style="width:{{ (node.level)*16 }}px;display:inline-block;">&#160;</span>
     <span id="arr_{{ node.id }}" class="arrow" onclick="toggleFolder('{{ node.id}}')">
-       {%if node.level+1<tree.preferredDepth %}&#9660;{% else %}&#9654;{% endif %}
+       {%if node.level+1<tree.preferredDepth %}&#9660;{% else %}&#9658;{% endif %}
     </span>
   {% endif %}
   {% if node.namespace %}

--- a/templates/html/navtree.js
+++ b/templates/html/navtree.js
@@ -23,7 +23,7 @@
  */
 var navTreeSubIndices = new Array();
 var arrowDown = '&#9660;';
-var arrowRight = '&#9654;';
+var arrowRight = '&#9658;';
 
 function getData(varName)
 {


### PR DESCRIPTION
The right  arrow (\&#9654;) is in Microsoft Edge displayed as an Emoji it displays as a white arrow inside a blue square with a black border instead of a monochrome arrow. Unicode contains another right arrow (\&#9258;) which displays correctly (also in Chrome, Opera, FireFox, Internet Explorer; in some even better).

The Unicode naming is a bit confusing:
- for the down arrow we only have:
  - \&#9660;  'BLACK DOWN-POINTING TRIANGLE'
- for the right arrow we have:
  - \&#9654; 'BLACK RIGHT-POINTING TRIANGLE'
  - \&#9658; 'BLACK RIGHT-POINTING POINTER'

so it looks logical to use both Triangles but this is not the case.