### PR TITLE
Add formula (images) to RTF output

### DIFF
--- a/doc/formulas.doc
+++ b/doc/formulas.doc
@@ -17,9 +17,8 @@
 /*! \page formulas Including formulas 
 
 Doxygen allows you to put \LaTeX formulas in the
-output (this works only for the HTML and \LaTeX output, 
-not for the RTF nor for the man page output). To be able to include 
-formulas (as images) in the HTML documentation, you will also need to 
+output (this works only for the HTML, \LaTeX and RTF output. To be able to include 
+formulas (as images) in the HTML and RTF documentation, you will also need to 
 have the following tools installed
 <ul>
 <li>\c latex: the \LaTeX compiler, needed to parse the formulas. 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11558,6 +11558,12 @@ void generateOutput()
     Doxygen::formulaList->generateBitmaps(Config_getString(HTML_OUTPUT));
     g_s.end();
   }
+  if (Doxygen::formulaList->count()>0 && generateRtf)
+  {
+    g_s.begin("Generating bitmaps for formulas in RTF...\n");
+    Doxygen::formulaList->generateBitmaps(Config_getString(RTF_OUTPUT));
+    g_s.end();
+  }
 
   if (Config_getBool(SORT_GROUP_NAMES))
   {

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -526,9 +526,21 @@ void RTFDocVisitor::visit(DocIncOperator *op)
 void RTFDocVisitor::visit(DocFormula *f)
 {
   if (m_hide) return;
-  // TODO: do something sensible here, like including a bitmap
   DBG_RTF("{\\comment RTFDocVisitor::visit(DocFormula)}\n");
-  m_t << f->text();
+  bool bDisplay = !f->isInline();
+  if (bDisplay) 
+  {
+    m_t << "\\par";
+    m_t << "{";
+    m_t << "\\pard\\plain";
+    m_t << "\\pard";
+    m_t << "\\qc";
+  }
+  m_t << "{ \\field\\flddirty {\\*\\fldinst  INCLUDEPICTURE \"" << f->relPath() << f->name() << ".png\" \\\\d \\\\*MERGEFORMAT}{\\fldrslt Image}}";
+  if (bDisplay) 
+  {
+    m_t << "\\par}";
+  }
   m_lastIsPara=FALSE;
 }
 


### PR DESCRIPTION
The RTF output was lacking the possibility to have formulas in it (were written as text). This patch generates the images analogous to the HTML, non MATHJAX, version and includes them in the output.