### PR TITLE
Bug 363762 - Tooltips are not shown in dot-generated graphs

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -3483,9 +3483,10 @@ DotInclDepGraph::DotInclDepGraph(FileDef *fd,bool inverse)
   m_inclDepFileName   = fd->includeDependencyGraphFileName();
   m_inclByDepFileName = fd->includedByDependencyGraphFileName();
   QCString tmp_url=fd->getReference()+"$"+fd->getOutputFileBase();
+  QCString tooltip = fd->briefDescriptionAsTooltip();
   m_startNode = new DotNode(m_curNodeNumber++,
                             fd->docName(),
-                            "",
+                            tooltip,
                             tmp_url.data(),
                             TRUE     // root node
                            );
@@ -3812,9 +3813,10 @@ DotCallGraph::DotCallGraph(MemberDef *md,bool inverse)
   {
     name = md->qualifiedName();
   }
+  QCString tooltip = md->briefDescriptionAsTooltip();
   m_startNode = new DotNode(m_curNodeNumber++,
                             linkToText(md->getLanguage(),name,FALSE),
-                            "",
+                            tooltip,
                             uniqueId.data(),
                             TRUE     // root node
                            );
@@ -4336,7 +4338,8 @@ DotGroupCollaboration::DotGroupCollaboration(GroupDef* gd)
 {
     QCString tmp_url = gd->getReference()+"$"+gd->getOutputFileBase();
     m_usedNodes = new QDict<DotNode>(1009);
-    m_rootNode = new DotNode(m_curNodeNumber++, gd->groupTitle(), "", tmp_url, TRUE );
+    QCString tooltip = gd->briefDescriptionAsTooltip();
+    m_rootNode = new DotNode(m_curNodeNumber++, gd->groupTitle(), tooltip, tmp_url, TRUE );
     m_rootNode->markAsVisible();
     m_usedNodes->insert(gd->name(), m_rootNode );
     m_edges.setAutoDelete(TRUE);

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1878,10 +1878,10 @@ void DotNode::writeBox(FTextStream &t,
           << m_url.right(m_url.length()-anchorPos) << "\"";
       }
     }
-    if (!m_tooltip.isEmpty())
-    {
-      t << ",tooltip=\"" << escapeTooltip(m_tooltip) << "\"";
-    }
+  }
+  if (!m_tooltip.isEmpty())
+  {
+    t << ",tooltip=\"" << escapeTooltip(m_tooltip) << "\"";
   }
   t << "];" << endl; 
 }


### PR DESCRIPTION
The basic problem mentioned in this issue was already solved in Mai 2009 (version 1.5.8 or earlier), in case a brief description is present this is displayed otherwise the node  number is specified)
A remaining thing was that the tooltip with the root nodes (gray nodes) was always something like Node0 irrespective of the brief description. This has been solved here.