### PR TITLE
Bug 363762 - Tooltips are not shown in dot-generated graphs (extension)

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1883,6 +1883,10 @@ void DotNode::writeBox(FTextStream &t,
   {
     t << ",tooltip=\"" << escapeTooltip(m_tooltip) << "\"";
   }
+  else
+  {
+    t << ",tooltip=\" \""; // space in tooltip is required otherwise still something like 'Node0' is used
+  }
   t << "];" << endl; 
 }
 


### PR DESCRIPTION
In case no brief description present, no tooltip is shown.