### PR TITLE
Resolve inconsistency in formula repositories.

### DIFF
--- a/doc/formulas.doc
+++ b/doc/formulas.doc
@@ -100,8 +100,8 @@ the section should contain valid command for the specific environment.
 
 \warning Currently, doxygen is not very fault tolerant in recovering 
 from typos in formulas. It may be necessary to remove the
-file <code>formula.repository</code> that is written to the html directory to 
-get rid of an incorrect formula.
+files <code>formula.repository</code> that are written to the html and rtf directories to 
+get rid of an incorrect formula as well as the <code>form_*</code> files.
 
 \htmlonly
 Go to the <a href="tables.html">next</a> section or return to the

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9752,14 +9752,17 @@ int readFileOrDirectory(const char *s,
 
 //----------------------------------------------------------------------------
 
-void readFormulaRepository()
+void readFormulaRepository(QCString dir, bool cmp)
 {
-  QFile f(Config_getString(HTML_OUTPUT)+"/formula.repository");
+  static int current_repository = 0; 
+  int new_repository = 0; 
+  QFile f(dir+"/formula.repository");
   if (f.open(IO_ReadOnly)) // open repository
   {
     msg("Reading formula repository...\n");
     QTextStream t(&f);
     QCString line;
+    Formula *f;
     while (!t.eof())
     {
       line=t.readLine().utf8();
@@ -9773,13 +9776,41 @@ void readFormulaRepository()
       {
         QCString formName = line.left(se);
         QCString formText = line.right(line.length()-se-1);
-        Formula *f=new Formula(formText);
-        Doxygen::formulaList->setAutoDelete(TRUE);
-        Doxygen::formulaList->append(f);
-        Doxygen::formulaDict->insert(formText,f);
-        Doxygen::formulaNameDict->insert(formName,f);
+        if (cmp)
+        {
+          if ((f=Doxygen::formulaDict->find(formText))==0)
+          {
+            err("discrepancy between formula repositories! Remove "
+                "formula.repository and from_* files from output directories.");
+            exit(1);
+          }
+          QCString formLabel;
+          formLabel.sprintf("\\form#%d",f->getId());
+          if (formLabel != formName)
+          {
+            err("discrepancy between formula repositories! Remove "
+                "formula.repository and from_* files from output directories.");
+            exit(1);
+          }
+          new_repository++;
+        }
+        else
+        {
+          f=new Formula(formText);
+          Doxygen::formulaList->setAutoDelete(TRUE);
+          Doxygen::formulaList->append(f);
+          Doxygen::formulaDict->insert(formText,f);
+          Doxygen::formulaNameDict->insert(formName,f);
+          current_repository++;
+        }
       }
     }
+  }
+  if (cmp && (current_repository != new_repository))
+  {
+    err("size discrepancy between formula repositories! Remove "
+        "formula.repository and from_* files from output directories.");
+    exit(1);
   }
 }
 
@@ -11070,7 +11101,12 @@ void parseInput()
 
   if (Config_getBool(GENERATE_HTML))
   {
-    readFormulaRepository();
+    readFormulaRepository(Config_getString(HTML_OUTPUT));
+  }
+  if (Config_getBool(GENERATE_RTF))
+  {
+    // in case GENERRATE_HTML is set we just have to compare, both repositories should be identical
+    readFormulaRepository(Config_getString(RTF_OUTPUT),Config_getBool(GENERATE_HTML));
   }
 
   /**************************************************************************

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -159,7 +159,7 @@ void searchInputFiles(StringList &inputFiles);
 void parseInput();
 void generateOutput();
 void readAliases();
-void readFormulaRepository();
+void readFormulaRepository(QCString dir, bool cmp = FALSE);
 void cleanUpDoxygen();
 int readFileOrDirectory(const char *s,
                         FileNameList *fnList,


### PR DESCRIPTION
HTML and RTF have their own directory with formula repository files. These can get out of sync when HTML and RTF versions are not always build together (and both are required again).