### PR TITLE
Bug 792449 -  markdown plantuml use of graphviz fails in plantuml, works in code file

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -88,7 +88,9 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
   {
     pumlArgs += "-graphvizdot \"";
     pumlArgs += dotPath;
-    pumlArgs += "dot\" ";
+    pumlArgs += "dot";
+    pumlArgs += portable_commandExtension();
+    pumlArgs += "\" ";
   }
   pumlArgs+="-o \"";
   pumlArgs+=outDir;


### PR DESCRIPTION
Added the commandExtension as required by plantuml in case the path is given.