### PR TITLE
Bug 124252 - A function cannot be documented as related to two classes.

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2544,12 +2544,23 @@ static bool handleEndParBlock(const QCString &)
 
 static bool handleRelated(const QCString &)
 {
+  if (!current->relates.isEmpty())
+  {
+    warn(yyFileName,yyLineNr,
+	"found multiple \\relates, \\relatesalso or \\memberof commands in a comment block, using last definition");
+  }
+  current->relatesType = Simple;
   BEGIN(RelatesParam1);
   return FALSE;
 }
 
 static bool handleRelatedAlso(const QCString &)
 {
+  if (!current->relates.isEmpty())
+  {
+    warn(yyFileName,yyLineNr,
+	"found multiple \\relates, \\relatesalso or \\memberof commands in a comment block, using last definition");
+  }
   current->relatesType = Duplicate;
   BEGIN(RelatesParam1);
   return FALSE;
@@ -2557,6 +2568,11 @@ static bool handleRelatedAlso(const QCString &)
 
 static bool handleMemberOf(const QCString &)
 {
+  if (!current->relates.isEmpty())
+  {
+    warn(yyFileName,yyLineNr,
+	"found multiple \\relates, \\relatesalso or \\memberof commands in a comment block, using last definition");
+  }
   current->relatesType = MemberOf;
   BEGIN(RelatesParam1);
   return FALSE;


### PR DESCRIPTION
Multiple use in one comment block of \relates or \relatesalso or \memberof or a mixture is silently ignored (only last command is active).
In this patch a warning is given and the right relatesType is set (in case of Simple the previous type remained).