### PR TITLE
Bug 784752 - Spurious error message when a conditional block contains a defgroup

### DIFF
--- a/src/commentscan.h
+++ b/src/commentscan.h
@@ -71,6 +71,10 @@ bool parseCommentBlock(ParserInterface *parser,
                        int &position,
                        bool &newEntryNeeded
 		     );
+/**
+ * Routine to set the state of the `parseCommentBlock` in respect to `\if` stack
+ */
+void setParseMore(const bool state);
 
 void groupEnterFile(const char *file,int line);
 void groupLeaveFile(const char *file,int line);

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2926,8 +2926,8 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
   //    isBrief,isAutoBriefOn,lineNr);
 
   initParser();
-  guards.setAutoDelete(TRUE);
-  guards.clear();
+  if (!parseMore)guards.setAutoDelete(TRUE);
+  if (!parseMore)guards.clear();
   langParser     = parser;
   current        = curEntry;
   if (comment.isEmpty()) return FALSE; // avoid empty strings
@@ -2983,7 +2983,7 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
     addOutput(getOverloadDocs());
   }
 
-  if (!guards.isEmpty())
+  if (!guards.isEmpty() && !parseMore)
   {
     warn(yyFileName,yyLineNr,"Documentation block ended in the middle of a conditional section!");
   }
@@ -3039,6 +3039,11 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
 }
 
 //---------------------------------------------------------------------------
+
+void setParseMore(const bool state)
+{
+  parseMore = state;
+}
 
 void groupEnterFile(const char *fileName,int)
 {

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2427,6 +2427,7 @@ static void handleCommentBlock(const QCString &doc,bool brief)
   }
   DBG_CTX((stderr,"call parseCommentBlock [%s]\n",doc.data()));
   int lineNr = brief ? current->briefLine : current->docLine;
+  setParseMore(FALSE);
   while (parseCommentBlock(
 	g_thisParser,
 	docBlockInBody ? subrCurrent.getFirst() : current,

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2611,6 +2611,7 @@ void MarkdownFileParser::parseInput(const char *fileName,
 
   bool needsEntry = FALSE;
   Protection prot=Public;
+  setParseMore(FALSE);
   while (parseCommentBlock(
         this,
         current,

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -322,6 +322,7 @@ static void handleCommentBlock(const QCString &doc,bool brief)
   int position = 0;
   bool needsEntry;
   int lineNr = brief ? current->briefLine : current->docLine;
+  setParseMore(FALSE);
   while (parseCommentBlock(
 	g_thisParser,
 	(docBlockInBody && previous) ? previous : current,

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6695,6 +6695,7 @@ static void handleCommentBlock(const QCString &doc,bool brief)
     docEntry->inbodyLine = lineNr;
   }
 
+  setParseMore(FALSE);
   while (parseCommentBlock(
 	g_thisParser,
 	docBlockInBody && previous ? previous : current,
@@ -6754,6 +6755,7 @@ static void handleParametersCommentBlocks(ArgumentList *al)
       current->brief.resize(0);
 
       //printf("handleParametersCommentBlock [%s]\n",doc.data());
+      setParseMore(FALSE);
       while (parseCommentBlock(
 	     g_thisParser,
 	     current,

--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -1524,6 +1524,7 @@ tcl_inf("-> %s\n",(const char *)tcl.string_comment);
 
         myPos0=myPos;
         myLine0=myLine;
+        setParseMore(FALSE);
         while (parseCommentBlock(tcl.this_parser, &myEntry0, myDoc, tcl.file_name,
           myLine, FALSE, tcl.config_autobrief, FALSE, myProt, myPos, myNew))
         {
@@ -1568,6 +1569,7 @@ tcl_inf("-> %s\n",(const char *)tcl.string_comment);
       else
       { // new entry
         tcl.entry_current = tcl_entry_new();
+        setParseMore(FALSE);
         while (parseCommentBlock(tcl.this_parser, tcl.entry_current, myDoc,
           tcl.file_name, myLine, FALSE, tcl.config_autobrief, FALSE,
           myProt, myPos, myNew))

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -290,6 +290,7 @@ void VhdlParser::handleCommentBlock(const char* doc1,bool brief)
     current->stat=true;
   }
 
+  setParseMore(FALSE);
   while (parseCommentBlock(
         g_thisParser,
         current,


### PR DESCRIPTION
Some commands (a.o. \defgroup) terminate the comment scanner and afterwards the comment scanner is "continued" but the state is not remembered but should have been (at least in respect to the "\if" stack).
To be in a defined stated the state is explicitly reset when a new file (block) is started).