### PR TITLE
Bug 630931 - \cond after @string literal containing backslash fails in C#

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1739,6 +1739,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 %x	SkipString
 %x	CopyLine
 %x	CopyString
+%x	CopyStringCs
 %x	CopyStringFtn
 %x      Include
 %x      IncludeID
@@ -1849,6 +1850,11 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 <CopyLine>"'"."'"			{ 
   					  outputArray(yytext,(int)yyleng);
 					}
+<CopyLine>@\"				{
+                                          if (getLanguageFromFileName(g_yyFileName)!=SrcLangExt_CSharp) REJECT;
+					  outputArray(yytext,(int)yyleng);
+					  BEGIN( CopyStringCs );
+					}
 <CopyLine>\"				{
 					  outputChar(*yytext);
 					  BEGIN( CopyString );
@@ -1861,10 +1867,13 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 <CopyString>[^\"\\\r\n]+		{
   					  outputArray(yytext,(int)yyleng);
 					}
+<CopyStringCs>[^\"\r\n]+		{
+  					  outputArray(yytext,(int)yyleng);
+					}
 <CopyString>\\.				{
 					  outputArray(yytext,(int)yyleng);
 					}
-<CopyString>\"				{
+<CopyString,CopyStringCs>\"		{
 					  outputChar(*yytext);
 					  BEGIN( CopyLine );
 					}


### PR DESCRIPTION
Special handling in preprocessor for CSharp literal strings (i.e. strings starting with @).