### PR TITLE
Bug 734308 - Error message when using memberof in a C macro

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -671,6 +671,10 @@ void ClassDef::internalInsertMember(MemberDef *md,
               case MemberType_Variable:
                 addMemberToList(MemberListType_variableMembers,md,FALSE);
                 break;
+              case MemberType_Define:
+                warn(md->getDefFileName(),md->getDefLine()-1,"A define (%s) cannot be made a member of %s",
+                     md->name().data(), this->name().data());
+                break;
               default:
                 err("Unexpected member type %d found!\n",md->memberType());
             }


### PR DESCRIPTION
Made a better warning message, a 'define' is a global setting and cannot be made a member of a struct / class.