### PR TITLE
Bug 796621 - @cond does not stop at @endcond Fortran

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -591,7 +591,15 @@ void replaceComment(int offset);
                                      copyToOutput(yytext,(int)yyleng); 
                                    }
 <SkipString>\\.                    { /* escaped character in string */
-                                     copyToOutput(yytext,(int)yyleng); 
+                                     if (g_lang==SrcLangExt_Fortran)
+                                     {
+                                       unput(yytext[1]);
+                                       copyToOutput(yytext,1);
+                                     }
+                                     else
+                                     {
+                                       copyToOutput(yytext,(int)yyleng);
+                                     }
                                    }
 <SkipString>"\""       	           { /* end of string */ 
                                      copyToOutput(yytext,(int)yyleng); 
@@ -604,7 +612,15 @@ void replaceComment(int offset);
                                      copyToOutput(yytext,(int)yyleng); 
                                    }
 <SkipChar>\\.		           { /* escaped character */
-                                     copyToOutput(yytext,(int)yyleng); 
+                                     if (g_lang==SrcLangExt_Fortran)
+                                     {
+                                       unput(yytext[1]);
+                                       copyToOutput(yytext,1);
+                                     }
+                                     else
+                                     {
+                                       copyToOutput(yytext,(int)yyleng);
+                                     }
                                    }
 <SkipChar>'                        { /* end of character literal */ 
                                      copyToOutput(yytext,(int)yyleng); 

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1194,9 +1194,6 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 					    g_insideBody=FALSE;
                                         }
  /*------ strings --------------------------------------------------*/ 
-<*>"\\\\"                               { str+=yytext; /* ignore \\  */}
-<*>"\\\""|\\\'                          { str+=yytext; /* ignore \"  */}
-
 <String>\n                              { // string with \n inside
 					  g_contLineNr++;
                                           str+=yytext;

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -383,14 +383,6 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
 
  /*------ ignore strings that are not initialization strings */ 
-<*>"\\\\"				{ if (yy_top_state() == Initialization
-					      || yy_top_state() == ArrayInitializer)
-					    initializer+=yytext;
-					}
-<*>"\\\""|\\\'                          { if (yy_top_state() == Initialization
-					      || yy_top_state() == ArrayInitializer)
-					    initializer+=yytext;
-					}
 <String>\"|\'                           { // string ends with next quote without previous backspace
                                           if (yytext[0]!=stringStartSymbol) { yyColNr -= (int)yyleng; REJECT; } // single vs double quote
 					  if (yy_top_state() == Initialization

--- a/src/pre.l
+++ b/src/pre.l
@@ -1740,6 +1740,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 %x	CopyLine
 %x	CopyString
 %x	CopyStringFtn
+%x	CopyStringFtnDouble
 %x      Include
 %x      IncludeID
 %x      EndImport
@@ -1851,7 +1852,14 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 					}
 <CopyLine>\"				{
 					  outputChar(*yytext);
-					  BEGIN( CopyString );
+                                          if (getLanguageFromFileName(g_yyFileName)!=SrcLangExt_Fortran)
+                                          {
+					    BEGIN( CopyString );
+                                          }
+                                          else
+                                          {
+					    BEGIN( CopyStringFtnDouble );
+                                          }
 					}
 <CopyLine>\'				{
                                           if (getLanguageFromFileName(g_yyFileName)!=SrcLangExt_Fortran) REJECT;
@@ -1859,7 +1867,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 					  BEGIN( CopyStringFtn );
 					}
 <CopyString>[^\"\\\r\n]+		{
-  					  outputArray(yytext,(int)yyleng);
+					  outputArray(yytext,(int)yyleng);
 					}
 <CopyString>\\.				{
 					  outputArray(yytext,(int)yyleng);
@@ -1868,8 +1876,18 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 					  outputChar(*yytext);
 					  BEGIN( CopyLine );
 					}
+<CopyStringFtnDouble>[^\"\\\r\n]+	{
+					  outputArray(yytext,(int)yyleng);
+					}
+<CopyStringFtnDouble>\\.		{
+					  outputArray(yytext,(int)yyleng);
+					}
+<CopyStringFtnDouble>\"			{
+					  outputChar(*yytext);
+					  BEGIN( CopyLine );
+					}
 <CopyStringFtn>[^\'\\\r\n]+		{
-  					  outputArray(yytext,(int)yyleng);
+					  outputArray(yytext,(int)yyleng);
 					}
 <CopyStringFtn>\\.			{
 					  outputArray(yytext,(int)yyleng);


### PR DESCRIPTION
The backslash (\) is in Fortran not an escape character but was handled as such, this has been corrected.
Handling of the different Fortran string types ('...' and "...") made more consistent.