### PR TITLE
Bug 565713 - Fortran: Does not recognize backslash at end of documentation line

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1934,6 +1934,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 					  }
   					}
 <CopyLine>"\\"\r?/\n			{ // strip line continuation characters
+                                          if (getLanguageFromFileName(g_yyFileName)==SrcLangExt_Fortran) outputChar(*yytext);
   					}
 <CopyLine>.				{
   					  outputChar(*yytext);


### PR DESCRIPTION
Don't remove the end backslash in case of Fortran