### PR TITLE
Bug 784322 - .tex file is wrong when generating a function whose name includes an underline

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2150,7 +2150,7 @@ void LatexGenerator::endParameterList()
 void LatexGenerator::startParameterType(bool first,const char *key)
 {
   t << "\\item[{";
-  if (!first && key) t << key;
+  if (!first && key) docify(key);
 }
 
 void LatexGenerator::endParameterType()


### PR DESCRIPTION
Correctly write the text to the text file (i.e. escape some characters)