### PR TITLE
Bug 693515 - The 'Examples:' section; bad/missing style and incorrect spelling

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1013,13 +1013,13 @@ void ClassDef::writeDetailedDocumentationBody(OutputList &ol)
   // write examples
   if (hasExamples() && m_impl->exampleSDict)
   {
-    ol.startSimpleSect(BaseOutputDocInterface::Examples,0,0,theTranslator->trExamples()+": ");
+    ol.startSimpleSect(BaseOutputDocInterface::Examples,0,0,theTranslator->trExamples());
     ol.startDescForItem();
     //ol.startParagraph();
     writeExample(ol,m_impl->exampleSDict);
     //ol.endParagraph();
     ol.endDescForItem();
-    ol.endSimpleSect();
+    ol.endSimpleSect(BaseOutputDocInterface::Examples);
   }
   //ol.newParagraph();
   writeSourceDef(ol,name());

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1942,10 +1942,20 @@ void HtmlGenerator::endDescTableData()
   t << "</td>";
 }
 
-void HtmlGenerator::startSimpleSect(SectionTypes,
+void HtmlGenerator::startSimpleSect(SectionTypes sect,
                                 const char *filename,const char *anchor,
                                 const char *title)
 {
+  if (sect == BaseOutputDocInterface::Examples)
+  {
+    QCString className;
+    className="examples";
+    t << "<dl class=\"" << className << "\"><dt>";
+    docify(title);
+    t << "</dt>" << endl;
+    return;
+  }
+
   t << "<dl><dt><b>";
   if (filename)
   {
@@ -1958,8 +1968,13 @@ void HtmlGenerator::startSimpleSect(SectionTypes,
   t << "</b></dt>";
 }
 
-void HtmlGenerator::endSimpleSect()
+void HtmlGenerator::endSimpleSect(SectionTypes sect)
 {
+  if (sect == BaseOutputDocInterface::Examples)
+  {
+    t << "</dl>" << endl;
+    return;
+  }
   t << "</dl>";
 }
 

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -249,7 +249,7 @@ class HtmlGenerator : public OutputGenerator
     //void startDescList(SectionTypes)      { t << "<dl compact><dt><b>" << endl; }
     //void endDescList()        { t << "</dl>"; }
     void startSimpleSect(SectionTypes,const char *,const char *,const char *);
-    void endSimpleSect();
+    void endSimpleSect(SectionTypes);
     void startParamList(ParamListTypes,const char *);
     void endParamList();
     //void writeDescItem()      { t << "<dd>" << endl; }

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2119,7 +2119,7 @@ void LatexGenerator::startSimpleSect(SectionTypes,const char *file,
   t << "]";
 }
 
-void LatexGenerator::endSimpleSect()
+void LatexGenerator::endSimpleSect(SectionTypes)
 {
   t << "\\end{Desc}" << endl;
 }

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -236,7 +236,7 @@ class LatexGenerator : public OutputGenerator
     void startDescList(SectionTypes)     { t << "\\begin{Desc}\n\\item["; }
     void endDescList()       { t << "\\end{Desc}" << endl; }
     void startSimpleSect(SectionTypes,const char *,const char *,const char *);
-    void endSimpleSect();
+    void endSimpleSect(SectionTypes);
     void startParamList(ParamListTypes,const char *title);
     void endParamList();
     void startDescForItem()     { t << "\\par" << endl; }

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -665,7 +665,7 @@ void ManGenerator::startSimpleSect(SectionTypes,const char *,
   paragraph=TRUE;
 }
 
-void ManGenerator::endSimpleSect()
+void ManGenerator::endSimpleSect(SectionTypes)
 {
 }
 

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -170,7 +170,7 @@ class ManGenerator : public OutputGenerator
     void startDescList(SectionTypes);
     void endDescList()        {}
     void startSimpleSect(SectionTypes,const char *,const char *,const char *);
-    void endSimpleSect();
+    void endSimpleSect(SectionTypes);
     void startParamList(ParamListTypes,const char *title);
     void endParamList();
     //void writeDescItem();
@@ -199,7 +199,7 @@ class ManGenerator : public OutputGenerator
     
     void startDescTable(const char *t) 
     { startSimpleSect(EnumValues,0,0,t); startDescForItem(); }
-    void endDescTable() { endDescForItem(); endSimpleSect(); }
+    void endDescTable() { endDescForItem(); endSimpleSect(BaseOutputDocInterface::NONE); }
     void startDescTableRow() {}
     void endDescTableRow() {}
     void startDescTableTitle() { startItemListItem(); startBold(); startEmphasis(); endItemListItem(); }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2309,11 +2309,11 @@ void MemberDef::_writeExamples(OutputList &ol)
   // write the list of examples that use this member
   if (hasExamples())
   {
-    ol.startSimpleSect(BaseOutputDocInterface::Examples,0,0,theTranslator->trExamples()+": ");
+    ol.startSimpleSect(BaseOutputDocInterface::Examples,0,0,theTranslator->trExamples());
     ol.startDescForItem();
     writeExample(ol,m_impl->exampleSDict);
     ol.endDescForItem();
-    ol.endSimpleSect();
+    ol.endSimpleSect(BaseOutputDocInterface::Examples);
   }
 }
 

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -145,7 +145,9 @@ class BaseOutputDocInterface : public CodeOutputInterface
                         Since, Date, Bug, Note,
                         Warning, Par, Deprecated, Pre, 
                         Post, Invar, Remark, Attention, 
-                        Todo, Test, RCS, */ EnumValues, 
+                        Todo, Test, RCS, */
+	                NONE, 
+	                EnumValues, 
                         Examples 
                       };
 
@@ -281,7 +283,7 @@ class BaseOutputDocInterface : public CodeOutputInterface
 
     virtual void startSimpleSect(SectionTypes t,const char *file,
                                  const char *anchor,const char *title) = 0;
-    virtual void endSimpleSect() = 0;
+    virtual void endSimpleSect(SectionTypes t = NONE) = 0;
     virtual void startParamList(ParamListTypes t,const char *title) = 0;
     virtual void endParamList() = 0;
 

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -324,8 +324,8 @@ class OutputList : public OutputDocInterface
     void startSimpleSect(SectionTypes t,const char *file,const char *anchor,
                          const char *title) 
     { forall(&OutputGenerator::startSimpleSect,t,file,anchor,title); }
-    void endSimpleSect() 
-    { forall(&OutputGenerator::endSimpleSect); }
+    void endSimpleSect(SectionTypes t) 
+    { forall(&OutputGenerator::endSimpleSect,t); }
     void startParamList(ParamListTypes t,const char *title) 
     { forall(&OutputGenerator::startParamList,t,title); }
     void endParamList() 

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2749,7 +2749,7 @@ void RTFGenerator::startSimpleSect(SectionTypes,const char *file,const char *anc
   t << rtf_Style_Reset << rtf_DList_DepthStyle();
 }
 
-void RTFGenerator::endSimpleSect()
+void RTFGenerator::endSimpleSect(SectionTypes)
 {
   DBG_RTF(t << "{\\comment (endSimpleSect)}"    << endl)
   m_omitParagraph = FALSE;

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -165,7 +165,7 @@ class RTFGenerator : public OutputGenerator
                       const char *,const char *,const char *) {}
     void startDescList(SectionTypes);
     void startSimpleSect(SectionTypes,const char *,const char *,const char *);
-    void endSimpleSect();
+    void endSimpleSect(SectionTypes);
     void startParamList(ParamListTypes,const char *);
     void endParamList();
     //void writeDescItem();

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -687,7 +687,7 @@ dl.reflist dd {
         line-height: 14px;
 }
 
-.params, .retval, .exception, .tparams {
+.params, .retval, .exception, .tparams, .examples {
         margin-left: 0px;
         padding-left: 0px;
 }       


### PR DESCRIPTION
Made implementation analogous to the implementation for parameters in respect to padding and the use of colon (:).