### PR TITLE
Tooltip was twice 'HTML escaped'

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -514,6 +514,27 @@ void HtmlCodeGenerator::docify(const char *str)
   }
 }
 
+void HtmlCodeGenerator::docify_tt(const char *str)
+{
+  m_t << getHtmlDirEmbedingChar(getTextDirByConfig(str));
+
+  if (str && m_streamSet)
+  {
+    const char *p=str;
+    char c;
+    while (*p)
+    {
+      c=*p++;
+      switch(c)
+      {
+        case '<':  m_t << "&lt;"; break;
+        case '>':  m_t << "&gt;"; break;
+        default:   m_t << c;
+      }
+    }
+  }
+}
+
 void HtmlCodeGenerator::writeLineNumber(const char *ref,const char *filename,
                                     const char *anchor,int l)
 {
@@ -606,7 +627,7 @@ void HtmlCodeGenerator::writeTooltip(const char *id, const DocLinkInfo &docInfo,
   if (desc)
   {
     m_t << "<div class=\"ttdoc\">";
-    docify(desc); // desc is already HTML escaped; but there are still < and > signs
+    docify_tt(desc); // desc is already HTML escaped; but there are still < and > signs
     m_t << "</div>";
   }
   if (!defInfo.file.isEmpty())

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -61,6 +61,7 @@ class HtmlCodeGenerator : public CodeOutputInterface
                         const char *anchor,const char *name,
                         const char *tooltip);
     void docify(const char *str);
+    void docify_tt(const char *str);
     bool m_streamSet;
     FTextStream m_t;
     int m_col;


### PR DESCRIPTION
The tooltip was already 'HTML escaped' except for some '<' and '>' characters but was again 'HTML escaped' resulting in e.g. that a single apostrophe (') was translated to `&#39;` and again to `&amp;#39;` resulting in `&#39;` in the tooltip.
Only '<' and '>' are now 'HTML escaped again'