### PR TITLE
Bug 667993 - HTML tags <u> and </u> not supported

### DIFF
--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -105,7 +105,6 @@ of a HTML tag are passed on to the HTML output only
 <li><tt>\</KBD\></tt>  Ends a <tt>\<KBD\></tt> section.
 <li><tt>\<U\></tt> Starts a section of underlined text.
 <li><tt>\</U\></tt> Ends a section of underlined text.
-<li><tt>\<STRONG\></tt> Starts a section of bold text.
 <li><tt>\<UL\></tt>    Starts an unnumbered item list.
 <li><tt>\</UL\></tt>   Ends an unnumbered item list.
 <li><tt>\<VAR\></tt>   Starts a piece of text displayed in an italic font.

--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -83,6 +83,8 @@ of a HTML tag are passed on to the HTML output only
 <li><tt>\</SMALL\></tt> Ends a <tt>\<SMALL\></tt> section.
 <li><tt>\<SPAN></tt>   Starts an inline text fragment with a specific style (HTML only)
 <li><tt>\</SPAN></tt>  Ends an inline text fragment with a specific style (HTML only)
+<li><tt>\<STRIKE\></tt> Starts a section of strike through text.
+<li><tt>\</STRIKE\></tt> Ends a section of strike through text.
 <li><tt>\<STRONG\></tt> Starts a section of bold text.
 <li><tt>\</STRONG\></tt> Ends a section of bold text.
 <li><tt>\<SUB\></tt>   Starts a piece of text displayed in subscript.
@@ -101,6 +103,9 @@ of a HTML tag are passed on to the HTML output only
 <li><tt>\</TT\></tt>   Ends a <tt>\<TT\></tt> section.
 <li><tt>\<KBD\></tt>   Starts a piece of text displayed in a typewriter font.
 <li><tt>\</KBD\></tt>  Ends a <tt>\<KBD\></tt> section.
+<li><tt>\<U\></tt> Starts a section of underlined text.
+<li><tt>\</U\></tt> Ends a section of underlined text.
+<li><tt>\<STRONG\></tt> Starts a section of bold text.
 <li><tt>\<UL\></tt>    Starts an unnumbered item list.
 <li><tt>\</UL\></tt>   Ends an unnumbered item list.
 <li><tt>\<VAR\></tt>   Starts a piece of text displayed in an italic font.

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -193,6 +193,8 @@ CommandMap htmlTagMap[] =
   { "span",       HTML_SPAN },
   { "div",        HTML_DIV },
   { "blockquote", HTML_BLOCKQUOTE },
+  { "strike",     HTML_STRIKE },
+  { "u",          HTML_UNDERLINE },
 
   { "c",            XML_C },
   // { "code",       XML_CODE },  <= ambiguous <code> is also a HTML tag

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -175,6 +175,8 @@ enum HtmlTagType
   HTML_SPAN      = 31,
   HTML_DIV       = 32,
   HTML_BLOCKQUOTE= 33,
+  HTML_STRIKE    = 34,
+  HTML_UNDERLINE = 35,
 
   XML_CmdMask    = 0x100,
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -196,6 +196,8 @@ void DocbookDocVisitor::visit(DocStyleChange *s)
       /* There is no equivalent Docbook tag for rendering Small text */
     case DocStyleChange::Small: /* XSLT Stylesheets can be used */ break;
                                                                    /* HTML only */
+    case DocStyleChange::Strike:  break;
+    case DocStyleChange::Underline:  break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
   }

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1056,7 +1056,8 @@ const char *DocStyleChange::styleString() const
     case DocStyleChange::Superscript:  return "superscript"; 
     case DocStyleChange::Preformatted: return "pre"; 
     case DocStyleChange::Div:          return "div";
-    case DocStyleChange::Span:         return "span";
+    case DocStyleChange::Strike:       return "strike";
+    case DocStyleChange::Underline:    return "u";
   }
   return "<invalid>";
 }
@@ -1580,6 +1581,26 @@ reparsetoken:
             else
             {
               handleStyleLeave(parent,children,DocStyleChange::Bold,tokenName);
+            }
+            break;
+          case HTML_STRIKE:
+            if (!g_token->endTag)
+            {
+              handleStyleEnter(parent,children,DocStyleChange::Strike,&g_token->attribs);
+            }
+            else
+            {
+              handleStyleLeave(parent,children,DocStyleChange::Strike,tokenName);
+            }
+            break;
+          case HTML_UNDERLINE:
+            if (!g_token->endTag)
+            {
+              handleStyleEnter(parent,children,DocStyleChange::Underline,&g_token->attribs);
+            }
+            else
+            {
+              handleStyleLeave(parent,children,DocStyleChange::Underline,tokenName);
             }
             break;
           case HTML_CODE:
@@ -5905,6 +5926,12 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
     case HTML_BOLD:
       handleStyleEnter(this,m_children,DocStyleChange::Bold,&g_token->attribs);
       break;
+    case HTML_STRIKE:
+      handleStyleEnter(this,m_children,DocStyleChange::Strike,&g_token->attribs);
+      break;
+    case HTML_UNDERLINE:
+      handleStyleEnter(this,m_children,DocStyleChange::Underline,&g_token->attribs);
+      break;
     case HTML_CODE:
       if (/*getLanguageFromFileName(g_fileName)==SrcLangExt_CSharp ||*/ g_xmlComment) 
         // for C# source or inside a <summary> or <remark> section we 
@@ -6313,6 +6340,12 @@ int DocPara::handleHtmlEndTag(const QCString &tagName)
     //  break;
     case HTML_BOLD:
       handleStyleLeave(this,m_children,DocStyleChange::Bold,"b");
+      break;
+    case HTML_STRIKE:
+      handleStyleLeave(this,m_children,DocStyleChange::Strike,"strike");
+      break;
+    case HTML_UNDERLINE:
+      handleStyleLeave(this,m_children,DocStyleChange::Underline,"u");
       break;
     case HTML_CODE:
       handleStyleLeave(this,m_children,DocStyleChange::Code,"code");

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -367,7 +367,9 @@ class DocStyleChange : public DocNode
                  Superscript   = (1<<6),
                  Preformatted  = (1<<7),
                  Span          = (1<<8),
-                 Div           = (1<<9)
+                 Div           = (1<<9),
+                 Strike        = (1<<10),
+                 Underline     = (1<<11)
                };
 
     DocStyleChange(DocNode *parent,uint position,Style s,bool enable,

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -394,8 +394,8 @@ WORD1NQ   {ESCWORD}|{CHARWORDQ}+|"{"|"}"
 WORD2NQ   "."|","|"("|")"|"["|"]"|":"|";"|"\?"|"="|"'"
 CAPTION   [cC][aA][pP][tT][iI][oO][nN]
 HTMLTAG   "<"(("/")?){ID}({WS}+{ATTRIB})*{WS}*(("/")?)">" 
-HTMLKEYL  "strong"|"center"|"table"|"caption"|"small"|"code"|"dfn"|"var"|"img"|"pre"|"sub"|"sup"|"tr"|"td"|"th"|"ol"|"ul"|"li"|"tt"|"kbd"|"em"|"hr"|"dl"|"dt"|"dd"|"br"|"i"|"a"|"b"|"p"
-HTMLKEYU  "STRONG"|"CENTER"|"TABLE"|"CAPTION"|"SMALL"|"CODE"|"DFN"|"VAR"|"IMG"|"PRE"|"SUB"|"SUP"|"TR"|"TD"|"TH"|"OL"|"UL"|"LI"|"TT"|"KBD"|"EM"|"HR"|"DL"|"DT"|"DD"|"BR"|"I"|"A"|"B"|"P"
+HTMLKEYL  "strong"|"center"|"table"|"caption"|"small"|"code"|"dfn"|"var"|"img"|"pre"|"sub"|"sup"|"tr"|"td"|"th"|"ol"|"ul"|"li"|"tt"|"kbd"|"em"|"hr"|"dl"|"dt"|"dd"|"br"|"i"|"a"|"b"|"p"|"strike"|"u"
+HTMLKEYU  "STRONG"|"CENTER"|"TABLE"|"CAPTION"|"SMALL"|"CODE"|"DFN"|"VAR"|"IMG"|"PRE"|"SUB"|"SUP"|"TR"|"TD"|"TH"|"OL"|"UL"|"LI"|"TT"|"KBD"|"EM"|"HR"|"DL"|"DT"|"DD"|"BR"|"I"|"A"|"B"|"P"|"STRIKE"|"U"
 HTMLKEYW  {HTMLKEYL}|{HTMLKEYU}
 REFWORD2_PRE   ("#"|"::")?((({ID}{TEMPLPART}?)|{ANONNS})("."|"#"|"::"|"-"|"/"))*({ID}{TEMPLPART}?(":")?)
 REFWORD2       {REFWORD2_PRE}{FUNCARG2}?

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -271,6 +271,12 @@ void HtmlDocVisitor::visit(DocStyleChange *s)
     case DocStyleChange::Bold:
       if (s->enable()) m_t << "<b" << htmlAttribsToString(s->attribs()) << ">";      else m_t << "</b>";
       break;
+    case DocStyleChange::Strike:
+      if (s->enable()) m_t << "<strike" << htmlAttribsToString(s->attribs()) << ">";      else m_t << "</strike>";
+      break;
+    case DocStyleChange::Underline:
+      if (s->enable()) m_t << "<u" << htmlAttribsToString(s->attribs()) << ">";      else m_t << "</u>";
+      break;
     case DocStyleChange::Italic:
       if (s->enable()) m_t << "<em" << htmlAttribsToString(s->attribs()) << ">";     else m_t << "</em>";
       break;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -242,7 +242,13 @@ void LatexDocVisitor::visit(DocStyleChange *s)
   switch (s->style())
   {
     case DocStyleChange::Bold:
-      if (s->enable()) m_t << "{\\bfseries ";      else m_t << "}";
+      if (s->enable()) m_t << "{\\bfseries{";      else m_t << "}}";
+      break;
+    case DocStyleChange::Strike:
+      if (s->enable()) m_t << "\\sout{";     else m_t << "}";
+      break;
+    case DocStyleChange::Underline:
+      if (s->enable()) m_t << "\\uline{";     else m_t << "}";
       break;
     case DocStyleChange::Italic:
       if (s->enable()) m_t << "{\\itshape ";     else m_t << "}";

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -120,6 +120,13 @@ void ManDocVisitor::visit(DocStyleChange *s)
       if (s->enable()) m_t << "\\fB";      else m_t << "\\fP";
       m_firstCol=FALSE;
       break;
+    case DocStyleChange::Strike:
+      /* not supported */
+      break;
+    case DocStyleChange::Underline: //underline is shown as emphasis
+      if (s->enable()) m_t << "\\fI";     else m_t << "\\fP";
+      m_firstCol=FALSE;
+      break;
     case DocStyleChange::Italic:
       if (s->enable()) m_t << "\\fI";     else m_t << "\\fP";
       m_firstCol=FALSE;

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -626,6 +626,8 @@ void PerlModDocVisitor::visit(DocStyleChange *s)
   switch (s->style())
   {
     case DocStyleChange::Bold:          style = "bold"; break;
+    case DocStyleChange::Strike:        style = "strike"; break;
+    case DocStyleChange::Underline:     style = "underline"; break;
     case DocStyleChange::Italic:        style = "italic"; break;
     case DocStyleChange::Code:          style = "code"; break;
     case DocStyleChange::Subscript:     style = "subscript"; break;

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -91,6 +91,12 @@ class PrintDocVisitor : public DocVisitor
         case DocStyleChange::Bold:
           if (s->enable()) printf("<bold>"); else printf("</bold>");
           break;
+        case DocStyleChange::Strike:
+          if (s->enable()) printf("<strike>"); else printf("</strike>");
+          break;
+        case DocStyleChange::Underline:
+          if (s->enable()) printf("<underline>"); else printf("</underline>");
+          break;
         case DocStyleChange::Italic:
           if (s->enable()) printf("<italic>"); else printf("</italic>");
           break;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -192,6 +192,12 @@ void RTFDocVisitor::visit(DocStyleChange *s)
     case DocStyleChange::Bold:
       if (s->enable()) m_t << "{\\b ";      else m_t << "} ";
       break;
+    case DocStyleChange::Strike:
+      if (s->enable()) m_t << "{\\strike ";      else m_t << "} ";
+      break;
+    case DocStyleChange::Underline:
+      if (s->enable()) m_t << "{\\ul ";      else m_t << "} ";
+      break;
     case DocStyleChange::Italic:
       if (s->enable()) m_t << "{\\i ";     else m_t << "} ";
       break;

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -164,6 +164,12 @@ void XmlDocVisitor::visit(DocStyleChange *s)
     case DocStyleChange::Bold:
       if (s->enable()) m_t << "<bold>";      else m_t << "</bold>";
       break;
+    case DocStyleChange::Strike:
+      if (s->enable()) m_t << "<strike>";      else m_t << "</strike>";
+      break;
+    case DocStyleChange::Underline:
+      if (s->enable()) m_t << "<underline>";      else m_t << "</underline>";
+      break;
     case DocStyleChange::Italic:
       if (s->enable()) m_t << "<emphasis>";     else m_t << "</emphasis>";
       break;

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1750,3 +1750,8 @@ tt, code, kbd, samp
   direction:ltr; 
 }
 /* @end */
+
+u {
+	text-decoration: underline;
+}
+

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -19,7 +19,7 @@
 \RequirePackage{adjustbox}
 \RequirePackage{amssymb}
 \RequirePackage{stackengine}
-
+\RequirePackage[normalem]{ulem} % for strikeout, but don't modify emphasis
 
 %---------- Internal commands used in this style file ----------------
 

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -384,6 +384,8 @@
     <xsd:choice>
       <xsd:element name="ulink" type="docURLLink" />
       <xsd:element name="bold" type="docMarkupType" />
+      <xsd:element name="strike" type="docMarkupType" />
+      <xsd:element name="underline" type="docMarkupType" />
       <xsd:element name="emphasis" type="docMarkupType" />
       <xsd:element name="computeroutput" type="docMarkupType" />
       <xsd:element name="subscript" type="docMarkupType" />


### PR DESCRIPTION
Added underline possibility and strike through possibility for the different output formats insofar it is possible (other similar possibilities are not always possible for all output formats either).