### PR TITLE
Bug PATCH -- updates reference link with no closing

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1117,7 +1117,8 @@ void HtmlGenerator::startIndexItem(const char *ref,const char *f)
     }
     t << "href=\"";
     t << externalRef(relPath,ref,TRUE);
-    if (f) t << f << Doxygen::htmlFileExtension << "\">";
+    if (f) t << f << Doxygen::htmlFileExtension;
+    t << "\">";
   }
   else
   {


### PR DESCRIPTION
For external tagfiles, there is an issue with the links being provided from the file list. Whenever there is a hypertext reference in HtmlGenerator::startIndexItem, this href never closes with an end quote and close bracket.

For example, this addition addresses the following issue beginning at href:
...<td class="entry"><span style="width:16px;display:inline-block;">&nbsp;</span><span class="icondoc"></span><a class="elRef" doxygen="/path/to/external/example.tag:../../external/html/" href="../../external/html/file.htmlfile.h&lt;/a&gt;&nbsp;[external]&lt;/td&gt;&lt;td class=" desc"=""></a></td>...

The main objective for the href is to close it as such:
<a ... href="../../external/html/file.html">htmlfile.h ...

Since the file path is true for ref and not f, the proposed changes will provide an external link to the tagfile beside the icon.

Running Doxygen 1.8.14 on HP-UX B.11.31.