### PR TITLE
Wrong link generated for inherited members when tag files are used.

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2717,13 +2717,16 @@ void HtmlGenerator::writeInheritedSectionTitle(
   DBG_HTML(t << "<!-- writeInheritedSectionTitle -->" << endl;)
   QCString a = anchor;
   if (!a.isEmpty()) a.prepend("#");
-  QCString classLink = QCString("<a class=\"el\" href=\"");
+  QCString classLink = QCString("<a class=\"el\" ");
   if (ref)
   {
-    classLink+= externalLinkTarget() + externalRef(relPath,ref,TRUE);
+    classLink+= externalLinkTarget();
+    classLink += " href=\"";
+    classLink+= externalRef(relPath,ref,TRUE);
   }
   else
   {
+    classLink += "href=\"";
     classLink+=relPath;
   }
   classLink+=file+Doxygen::htmlFileExtension+a;


### PR DESCRIPTION
In case a tag file is used and `EXT_LINKS_IN_WINDOW` is set to `YES` a link is generated of the form:
`Public Member Functions inherited from <a class="el" href="target="_blank" https://doc.qt.io/archives/qt-5.10/qobject.html">`
instead of
`Public Member Functions inherited from <a class="el" target="_blank" href="https://doc.qt.io/archives/qt-5.10/qobject.html">`

When `EXT_LINKS_IN_WINDOW` is set to `NO` a correct link is generated but the external documentation comes straight forward in the current window.

(relevant link: https://stackoverflow.com/questions/51323207/doxygen-external-link-to-qt-classes)