### PR TITLE
redundant input_filter runs significantly reduce performance when FILTER_SOURCE_FILES and INLINE_SOURCES are both enabled

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -779,6 +779,17 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='int' id='FILTER_CACHE_SIZE' minval='1' maxval='100000' defval='1'>
+      <docs>
+<![CDATA[
+ The size of the filter lookup cache can be 
+ set using \c FILTER_CACHE_SIZE. This cache is used to resolve some speed issues
+ when using \ref cfg_filter_cache_size "FILTER_SOURCE_FILE". When using the tag
+ \c FILTER_CACHE_SIZE a FIFO queue is build with the filtered files of size
+ \c FILTER_CACHE_SIZE entries, these files are, temporary, written to disk.
+]]>
+      </docs>
+    </option>
   </group>
   <group name='Build' docs='Build related configuration options'>
     <option type='bool' id='EXTRACT_ALL' defval='0'>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10643,7 +10643,9 @@ void adjustConfiguration()
 #ifdef HAS_SIGNALS
 static void stopDoxygen(int)
 {
+  int filterCacheSize = Config_getInt(FILTER_CACHE_SIZE);
   QDir thisDir;
+  char dum[10];
   msg("Cleaning up...\n");
   if (!Doxygen::entryDBFileName.isEmpty())
   {
@@ -10655,11 +10657,19 @@ static void stopDoxygen(int)
   }
   if (!Doxygen::defFiltFileName.isEmpty())
   {
-    thisDir.remove(Doxygen::defFiltFileName);
+    for (int i = 0; i < filterCacheSize; i++)
+    {
+      sprintf(dum,"_%d",i);
+      thisDir.remove(Doxygen::defFiltFileName + dum);
+    }
   }
   if (!Doxygen::utlFiltFileName.isEmpty())
   {
-    thisDir.remove(Doxygen::utlFiltFileName);
+    for (int i = 0; i < filterCacheSize; i++)
+    {
+      sprintf(dum,"_%d",i);
+      thisDir.remove(Doxygen::utlFiltFileName + dum);
+    }
   }
   killpg(0,SIGINT);
   exit(1);
@@ -10751,7 +10761,9 @@ static void exitDoxygen()
 {
   if (!g_successfulRun)  // premature exit
   {
+    int filterCacheSize = Config_getInt(FILTER_CACHE_SIZE);
     QDir thisDir;
+    char dum[10];
     msg("Exiting...\n");
     if (!Doxygen::entryDBFileName.isEmpty())
     {
@@ -10763,11 +10775,19 @@ static void exitDoxygen()
     }
     if (!Doxygen::defFiltFileName.isEmpty())
     {
-      thisDir.remove(Doxygen::defFiltFileName);
+      for (int i = 0; i < filterCacheSize; i++)
+      {
+        sprintf(dum,"_%d",i);
+        thisDir.remove(Doxygen::defFiltFileName + dum);
+      }
     }
     if (!Doxygen::utlFiltFileName.isEmpty())
     {
-      thisDir.remove(Doxygen::utlFiltFileName);
+      for (int i = 0; i < filterCacheSize; i++)
+      {
+        sprintf(dum,"_%d",i);
+        thisDir.remove(Doxygen::utlFiltFileName + dum);
+      }
     }
   }
 }
@@ -11004,9 +11024,9 @@ void parseInput()
 #endif
 
   uint pid = portable_pid();
-  Doxygen::defFiltFileName.sprintf("doxygen_deffilt_%d.tmp",pid);
+  Doxygen::defFiltFileName.sprintf("doxygen_deffilt_%d",pid);
   Doxygen::defFiltFileName.prepend(outputDirectory+"/");
-  Doxygen::utlFiltFileName.sprintf("doxygen_utlfilt_%d.tmp",pid);
+  Doxygen::utlFiltFileName.sprintf("doxygen_utlfilt_%d",pid);
   Doxygen::utlFiltFileName.prepend(outputDirectory+"/");
   Doxygen::objDBFileName.sprintf("doxygen_objdb_%d.tmp",pid);
   Doxygen::objDBFileName.prepend(outputDirectory+"/");
@@ -11831,8 +11851,14 @@ void generateOutput()
   Doxygen::symbolStorage->close();
   QDir thisDir;
   thisDir.remove(Doxygen::objDBFileName);
-  thisDir.remove(Doxygen::defFiltFileName);
-  thisDir.remove(Doxygen::utlFiltFileName);
+  int filterCacheSize = Config_getInt(FILTER_CACHE_SIZE);
+  char dum[10];
+  for (int i = 0; i < filterCacheSize; i++)
+  {
+    sprintf(dum,"_%d",i);
+    thisDir.remove(Doxygen::defFiltFileName + dum);
+    thisDir.remove(Doxygen::utlFiltFileName + dum);
+  }
   Config::deinit();
   QTextCodec::deleteAllCodecs();
   delete Doxygen::symbolMap;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -167,6 +167,8 @@ bool             Doxygen::suppressDocWarnings = FALSE;
 Store           *Doxygen::symbolStorage;
 QCString         Doxygen::objDBFileName;
 QCString         Doxygen::entryDBFileName;
+QCString         Doxygen::defFiltFileName;
+QCString         Doxygen::utlFiltFileName;
 bool             Doxygen::gatherDefines = TRUE;
 IndexList       *Doxygen::indexList;
 int              Doxygen::subpageNestingLevel = 0;
@@ -10651,6 +10653,14 @@ static void stopDoxygen(int)
   {
     thisDir.remove(Doxygen::objDBFileName);
   }
+  if (!Doxygen::defFiltFileName.isEmpty())
+  {
+    thisDir.remove(Doxygen::defFiltFileName);
+  }
+  if (!Doxygen::utlFiltFileName.isEmpty())
+  {
+    thisDir.remove(Doxygen::utlFiltFileName);
+  }
   killpg(0,SIGINT);
   exit(1);
 }
@@ -10750,6 +10760,14 @@ static void exitDoxygen()
     if (!Doxygen::objDBFileName.isEmpty())
     {
       thisDir.remove(Doxygen::objDBFileName);
+    }
+    if (!Doxygen::defFiltFileName.isEmpty())
+    {
+      thisDir.remove(Doxygen::defFiltFileName);
+    }
+    if (!Doxygen::utlFiltFileName.isEmpty())
+    {
+      thisDir.remove(Doxygen::utlFiltFileName);
     }
   }
 }
@@ -10986,6 +11004,10 @@ void parseInput()
 #endif
 
   uint pid = portable_pid();
+  Doxygen::defFiltFileName.sprintf("doxygen_deffilt_%d.tmp",pid);
+  Doxygen::defFiltFileName.prepend(outputDirectory+"/");
+  Doxygen::utlFiltFileName.sprintf("doxygen_utlfilt_%d.tmp",pid);
+  Doxygen::utlFiltFileName.prepend(outputDirectory+"/");
   Doxygen::objDBFileName.sprintf("doxygen_objdb_%d.tmp",pid);
   Doxygen::objDBFileName.prepend(outputDirectory+"/");
   Doxygen::entryDBFileName.sprintf("doxygen_entrydb_%d.tmp",pid);
@@ -11809,6 +11831,8 @@ void generateOutput()
   Doxygen::symbolStorage->close();
   QDir thisDir;
   thisDir.remove(Doxygen::objDBFileName);
+  thisDir.remove(Doxygen::defFiltFileName);
+  thisDir.remove(Doxygen::utlFiltFileName);
   Config::deinit();
   QTextCodec::deleteAllCodecs();
   delete Doxygen::symbolMap;

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -140,6 +140,8 @@ class Doxygen
     static Store                    *symbolStorage;
     static QCString                  objDBFileName;
     static QCString                  entryDBFileName;
+    static QCString                  defFiltFileName;
+    static QCString                  utlFiltFileName;
     static CiteDict                 *citeDict;
     static bool                      gatherDefines;
     static bool                      userComments;


### PR DESCRIPTION
When filtering output write the result to a temporary file that can be reread in case  the next call to the filter routine is again for the same file  (e.g. for inline source code or code snippets). Reading a file is much faster than running an popen call i.e. spawning a subprocess  (that would anyway have to read the file and  and the result has to be read from a pipe).