### PR TITLE
Bug 520975 - Unnamed parameters parsed incorrectly

### DIFF
--- a/src/defargs.l
+++ b/src/defargs.l
@@ -52,6 +52,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <qregexp.h>
+#include <qstringlist.h>
 
 #include "defargs.h"
 #include "entry.h"
@@ -102,6 +103,17 @@ static int yyread(char *buf,int max_size)
     return c;
 }
 
+/* bug_520975 */
+static bool checkSpecialType(QCString &typ)
+{
+  QStringList qsl=QStringList::split(' ',typ);
+  for(uint j=0;j<qsl.count();j++)
+  {
+    if (!(qsl[j] == "unsigned" || qsl[j] == "signed" ||
+          qsl[j] == "volatile" || qsl[j] == "const")) return FALSE;
+  }
+  return TRUE;
+}
 %}
 
 B       [ \t]
@@ -384,8 +396,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 						    a->type.mid(sv)=="union"     ||
 						    a->type.mid(sv)=="class"     ||
 						    a->type.mid(sv)=="typename"  ||
-						    a->type=="const"               ||
-						    a->type=="volatile"
+						    checkSpecialType(a->type)
 						   )
 						{ 
 						  a->type = a->type + " " + a->name;

--- a/src/defargs.l
+++ b/src/defargs.l
@@ -104,8 +104,10 @@ static int yyread(char *buf,int max_size)
 }
 
 /* bug_520975 */
-static bool checkSpecialType(QCString &typ)
+static bool checkSpecialType(QCString &typ, QCString &nam)
 {
+  if (nam == "unsigned" || nam == "signed" ||
+      nam == "volatile" || nam == "const") return TRUE;
   QStringList qsl=QStringList::split(' ',typ);
   for(uint j=0;j<qsl.count();j++)
   {
@@ -396,7 +398,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 						    a->type.mid(sv)=="union"     ||
 						    a->type.mid(sv)=="class"     ||
 						    a->type.mid(sv)=="typename"  ||
-						    checkSpecialType(a->type)
+						    checkSpecialType(a->type,  a->name)
 						   )
 						{ 
 						  a->type = a->type + " " + a->name;


### PR DESCRIPTION
Added "signed" and "unsigned" to the list of "special types" analogous to "const" and "volatile"
Created a function for this that would make it possible to have also constructs like "const const" recognized.