### PR TITLE
Bug 610436 - <![CDATA[ is not handled inside C# comments

### DIFF
--- a/doc/xmlcmds.doc
+++ b/doc/xmlcmds.doc
@@ -70,6 +70,9 @@ Here is the list of tags supported by doxygen:
 <li><tt>\<typeparamref name="paramName"\></tt> Refers to a parameter with name
                          "paramName". Similar to using \ref cmda "\\a".
 <li><tt>\<value\></tt>   Identifies a property. Ignored by doxygen.
+<li><tt>\<![CDATA[...]]\></tt> The text inside this tag (on the ...) is  handled as normal
+                         doxygen comment except for the XML special characters `<`, `>` and
+                         `&` that are used as if they were escaped.
 </ul>
 
 Here is an example of a typical piece of code using some of the above commands:

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -989,6 +989,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 %x	CiteLabel
 %x	CopyDoc
 %x      GuardExpr
+%x      CdataSection
 
 %%
 
@@ -1081,13 +1082,16 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           insidePre=FALSE;
                                           addOutput(yytext);
                                         }
-<Comment>{RCSTAG}			{ // RCS tag which end a brief description
-  					  setOutput(OutputDoc);
-					  REJECT;
-  					}
-<Comment>"<!--"				{ 
-  					  BEGIN(HtmlComment);
-					}
+<Comment>{RCSTAG}                       { // RCS tag which end a brief description
+                                          setOutput(OutputDoc);
+                                          REJECT;
+                                        }
+<Comment>"<!--"                         { 
+                                          BEGIN(HtmlComment);
+                                        }
+<Comment>"<!\[CDATA\["                  {
+                                          BEGIN(CdataSection);
+                                        }
 <Comment>{B}*{CMD}"endinternal"{B}*	{
                                           addOutput("\\endinternal "); 
                                           if (!inInternalDocs)
@@ -1317,6 +1321,24 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					}
 <HtmlComment>.				{ // ignore every else
   					}
+
+<CdataSection>"\]\]>"                   {
+                                          BEGIN( Comment );
+                                        }
+<CdataSection>{DOCNL}                   { 
+                                          addOutput('\n');
+                                          if (*yytext=='\n') yyLineNr++;
+                                        }
+<CdataSection>[<>&]                     { // the special XML characters for iwhich the CDATA section is especially used
+                                          addOutput('\\');
+                                          addOutput(*yytext);
+                                        }
+<CdataSection>[^\\\n\]<>&]+             {
+                                          addOutput(yytext);
+                                        }
+<CdataSection>.                         { 
+                                          addOutput(*yytext);
+                                        }
 
  /* --------------   Rules for handling formulas ---------------- */
  


### PR DESCRIPTION
Added handling of "\<![CDATA[ ... ]]>" i.e. XML CDATA sections in an analogous way top HTML comment but in this case the text is retained (as normal doxygen comment)  and the special XML characters `<`,`>` and `&` are taken as if they were escaped.