### PR TITLE
Bug 648180 - Fortran: tagfile.tag:789: warning: Unknown compound attribute `type' found!

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1582,7 +1582,11 @@ void ClassDef::writeSummaryLinks(OutputList &ol)
 void ClassDef::writeTagFile(FTextStream &tagFile)
 {
   if (!isLinkableInProject()) return;
-  tagFile << "  <compound kind=\"" << compoundTypeString();
+  tagFile << "  <compound kind=\"";
+  if (isFortran() && (compoundTypeString() == "type")) 
+    tagFile << "struct";
+  else
+    tagFile << compoundTypeString();
   tagFile << "\"";
   if (isObjectiveC()) { tagFile << " objc=\"yes\""; }
   tagFile << ">" << endl;
@@ -4498,6 +4502,11 @@ bool ClassDef::isForwardDeclared() const
 bool ClassDef::isObjectiveC() const
 {
   return getLanguage()==SrcLangExt_ObjC;
+}
+
+bool ClassDef::isFortran() const
+{
+  return getLanguage()==SrcLangExt_Fortran;
 }
 
 bool ClassDef::isCSharp() const

--- a/src/classdef.h
+++ b/src/classdef.h
@@ -266,6 +266,9 @@ class ClassDef : public Definition
     /** Returns TRUE if this class is implemented in Objective-C */
     bool isObjectiveC() const;
 
+    /** Returns TRUE if this class is implemented in Fortran */
+    bool isFortran() const;
+
     /** Returns TRUE if this class is implemented in C# */
     bool isCSharp() const;
 


### PR DESCRIPTION
In Fortran the keyword 'type' is used that in the context of the tag file is 'struct'.