### PR TITLE
Bug 579628 - Merging of consecutive repeated commands creates poorly-structured HTML

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -80,6 +80,15 @@ p.endtd {
 	margin-bottom: 2px;
 }
 
+p.interli {
+}
+
+p.interdd {
+}
+
+p.intertd {
+}
+
 /* @end */
 
 caption {


### PR DESCRIPTION
Most issues from this report were already implemented. Extended for cross reference lists with the possibility to "style" intermediate items as well.
(also some code structure, i.e. mnemonics instead of numbers).