### PR TITLE
Improvements in handling special characters in LaTeX

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6741,6 +6741,16 @@ void filterLatexString(FTextStream &t,const char *str,
     {
       switch(c)
       {
+        case 0xef: // handle U+FFFD i.e. "Replacement character" caused by octal: 357 277 275 / hexadecimal 0xef 0xbf 0xbd
+                   // the LaTeX command \ucr has been defined in doxygen.sty
+          if ((unsigned char)*(p) == 0xbf && (unsigned char)*(p+1) == 0xbd)
+          {
+            t << "{\\ucr}";
+            p += 2;
+          }
+          else
+            t << (char)c;
+          break;
         case '\\': t << "\\(\\backslash\\)"; break;
         case '{':  t << "\\{"; break;
         case '}':  t << "\\}"; break;
@@ -6762,6 +6772,16 @@ void filterLatexString(FTextStream &t,const char *str,
     {
       switch(c)
       {
+        case 0xef: // handle U+FFFD i.e. "Replacement character" caused by octal: 357 277 275 / hexadecimal 0xef 0xbf 0xbd
+                   // the LaTeX command \ucr has been defined in doxygen.sty
+          if ((unsigned char)*(p) == 0xbf && (unsigned char)*(p+1) == 0xbd)
+          {
+            t << "{\\ucr}";
+            p += 2;
+          }
+          else
+            t << (char)c;
+          break;
         case '#':  t << "\\#";           break;
         case '$':  t << "\\$";           break;
         case '%':  t << "\\%";           break;
@@ -8865,19 +8885,10 @@ void writeLatexSpecialFormulaChars(FTextStream &t)
     sup3[1]= 0xB3;
     sup3[2]= 0;
 
-    t << "\\ifthenelse{\\isundefined{\\DeclareUnicodeCharacter}}{%\n"
-         "  \\catcode`\\" << pminus << "=13% Superscript minus\n"
-         "  \\def" << pminus << "{${}^{-}$}\n"
-         "  \\catcode`\\" << psup2 << "=13% Superscript two\n"
-         "  \\def" << psup2 << "{${}^{2}$}\n"
-         "  \\catcode`\\"<<psup3<<"=13% Superscript three\n"
-         "  \\def"<<psup3<<"{${}^{3}$}\n"
-         "}{%\n"
-         "  \\DeclareUnicodeCharacter{207B}{${}^{-}$}% Superscript minus\n"
-         "  \\DeclareUnicodeCharacter{C2B2}{${}^{2}$}% Superscript two\n"
-         "  \\DeclareUnicodeCharacter{C2B3}{${}^{3}$}% Superscript three\n"
-         "  \\DeclareUnicodeCharacter{2212}{-}% Just a minus sign\n"
-         "}\n"
+    t << "\\usepackage{newunicodechar}\n"
+         "  \\newunicodechar{" << pminus << "}{${}^{-}$}% Superscript minus\n"
+         "  \\newunicodechar{" << psup2  << "}{${}^{2}$}% Superscript two\n"
+         "  \\newunicodechar{" << psup3  << "}{${}^{3}$}% Superscript three\n"
          "\n";
 }
 

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -87,6 +87,8 @@
 % Necessary for redefining not defined charcaters, i.e. "Replacement Character" in tex output.
 \newlength{\CodeWidthChar}
 \newlength{\CodeHeightChar}
+\settowidth{\CodeWidthChar}{?}
+\settoheight{\CodeHeightChar}{?}
 % Necessary for hanging indent
 \newlength{\DoxyCodeWidth}
 
@@ -117,21 +119,14 @@
 }{%
   \normalfont%
   \normalsize%
+  \settowidth{\CodeWidthChar}{?}%
+  \settoheight{\CodeHeightChar}{?}%
 }
 
 % Redefining not defined characters, i.e. "Replacement Character" in tex output.
 \def\ucr{\adjustbox{width=\CodeWidthChar,height=\CodeHeightChar}{\stackinset{c}{}{c}{-.2pt}{%
    \textcolor{white}{\sffamily\bfseries\small ?}}{%
    \rotatebox{45}{$\blacksquare$}}}}
-
-% Choosing right setup for "Replacement character"
-\ifthenelse{\isundefined{\DeclareUnicodeCharacter}}{%
-  \catcode`\�=13
-  \def�{\ucr}
-}{%
-  \RequirePackage[utf8]{inputenc}
-  \DeclareUnicodeCharacter{FFFD}{\ucr}
-}
 
 % Used by @example, @include, @includelineno and @dontinclude
 \newenvironment{DoxyCodeInclude}[1]{%


### PR DESCRIPTION
- In case a corrupted character is found LaTeX shows this as a U+FFFD , the character in the code is 0xef 0xbf 0xbd. This character was in the doxygen LaTex code already replaced with `\ucr` but this didn't work properly with TexLive 2015 and the code is now detected in the doxygen code and directly replaced `\ucr`
- other special characters are now handled, in a way that works in all engines, by means of `\newunicodechar`
- the size of the `\ucr` was not set in case it was used in 'running text' and not inside e.g. a code section.