### PR TITLE
Not showing external project in HTML hierarchy class pages

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -304,7 +304,7 @@ void FTVHelp::generateLink(FTextStream &t,FTVNode *n)
     }
     else
     {
-      t << ">";
+      t << "\">";
     }
     t << convertToHtml(n->name);
     t << "</a>";


### PR DESCRIPTION
The reference to the external project was not closed properly.
The problem in the HTML code was discovered when looking at the example of issue #3791. On the 'hierarchy' page the reference to the external project didn't appear.