### PR TITLE
Correction for `doxygen -g`

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10467,6 +10467,10 @@ void readConfiguration(int argc, char **argv)
     {
       configName="doxyfile";
     }
+    else if (genConfig)
+    {
+      configName="Doxyfile";
+    }
     else
     {
       err("Doxyfile not found and no input file specified!\n");


### PR DESCRIPTION
Regression, the command `doxygen -g` didn't work anymore when no `Doxyfile` was present.
(commands like `doxygen -g MY_Doxyfile` still worked even when `MY_Doxyfile` was not present).