### PR TITLE
Bug 635155 - Bad protection type in xml output for private union

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2645,6 +2645,18 @@ void MemberDef::writeDocumentation(MemberList *ml,
       if (vmd->isEnumerate() && ldef.mid(i,l)==vmd->name())
       {
         ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs);
+        if (sl.count()>0)
+        {
+          ol.pushGeneratorState();
+          ol.disableAll();
+          ol.enable(OutputGenerator::Html);
+          ol.writeString("<table class=\"mlabels\">\n");
+          ol.writeString("  <tr>\n");
+          ol.writeString("  <td class=\"mlabels-left\">\n");
+          ol.popGeneratorState();
+          htmlEndLabelTable=TRUE;
+        }
+
         ol.startMemberDoc(ciname,name(),memAnchor,name(),memCount,memTotal,showInline);
         linkifyText(TextGeneratorOLImpl(ol),scopedContainer,getBodyDef(),this,ldef.left(i));
         vmd->writeEnumDeclaration(ol,getClassDef(),getNamespaceDef(),getFileDef(),getGroupDef());
@@ -2667,6 +2679,18 @@ void MemberDef::writeDocumentation(MemberList *ml,
         ei=i+l;
       }
       // first si characters of ldef contain compound type name
+      if (sl.count()>0)
+      {
+        ol.pushGeneratorState();
+        ol.disableAll();
+        ol.enable(OutputGenerator::Html);
+        ol.writeString("<table class=\"mlabels\">\n");
+        ol.writeString("  <tr>\n");
+        ol.writeString("  <td class=\"mlabels-left\">\n");
+        ol.popGeneratorState();
+        htmlEndLabelTable=TRUE;
+      }
+
       ol.startMemberDocName(isObjCMethod());
       ol.docify(ldef.left(si));
       ol.docify(" { ... } ");

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6917,7 +6917,7 @@ static void parseCompounds(Entry *rt)
 	  }
 	  else
 	  {
-	    current->protection = protection = Public ;
+	    current->protection = protection = ce->protection;
 	  }
 	}
 	else 


### PR DESCRIPTION
The protection for a.o. union was reset to "public" but but it should stay (analogous to e.g. enum) on the protection of the section (left Object-C untouched).
In the HTML documentation the "protected" and "private" labels were not considered at all in case of e.g. union