### PR TITLE
Bug 734820 - "remove" is treated as a keyword (green) in the source browser for C++

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2417,7 +2417,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
                                         }
 <Body>{KEYWORD}/([^a-z_A-Z0-9]) 	{
                                           if (g_insideJava && qstrcmp("internal",yytext) ==0) REJECT;
-                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
+                                          if (g_insideCpp && (QCString(yytext) == "remove" ||QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  if (QCString(yytext)=="typedef")
@@ -2428,13 +2428,13 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  endFontClass();
   					}
 <Body>{KEYWORD}/{B}* 			{
-                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
+                                          if (g_insideCpp && (QCString(yytext) == "remove" ||QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  endFontClass();
   					}
 <Body>{KEYWORD}/{BN}*"(" 		{
-                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
+                                          if (g_insideCpp && (QCString(yytext) == "remove" ||QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  endFontClass();
@@ -2989,7 +2989,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <MemberCall2,FuncCall>{KEYWORD}/([^a-z_A-Z0-9]) {
 					  //addParmType();
 					  //g_parmName=yytext; 
-                                          if (g_insideCpp && (QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
+                                          if (g_insideCpp && (QCString(yytext) == "remove" ||QCString(yytext) =="set" ||QCString(yytext) =="get")) REJECT;
   					  startFontClass("keyword");
   					  g_code->codify(yytext);
 					  endFontClass();


### PR DESCRIPTION
Removed "remove" as keyword for C type of languages.