### PR TITLE
Bug 741120 - refid are not globally unique anymore

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -469,6 +469,16 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='string' id='SHORT_NAMES_PREFIX' format='string' depensd='SHORT_NAMES'>
+      <docs>
+<![CDATA[
+ If \c SHORT_NAMES_PREFIX is specified the \c SHORT_NAMES_PREFIX is preprended to the short
+ name as described with \ref cfg_short_names "SHORT_NAMES" together with an undescore. The
+ resulting filename is processed according to the normal character replacement settings of
+ doxygen for file names.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='JAVADOC_AUTOBRIEF' defval='0'>
       <docs>
 <![CDATA[

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5544,6 +5544,7 @@ QCString convertNameToFile(const char *name,bool allowDots,bool allowUnderscore)
 {
   if (name==0 || name[0]=='\0') return "";
   static bool shortNames = Config_getBool(SHORT_NAMES);
+  static QCString shortNamesPrefix = Config_getBool(SHORT_NAMES_PREFIX);
   static bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
   QCString result;
   if (shortNames) // use short names only
@@ -5563,7 +5564,22 @@ QCString convertNameToFile(const char *name,bool allowDots,bool allowUnderscore)
     {
       num = *value;
     }
-    result.sprintf("a%05d",num); 
+    if (shortNamesPrefix.isEmpty())
+    {
+      result.sprintf("a%05d",num); 
+    }
+    else
+    {
+      result.sprintf("%s_a%05d",shortNamesPrefix.data(),num); 
+      result=escapeCharsInString(result,allowDots,allowUnderscore);
+      int resultLen = result.length();
+      if (resultLen>=128) // prevent names that cannot be created!
+      {
+        warn_uncond("short name plus prefix (SHORT_NAMES_PREFIX) extends allowed file name length, prefix dropped!\n");
+        shortNamesPrefix="";
+        result.sprintf("a%05d",num); 
+      }
+    }
   }
   else // long names
   {


### PR DESCRIPTION
Made possibility to prepend a prefix (`SHORT_NAMES_PREFIX`) to the short file name (configuration `SHORT_NAMES = YES`) to create the possibility to make the "short names" unique between projects.