### PR TITLE
Include height item in XML output

### DIFF
--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -65,7 +65,7 @@ static void visitPreStart(FTextStream &t, const char *cmd, const bool doCaption,
   {
     t << " width=\"" << convertToXML(width) << "\"";
   }
-  else if (!height.isEmpty())
+  if (!height.isEmpty())
   {
     t << " height=\"" << convertToXML(height) << "\"";
   }


### PR DESCRIPTION
When width and height are given with the `\image` command only the `width=` is placed in the output. contrary to e.g. HTML. This has been corrected.

Based on: https://stackoverflow.com/questions/38778067/doxygen-image-tag-size-specification-syntax