### PR TITLE
 'self' keyword in PHP documentation

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1324,7 +1324,9 @@ static void generateFunctionLink(CodeOutputInterface &ol,const char *funcName)
   //CodeClassDef *ccd=0;
   ClassDef *ccd=0;
   QCString locScope=g_classScope;
-  QCString locFunc=removeRedundantWhiteSpace(funcName);
+  QString qq=removeRedundantWhiteSpace(funcName);
+  if (g_insidePHP && qq.startsWith("self::")) qq=qq.mid(4);
+  QCString locFunc(qq.data());
   QCString funcScope;
   QCString funcWithScope=locFunc;
   QCString funcWithFullScope=locFunc;


### PR DESCRIPTION
In PHP the word `self` was not color coded and the functions were not referenced in the CALL / CALLER graphs, REFERENCES / REFERENCED lists.