### PR TITLE
travis: add tests for linux-ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,25 @@
 language: cpp
+os:
+    - linux-ppc64le 
+    - linux
+dist: xenial
 compiler:
   - gcc
   - clang
 sudo: required
 
-before_install:
-    - sudo apt-add-repository ppa:smspillaz/cmake-2.8.12 -y
-    - sudo apt-get update -qq
-
-install:
-    - sudo apt-get install -qq texlive
-    - sudo apt-get install -qq texlive-extra-utils
-    - sudo apt-get install -q -y texlive-latex-extra
-    - sudo apt-get install -qq libxml2-utils
-    - sudo apt-get install -qq cmake cmake-data
+addons:
+    apt:
+        update: true
+        packages:
+            - texlive
+            - texlive-extra-utils
+            - texlive-latex-extra
+            - texlive-font-utils
+            - ghostscript
+            - libxml2-utils
+            - cmake
+            - cmake-data
 
 script:
     - mkdir build


### PR DESCRIPTION
I have modified the .travis.yml file so it also supports builds to IBM Power in order to maintain compatibility with it. In doing so, the following things were changed:

- Usage of os: linux-ppc64le in the os list and dist changed to xenial
- Removal of the ppa:smspillaz/cmake-2.8.12 repo (caused errors in ppc64le builds)
- Addition of 2 texlive-font-utils and ghostscript packages for compatible builds in linux (works fine without them in ppc64le but need them in linux builds)
- Structure of the apt-get installations (makes it look a bit nicer)

