### PR TITLE
Possibility to have a \image command inside a <A> tag

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1561,6 +1561,9 @@ reparsetoken:
             doctokenizerYYsetStatePara();
           }
           break;
+        case CMD_IMAGE:
+          ((DocPara *)parent) -> handleImage("image");
+          break;
         default:
           return FALSE;
       }


### PR DESCRIPTION
Enable the possibility to have a `\image` command inside a `<A>` tag