### PR TITLE
Automatic detection of UCS-2 based on BOM corrected

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7949,8 +7949,8 @@ bool readInputFile(const char *fileName,BufStr &inBuf,bool filter,bool isSourceC
 
   int start=0;
   if (size>=2 &&
-      ((inBuf.at(0)==-1 && inBuf.at(1)==-2) || // Little endian BOM
-       (inBuf.at(0)==-2 && inBuf.at(1)==-1)    // big endian BOM
+      (((uchar)inBuf.at(0)==0xFF && (uchar)inBuf.at(1)==0xFE) || // Little endian BOM
+       ((uchar)inBuf.at(0)==0xFE && (uchar)inBuf.at(1)==0xFF)    // big endian BOM
       )
      ) // UCS-2 encoded file
   {


### PR DESCRIPTION
Based on the travis messages (in total 4):

```
/home/travis/build/doxygen/doxygen/src/util.cpp:7952:20: warning: comparison of
      constant -1 with expression of type 'char' is always false
      [-Wtautological-constant-out-of-range-compare]
      ((inBuf.at(0)==-1 && inBuf.at(1)==-2) || // Little endian BOM
        ~~~~~~~~~~~^ ~~
```
and subsequent tests, the automatic detection of the UCS-2 BOM failed, this has been corected.