### PR TITLE
Correcting labels for citations

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1877,11 +1877,8 @@ DocAnchor::DocAnchor(DocNode *parent,const QCString &id,bool newAnchor)
   {
     warn_doc_error(g_fileName,doctokenizerYYlineno,"Empty anchor label");
   }
-  if (newAnchor) // found <a name="label">
-  {
-    m_anchor = id;
-  }
-  else if (id.left(CiteConsts::anchorPrefix.length()) == CiteConsts::anchorPrefix) 
+
+  if (id.left(CiteConsts::anchorPrefix.length()) == CiteConsts::anchorPrefix) 
   {
     CiteInfo *cite = Doxygen::citeDict->find(id.mid(CiteConsts::anchorPrefix.length()));
     if (cite) 
@@ -1895,6 +1892,10 @@ DocAnchor::DocAnchor(DocNode *parent,const QCString &id,bool newAnchor)
       m_anchor = "invalid";
       m_file = "invalid";
     }
+  }
+  else if (newAnchor) // found <a name="label">
+  {
+    m_anchor = id;
   }
   else // found \anchor label
   {

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -488,7 +488,7 @@ void XmlDocVisitor::visitPre(DocPara *)
 void XmlDocVisitor::visitPost(DocPara *)
 {
   if (m_hide) return;
-  m_t << "</para>";
+  m_t << "</para>" << endl;
 }
 
 void XmlDocVisitor::visitPre(DocRoot *)

--- a/testing/012/citelist.xml
+++ b/testing/012/citelist.xml
@@ -9,7 +9,7 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="_1CITEREF_knuth79"/>[1]</term>
+            <term><anchor id="citelist_1CITEREF_knuth79"/>[1]</term>
           </varlistentry>
           <listitem>
             <para>Donald<nonbreakablespace/>E. Knuth. <emphasis>Tex and Metafont, New Directions in Typesetting</emphasis>. American Mathematical Society and Digital Press, Stanford, 1979.</para>


### PR DESCRIPTION
The labels for RTF and XML were incorrect due to the fact that the wrong branch was chosen in the code (the newAnchor was set for the results of the `\cite ` command as well).
Small readability issue with XML (when there are a lot of citations).