### PR TITLE
Bug 748927 - Navigation incorrect with escaped symbols

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1588,8 +1588,12 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 <PageDocArg1>.				{ // ignore other stuff
   					}
 <PageDocArg2>.*"\n"			{ // second argument; page title
-  				          yyLineNr++;
-					  current->args = yytext;
+					  yyLineNr++;
+					  // bug 748927
+					  QCString tmp = yytext;
+					  tmp = substitute(substitute(tmp,"@<","&lt;"),"@>","&gt;");
+					  tmp = substitute(substitute(tmp,"\\<","&lt;"),"\\>","&gt;");
+					  current->args = tmp;
 					  addOutput('\n');
 					  BEGIN( Comment );
 					}


### PR DESCRIPTION
Due to the fact that constructs like `<my>` in a page title are seen as an XML-tag (with a resulting warning) the `<` should be escaped but this leads to the fact that the escape sign is shown in the bars on top of a HTML page.
The basic problem is due to the fact that page titles are not really interpreted by doxygen (as "nothing" can be, generically, handled in the title of a page).