### PR TITLE
perlmod syntax correction

### DIFF
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1254,6 +1254,7 @@ void PerlModDocVisitor::visitPre(DocParamSect *s)
     err("unknown parameter section found\n");
     break;
   }
+  m_output.openHash();
   openOther();
   openSubBlock(type);
 }
@@ -1262,6 +1263,7 @@ void PerlModDocVisitor::visitPost(DocParamSect *)
 {
   closeSubBlock();
   closeOther();
+  m_output.closeHash();
 }
 
 void PerlModDocVisitor::visitPre(DocParamList *pl)


### PR DESCRIPTION
# What is the problem
- doxygen perlmod generates the wrong result for  retvals / params / templateparam  type.
- ex.] Although  we want to get hash value ,  we can get only list.
```
            detailed => {
              doc => [
                params => [
                  {
                    parameters => [
                      {
                        name => 'isOn',
                        dir => 'in'
                      }
                    ],
                    doc => [
                      {
```

- We should have the following result. Because **"params => ..."**  is in hash braces.
```
            detailed => {
              doc => [
                {
                  params => [
                    {
                      parameters => [
                        {
                          name => 'isOn',
                          dir => 'in'
                        }
                      ],
                      doc => [
                        {
```

# What can not we do
- Can not run the doxylatex.pl (./OUTPUT/perlmod)
- We can not get the perl variables to make a  successfully.

# Modified Code
- add hash notation  : diff

```
diff --git a/src/perlmodgen.cpp b/src/perlmodgen.cpp
index ef5cbc22..7bf0b823 100644
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1254,6 +1254,7 @@ void PerlModDocVisitor::visitPre(DocParamSect *s)
     err("unknown parameter section found\n");
     break;
   }
+  m_output.openHash();
   openOther();
   openSubBlock(type);
 }
@@ -1262,6 +1263,7 @@ void PerlModDocVisitor::visitPost(DocParamSect *)
 {
   closeSubBlock();
   closeOther();
+  m_output.closeHash();
 }
```