### PR TITLE
Markdown list wrong displayed

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1949,7 +1949,7 @@ void writeOneLineHeaderOrRuler(GrowBuf &out,const char *data,int size)
     out.addStr(data,size);
     if (hasLineBreak(data,size))
     {
-      out.addStr("<br>");
+      out.addStr("\n");
     }
   }
 }


### PR DESCRIPTION
In some, rare, cases a markdown list was wrongly displayed (regression due to change of place of markdown handling)

```
/** @mainpage
 *
 * * elem1
 * * elem2
 *
 Some text (actually found due to a table)
 */
```

Important point is the missing '*' in the line 'Some...'.