### PR TITLE
Bug fix (very tiny) for plantuml

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -47,7 +47,7 @@ QCString writePlantUMLSource(const QCString &outDir,const QCString &fileName,con
   }
   QCString text = "@startuml\n";
   text+=content;
-  text+="@enduml\n";
+  text+="\n@enduml\n";
   file.writeBlock( text, text.length() );
   file.close();
   return baseName;


### PR DESCRIPTION
# What is the problem
-  Most of @startuml are running well. But , the following plantuml is not processed. 
```
 /**
 * @brief Clear the rule.
 * @startuml
 * participant CReceiver
 * opt MsgFromSender()
 *  alt cmd=IGN_STATUS_IN && value == 0
 *     alt
 *            CReceiver ->> CHmi : Draw_HMI sendMsg() ->  sendMessage(HMI,MSGIDN,...)
 *      else
 *          note right CReceiver : Draw Directly
 *      end
 *  else
 *      note right CReceiver : mbBlockDraw = false
 *  end
 * end
 * @enduml
 */
```

# debugging method
- change into DOT_CLEANUP = NO in Doxyfile   to remain the plantuml file for debugging.
- the following context is result of remaining plantuml file.
```
@startuml
  participant CReceiver
  opt MsgFromSender()
   alt cmd=IGN_STATUS_IN && value == 0
      alt
             CReceiver ->> CHmi : Draw_HMI sendMsg() ->  sendMessage(HMI,MSGIDN,...)
       else
           note right CReceiver : Draw Directly
       end
   else
       note right CReceiver : mbBlockDraw = false
   end
  end@enduml
```

# Solution
- add return in front of @enduml