### PR TITLE
Truncated split bar in HTML output between treeview and normal text area

### DIFF
--- a/templates/html/navtree.css
+++ b/templates/html/navtree.css
@@ -96,7 +96,7 @@
 .ui-resizable-e {
   background-image:url("splitbar.png");
   background-size:100%;
-  background-repeat:no-repeat;
+  background-repeat:repeat-y;
   background-attachment: scroll;
   cursor:ew-resize;
   height:100%;


### PR DESCRIPTION
In case of of choosing small letters in the browser or having a large display one can see that the split bar ends at a certain point.