### PR TITLE
File list creation performance improvement.

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9633,7 +9633,7 @@ int readDir(QFileInfo *fi,
             {
               fn = new FileName(cfi->absFilePath().utf8(),name);
               fn->append(fd);
-              if (fnList) fnList->inSort(fn);
+              if (fnList) fnList->append(fn);
               fnDict->insert(name,fn);
             }
           }
@@ -9732,7 +9732,7 @@ int readFileOrDirectory(const char *s,
               {
                 fn = new FileName(filePath,name);
                 fn->append(fd);
-                if (fnList) fnList->inSort(fn);
+                if (fnList) fnList->append(fn);
                 fnDict->insert(name,fn);
               }
             }
@@ -10923,6 +10923,7 @@ void searchInputFiles()
     }
     s=inputList.next();
   }
+  Doxygen::inputNameList->sort();
   delete killDict;
   g_s.end();
 }


### PR DESCRIPTION
For my use case with several thousands of input files, profiling showed that about an hour is spend in just creating the file list, because it uses the inSort() function. 
This proposed change reduces creating the file list from about an hour to a few seconds !!

Reading a few thousands of input files in alphabetical order is very slow because of using the inSort construct. The inSort function does a linear loop through the list to find the right alphabetical position, leading to a quadratic algorithm. 
But during the creation of the file list there is no need to keep it sorted - it is not used at all yet. Therefore I propose to just append them and to do a final sort at the end of the creation of the file list.
