### PR TITLE
Issue_6456 Using # in links causes errors in PDF generation

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -215,13 +215,14 @@ void LatexDocVisitor::visit(DocURL *u)
   if (m_hide) return;
   if (Config_getBool(PDF_HYPERLINKS))
   {
+	m_t << endl << "%% AME " << u->url() <<endl;
     m_t << "\\href{";
     if (u->isEmail()) m_t << "mailto:";
-    m_t << u->url() << "}";
+    m_t << latexFilterURL(u->url()) << "}";
   }
-  m_t << "\\texttt{ ";
+  m_t << "{\\texttt{ ";
   filter(u->url());
-  m_t << "}";
+  m_t << "}}";
 }
 
 void LatexDocVisitor::visit(DocLineBreak *)
@@ -1245,17 +1246,18 @@ void LatexDocVisitor::visitPre(DocHRef *href)
   if (m_hide) return;
   if (Config_getBool(PDF_HYPERLINKS))
   {
+	m_t << endl << "%% AME " << href->url() <<endl;
     m_t << "\\href{";
-    m_t << href->url();
+    m_t << latexFilterURL(href->url());
     m_t << "}";
   }
-  m_t << "\\texttt{ ";
+  m_t << "{\\texttt{ ";
 }
 
 void LatexDocVisitor::visitPost(DocHRef *) 
 {
   if (m_hide) return;
-  m_t << "}";
+  m_t << "}}";
 }
 
 void LatexDocVisitor::visitPre(DocHtmlHeader *header)

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1369,12 +1369,12 @@ void LatexGenerator::startHtmlLink(const char *url)
     t << url;
     t << "}";
   }
-  t << "\\texttt{ ";
+  t << "{\\texttt{ ";
 }
 
 void LatexGenerator::endHtmlLink()
 {
-  t << "}";
+  t << "}}";
 }
 
 //void LatexGenerator::writeMailLink(const char *url)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6964,6 +6964,25 @@ QCString latexEscapePDFString(const char *s)
   return result.data();
 }
 
+QCString latexFilterURL(const char *s)
+{
+  QGString result;
+  FTextStream t(&result);
+  const char *p=s;
+  char c;
+  while ((c=*p++))
+  {
+    switch (c)
+    {
+      case '#':  t << "\\#"; break;
+      default:
+        t << c;
+        break;
+    }
+  }
+  return result.data();
+}
+
 
 QCString rtfFormatBmkStr(const char *name)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -346,6 +346,7 @@ void filterLatexString(FTextStream &t,const char *str,
 QCString latexEscapeLabelName(const char *s,bool insideTabbing);
 QCString latexEscapeIndexChars(const char *s,bool insideTabbing);
 QCString latexEscapePDFString(const char *s);
+QCString latexFilterURL(const char *s);
 
 QCString rtfFormatBmkStr(const char *name);
 


### PR DESCRIPTION
- The # sign in an URL needs to be escaped as longtabu reads the table body as the argument to a command, so the self-escaping mechanism of \href cannot work (from https://tex.stackexchange.com/questions/447461/having-a-hash-sign-in-href-in-a-longtabu-cell)
- a regression regarding the change from `\tt` to `\texttt` (needed `{  ... }` as `\href` has 2 arguments )