### PR TITLE
Dramatically reduce the time when rerun the doxygen with plantuml comments (Imporvement of performance)

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3491,6 +3491,22 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='PLANTUML_CACHE' defval='0'>
+      <docs>
+<![CDATA[
+If the \c PLANTUML_CACHE tag is set to \c YES, doxygen will
+create the intermediate plantuml files (*.cache.pu & others) that are used to improve the performance.
+]]>
+      </docs>
+    </option>
+    <option type='bool' id='PLANTUML_CACHE_DEBUG_PRINT' defval='0' depends='PLANTUML_CACHE'>
+      <docs>
+<![CDATA[
+If the \c PLANTUML_CACHE_DEBUG_PRINT tag is set to \c YES, doxygen will
+print how to reuse this cache and how to improve the performance.
+]]>
+      </docs>
+    </option>
     <option type='int' id='DOT_GRAPH_MAX_NODES' minval='0' maxval='10000' defval='50' depends='HAVE_DOT'>
       <docs>
 <![CDATA[

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -69,8 +69,8 @@ struct comparer
 };
 
 extern void restoreCacheFromFile(std::string *path);
-static std::map<std::string, std::string, comparer> *puMap = nullptr;	//* plantuml Map < plantuml_contents , plantuml.[format] binary name> 
-static std::map<std::string, int, comparer> *puDir = nullptr;		//* directory Map
+static std::map<std::string, std::string, comparer> *puMap = NULL;	//* plantuml Map < plantuml_contents , plantuml.[format] binary name> 
+static std::map<std::string, int, comparer> *puDir = NULL;		//* directory Map
 
 void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutputFormat format)
 {
@@ -162,7 +162,7 @@ void generatePlantUMLOutput(const char *baseName,const char *outDir,PlantUMLOutp
   bool puCacheMatchFlag = false;
   portable_sysTimerStart();
   if (Config_getBool(PLANTUML_CACHE)){
-    if(puMap == nullptr){
+    if(puMap == NULL){
       puMap = new (std::map<std::string,std::string,comparer>);
       puDir = new (std::map<std::string,int,comparer>);
     }

--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -30,6 +30,12 @@ enum PlantUMLOutputFormat { PUML_BITMAP, PUML_EPS, PUML_SVG };
 QCString writePlantUMLSource(const QCString &outDir,const QCString &fileName,const QCString &content);
 
 /** Convert a PlantUML file to an image.
+ *  @details if PLANTUML_CACHE = YES , doxygen performance will be improved from running second trials.
+ *     Process of using cache
+ *     1. restoreCacheFromFile() : caching files - *.png.cache.pu (plantuml)   *.png.cache (png binary)
+ *     2. if plantuml is matched in caches (puMap) , you reuse cached file.   (print "Running copy")
+ *     3. if plantuml is not matched in caches (puMap), you generate png with JAVA and save generate png(image) file for cache. (print "Running JAVA")
+ *
  *  @param[in] baseName the name of the generated file (as returned by writePlantUMLSource())
  *  @param[in] outDir   the directory to write the resulting image into.
  *  @param[in] format   the image format to generate.


### PR DESCRIPTION
# What is the problem
- When we make doxygen output , each plantuml comment spends a lot of time (more than 1 second).
	- If doxygen generates 6 plantuml , it takes 18.124 sec (98%). But total time is 18.498 sec (100%).
	- Generating plantuml on java occupied most of time.
- It regenerate all plantuml output even though we change or add just one plantuml comments  or we change the doxygen comments.
	- Reuse the pre-generated plantuml output!!

# Main Idea
- Goal
	- Reduce the running time of doxygen from making plantuml result.
- Method
	- Reuse the result(png or svg ...) of unchanged plantuml comments.

```
9.689 sec: Total elapsed time: 9.689 seconds
(of which 9.340 seconds waiting for external tools to finish)
```
- According to upper timeline ,  generating images with java is a big burden.
- So I try to remove java running process.   I guess we can reduce the java running time if we reuse already generated images.

# What to do
- add configuration value in Doxyfile
	- PLANTUML_CACHE = YES
	- PLANTUML_CACHE_DEBUG_PRINT = YES			<- It has dependency on PLANTUML_CACHE
- We reduced the time to run the java process for making the plantuml result (png, svg ...).
- Changed Configuration (Doxyfile)
	- HAVE_DOT               = YES
	- DOT_IMAGE_FORMAT       = png
	- GENERATE_HTML          = YES
		- generate  png  file from plantuml
	- GENERATE_DOCBOOK       = YES
		- generate  png  file from plantuml
	- GENERATE_PERLMOD       = YES
		- make a perl module
- results
	- Original : original doxygen makes html and docbook plantuml png separately. (my example has 3 plantuml comments in source code.)
	- First Trial [^1] : When we use modified version , html is running first and then reuse the html's plantuml png results for generating docbook.
		- reduce the time to make a docbook plantuml result.
	- Second Trial [^2] : Change One comment : When we change one of three plantuml comments, we can reuse the previous compiled doxygen result.
		- reduce the time to make a plantuml for unchanged plantuml.
	- Change output type [^3] : When we change output format png into svg, we can resue the previous compiled doxygen result about same contents..
		- DOT_IMAGE_FORMAT       = png  -> svg
		- reduce the time to make a plantuml for unchanged plantuml with the same format..

|        Test Type          |  Original  |  First [^1] | Change One [^2] | Change output type [^3] |
|---------------------------|------------|-------------|-----------------|-------------------------|
| Elapsed Time              | 18.498 sec | 9.689 sec   |  3.153 sec      |  9.744 sec              |
| Guessing Time (Only HTML) | 9.498 sec  | 9.498 sec   |  3.153 sec      |  9.744 sec              |

- Analysis from results
	- Although you use only html type ,  you can get the benefit from second trials.


[^1] : First - When we use modified version , html is running first and then reuse the html's plantuml png results for generating docbook.
[^2] : Change One - When we change one of three plantuml comments, we can reuse the previous compiled doxygen result.
[^3] : Change output type - When we change output format png into svg, we can reuse the previous compiled doxygen result about same contents..