### PR TITLE
Correcting warning messages and echoing unknown command

### DIFF
--- a/src/docparser.h
+++ b/src/docparser.h
@@ -1151,7 +1151,7 @@ class DocPara : public CompAccept<DocPara>
     bool isFirst() const        { return m_isFirst; }
     bool isLast() const         { return m_isLast; }
 
-    int handleCommand(const QCString &cmdName);
+    int handleCommand(const QCString &cmdName,const int tok);
     int handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &tagHtmlAttribs);
     int handleHtmlEndTag(const QCString &tagName);
     int handleSimpleSection(DocSimpleSect::Type t,bool xmlContext=FALSE);

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -34,12 +34,13 @@ enum Tokens
   TK_WHITESPACE    = 3,
   TK_LISTITEM      = 4,
   TK_ENDLIST       = 5,
-  TK_COMMAND       = 6,
+  TK_COMMAND       = 6, //! Command starting with `@`
   TK_HTMLTAG       = 7,
   TK_SYMBOL        = 8,
   TK_NEWPARA       = 9,
   TK_RCSTAG        = 10,
   TK_URL           = 11,
+  TK_COMMAND1      = 12, //! Command starting with `\`
 
   RetVal_OK             = 0x10000,
   RetVal_SimpleSec      = 0x10001,

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -122,6 +122,7 @@ const char *tokToString(int token)
     case TK_NEWPARA:     return "TK_NEWPARA";
     case TK_RCSTAG:      return "TK_RCSTAG";
     case TK_URL:         return "TK_URL";
+    case TK_COMMAND1:    return "TK_COMMAND1";
   }
   return "ERROR";
 }
@@ -572,14 +573,14 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 			 bool ok;
 			 g_token->id = QCString(yytext).right((int)yyleng-6).toInt(&ok);
 			 ASSERT(ok);
-			 return TK_COMMAND;
+			 return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
   		       }
 <St_Para>{CMD}"n"\n    { /* \n followed by real newline */
                          yylineno++;
                          g_token->name = yytext+1;
 			 g_token->name = g_token->name.stripWhiteSpace();
 			 g_token->paramDir=TokenInfo::Unspecified;
-                         return TK_COMMAND;
+			 return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
                        }
 <St_Para>{SPCMD1}      |
 <St_Para>{SPCMD2}      |
@@ -587,7 +588,7 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                          g_token->name = yytext+1;
 			 g_token->name = g_token->name.stripWhiteSpace();
 			 g_token->paramDir=TokenInfo::Unspecified;
-                         return TK_COMMAND;
+                         return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
   		       }
 <St_Para>{PARAMIO}     { /* param [in,out] command */
   			 g_token->name = "param";
@@ -613,7 +614,7 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 			 {
 			   g_token->paramDir=TokenInfo::Unspecified;
 			 }
-			 return TK_COMMAND;
+			 return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
   		       }
 <St_Para>("http:"|"https:"|"ftp:"|"file:"|"news:"){URLMASK}/\. { // URL.
                          g_token->name=yytext;
@@ -732,7 +733,7 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                        }
 <St_Text>[\\@<>&$#%~]  {
                          g_token->name = yytext;
-                         return TK_COMMAND;
+                         return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
   		       }
 <St_Para>({BLANK}*\n)+{BLANK}*\n/{LISTITEM} { /* skip trailing paragraph followed by new list item */
                          if (g_insidePre || g_autoListLevel==0)
@@ -925,7 +926,7 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 <St_TitleN>{SPCMD2}    { /* special command */ 
                          g_token->name = yytext+1;
 			 g_token->paramDir=TokenInfo::Unspecified;
-                         return TK_COMMAND;
+                         return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
                        }
 <St_TitleN>{ID}"="     { /* attribute */
                          if (yytext[0]=='%') // strip % if present
@@ -959,7 +960,7 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 <St_TitleQ>{SPCMD2}    { /* special command */ 
                          g_token->name = yytext+1;
 			 g_token->paramDir=TokenInfo::Unspecified;
-                         return TK_COMMAND;
+                         return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
                        }
 <St_TitleQ>{WORD1NQ}   |
 <St_TitleQ>{WORD2NQ}   { /* word */
@@ -1090,7 +1091,7 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 <St_Ref2>{SPCMD2}      { /* special command */ 
                          g_token->name = yytext+1;
 			 g_token->paramDir=TokenInfo::Unspecified;
-                         return TK_COMMAND;
+                         return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
                        }
 <St_Ref2>{WORD1NQ}     |
 <St_Ref2>{WORD2NQ}     {
@@ -1322,7 +1323,7 @@ REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 <*>[\\@<>&$#%~"=]      { /* unescaped special character */
                          //warn(g_fileName,yylineno,"Unexpected character `%s', assuming command \\%s was meant.",yytext,yytext); 
 			 g_token->name = yytext;
-			 return TK_COMMAND;
+			 return (yytext[0] == '@' ? TK_COMMAND : TK_COMMAND1);
                        }
 <*>.                   { 
                          warn(g_fileName,yylineno,"Unexpected character `%s'",yytext);


### PR DESCRIPTION
- In case an unknown command is given this was shown as a warning but not as normal text in the output, for this also a distinction between `\`and `@` commands has to be made
- corrected command name in warning messages when handling arguments
- making handling of some warning messages consistent