### PR TITLE
Issue 6469: Java method calls are ignored in generating call/caller graph with Graphviz

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2627,6 +2627,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  addType();
   					  g_name=varname; 
 					}
+<Body>{SCOPETNAME}{B}*"<"[^\n\/\-\.\{\"\>]*">"/{BN}*"(" |
 <Body>{SCOPETNAME}/{BN}*"("		{ // a() or c::a() or t<A,B>::a() or A\B\foo()
   					  addType();
 					  generateFunctionLink(*g_code,yytext);


### PR DESCRIPTION
Added possibility for `List<String> list = new ArrayList<>();` and `List<String> list = new ArrayList<String>();` i.e. the `<...>` in the `new` part