### PR TITLE
WIP: Init Windows AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,7 @@ init:
 install:
   - ps: Invoke-WebRequest https://github.com/lexxmark/winflexbison/releases/download/v2.5.15/win_flex_bison-2.5.15.zip -OutFile flex.zip
   - 7z x flex.zip -oC:\deps\flex
-  - rename C:\deps\flex\win_bison.exe bison.exe
-  - rename C:\deps\flex\win_flex.exe flex.exe
-  - ps: Invoke-WebRequest https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/gs923w32.exe -OutFile gswin32c.exe
+  - ps: Invoke-WebRequest https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs924/gs924w32.exe -OutFile gswin32c.exe
   - gswin32c /S /D=C:\deps\ghostscript
   - ps: choco install -y miktex
   - refreshenv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+image: Visual Studio 2017
+
+configuration:
+  - Release
+  - Debug
+
+platform:
+  - x64
+  - Win32
+
+environment:
+  # VS VERSION IN CMAKE STYLE
+  matrix:
+    - VSVERSION: "15 2017"
+    - VSVERSION: "14 2015"
+
+init:
+  - cmake --version
+
+install:
+  - ps: Invoke-WebRequest https://github.com/lexxmark/winflexbison/releases/download/v2.5.15/win_flex_bison-2.5.15.zip -OutFile flex.zip
+  - 7z x flex.zip -oC:\deps\flex
+  - rename C:\deps\flex\win_bison.exe bison.exe
+  - rename C:\deps\flex\win_flex.exe flex.exe
+  - set "PATH=%PATH%;C:\deps\flex"
+
+before_build:
+  - if "%platform%"=="Win32" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION%" )
+  - if "%platform%"=="x64" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION% Win64")
+  - mkdir build
+  - cd build
+  - cmake .. -G "%CMAKE_GENERATOR_NAME%
+
+build:
+  project: "build\\PACKAGE.vcxproj"
+  parallel: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,21 +16,35 @@ environment:
 
 init:
   - cmake --version
+  - perl --version
+  - msbuild /version
 
 install:
   - ps: Invoke-WebRequest https://github.com/lexxmark/winflexbison/releases/download/v2.5.15/win_flex_bison-2.5.15.zip -OutFile flex.zip
   - 7z x flex.zip -oC:\deps\flex
   - rename C:\deps\flex\win_bison.exe bison.exe
   - rename C:\deps\flex\win_flex.exe flex.exe
-  - set "PATH=%PATH%;C:\deps\flex"
+  - ps: Invoke-WebRequest https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/gs923w32.exe -OutFile gswin32c.exe
+  - gswin32c /S /D=C:\deps\ghostscript
+  - ps: choco install -y miktex
+  - refreshenv
+  - pip install conan
+  - conan install libxml2/2.9.8@bincrafters/stable -g virtualrunenv
+  - activate_run.bat
+  - set "PATH=%PATH%;C:\deps\ghostscript\bin;C:\deps\flex"
 
 before_build:
   - if "%platform%"=="Win32" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION%" )
   - if "%platform%"=="x64" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION% Win64")
   - mkdir build
   - cd build
-  - cmake .. -G "%CMAKE_GENERATOR_NAME%
+  - cmake -G "%CMAKE_GENERATOR_NAME%" ..
 
 build:
   project: "build\\PACKAGE.vcxproj"
   parallel: true
+
+test_script:
+  - msbuild "testing\tests.vcxproj" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - cmake -G "%CMAKE_GENERATOR_NAME%" -D build_doc=ON ..
+  - msbuild "doc\docs.vcxproj" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ before_build:
 
 build:
   project: "build\\PACKAGE.vcxproj"
-  parallel: true
+  parallel: false
 
 test_script:
   - msbuild "testing\tests.vcxproj" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
This adds AppVeyor configuration to tests doxygen builds in the following build matrix:

[VS Studio 2015, 2017] x [Release, Debug] x [32bit, 64bit]

To enable AppVeyor for this repository, you need to go to https://ci.appveyor.com/projects, login with your GitHub account and add the repository as a project.

The result will look like this: https://ci.appveyor.com/project/Croydon/doxygen/build/1.0.6

Voila, continuous testing for Windows 😄 