### PR TITLE
Sorting of index in case of LaTeX

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6865,11 +6865,37 @@ void filterLatexString(FTextStream &t,const char *str,
   }
 }
 
+static void reFilterLatexString(FTextStream &t,const char *str)
+{
+  if (str==0) return;
+  const unsigned char *p=(const unsigned char *)str;
+  unsigned char c;
+  unsigned char pc='\0';
+  while (*p)
+  {
+    c=*p++;
+
+    switch(c)
+    {
+      case '\\':
+        if (*p == '+') p++;
+        else t << '\\';
+        break;
+      default:
+        t << (char)c;
+        break;
+    }
+    pc = c;
+  }
+}
+
 QCString latexEscapeLabelName(const char *s,bool insideTabbing)
 {
   QGString result;
+  QGString result1;
   QCString tmp(qstrlen(s)+1);
   FTextStream t(&result);
+  FTextStream t1(&result1);
   const char *p=s;
   char c;
   int i;
@@ -6899,7 +6925,13 @@ QCString latexEscapeLabelName(const char *s,bool insideTabbing)
         break;
     }
   }
-  return result.data();
+  if (!insideTabbing)
+  {
+    reFilterLatexString(t1,result.data());
+    return result1.data();
+  }
+  else
+    return result.data();
 }
 
 QCString latexEscapeIndexChars(const char *s,bool insideTabbing)


### PR DESCRIPTION
In case of LaTeX the sorting was so that lowercase came after uppercase e.g.: `username` came after `useSsl`, although the index should be case insensitive.
The problem was that the sort key was filtered in such a way that a.o. uppercase symbols were preceded by `\+` for hyphenation. The key doesn't need this hyphenation (as there is a separate field for the display name).
The `\+` has been filtered out now.