### PR TITLE
Missing opening round bracket in case of an exception

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2159,7 +2159,7 @@ void LatexGenerator::endParameterName(bool last,bool /*emptyList*/,bool closeBra
 void LatexGenerator::exceptionEntry(const char* prefix,bool closeBracket)
 {
   if (prefix)
-      t << " " << prefix;
+      t << " " << prefix << "(";
   else if (closeBracket)
       t << ")";
   t << " ";

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2795,7 +2795,7 @@ void RTFGenerator::exceptionEntry(const char* prefix,bool closeBracket)
 {
   DBG_RTF(t << "{\\comment (exceptionEntry)}"    << endl)
   if (prefix)
-      t << " " << prefix;
+      t << " " << prefix << "(";
   else if (closeBracket)
       t << ")";
   t << " ";


### PR DESCRIPTION
In case of RTF / LaTeX the opening round bracket was missing after the word "throw"
(see e.g. in the manual the `\fn` example the detailed function description)