### PR TITLE
Don't link to non existing / not accessible namespaces , in CSharp, in the source code

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -983,7 +983,7 @@ static void generateClassOrGlobalLink(CodeOutputInterface &ol,const char *clName
       }
     }
     NamespaceDef *nd = getResolvedNamespace(className);
-    if (nd)
+    if (nd && nd->isLinkableInProject())
     {
       g_theCallContext.setScope(nd);
       addToSearchIndex(className);


### PR DESCRIPTION
In the following  the 'test' and 'System' were linked in the source code, this should not be the case.

```
using test;
using System;
using System.IO;

namespace NON
{
}
```