### PR TITLE
Order resources not only on filename but also dirname

### DIFF
--- a/src/res2cc_cmd.py
+++ b/src/res2cc_cmd.py
@@ -98,10 +98,11 @@ def main():
 	directory = sys.argv[1]
 	files = []
 	for dirName, subdirList, fileList in walk(directory):
-		for fname in sorted(fileList):
+		for fname in fileList:
 			subdir = dirName[len(directory)+1:] if dirName.startswith(directory) else dirName
 			if subdir:
 				files.append(File.factory(directory,subdir,fname))
+	files.sort(key=lambda f: f.subdir + "/" + f.fileName)
 	outputFile = open(sys.argv[2],"w")
 	print("#include \"resourcemgr.h\"\n",file=outputFile)
 	for f in files:


### PR DESCRIPTION
Although the resource generation sorted files for each subdirectory, total 
order, i.e. including subdirectories, was not stable. As a result, the
generated resources.cpp could be different on each build run.

Fixes #6152