### PR TITLE
Preprocessor crash in case of a `@` at end of `#if` construct

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1172,6 +1172,11 @@ QCString removeIdsAndMarkers(const char *s)
 	{
 	  // skip
 	}
+	else if (*(p+1)=='\000')
+	{
+	  result+=c;
+	  return result;
+	}
 	p+=2;
       }
       else if (isdigit(c)) // number


### PR DESCRIPTION
Example:
```
#if @VTKMANTA_BUILD_SHARED_LIBS_CONFIG@
# define @PROJECT_NAME@_SHARED
#endif
```