### PR TITLE
Issue 6494: asterisks before args and kwargs are ignored in python

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -118,6 +118,7 @@ static bool             g_packageCommentAllowed;
 static bool             g_start_init = FALSE;
 static int              g_search_count = 0;
 
+static QCString         g_argType = "";
 //-----------------------------------------------------------------------------
 
 
@@ -959,12 +960,16 @@ STARTDOCSYMS      "##"
     ({BB}|",")          {
                         }
 
+    [\*]+               {
+                          g_argType = yytext;
+                        }
     {IDENTIFIER}        { // Name of parameter
 			  lineCount();
 			  Argument *a = new Argument;
 			  current->argList->append(a);
 			  current->argList->getLast()->name = QCString(yytext).stripWhiteSpace();
-			  current->argList->getLast()->type = "";
+			  current->argList->getLast()->type = g_argType;
+                          g_argType = "";
                         }
     "="		        { // default value
                           // TODO: this rule is too simple, need to be able to


### PR DESCRIPTION
Added asterisks in the type field.

The type is temporary stored in a variable as the argument field has not yet been defined for its argument.