### PR TITLE
Namespace with name docstrings_linebreak

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1430,7 +1430,7 @@ STARTDOCSYMS      "##"
 			        actualDoc.prepend("\\verbatim ");
 			        actualDoc.append("\\endverbatim ");
 			      }
-			      actualDoc.prepend("\\namespace "+g_moduleScope+"\\_linebr ");
+			      actualDoc.prepend("\\namespace "+g_moduleScope+" ");
 			      handleCommentBlock(actualDoc, FALSE);
 			    }
 			    if ((docBlockContext==ClassBody /*&& !g_hideClassDocs*/) ||


### PR DESCRIPTION
As a regression on pull request #674 in respect to the moving of the markdown handling place the `\_linebreak` command is not translated anymore.
In fact the `\_linebreak` is not necessary at all only the space is required as the `\namespace` command takes just one word as argument.

Problem has been observed in the doxygen documentation in the appendix "Python Docstring Example"