### PR TITLE
Close last code line properly.

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2222,11 +2222,9 @@ void LatexGenerator::startCodeFragment()
 
 void LatexGenerator::endCodeFragment()
 {
-  //if (DoxyCodeOpen)
-  //{
-  //  t << "}\n";
-  //  DoxyCodeOpen = FALSE;
-  //}
+  //endCodeLine checks is there is still an open code line, if so closes it.
+  endCodeLine();
+
   t << "\\end{DoxyCode}\n";
   DoxyCodeOpen = FALSE;
 }


### PR DESCRIPTION
When ending code fragment, check if last code line is closed, if this is not the case close it.
(problem observed with inline code in Python, but might happen on other places as well)