### PR TITLE
Init macOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 os:
-    - linux-ppc64le 
+    - linux-ppc64le
     - linux
 dist: xenial
 compiler:
@@ -21,6 +21,32 @@ addons:
             - libxml2-utils
             - cmake
             - cmake-data
+
+jobs:
+    include:
+        - os: osx
+          compiler: clang
+
+before_script:
+    - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+        pip install --quiet conan;
+        export HOMEBREW_NO_AUTO_UPDATE=1;
+        brew install ghostscript;
+
+        travis_wait brew cask install mactex-no-gui;
+        curl -O -L http://mirrors.ctan.org/support/epstopdf.zip;
+        unzip epstopdf.zip;
+        mkdir -p /Users/travis/Library/TeX/texbin/;
+        mv epstopdf/epstopdf.pl /Users/travis/Library/TeX/texbin/epstopdf;
+        chmod a+x /Users/travis/Library/TeX/texbin/epstopdf;
+        rm -rf epstopdf*;
+        export PATH=/Users/travis/Library/TeX/texbin:/Library/TeX/texbin:$PATH;
+
+        conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan;
+        printf "[requires] \nlibxml2/2.9.8@bincrafters/stable \nQt/5.11.1@bincrafters/stable" >> conanfile.txt;
+        conan install . -g virtualrunenv;
+        source activate_run.sh;
+      fi;
 
 script:
     - mkdir build

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 Doxygen
 ===============
-Doxygen is the de facto standard tool for generating documentation from 
-annotated C++ sources, but it also supports other popular programming 
-languages such as C, Objective-C, C#, PHP, Java, Python, IDL 
-(Corba, Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL, Tcl, 
+Doxygen is the de facto standard tool for generating documentation from
+annotated C++ sources, but it also supports other popular programming
+languages such as C, Objective-C, C#, PHP, Java, Python, IDL
+(Corba, Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL, Tcl,
 and to some extent D.
 
 Doxygen can help you in three ways:
 
-1. It can generate an on-line documentation browser (in HTML) and/or an 
-   off-line reference manual (in LaTeX) from a set of documented source files. 
-   There is also support for generating output in RTF (MS-Word), PostScript, 
-   hyperlinked PDF, compressed HTML, DocBook and Unix man pages. 
-   The documentation is extracted directly from the sources, which makes 
+1. It can generate an on-line documentation browser (in HTML) and/or an
+   off-line reference manual (in LaTeX) from a set of documented source files.
+   There is also support for generating output in RTF (MS-Word), PostScript,
+   hyperlinked PDF, compressed HTML, DocBook and Unix man pages.
+   The documentation is extracted directly from the sources, which makes
    it much easier to keep the documentation consistent with the source code.
-2. You can configure doxygen to extract the code structure from undocumented 
-   source files. This is very useful to quickly find your way in large 
-   source distributions. Doxygen can also visualize the relations between 
-   the various elements by means of include dependency graphs, inheritance 
+2. You can configure doxygen to extract the code structure from undocumented
+   source files. This is very useful to quickly find your way in large
+   source distributions. Doxygen can also visualize the relations between
+   the various elements by means of include dependency graphs, inheritance
    diagrams, and collaboration diagrams, which are all generated automatically.
-3. You can also use doxygen for creating normal documentation (as I did for 
+3. You can also use doxygen for creating normal documentation (as I did for
    the doxygen user manual and doxygen web-site).
 
 Download
@@ -29,7 +29,7 @@ The latest binaries and source of Doxygen can be downloaded from:
 
 Developers
 ---------
-* Linux Build Status: <a href="https://travis-ci.org/doxygen/doxygen"><img src="https://secure.travis-ci.org/doxygen/doxygen.png?branch=master"/></a>
+* Linux & macOS Build Status: <a href="https://travis-ci.org/doxygen/doxygen"><img src="https://secure.travis-ci.org/doxygen/doxygen.png?branch=master"/></a>
 * Windows Build Status: <a href="https://ci.appveyor.com/project/doxygen/doxygen"><img src="https://ci.appveyor.com/api/projects/status/github/doxygen/doxygen"/></a>
 
 * Coverity Scan Build Status: <a href="https://scan.coverity.com/projects/2860"> <img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/2860/badge.svg"/> </a>
@@ -37,7 +37,7 @@ Developers
 * Doxygen's Doxygen Documentation: <a href="https://codedocs.xyz/doxygen/doxygen/"><img src="https://codedocs.xyz/doxygen/doxygen.svg"/></a>
 
 * Install
-  * Quick install see (./INSTALL) 
+  * Quick install see (./INSTALL)
   * else http://www.doxygen.org/manual/install.html
 
 * Project stats: https://www.openhub.net/p/doxygen
@@ -60,7 +60,7 @@ There are three mailing lists:
 
 Source Code
 ----------------------------------
-In May 2013, Doxygen moved from 
+In May 2013, Doxygen moved from
 subversion to git hosted at GitHub
 * https://github.com/doxygen/doxygen
 


### PR DESCRIPTION
Installing `mactex-no-gui` takes quite some time unfortunately, but I don't see any working alternative right now. However, I still think that the time is acceptable overall.

And tests and docs work this time out of the box in opposition to AppVeyor 😄 