### PR TITLE
Fixing coverity messages  (Namespace tag)

### DIFF
--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -326,6 +326,7 @@ void NamespaceDef::writeTagFile(FTextStream &tagFile)
             }
           }
         }
+        break;
       case LayoutDocEntry::MemberDecl:
         {
           LayoutDocEntryMemberDecl *lmd = (LayoutDocEntryMemberDecl*)lde;


### PR DESCRIPTION
Correcting missing break in namespace when writing a tag file.

(Could not find a case; incase the FALL THROUGH case is correct this has to be clearly indicated in the code).