### PR TITLE
Usage of '{', '}' and ',' in ALIAS

### DIFF
--- a/doc/custcmd.doc
+++ b/doc/custcmd.doc
@@ -44,6 +44,11 @@ Note that you can put `\n`'s in the value part of an alias to insert newlines
 (in the resulting output). You can put `^^` in the value part of an alias to
 insert a newline as if a physical newline was in the original file.
 
+Note when you need a literal `{` or `}` or `,` in the value part of an alias you have to
+escape them by means of a backslash (`\`), this can lead to conflicts with the
+commands \c \\{ and \c \\} for these it is advised to use the version \c @@{ and \c @@} or
+use a double escape (\c \\\\{ and \c \\\\})
+
 Also note that you can redefine existing special commands if you wish.
 
 Some commands, such as \ref cmdxrefitem "\\xrefitem" are designed to be used in

--- a/src/config.xml
+++ b/src/config.xml
@@ -551,6 +551,30 @@ Go to the <a href="commands.html">next</a> section or return to the
  a physical newline was in the original file.
 ]]>
       </docs>
+      <docs doxyfile='0' documentation='0'>
+<![CDATA[
+ When you need a literal `{` or `}` or `,` in the value part of an alias you have to
+ escape them by means of a backslash, this can lead to conflicts with the
+ commands \c \\{ and \c \\} for these it is advised to use the version \c @{ and \c @} or
+ use a double escape (\c \\\\{ and \c \\\\})
+]]>
+      </docs>
+      <docs doxywizard='0' documentation='0'>
+<![CDATA[
+ When you need a literal `{` or `}` or `,` in the value part of an alias you have to
+ escape them by means of a backslash (\c \\), this can lead to conflicts with the
+ commands \c \\{ and \c \\} for these it is advised to use the version \c @{ and \c @} or
+ use a double escape (\c \\\\{ and \c \\\\})
+]]>
+      </docs>
+      <docs doxyfile='0' doxywizard='0'>
+<![CDATA[
+ When you need a literal `{` or `}` or `,` in the value part of an alias you have to
+ escape them by means of a backslash (`\`), this can lead to conflicts with the
+ commands \c \\{ and \c \\} for these it is advised to use the version \c @@{ and \c @@} or
+ use a double escape (\c \\\\{ and \c \\\\})
+]]>
+      </docs>
     </option>
     <option type='list' id='TCL_SUBST' format='string'>
       <docs>


### PR DESCRIPTION
Based on the stack overflow question: https://stackoverflow.com/questions/52314045/how-to-use-addtogroup-with-an-aliases-command/52314821#52314821

```
ALIASES += opengroup{1}="^^* \addtogroup \1_GROUP ^^ * \{ ^^"
ALIASES += close="\}"
```

```
/** \opengroup{LEVEL_1} */
// ...code statements...
/** \close */ // opengroup
```

Does not create a group due to the change of `\{`  to just `}`, this behavior has been documented now.