### PR TITLE
Add possibility for adding doxygen configuration items to, all, tests during runtime.

### DIFF
--- a/testing/README.txt
+++ b/testing/README.txt
@@ -27,6 +27,9 @@ optional parameters:
   --xhtml               create xhtml output and check with xmllint
   --pdf                 create LaTeX output and create pdf from it
   --keep                keep result directories
+  --cfg CFGS [CFGS ...]
+                        run test with extra doxygen configuration settings
+                        (the option may be specified multiple times
 In case neither --xml, --pdf or --xhtml is used the default is set to --xml.
 
 The runtest.pl has the following dependencies on 3rd party tools:

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -82,6 +82,12 @@ class Tester:
 			if (self.args.pdf):
 				print('GENERATE_LATEX=YES', file=f)
 				print('LATEX_OUTPUT=%s/latex' % self.test_out, file=f)
+			if (self.args.cfgs):
+				for cfg in list(itertools.chain.from_iterable(self.args.cfgs)):
+					if cfg.find('=') == -1:
+						print("Not a doxygen configuration item, missing '=' sign: '%s'."%cfg)
+						sys.exit(1)
+					print(cfg, file=f)
 
 		if 'check' not in self.config or not self.config['check']:
 			print('Test doesn\'t specify any files to check')
@@ -268,7 +274,7 @@ def main():
 	parser = argparse.ArgumentParser(description='run doxygen tests')
 	parser.add_argument('--updateref',help=
 		'update the reference files. Should be used in combination with -id to '
-                'update the reference file(s) for the given test',action="store_true")
+		'update the reference file(s) for the given test',action="store_true")
 	parser.add_argument('--doxygen',nargs='?',default='doxygen',help=
 		'path/name of the doxygen executable')
 	parser.add_argument('--xmllint',nargs='?',default='xmllint',help=
@@ -293,6 +299,9 @@ def main():
 		action="store_true")
 	parser.add_argument('--keep',help='keep result directories',
 		action="store_true")
+	parser.add_argument('--cfg',nargs='+',dest='cfgs',action='append',help=
+		'run test with extra doxygen configuration settings '
+		'(the option may be specified multiple times')
 	test_flags = os.getenv('TEST_FLAGS', default='').split()
 	args = parser.parse_args(test_flags + sys.argv[1:])
 


### PR DESCRIPTION
Creating possibility to add extra doxygen configuration items to tests (e.g. `QUIET=NO`)