### PR TITLE
AppVeyor: Fix MikTex version and re-enable tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2017
 
 configuration:
   - Release
-#  - Debug
+  - Debug
 
 platform:
   - x64
@@ -24,7 +24,11 @@ install:
   - 7z x flex.zip -oC:\deps\flex
   - ps: Invoke-WebRequest https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs924/gs924w32.exe -OutFile gswin32c.exe
   - gswin32c /S /D=C:\deps\ghostscript
-  - ps: choco install -y miktex
+  - ps: if($env:platform -eq "x64") { Invoke-WebRequest https://miktex.org/download/win/miktexsetup-x64.zip -OutFile miktexsetup.zip }
+  - ps: if($env:platform -eq "Win32") { Invoke-WebRequest https://miktex.org/download/win/miktexsetup-x86.zip -OutFile miktexsetup.zip }
+  - 7z x miktexsetup.zip -oC:\tmpmiktex
+  - C:\tmpmiktex\miktexsetup --local-package-repository=C:\temp\miktex --package-set=basic download
+  - C:\tmpmiktex\miktexsetup --verbose --local-package-repository=C:\temp\miktex --package-set=basic install
   - refreshenv
   - pip install conan
   - conan install libxml2/2.9.8@bincrafters/stable -g virtualrunenv
@@ -42,7 +46,7 @@ build:
   project: "build\\PACKAGE.vcxproj"
   parallel: false
 
-#test_script:
-#  - msbuild "testing\tests.vcxproj" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-#  - cmake -G "%CMAKE_GENERATOR_NAME%" -D build_doc=ON ..
+test_script:
+  - msbuild "testing\tests.vcxproj" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - cmake -G "%CMAKE_GENERATOR_NAME%" -D build_doc=ON ..
 #  - msbuild "doc\docs.vcxproj" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
Now, where the VS2017 debug bug is fixed we can re-enable the debug builds in AppVeyor.

Also all AppVeyor builds did fail, since the MikTex version in chocolatey is outdated and download mirrors started to remove outdated versions, which leds to a 404 error.

So I switched over to install it (again) directly from the MikTex website, which comes with the bonus that we always install the latest version.

Docs are still not working, because it seems to need stuff which is only available in the full download and this simply takes to much time over the installer as it downloads and install every part individually, so we can't take this way or we will hit regularly the 1h limit and have failures again.