### PR TITLE
Search for contructors when linking function calls

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -865,7 +865,8 @@ static bool getLinkInScope(const QCString &c,  // scope
   NamespaceDef *nd;
   GroupDef     *gd;
   DBG_CTX((stderr,"getLinkInScope: trying `%s'::`%s' varOnly=%d\n",c.data(),m.data(),varOnly));
-  if (getDefs(c,m,"()",md,cd,fd,nd,gd,FALSE,g_sourceFileDef,FALSE,g_forceTagReference) && 
+  if ((getDefs(c,m,"()",md,cd,fd,nd,gd,FALSE,g_sourceFileDef,FALSE,g_forceTagReference) ||
+      getDefs(m,m,"()",md,cd,fd,nd,gd,FALSE,g_sourceFileDef,FALSE,g_forceTagReference)) && // check for class constructor
       (!varOnly || md->isVariable()))
   {
     if (md->isLinkable())


### PR DESCRIPTION
Search for function with it's own name used as scope in order to catch
class constructors when linking funtion call for call graph generation.

Resolves: #6508