### PR TITLE
issue_6524: Markdown formats missing in doxygen outputs.

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -173,7 +173,18 @@ Examples:
 *    __double underscores__
 
 See section \ref mddox_emph_spans for more info how doxygen handles
-emphasis spans slightly different than standard Markdown.
+emphasis / strikethrough spans slightly different than standard / Markdown GitHub Flavored Markdown.
+
+\subsection md_strikethrough Strikethrough
+
+To strikethrough a text fragment you start and end the fragment with two tildes.
+
+Examples:
+
+*    ~~double tilde~~
+
+See section \ref mddox_emph_spans for more info how doxygen handles
+emphasis / strikethrough spans slightly different than standard Markdown / GitHub Flavored Markdown.
 
 \subsection md_codespan code spans
 
@@ -567,22 +578,22 @@ For Item1 the indentation is 4 (when treating the list marker as whitespace),
 so the next paragraph "More text..." starts at the same indentation level 
 and is therefore not seen as a code block.
 
-\subsection mddox_emph_spans Emphasis limits
+\subsection mddox_emph_spans Emphasis and strikethrough limits
 
-Unlike standard Markdown, doxygen will not touch internal underscores or
-stars, so the following will appear as-is:
+Unlike standard Markdown and Github Flavored Markdown doxygen will not touch internal underscores or
+stars or tildes, so the following will appear as-is:
 
     a_nice_identifier
 
-Furthermore, a `*` or `_` only starts an emphasis if
+Furthermore, a `*` or `_` only starts an emphasis  and a `~` only starts a strikethrough if
 - it is followed by an alphanumerical character, and
 - it is preceded by a space, newline, or one the following characters `<{([,:;`
 
-An emphasis ends if
+An emphasis or a strikethrough ends if
 - it is not followed by an alphanumerical character, and
 - it is not preceded by a space, newline, or one the following characters `({[<=+-\@`
 
-Lastly, the span of the emphasis is limited to a single paragraph.
+Lastly, the span of the emphasis or strikethrough is limited to a single paragraph.
 
 
 \subsection mddox_code_spans Code Spans Limits

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -396,9 +396,11 @@ static int processEmphasis2(GrowBuf &out, const char *data, int size, char c)
         data[i-1]!='\n'
        )
     {
-      out.addStr("<strong>");
+      if (c == '~') out.addStr("<strike>");
+      else out.addStr("<strong>");
       processInline(out,data,i);
-      out.addStr("</strong>");
+      if (c == '~') out.addStr("</strike>");
+      else out.addStr("</strong>");
       return i + 2;
     }
     i++;
@@ -616,7 +618,7 @@ static int processEmphasis(GrowBuf &out,const char *data,int offset,int size)
 
   char c = data[0];
   int ret;
-  if (size>2 && data[1]!=c) // _bla or *bla
+  if (size>2 && c!='~' && data[1]!=c) // _bla or *bla
   {
     // whitespace cannot follow an opening emphasis
     if (data[1]==' ' || data[1]=='\n' || 
@@ -635,7 +637,7 @@ static int processEmphasis(GrowBuf &out,const char *data,int offset,int size)
     }
     return ret+2;
   }
-  if (size>4 && data[1]==c && data[2]==c && data[3]!=c) // ___bla or ***bla
+  if (size>4 && c!='~' && data[1]==c && data[2]==c && data[3]!=c) // ___bla or ***bla
   {
     if (data[3]==' ' || data[3]=='\n' || 
         (ret = processEmphasis3(out, data+3, size-3, c)) == 0)
@@ -2513,6 +2515,7 @@ QCString processMarkdown(const QCString &fileName,const int lineNr,Entry *e,cons
     // setup callback table for special characters
     g_actions[(unsigned int)'_']=processEmphasis;
     g_actions[(unsigned int)'*']=processEmphasis;
+    g_actions[(unsigned int)'~']=processEmphasis;
     g_actions[(unsigned int)'`']=processCodeSpan;
     g_actions[(unsigned int)'\\']=processSpecialCommand;
     g_actions[(unsigned int)'@']=processSpecialCommand;


### PR DESCRIPTION
Support for strikethrough by means of `~~<text>~~`

See also https://help.github.com/articles/basic-writing-and-formatting-syntax/ paragraph about "styling" text".