### PR TITLE
Bug 677092 - single quote in HTML section of PHP breaks doxygen

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3079,6 +3079,10 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					  *pCopyQuotedGString+=*yytext;
   					  BEGIN( lastStringContext ); 
 					}
+<CopyGString,CopyPHPGString>"<?php"	{ // we had an odd number of quotes.
+					  *pCopyQuotedGString += yytext;
+  					  BEGIN( lastStringContext ); 
+					}
 <CopyGString,CopyPHPGString>"/*"|"*/"|"//" {
   					  *pCopyQuotedGString+=yytext;
   					}


### PR DESCRIPTION
Close string also when entering a new php (`<?php`) block

Also solves:
Bug 695337 - Inline HTML containing a single apostrophe (') appears to interfere with Doxygen parsing.
Bug 156160 - Doesn't support quotes in HTML code embedded into a PHP script