### PR TITLE
Bug 750331 - Detailed file documentation is being rolled into the author field

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2297,6 +2297,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 static bool handleBrief(const QCString &, const QCStringList &)
 {
   //printf("handleBrief\n");
+  addOutput("\n"); // see also handleDetails
   setOutput(OutputBrief);
   return FALSE;
 }


### PR DESCRIPTION
See to it that the previous command is properly closed when starting a brief section.