### PR TITLE
Bug 751700 - Main page absent in TOC of CHM, if PROJECT_NAME is empty

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -66,7 +66,7 @@ namespace Config
    *  and replaces environment variables.
    *  \param clearHeaderAndFooter set to TRUE when writing header and footer templates.
    */
-  void postProcess(bool clearHeaderAndFooter);
+  void postProcess(bool clearHeaderAndFooter, bool compare = FALSE);
 
   /*! Check the validity of the parsed options and correct or warn the user where needed. */
   void checkAndCorrect();

--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -75,6 +75,7 @@ class ConfigOption
     virtual void writeTemplate(FTextStream &t,bool sl,bool upd) = 0;
     virtual void compareDoxyfile(FTextStream &t) = 0;
     virtual void convertStrToVal() {}
+    virtual void emptyValueToDefault() {}
     virtual void substEnvVars() = 0;
     virtual void init() {}
 
@@ -189,6 +190,7 @@ class ConfigString : public ConfigOption
     void compareDoxyfile(FTextStream &t);
     void substEnvVars();
     void init() { m_value = m_defValue.copy(); }
+    void emptyValueToDefault() { if(m_value.isEmpty()) m_value=m_defValue; };
   
   private:
     QCString m_value;
@@ -490,6 +492,10 @@ class ConfigImpl
      *  to real values for non-string type options (like int, and bools)
      */
     void convertStrToVal();
+
+    /*! Sets default value in case value is empty
+     */
+    void emptyValueToDefault();
 
     /*! Replaces references to environment variable by the actual value
      *  of the environment variable.

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -983,6 +983,15 @@ void ConfigImpl::convertStrToVal()
     option->convertStrToVal();
   }
 }
+void ConfigImpl::emptyValueToDefault()
+{
+  QListIterator<ConfigOption> it = iterator();
+  ConfigOption *option;
+  for (;(option=it.current());++it)
+  {
+    option->emptyValueToDefault();
+  }
+}
 
 static void substEnvVarsInString(QCString &s)
 {
@@ -1854,7 +1863,7 @@ void Config::writeTemplate(FTextStream &t,bool shortList,bool update)
 
 void Config::compareDoxyfile(FTextStream &t)
 {
-  postProcess(FALSE);
+  postProcess(FALSE, TRUE);
   ConfigImpl::instance()->compareDoxyfile(t);
 }
 
@@ -1863,9 +1872,10 @@ bool Config::parse(const char *fileName,bool update)
   return ConfigImpl::instance()->parse(fileName,update);
 }
 
-void Config::postProcess(bool clearHeaderAndFooter)
+void Config::postProcess(bool clearHeaderAndFooter, bool compare)
 {
   ConfigImpl::instance()->substituteEnvironmentVars();
+  if (!compare)ConfigImpl::instance()->emptyValueToDefault();
   ConfigImpl::instance()->convertStrToVal();
 
   // avoid bootstrapping issues when the config file already


### PR DESCRIPTION
In case a string is empty the default should be taken and not left blank.