### PR TITLE
Add python function annotations support

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1059,12 +1059,13 @@ STARTDOCSYMS      "##"
 			  g_defVal+=*yytext;
        			}
      ")"		|
+     "="		|
      ","		{
 			  if (g_braceCount == 0)
 			  {
 			    if (current->argList->getLast())
 			      current->argList->getLast()->type += g_defVal.data();
-			    if (*yytext == ')')
+			    if (*yytext != ',')
 			      unput(*yytext);
 			    BEGIN(FunctionParams);
 			  }

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -119,6 +119,7 @@ static bool             g_start_init = FALSE;
 static int              g_search_count = 0;
 
 static QCString         g_argType = "";
+static bool             g_funcParamsEnd;
 //-----------------------------------------------------------------------------
 
 
@@ -514,6 +515,8 @@ STARTDOCSYMS      "##"
 %x FunctionDec
 %x FunctionParams
 %x FunctionBody
+%x FunctionAnnotation
+%x FunctionTypeAnnotation
 %x FunctionParamDefVal
 
   /* Class states */
@@ -933,7 +936,6 @@ STARTDOCSYMS      "##"
 }
 
 <FunctionDec>{
-
     {IDENTIFIER}            {
 			      //found function name
 			      if (current->type.isEmpty()) 
@@ -944,16 +946,26 @@ STARTDOCSYMS      "##"
 			      current->name = current->name.stripWhiteSpace();
 			      newFunction();
                             }
-    {B}":"		    { // function without arguments
+    {B}":"{B}		    { // function without arguments
 			      g_specialBlock = TRUE; // expecting a docstring
 			      bodyEntry = current;
                               current->bodyLine  = yyLineNr;
-                              BEGIN( FunctionBody );
+                              BEGIN(FunctionBody);
 			    }
 
-    {B}"("                  {
-			       BEGIN( FunctionParams );
+    "->"                    {
+			      g_defVal.resize(0);
+			      g_braceCount = 0;
+			      BEGIN(FunctionTypeAnnotation);
 		            }
+    {B}"("                  {
+			      g_funcParamsEnd = FALSE;
+			      BEGIN(FunctionParams);
+		            }
+    ")"                     { // end of parameter list
+        		      current->args = argListToString(current->argList);
+        		      g_funcParamsEnd = TRUE;
+                            }
 }
 
 <FunctionParams>{
@@ -975,20 +987,18 @@ STARTDOCSYMS      "##"
                           // TODO: this rule is too simple, need to be able to
                           // match things like =")" as well!
 			  g_defVal.resize(0);
-			  g_braceCount=0;
+			  g_braceCount = 0;
 			  BEGIN(FunctionParamDefVal);
       			}
-
-     ")"                { // end of parameter list
-        		  current->args = argListToString(current->argList);
+     ")"                {
+			  unput(*yytext);
+			  BEGIN(FunctionDec);
                         }
-
      ":"{B}             {
-			  g_specialBlock = TRUE; // expecting a docstring
-			  bodyEntry = current;
-                          current->bodyLine  = yyLineNr;
-                          BEGIN( FunctionBody );
-                        }
+			  g_defVal.resize(0);
+			  g_braceCount = 0;
+			  BEGIN(FunctionAnnotation);
+			}
     {POUNDCOMMENT}	{ // a comment
 			}
     {PARAMNONEMPTY}     { // Default rule inside arguments.
@@ -996,31 +1006,124 @@ STARTDOCSYMS      "##"
 
 }
 
+<FunctionTypeAnnotation>{
+     "["		|
+     "("		{
+     			  ++g_braceCount;
+     			  g_defVal+=*yytext;
+     			}
+     "]"		|
+     ")"		{
+			  --g_braceCount;
+			  g_defVal+=*yytext;
+       			}
+     ":"		{
+			  if (g_braceCount == 0)
+			  {
+			    current->type = g_defVal.data();
+			    unput(*yytext);
+			    BEGIN(FunctionDec);
+			  }
+			  else
+     			    g_defVal+=*yytext;
+       			}
+     "'"                {
+			  g_defVal+=*yytext;
+			  g_copyString=&g_defVal;
+			  g_stringContext=FunctionTypeAnnotation;
+			  BEGIN(SingleQuoteString);
+                        }
+     "\""               {
+			  g_defVal+=*yytext;
+			  g_copyString=&g_defVal;
+			  g_stringContext=FunctionTypeAnnotation;
+			  BEGIN(DoubleQuoteString);
+                        }
+     \n                 {
+			  g_defVal+=*yytext;
+			  incLineNr();
+			}
+     .			{
+			  g_defVal+=*yytext;
+       			}
+}
+
+<FunctionAnnotation>{
+     "["		|
+     "("		{
+     			  ++g_braceCount;
+     			  g_defVal+=*yytext;
+     			}
+     "]"		{
+			  --g_braceCount;
+			  g_defVal+=*yytext;
+       			}
+     ")"		|
+     ","		{
+			  if (g_braceCount == 0)
+			  {
+			    if (current->argList->getLast())
+			      current->argList->getLast()->type += g_defVal.data();
+			    if (*yytext == ')')
+			      unput(*yytext);
+			    BEGIN(FunctionParams);
+			  }
+			  else
+			  {
+			    if (*yytext == ')')
+			      --g_braceCount;
+			    g_defVal += *yytext;
+     			  }
+       			}
+     "'"                {
+			  g_defVal+=*yytext;
+			  g_copyString=&g_defVal;
+			  g_stringContext=FunctionAnnotation;
+			  BEGIN(SingleQuoteString);
+                        }
+     "\""               {
+			  g_defVal+=*yytext;
+			  g_copyString=&g_defVal;
+			  g_stringContext=FunctionAnnotation;
+			  BEGIN(DoubleQuoteString);
+                        }
+     \n                 {
+			  g_defVal+=*yytext;
+			  incLineNr();
+       			}
+     .			{
+			  g_defVal+=*yytext;
+       			}
+}
+
 <FunctionParamDefVal>{
      "["		| 
      "("		{ // internal opening brace, assumption is that we have correct code so braces do match
-       			  g_braceCount++;
+       			  ++g_braceCount;
 			  g_defVal+=*yytext;
        			}
-     ","		| 
-     "]"		| 
-     ")"		{
-       			  if (g_braceCount==0)  // end of default argument
+     "]"		{
+			  --g_braceCount;
+			  g_defVal+=*yytext;
+       			}
+     ")"		|
+     ","		{
+			  if (g_braceCount == 0)
 			  {
 			    if (current->argList->getLast())
-			    {
 			      current->argList->getLast()->defval=QCString(g_defVal.data()).stripWhiteSpace();
-			    }
-			    if (*yytext != ',')
-			      current->args = argListToString(current->argList);
+			    if (*yytext == ')')
+			      unput(*yytext);
 			    BEGIN(FunctionParams);
 			  }
-			  else // continue
-			  {
-			    if (*yytext != ',')g_braceCount--;
-			    g_defVal+=*yytext;
-			  }
+     			  else
+     			  {
+			    if (*yytext == ')')
+			      --g_braceCount;
+     			    g_defVal += *yytext;
+     			  }
        			}
+
      "'"                {
                           g_defVal+=*yytext;
                           g_copyString=&g_defVal;

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1007,11 +1007,13 @@ STARTDOCSYMS      "##"
 }
 
 <FunctionTypeAnnotation>{
+     "{"		|
      "["		|
      "("		{
      			  ++g_braceCount;
      			  g_defVal+=*yytext;
      			}
+     "}"		|
      "]"		|
      ")"		{
 			  --g_braceCount;
@@ -1049,11 +1051,13 @@ STARTDOCSYMS      "##"
 }
 
 <FunctionAnnotation>{
+     "{"		|
      "["		|
      "("		{
      			  ++g_braceCount;
      			  g_defVal+=*yytext;
      			}
+     "}"		|
      "]"		{
 			  --g_braceCount;
 			  g_defVal+=*yytext;
@@ -1098,11 +1102,13 @@ STARTDOCSYMS      "##"
 }
 
 <FunctionParamDefVal>{
+     "{"		| 
      "["		| 
      "("		{ // internal opening brace, assumption is that we have correct code so braces do match
        			  ++g_braceCount;
 			  g_defVal+=*yytext;
        			}
+     "}"		|
      "]"		{
 			  --g_braceCount;
 			  g_defVal+=*yytext;


### PR DESCRIPTION
This PR adds function annotations (type hints) support for python scanner.

Function annotations syntax is described in [PEP 3107](https://www.python.org/dev/peps/pep-3107/).
Related issue: #6462 

Now it's possible to detect function and parameters types.

You may check result sqlite DB:

    doxygen Doxyfile && sqlite3 doxygen_sqlite3.db "select type,name,argsstring from memberdef"

---

`Doxyfile`:

```
GENERATE_HTML          = NO
INPUT                  = args.py
```

`args.py`:

```python
def foo1(param1: int, param2: str):
    """Example function"""
    pass

def foo2(get_next_item: Callable[[], str]) -> CallableX[int]:
    pass

def foo3(on_success: Callable[[int], None],
    on_error: Callable[[int, Exception], None]) -> bool:
    pass

def foo4():
    """Helper func."""
    pass

def foo5(xparam=(1, None), yparam=(False, 4.5), *args) -> []:
    pass

def foo6(cli, start_point, verbose=(1,False), raise_=(False, [2, 3])):
    pass

def foo7(value=[1, 2, 3, 4, 5]): # [dangerous-default-value]
    return value

def foo8(x, y):
    pass

def foo9():
    """Same as foo4()."""
    pass

def foo10() -> str:
    pass

class MyClass:
    def foo11(self, xparam=(1, None), yparam=(False, 4.5), *args) -> []:
        pass
```

NOTE: `params` table still contains incorrect values; `stringToArgumentList()`  in `defargs.l` parses python args incorrectly.


