### PR TITLE
Bold text terminated by plus sign

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -76,7 +76,7 @@
 // so for example *bla (*.txt) is cool*
 #define ignoreCloseEmphChar(i) \
   (data[i]=='('  || data[i]=='{' || data[i]=='[' || data[i]=='<' || \
-   data[i]=='='  || data[i]=='+' || data[i]=='-' || data[i]=='\\' || \
+   data[i]=='\\' || \
    data[i]=='@')
 
 //----------


### PR DESCRIPTION
No reason to have '+,'-' or '=' with ignore characters.
See also: https://stackoverflow.com/questions/52696929/markdown-bold-text