### PR TITLE
Numbers in comment disappear

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1638,7 +1638,7 @@ const char* prepassFixedForm(const char* contents, int *hasContLine)
 	}
         // fallthrough
       default:
-        if ((column < 6) && ((c - '0') >= 0) && ((c - '0') <= 9)) { // remove numbers, i.e. labels from first 5 positions.
+        if (!commented && (column < 6) && ((c - '0') >= 0) && ((c - '0') <= 9)) { // remove numbers, i.e. labels from first 5 positions.
             newContents[j]=' ';
         }
         else if(column==6 && emptyLabel) { // continuation


### PR DESCRIPTION
In fixed formatted Fortran code the numbers in the first positions of the comment were filtered out.
This is a regression on pull request #655

example where the number '1' disappears:

```
!> \details
!>  1.) First point
      subroutine tst
      end subroutine
```