### PR TITLE
issue_6547 Call graph missing due to ALIASES

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9889,7 +9889,7 @@ static void escapeAliases()
     while ((in=value.find("^^",p))!=-1)
     {
       newValue+=value.mid(p,in-p);
-      newValue+="\n";
+      newValue+="\\_linebr";
       p=in+2;
     }
     newValue+=value.mid(p,value.length()-p);


### PR DESCRIPTION
Replace the `^^` in an alias not with an physical newline but with a doxygen synthetic newline.
Shown problem is due to the fact that line matching didn't work anymore due to the fact that a physical newline was inserted (ever better seen when enabling `INLINE_SOURCES`)