### PR TITLE
Flexibility in setting Python protection

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -883,7 +883,7 @@ Structural indicators
   Note that doxygen automatically detects the protection level of members
   in object-oriented languages. This command is intended for use only when
   the language does not support the concept of protection level natively
-  (e.g. C, PHP 4).
+  (e.g. C, PHP 4). For Python see see also \ref cfg_python_protection "PYTHON_PROTECTION".
 
   For starting a section of private members, in a way similar to the
   "private:" class marker in C++, use \ref cmdprivatesection "\\privatesection".
@@ -926,7 +926,7 @@ Structural indicators
   Note that doxygen automatically detects the protection level of members
   in object-oriented languages. This command is intended for use only when
   the language does not support the concept of protection level natively
-  (e.g. C, PHP 4).
+  (e.g. C, PHP 4). For Python see see also \ref cfg_python_protection "PYTHON_PROTECTION".
 
   For starting a section of protected members, in a way similar to the
   "protected:" class marker in C++, use \ref cmdprotectedsection "\\protectedsection".
@@ -967,7 +967,7 @@ Structural indicators
   Note that doxygen automatically detects the protection level of members
   in object-oriented languages. This command is intended for use only when
   the language does not support the concept of protection level natively
-  (e.g. C, PHP 4).
+  (e.g. C, PHP 4). For Python see see also \ref cfg_python_protection "PYTHON_PROTECTION".
 
   For starting a section of public members, in a way similar to the
   "public:" class marker in C++, use \ref cmdpublicsection "\\publicsection".

--- a/src/config.xml
+++ b/src/config.xml
@@ -586,6 +586,19 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='list' id='PYTHON_PROTECTION' format='string'>
+      <docs>
+<![CDATA[
+This tag can be used to specify the protection indicators for Python methods and variables. An indicator hast the basic form <code>\<keyword\>=(\<start\>,\<end\>)</code>) or <code>\<keyword\>=\<start\></code>. The `<keyword>` can have the values `public`, `private` or `protected`.
+In case the name of the function / variable starts with \c \<start\> and ends with \c \<end\> the protection as specified with  \c \<keyword\> is applied. In case \c \<start\> or \c \<end\> is not specified the correcsponding test (on start or end) is not executed.
+\note by just setting `public=` the complete automatic detection is disabled.
+
+<br>If left blank, the following values are used:
+]]>
+      </docs>
+      <value name='public=(__,__)'/>
+      <value name='private=_'/>
+    </option>
     <option type='bool' id='OPTIMIZE_OUTPUT_FOR_C' defval='0'>
       <docs>
 <![CDATA[

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1819,6 +1819,13 @@ void Config::checkAndCorrect()
 
   checkFileName(ConfigImpl_getString("GENERATE_TAGFILE"),"GENERATE_TAGFILE");
 
+  QStrList &pythonProtection = ConfigImpl_getList("PYTHON_PROTECTION");
+  if (pythonProtection.isEmpty())
+  {
+    pythonProtection.append("public=(__,__)");
+    pythonProtection.append("private=_");
+  }
+
 #if 0 // TODO: this breaks test 25; SOURCEBROWSER = NO and SOURCE_TOOLTIPS = YES.
       // So this and other regressions should be analysed and fixed before this can be enabled
   // disable any boolean options that depend on disabled options

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -119,6 +119,20 @@ static bool             g_start_init = FALSE;
 static int              g_search_count = 0;
 
 static QCString         g_argType = "";
+
+class PyProt
+{
+  public:
+    PyProt(QCString protKey,QCString protValStart,QCString protValEnd,Protection prot) :
+      m_protKey(protKey), m_protValStart(protValStart), m_protValEnd(protValEnd), m_prot(prot) { }
+
+    QCString m_protKey;
+    QCString m_protValStart;
+    QCString m_protValEnd;
+    Protection m_prot;
+};
+static QList<PyProt> listPyProt;
+
 //-----------------------------------------------------------------------------
 
 
@@ -154,12 +168,83 @@ static void newEntry()
   initEntry();
 }
 
+static void getPythonProtections()
+{
+  static bool first = true;
+  if (!first) return;
+  first = false;
+  QStrList protList = Config_getList(PYTHON_PROTECTION);
+  for (uint cnt=0; cnt < protList.count(); ++cnt)
+  {
+    QCString prot = protList.at(cnt);
+    prot = prot.stripWhiteSpace();
+    QCString protKey = prot;
+    QCString protValStart;
+    QCString protValEnd;
+    int i = prot.find('=');
+    if (i>=0)  // found '='
+    {
+      protKey = prot.left(i);
+      protValStart = prot.right(prot.length() - i - 1).stripWhiteSpace();
+      // lets see if brackets are present at first and last position
+      if (protValStart.at(0) == '(' &&  protValStart.at(protValStart.length() - 1) == ')')
+      {
+        protValStart = protValStart.mid(1,protValStart.length() - 2);
+        i = protValStart.find(',');
+        if (i>=0)
+        {
+          protValEnd = protValStart.right(protValStart.length() - i - 1).stripWhiteSpace();
+          protValStart = protValStart.left(i).stripWhiteSpace();
+        }
+      }
+    }
+    if (protKey == "private")
+    {
+      if (!protValStart.isEmpty() || !protValEnd.isEmpty())
+      {
+        listPyProt.append(new PyProt(protKey,protValStart,protValEnd,Private));
+      }
+    }
+    else if (protKey == "protected")
+    {
+      if (!protValStart.isEmpty() || !protValEnd.isEmpty())
+      {
+        listPyProt.append(new PyProt(protKey,protValStart,protValEnd,Protected));
+      }
+    }
+    else if (protKey == "public")
+    {
+      if (!protValStart.isEmpty() || !protValEnd.isEmpty())
+      {
+        listPyProt.append(new PyProt(protKey,protValStart,protValEnd,Public));
+      }
+    }
+    else
+    {
+      warn(yyFileName,yyLineNr,"Unknown option specified with PYTHON_PROTECTION : `%s'", prot.stripWhiteSpace().data());
+    }
+  }
+}
+
+static void setPythonProtections()
+{
+  for (uint j = 0; j < listPyProt.count(); j++)
+  {
+    if ((listPyProt.at(j)->m_protValStart.isEmpty() ||
+         current->name.left(listPyProt.at(j)->m_protValStart.length())==listPyProt.at(j)->m_protValStart) &&
+        (listPyProt.at(j)->m_protValEnd.isEmpty() ||
+         current->name.right(listPyProt.at(j)->m_protValEnd.length())==listPyProt.at(j)->m_protValEnd))
+    {
+      current->protection=listPyProt.at(j)->m_prot;
+      return;
+    }
+  }
+}
+
 static void newVariable()
 {
-  if (!current->name.isEmpty() && current->name.at(0)=='_') // mark as private
-  {
-    current->protection=Private;
-  }
+  getPythonProtections();
+  setPythonProtections();
   if (current_root->section&Entry::COMPOUND_MASK) // mark as class variable
   {
     current->stat = TRUE;
@@ -169,16 +254,8 @@ static void newVariable()
 
 static void newFunction()
 {
-  if (current->name.left(2)=="__" && current->name.right(2)=="__")
-  {
-    // special method name, see
-    // http://docs.python.org/ref/specialnames.html
-    current->protection=Public;
-  }
-  else if (current->name.at(0)=='_')
-  {
-    current->protection=Private;
-  }
+  getPythonProtections();
+  setPythonProtections();
 }
 
 static inline int computeIndent(const char *s)


### PR DESCRIPTION
Python does not have a real knowledge of protection in respect to variables and functions (i.e. public / private / protected). There are some ad-hoc rules but they changed over time as well.
Doxygen uses  some build in settings for protection i.e. methods starting with '\_\_' and ending with '\_\_' are public other variables and methods starting with '_' are private. This change makes it possible for the user to define his own rules for the protection within Python.

(Loosely based on issue #6554)