### PR TITLE
issue_6547 Call graph missing due to ALIASES

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9889,7 +9889,7 @@ static void escapeAliases()
     while ((in=value.find("^^",p))!=-1)
     {
       newValue+=value.mid(p,in-p);
-      newValue+="\\_linebr";
+      newValue+="@_linebr";
       p=in+2;
     }
     newValue+=value.mid(p,value.length()-p);


### PR DESCRIPTION
The fix as given in pull request #6548 worked but at some places it didn't work as the backslash (`\`) was eaten, replacing the backslash with a `@` solves the issue.