### PR TITLE
Remove obsolete line from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ Developers
 
 * Doxygen's Doxygen Documentation: <a href="https://codedocs.xyz/doxygen/doxygen/"><img src="https://codedocs.xyz/doxygen/doxygen.svg"/></a>
 
-* Install
-  * Quick install see (./INSTALL)
-  * else http://www.doxygen.org/manual/install.html
+* Install: Please read the installation section of the manual (http://www.doxygen.org/manual/install.html)
 
 * Project stats: https://www.openhub.net/p/doxygen
 


### PR DESCRIPTION
The README.md contained a reference to the file INSTALL but this file only contains a reference to the manual plus address.