### PR TITLE
Bug 749049 - Doxygen not creating call graphs for C# methods if namespace contains the classname

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2172,8 +2172,12 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
   					  g_code->codify(yytext);
 					  endFontClass();
 					}
+<ClassName>{ID}("."{ID})*	        |
 <ClassName>{ID}("::"{ID})*	        {
-                                          g_curClassName=yytext;
+                                          if(g_insideCS)
+                                            g_curClassName=substitute(yytext,".","::");
+                                          else
+                                            g_curClassName=yytext;
 					  addType();
                                           if (g_curClassName=="alignas")
                                           {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3840,6 +3840,28 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  else
 					  {
 					    current->endBodyLine = yyLineNr;
+                                            if (current->section == Entry::NAMESPACE_SEC && current->type == "namespace")
+                                            {
+                                              int split_point;
+                                              while ((split_point = current->name.find("::")) != -1)
+                                              {
+                                                Entry *new_current = new Entry(*current);
+                                                current->program = "";
+                                                new_current->doc = "";
+                                                new_current->docLine = 0;
+                                                new_current->docFile = "";
+                                                new_current->brief = "";
+                                                new_current->briefLine = 0;
+                                                new_current->briefFile = "";
+                                                new_current->name  = current->name.mid(split_point + 2);
+                                                current->name  = current->name.left(split_point);
+                                                if (!current_root->name.isEmpty()) current->name.prepend(current_root->name+"::");
+
+                                                current_root->addSubEntry(current);
+                                                current_root = current;
+                                                current = new_current;
+                                              }
+                                            }
 					    QCString &cn = current->name;
 					    QCString rn = current_root->name.copy();
 					    //printf("cn=`%s' rn=`%s' isTypedef=%d\n",cn.data(),rn.data(),isTypedef);


### PR DESCRIPTION
Problem is the '.' in the namespace name.

For Csharp:
```
    namespace N1.N2
    {
```
is equivalent to
```
    namespace N1
    {
      namespace N2
      {

```
This splitting has to be considered in the scanner so the different namespaces are mentioned. In the code.l the '.' was not handled.