### PR TITLE
Wrong separator in index for a.o. Python, C#

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2560,7 +2560,7 @@ void MemberDef::writeDocumentation(MemberList *ml,
 
   QCString scopeName = scName;
   QCString memAnchor = anchor();
-  QCString ciname = container->name();
+  QCString ciname = container->displayName();
   Definition *scopedContainer = container; // see bug 753608
   if (container->definitionType()==TypeGroup)
   {


### PR DESCRIPTION
In e.g. the LaTeX output the separator for Pyton, C# is given as '::', this should be '.' .
With this fix the problems in the index are gone.