### PR TITLE
issue_6566: INHERIT_DOCS not working for python

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7697,7 +7697,7 @@ static void computeMemberRelations()
           //       bmcd->name().data(),bmd->name().data(),bmd
           //      );
           if (md!=bmd && bmcd && mcd && bmcd!=mcd &&
-              (bmd->virtualness()!=Normal ||
+              (bmd->virtualness()!=Normal || bmd->getLanguage()==SrcLangExt_Python ||
                bmcd->compoundType()==ClassDef::Interface ||
                bmcd->compoundType()==ClassDef::Protocol
               ) &&


### PR DESCRIPTION
methods in Python are always "virtual" (but there is no way to signal it).