### PR TITLE
Multiple addindex commands in HTML with same name

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -67,7 +67,12 @@ static const char *contexts[10] =
 static QCString convertIndexWordToAnchor(const QString &word)
 {
   static char hex[] = "0123456789abcdef";
+  static int cnt = 0;
   QCString result="a";
+  QCString cntStr;
+  result += cntStr.setNum(cnt);
+  result += "_";
+  cnt++;
   const char *str = word.data();
   unsigned char c;
   if (str)

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -115,7 +115,7 @@ void HtmlHelpIndex::addItem(const char *level1,const char *level2,
   {
     return;
   }
-  if (dict->find(key)==0) // new key
+  if (dict->find(key+anchor)==0) // new key
   {
     //printf(">>>>>>>>> HtmlHelpIndex::addItem(%s,%s,%s,%s)\n",
     //      level1,level2,url,anchor);
@@ -125,7 +125,7 @@ void HtmlHelpIndex::addItem(const char *level1,const char *level2,
     f->anchor   = anchor;
     f->link     = hasLink;
     f->reversed = reversed;
-    dict->append(key,f);
+    dict->append(key+anchor,f);
   }
 }
 
@@ -187,7 +187,7 @@ void HtmlHelpIndex::writeFields(FTextStream &t)
       level1  = f->name.copy();
     }
 
-    if (level1!=lastLevel1)
+    //if (level1!=lastLevel1)
     { // finish old list at level 2
       if (level2Started) t << "  </UL>" << endl;
       level2Started=FALSE;


### PR DESCRIPTION
It is possible to specify an addindex multiple times. In HTML this resulted in
- a 'a' tag with with the same 'name' attribute
- in CHM only one occurrence was shown.

this has been corrected.
(see e.g. the index of 'flex' in the CHM manual generated ffrom master).