### PR TITLE
RTF layout regarding References and Referenced by

### DIFF
--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2180,11 +2180,12 @@ void RTFGenerator::newParagraph()
   m_omitParagraph = FALSE;
 }
 
-void RTFGenerator::startParagraph(const char *)
+void RTFGenerator::startParagraph(const char *txt)
 {
   DBG_RTF(t << "{\\comment startParagraph}" << endl)
   newParagraph();
   t << "{" << endl;
+  if (QCString(txt) == "reference") t << "\\ql" << endl;
 }
 
 void RTFGenerator::endParagraph()


### PR DESCRIPTION
The layout was so that lines were stretched to to complete lines from left to right (Justified). For "normal" text this is fine, but not for lists like this, so set alignment here to: Left aligned