### PR TITLE
Spelling of the word Javadoc

### DIFF
--- a/doc/autolink.doc
+++ b/doc/autolink.doc
@@ -80,7 +80,7 @@
     are required to identify the target, i.e. 'func(int) const' and 'func(int)'
     target different member functions.
   \par Note 3: 
-    For JavaDoc compatibility a \# may be used instead of a :: in 
+    For Javadoc compatibility a \# may be used instead of a :: in 
     the patterns above.
   \par Note 4:
     In the documentation of a class containing a member foo, 

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3280,7 +3280,7 @@ class Receiver
   \addindex \\\@
   This command writes an at-sign (\c \@) to the output.
   The at-sign has to be escaped in some cases
-  because doxygen uses it to detect JavaDoc commands.
+  because doxygen uses it to detect Javadoc commands.
 
 <hr>
 \section cmdtilde \\~[LanguageId]

--- a/doc/docblocks.doc
+++ b/doc/docblocks.doc
@@ -55,7 +55,7 @@ used to provide tooltips at places where an item is referenced.
 
 There are several ways to mark a comment block as a detailed description:
 <ol>
-<li> You can use the JavaDoc style, which consist of a C-style comment
+<li> You can use the Javadoc style, which consist of a C-style comment
 block starting with two *'s, like this:
 
 \verbatim
@@ -143,7 +143,7 @@ Here is an example:
 
 <li>If \ref cfg_javadoc_autobrief "JAVADOC_AUTOBRIEF" is set to \c YES 
     in the configuration file, 
-    then using JavaDoc style comment
+    then using Javadoc style comment
     blocks will automatically start a brief description which ends at the
     first dot followed by a space or new line. Here is an example:
 
@@ -299,8 +299,8 @@ sentence of the detailed descriptions
 tag to \c NO). Both the brief and the detailed descriptions are optional 
 for the Qt style. 
 
-By default a JavaDoc style documentation block behaves the same way as a
-Qt style documentation block. This is not according the JavaDoc specification
+By default a Javadoc style documentation block behaves the same way as a
+Qt style documentation block. This is not according the Javadoc specification
 however, where the first sentence of the documentation block is automatically
 treated as a brief description. To enable this behavior you should set
 \ref cfg_javadoc_autobrief "JAVADOC_AUTOBRIEF" to YES in the configuration
@@ -312,7 +312,7 @@ Here is an example:
 \endverbatim
 
 Here is the same piece of code as shown above, this time documented using the 
-JavaDoc style and \ref cfg_javadoc_autobrief "JAVADOC_AUTOBRIEF" set to YES:
+Javadoc style and \ref cfg_javadoc_autobrief "JAVADOC_AUTOBRIEF" set to YES:
 \include jdstyle.cpp
  \htmlonly
  </p>
@@ -348,7 +348,7 @@ duplication of information. So in practice you should \e avoid the use of
 structural commands \e unless other requirements force you to do so.
 
 Structural commands (like \ref cmd_intro "all other commands") start with a backslash 
-(<tt>\\</tt>), or an at-sign (<tt>\@</tt>) if you prefer JavaDoc style, 
+(<tt>\\</tt>), or an at-sign (<tt>\@</tt>) if you prefer Javadoc style, 
 followed by a command name and one or more parameters.
 For instance, if you want to document the class \c Test in the example
 above, you could have also put the following documentation block somewhere

--- a/doc/features.doc
+++ b/doc/features.doc
@@ -33,7 +33,7 @@
 <li>Supports documentation of files, namespaces, packages, classes, 
     structs, unions, templates, variables, functions, typedefs, enums and 
     defines. 
-<li>JavaDoc (1.1), qdoc3 (partially), and ECMA-334 (C# spec.) compatible.
+<li>Javadoc (1.1), qdoc3 (partially), and ECMA-334 (C# spec.) compatible.
 <li>Comes with a GUI frontend (Doxywizard) to ease editing the options and 
     run doxygen. The GUI is available on Windows, Linux, and MacOSX.
 <li>Automatically generates class and collaboration diagrams in HTML (as clickable 

--- a/examples/jdstyle.cfg
+++ b/examples/jdstyle.cfg
@@ -1,4 +1,4 @@
-PROJECT_NAME      = "JavaDoc Style"
+PROJECT_NAME      = "Javadoc Style"
 OUTPUT_DIRECTORY  = ../html/examples/jdstyle
 GENERATE_LATEX    = YES
 GENERATE_MAN      = NO

--- a/src/commentscan.h
+++ b/src/commentscan.h
@@ -40,7 +40,7 @@ class ParserInterface;
  *  @param[in,out] lineNr The line number at which the comment block was found.
  *         When the function returns it will be set to the last line parsed.
  *  @param[in] isBrief TRUE iff this comment block represents a brief description.
- *  @param[in] isJavaDocStyle TRUE iff this comment block is in "JavaDoc" style.
+ *  @param[in] isJavadocStyle TRUE iff this comment block is in "Javadoc" style.
  *         This means that it starts as a brief description until the end of
  *         the sentences is found and then proceeds as a detailed description.
  *  @param[in] isInbody TRUE iff this comment block is located in the body of
@@ -65,7 +65,7 @@ bool parseCommentBlock(ParserInterface *parser,
 	               const QCString &fileName,
 		       int  &lineNr,
 		       bool isBrief,
-		       bool isJavaDocStyle,
+		       bool isJavadocStyle,
                        bool isInbody,
 		       Protection &prot,
                        int &position,


### PR DESCRIPTION
The current spelling (also for the older versions) is Javadoc.
Changed on all possible documentation visible places (external and internal).