### PR TITLE
Issue_6585: Unexpected anchor tags in tag-files

### DIFF
--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -102,6 +102,7 @@ class TagClassInfo
     QCString name;
     QCString filename;
     QCString clangId;
+    QCString anchor;
     TagAnchorInfoList docAnchors;
     QList<BaseInfo> *bases;
     QList<TagMemberInfo> members;
@@ -382,7 +383,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unknown compound attribute `%s' found!\n",kind.data());
+        warn("Unknown compound attribute `%s' found!",kind.data());
         m_state = Invalid;
       }
       if (isObjC=="yes" && m_curClass)
@@ -410,7 +411,7 @@ class TagFileParser : public QXmlDefaultHandler
         case InPackage:   m_tagFilePackages.append(m_curPackage); 
                           m_curPackage=0; break; 
         default:
-                          warn("tag `compound' was not expected!\n");
+                          warn("tag `compound' was not expected!");
       }
     }
 
@@ -456,7 +457,7 @@ class TagFileParser : public QXmlDefaultHandler
         case InNamespace: m_curNamespace->members.append(m_curMember); break;
         case InGroup:     m_curGroup->members.append(m_curMember); break;
         case InPackage:   m_curPackage->members.append(m_curMember); break;
-        default:   warn("Unexpected tag `member' found\n"); break; 
+        default:   warn("Unexpected tag `member' found"); break; 
       }
     }
 
@@ -474,7 +475,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Found enumvalue tag outside of member tag\n");
+        warn("Found `enumvalue' tag outside of member tag");
       }
     }
 
@@ -502,7 +503,7 @@ class TagFileParser : public QXmlDefaultHandler
         case InMember:    m_curMember->docAnchors.append(new TagAnchorInfo(m_fileName,m_curString,m_title)); break;
         case InPackage:   m_curPackage->docAnchors.append(new TagAnchorInfo(m_fileName,m_curString,m_title)); break;
         case InDir:       m_curDir->docAnchors.append(new TagAnchorInfo(m_fileName,m_curString,m_title)); break;
-        default:   warn("Unexpected tag `member' found\n"); break; 
+        default:   warn("Unexpected tag `docanchor' found"); break; 
       }
     }
 
@@ -515,7 +516,7 @@ class TagFileParser : public QXmlDefaultHandler
         case InNamespace: m_curNamespace->classList.append(m_curString); break;
         case InGroup:     m_curGroup->classList.append(m_curString); break;
         case InPackage:   m_curPackage->classList.append(m_curString); break;
-        default:   warn("Unexpected tag `class' found\n"); break; 
+        default:   warn("Unexpected tag `class' found"); break; 
       }
     }
 
@@ -526,7 +527,7 @@ class TagFileParser : public QXmlDefaultHandler
         case InNamespace: m_curNamespace->classList.append(m_curString); break;
         case InFile:      m_curFile->namespaceList.append(m_curString); break;
         case InGroup:     m_curGroup->namespaceList.append(m_curString); break;
-        default:   warn("Unexpected tag `namespace' found\n"); break; 
+        default:   warn("Unexpected tag `namespace' found"); break; 
       }
     }
 
@@ -536,7 +537,7 @@ class TagFileParser : public QXmlDefaultHandler
       {
         case InGroup:      m_curGroup->fileList.append(m_curString); break;
         case InDir:        m_curDir->fileList.append(m_curString); break;
-        default:   warn("Unexpected tag `file' found\n"); break; 
+        default:   warn("Unexpected tag `file' found"); break; 
       }
     }
 
@@ -545,7 +546,7 @@ class TagFileParser : public QXmlDefaultHandler
       switch(m_state)
       {
         case InGroup:      m_curGroup->fileList.append(m_curString); break;
-        default:   warn("Unexpected tag `page' found\n"); break; 
+        default:   warn("Unexpected tag `page' found"); break; 
       }
     }
 
@@ -554,7 +555,7 @@ class TagFileParser : public QXmlDefaultHandler
       switch(m_state)
       {
         case InDir:      m_curDir->subdirList.append(m_curString); break;
-        default:   warn("Unexpected tag `page' found\n"); break; 
+        default:   warn("Unexpected tag `dir' found"); break; 
       }
     }
 
@@ -578,7 +579,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `type' found\n");
+        warn("Unexpected tag `type' found");
       }
     }
 
@@ -594,7 +595,7 @@ class TagFileParser : public QXmlDefaultHandler
         case InDir:       m_curDir->name       = m_curString; break;
         case InMember:    m_curMember->name    = m_curString; break;
         case InPackage:   m_curPackage->name   = m_curString; break;
-        default: warn("Unexpected tag `name' found\n"); break; 
+        default: warn("Unexpected tag `name' found"); break; 
       }
     }
 
@@ -628,7 +629,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `base' found\n");
+        warn("Unexpected tag `base' found");
       }
     }
 
@@ -640,7 +641,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `base' found\n");
+        warn("Unexpected tag `base' found");
       }
     }
 
@@ -657,7 +658,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `includes' found\n");
+        warn("Unexpected tag `includes' found");
       }
       m_curString="";
     }
@@ -680,7 +681,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `templarg' found\n");
+        warn("Unexpected tag `templarg' found");
       }
     }
 
@@ -695,7 +696,7 @@ class TagFileParser : public QXmlDefaultHandler
         case InPage:      m_curPage->filename      = m_curString;    break;
         case InPackage:   m_curPackage->filename   = m_curString;    break;
         case InDir:       m_curDir->filename       = m_curString;    break;
-        default: warn("Unexpected tag `filename' found\n"); break; 
+        default: warn("Unexpected tag `filename' found"); break; 
       }
     }
 
@@ -705,7 +706,7 @@ class TagFileParser : public QXmlDefaultHandler
       {
         case InFile:      m_curFile->path          = m_curString;    break;
         case InDir:       m_curDir->path           = m_curString;    break;
-        default: warn("Unexpected tag `path' found\n");     break; 
+        default: warn("Unexpected tag `path' found");     break; 
       }
     }
     
@@ -715,9 +716,13 @@ class TagFileParser : public QXmlDefaultHandler
       {
         m_curMember->anchor = m_curString; 
       }
+      else if (m_state==InClass)
+      {
+        m_curClass->anchor = m_curString; 
+      }
       else
       {
-        warn("Unexpected tag `anchor' found\n");
+        warn("Unexpected tag `anchor' found");
       }
     }
 
@@ -737,7 +742,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("warning: Unexpected tag `anchor' found\n");
+        warn("Unexpected tag `clangid' found");
       }
     }
 
@@ -751,7 +756,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `anchorfile' found\n");
+        warn("Unexpected tag `anchorfile' found");
       }
     }
     
@@ -763,7 +768,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `arglist' found\n");
+        warn("Unexpected tag `arglist' found");
       }
     }
     void endTitle()
@@ -772,7 +777,7 @@ class TagFileParser : public QXmlDefaultHandler
       {
         case InGroup:     m_curGroup->title     = m_curString;    break;
         case InPage:      m_curPage->title      = m_curString;    break;
-        default: warn("Unexpected tag `title' found\n"); break; 
+        default: warn("Unexpected tag `title' found"); break; 
       }
     }
 
@@ -784,7 +789,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else
       {
-        warn("Unexpected tag `subgroup' found\n");
+        warn("Unexpected tag `subgroup' found");
       }
     }
 
@@ -879,7 +884,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else 
       {
-        warn("Unknown tag `%s' found!\n",name.data());
+        warn("Unknown tag `%s' found!",name.data());
       }
       return TRUE;
     }
@@ -894,7 +899,7 @@ class TagFileParser : public QXmlDefaultHandler
       }
       else 
       {
-        warn("Unknown tag `%s' found!\n",name.data());
+        warn("Unknown tag `%s' found!",name.data());
       }
       return TRUE;
     }
@@ -1158,7 +1163,7 @@ void TagFileParser::addDocAnchors(Entry *e,const TagAnchorInfoList &l)
     }
     else
     {
-      warn("Duplicate anchor %s found\n",ta->label.data());
+      warn("Duplicate anchor %s found",ta->label.data());
     }
   }
 }
@@ -1335,6 +1340,7 @@ void TagFileParser::buildLists(Entry *root)
     addDocAnchors(ce,tci->docAnchors);
     TagInfo *ti  = new TagInfo;
     ti->tagName  = m_tagName;
+    ti->anchor   = tci->anchor;
     ti->fileName = tci->filename;
     ce->id       = tci->clangId;
     ce->tagInfo  = ti;


### PR DESCRIPTION
- An anchor tag can also be in a `<compound>` added it.
- corrected some warnings (wrong tag name)
- some layout modifications regarding end of line (automatically nowadays with the call to the warn function