### PR TITLE
Multiple `\xreflist` in one page with same key

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -148,8 +148,6 @@ void RefList::generatePage()
   for (it.toFirst();(item=it.current());++it)
   {
     doc += " <dt>";
-    doc +=  "\\anchor ";
-    doc += item->listAnchor;
     doc += "\n";
     if (item->scope)
     {
@@ -174,13 +172,18 @@ void RefList::generatePage()
       // escape \'s in argument list (see issue #6533)
       doc += substitute(substitute(item->args,"@","@@"),"\\","\\\\");
     }
-    doc += "</dt><dd> ";
+    doc += "</dt><dd> \\anchor ";
+    doc += item->listAnchor;
+    doc += " ";
     doc += item->text;
     QListIterator<RefItem> li(item->extraItems);
     RefItem *extraItem;
     for (li.toFirst();(extraItem=li.current());++li)
     {
-      doc += "<p>" + extraItem->text;
+      doc += "<p> \\anchor ";
+      doc += extraItem->listAnchor;
+      doc += " ";
+      doc += extraItem->text;
     }
     doc += "</dd>";
   }

--- a/testing/009/bug.xml
+++ b/testing/009/bug.xml
@@ -9,17 +9,16 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="bug_1_bug000001"/>Class <ref refid="class_bug" kindref="compound">Bug</ref></term>
+            <term>Class <ref refid="class_bug" kindref="compound">Bug</ref></term>
           </varlistentry>
           <listitem>
-            <para>Class bug.  </para>
+            <para><anchor id="bug_1_bug000001"/>Class bug.  </para>
           </listitem>
           <varlistentry>
-            <term><anchor id="bug_1_bug000002"/>Member <ref refid="class_bug_1a1f720954dd97cd1203e80501a6eae74c" kindref="member">Bug::foo</ref>  ()</term>
+            <term>Member <ref refid="class_bug_1a1f720954dd97cd1203e80501a6eae74c" kindref="member">Bug::foo</ref>  ()</term>
           </varlistentry>
           <listitem>
-            <para>Function bug<itemizedlist><listitem><para>list item 1 in bug</para></listitem><listitem><para>list item 2 in bug</para></listitem></itemizedlist>
-</para>
+            <para><anchor id="bug_1_bug000002"/>Function bug<itemizedlist><listitem><para>list item 1 in bug</para></listitem><listitem><para>list item 2 in bug</para></listitem></itemizedlist></para>
           </listitem>
         </variablelist>
       </para>

--- a/testing/009/deprecated.xml
+++ b/testing/009/deprecated.xml
@@ -9,16 +9,16 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="deprecated_1_deprecated000001"/>Class <ref refid="class_deprecated" kindref="compound">Deprecated</ref></term>
+            <term>Class <ref refid="class_deprecated" kindref="compound">Deprecated</ref></term>
           </varlistentry>
           <listitem>
-            <para>This class is deprecated  </para>
+            <para><anchor id="deprecated_1_deprecated000001"/>This class is deprecated  </para>
           </listitem>
           <varlistentry>
-            <term><anchor id="deprecated_1_deprecated000002"/>Member <ref refid="class_deprecated_1a1d5f6803e72c625727e7083d1722dbf9" kindref="member">Deprecated::deprecated</ref>  ()</term>
+            <term>Member <ref refid="class_deprecated_1a1d5f6803e72c625727e7083d1722dbf9" kindref="member">Deprecated::deprecated</ref>  ()</term>
           </varlistentry>
           <listitem>
-            <para>No not use this function anymore. </para>
+            <para><anchor id="deprecated_1_deprecated000002"/>No not use this function anymore. </para>
           </listitem>
         </variablelist>
       </para>

--- a/testing/009/reminders.xml
+++ b/testing/009/reminders.xml
@@ -9,16 +9,16 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="reminders_1_reminders000001"/>Class <ref refid="class_reminder" kindref="compound">Reminder</ref></term>
+            <term>Class <ref refid="class_reminder" kindref="compound">Reminder</ref></term>
           </varlistentry>
           <listitem>
-            <para>A reminder  </para>
+            <para><anchor id="reminders_1_reminders000001"/>A reminder  </para>
           </listitem>
           <varlistentry>
-            <term><anchor id="reminders_1_reminders000002"/>Member <ref refid="class_reminder_1a173b5218bb11287b0e86a550d9f0728d" kindref="member">Reminder::reminder</ref>  ()</term>
+            <term>Member <ref refid="class_reminder_1a173b5218bb11287b0e86a550d9f0728d" kindref="member">Reminder::reminder</ref>  ()</term>
           </varlistentry>
           <listitem>
-            <para>Need to rework this before the next release. </para>
+            <para><anchor id="reminders_1_reminders000002"/>Need to rework this before the next release. </para>
           </listitem>
         </variablelist>
       </para>

--- a/testing/009/test.xml
+++ b/testing/009/test.xml
@@ -9,16 +9,16 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="test_1_test000001"/>Class <ref refid="class_test" kindref="compound">Test</ref></term>
+            <term>Class <ref refid="class_test" kindref="compound">Test</ref></term>
           </varlistentry>
           <listitem>
-            <para>This is part of testing  </para>
+            <para><anchor id="test_1_test000001"/>This is part of testing  </para>
           </listitem>
           <varlistentry>
-            <term><anchor id="test_1_test000002"/>Member <ref refid="class_test_1a9fc54b716f326514a4c5f434137f4fc0" kindref="member">Test::test</ref>  ()</term>
+            <term>Member <ref refid="class_test_1a9fc54b716f326514a4c5f434137f4fc0" kindref="member">Test::test</ref>  ()</term>
           </varlistentry>
           <listitem>
-            <para>more things to test. </para>
+            <para><anchor id="test_1_test000002"/>more things to test. </para>
           </listitem>
         </variablelist>
       </para>

--- a/testing/009/todo.xml
+++ b/testing/009/todo.xml
@@ -9,16 +9,16 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="todo_1_todo000001"/>Class <ref refid="class_todo" kindref="compound">Todo</ref></term>
+            <term>Class <ref refid="class_todo" kindref="compound">Todo</ref></term>
           </varlistentry>
           <listitem>
-            <para>This still needs to be done.  </para>
+            <para><anchor id="todo_1_todo000001"/>This still needs to be done.  </para>
           </listitem>
           <varlistentry>
-            <term><anchor id="todo_1_todo000002"/>Member <ref refid="class_todo_1a9e70ec9176ac4c1b20e011b4daddc9d8" kindref="member">Todo::todo</ref>  ()</term>
+            <term>Member <ref refid="class_todo_1a9e70ec9176ac4c1b20e011b4daddc9d8" kindref="member">Todo::todo</ref>  ()</term>
           </varlistentry>
           <listitem>
-            <para>more things to do here </para>
+            <para><anchor id="todo_1_todo000002"/>more things to do here </para>
           </listitem>
         </variablelist>
       </para>


### PR DESCRIPTION
In case there are multiple `\xreflist` commands with the same key only the first item has a correct linking possibility, the subsequent items don't have it.
Resulting in warnings in e.g. docbook and LaTeX output