### PR TITLE
issue_6589 anchor after test command in a namespace produces duplicate tests

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -131,7 +131,15 @@ void RefList::insertIntoList(const char *key,RefItem *item)
   {
     if (ri!=item)
     {
-      ri->extraItems.append(item);
+      // We also have to check if the item is not already in the "extra" list
+      QListIterator<RefItem> li(ri->extraItems);
+      RefItem *extraItem;
+      bool doubleItem = false;
+      for (li.toFirst();(extraItem=li.current());++li)
+      {
+        if (item == extraItem) doubleItem = true;
+      }
+      if (!doubleItem) ri->extraItems.append(item);
     }
   }
 }


### PR DESCRIPTION
Not only should be checked whether the item to be inserted is the main item but also if it is not one of the extra items