### PR TITLE
issue_6594 using ingroup and anchor causes tests to disappear

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1644,13 +1644,21 @@ void Definition::mergeRefItems(Definition *d)
       m_impl->xrefListItems->setAutoDelete(TRUE);
     }
     QListIterator<ListItemInfo> slii(*xrefList);
+    QListIterator<ListItemInfo> mlii(*m_impl->xrefListItems);
     ListItemInfo *lii;
+    ListItemInfo *mii;
     for (slii.toFirst();(lii=slii.current());++slii)
     {
-      if (_getXRefListId(lii->type)==-1)
+      bool found = false;
+      for (mlii.toFirst();(mii=mlii.current());++mlii)
       {
-        m_impl->xrefListItems->append(new ListItemInfo(*lii));
+        if ((qstrcmp(lii->type,mii->type)==0) && (lii->itemId == mii->itemId))
+	{
+          found = true;
+          break;
+	}
       }
+      if (!found) m_impl->xrefListItems->append(new ListItemInfo(*lii));
     } 
   }
 }


### PR DESCRIPTION
The determination whether or not a reference item was in a list was based on the list name and it returned the first list item id. With multiple items only the first item was found.
Checking whether or not an item should be appended is now based on the list name and the item id.