### PR TITLE
Inconsistency in respect to tgroup in docbook

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -941,7 +941,8 @@ void DocbookDocVisitor::visitPost(DocHtmlTable *)
 {
 DB_VIS_C
   if (m_hide) return;
-  m_t << "    </tbody>" << endl;
+  if (bodySet) m_t << "    </tbody>" << endl;
+  bodySet = FALSE;
   m_t << "    </tgroup>" << endl;
   m_t << "</informaltable>" << endl;
 }


### PR DESCRIPTION
The `tgroup` close tag was set although the open tag was not used. The close tag needed 'protection' by means of the bodySet variable.