### PR TITLE
issue_6597 SIGSEGV presumably caused by C++ "using" declaration

### DIFF
--- a/src/defgen.cpp
+++ b/src/defgen.cpp
@@ -146,7 +146,7 @@ void generateDEFForMember(MemberDef *md,
     stringToArgumentList(md->argsString(),declAl);
     QCString fcnPrefix = "  " + memPrefix + "param-";
 
-    if (declAl->count()>0)
+    if (defAl && declAl->count()>0)
     {
       ArgumentListIterator declAli(*declAl);
       ArgumentListIterator defAli(*defAl);

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1609,7 +1609,7 @@ void PerlModGenerator::generatePerlModForMember(MemberDef *md,Definition *)
     m_output.openList("parameters");
     ArgumentList *declAl = md->declArgumentList();
     ArgumentList *defAl  = md->argumentList();
-    if (declAl && declAl->count()>0)
+    if (declAl && defAl && declAl->count()>0)
     {
       ArgumentListIterator declAli(*declAl);
       ArgumentListIterator defAli(*defAl);

--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -1017,7 +1017,7 @@ static void insertMemberFunctionParams(int memberdef_id, const MemberDef *md, co
 {
   ArgumentList *declAl = md->declArgumentList();
   ArgumentList *defAl = md->argumentList();
-  if (declAl!=0 && declAl->count()>0)
+  if (declAl!=0 && defAl!=0 && declAl->count()>0)
   {
     ArgumentListIterator declAli(*declAl);
     ArgumentListIterator defAli(*defAl);


### PR DESCRIPTION
Crash appears in  in the autogen,  perlmod and sqlite3 code generation. In the xml code generation the problem does not appear due to the protection against the NULL pointer.
Added protection on the other places as well