### PR TITLE
Bug 793201 - "warning: Unexpected character" generated when using "todo" command in an Objective-C category

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -54,6 +54,7 @@ static const char *g_inputString;
 static QCString g_fileName;
 static bool g_insidePre;
 static int g_sharpCount=0;
+static int g_roundCount=0;
 
 // context for section finding phase
 static Definition  *g_definition;
@@ -449,6 +450,7 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 %x St_Anchor
 %x St_Snippet
 %x St_SetScope
+%x St_SetScopeRoundEnd
 %x St_SetScopeEnd
 %x St_Options
 
@@ -1069,6 +1071,12 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                          g_sharpCount=1;
                          BEGIN(St_SetScopeEnd);
                        }
+<St_SetScope>{SCOPEMASK}"(" {
+                         g_token->name = yytext;
+                         g_token->name = g_token->name.stripWhiteSpace();
+                         g_roundCount=1;
+                         BEGIN(St_SetScopeRoundEnd);
+                       }
 <St_SetScope>{BLANK}   {
                        }
 <St_SetScopeEnd>"<"    {
@@ -1084,6 +1092,21 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                          }
                        }
 <St_SetScopeEnd>.      {
+                         g_token->name += yytext;
+                       }
+<St_SetScopeRoundEnd>")"    {
+                         g_token->name += yytext;
+                         g_roundCount++;
+                       }
+<St_SetScopeRoundEnd>")"    {
+                         g_token->name += yytext;
+                         g_roundCount--;
+                         if (g_roundCount<=0)
+                         {
+                           return TK_WORD;
+                         }
+                       }
+<St_SetScopeRoundEnd>.      {
                          g_token->name += yytext;
                        }
 <St_Ref2>"&"{ID}";"    { /* symbol */

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5395,6 +5395,28 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					    BEGIN( ClassTemplSpec );
 					  }
 					}
+<CompoundName>{SCOPENAME}{BN}*/"("	{
+					  if (insideCS) // C# generic class
+					  {
+                                            REJECT;
+					  }
+					  else if (!insideObjC) // C++ template specialization
+					  {
+                                            REJECT;
+					  }
+					  roundCount = 0;
+					  current->name = yytext ;
+					  if (current->spec & Entry::Protocol)
+					  {
+					    current->name+="-p";
+					  }
+					  lineCount();
+					  lastClassTemplSpecContext = ClassVar;
+					  if (insideObjC) // protocol list
+					  {
+					    BEGIN( ObjCProtocolList );
+					  }
+					}
 <CSGeneric>"<"				{
 					  if (current->tArgLists==0)
 					  {
@@ -5414,7 +5436,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  currentArgumentContext = ClassVar;
 					  BEGIN( ReadTempArgs );
   					}
-<ObjCProtocolList>"<"			{
+<ObjCProtocolList>"<"|"("		{
   					  insideProtocolList=TRUE;
   					  BEGIN( Bases );
   					}
@@ -6018,7 +6040,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					  lastStringContext=SkipRound;
 					  BEGIN(SkipString);
   					}
-<Bases>","|(">"({BN}*"{")?)|({BN}+"implements"{BN}*)	{ lineCount();
+<Bases>","|((">"|")")({BN}*"{")?)|({BN}+"implements"{BN}*)	{ lineCount();
                                           if (insideProtocolList)
 					  {
 					    baseName+="-p";
@@ -6046,7 +6068,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  }
 					  baseVirt=Normal;
 					  baseName.resize(0);
-                                          if (*yytext=='>')
+                                          if ((*yytext=='>') || (*yytext==')'))
 					  { // end of a ObjC protocol list
   					    insideProtocolList=FALSE;
 					    if (yyleng==1)


### PR DESCRIPTION
Added possibility to use round brackets with the Objective-C `@interface` (analogous to the sharp brackets).