### PR TITLE
Consistency in headings and layout for template parameters (tparam)

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1447,11 +1447,8 @@ void LatexDocVisitor::visitPre(DocParamSect *s)
       filter(theTranslator->trExceptions());
       break;
     case DocParamSect::TemplateParam: 
-      /* TODO: add this 
-      filter(theTranslator->trTemplateParam()); break;
-      */
       m_t << "\n\\begin{DoxyTemplParams}{";
-      filter("Template Parameters");
+      filter(theTranslator->trTemplateParameters());
       break;
     default:
       ASSERT(0);

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -906,10 +906,7 @@ void ManDocVisitor::visitPre(DocParamSect *s)
     case DocParamSect::Exception: 
       m_t << theTranslator->trExceptions(); break;
     case DocParamSect::TemplateParam: 
-      /* TODO: add this 
-      m_t << theTranslator->trTemplateParam(); break;
-      */
-      m_t << "Template Parameters"; break;
+      m_t << theTranslator->trTemplateParameters(); break;
     default:
       ASSERT(0);
   }

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1294,10 +1294,7 @@ void RTFDocVisitor::visitPre(DocParamSect *s)
     case DocParamSect::Exception: 
       m_t << theTranslator->trExceptions(); break;
     case DocParamSect::TemplateParam: 
-      /* TODO: add this 
-      m_t << theTranslator->trTemplateParam(); break;
-      */
-      m_t << "Template Parameters"; break;
+      m_t << theTranslator->trTemplateParameters(); break;
     default:
       ASSERT(0);
   }

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -701,17 +701,17 @@ dl.reflist dd {
         padding-left: 0px;
 }       
 
-.params .paramname, .retval .paramname {
+.params .paramname, .retval .paramname, .tparams .paramname {
         font-weight: bold;
         vertical-align: top;
 }
         
-.params .paramtype {
+.params .paramtype, .tparams .paramtype {
         font-style: italic;
         vertical-align: top;
 }       
         
-.params .paramdir {
+.params .paramdir, .tparams .paramdir {
         font-family: "courier new",courier,monospace;
         vertical-align: top;
 }


### PR DESCRIPTION
- at some places the translation of the "Template Parameters" was not yet done
- layout of the template parameters table in HTML had no default. Should be analogous to the table for normal parameters