### PR TITLE
Create command for escaped equal sign

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -213,6 +213,7 @@ documentation:
 \refitem cmdamp \\\&
 \refitem cmdtilde \\~
 \refitem cmdlt \\\<
+\refitem cmdeq \\=
 \refitem cmdgt \\\>
 \refitem cmdhash \\\#
 \refitem cmdperc \\\%
@@ -3432,6 +3433,14 @@ class Receiver
   prevent ending a brief description when \ref cfg_javadoc_autobrief "JAVADOC_AUTOBRIEF" is enabled
   or to prevent starting a numbered list when the dot follows a number at
   the start of a line.
+
+<hr>
+\section cmdeq \\=
+
+  \addindex \\=
+  This command writes an equal sign (`=`) to the output. This
+  character sequence has to be escaped in some cases, because it is used
+  in Markdown header processing.
 
 <hr>
 \section cmddcolon \\::

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -111,6 +111,7 @@ CommandMap cmdMap[] =
   { "\\",            CMD_BSLASH },
   { "@",             CMD_AT },
   { "<",             CMD_LESS },
+  { "=",             CMD_EQUAL },
   { ">",             CMD_GREATER },
   { "&",             CMD_AMP },
   { "$",             CMD_DOLLAR },

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -136,7 +136,8 @@ enum CommandType
   CMD_MINUS        = 106,
   CMD_INCLUDEDOC   = 107,
   CMD_SNIPPETDOC   = 108,
-  CMD_SNIPWITHLINES= 109
+  CMD_SNIPWITHLINES= 109,
+  CMD_EQUAL        = 110
 };
 
 enum HtmlTagType

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1437,6 +1437,9 @@ reparsetoken:
         case CMD_MINUS:
           children.append(new DocSymbol(parent,DocSymbol::Sym_Minus));
           break;
+        case CMD_EQUAL:
+          children.append(new DocSymbol(parent,DocSymbol::Sym_Equal));
+          break;
         case CMD_EMPHASIS:
           {
             children.append(new DocStyleChange(parent,g_nodeStack.count(),DocStyleChange::Italic,TRUE));
@@ -3257,6 +3260,7 @@ int DocIndexEntry::parse()
         case CMD_PUNT:    m_entry+='.';  break;
         case CMD_PLUS:    m_entry+='+';  break;
         case CMD_MINUS:   m_entry+='-';  break;
+        case CMD_EQUAL:   m_entry+='=';  break;
         default:
           warn_doc_error(g_fileName,doctokenizerYYlineno,"Unexpected command %s found as argument of \\addindex",
                     qPrint(g_token->name));
@@ -5420,6 +5424,9 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
     case CMD_MINUS:
       m_children.append(new DocSymbol(this,DocSymbol::Sym_Minus));
       break;
+    case CMD_EQUAL:
+      m_children.append(new DocSymbol(this,DocSymbol::Sym_Equal));
+      break;
     case CMD_SA:
       g_inSeeBlock=TRUE;
       retval = handleSimpleSection(DocSimpleSect::See);
@@ -6974,6 +6981,9 @@ void DocText::parse()
             break;
           case CMD_MINUS:
             m_children.append(new DocSymbol(this,DocSymbol::Sym_Minus));
+            break;
+          case CMD_EQUAL:
+            m_children.append(new DocSymbol(this,DocSymbol::Sym_Equal));
             break;
           default:
             warn_doc_error(g_fileName,doctokenizerYYlineno,"Unexpected command `%s' found",

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -454,7 +454,7 @@ class DocSymbol : public DocNode
                    /* doxygen commands mapped */
                    Sym_BSlash, Sym_At, Sym_Less, Sym_Greater, Sym_Amp,
                    Sym_Dollar, Sym_Hash, Sym_DoubleColon, Sym_Percent, Sym_Pipe,
-                   Sym_Quot, Sym_Minus, Sym_Plus, Sym_Dot
+                   Sym_Quot, Sym_Minus, Sym_Plus, Sym_Dot, Sym_Equal
                  };
     enum PerlType { Perl_unknown = 0, Perl_string, Perl_char, Perl_symbol, Perl_umlaut,
                     Perl_acute, Perl_grave, Perl_circ, Perl_slash, Perl_tilde,

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -358,7 +358,7 @@ FILEMASK  ({FILESCHAR}*{FILEECHAR}+("."{FILESCHAR}*{FILEECHAR}+)*)|{HFILEMASK}
 LINKMASK  [^ \t\n\r\\@<&${}]+("("[^\n)]*")")?({BLANK}*("const"|"volatile"){BLANK}+)? 
 VERBATIM  "verbatim"{BLANK}*
 SPCMD1    {CMD}([a-z_A-Z][a-z_A-Z0-9]*|{VERBATIM}|"--"|"---")
-SPCMD2    {CMD}[\\@<>&$#%~".+|-]
+SPCMD2    {CMD}[\\@<>&$#%~".+=|-]
 SPCMD3    {CMD}form#[0-9]+
 SPCMD4    {CMD}"::"
 INOUT	  "inout"|"in"|"out"|("in"{BLANK}*","{BLANK}*"out")|("out"{BLANK}*","{BLANK}*"in")

--- a/src/htmlentity.cpp
+++ b/src/htmlentity.cpp
@@ -314,7 +314,8 @@ static struct htmlEntityInfo
   { SYM(Quot),     "\"",           "\"",         "\"",                   "&quot;",        "\"",                     "\"",     "\"",          { "\"",         DocSymbol::Perl_char    }},
   { SYM(Minus),    "-",            "-",          "-",                    "-",             "-\\/",                   "-",      "-",           { "-",          DocSymbol::Perl_char    }},
   { SYM(Plus),     "+",            "+",          "+",                    "+",             "+",                      "+",      "+",           { "+",          DocSymbol::Perl_char    }},
-  { SYM(Dot),      ".",            ".",          ".",                    ".",             ".",                      ".",      ".",           { ".",          DocSymbol::Perl_char    }}
+  { SYM(Dot),      ".",            ".",          ".",                    ".",             ".",                      ".",      ".",           { ".",          DocSymbol::Perl_char    }},
+  { SYM(Equal),    "=",            "=",          "=",                    "=",             "=",                      "=",      "=",           { "=",          DocSymbol::Perl_char    }}
 };
 
 static const int g_numHtmlEntities = (int)(sizeof(g_htmlEntities)/ sizeof(*g_htmlEntities));


### PR DESCRIPTION
 This command writes an equal sign (`=`) to the output. This  character sequence has to be escaped in some cases, because it is used in Markdown header processing.