### PR TITLE
Bug 706603 Invalid warnings regarding todos when source file name contains a '-'

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1058,7 +1058,7 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 <St_IntRef>{BLANK}+"\"" {
                          BEGIN(St_Ref2);
                        }
-<St_SetScope>({SCOPEMASK}|{ANONNS}){BLANK} {
+<St_SetScope>({SCOPEMASK}|{ANONNS}){BLANK}|{FILEMASK} {
                          g_token->name = yytext;
                          g_token->name = g_token->name.stripWhiteSpace();
 			 return TK_WORD;


### PR DESCRIPTION
Handling also filenames in scope environment