### PR TITLE
Extending \cite command with '-' and '?' characters.

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -223,7 +223,6 @@ void CiteDict::generatePage() const
 
     if      (line.find("<!-- BEGIN BIBLIOGRAPHY")!=-1) insideBib=TRUE;
     else if (line.find("<!-- END BIBLIOGRAPH")!=-1)    insideBib=FALSE;
-    else if (insideBib) doc+=line+"\n";
     int i;
     // determine text to use at the location of the @cite command
     if (insideBib && (i=line.find("name=\"CITEREF_"))!=-1)
@@ -234,14 +233,17 @@ void CiteDict::generatePage() const
       {
         QCString label = line.mid(i+14,j-i-14);
         QCString number = line.mid(j+2,k-j-1);
+        label = substitute(substitute(label,"&ndash;","--"),"&mdash;","---");
         CiteInfo *ci = m_entries.find(label);
         //printf("label='%s' number='%s' => %p\n",label.data(),number.data(),ci);
+        line = line.left(i+14) + label + line.right(line.length()-j);
         if (ci)
         {
           ci->text = number;
         }
       }
     }
+    if (insideBib) doc+=line+"\n";
   }
   //printf("doc=[%s]\n",doc.data());
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -696,7 +696,13 @@ static void addSection()
 
 static void addCite()
 {
-  Doxygen::citeDict->insert(yytext);
+  QCString name=yytext;
+  if (yytext[0] =='"')
+  {
+    name=yytext+1;
+    name=name.left(yyleng-2);
+  }
+  Doxygen::citeDict->insert(name.data());
 }
 
 //-----------------------------------------------------------------------------
@@ -943,9 +949,9 @@ FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+@&#]
 FILE      ({FILESCHAR}*{FILEECHAR}+("."{FILESCHAR}*{FILEECHAR}+)*)|("\""[^\n\"]*"\"")
 ID        "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
-CITESCHAR [a-z_A-Z0-9\x80-\xFF]
-CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/]*
-CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*
+CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
+CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]*
+CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*"\""
 SCOPEID   {ID}({ID}*{BN}*"::"{BN}*)*({ID}?)
 SCOPENAME "$"?(({ID}?{BN}*("::"|"."){BN}*)*)((~{BN}*)?{ID})
 TMPLSPEC  "<"{BN}*[^>]+{BN}*">"

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -341,9 +341,9 @@ EMOJI     (":"[a-z_A-Z0-9\x80-\xFF"'+()&\*\.!,#-]":"|":"[a-z_A-Z0-9\x80-\xFF"'+(
 ID        "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
 PHPTYPE   [\\:a-z_A-Z0-9\x80-\xFF\-]+
-CITESCHAR [a-z_A-Z0-9\x80-\xFF]
-CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/]*
-CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*
+CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
+CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]
+CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*"\""
 MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z_A-Z0-9\-]+
 OPTSTARS  ("//"{BLANK}*)?"*"*{BLANK}*
 LISTITEM  {BLANK}*[-]("#")?{WS}
@@ -1047,7 +1047,15 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 			 return 0;
   		       }
 <St_Cite>{CITEID}      { // label to cite
-  			 g_token->name=yytext;
+                         if (yytext[0] =='"')
+                         {
+                           g_token->name=yytext+1;
+                           g_token->name=g_token->name.left(yyleng-2);
+                         }
+                         else
+                         {
+                           g_token->name=yytext;
+                         }
 			 return TK_WORD;
   		       }
 <St_Cite>{BLANK}       { // white space


### PR DESCRIPTION
In the `\cite` label some extra characters are enabled, '-' and '?', as the '--' and '---' have been converted beforehand they have to be converted back and the corresponding labels also have to between double quotes (which are striped away).