### PR TITLE
Unique anchor for 'member-group' from \name command

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1569,7 +1569,14 @@ void ClassDef::writeSummaryLinks(OutputList &ol)
         MemberList * ml = getMemberList(lmd->type);
         if (ml && ml->declVisible())
         {
-          ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+          if (ml->listType()==MemberListType_memberGroup)
+          {
+            ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()) + "_" + lmd->title(lang),lmd->title(lang),first);
+	  }
+	  else
+          {
+            ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+	  }
           first=FALSE;
         }
       }

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -663,7 +663,14 @@ void FileDef::writeSummaryLinks(OutputList &ol)
       MemberList * ml = getMemberList(lmd->type);
       if (ml && ml->declVisible())
       {
-        ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+        if (ml->listType()==MemberListType_memberGroup)
+        {
+          ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()) + "_" + lmd->title(lang),lmd->title(lang),first);
+	}
+	else
+        {
+          ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+	}
         first=FALSE;
       }
     }

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1069,7 +1069,14 @@ void GroupDef::writeSummaryLinks(OutputList &ol)
       MemberList * ml = getMemberList(lmd->type);
       if (ml && ml->declVisible())
       {
-        ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+        if (ml->listType()==MemberListType_memberGroup)
+        {
+          ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()) + "_" + lmd->title(lang),lmd->title(lang),first);
+	}
+	else
+        {
+          ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+	}
         first=FALSE;
       }
     }

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -582,7 +582,14 @@ void MemberList::writeDeclarations(OutputList &ol,
       }
       else
       {
-        ol.startMemberHeader(listTypeAsString(m_listType));
+	if (m_listType==MemberListType_memberGroup)
+	{
+          ol.startMemberHeader(listTypeAsString(m_listType) + "_" + title);
+	}
+	else
+	{
+          ol.startMemberHeader(listTypeAsString(m_listType));
+	}
       }
       ol.parseText(title);
       if (showInline)

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -541,7 +541,14 @@ void NamespaceDef::writeSummaryLinks(OutputList &ol)
       MemberList * ml = getMemberList(lmd->type);
       if (ml && ml->declVisible())
       {
-        ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+        if (ml->listType()==MemberListType_memberGroup)
+        {
+          ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()) + "_" + lmd->title(lang),lmd->title(lang),first);
+	}
+	else
+        {
+          ol.writeSummaryLink(0,MemberList::listTypeAsString(ml->listType()),lmd->title(lang),first);
+	}
         first=FALSE;
       }
     }


### PR DESCRIPTION
Based on the CGAL code a problem was found regarding the 'member-group' anchor. This anchor comes from the `\name` command and is a generic anchor, but the `\name` can occur multiple times. The anchor has been extended to an unique name in the file.