### PR TITLE
Correct list of not used translator functions

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -114,7 +114,7 @@ configure_file(${CMAKE_SOURCE_DIR}/doc/doxyindexer.1      ${PROJECT_BINARY_DIR}/
 
 # doc/language.doc (see tag Doxyfile:INPUT)
 add_custom_command(
-        COMMAND ${PYTHON_EXECUTABLE} translator.py
+        COMMAND ${PYTHON_EXECUTABLE} translator.py ${CMAKE_SOURCE_DIR}
         DEPENDS ${PROJECT_BINARY_DIR}/doc/maintainers.txt ${PROJECT_BINARY_DIR}/doc/language.tpl ${PROJECT_BINARY_DIR}/doc/translator.py
         OUTPUT language.doc
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc


### PR DESCRIPTION
All translator function functions were mentioned as not used.
- the directory to find the places where the sources are that use translator functions was pointing to the src directory of the build tree instead the src directory in the source tree (source files are not copied) and thus finding no applicable sources.
- furthermore the test whether or not a function was based on the name of a function but in case a name is the short form of an other function and the longer name was not used it was still shown as used.