### PR TITLE
Bug 738840 - Inheritance by non-documented classes shows the name of the undocumented class

### DIFF
--- a/src/classdef.h
+++ b/src/classdef.h
@@ -71,6 +71,11 @@ class ClassDef : public Definition
                         Singleton, //=Entry::CLASS_SEC
                       };
 
+    /** The various inheritance types for counting*/
+    enum inheritaceType{INHERITS       = 0x01,
+                        INHERITED_BY   = 0x02,
+                        INHERITED_BOTH = INHERITS | INHERITED_BY
+    };
     /** Creates a new compound definition.
      *  \param fileName  full path and file name in which this compound was
      *                   found.
@@ -407,7 +412,7 @@ class ClassDef : public Definition
     void addGroupedInheritedMembers(OutputList &ol,MemberListType lt,
                               ClassDef *inheritedFrom,const QCString &inheritId);
     int countMembersIncludingGrouped(MemberListType lt,ClassDef *inheritedFrom,bool additional);
-    int countInheritanceNodes();
+    int countInheritanceNodes(inheritaceType inher);
     void writeTagFile(FTextStream &);
     
     bool visited;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1935,7 +1935,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
       Cachable &cache = getCache();
       if (cache.inheritanceNodes==-1)
       {
-        cache.inheritanceNodes=m_classDef->countInheritanceNodes();
+        cache.inheritanceNodes=m_classDef->countInheritanceNodes(ClassDef::INHERITED_BOTH);
       }
       return cache.inheritanceNodes>0;
     }


### PR DESCRIPTION
In the graphs the 'hidden' classes were not shown but in the textual representation the hidden classes were shown.
Now the 'hidden' classes are not shown in the textual representation either.