### PR TITLE
Issue #6631 Code blocks incorrectly formatted in Latex

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -165,11 +165,6 @@ void LatexCodeGenerator::writeCodeLink(const char *ref,const char *f,
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   static bool usePDFLatex   = Config_getBool(USE_PDFLATEX);
   int l = qstrlen(name);
-  if (m_col+l>80)
-  {
-    m_t << "\n      ";
-    m_col=0;
-  }
   if (!ref && usePDFLatex && pdfHyperlinks)
   {
     m_t << "\\mbox{\\hyperlink{";


### PR DESCRIPTION
The line wrapping is automatically done in the DoxyCodeLine environment, so no need for extra spaces etc.

(The m_col is still required for resolving tab positions)