### PR TITLE
issue #6632 References to Objective C protocols by name broken in 1.8.12

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -162,7 +162,10 @@ void RefList::generatePage()
       if (item->scope->name() != "<globalScope>")
       {
         doc += "\\_setscope ";
-        doc += item->scope->name();
+	if (item->scope->name().right(3)==" -p")
+	  doc += item->scope->name().left(item->scope->name().length()-3) + "-p";
+        else
+          doc += item->scope->name();
         doc += " ";
       }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1424,8 +1424,12 @@ static ClassDef *getResolvedClassRec(const Definition *scope,
       di = Doxygen::symbolMap->find(name+"-p");
       if (di==0)
       {
-        //printf("no such symbol!\n");
-        return 0;
+        di = Doxygen::symbolMap->find(name+" -p");
+        if (di==0)
+        {
+          //printf("no such symbol!\n");
+          return 0;
+        }
       }
     //}
   }
@@ -4556,7 +4560,8 @@ static bool getScopeDefs(const char *docScope,const char *scope,
     if (scopeOffset>0) fullName.prepend(docScopeName.left(scopeOffset)+"::");
 
     if (((cd=getClass(fullName)) ||         // normal class
-         (cd=getClass(fullName+"-p")) //||    // ObjC protocol
+         (cd=getClass(fullName+"-p")) ||    // ObjC protocol
+         (cd=getClass(fullName+" -p")) //||    // ObjC protocol
          //(cd=getClass(fullName+"-g"))       // C# generic
         ) && cd->isLinkable())
     {


### PR DESCRIPTION
The issue is the change in the spacing for protocols.

In 1.8.11 the option `-d functions` gave (a.o): `member callbackMethod of class MyProtocol-p`
In 1.8.12 the result is: `member callbackMethod of class MyProtocol -p`
(Note the extra space).