### PR TITLE
Reference text in reference list seen as emoji

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -171,7 +171,26 @@ void RefList::generatePage()
     doc += item->name;
     doc += " \"";
     // escape \'s in title, see issue #5901
-    doc += substitute(item->title,"\\","\\\\");
+    // prevent Obj-C names in e.g. todo list are seen as emoji
+    if (item->scope)
+    {
+      switch(item->scope->definitionType())
+      {
+        case Definition::TypeClass:
+        case Definition::TypeNamespace:
+        case Definition::TypeMember:
+        case Definition::TypePackage:
+          doc += substitute(substitute(item->title,"\\","\\\\"),":","&Colon;");
+          break;
+        default:
+          doc += substitute(item->title,"\\","\\\\");
+          break;
+      }
+    }
+    else
+    {
+      doc += substitute(item->title,"\\","\\\\");
+    }
     doc += "\" ";
     // write declaration in case a function with arguments
     if (!item->args.isEmpty()) 


### PR DESCRIPTION
In Objective-C the separator for classes / protocols / functions is a single colon `:` resulting in recognizing it as an non existing emoji.
Note that this can only happen with generated names, in e.g. a page name an emoji can be used.