### PR TITLE
Doxygen creates empty image titles for Docbook output

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -904,7 +904,8 @@ DB_GEN_C
 void DocbookGenerator::endClassDiagram(const ClassDiagram &d, const char *fileName,const char *)
 {
 DB_GEN_C
-  visitPreStart(t, FALSE, relPath + fileName + ".png", NULL, NULL);
+  QList<DocNode> dummy;
+  visitPreStart(t, FALSE, NULL, dummy, relPath + fileName + ".png", NULL, NULL);
   d.writeImage(t,dir,relPath,fileName,FALSE);
   visitPostEnd(t, FALSE);
   t << "</para>" << endl;

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -20,16 +20,14 @@
 
 #include "docvisitor.h"
 #include <qstack.h>
+#include <qlist.h>
 #include <qcstring.h>
+#include <docparser.h>
 
 class FTextStream;
 class CodeOutputInterface;
 class QCString;
 
-void visitPreStart(FTextStream &t, bool hasCaption, QCString name,  QCString width,  QCString height, bool inlineImage=FALSE);
-void visitPostEnd(FTextStream &t, bool hasCaption, bool inlineImage = FALSE);
-
-/*! @brief Concrete visitor implementation for Docbook output. */
 class DocbookDocVisitor : public DocVisitor
 {
     public:
@@ -150,15 +148,15 @@ class DocbookDocVisitor : public DocVisitor
     void pushEnabled();
     void popEnabled();
     void startMscFile(const QCString &fileName,const QCString &width,
-    const QCString &height, bool hasCaption);
+    const QCString &height, bool hasCaption,QList<DocNode> childs);
     void endMscFile(bool hasCaption);
     void writeMscFile(const QCString &fileName, DocVerbatim *s);
     void startDiaFile(const QCString &fileName,const QCString &width,
-                      const QCString &height, bool hasCaption);
+                      const QCString &height, bool hasCaption,QList<DocNode> childs);
     void endDiaFile(bool hasCaption);
     void writeDiaFile(const QCString &fileName, DocVerbatim *s);
     void startDotFile(const QCString &fileName,const QCString &width,
-    const QCString &height, bool hasCaption);
+    const QCString &height, bool hasCaption,QList<DocNode> childs);
     void endDotFile(bool hasCaption);
     void writeDotFile(const QCString &fileName, DocVerbatim *s);
     void writePlantUMLFile(const QCString &fileName, DocVerbatim *s);
@@ -172,5 +170,10 @@ class DocbookDocVisitor : public DocVisitor
     QStack<bool> m_enabled;
     QCString m_langExt;
 };
+
+void visitPreStart(FTextStream &t, bool hasCaption, DocbookDocVisitor *parent, QList<DocNode> children, QCString name,  QCString width,  QCString height, bool inlineImage=FALSE);
+void visitPostEnd(FTextStream &t, bool hasCaption, bool inlineImage = FALSE);
+
+/*! @brief Concrete visitor implementation for Docbook output. */
 
 #endif


### PR DESCRIPTION
The title of an image needs to be at a specific place in docbook. The current place was incorrect

(based on https://stackoverflow.com/questions/53448764/doxygen-creates-empty-image-titles-for-docbook-output)