### PR TITLE
Unbalanced start of lists resulting in not creatable pdf of rtf document

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1866,7 +1866,6 @@ static void writeAnnotatedClassList(OutputList &ol,ClassDef::CompoundType ct)
 
   static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
 
-  ol.startIndexList();
   ClassSDict::Iterator cli(*Doxygen::classSDict);
   ClassDef *cd;
 


### PR DESCRIPTION
Line was removed but #6415 but apparently reintroduced by a later issue.
The problem shows with a number of the standard doxygen tests when enabling either e.g `--rtf` or `--latex`