### PR TITLE
Incorrect number of start / end paragraph tags for xhtml with htmlonly

### DIFF
--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -159,8 +159,8 @@ class HtmlDocVisitor : public DocVisitor
     void pushEnabled();
     void popEnabled();
 
-    void forceEndParagraph(DocNode *n);
-    void forceStartParagraph(DocNode *n);
+    bool forceEndParagraph(DocNode *n);
+    void forceStartParagraph(DocNode *n, bool forced = false);
 
     //--------------------------------------
     // state variables


### PR DESCRIPTION
In case of `\htmlonly[block]` the a force closed paragraph is not always force opened again.
Problem can be seen with the default doxygen test 20 (`[020_only.dox]: test the \*only and \*endonly commands`).