### PR TITLE
Incorrect  tag sequence for xhtml with class diagram possible

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -2010,6 +2010,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
               d.writeImage(t,g_globals.outputDir,
                            relPathAsString(),
                            m_classDef->getOutputFileBase());
+	      t << "<div/></map>" << endl;
               t << "</div>";
             }
             break;

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -1380,7 +1380,5 @@ void ClassDiagram::writeImage(FTextStream &t,const char *path,
 #define IMAGE_EXT ".png"
   image.save((QCString)path+"/"+fileName+IMAGE_EXT);
   Doxygen::indexList->addImageFile(QCString(fileName)+IMAGE_EXT);
-  
-  if (generateMap) t << "</map>" << endl;
 }
 

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1397,6 +1397,7 @@ void HtmlGenerator::endClassDiagram(const ClassDiagram &d,
   t << "_map\">" << endl;
 
   d.writeImage(t,dir,relPath,fileName);
+  t << "<div/></map>" << endl;
   t << " </div>";
   endSectionContent(t);
   m_sectionCount++;


### PR DESCRIPTION
In case of a class diagram without mapping information the `map` tag is written without content. This is not allowed and results in xhtml (as reported by xmllint) in:
`Element map content does not follow the DTD, expecting ((p | h1 | h2 | h3 | h4 | h5 | h6 | div | ul | ol | dl | menu | dir | pre | hr | blockquote | address | center | noframes | isindex | fieldset | table | form | noscript | ins | del | script)+ | area+), got ()`
By adding a dummy 'paragraph' `<div/>` this can be overcome,
The closing tag for `map` has been placed on a bit a more logical place, showing the open and close tag together.
Problem can be seen with the default doxygen test 11 (`[011_category.m]: test the \interface and \category command`).