### PR TITLE
Incorrect tag sequence possible for images possible in case of xhtml

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -2001,17 +2001,32 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
         {
           case ContextOutputFormat_Html:
             {
+              QGString result;
+              FTextStream tt(&result);
+
               QCString name = convertToHtml(m_classDef->displayName());
-              t << "<div class=\"center\">" << endl;
-              t << "<img src=\"";
-              t << relPathAsString() << m_classDef->getOutputFileBase();
-              t << ".png\" usemap=\"#" << convertToId(name) << "_map\" alt=\"\"/>" << endl;
-              t << "<map id=\"" << convertToId(name) << "_map\" name=\"" << convertToId(name) << "_map\">" << endl;
-              d.writeImage(t,g_globals.outputDir,
+              d.writeImage(tt,g_globals.outputDir,
                            relPathAsString(),
                            m_classDef->getOutputFileBase());
-	      t << "<div/></map>" << endl;
-              t << "</div>";
+              if (!result.isEmpty())
+              {
+                t << "<div class=\"center\">" << endl;
+                t << "  <img src=\"";
+                t << relPathAsString() << m_classDef->getOutputFileBase();
+                t << ".png\" usemap=\"#" << convertToId(name) << "_map\" alt=\"\"/>" << endl;
+                t << "  <map id=\"" << convertToId(name) << "_map\" name=\"" << convertToId(name) << "_map\">" << endl;
+	        t << result;
+	        t << "  </map>" << endl;
+                t << "</div>";
+              }
+              else
+              {
+                t << "<div class=\"center\">" << endl;
+                t << "  <img src=\"";
+                t << relPathAsString() << m_classDef->getOutputFileBase();
+                t << ".png\" alt=\"\"/>" << endl;
+                t << "</div>";
+              }
             }
             break;
           case ContextOutputFormat_Latex:

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1108,12 +1108,18 @@ bool DotFilePatcher::run()
       int n = sscanf(line.data()+i,"<!-- MAP %d",&mapId);
       if (n==1 && mapId>=0 && mapId<(int)m_maps.count())
       {
+        QGString result;
+        FTextStream tt(&result);
         Map *map = m_maps.at(mapId);
         //printf("patching MAP %d in file %s with contents of %s\n",
         //   mapId,m_patchFile.data(),map->mapFile.data());
-        t << "<map name=\"" << map->label << "\" id=\"" << map->label << "\">" << endl;
-        convertMapFile(t,map->mapFile,map->relPath,map->urlOnly,map->context);
-        t << "</map>" << endl;
+        convertMapFile(tt,map->mapFile,map->relPath,map->urlOnly,map->context);
+        if (!result.isEmpty())
+        {
+          t << "<map name=\"" << map->label << "\" id=\"" << map->label << "\">" << endl;
+          t << result;
+          t << "</map>" << endl;
+        }
       }
       else // error invalid map id!
       {
@@ -4315,13 +4321,18 @@ void writeDotImageMapFromFile(FTextStream &t,
   }
   else // bitmap graphics
   {
+    QGString result;
+    FTextStream tt(&result);
+
     t << "<img src=\"" << relPath << imgName << "\" alt=\""
-      << imgName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>" << endl
-      << "<map name=\"" << mapName << "\" id=\"" << mapName << "\">";
-
-    convertMapFile(t, absOutFile, relPath ,TRUE, context);
-
-    t << "</map>" << endl;
+      << imgName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>" << endl;
+    convertMapFile(tt, absOutFile, relPath ,TRUE, context);
+    if (!result.isEmpty())
+    {
+      t << "<map name=\"" << mapName << "\" id=\"" << mapName << "\">";
+      t << result;
+      t << "</map>" << endl;
+    }
   }
   d.remove(absOutFile);
 }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1384,21 +1384,34 @@ void HtmlGenerator::startClassDiagram()
 void HtmlGenerator::endClassDiagram(const ClassDiagram &d,
                                 const char *fileName,const char *name)
 {
+  QGString result;
+  FTextStream tt(&result);
+
   endSectionHeader(t);
   startSectionSummary(t,m_sectionCount);
   endSectionSummary(t);
   startSectionContent(t,m_sectionCount);
-  t << " <div class=\"center\">" << endl;
-  t << "  <img src=\"";
-  t << relPath << fileName << ".png\" usemap=\"#" << convertToId(name);
-  t << "_map\" alt=\"\"/>" << endl;
-  t << "  <map id=\"" << convertToId(name);
-  t << "_map\" name=\"" << convertToId(name);
-  t << "_map\">" << endl;
-
-  d.writeImage(t,dir,relPath,fileName);
-  t << "<div/></map>" << endl;
-  t << " </div>";
+  d.writeImage(tt,dir,relPath,fileName);
+  if (!result.isEmpty())
+  {
+    t << " <div class=\"center\">" << endl;
+    t << "  <img src=\"";
+    t << relPath << fileName << ".png\" usemap=\"#" << convertToId(name);
+    t << "_map\" alt=\"\"/>" << endl;
+    t << "  <map id=\"" << convertToId(name);
+    t << "_map\" name=\"" << convertToId(name);
+    t << "_map\">" << endl;
+    t << result;
+    t << "  </map>" << endl;
+    t << "</div>";
+  }
+  else
+  {
+    t << " <div class=\"center\">" << endl;
+    t << "  <img src=\"";
+    t << relPath << fileName << ".png\" alt=\"\"/>" << endl;
+    t << " </div>";
+  }
   endSectionContent(t);
   m_sectionCount++;
 }

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -217,9 +217,16 @@ void writeMscImageMapFromFile(FTextStream &t,const QCString &inFile,
     default:
       t << "unknown";
   }
-  t << "\" alt=\""
-    << baseName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>" << endl;
   QCString imap = getMscImageMapFromFile(inFile,outDir,relPath,context);
-  t << "<map name=\"" << mapName << "\" id=\"" << mapName << "\">" << imap << "</map>" << endl;
+  if (!imap.isEmpty())
+  {
+    t << "\" alt=\""
+      << baseName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>" << endl;
+    t << "<map name=\"" << mapName << "\" id=\"" << mapName << "\">" << imap << "</map>" << endl;
+  }
+  else
+  {
+    t << "\" alt=\"" << baseName << "\" border=\"0\"/>" << endl;
+  }
 }
 


### PR DESCRIPTION
Message:
`< Element map content does not follow the DTD, expecting ((p | h1 | h2 | h3 | h4 | h5 | h6 | div | ul | ol | dl | menu | dir | pre | hr | blockquote | address | center | noframes | isindex | fieldset
| table | form | noscript | ins | del | script)+ | area+), got (area area div)`
The problem first surfaced with test 11 (empty map tag), but the solution given at that moment (`<div/>)`) did work for test 11, but was not correct for test 27.

Problem can be seen with the default doxygen test 27 (`[027_extends.c]: test the \extends, \implements, \memberof, \private, and \public commands`).