### PR TITLE
Incorrect tag sequence for xhtml with latexinclude command possible

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -173,6 +173,7 @@ static bool isDocIncludeVisible(DocInclude *s)
   switch (s->type())
   {
     case DocInclude::DontInclude:
+    case DocInclude::LatexInclude:
       return FALSE;
     default:
       return TRUE;


### PR DESCRIPTION
Analogous to DontInclude (test 21) the wrong xhtml tag sequence can also occur with `\latexinclude`