### PR TITLE
Wrong counting of lines during VHDL code output

### DIFF
--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1505,7 +1505,7 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
                              {
                                codifyLines(text,0,FALSE,TRUE);
                              }
-                             g_yyLineNr++; // skip complete line
+                             else g_yyLineNr++; // skip complete line, but count line
                            }
                            else // normal comment
                            {


### PR DESCRIPTION
The code coloring of the output stops at an early stage, resulting in incorrect HTML / LaTeX / ... output, due to a double counting of the lines in case of `STRIP_CODE_COMMENTS=NO`.

Problem is visible when looking at the documentation of the VHDL documentation block in the manual for VHDL code in e.g. HTML and LaTex (Note problem occurs in the 1.8.15 master, not in the 1.8.14 version).