### PR TITLE
XHTML problem with class index table

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2284,11 +2284,12 @@ static void writeAlphabeticalClassList(OutputList &ol, ClassDef::CompoundType ct
               }
               ol.writeNonBreakableSpace(3);
             }
-            ++(*colIterators[j]);
-            if (cell->letter()!=0 || cell->classDef()!=(ClassDef*)0x8)
-            {
-              ol.writeString("</td>");
+	    else 
+	    {
+              ol.writeString("<td>");
             }
+            ++(*colIterators[j]);
+            ol.writeString("</td>");
           }
         }
         else


### PR DESCRIPTION
When running xhtml checker on the doxygen diagram example we get:
```
Element tr content does not follow the DTD, expecting (th | td)+, got
Document diagrams/xhtml/classes.xhtml does not validate
```
This is due to an empty `<tr></tr>`, adding the appropriate column definitions solves the problem.