### PR TITLE
XHTML problem with name attribute with VHDL name attribute

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1547,7 +1547,7 @@ void HtmlGenerator::startMemberHeader(const char *anchor, int typ)
   t << "<tr class=\"heading\"><td colspan=\"" << typ << "\"><h2 class=\"groupheader\">";
   if (anchor)
   {
-    t << "<a name=\"" << anchor << "\"></a>" << endl;
+    t << "<a name=\"" << convertToId(anchor) << "\"></a>" << endl;
   }
 }
 
@@ -2792,7 +2792,7 @@ void HtmlGenerator::writeSummaryLink(const char *file,const char *anchor,const c
   else
   {
     t << "#";
-    t << anchor;
+    t << convertToId(anchor);
   }
   t << "\">";
   t << title;


### PR DESCRIPTION
When running xhtml checker on the doxygen mux example we get:
```
Syntax of value for attribute name of a is not valid
Document mux/xhtml/classmux__using__with.xhtml does not validate
```
This is due to a space in the name tag, substituting the appropriate code solves the problem (double calling of the routine has no effect).