### PR TITLE
XHTML problem with multiple use of node numbers in id attribute

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -24,6 +24,7 @@
 #include <qthread.h>
 #include <qmutex.h>
 #include <qwaitcondition.h>
+#include <qregexp.h>
 
 #include "dot.h"
 #include "doxygen.h"
@@ -376,6 +377,7 @@ static bool convertMapFile(FTextStream &t,const char *mapName,
                            const QCString &context=QCString())
 {
   QFile f(mapName);
+  static QRegExp re("id=\"node[0-9]*\"");
   if (!f.open(IO_ReadOnly)) 
   {
     err("problems opening map file %s for inclusion in the docs!\n"
@@ -394,7 +396,7 @@ static bool convertMapFile(FTextStream &t,const char *mapName,
 
       if (buf.left(5)=="<area")
       {
-        t << replaceRef(buf,relPath,urlOnly,context);
+        t << replaceRef(buf,relPath,urlOnly,context).replace(re,"");
       }
     }
   }


### PR DESCRIPTION
When running xhtml checker on the doxygen diagram example we get:
```
diagrams/html/class_a.html:66: element area: validity error : ID node1 already defined
<area shape="rect" id="node1" title=" " alt="" coords="5,5,44,32"/>
                                                                 ^
ID node1 already defined
Document diagrams/html/class_a.html does not validate
```
This is due to the fact that the map file is used as generated by `dot`, and here the `id` values start each time with `node1`. The `id` is not used and can be omitted.