### PR TITLE
XHTML incorrect attribute values for align and valign

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -262,6 +262,12 @@ static void handleHtmlTag()
 	if (i<(int)yyleng) c=tagText.at(++i);
       }
       opt.value  = tagText.mid(startAttrib,endAttrib-startAttrib); 
+      if (opt.name == "align") opt.value = opt.value.lower();
+      else if (opt.name == "valign")
+      {
+        opt.value = opt.value.lower();
+        if (opt.value == "center") opt.value="middle";
+      }
     }
     else // start next option
     {


### PR DESCRIPTION
The attribute values of the `align` and `valign` attribute have to be in lowercase and the `valign` attribute value `center` does not exist but has to be `middle`.
Most browsers do accept the 'incorrect' values but it is better to have the right values present.
(Found by means of the CGAL/cgal repository)