### PR TITLE
XHTML problem with name attribute with VHDL name attribute

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1737,7 +1737,7 @@ void ClassDef::writeSummaryLinks(OutputList &ol)
     SDict<QCString>::Iterator li(m_impl->vhdlSummaryTitles);
     for (li.toFirst();li.current();++li)
     {
-      ol.writeSummaryLink(0,li.current()->data(),li.current()->data(),first);
+      ol.writeSummaryLink(0,convertToId(li.current()->data()),li.current()->data(),first);
       first=FALSE;
     }
   }

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2329,7 +2329,7 @@ void VhdlDocGen::writeVHDLDeclarations(MemberList* ml,OutputList &ol,
 
   if (title)
   {
-    ol.startMemberHeader(title,type == VhdlDocGen::PORT ? 3 : 2);
+    ol.startMemberHeader(convertToId(title),type == VhdlDocGen::PORT ? 3 : 2);
     ol.parseText(title);
     ol.endMemberHeader();
     ol.docify(" ");


### PR DESCRIPTION
When running xhtml checker on the doxygen diagram example we get:
```
Syntax of value for attribute name of a is not valid
Document mux/xhtml/classmux__using__with.xhtml does not validate
```
This is due to a space in the name tag, substituting the appropriate code solves the problem.
As this is a VHDL specific problem only these strings are converted.