### PR TITLE
Don't create anchors for anonymous groups (\name)

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -641,8 +641,7 @@ void FileDef::writeMemberGroups(OutputList &ol)
     MemberGroup *mg;
     for (;(mg=mgli.current());++mgli)
     {
-      if ((!mg->allMembersInSameSection() || !m_subGrouping) 
-          && !mg->header().isEmpty())
+      if (!mg->allMembersInSameSection() || !m_subGrouping) 
       {
         mg->writeDeclarations(ol,0,0,this,0);
       }

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -642,7 +642,7 @@ void FileDef::writeMemberGroups(OutputList &ol)
     for (;(mg=mgli.current());++mgli)
     {
       if ((!mg->allMembersInSameSection() || !m_subGrouping) 
-          && mg->header()!="[NOHEADER]")
+          && !mg->header().isEmpty())
       {
         mg->writeDeclarations(ol,0,0,this,0);
       }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3375,7 +3375,7 @@ void MemberDef::setMemberGroup(MemberGroup *grp)
 bool MemberDef::visibleMemberGroup(bool hideNoHeader)
 {
   return m_impl->memberGroup!=0 &&
-          (!hideNoHeader || m_impl->memberGroup->header()!="[NOHEADER]");
+          (!hideNoHeader || !m_impl->memberGroup->header().isEmpty());
 }
 
 QCString MemberDef::getScopeString() const

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3374,8 +3374,9 @@ void MemberDef::setMemberGroup(MemberGroup *grp)
 
 bool MemberDef::visibleMemberGroup(bool hideNoHeader)
 {
-  return m_impl->memberGroup!=0 &&
-          (!hideNoHeader || !m_impl->memberGroup->header().isEmpty());
+  return m_impl->memberGroup!=0;
+  //return m_impl->memberGroup!=0 &&
+  //        (!hideNoHeader || m_impl->memberGroup->header()!="[NOHEADER]");
 }
 
 QCString MemberDef::getScopeString() const

--- a/src/membergroup.cpp
+++ b/src/membergroup.cpp
@@ -112,7 +112,8 @@ void MemberGroup::writeDeclarations(OutputList &ol,
 {
   //printf("MemberGroup::writeDeclarations() %s\n",grpHeader.data());
   QCString ldoc = doc;
-  if (!ldoc.isEmpty()) ldoc.prepend("<a name=\""+anchor()+"\" id=\""+anchor()+"\"></a>");
+  QCString anc = anchor();
+  if (!ldoc.isEmpty() & !anc.isEmpty()) ldoc.prepend("<a name=\""+anc+"\" id=\""+anc+"\"></a>");
   memberList->writeDeclarations(ol,cd,nd,fd,gd,grpHeader,ldoc,FALSE,showInline);
 }
 
@@ -322,9 +323,8 @@ QCString MemberGroup::anchor() const
 {
   uchar md5_sig[16];
   QCString sigStr(33);
-  QCString locHeader = grpHeader;
-  if (locHeader.isEmpty()) locHeader="[NOHEADER]";
-  MD5Buffer((const unsigned char *)locHeader.data(),locHeader.length(),md5_sig);
+  if (grpHeader.isEmpty()) return "";
+  MD5Buffer((const unsigned char *)grpHeader.data(),grpHeader.length(),md5_sig);
   MD5SigToString(md5_sig,sigStr.rawData(),33);
   return "amgrp"+sigStr;
 }
@@ -334,7 +334,9 @@ void MemberGroup::addListReferences(Definition *def)
   memberList->addListReferences(def);
   if (m_xrefListItems && def)
   {
-    QCString name = def->getOutputFileBase()+"#"+anchor();
+    QCString name = def->getOutputFileBase();
+    QCString anc = anchor();
+    if (!anc.isEmpty()) name += "#"+anc;
     addRefItem(m_xrefListItems,
         name,
         theTranslator->trGroup(TRUE,TRUE),

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -646,7 +646,7 @@ void MemberList::writeDeclarations(OutputList &ol,
       MemberGroup *mg;
       while ((mg=mgli.current()))
       {
-        bool hasHeader=!mg->header().isEmpty() && mg->header()!="[NOHEADER]";
+        bool hasHeader=!mg->header().isEmpty();
         if (inheritId.isEmpty())
         {
           //printf("mg->header=%s hasHeader=%d\n",mg->header().data(),hasHeader);

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -556,7 +556,7 @@ void NamespaceDef::writeMemberGroups(OutputList &ol)
     for (;(mg=mgli.current());++mgli)
     {
       if ((!mg->allMembersInSameSection() || !m_subGrouping) 
-          && mg->header()!="[NOHEADER]")
+          && !mg->header().isEmpty())
       {
         mg->writeDeclarations(ol,0,this,0,0);
       }

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -555,8 +555,7 @@ void NamespaceDef::writeMemberGroups(OutputList &ol)
     MemberGroup *mg;
     for (;(mg=mgli.current());++mgli)
     {
-      if ((!mg->allMembersInSameSection() || !m_subGrouping) 
-          && !mg->header().isEmpty())
+      if (!mg->allMembersInSameSection() || !m_subGrouping) 
       {
         mg->writeDeclarations(ol,0,this,0,0);
       }

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2352,7 +2352,7 @@ void VhdlDocGen::writeVHDLDeclarations(MemberList* ml,OutputList &ol,
       if (membersHaveSpecificType(mg->members(),type))
       {
         //printf("mg->header=%s\n",mg->header().data());
-        bool hasHeader=mg->header()!="[NOHEADER]";
+        bool hasHeader=!mg->header().isEmpty();
         ol.startMemberGroupHeader(hasHeader);
         if (hasHeader)
         {


### PR DESCRIPTION
An anchor with the value `[NOHEADER]` was created for anonymous `\name` commands, resulting in the possibility multiple times the same anchor on a page.
Furthermore there were several tests on `[NOHEADER]` although the header was never set to `[NOHEADER]` (except locally when calculating the anchor), test has been changed to test on empty headers.