### PR TITLE
Update of changelog

### DIFF
--- a/doc/changelog.doc
+++ b/doc/changelog.doc
@@ -8,123 +8,123 @@
 <a name="1.8.14"></a>
 </p>
 <ul>
-<li>Add language type attribute to programlisting tag [<a href="http://github.com/doxygen/doxygen/commit/141dbfd5a4f79c98da14a1b414c6db4e1b34618b">view</a>]</li>
-<li>Add links behind nav entries &quot;Namespaces&quot; and &quot;Files&quot; (matching &quot;Classes&quot;) [<a href="http://github.com/doxygen/doxygen/commit/464919adf1cdae9057ff840f40c60472b4c30bfd">view</a>]</li>
-<li>Allow case insensitive file pattern matching based on CASE_SENSE_NAMES [<a href="http://github.com/doxygen/doxygen/commit/bd759f9a3aa4096bc8574ea45ad6b23fed830742">view</a>]</li>
-<li>Async load of mathjax javascript [<a href="http://github.com/doxygen/doxygen/commit/340e516dbf5efd3ae21d964e92369e97b252e4ab">view</a>]</li>
-<li>Avoid generating unused dir_* output files for non HTML output formats [<a href="http://github.com/doxygen/doxygen/commit/38987846ec0752b8deee7bab69c7890aa861af00">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3138">3138</a> - Wrong spacing in function names with french language (latex output) [<a href="http://github.com/doxygen/doxygen/commit/9d478d2fedd091ceac8e689507676292f5455882">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4289">4289</a> - does ALIAS work for VHDL code? [<a href="http://github.com/doxygen/doxygen/commit/05364c46f806e73cce76be37a6a31230d0468507">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5468">5468</a> - (UnFriendlyTemplate) Spurious warning when documenting friend template [<a href="http://github.com/doxygen/doxygen/commit/2fe7bc7f1df9a2483355b0743b5e0455aaccc969">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5525">5525</a> - parser misinterpreting fortran [<a href="http://github.com/doxygen/doxygen/commit/747fc768476aef8b8b70fdd78749702a410dcd29">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5724">5724</a> - Duplicate attribute (target=&quot;_top&quot; target=&quot;_top&quot;) generated in .SVG files [<a href="http://github.com/doxygen/doxygen/commit/97bfbfa6c4d4eb07ac8c60545086c3370e9683b8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6128">6128</a> - Usage of underscore&#39;s in parameter names [<a href="http://github.com/doxygen/doxygen/commit/c10af45c61a1f9b25c514f397ace16c94cc7c8df">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6135">6135</a> - [1.8.13 Regression] Segfault building the breathe docs [<a href="http://github.com/doxygen/doxygen/commit/0f02761a158a5e9ddbd5801682482af8986dbc35">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6137">6137</a> - XML Parsing Error for operator&lt;&lt; methods when outputting to XHTML [<a href="http://github.com/doxygen/doxygen/commit/0e8530e42b69c909ef2c26468b24dfb88cc0997f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6139">6139</a> - Menu does not work without Javascript [<a href="http://github.com/doxygen/doxygen/commit/1be97720b7820361e85242d08d4cac3e46570bfe">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6141">6141</a> - Too greedy behavior of @ref const matching [<a href="http://github.com/doxygen/doxygen/commit/04001c8926fb0f37dfcf284b3637b182125bba75">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6169">6169</a> - doxygen build fails [<a href="http://github.com/doxygen/doxygen/commit/bb5c8dd29782ecbb05a4ef9788f2507e9a156848">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6170">6170</a> - Add &quot;\~&quot; command to internatioalization article [<a href="http://github.com/doxygen/doxygen/commit/e204b982eebd54bd15148a520da6608935e33e50">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6223">6223</a> - Problem RTF output: The class list &quot;classes&quot; within the namespace report is wrong indicated. [<a href="http://github.com/doxygen/doxygen/commit/753c06281f6b2e9172c449157fc9f863063232e3">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6238">6238</a> - parsing error in Fortran file with preprocessing [<a href="http://github.com/doxygen/doxygen/commit/2f5e22a4be9d237a150d04659bf6abec1349fbd9">view</a>]
-, [<a href="http://github.com/doxygen/doxygen/commit/ec12eb659d8c8e78ad4bb15d1a941ac3153a0f66">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6259">6259</a> - Problem parsing c++ gnu::visibility [<a href="http://github.com/doxygen/doxygen/commit/d8001efd89146e04d92f5ea41ab27a7de09b6c53">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6262">6262</a> - C++: False warning message when inheriting class from tag file [<a href="http://github.com/doxygen/doxygen/commit/aac84d5624b96d8937ff543ab8724c269b8726ab">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6273">6273</a> - Error in markdown emphasis examples [<a href="http://github.com/doxygen/doxygen/commit/81956108f2e6e97bf4dd0f1011fcae1b5c4c4408">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6277">6277</a> - Increasing access of inherited C++ members with &#39;using...&#39; is not recognized by Doxygen [<a href="http://github.com/doxygen/doxygen/commit/9468ede259153cf79eb8d61635389744e9a2ee7d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6286">6286</a> - C++ parameter from lambda not recognized [<a href="http://github.com/doxygen/doxygen/commit/7b43be09e513ea6f86f9ca53ce05c94d63eada4c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6290">6290</a> - Doxygen not showing the public, non-static member function [<a href="http://github.com/doxygen/doxygen/commit/137b2e8dd03a98e692c2f6d813b47f19f2c64e5b">view</a>]</li>
-<li>CMake: avoid if() around the whole contents of documentation CMakeLists.txt [<a href="http://github.com/doxygen/doxygen/commit/62e87408cb7094eeac130775e62d5b7a6f4a79c9">view</a>]</li>
-<li>CMake: avoid if() around the whole contents of plugin CMakeLists.txt [<a href="http://github.com/doxygen/doxygen/commit/7c1c75a2c5583415d178e0e46a1a356bef9b0c84">view</a>]</li>
-<li>CMake: let CMake handle the C++ standard setting if target_compile_features() is used [<a href="http://github.com/doxygen/doxygen/commit/ca7e60edd370949cfb2adb83ca0b532bb3fdc441">view</a>]</li>
-<li>CMake: let file(MAKE_DIRECTORY) create all directories at once [<a href="http://github.com/doxygen/doxygen/commit/0d7be027a6fea2ac198dded58f8b55cda1bbe962">view</a>]</li>
-<li>CMake: remove CUSTOM_(LINK|INCLUDE)_DIR [<a href="http://github.com/doxygen/doxygen/commit/28f09783b1e45a827729abaca61f963dd869381b">view</a>]</li>
-<li>CMake: remove needless variable expansions [<a href="http://github.com/doxygen/doxygen/commit/975fb19eb07bc65ef48ddd5f26bf6be2736d0e0a">view</a>]</li>
-<li>CMake: remove unused program searching [<a href="http://github.com/doxygen/doxygen/commit/02f726b63e2b3a2ed4c5da43c164dcaad5fcfe94">view</a>]</li>
-<li>CMake: search for Qt5 only in config file mode [<a href="http://github.com/doxygen/doxygen/commit/ac5ca4ef86ad50232be75a65fab99302307b7795">view</a>]</li>
-<li>CMake: use GNUInstallDirs module for man pages directory [<a href="http://github.com/doxygen/doxygen/commit/fcf5fecb64d5c194430e10cbe52482b14224d645">view</a>]</li>
-<li>CMake: use add_test to create a test [<a href="http://github.com/doxygen/doxygen/commit/b54b843accb97105ae4afaf24136e33bfd1ea9d4">view</a>]</li>
-<li>CMakeLists: Avoid MSVC iconv changes for MinGW builds [<a href="http://github.com/doxygen/doxygen/commit/9532e0f19532e9d76c3f1092d131af91125a2dff">view</a>]</li>
-<li>Call endMemberItem consistently. [<a href="http://github.com/doxygen/doxygen/commit/1aafbbc97bdb643cae8be036f2b9ab569ca7f15e">view</a>]</li>
-<li>Change navtree collapsed list icon [<a href="http://github.com/doxygen/doxygen/commit/b3869a3ed82957c1785dc955876885f8b73a020b">view</a>]</li>
-<li>Code color of , (comma) together with only in use statement [<a href="http://github.com/doxygen/doxygen/commit/6f7264f4a16f5b1240291c6d33a0e4cc98ba30e4">view</a>]</li>
-<li>Corrected small type [<a href="http://github.com/doxygen/doxygen/commit/4360982dbaee9b32973a95ba88290022d0643e10">view</a>]</li>
-<li>Correction display of backtick in LaTeX [<a href="http://github.com/doxygen/doxygen/commit/beaa386ca97341e66ad673660c808993240df637">view</a>]</li>
-<li>Correction of non reachable links and redirected links in documentation. [<a href="http://github.com/doxygen/doxygen/commit/31cf78d223e52fe078ad9b0651672aeb73926065">view</a>]</li>
-<li>Documentation, correct referenced file [<a href="http://github.com/doxygen/doxygen/commit/c93a7c34e7efd5ae1f2c3e4d230e29a333bc237a">view</a>]</li>
-<li>Doxygen/VHDLdocgen: [<a href="http://github.com/doxygen/doxygen/commit/77e0cf86eadbec22b81e26e083ffc831240869da">view</a>]</li>
-<li>Encode invalid XML characters instead of skipping them. [<a href="http://github.com/doxygen/doxygen/commit/b6a7abf02652b74872b9c676fcfa545e18d9bde7">view</a>]</li>
-<li>Expose TOC placeholder in XML output. [<a href="http://github.com/doxygen/doxygen/commit/fe760977e2cb643b94fbf21847e0c81e8a080966">view</a>]</li>
-<li>Expose underlying enum type in the XML output. [<a href="http://github.com/doxygen/doxygen/commit/17bceb8f4580535de52d19e8cadf0d088f972bef">view</a>]</li>
-<li>Fetch filename property from object instead of hardcoded duplicated string [<a href="http://github.com/doxygen/doxygen/commit/84fd1fecfe2de7b4f8c88e1923ef7d5958dc70b0">view</a>]</li>
-<li>Fix C# property initializer parsing [<a href="http://github.com/doxygen/doxygen/commit/14a0bcc74a121525917aefc8c9034e283e94884b">view</a>]</li>
-<li>Fix for regression in XML output generation after fixing bug 789168 [<a href="http://github.com/doxygen/doxygen/commit/1a1fdbed64de6ce01959b2e4d0988be823fb6bad">view</a>]</li>
-<li>Fix <a href="https://github.com/doxygen/doxygen/issues/6210">6210</a>. [<a href="http://github.com/doxygen/doxygen/commit/c87f730fe4bc40f72ed5fa52fe032a7bdf2d549c">view</a>]</li>
-<li>Fix minor markup issue in the documentation. [<a href="http://github.com/doxygen/doxygen/commit/b4df85466cf0447d46f311046fc5b3fe062b957f">view</a>]</li>
-<li>Fix not initialized pointer when parser is starting on a new file. [<a href="http://github.com/doxygen/doxygen/commit/52fb4cd5bb085960476e0cd256cc81db1370839d">view</a>]</li>
-<li>Fix typo [<a href="http://github.com/doxygen/doxygen/commit/d6e9db71645d895450993972ed41406c1cf1fc52">view</a>]</li>
-<li>Fix: add missing newline char &#39;\n&#39; [<a href="http://github.com/doxygen/doxygen/commit/856a43cfe08179ebbcebe656262b0229925547c8">view</a>]</li>
-<li>Fix: add missing semicolon &#39;;&#39; at end of line [<a href="http://github.com/doxygen/doxygen/commit/507880a0c7ed6029ce7ede2e85d23a9650a3f6bf">view</a>]</li>
-<li>Fix: change &#39;CMakefiles&#39; to &#39;CMakeFiles&#39; (the &#39;F&#39; is uppercase) [<a href="http://github.com/doxygen/doxygen/commit/bcc09aa2ba01eff458a00aff853d58ed8213a5da">view</a>]</li>
-<li>Fix: perl script regexp to toggle flex debug information [<a href="http://github.com/doxygen/doxygen/commit/b11b19badf4ef7318512c28f448dbecd6a47a715">view</a>]</li>
-<li>Fixed problem where automatic line breaking caused missing vertical bars in the parameter table for Latex output. [<a href="http://github.com/doxygen/doxygen/commit/5fc82b2275e202438ac61b070ac5f4be0df792d6">view</a>]</li>
-<li>Fixes for cross platform build with new LLVM/CLANG version [<a href="http://github.com/doxygen/doxygen/commit/b0aae61c97966cb9d424b500d7ced5bdf500d8db">view</a>]</li>
-<li>Fixup man page NAME section when page has title [<a href="http://github.com/doxygen/doxygen/commit/9d0908359363dbb43236767669c214721700acf7">view</a>]</li>
-<li>Function declaration following a function definition incorrectly listed as calling dependencing [<a href="http://github.com/doxygen/doxygen/commit/436fc7ed1158d517dd6f6d25aa3e05568f8c3d94">view</a>]</li>
-<li>Further cleanup of lodepng code [<a href="http://github.com/doxygen/doxygen/commit/c627108f3315144f5d9fb84d0197502b939caf7d">view</a>]</li>
-<li>Implement &quot;double-space line breaks&quot; syntax in Markdown [<a href="http://github.com/doxygen/doxygen/commit/e4596c7eab90ba4d307e2c212cefeab8ac820269">view</a>]</li>
-<li>Improve Chinese translation [<a href="http://github.com/doxygen/doxygen/commit/ded5247523ec8d47129405df3999ce391cca9e2d">view</a>]</li>
-<li>Inline attribute got reset for functions returning an explicit struct type [<a href="http://github.com/doxygen/doxygen/commit/127a43d464790dd0312794fe7ae1d92247cd9eef">view</a>]</li>
-<li>Isolated none-existing posix threading functions on Android [<a href="http://github.com/doxygen/doxygen/commit/4e25f081847cf2717ad561214e90d9750da5a511">view</a>]</li>
-<li>Marks JS as freely licensed [<a href="http://github.com/doxygen/doxygen/commit/6b5617e5a4c87afd2c7f2f7b8cb03de2b6735627">view</a>]</li>
-<li>Misc. doxy and comment typos [<a href="http://github.com/doxygen/doxygen/commit/1764f7a0f199b9f2a85f885cfd0f1804f8292c49">view</a>]</li>
-<li>Misc. typos [<a href="http://github.com/doxygen/doxygen/commit/9fd7f3aeb4c2e78bda669bf4ef6fff1c12c062a4">view</a>]</li>
-<li>New table features mentioned in the documentation were not enabled. [<a href="http://github.com/doxygen/doxygen/commit/c120ac4762331513305e8a19fd9b267b2d4f9e41">view</a>]</li>
-<li>Pass strings as const references. [<a href="http://github.com/doxygen/doxygen/commit/ebf75c1fe8a0ff2cc9235155b6d63367944d6342">view</a>]</li>
-<li>Physical newlines in ALIASES configuration tags. [<a href="http://github.com/doxygen/doxygen/commit/d6801c4c5eaeebc5e14f5d1cd7c312ad82c1dbbd">view</a>]</li>
-<li>Propagate language information to all &lt;programlisting&gt; XML elements. [<a href="http://github.com/doxygen/doxygen/commit/eaf8edbac7e6a1873aa5c4ff0df063cd367351d6">view</a>]</li>
-<li>Properly copy images for the XML output. [<a href="http://github.com/doxygen/doxygen/commit/507dd0a60dd12c61ff2088db419187efc928c010">view</a>]</li>
-<li>Provide dot path to plantuml [<a href="http://github.com/doxygen/doxygen/commit/c24cb9a74ef0af854455047f29f9925d79ac0195">view</a>]</li>
-<li>Provide information about enum type &quot;strongness&quot; in the XML output. [<a href="http://github.com/doxygen/doxygen/commit/169cad806ea795e5c425fd397aa0de54cbc0a81e">view</a>]</li>
-<li>Provide page brief in &lt;briefdescription&gt; of XML output. [<a href="http://github.com/doxygen/doxygen/commit/bd2cf98e75c600e0c2f5ae95301df8745d65571a">view</a>]</li>
-<li>Provide template parameters also for type aliases in the XML output. [<a href="http://github.com/doxygen/doxygen/commit/21f0ca0085c034a37df07c1ab690472bada0a1f1">view</a>]</li>
-<li>Removed -Wno-deprecated flag from bison as it is not support on the bison 2.3 that ships with XCode [<a href="http://github.com/doxygen/doxygen/commit/6c288bf0e7548117aa358719aaecffedcc579590">view</a>]</li>
-<li>Restore &#39;make tests&#39; rule [<a href="http://github.com/doxygen/doxygen/commit/7ce59c9fbd5e99619a9ab0ac6177d21e6aca49c7">view</a>]</li>
-<li>Restore Makefile in vhdlparser dir [<a href="http://github.com/doxygen/doxygen/commit/aee944fe954de993a4273fafef6b5f0c726be7f3">view</a>]</li>
-<li>Spelling correction [<a href="http://github.com/doxygen/doxygen/commit/4cca51612a50a9016be5adbd6ccdc26c03d12b58">view</a>]</li>
-<li>Stripped unused LodePNG code to prevent false positives for coverity [<a href="http://github.com/doxygen/doxygen/commit/64865ad3e91fffe6e50b51b29ae2a54126f80126">view</a>]</li>
-<li>Suppresses warning for XML &lt;see langword=&quot;...&quot;/&gt; [<a href="http://github.com/doxygen/doxygen/commit/a3c5958b437b5dc9de91de5f40917ec53532b60a">view</a>]</li>
-<li>Suppression warnings about deprecated directive [<a href="http://github.com/doxygen/doxygen/commit/cd0faad90e9b6ce83fa1f7b4fb27a39357b0cae3">view</a>]</li>
-<li>Update .travis.yml [<a href="http://github.com/doxygen/doxygen/commit/5f028fd744526148aace4c971f739c9876b6108a">view</a>]
-, [<a href="http://github.com/doxygen/doxygen/commit/b7fc8a384b091f5761159d263ec27e30c3160a50">view</a>]</li>
-<li>Update mathjax path [<a href="http://github.com/doxygen/doxygen/commit/57e69ba26eff5eac4b31b088cd7d3dfa7532f12c">view</a>]</li>
-<li>Updated translator_de.h to doxygen 1.8.13 [<a href="http://github.com/doxygen/doxygen/commit/a9e3d5378ffbef542045d04239482bd6fec33e15">view</a>]</li>
-<li>Use hidden symbol visibility by default [<a href="http://github.com/doxygen/doxygen/commit/dcb3b2d0b888902a062eefd8200ea194ed1c42d6">view</a>]</li>
-<li>Use language identifier instead of file extension for language attribute [<a href="http://github.com/doxygen/doxygen/commit/ed9acb6e1bb81a2eec334180f7b8c1bf0598b444">view</a>]</li>
-<li>Use language in stead of lang for language name attribute [<a href="http://github.com/doxygen/doxygen/commit/4e4741221f4290412ef4a6b6bbfe9799abafaf6c">view</a>]</li>
-<li>Update of the Brazillian translation [<a href="http://github.com/doxygen/doxygen/commit/d283dfcdcaa0837e84d7995676d436fa04e96d1f">view</a>]</li>
-<li>[preprocessing.doc] typo amended [<a href="http://github.com/doxygen/doxygen/commit/6b67a64bd0bd1c6759294c323433dbd7d37df6ac">view</a>]</li>
-<li>add decimal to base identifier [<a href="http://github.com/doxygen/doxygen/commit/9cbc1a04e584e83d91ff3f7501f38b0a825e1953">view</a>]</li>
-<li>add the number of conditionals path and bugfix [<a href="http://github.com/doxygen/doxygen/commit/20af63f43e583a31dfe93f78807aa868f9b9ff14">view</a>]</li>
-<li>build: fix the way lang_cfg.h is generated [<a href="http://github.com/doxygen/doxygen/commit/cc3a9e611c15f32ae4913a87306699db60758245">view</a> and <a href="http://github.com/doxygen/doxygen/commit/a4b6f59e0c99457ba8f4f71782e51d50b7a1057f">view</a>]</li>
-<li>bump version number for the development version/next release [<a href="http://github.com/doxygen/doxygen/commit/0a6d8bf6f5ef3a537de6ab517d0ae9c4f5d558d0">view</a>]</li>
-<li>const-ify [<a href="http://github.com/doxygen/doxygen/commit/5df4341210ec2374b8b7c09f5df3cd8f4ff60f65">view</a>]</li>
-<li>dot.cpp: Fix DotGfxHierarchyTable first class node loop [<a href="http://github.com/doxygen/doxygen/commit/c7348b4483ace9b5608fbbe949eab02921eb0e70">view</a>]</li>
-<li>fix spelling [<a href="http://github.com/doxygen/doxygen/commit/bca94d6ca30bde5f01dd17a83cfa63268c0ca664">view</a>]</li>
-<li>fix test to support new programlisting attribute [<a href="http://github.com/doxygen/doxygen/commit/a9963fd94acd5839e818890b6a356d6b335c1f74">view</a>]</li>
-<li>fix typo [<a href="http://github.com/doxygen/doxygen/commit/f88ebaf9f23c3151f312400d77150eeeeb8158c2">view</a>]</li>
-<li>fixes vhdl literal bug [<a href="http://github.com/doxygen/doxygen/commit/6c387a6be9128ced0b89f6fc75946cd1a85096fb">view</a>]</li>
-<li>line continuation characters inside comments embedded in a macro definition appeared in the output [<a href="http://github.com/doxygen/doxygen/commit/898b6044194d5967099adfadab454cd09a4f360e">view</a>]</li>
-<li>make use of clang compilation database [<a href="http://github.com/doxygen/doxygen/commit/818aefcecf3cca986c971cd236bd7b77337db955">view</a>]</li>
-<li>new addon doxyparse, a source parsing engine [<a href="http://github.com/doxygen/doxygen/commit/e6dcc3b6c6dd449800eeebc172c1d15367d61d74">view</a>]</li>
-<li>sqlite3gen: add index on params [<a href="http://github.com/doxygen/doxygen/commit/3b3d1edeacde99719456b8f1616077707a5a2012">view</a>]</li>
-<li>sqlite3gen: add missing protectedsettable column [<a href="http://github.com/doxygen/doxygen/commit/ba8e4323290da4cb6de59060c77fe02a4df694b4">view</a>]</li>
-<li>sqlite3gen: add openDbConnection [<a href="http://github.com/doxygen/doxygen/commit/5596fcd158e7c53638324cea8ba3da31b2c32620">view</a>]</li>
-<li>sqlite3gen: start checking operations status [<a href="http://github.com/doxygen/doxygen/commit/74cebdbbbc2c267c254ab2c337ee06250ab8424d">view</a>]</li>
-<li>sqlite3gen: use sqlite3_exec for schema setup [<a href="http://github.com/doxygen/doxygen/commit/1ec8f0eb9169fc3f9ab82b60712a332bf60728bf">view</a>]</li>
-<li>typos [<a href="http://github.com/doxygen/doxygen/commit/5711b54b4813a2f4ce3b858e496ac846cbda69e5">view</a>]</li>
-<li>update compound.xsd to add language attribute [<a href="http://github.com/doxygen/doxygen/commit/0259d2a8bf9571e06873b80df96fd2ff29723dbc">view</a>]</li>
-<li>using YAML in the output of &quot;doxyparse&quot; [<a href="http://github.com/doxygen/doxygen/commit/82dbb5fe863e13175eda130dcc728b102101ccda">view</a>]</li>
+<li>Add language type attribute to programlisting tag [<a href="https://github.com/doxygen/doxygen/commit/141dbfd5a4f79c98da14a1b414c6db4e1b34618b">view</a>]</li>
+<li>Add links behind nav entries &quot;Namespaces&quot; and &quot;Files&quot; (matching &quot;Classes&quot;) [<a href="https://github.com/doxygen/doxygen/commit/464919adf1cdae9057ff840f40c60472b4c30bfd">view</a>]</li>
+<li>Allow case insensitive file pattern matching based on CASE_SENSE_NAMES [<a href="https://github.com/doxygen/doxygen/commit/bd759f9a3aa4096bc8574ea45ad6b23fed830742">view</a>]</li>
+<li>Async load of mathjax javascript [<a href="https://github.com/doxygen/doxygen/commit/340e516dbf5efd3ae21d964e92369e97b252e4ab">view</a>]</li>
+<li>Avoid generating unused dir_* output files for non HTML output formats [<a href="https://github.com/doxygen/doxygen/commit/38987846ec0752b8deee7bab69c7890aa861af00">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3138">3138</a> - Wrong spacing in function names with french language (latex output) [<a href="https://github.com/doxygen/doxygen/commit/9d478d2fedd091ceac8e689507676292f5455882">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4289">4289</a> - does ALIAS work for VHDL code? [<a href="https://github.com/doxygen/doxygen/commit/05364c46f806e73cce76be37a6a31230d0468507">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5468">5468</a> - (UnFriendlyTemplate) Spurious warning when documenting friend template [<a href="https://github.com/doxygen/doxygen/commit/2fe7bc7f1df9a2483355b0743b5e0455aaccc969">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5525">5525</a> - parser misinterpreting fortran [<a href="https://github.com/doxygen/doxygen/commit/747fc768476aef8b8b70fdd78749702a410dcd29">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5724">5724</a> - Duplicate attribute (target=&quot;_top&quot; target=&quot;_top&quot;) generated in .SVG files [<a href="https://github.com/doxygen/doxygen/commit/97bfbfa6c4d4eb07ac8c60545086c3370e9683b8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6128">6128</a> - Usage of underscore&#39;s in parameter names [<a href="https://github.com/doxygen/doxygen/commit/c10af45c61a1f9b25c514f397ace16c94cc7c8df">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6135">6135</a> - [1.8.13 Regression] Segfault building the breathe docs [<a href="https://github.com/doxygen/doxygen/commit/0f02761a158a5e9ddbd5801682482af8986dbc35">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6137">6137</a> - XML Parsing Error for operator&lt;&lt; methods when outputting to XHTML [<a href="https://github.com/doxygen/doxygen/commit/0e8530e42b69c909ef2c26468b24dfb88cc0997f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6139">6139</a> - Menu does not work without Javascript [<a href="https://github.com/doxygen/doxygen/commit/1be97720b7820361e85242d08d4cac3e46570bfe">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6141">6141</a> - Too greedy behavior of @ref const matching [<a href="https://github.com/doxygen/doxygen/commit/04001c8926fb0f37dfcf284b3637b182125bba75">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6169">6169</a> - doxygen build fails [<a href="https://github.com/doxygen/doxygen/commit/bb5c8dd29782ecbb05a4ef9788f2507e9a156848">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6170">6170</a> - Add &quot;\~&quot; command to internatioalization article [<a href="https://github.com/doxygen/doxygen/commit/e204b982eebd54bd15148a520da6608935e33e50">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6223">6223</a> - Problem RTF output: The class list &quot;classes&quot; within the namespace report is wrong indicated. [<a href="https://github.com/doxygen/doxygen/commit/753c06281f6b2e9172c449157fc9f863063232e3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6238">6238</a> - parsing error in Fortran file with preprocessing [<a href="https://github.com/doxygen/doxygen/commit/2f5e22a4be9d237a150d04659bf6abec1349fbd9">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/ec12eb659d8c8e78ad4bb15d1a941ac3153a0f66">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6259">6259</a> - Problem parsing c++ gnu::visibility [<a href="https://github.com/doxygen/doxygen/commit/d8001efd89146e04d92f5ea41ab27a7de09b6c53">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6262">6262</a> - C++: False warning message when inheriting class from tag file [<a href="https://github.com/doxygen/doxygen/commit/aac84d5624b96d8937ff543ab8724c269b8726ab">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6273">6273</a> - Error in markdown emphasis examples [<a href="https://github.com/doxygen/doxygen/commit/81956108f2e6e97bf4dd0f1011fcae1b5c4c4408">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6277">6277</a> - Increasing access of inherited C++ members with &#39;using...&#39; is not recognized by Doxygen [<a href="https://github.com/doxygen/doxygen/commit/9468ede259153cf79eb8d61635389744e9a2ee7d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6286">6286</a> - C++ parameter from lambda not recognized [<a href="https://github.com/doxygen/doxygen/commit/7b43be09e513ea6f86f9ca53ce05c94d63eada4c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6290">6290</a> - Doxygen not showing the public, non-static member function [<a href="https://github.com/doxygen/doxygen/commit/137b2e8dd03a98e692c2f6d813b47f19f2c64e5b">view</a>]</li>
+<li>CMake: avoid if() around the whole contents of documentation CMakeLists.txt [<a href="https://github.com/doxygen/doxygen/commit/62e87408cb7094eeac130775e62d5b7a6f4a79c9">view</a>]</li>
+<li>CMake: avoid if() around the whole contents of plugin CMakeLists.txt [<a href="https://github.com/doxygen/doxygen/commit/7c1c75a2c5583415d178e0e46a1a356bef9b0c84">view</a>]</li>
+<li>CMake: let CMake handle the C++ standard setting if target_compile_features() is used [<a href="https://github.com/doxygen/doxygen/commit/ca7e60edd370949cfb2adb83ca0b532bb3fdc441">view</a>]</li>
+<li>CMake: let file(MAKE_DIRECTORY) create all directories at once [<a href="https://github.com/doxygen/doxygen/commit/0d7be027a6fea2ac198dded58f8b55cda1bbe962">view</a>]</li>
+<li>CMake: remove CUSTOM_(LINK|INCLUDE)_DIR [<a href="https://github.com/doxygen/doxygen/commit/28f09783b1e45a827729abaca61f963dd869381b">view</a>]</li>
+<li>CMake: remove needless variable expansions [<a href="https://github.com/doxygen/doxygen/commit/975fb19eb07bc65ef48ddd5f26bf6be2736d0e0a">view</a>]</li>
+<li>CMake: remove unused program searching [<a href="https://github.com/doxygen/doxygen/commit/02f726b63e2b3a2ed4c5da43c164dcaad5fcfe94">view</a>]</li>
+<li>CMake: search for Qt5 only in config file mode [<a href="https://github.com/doxygen/doxygen/commit/ac5ca4ef86ad50232be75a65fab99302307b7795">view</a>]</li>
+<li>CMake: use GNUInstallDirs module for man pages directory [<a href="https://github.com/doxygen/doxygen/commit/fcf5fecb64d5c194430e10cbe52482b14224d645">view</a>]</li>
+<li>CMake: use add_test to create a test [<a href="https://github.com/doxygen/doxygen/commit/b54b843accb97105ae4afaf24136e33bfd1ea9d4">view</a>]</li>
+<li>CMakeLists: Avoid MSVC iconv changes for MinGW builds [<a href="https://github.com/doxygen/doxygen/commit/9532e0f19532e9d76c3f1092d131af91125a2dff">view</a>]</li>
+<li>Call endMemberItem consistently. [<a href="https://github.com/doxygen/doxygen/commit/1aafbbc97bdb643cae8be036f2b9ab569ca7f15e">view</a>]</li>
+<li>Change navtree collapsed list icon [<a href="https://github.com/doxygen/doxygen/commit/b3869a3ed82957c1785dc955876885f8b73a020b">view</a>]</li>
+<li>Code color of , (comma) together with only in use statement [<a href="https://github.com/doxygen/doxygen/commit/6f7264f4a16f5b1240291c6d33a0e4cc98ba30e4">view</a>]</li>
+<li>Corrected small type [<a href="https://github.com/doxygen/doxygen/commit/4360982dbaee9b32973a95ba88290022d0643e10">view</a>]</li>
+<li>Correction display of backtick in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/beaa386ca97341e66ad673660c808993240df637">view</a>]</li>
+<li>Correction of non reachable links and redirected links in documentation. [<a href="https://github.com/doxygen/doxygen/commit/31cf78d223e52fe078ad9b0651672aeb73926065">view</a>]</li>
+<li>Documentation, correct referenced file [<a href="https://github.com/doxygen/doxygen/commit/c93a7c34e7efd5ae1f2c3e4d230e29a333bc237a">view</a>]</li>
+<li>Doxygen/VHDLdocgen: [<a href="https://github.com/doxygen/doxygen/commit/77e0cf86eadbec22b81e26e083ffc831240869da">view</a>]</li>
+<li>Encode invalid XML characters instead of skipping them. [<a href="https://github.com/doxygen/doxygen/commit/b6a7abf02652b74872b9c676fcfa545e18d9bde7">view</a>]</li>
+<li>Expose TOC placeholder in XML output. [<a href="https://github.com/doxygen/doxygen/commit/fe760977e2cb643b94fbf21847e0c81e8a080966">view</a>]</li>
+<li>Expose underlying enum type in the XML output. [<a href="https://github.com/doxygen/doxygen/commit/17bceb8f4580535de52d19e8cadf0d088f972bef">view</a>]</li>
+<li>Fetch filename property from object instead of hardcoded duplicated string [<a href="https://github.com/doxygen/doxygen/commit/84fd1fecfe2de7b4f8c88e1923ef7d5958dc70b0">view</a>]</li>
+<li>Fix C# property initializer parsing [<a href="https://github.com/doxygen/doxygen/commit/14a0bcc74a121525917aefc8c9034e283e94884b">view</a>]</li>
+<li>Fix for regression in XML output generation after fixing bug 789168 [<a href="https://github.com/doxygen/doxygen/commit/1a1fdbed64de6ce01959b2e4d0988be823fb6bad">view</a>]</li>
+<li>Fix <a href="https://github.com/doxygen/doxygen/issues/6210">6210</a>. [<a href="https://github.com/doxygen/doxygen/commit/c87f730fe4bc40f72ed5fa52fe032a7bdf2d549c">view</a>]</li>
+<li>Fix minor markup issue in the documentation. [<a href="https://github.com/doxygen/doxygen/commit/b4df85466cf0447d46f311046fc5b3fe062b957f">view</a>]</li>
+<li>Fix not initialized pointer when parser is starting on a new file. [<a href="https://github.com/doxygen/doxygen/commit/52fb4cd5bb085960476e0cd256cc81db1370839d">view</a>]</li>
+<li>Fix typo [<a href="https://github.com/doxygen/doxygen/commit/d6e9db71645d895450993972ed41406c1cf1fc52">view</a>]</li>
+<li>Fix: add missing newline char &#39;\n&#39; [<a href="https://github.com/doxygen/doxygen/commit/856a43cfe08179ebbcebe656262b0229925547c8">view</a>]</li>
+<li>Fix: add missing semicolon &#39;;&#39; at end of line [<a href="https://github.com/doxygen/doxygen/commit/507880a0c7ed6029ce7ede2e85d23a9650a3f6bf">view</a>]</li>
+<li>Fix: change &#39;CMakefiles&#39; to &#39;CMakeFiles&#39; (the &#39;F&#39; is uppercase) [<a href="https://github.com/doxygen/doxygen/commit/bcc09aa2ba01eff458a00aff853d58ed8213a5da">view</a>]</li>
+<li>Fix: perl script regexp to toggle flex debug information [<a href="https://github.com/doxygen/doxygen/commit/b11b19badf4ef7318512c28f448dbecd6a47a715">view</a>]</li>
+<li>Fixed problem where automatic line breaking caused missing vertical bars in the parameter table for Latex output. [<a href="https://github.com/doxygen/doxygen/commit/5fc82b2275e202438ac61b070ac5f4be0df792d6">view</a>]</li>
+<li>Fixes for cross platform build with new LLVM/CLANG version [<a href="https://github.com/doxygen/doxygen/commit/b0aae61c97966cb9d424b500d7ced5bdf500d8db">view</a>]</li>
+<li>Fixup man page NAME section when page has title [<a href="https://github.com/doxygen/doxygen/commit/9d0908359363dbb43236767669c214721700acf7">view</a>]</li>
+<li>Function declaration following a function definition incorrectly listed as calling dependencing [<a href="https://github.com/doxygen/doxygen/commit/436fc7ed1158d517dd6f6d25aa3e05568f8c3d94">view</a>]</li>
+<li>Further cleanup of lodepng code [<a href="https://github.com/doxygen/doxygen/commit/c627108f3315144f5d9fb84d0197502b939caf7d">view</a>]</li>
+<li>Implement &quot;double-space line breaks&quot; syntax in Markdown [<a href="https://github.com/doxygen/doxygen/commit/e4596c7eab90ba4d307e2c212cefeab8ac820269">view</a>]</li>
+<li>Improve Chinese translation [<a href="https://github.com/doxygen/doxygen/commit/ded5247523ec8d47129405df3999ce391cca9e2d">view</a>]</li>
+<li>Inline attribute got reset for functions returning an explicit struct type [<a href="https://github.com/doxygen/doxygen/commit/127a43d464790dd0312794fe7ae1d92247cd9eef">view</a>]</li>
+<li>Isolated none-existing posix threading functions on Android [<a href="https://github.com/doxygen/doxygen/commit/4e25f081847cf2717ad561214e90d9750da5a511">view</a>]</li>
+<li>Marks JS as freely licensed [<a href="https://github.com/doxygen/doxygen/commit/6b5617e5a4c87afd2c7f2f7b8cb03de2b6735627">view</a>]</li>
+<li>Misc. doxy and comment typos [<a href="https://github.com/doxygen/doxygen/commit/1764f7a0f199b9f2a85f885cfd0f1804f8292c49">view</a>]</li>
+<li>Misc. typos [<a href="https://github.com/doxygen/doxygen/commit/9fd7f3aeb4c2e78bda669bf4ef6fff1c12c062a4">view</a>]</li>
+<li>New table features mentioned in the documentation were not enabled. [<a href="https://github.com/doxygen/doxygen/commit/c120ac4762331513305e8a19fd9b267b2d4f9e41">view</a>]</li>
+<li>Pass strings as const references. [<a href="https://github.com/doxygen/doxygen/commit/ebf75c1fe8a0ff2cc9235155b6d63367944d6342">view</a>]</li>
+<li>Physical newlines in ALIASES configuration tags. [<a href="https://github.com/doxygen/doxygen/commit/d6801c4c5eaeebc5e14f5d1cd7c312ad82c1dbbd">view</a>]</li>
+<li>Propagate language information to all &lt;programlisting&gt; XML elements. [<a href="https://github.com/doxygen/doxygen/commit/eaf8edbac7e6a1873aa5c4ff0df063cd367351d6">view</a>]</li>
+<li>Properly copy images for the XML output. [<a href="https://github.com/doxygen/doxygen/commit/507dd0a60dd12c61ff2088db419187efc928c010">view</a>]</li>
+<li>Provide dot path to plantuml [<a href="https://github.com/doxygen/doxygen/commit/c24cb9a74ef0af854455047f29f9925d79ac0195">view</a>]</li>
+<li>Provide information about enum type &quot;strongness&quot; in the XML output. [<a href="https://github.com/doxygen/doxygen/commit/169cad806ea795e5c425fd397aa0de54cbc0a81e">view</a>]</li>
+<li>Provide page brief in &lt;briefdescription&gt; of XML output. [<a href="https://github.com/doxygen/doxygen/commit/bd2cf98e75c600e0c2f5ae95301df8745d65571a">view</a>]</li>
+<li>Provide template parameters also for type aliases in the XML output. [<a href="https://github.com/doxygen/doxygen/commit/21f0ca0085c034a37df07c1ab690472bada0a1f1">view</a>]</li>
+<li>Removed -Wno-deprecated flag from bison as it is not support on the bison 2.3 that ships with XCode [<a href="https://github.com/doxygen/doxygen/commit/6c288bf0e7548117aa358719aaecffedcc579590">view</a>]</li>
+<li>Restore &#39;make tests&#39; rule [<a href="https://github.com/doxygen/doxygen/commit/7ce59c9fbd5e99619a9ab0ac6177d21e6aca49c7">view</a>]</li>
+<li>Restore Makefile in vhdlparser dir [<a href="https://github.com/doxygen/doxygen/commit/aee944fe954de993a4273fafef6b5f0c726be7f3">view</a>]</li>
+<li>Spelling correction [<a href="https://github.com/doxygen/doxygen/commit/4cca51612a50a9016be5adbd6ccdc26c03d12b58">view</a>]</li>
+<li>Stripped unused LodePNG code to prevent false positives for coverity [<a href="https://github.com/doxygen/doxygen/commit/64865ad3e91fffe6e50b51b29ae2a54126f80126">view</a>]</li>
+<li>Suppresses warning for XML &lt;see langword=&quot;...&quot;/&gt; [<a href="https://github.com/doxygen/doxygen/commit/a3c5958b437b5dc9de91de5f40917ec53532b60a">view</a>]</li>
+<li>Suppression warnings about deprecated directive [<a href="https://github.com/doxygen/doxygen/commit/cd0faad90e9b6ce83fa1f7b4fb27a39357b0cae3">view</a>]</li>
+<li>Update .travis.yml [<a href="https://github.com/doxygen/doxygen/commit/5f028fd744526148aace4c971f739c9876b6108a">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/b7fc8a384b091f5761159d263ec27e30c3160a50">view</a>]</li>
+<li>Update mathjax path [<a href="https://github.com/doxygen/doxygen/commit/57e69ba26eff5eac4b31b088cd7d3dfa7532f12c">view</a>]</li>
+<li>Updated translator_de.h to doxygen 1.8.13 [<a href="https://github.com/doxygen/doxygen/commit/a9e3d5378ffbef542045d04239482bd6fec33e15">view</a>]</li>
+<li>Use hidden symbol visibility by default [<a href="https://github.com/doxygen/doxygen/commit/dcb3b2d0b888902a062eefd8200ea194ed1c42d6">view</a>]</li>
+<li>Use language identifier instead of file extension for language attribute [<a href="https://github.com/doxygen/doxygen/commit/ed9acb6e1bb81a2eec334180f7b8c1bf0598b444">view</a>]</li>
+<li>Use language in stead of lang for language name attribute [<a href="https://github.com/doxygen/doxygen/commit/4e4741221f4290412ef4a6b6bbfe9799abafaf6c">view</a>]</li>
+<li>Update of the Brazillian translation [<a href="https://github.com/doxygen/doxygen/commit/d283dfcdcaa0837e84d7995676d436fa04e96d1f">view</a>]</li>
+<li>[preprocessing.doc] typo amended [<a href="https://github.com/doxygen/doxygen/commit/6b67a64bd0bd1c6759294c323433dbd7d37df6ac">view</a>]</li>
+<li>add decimal to base identifier [<a href="https://github.com/doxygen/doxygen/commit/9cbc1a04e584e83d91ff3f7501f38b0a825e1953">view</a>]</li>
+<li>add the number of conditionals path and bugfix [<a href="https://github.com/doxygen/doxygen/commit/20af63f43e583a31dfe93f78807aa868f9b9ff14">view</a>]</li>
+<li>build: fix the way lang_cfg.h is generated [<a href="https://github.com/doxygen/doxygen/commit/cc3a9e611c15f32ae4913a87306699db60758245">view</a> and <a href="https://github.com/doxygen/doxygen/commit/a4b6f59e0c99457ba8f4f71782e51d50b7a1057f">view</a>]</li>
+<li>bump version number for the development version/next release [<a href="https://github.com/doxygen/doxygen/commit/0a6d8bf6f5ef3a537de6ab517d0ae9c4f5d558d0">view</a>]</li>
+<li>const-ify [<a href="https://github.com/doxygen/doxygen/commit/5df4341210ec2374b8b7c09f5df3cd8f4ff60f65">view</a>]</li>
+<li>dot.cpp: Fix DotGfxHierarchyTable first class node loop [<a href="https://github.com/doxygen/doxygen/commit/c7348b4483ace9b5608fbbe949eab02921eb0e70">view</a>]</li>
+<li>fix spelling [<a href="https://github.com/doxygen/doxygen/commit/bca94d6ca30bde5f01dd17a83cfa63268c0ca664">view</a>]</li>
+<li>fix test to support new programlisting attribute [<a href="https://github.com/doxygen/doxygen/commit/a9963fd94acd5839e818890b6a356d6b335c1f74">view</a>]</li>
+<li>fix typo [<a href="https://github.com/doxygen/doxygen/commit/f88ebaf9f23c3151f312400d77150eeeeb8158c2">view</a>]</li>
+<li>fixes vhdl literal bug [<a href="https://github.com/doxygen/doxygen/commit/6c387a6be9128ced0b89f6fc75946cd1a85096fb">view</a>]</li>
+<li>line continuation characters inside comments embedded in a macro definition appeared in the output [<a href="https://github.com/doxygen/doxygen/commit/898b6044194d5967099adfadab454cd09a4f360e">view</a>]</li>
+<li>make use of clang compilation database [<a href="https://github.com/doxygen/doxygen/commit/818aefcecf3cca986c971cd236bd7b77337db955">view</a>]</li>
+<li>new addon doxyparse, a source parsing engine [<a href="https://github.com/doxygen/doxygen/commit/e6dcc3b6c6dd449800eeebc172c1d15367d61d74">view</a>]</li>
+<li>sqlite3gen: add index on params [<a href="https://github.com/doxygen/doxygen/commit/3b3d1edeacde99719456b8f1616077707a5a2012">view</a>]</li>
+<li>sqlite3gen: add missing protectedsettable column [<a href="https://github.com/doxygen/doxygen/commit/ba8e4323290da4cb6de59060c77fe02a4df694b4">view</a>]</li>
+<li>sqlite3gen: add openDbConnection [<a href="https://github.com/doxygen/doxygen/commit/5596fcd158e7c53638324cea8ba3da31b2c32620">view</a>]</li>
+<li>sqlite3gen: start checking operations status [<a href="https://github.com/doxygen/doxygen/commit/74cebdbbbc2c267c254ab2c337ee06250ab8424d">view</a>]</li>
+<li>sqlite3gen: use sqlite3_exec for schema setup [<a href="https://github.com/doxygen/doxygen/commit/1ec8f0eb9169fc3f9ab82b60712a332bf60728bf">view</a>]</li>
+<li>typos [<a href="https://github.com/doxygen/doxygen/commit/5711b54b4813a2f4ce3b858e496ac846cbda69e5">view</a>]</li>
+<li>update compound.xsd to add language attribute [<a href="https://github.com/doxygen/doxygen/commit/0259d2a8bf9571e06873b80df96fd2ff29723dbc">view</a>]</li>
+<li>using YAML in the output of &quot;doxyparse&quot; [<a href="https://github.com/doxygen/doxygen/commit/82dbb5fe863e13175eda130dcc728b102101ccda">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -135,60 +135,60 @@
 <a name="1.8.13"></a>
 </p>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5279">5279</a> - C++/CLI indexed property not documented [<a href="http://github.com/doxygen/doxygen/commit/80656d68a0838483ea2988adf028e2d85292a109">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5280">5280</a> - Grouping of results fail when using built-in javascript search [<a href="http://github.com/doxygen/doxygen/commit/0615b1b023f7888dfdbeee7673d6d0bcc7b803df">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5400">5400</a> - &#39;static&#39; and &#39;throw&#39; C++ keywords not colored [<a href="http://github.com/doxygen/doxygen/commit/794ae9cbc40b73d00cce5f0096b53f18e1d3e325">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5476">5476</a> - wrong collaboration diagram when in template used scoped argument type [<a href="http://github.com/doxygen/doxygen/commit/adb44ae6ef1d102caea1338373be078bf4a5d640">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5882">5882</a> - Multiline //!&lt; behavior changed [<a href="http://github.com/doxygen/doxygen/commit/d4accb68ff6536dcf128236b7e1e8d0239d4ffc2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5917">5917</a> - C++11 &quot;using&quot; type alias for function pointer with no arguments is formatted incorrectly [<a href="http://github.com/doxygen/doxygen/commit/d4c24c28ffcf7143bcdfecee1c8b55f704274d37">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5930">5930</a> - fails to build with an unreleased python version [<a href="http://github.com/doxygen/doxygen/commit/5c6f0fdf1ebbd4c28f524a0347fe556ff2421504">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6044">6044</a> - doxygen warning parsing C++11 &quot;using&quot; declaration [<a href="http://github.com/doxygen/doxygen/commit/5730198d20511d93c20aa7870fc2bd11f478db85">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6060">6060</a> - Tag file size double between each run [<a href="http://github.com/doxygen/doxygen/commit/155bd0110585d401d0f898baf9c69b2ec46833ff">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6062">6062</a> - C++11 ref-qualifiers do not appear in Member Function Documentation section [<a href="http://github.com/doxygen/doxygen/commit/9ef1bf94eef1af591c40102b930fef95250b8142">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6063">6063</a> - Web-page bug: Comment blocks in VHDL [<a href="http://github.com/doxygen/doxygen/commit/6c6b847bcd16cc818165b51e62dc11a947f7e084">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6067">6067</a> - French description for &quot;Namespace Members&quot; is wrong and causes fatal javascript error [<a href="http://github.com/doxygen/doxygen/commit/b5e1e195bc207c7bb93df4e51253f9f3a1026a3d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6068">6068</a> - Class name &#39;internal&#39; breaks class hierarchy in C++ [<a href="http://github.com/doxygen/doxygen/commit/b93dbcdab6dfc5681ec49f1d567698b7c4dc6846">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6084">6084</a> - __xxx__ not interpreted as markdown when xxx begins with a non-word character (e.g. __-1__) [<a href="http://github.com/doxygen/doxygen/commit/a95c07ecc0a2f1205883d8420a8280c5701c901c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6093">6093</a> - Underscores in type or member name cause unwanted hyphenation in PDF output Data Fields [<a href="http://github.com/doxygen/doxygen/commit/d571efb062fbe17d7257f3971e3db6c9cba833d0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6094">6094</a> - &quot;name&quot; attribute of image map not urlencoded, not working in Chrome [<a href="http://github.com/doxygen/doxygen/commit/6300c03b6201ca7981388a6d3c01486f8a8adba0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6105">6105</a> - Please add HTML classes to &quot;Definition at...&quot; &amp; &quot;Referenced by...&quot; for CSS [<a href="http://github.com/doxygen/doxygen/commit/d2593e56cd52ecee2424d844916f95e12fef27c8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6109">6109</a> - INLINE_SIMPLE_STRUCTS with enums in classes does not work [<a href="http://github.com/doxygen/doxygen/commit/71d7a9399db016cba83ccd63c6ba7e0fac1cd44d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6115">6115</a> - Modify in some pronunciation expression in Korean [<a href="http://github.com/doxygen/doxygen/commit/cd3e39d7db634d9e11afc8e46269eb509ae10e40">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6123">6123</a> - Unknown reference in manual [<a href="http://github.com/doxygen/doxygen/commit/dde15c9748053ecb68ba046ebd0fdfe625be0e2e">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6125">6125</a> - referencing Python files via tagfile broken [<a href="http://github.com/doxygen/doxygen/commit/dc02bb977ebc6c683012c106e16e0190ac72b454">view</a>]</li>
-<li>Add NVARCHAR as a SQL type [<a href="http://github.com/doxygen/doxygen/commit/6a85240e65bb5e3d59d2cd161eb8cf241e27ed7d">view</a>]</li>
-<li>Add mscgen images to index.qhp [<a href="http://github.com/doxygen/doxygen/commit/f50d9ed4cdc7d4e7884bb64fddb01b017b880778">view</a>]</li>
-<li>Add sql syntax highlighting to code blocks [<a href="http://github.com/doxygen/doxygen/commit/adf4a90340921cf7a120ae918af776355cf8ca0f">view</a>]</li>
-<li>Add support for more CSS formatting and column/row spanning in markdown tables [<a href="http://github.com/doxygen/doxygen/commit/7f35695022d3baa8fc8c8d1b9a9f3368a0963871">view</a>]</li>
-<li>Added missing language value for SQL to XML output [<a href="http://github.com/doxygen/doxygen/commit/b196b1a28151d75d9546dcc407947fbf29789cc5">view</a>]</li>
-<li>Adds plantuml support Qt compressed help file [<a href="http://github.com/doxygen/doxygen/commit/c7b740d96288f19e31bd35405306c49bb9fc20c4">view</a>]</li>
-<li>Check for undocumented params warnings if members detailed documentation is not written [<a href="http://github.com/doxygen/doxygen/commit/bae3c91812f8a6f845337f8c32d55495c4aa3522">view</a>]</li>
-<li>Cleanup: removed redundant =NULL from interfaces, or replaced by =0 where it was needed. [<a href="http://github.com/doxygen/doxygen/commit/3b8b2e1a4b846a5c1b87f4a8ddc837462709895a">view</a>]</li>
-<li>Clear header/footer information in ConfigImpl for postProcess [<a href="http://github.com/doxygen/doxygen/commit/5881b1bb624ee6115dc635ba44366d259cc6a10f">view</a>]</li>
-<li>Documentation small corrections [<a href="http://github.com/doxygen/doxygen/commit/ae033324fed6ff9b3febe12b5777f19c04e065d2">view</a>]</li>
-<li>Doxygen error: Found &#39;;&#39; while parsing initializer list [<a href="http://github.com/doxygen/doxygen/commit/985faf287233badf65fa33d21bde17afa6970d60">view</a>]</li>
-<li>Fix for PlantUML configuration [<a href="http://github.com/doxygen/doxygen/commit/701598719c7c4301f2614b38184dfb37cd1704bc">view</a>]</li>
-<li>Fix plantuml generation issue [<a href="http://github.com/doxygen/doxygen/commit/6c87c75e197e673d74949839d59fe8b0842e86ff">view</a>]</li>
-<li>Fix: Add missing jquery.js, dynsections.js &amp; optional svgpan.js to QCH file [<a href="http://github.com/doxygen/doxygen/commit/bf9415698e53d79b4b94bdf64a52be4347eb3150">view</a>]</li>
-<li>Fix: replace deprecated {\bf with \textbf{ in LaTeX generator [<a href="http://github.com/doxygen/doxygen/commit/1d85e00dd1238f74babf0a1d7eeeaf3e2ba659f2">view</a>]</li>
-<li>Fixed constexp.y bison issue [<a href="http://github.com/doxygen/doxygen/commit/e12ec76f044b07d4e4fe167c93103be2879abaca">view</a>]</li>
-<li>Fixed cross referencing issue when using bitfields. [<a href="http://github.com/doxygen/doxygen/commit/2a5357a0fac644ffb1bf49569344b9bc57603a29">view</a>]</li>
-<li>Fixed jump to anchor issue when navigating to source file [<a href="http://github.com/doxygen/doxygen/commit/94b726f4273df805846d7fdcd2e9d5bd7627f628">view</a>]</li>
-<li>Fixed problem generating per letter namespace member index pages. [<a href="http://github.com/doxygen/doxygen/commit/2b722b57f20e044b061423109bfa7168a7a1b913">view</a>]</li>
-<li>Fixed svgpan.js issue with Chrome causing empty SVG graphs [<a href="http://github.com/doxygen/doxygen/commit/5f01f783e2387a5d44ad70fbff5365aa0e5df938">view</a>]</li>
-<li>Fixed typedef and define strings for Spanish translation [<a href="http://github.com/doxygen/doxygen/commit/f69eb5d79885788d6bfc6303f34f5f016b326f1c">view</a>]</li>
-<li>Fixup man only output to use generator state push pop [<a href="http://github.com/doxygen/doxygen/commit/051fb8a536e1d52aa0a0422186975852dd139c06">view</a>]</li>
-<li>For manpages remove trailing dash when no brief description [<a href="http://github.com/doxygen/doxygen/commit/98d3f8e7d581c589e7bd1a7faf98fc6736847cf1">view</a>]</li>
-<li>Made the RTF output honor the PAPER_TYPE option. [<a href="http://github.com/doxygen/doxygen/commit/5e894a760a6584ade2f5417e2577b66c65b51fd9">view</a>]</li>
-<li>New classes for generated HTML div elements. [<a href="http://github.com/doxygen/doxygen/commit/84017cac3bc9d08aa95a90cf0e44b913c492c939">view</a>]</li>
-<li>Option for PlantUML configuration file [<a href="http://github.com/doxygen/doxygen/commit/d4b0b88e189027d514fa84de75100ff1fe6e681a">view</a>]</li>
-<li>Removed x flag from util* source files [<a href="http://github.com/doxygen/doxygen/commit/16d57031188698c7e79dd64554efc56044e91c8f">view</a>]</li>
-<li>Replaced section marker before members by diamond shaped bullet [<a href="http://github.com/doxygen/doxygen/commit/da21ad5b5147182c2117751d8c517b81dd57277f">view</a>]</li>
-<li>Reverting pull request #537 until it will be fixed [<a href="http://github.com/doxygen/doxygen/commit/fd67ef1f66afb0b51a784866b806ba8f04e12dfb">view</a>]</li>
-<li>Update Swedish translation [<a href="http://github.com/doxygen/doxygen/commit/78b43ec9b5469a9e757cd658d21907fa593ed1aa">view</a>]</li>
-<li>Updated the Polish translation [<a href="http://github.com/doxygen/doxygen/commit/158b7bdb697d19736692105161af3e891ae7732e">view</a>]</li>
-<li>bison: use %declarations instead of command line options. [<a href="http://github.com/doxygen/doxygen/commit/97c2c1d6f323d6d38dda4820c00ca8ca8f5b6940">view</a>]</li>
-<li>flex: use %option instead of command line options. [<a href="http://github.com/doxygen/doxygen/commit/0bdb01d4b6ced07750d8e449fd4ffab5554d8a24">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5279">5279</a> - C++/CLI indexed property not documented [<a href="https://github.com/doxygen/doxygen/commit/80656d68a0838483ea2988adf028e2d85292a109">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5280">5280</a> - Grouping of results fail when using built-in javascript search [<a href="https://github.com/doxygen/doxygen/commit/0615b1b023f7888dfdbeee7673d6d0bcc7b803df">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5400">5400</a> - &#39;static&#39; and &#39;throw&#39; C++ keywords not colored [<a href="https://github.com/doxygen/doxygen/commit/794ae9cbc40b73d00cce5f0096b53f18e1d3e325">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5476">5476</a> - wrong collaboration diagram when in template used scoped argument type [<a href="https://github.com/doxygen/doxygen/commit/adb44ae6ef1d102caea1338373be078bf4a5d640">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5882">5882</a> - Multiline //!&lt; behavior changed [<a href="https://github.com/doxygen/doxygen/commit/d4accb68ff6536dcf128236b7e1e8d0239d4ffc2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5917">5917</a> - C++11 &quot;using&quot; type alias for function pointer with no arguments is formatted incorrectly [<a href="https://github.com/doxygen/doxygen/commit/d4c24c28ffcf7143bcdfecee1c8b55f704274d37">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5930">5930</a> - fails to build with an unreleased python version [<a href="https://github.com/doxygen/doxygen/commit/5c6f0fdf1ebbd4c28f524a0347fe556ff2421504">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6044">6044</a> - doxygen warning parsing C++11 &quot;using&quot; declaration [<a href="https://github.com/doxygen/doxygen/commit/5730198d20511d93c20aa7870fc2bd11f478db85">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6060">6060</a> - Tag file size double between each run [<a href="https://github.com/doxygen/doxygen/commit/155bd0110585d401d0f898baf9c69b2ec46833ff">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6062">6062</a> - C++11 ref-qualifiers do not appear in Member Function Documentation section [<a href="https://github.com/doxygen/doxygen/commit/9ef1bf94eef1af591c40102b930fef95250b8142">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6063">6063</a> - Web-page bug: Comment blocks in VHDL [<a href="https://github.com/doxygen/doxygen/commit/6c6b847bcd16cc818165b51e62dc11a947f7e084">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6067">6067</a> - French description for &quot;Namespace Members&quot; is wrong and causes fatal javascript error [<a href="https://github.com/doxygen/doxygen/commit/b5e1e195bc207c7bb93df4e51253f9f3a1026a3d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6068">6068</a> - Class name &#39;internal&#39; breaks class hierarchy in C++ [<a href="https://github.com/doxygen/doxygen/commit/b93dbcdab6dfc5681ec49f1d567698b7c4dc6846">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6084">6084</a> - __xxx__ not interpreted as markdown when xxx begins with a non-word character (e.g. __-1__) [<a href="https://github.com/doxygen/doxygen/commit/a95c07ecc0a2f1205883d8420a8280c5701c901c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6093">6093</a> - Underscores in type or member name cause unwanted hyphenation in PDF output Data Fields [<a href="https://github.com/doxygen/doxygen/commit/d571efb062fbe17d7257f3971e3db6c9cba833d0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6094">6094</a> - &quot;name&quot; attribute of image map not urlencoded, not working in Chrome [<a href="https://github.com/doxygen/doxygen/commit/6300c03b6201ca7981388a6d3c01486f8a8adba0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6105">6105</a> - Please add HTML classes to &quot;Definition at...&quot; &amp; &quot;Referenced by...&quot; for CSS [<a href="https://github.com/doxygen/doxygen/commit/d2593e56cd52ecee2424d844916f95e12fef27c8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6109">6109</a> - INLINE_SIMPLE_STRUCTS with enums in classes does not work [<a href="https://github.com/doxygen/doxygen/commit/71d7a9399db016cba83ccd63c6ba7e0fac1cd44d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6115">6115</a> - Modify in some pronunciation expression in Korean [<a href="https://github.com/doxygen/doxygen/commit/cd3e39d7db634d9e11afc8e46269eb509ae10e40">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6123">6123</a> - Unknown reference in manual [<a href="https://github.com/doxygen/doxygen/commit/dde15c9748053ecb68ba046ebd0fdfe625be0e2e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6125">6125</a> - referencing Python files via tagfile broken [<a href="https://github.com/doxygen/doxygen/commit/dc02bb977ebc6c683012c106e16e0190ac72b454">view</a>]</li>
+<li>Add NVARCHAR as a SQL type [<a href="https://github.com/doxygen/doxygen/commit/6a85240e65bb5e3d59d2cd161eb8cf241e27ed7d">view</a>]</li>
+<li>Add mscgen images to index.qhp [<a href="https://github.com/doxygen/doxygen/commit/f50d9ed4cdc7d4e7884bb64fddb01b017b880778">view</a>]</li>
+<li>Add sql syntax highlighting to code blocks [<a href="https://github.com/doxygen/doxygen/commit/adf4a90340921cf7a120ae918af776355cf8ca0f">view</a>]</li>
+<li>Add support for more CSS formatting and column/row spanning in markdown tables [<a href="https://github.com/doxygen/doxygen/commit/7f35695022d3baa8fc8c8d1b9a9f3368a0963871">view</a>]</li>
+<li>Added missing language value for SQL to XML output [<a href="https://github.com/doxygen/doxygen/commit/b196b1a28151d75d9546dcc407947fbf29789cc5">view</a>]</li>
+<li>Adds plantuml support Qt compressed help file [<a href="https://github.com/doxygen/doxygen/commit/c7b740d96288f19e31bd35405306c49bb9fc20c4">view</a>]</li>
+<li>Check for undocumented params warnings if members detailed documentation is not written [<a href="https://github.com/doxygen/doxygen/commit/bae3c91812f8a6f845337f8c32d55495c4aa3522">view</a>]</li>
+<li>Cleanup: removed redundant =NULL from interfaces, or replaced by =0 where it was needed. [<a href="https://github.com/doxygen/doxygen/commit/3b8b2e1a4b846a5c1b87f4a8ddc837462709895a">view</a>]</li>
+<li>Clear header/footer information in ConfigImpl for postProcess [<a href="https://github.com/doxygen/doxygen/commit/5881b1bb624ee6115dc635ba44366d259cc6a10f">view</a>]</li>
+<li>Documentation small corrections [<a href="https://github.com/doxygen/doxygen/commit/ae033324fed6ff9b3febe12b5777f19c04e065d2">view</a>]</li>
+<li>Doxygen error: Found &#39;;&#39; while parsing initializer list [<a href="https://github.com/doxygen/doxygen/commit/985faf287233badf65fa33d21bde17afa6970d60">view</a>]</li>
+<li>Fix for PlantUML configuration [<a href="https://github.com/doxygen/doxygen/commit/701598719c7c4301f2614b38184dfb37cd1704bc">view</a>]</li>
+<li>Fix plantuml generation issue [<a href="https://github.com/doxygen/doxygen/commit/6c87c75e197e673d74949839d59fe8b0842e86ff">view</a>]</li>
+<li>Fix: Add missing jquery.js, dynsections.js &amp; optional svgpan.js to QCH file [<a href="https://github.com/doxygen/doxygen/commit/bf9415698e53d79b4b94bdf64a52be4347eb3150">view</a>]</li>
+<li>Fix: replace deprecated {\bf with \textbf{ in LaTeX generator [<a href="https://github.com/doxygen/doxygen/commit/1d85e00dd1238f74babf0a1d7eeeaf3e2ba659f2">view</a>]</li>
+<li>Fixed constexp.y bison issue [<a href="https://github.com/doxygen/doxygen/commit/e12ec76f044b07d4e4fe167c93103be2879abaca">view</a>]</li>
+<li>Fixed cross referencing issue when using bitfields. [<a href="https://github.com/doxygen/doxygen/commit/2a5357a0fac644ffb1bf49569344b9bc57603a29">view</a>]</li>
+<li>Fixed jump to anchor issue when navigating to source file [<a href="https://github.com/doxygen/doxygen/commit/94b726f4273df805846d7fdcd2e9d5bd7627f628">view</a>]</li>
+<li>Fixed problem generating per letter namespace member index pages. [<a href="https://github.com/doxygen/doxygen/commit/2b722b57f20e044b061423109bfa7168a7a1b913">view</a>]</li>
+<li>Fixed svgpan.js issue with Chrome causing empty SVG graphs [<a href="https://github.com/doxygen/doxygen/commit/5f01f783e2387a5d44ad70fbff5365aa0e5df938">view</a>]</li>
+<li>Fixed typedef and define strings for Spanish translation [<a href="https://github.com/doxygen/doxygen/commit/f69eb5d79885788d6bfc6303f34f5f016b326f1c">view</a>]</li>
+<li>Fixup man only output to use generator state push pop [<a href="https://github.com/doxygen/doxygen/commit/051fb8a536e1d52aa0a0422186975852dd139c06">view</a>]</li>
+<li>For manpages remove trailing dash when no brief description [<a href="https://github.com/doxygen/doxygen/commit/98d3f8e7d581c589e7bd1a7faf98fc6736847cf1">view</a>]</li>
+<li>Made the RTF output honor the PAPER_TYPE option. [<a href="https://github.com/doxygen/doxygen/commit/5e894a760a6584ade2f5417e2577b66c65b51fd9">view</a>]</li>
+<li>New classes for generated HTML div elements. [<a href="https://github.com/doxygen/doxygen/commit/84017cac3bc9d08aa95a90cf0e44b913c492c939">view</a>]</li>
+<li>Option for PlantUML configuration file [<a href="https://github.com/doxygen/doxygen/commit/d4b0b88e189027d514fa84de75100ff1fe6e681a">view</a>]</li>
+<li>Removed x flag from util* source files [<a href="https://github.com/doxygen/doxygen/commit/16d57031188698c7e79dd64554efc56044e91c8f">view</a>]</li>
+<li>Replaced section marker before members by diamond shaped bullet [<a href="https://github.com/doxygen/doxygen/commit/da21ad5b5147182c2117751d8c517b81dd57277f">view</a>]</li>
+<li>Reverting pull request #537 until it will be fixed [<a href="https://github.com/doxygen/doxygen/commit/fd67ef1f66afb0b51a784866b806ba8f04e12dfb">view</a>]</li>
+<li>Update Swedish translation [<a href="https://github.com/doxygen/doxygen/commit/78b43ec9b5469a9e757cd658d21907fa593ed1aa">view</a>]</li>
+<li>Updated the Polish translation [<a href="https://github.com/doxygen/doxygen/commit/158b7bdb697d19736692105161af3e891ae7732e">view</a>]</li>
+<li>bison: use %declarations instead of command line options. [<a href="https://github.com/doxygen/doxygen/commit/97c2c1d6f323d6d38dda4820c00ca8ca8f5b6940">view</a>]</li>
+<li>flex: use %option instead of command line options. [<a href="https://github.com/doxygen/doxygen/commit/0bdb01d4b6ced07750d8e449fd4ffab5554d8a24">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -199,156 +199,156 @@
 <a name="1.8.12"></a>
 </p>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1662">1662</a> - Fix missing title in non-page docanchors from tag files [<a href="http://github.com/doxygen/doxygen/commit/616b392e9bc8984251d969577a5b63974efb1eef">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2763">2763</a> - FILTER_PATTERNS won&#39;t take command with arguments [<a href="http://github.com/doxygen/doxygen/commit/ce7a983c2849e4c8fa72189a896e594a8497dd4c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4691">4691</a> - Uses &lt;img&gt; instead of &lt;object&gt; html tag for SVG images [<a href="http://github.com/doxygen/doxygen/commit/8ccd98643a3b88aaa3245b76202666900a2cd401">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5174">5174</a> - error state 21 with fortran code (fixed format) [<a href="http://github.com/doxygen/doxygen/commit/fdee5e9fade0ff5a578817048c6205f2a9acbced">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5323">5323</a> - Missing Page References in the Index Chapters of the LaTex/PDF output [<a href="http://github.com/doxygen/doxygen/commit/efd49dacfbae1ad55d7922a748e2c1d60068b014">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5411">5411</a> - Inherited member of template class issues warning and is not documented [<a href="http://github.com/doxygen/doxygen/commit/4dfc5887660284b345eb93b6c07dc1f91e780fac">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5711">5711</a> - Fortran: attributes after a blank line are ignored / Bug <a href="https://github.com/doxygen/doxygen/issues/3880">3880</a> - FORTRAN: comment in subroutine argument list [<a href="http://github.com/doxygen/doxygen/commit/e9ebf43585bffee80c31dd69538feae2a4525178">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5791">5791</a> - Doxygen handles comments in Objective-C code blocks incorrectly. [<a href="http://github.com/doxygen/doxygen/commit/c2e0ce14c65584f42e875f0abdbe5466d1414636">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5804">5804</a> - Representation of arrows [<a href="http://github.com/doxygen/doxygen/commit/ab96c077a8cd99308e6ae90c3c861ab1c0e911d7">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5811">5811</a> - Markdown: &gt; escaped within backticks [<a href="http://github.com/doxygen/doxygen/commit/5f9d80b2ce73a7e7fb0f4fc16f3ef5fee0cf8105">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5826">5826</a> - Use UTC timezone when displaying QDateTimes parsed from SOURCE_DATE_EPOCH [<a href="http://github.com/doxygen/doxygen/commit/5801460b3141871222569fb99e7964e9a2925d71">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5832">5832</a> - last entry missing in a @name group of typedefs [<a href="http://github.com/doxygen/doxygen/commit/ee2d6faecab57c1f929d6868ae6eb9bdaa53d654">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5843">5843</a> - Link of typedef within namespace on group pages missing [<a href="http://github.com/doxygen/doxygen/commit/0bd419e0a4fabf615fb72eb92bf561d3dfc96a11">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5891">5891</a> - __init__.py causes to ignore some inheritance [<a href="http://github.com/doxygen/doxygen/commit/607b8a302297169e4319280dba2a61dcbe042965">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5923">5923</a> - Figure title needs to be on separate line in order for it to work [<a href="http://github.com/doxygen/doxygen/commit/07521a7f050607609b9d04e8f3c58ed4754c47c3">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5933">5933</a> - Phantom variables/functions in XML, created from non-code files [<a href="http://github.com/doxygen/doxygen/commit/7dc9b378a107b1ccae2245b3f3f3d628db2bd008">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5937">5937</a> - CASE_SENSE_NAMES ignored [<a href="http://github.com/doxygen/doxygen/commit/fab854a10f358c15a69291a59388ea0c184bce20">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5938">5938</a> - Spaces between the closing bracket of the typename and the opening bracket of the parameter list cause detection issues. [<a href="http://github.com/doxygen/doxygen/commit/622d18637f9d633b184e43fd3594b661cf4e9375">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5941">5941</a> - python unicode docstrings are ignored [<a href="http://github.com/doxygen/doxygen/commit/936f242956350825d870f7396ae5d6106fe3081d">view</a>]
-, [<a href="http://github.com/doxygen/doxygen/commit/be100f882604a23d94025fee6d059bdb5ec28d3e">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5945">5945</a> - Do not allow ligatures in log output [<a href="http://github.com/doxygen/doxygen/commit/894bdfdf268ba24a268fa72d7b33899a9f3a126b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5958">5958</a> - References for one function can inherit References from subsequent non documented function [<a href="http://github.com/doxygen/doxygen/commit/9abcad810b8d41d338d501ff5b32524e1ced7f33">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5961">5961</a> - External search does not properly escape user supplied data, resulting in vulnerability [<a href="http://github.com/doxygen/doxygen/commit/1cc1adad2de03a0f013881b8960daf89aa155081">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5962">5962</a> - regression, Unescaped percent sign in doxygen output [<a href="http://github.com/doxygen/doxygen/commit/d4ab02c2da7df472bebbf2724419ba00f2de229c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5964">5964</a> - hyperref link label drop underscores [<a href="http://github.com/doxygen/doxygen/commit/537a1c67f316c5a9d2d4542e94a4ace439a78b3a">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5965">5965</a> - Directory list is not generated in HTML output [<a href="http://github.com/doxygen/doxygen/commit/b6b87054121422009f2d5316a279869faaa33d16">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5967">5967</a> - imported section anchors are copied in project tagfile [<a href="http://github.com/doxygen/doxygen/commit/8542ec9c8647da15de486635de40c25f99fc8c63">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5970">5970</a> - Exclusion of a new line at the end of source code file causing nesting of HTML code for function documentation [<a href="http://github.com/doxygen/doxygen/commit/7228bca81e8d054413f85f8758fc13866ab4b85b">view</a>]
-, [<a href="http://github.com/doxygen/doxygen/commit/c2c9ed6bd2a94ad25f31a22f70489406c52e5e6f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5975">5975</a> - Recent File list allows only 2 entries [<a href="http://github.com/doxygen/doxygen/commit/0f53af1270a0032d4c24d93aeb7cce245427bf8d">view</a>]
-, [<a href="http://github.com/doxygen/doxygen/commit/48b1c6e240238f7dc3965735dfb00900d2c75383">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5978">5978</a> - doxygen crashes no resolved [<a href="http://github.com/doxygen/doxygen/commit/0e45c10d7db6dc82aa0828df7e30ec4c8c5a1f97">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5980">5980</a> - generated xml has errors [<a href="http://github.com/doxygen/doxygen/commit/d3078f4e2e0fcb6dd5f82781b54dab8647f7ccc4">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5981">5981</a> - quick link index in alphabetical class list in classes.html doesn&#39;t work [<a href="http://github.com/doxygen/doxygen/commit/ec1ef7b4971540bbe042b16d7ebd3f2a0e0e57f1">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5982">5982</a> - Bad character escaping scheme in HTML anchor generation. [<a href="http://github.com/doxygen/doxygen/commit/6136cf9e3ad70d58cac4d8022cce8c8729805119">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5983">5983</a> - `@addindex`entries fail to link to the exact location in Compiled HTML Help. [<a href="http://github.com/doxygen/doxygen/commit/8dea6e11faf3969c3b6b17b700533f43c9ca73f8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5985">5985</a> - Java: final keyword on a parameter brakes docs inherinance [<a href="http://github.com/doxygen/doxygen/commit/dfd0336f1a97e189d49e29860db1c43915aced76">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5991">5991</a> - Using `@page` to add title to Markdown file generates surplus empty page. [<a href="http://github.com/doxygen/doxygen/commit/42c7d88ffc11651d1fb6b997fd23cc938bce4a39">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5998">5998</a> - DOT_PATH not expanded [<a href="http://github.com/doxygen/doxygen/commit/752523cd122d6ffdd72c89955005d77819740675">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5999">5999</a> - Files with incorrect extensions (.doc) are picked up by doxygen [<a href="http://github.com/doxygen/doxygen/commit/14b04be2af279e1093f17d6b933d1e9ab530e128">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6002">6002</a> - python: missing cross-links in sources (option SOURCE_BROWSER = YES) [<a href="http://github.com/doxygen/doxygen/commit/f3aeedf7b570c0c06af44a4f8bb66eba6b78c2f2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6007">6007</a> - VHDL: missing last sign in html documentation of constant declaration [<a href="http://github.com/doxygen/doxygen/commit/b00761b30a1d399f95adfe823937c05a64476155">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6009">6009</a> - HTML Tables with 10+ columns are broken for LaTeX based output [<a href="http://github.com/doxygen/doxygen/commit/61919f5483c717370742f2d238dcac88695d1990">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6010">6010</a> - Enumerations heading present but none listed [<a href="http://github.com/doxygen/doxygen/commit/e7ac59b018cdf609cc7c6819f38a7de05c699058">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6020">6020</a> - ALIASES stop working after verbatim with formula and /** */ [<a href="http://github.com/doxygen/doxygen/commit/36731bc9b573cdee6d699d0f66b4b34ad5b8f9ac">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6031">6031</a> - Doxygen segfault (return code 134) when parsing a c++ enum class contained in a class [<a href="http://github.com/doxygen/doxygen/commit/f37c0e58c47c43e96417d4dcf1559e3f9d1b323b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6032">6032</a> - Segmentation fault when processing md containing only header [<a href="http://github.com/doxygen/doxygen/commit/0d9fc8dc45de49a050b1d13f03ff9f4713f736fb">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6033">6033</a> - Invalid XHTML if the directives brief and exception are following immediately [<a href="http://github.com/doxygen/doxygen/commit/1c8d2ecc67997ee88dfabbeafdbc2e9805a10e3f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6035">6035</a> - Can&#39;t scroll using finger documentation in Chrome browser on Android OS [<a href="http://github.com/doxygen/doxygen/commit/478c1475ba8cbe508c39589c639662e317b959db">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6048">6048</a> - doxygen generates incorrect documentation for C enum in latex [<a href="http://github.com/doxygen/doxygen/commit/5b2e30aa0847f622e053b6ac6aa9c727f7ea42b3">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6055">6055</a> - Code snippet always shows line numbers from 1 [<a href="http://github.com/doxygen/doxygen/commit/9ae1af9b8679a0f14cb568d1db3afcc6e3ba40a6">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6056">6056</a> - Broken links in HTML output with SHOW_FILES=NO [<a href="http://github.com/doxygen/doxygen/commit/d2eeb765ffcf808812e7ac1c846dee97b85ad4bf">view</a>]</li>
-<li>Add caption in verbatim blocks. [<a href="http://github.com/doxygen/doxygen/commit/f075557bf207d67cf2638298cbdd843cc1a2f7d7">view</a>]</li>
-<li>Add parameter in/out specifiers to output. [<a href="http://github.com/doxygen/doxygen/commit/5592c705d8ac98f579e2675c12777330c4c322c9">view</a>]</li>
-<li>Add section title to output. [<a href="http://github.com/doxygen/doxygen/commit/989a0137df8f8e11df67de1a2ded73712b46a8fd">view</a>]</li>
-<li>Added .codedocs file [<a href="http://github.com/doxygen/doxygen/commit/5dee6e8aab6f8c76203a3296ef374e035cf55d34">view</a>]</li>
-<li>Added an option to add &quot;anonymous&quot; headings to the table of contents (currently Markdown only). [<a href="http://github.com/doxygen/doxygen/commit/7e564896fcc41c2b1a6bd5c86ebebab0de7ea5f9">view</a>]</li>
-<li>Added generating template files and reading templates from disk if present [<a href="http://github.com/doxygen/doxygen/commit/d38d33cef2241cd8d29c99f519d21ae225453357">view</a>]</li>
-<li>Added missing free [<a href="http://github.com/doxygen/doxygen/commit/4dc6c6c2f01b7b7bda82f5c3dbf4f78e489341bc">view</a>]</li>
-<li>Added support for encoding tag to the template engine used for HTML help indices [<a href="http://github.com/doxygen/doxygen/commit/7b887cfbffd73ea12fe0171c149f49c4540aac40">view</a>]</li>
-<li>Adding compilation options for flex/lex and bison/yacc [<a href="http://github.com/doxygen/doxygen/commit/c873fad0b4c2948551e53c082a3829243c4ccb9f">view</a>]</li>
-<li>Adding partial htmlhelp support to template system [<a href="http://github.com/doxygen/doxygen/commit/d3f2fcd53000fc4a09cf56c90930f8c8e2ad02b4">view</a>]</li>
-<li>Adjusted Doxygen to doxygen in running text in the manual [<a href="http://github.com/doxygen/doxygen/commit/4f80d144f98fc998de5118855eec73797a65bf2e">view</a>]</li>
-<li>Allow verbatim code block to be placed on the output. [<a href="http://github.com/doxygen/doxygen/commit/4530978dba88a0d6ccc369e480e6b9a98d29fa1e">view</a>]</li>
-<li>Also map .f95, .f03 and .f08 file types to Fortran [<a href="http://github.com/doxygen/doxygen/commit/dc6019413c4609c49322e80d1ec2b089e85486f3">view</a>]</li>
-<li>Another possible fix [<a href="http://github.com/doxygen/doxygen/commit/445347566078a1cc64705f28932e1da5bf9f531f">view</a>]</li>
-<li>Applied responsive design to menu bar using smartmenus [<a href="http://github.com/doxygen/doxygen/commit/8480d35beef57ed08139b58972bfb83a3b37422c">view</a>]</li>
-<li>Assertion failure generation documentation [<a href="http://github.com/doxygen/doxygen/commit/fdefe70a955c8140f080974319bbf97364d3e610">view</a>]</li>
-<li>Bug fix for rendering the VHDL Hierarchy (thanks to a patch by Martin Kreis) [<a href="http://github.com/doxygen/doxygen/commit/10256be351f8f00ba5986750a08df1108bf6a4f7">view</a>]</li>
-<li>Building doxyapp fails after update of config methodology to improve performance [<a href="http://github.com/doxygen/doxygen/commit/cf1706776bd93367dd357f505d04a7b10553f65f">view</a>]</li>
-<li>Bump version for GIT repo [<a href="http://github.com/doxygen/doxygen/commit/295a467a2ebee260d95c7bb3e3c616554b7782b1">view</a>]</li>
-<li>CMAKE: Fix building on Windows with VS 2015 [<a href="http://github.com/doxygen/doxygen/commit/6b80cc4181dc73a061b049e3283e6e2d8a4e5346">view</a>]</li>
-<li>Changed configuration mechanism to directly access options in order to improve performance [<a href="http://github.com/doxygen/doxygen/commit/a93ec7221d1a258f0268e0c081782478372efe0b">view</a>]</li>
-<li>Code with &quot;extension&quot; unparsed shows line numbers [<a href="http://github.com/doxygen/doxygen/commit/2b229f69041023f5f473385ee587ef7743850f55">view</a>]</li>
-<li>Color code word OPERATOR and ASSIGNMENT as keyword in FORTRAN code [<a href="http://github.com/doxygen/doxygen/commit/3f559575d63f2fd29888107afae85f4cc902b189">view</a>]</li>
-<li>Color code word RESULT as keyword in FORTRAN code [<a href="http://github.com/doxygen/doxygen/commit/0f047eb1862193713889d10bccb4894df1f7c23d">view</a>]</li>
-<li>Determination of end of parameter list [<a href="http://github.com/doxygen/doxygen/commit/80f08d11c9a21db86bbeb106194f4e76f67bd50e">view</a>]</li>
-<li>Disable selecting line number [<a href="http://github.com/doxygen/doxygen/commit/7bda78adac5d72396526c503325020a11cc12464">view</a>]</li>
-<li>Disabled debug prints [<a href="http://github.com/doxygen/doxygen/commit/3e03e42e2b10bf2ccba5ab35e52c665ac35cfa15">view</a>]</li>
-<li>Documentation for extensions .f95, .f03 and .f08 [<a href="http://github.com/doxygen/doxygen/commit/4c2e91c10dc6d007c410cd282a00fc7a42d38a0d">view</a>]</li>
-<li>Doxygen fails to copy logo image to LaTex output dir [<a href="http://github.com/doxygen/doxygen/commit/711c6c0bee87d47d70b3ffa9ca8b39b704e91723">view</a>]</li>
-<li>FORTRAN determination string in preprocessing [<a href="http://github.com/doxygen/doxygen/commit/4a7673fed2f28a24e0c7e8bb94621b0e14ac9ed5">view</a>]</li>
-<li>Feature: Translations for german language (changes since 1.8.4) [<a href="http://github.com/doxygen/doxygen/commit/261077497f2bcc3364e182e338d914c470a0a235">view</a>]</li>
-<li>Fix STRIP_FROM_PATH when running from drive root [<a href="http://github.com/doxygen/doxygen/commit/fd808ae3c1e37a8d476d250cf6b4325624a9eccb">view</a>]</li>
-<li>Fix Windows build instructions. [<a href="http://github.com/doxygen/doxygen/commit/eec8d0a31161746041fc94ccbba5a54aecd8cf93">view</a>]</li>
-<li>Fix documentation typos [<a href="http://github.com/doxygen/doxygen/commit/770adb37b2072bbea5412f9cc2058d98d1de60e4">view</a>]</li>
-<li>Fix for HTML output when using server side search and the new menu bar [<a href="http://github.com/doxygen/doxygen/commit/0faf45600c6c640bfaf11b017d43a4b9de193ebf">view</a>]</li>
-<li>Fix for changed references due to different removeRedudantWhiteSpace() implementation [<a href="http://github.com/doxygen/doxygen/commit/f26cc41d0d3d436c809c293a56c66c1f5f953745">view</a>]</li>
-<li>Fix for empty file name [<a href="http://github.com/doxygen/doxygen/commit/0fead5249b8ef2c3c5cbbbd712855bae877aa27b">view</a>]</li>
-<li>Fix for error in travis.yml [<a href="http://github.com/doxygen/doxygen/commit/81cf39f249c58db66368d60d596ac164d886ae90">view</a>]</li>
-<li>Fix issue escaping backslash inside markdown style code span [<a href="http://github.com/doxygen/doxygen/commit/402970f77f961b85b6371c8e53bd69981435c2d7">view</a>]</li>
-<li>Fix linker flags for building with clang on Windows [<a href="http://github.com/doxygen/doxygen/commit/41846b467bea58b904e26ce139394f7371ea5870">view</a>]</li>
-<li>Fix order of member initilaization [<a href="http://github.com/doxygen/doxygen/commit/6b1ebb6bcb345d8997054492c21276dc2dc36416">view</a>]</li>
-<li>Fix return-type warnings with -DNDEBUG [<a href="http://github.com/doxygen/doxygen/commit/f4574baf118da6aa2051b865040a9948bb0d22c9">view</a>]</li>
-<li>Fix search box rendering in HTML when menu bar is disabled [<a href="http://github.com/doxygen/doxygen/commit/ee9a0664c03c306d0aeb127295ced29f8078ae03">view</a>]</li>
-<li>Fix uppercase letters B-Z being unnecessarily escaped in index HTML anchors. [<a href="http://github.com/doxygen/doxygen/commit/0f699ab17cb88beff0ae4aa9b10042c0ccaff937">view</a>]</li>
-<li>Fixed for index.hhp output when using template engine [<a href="http://github.com/doxygen/doxygen/commit/e629fc64d42121e86bf2230a3b515d1d0d868dcd">view</a>]</li>
-<li>Fixed issue escaping ndashes (\--) and mdashes (\---) [<a href="http://github.com/doxygen/doxygen/commit/ef56187f733d946e4df130d9783eadea41ec1c97">view</a>]</li>
-<li>Fixed problem with -w command when no Doxyfile was present and specified [<a href="http://github.com/doxygen/doxygen/commit/7c3126407bbb46717a4e0a09b61ee001702af7bf">view</a>]</li>
-<li>Fixed two regressions found during extensive testing [<a href="http://github.com/doxygen/doxygen/commit/d9166baf589f50e94597829b04d0cabee4573130">view</a>]</li>
-<li>Fixed typos. [<a href="http://github.com/doxygen/doxygen/commit/a787b94d11e9f337570bfab1d36a36b37438ccea">view</a>]</li>
-<li>Fixed wrong &lt;p&gt; nesting issue for call/caller graphs [<a href="http://github.com/doxygen/doxygen/commit/50c78a6f0d720617c5a82045b5b2cd18882a15a9">view</a>]</li>
-<li>Fortran inline source code and crash on Linux [<a href="http://github.com/doxygen/doxygen/commit/661991e55f7ae18e8143733f364d9d7864ec66d9">view</a>]</li>
-<li>Improve output on mobile devices [<a href="http://github.com/doxygen/doxygen/commit/e0dc837a14a466dd4fb58a0a1e6e72b5c400f563">view</a>]</li>
-<li>Improved list of files in htmlhelp.hhp [<a href="http://github.com/doxygen/doxygen/commit/f7a05140593d854955151e4286205ef1f908e07b">view</a>]</li>
-<li>Improved sorting performance for directories and files [<a href="http://github.com/doxygen/doxygen/commit/5475bf2e9a0f1517567186b47595b8dad2b6b3a3">view</a>]</li>
-<li>Include command show line number (e.g. LaTeX) [<a href="http://github.com/doxygen/doxygen/commit/a4bde1e1e71a24d6c714377be4265e95deb1acf3">view</a>]</li>
-<li>Initialization of python variables and type determination [<a href="http://github.com/doxygen/doxygen/commit/46ba7769c4a0600c47f3de6871815398bab7ca91">view</a>]</li>
-<li>Introducing commands includedoc and snippetdoc [<a href="http://github.com/doxygen/doxygen/commit/ba848363081c44c9aa9e91b193054983f562e90c">view</a>]</li>
-<li>Latex page numbering [<a href="http://github.com/doxygen/doxygen/commit/044f2c49882815f58c88b12a0086ad71dd97f071">view</a>]</li>
-<li>Minor build fixes [<a href="http://github.com/doxygen/doxygen/commit/5a7a5477cd60ea7cc10b8132862a4928af788028">view</a>]</li>
-<li>Minor correction for BUILD.txt [<a href="http://github.com/doxygen/doxygen/commit/89ef13dbb6c8ac81a9c118f4f031c45cdc66e3a3">view</a>]</li>
-<li>Minor performance improvement sorting directories [<a href="http://github.com/doxygen/doxygen/commit/67827956351f78516a7c48df366dcf521c51c6eb">view</a>]</li>
-<li>Minor update to the installation instructions [<a href="http://github.com/doxygen/doxygen/commit/840d3d18a172edaf92f7780340b1aee4198846fe">view</a>]</li>
-<li>Missing semicolon in navtree.css [<a href="http://github.com/doxygen/doxygen/commit/360987c61462c185942e5055a345dd777920216a">view</a>]</li>
-<li>Modified (readability) layout for member title in HTML and LaTex [<a href="http://github.com/doxygen/doxygen/commit/a2ae382198092537b6b5c85f9c7e5615046d3c78">view</a>]</li>
-<li>Optimized use of convertNameToFile to improve performance [<a href="http://github.com/doxygen/doxygen/commit/d168f8bfef6aac5a71eccad36dced78d55765ae1">view</a>]</li>
-<li>PDF generation stops when image with caption is included in a table. [<a href="http://github.com/doxygen/doxygen/commit/1d77a4ed407aaa24eae53f501d1a5ce38b352504">view</a>]
-, [<a href="http://github.com/doxygen/doxygen/commit/7b0b7ef746ae15df3894847f5b43a29ae20c9599">view</a>]</li>
-<li>Parse more than 1 size indiction in defaultHandleTitleAndSize [<a href="http://github.com/doxygen/doxygen/commit/2bcf196332084067c3d2409fa07992a6b833473d">view</a>]</li>
-<li>Problem jumping to line number in source code due to wrong hypertarget name [<a href="http://github.com/doxygen/doxygen/commit/ed875603dc42d3a5ebbcfd89540b1f7ecf472ece">view</a>]</li>
-<li>Python strip code comments [<a href="http://github.com/doxygen/doxygen/commit/a19feec4a7864dc17fcb570330ae2f7b9a5c6e45">view</a>]</li>
-<li>Reimplemented node renumbering for dot graph to improve performance [<a href="http://github.com/doxygen/doxygen/commit/fb66cae35cd59d1026fe3c6de46ae3a2ed6f9f91">view</a>]</li>
-<li>Remove unused variables [<a href="http://github.com/doxygen/doxygen/commit/aa61a4b33e2dd5c0f4809dd23f4561bd225270f9">view</a>]
-, [<a href="http://github.com/doxygen/doxygen/commit/e698e53d2c04833143e5ab60f0983e3c683cf85d">view</a>]</li>
-<li>Removed ambiguity in the XML schema definition [<a href="http://github.com/doxygen/doxygen/commit/13946338f9e5fcdb6dca7f8e4c2429ca000455fb">view</a>]</li>
-<li>Revert #291 [<a href="http://github.com/doxygen/doxygen/commit/6ea76e0d89aff8399117e602a3eab1f7d93e466b">view</a>]</li>
-<li>Simplified code of fix for Bug <a href="https://github.com/doxygen/doxygen/issues/5982">5982</a> [<a href="http://github.com/doxygen/doxygen/commit/e70b45fa4398450b588122f9d36b1ed514fc336a">view</a>]</li>
-<li>Sorting in latex index and missing \@ in index [<a href="http://github.com/doxygen/doxygen/commit/558958dca5e5cb50bd33f3344cab151aba9ce076">view</a>]</li>
-<li>Split apt-get install commands in travis config in an attempt to reduce timeouts [<a href="http://github.com/doxygen/doxygen/commit/2f6f48567cb48d21361237a7905e27744e0acf91">view</a>]</li>
-<li>Style fixes and added numbering to overloaded members [<a href="http://github.com/doxygen/doxygen/commit/5af8d5e87657a2d3986783493c618df335b3771c">view</a>]</li>
-<li>Table of contents breaks when documentation spans multiple comment blocks with same @page [<a href="http://github.com/doxygen/doxygen/commit/7f7f7273f816335d556668b86aa99d05f7f09992">view</a>]</li>
-<li>Unified display of enum values across output formats and languages [<a href="http://github.com/doxygen/doxygen/commit/9c915b83bc06babe6f0127f6446143ea50d00b62">view</a>]</li>
-<li>Unify handling of extra packages in formula.cpp and latexgen.cpp so formula.cpp handles package arguments correctly [<a href="http://github.com/doxygen/doxygen/commit/4d2e203a55a2af8f15a3933b86201e6e9b6901b3">view</a>]</li>
-<li>Update LICENSE file to latest from FSF [<a href="http://github.com/doxygen/doxygen/commit/48eb44a00b4b805fda0da82620d7efb135116d23">view</a>]</li>
-<li>Update copyright year in docs [<a href="http://github.com/doxygen/doxygen/commit/b721f6e1707f8cc446c0d7f9956e6d4aa9f17bc9">view</a>]</li>
-<li>Updated README.md to include code docs [<a href="http://github.com/doxygen/doxygen/commit/3911ebdad44a91a6b825051a1ae0f7b280c84567">view</a>]</li>
-<li>Updated stylesheet for the manual to fix layout issue in the navigation tree [<a href="http://github.com/doxygen/doxygen/commit/64597bbe46169c08b591a8714f48d314c5341cc2">view</a>]</li>
-<li>Warnings from CLANG compiler [<a href="http://github.com/doxygen/doxygen/commit/fdfb027f346c30d6cd209b366e6cb879fb11cbcb">view</a>]</li>
-<li>fix ninja build error [<a href="http://github.com/doxygen/doxygen/commit/c4cdfdf65073824d7badb38a1f535310b93d50a9">view</a>]</li>
-<li>fixed rtf subsection [<a href="http://github.com/doxygen/doxygen/commit/17bd813313cf073a437001f2fa550f286458586e">view</a>]</li>
-<li>mangen.h: remove italic in brief member descriptions [<a href="http://github.com/doxygen/doxygen/commit/5716f0aee08bfc9daf7ab7e22566e5acc51446d0">view</a>]</li>
-<li>reimplemented removeRedundantWhiteSpace() to improve performance [<a href="http://github.com/doxygen/doxygen/commit/00ee930a1d73e11885197102c54fd4c8141127da">view</a>]</li>
-<li>sqlite3gen: defnname -&gt; defname [<a href="http://github.com/doxygen/doxygen/commit/79a53cc464ef814adf6b64d45a15fee6676f15d6">view</a>]</li>
-<li>sqlite3gen: export proper memberdef refid [<a href="http://github.com/doxygen/doxygen/commit/918cf6871359da9d14dd6d3e7c4d00d6ca9a496e">view</a>]</li>
-<li>sqlite3gen: insert xrefs using integer refids [<a href="http://github.com/doxygen/doxygen/commit/bac76c1957de71e3e0bddc23ccd46b7b2537c8a1">view</a>]</li>
-<li>sqlite3gen: stripFromPath on all calls to insertFile [<a href="http://github.com/doxygen/doxygen/commit/87222afcfe6089899c8ded60b23692fd40997856">view</a>]</li>
-<li>sqlite3gen: stripWhitespace on bitfield&#39;s text [<a href="http://github.com/doxygen/doxygen/commit/6f4561608adaf8230c2fa015770dfeeab5ce3ba8">view</a>]</li>
-<li>sqlite3gen: sync with xmlgen [<a href="http://github.com/doxygen/doxygen/commit/8208b2d5514a3c29659ae967da544adc21585212">view</a>]</li>
-<li>sqlite3gen: use the refid stored in the refids table [<a href="http://github.com/doxygen/doxygen/commit/9b02db93e7e78aedc0a0ca7fd2701c81dc153487">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1662">1662</a> - Fix missing title in non-page docanchors from tag files [<a href="https://github.com/doxygen/doxygen/commit/616b392e9bc8984251d969577a5b63974efb1eef">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2763">2763</a> - FILTER_PATTERNS won&#39;t take command with arguments [<a href="https://github.com/doxygen/doxygen/commit/ce7a983c2849e4c8fa72189a896e594a8497dd4c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4691">4691</a> - Uses &lt;img&gt; instead of &lt;object&gt; html tag for SVG images [<a href="https://github.com/doxygen/doxygen/commit/8ccd98643a3b88aaa3245b76202666900a2cd401">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5174">5174</a> - error state 21 with fortran code (fixed format) [<a href="https://github.com/doxygen/doxygen/commit/fdee5e9fade0ff5a578817048c6205f2a9acbced">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5323">5323</a> - Missing Page References in the Index Chapters of the LaTex/PDF output [<a href="https://github.com/doxygen/doxygen/commit/efd49dacfbae1ad55d7922a748e2c1d60068b014">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5411">5411</a> - Inherited member of template class issues warning and is not documented [<a href="https://github.com/doxygen/doxygen/commit/4dfc5887660284b345eb93b6c07dc1f91e780fac">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5711">5711</a> - Fortran: attributes after a blank line are ignored / Bug <a href="https://github.com/doxygen/doxygen/issues/3880">3880</a> - FORTRAN: comment in subroutine argument list [<a href="https://github.com/doxygen/doxygen/commit/e9ebf43585bffee80c31dd69538feae2a4525178">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5791">5791</a> - Doxygen handles comments in Objective-C code blocks incorrectly. [<a href="https://github.com/doxygen/doxygen/commit/c2e0ce14c65584f42e875f0abdbe5466d1414636">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5804">5804</a> - Representation of arrows [<a href="https://github.com/doxygen/doxygen/commit/ab96c077a8cd99308e6ae90c3c861ab1c0e911d7">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5811">5811</a> - Markdown: &gt; escaped within backticks [<a href="https://github.com/doxygen/doxygen/commit/5f9d80b2ce73a7e7fb0f4fc16f3ef5fee0cf8105">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5826">5826</a> - Use UTC timezone when displaying QDateTimes parsed from SOURCE_DATE_EPOCH [<a href="https://github.com/doxygen/doxygen/commit/5801460b3141871222569fb99e7964e9a2925d71">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5832">5832</a> - last entry missing in a @name group of typedefs [<a href="https://github.com/doxygen/doxygen/commit/ee2d6faecab57c1f929d6868ae6eb9bdaa53d654">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5843">5843</a> - Link of typedef within namespace on group pages missing [<a href="https://github.com/doxygen/doxygen/commit/0bd419e0a4fabf615fb72eb92bf561d3dfc96a11">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5891">5891</a> - __init__.py causes to ignore some inheritance [<a href="https://github.com/doxygen/doxygen/commit/607b8a302297169e4319280dba2a61dcbe042965">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5923">5923</a> - Figure title needs to be on separate line in order for it to work [<a href="https://github.com/doxygen/doxygen/commit/07521a7f050607609b9d04e8f3c58ed4754c47c3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5933">5933</a> - Phantom variables/functions in XML, created from non-code files [<a href="https://github.com/doxygen/doxygen/commit/7dc9b378a107b1ccae2245b3f3f3d628db2bd008">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5937">5937</a> - CASE_SENSE_NAMES ignored [<a href="https://github.com/doxygen/doxygen/commit/fab854a10f358c15a69291a59388ea0c184bce20">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5938">5938</a> - Spaces between the closing bracket of the typename and the opening bracket of the parameter list cause detection issues. [<a href="https://github.com/doxygen/doxygen/commit/622d18637f9d633b184e43fd3594b661cf4e9375">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5941">5941</a> - python unicode docstrings are ignored [<a href="https://github.com/doxygen/doxygen/commit/936f242956350825d870f7396ae5d6106fe3081d">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/be100f882604a23d94025fee6d059bdb5ec28d3e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5945">5945</a> - Do not allow ligatures in log output [<a href="https://github.com/doxygen/doxygen/commit/894bdfdf268ba24a268fa72d7b33899a9f3a126b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5958">5958</a> - References for one function can inherit References from subsequent non documented function [<a href="https://github.com/doxygen/doxygen/commit/9abcad810b8d41d338d501ff5b32524e1ced7f33">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5961">5961</a> - External search does not properly escape user supplied data, resulting in vulnerability [<a href="https://github.com/doxygen/doxygen/commit/1cc1adad2de03a0f013881b8960daf89aa155081">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5962">5962</a> - regression, Unescaped percent sign in doxygen output [<a href="https://github.com/doxygen/doxygen/commit/d4ab02c2da7df472bebbf2724419ba00f2de229c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5964">5964</a> - hyperref link label drop underscores [<a href="https://github.com/doxygen/doxygen/commit/537a1c67f316c5a9d2d4542e94a4ace439a78b3a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5965">5965</a> - Directory list is not generated in HTML output [<a href="https://github.com/doxygen/doxygen/commit/b6b87054121422009f2d5316a279869faaa33d16">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5967">5967</a> - imported section anchors are copied in project tagfile [<a href="https://github.com/doxygen/doxygen/commit/8542ec9c8647da15de486635de40c25f99fc8c63">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5970">5970</a> - Exclusion of a new line at the end of source code file causing nesting of HTML code for function documentation [<a href="https://github.com/doxygen/doxygen/commit/7228bca81e8d054413f85f8758fc13866ab4b85b">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/c2c9ed6bd2a94ad25f31a22f70489406c52e5e6f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5975">5975</a> - Recent File list allows only 2 entries [<a href="https://github.com/doxygen/doxygen/commit/0f53af1270a0032d4c24d93aeb7cce245427bf8d">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/48b1c6e240238f7dc3965735dfb00900d2c75383">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5978">5978</a> - doxygen crashes no resolved [<a href="https://github.com/doxygen/doxygen/commit/0e45c10d7db6dc82aa0828df7e30ec4c8c5a1f97">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5980">5980</a> - generated xml has errors [<a href="https://github.com/doxygen/doxygen/commit/d3078f4e2e0fcb6dd5f82781b54dab8647f7ccc4">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5981">5981</a> - quick link index in alphabetical class list in classes.html doesn&#39;t work [<a href="https://github.com/doxygen/doxygen/commit/ec1ef7b4971540bbe042b16d7ebd3f2a0e0e57f1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5982">5982</a> - Bad character escaping scheme in HTML anchor generation. [<a href="https://github.com/doxygen/doxygen/commit/6136cf9e3ad70d58cac4d8022cce8c8729805119">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5983">5983</a> - `@addindex`entries fail to link to the exact location in Compiled HTML Help. [<a href="https://github.com/doxygen/doxygen/commit/8dea6e11faf3969c3b6b17b700533f43c9ca73f8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5985">5985</a> - Java: final keyword on a parameter brakes docs inherinance [<a href="https://github.com/doxygen/doxygen/commit/dfd0336f1a97e189d49e29860db1c43915aced76">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5991">5991</a> - Using `@page` to add title to Markdown file generates surplus empty page. [<a href="https://github.com/doxygen/doxygen/commit/42c7d88ffc11651d1fb6b997fd23cc938bce4a39">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5998">5998</a> - DOT_PATH not expanded [<a href="https://github.com/doxygen/doxygen/commit/752523cd122d6ffdd72c89955005d77819740675">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5999">5999</a> - Files with incorrect extensions (.doc) are picked up by doxygen [<a href="https://github.com/doxygen/doxygen/commit/14b04be2af279e1093f17d6b933d1e9ab530e128">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6002">6002</a> - python: missing cross-links in sources (option SOURCE_BROWSER = YES) [<a href="https://github.com/doxygen/doxygen/commit/f3aeedf7b570c0c06af44a4f8bb66eba6b78c2f2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6007">6007</a> - VHDL: missing last sign in html documentation of constant declaration [<a href="https://github.com/doxygen/doxygen/commit/b00761b30a1d399f95adfe823937c05a64476155">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6009">6009</a> - HTML Tables with 10+ columns are broken for LaTeX based output [<a href="https://github.com/doxygen/doxygen/commit/61919f5483c717370742f2d238dcac88695d1990">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6010">6010</a> - Enumerations heading present but none listed [<a href="https://github.com/doxygen/doxygen/commit/e7ac59b018cdf609cc7c6819f38a7de05c699058">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6020">6020</a> - ALIASES stop working after verbatim with formula and /** */ [<a href="https://github.com/doxygen/doxygen/commit/36731bc9b573cdee6d699d0f66b4b34ad5b8f9ac">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6031">6031</a> - Doxygen segfault (return code 134) when parsing a c++ enum class contained in a class [<a href="https://github.com/doxygen/doxygen/commit/f37c0e58c47c43e96417d4dcf1559e3f9d1b323b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6032">6032</a> - Segmentation fault when processing md containing only header [<a href="https://github.com/doxygen/doxygen/commit/0d9fc8dc45de49a050b1d13f03ff9f4713f736fb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6033">6033</a> - Invalid XHTML if the directives brief and exception are following immediately [<a href="https://github.com/doxygen/doxygen/commit/1c8d2ecc67997ee88dfabbeafdbc2e9805a10e3f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6035">6035</a> - Can&#39;t scroll using finger documentation in Chrome browser on Android OS [<a href="https://github.com/doxygen/doxygen/commit/478c1475ba8cbe508c39589c639662e317b959db">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6048">6048</a> - doxygen generates incorrect documentation for C enum in latex [<a href="https://github.com/doxygen/doxygen/commit/5b2e30aa0847f622e053b6ac6aa9c727f7ea42b3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6055">6055</a> - Code snippet always shows line numbers from 1 [<a href="https://github.com/doxygen/doxygen/commit/9ae1af9b8679a0f14cb568d1db3afcc6e3ba40a6">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6056">6056</a> - Broken links in HTML output with SHOW_FILES=NO [<a href="https://github.com/doxygen/doxygen/commit/d2eeb765ffcf808812e7ac1c846dee97b85ad4bf">view</a>]</li>
+<li>Add caption in verbatim blocks. [<a href="https://github.com/doxygen/doxygen/commit/f075557bf207d67cf2638298cbdd843cc1a2f7d7">view</a>]</li>
+<li>Add parameter in/out specifiers to output. [<a href="https://github.com/doxygen/doxygen/commit/5592c705d8ac98f579e2675c12777330c4c322c9">view</a>]</li>
+<li>Add section title to output. [<a href="https://github.com/doxygen/doxygen/commit/989a0137df8f8e11df67de1a2ded73712b46a8fd">view</a>]</li>
+<li>Added .codedocs file [<a href="https://github.com/doxygen/doxygen/commit/5dee6e8aab6f8c76203a3296ef374e035cf55d34">view</a>]</li>
+<li>Added an option to add &quot;anonymous&quot; headings to the table of contents (currently Markdown only). [<a href="https://github.com/doxygen/doxygen/commit/7e564896fcc41c2b1a6bd5c86ebebab0de7ea5f9">view</a>]</li>
+<li>Added generating template files and reading templates from disk if present [<a href="https://github.com/doxygen/doxygen/commit/d38d33cef2241cd8d29c99f519d21ae225453357">view</a>]</li>
+<li>Added missing free [<a href="https://github.com/doxygen/doxygen/commit/4dc6c6c2f01b7b7bda82f5c3dbf4f78e489341bc">view</a>]</li>
+<li>Added support for encoding tag to the template engine used for HTML help indices [<a href="https://github.com/doxygen/doxygen/commit/7b887cfbffd73ea12fe0171c149f49c4540aac40">view</a>]</li>
+<li>Adding compilation options for flex/lex and bison/yacc [<a href="https://github.com/doxygen/doxygen/commit/c873fad0b4c2948551e53c082a3829243c4ccb9f">view</a>]</li>
+<li>Adding partial htmlhelp support to template system [<a href="https://github.com/doxygen/doxygen/commit/d3f2fcd53000fc4a09cf56c90930f8c8e2ad02b4">view</a>]</li>
+<li>Adjusted Doxygen to doxygen in running text in the manual [<a href="https://github.com/doxygen/doxygen/commit/4f80d144f98fc998de5118855eec73797a65bf2e">view</a>]</li>
+<li>Allow verbatim code block to be placed on the output. [<a href="https://github.com/doxygen/doxygen/commit/4530978dba88a0d6ccc369e480e6b9a98d29fa1e">view</a>]</li>
+<li>Also map .f95, .f03 and .f08 file types to Fortran [<a href="https://github.com/doxygen/doxygen/commit/dc6019413c4609c49322e80d1ec2b089e85486f3">view</a>]</li>
+<li>Another possible fix [<a href="https://github.com/doxygen/doxygen/commit/445347566078a1cc64705f28932e1da5bf9f531f">view</a>]</li>
+<li>Applied responsive design to menu bar using smartmenus [<a href="https://github.com/doxygen/doxygen/commit/8480d35beef57ed08139b58972bfb83a3b37422c">view</a>]</li>
+<li>Assertion failure generation documentation [<a href="https://github.com/doxygen/doxygen/commit/fdefe70a955c8140f080974319bbf97364d3e610">view</a>]</li>
+<li>Bug fix for rendering the VHDL Hierarchy (thanks to a patch by Martin Kreis) [<a href="https://github.com/doxygen/doxygen/commit/10256be351f8f00ba5986750a08df1108bf6a4f7">view</a>]</li>
+<li>Building doxyapp fails after update of config methodology to improve performance [<a href="https://github.com/doxygen/doxygen/commit/cf1706776bd93367dd357f505d04a7b10553f65f">view</a>]</li>
+<li>Bump version for GIT repo [<a href="https://github.com/doxygen/doxygen/commit/295a467a2ebee260d95c7bb3e3c616554b7782b1">view</a>]</li>
+<li>CMAKE: Fix building on Windows with VS 2015 [<a href="https://github.com/doxygen/doxygen/commit/6b80cc4181dc73a061b049e3283e6e2d8a4e5346">view</a>]</li>
+<li>Changed configuration mechanism to directly access options in order to improve performance [<a href="https://github.com/doxygen/doxygen/commit/a93ec7221d1a258f0268e0c081782478372efe0b">view</a>]</li>
+<li>Code with &quot;extension&quot; unparsed shows line numbers [<a href="https://github.com/doxygen/doxygen/commit/2b229f69041023f5f473385ee587ef7743850f55">view</a>]</li>
+<li>Color code word OPERATOR and ASSIGNMENT as keyword in FORTRAN code [<a href="https://github.com/doxygen/doxygen/commit/3f559575d63f2fd29888107afae85f4cc902b189">view</a>]</li>
+<li>Color code word RESULT as keyword in FORTRAN code [<a href="https://github.com/doxygen/doxygen/commit/0f047eb1862193713889d10bccb4894df1f7c23d">view</a>]</li>
+<li>Determination of end of parameter list [<a href="https://github.com/doxygen/doxygen/commit/80f08d11c9a21db86bbeb106194f4e76f67bd50e">view</a>]</li>
+<li>Disable selecting line number [<a href="https://github.com/doxygen/doxygen/commit/7bda78adac5d72396526c503325020a11cc12464">view</a>]</li>
+<li>Disabled debug prints [<a href="https://github.com/doxygen/doxygen/commit/3e03e42e2b10bf2ccba5ab35e52c665ac35cfa15">view</a>]</li>
+<li>Documentation for extensions .f95, .f03 and .f08 [<a href="https://github.com/doxygen/doxygen/commit/4c2e91c10dc6d007c410cd282a00fc7a42d38a0d">view</a>]</li>
+<li>Doxygen fails to copy logo image to LaTex output dir [<a href="https://github.com/doxygen/doxygen/commit/711c6c0bee87d47d70b3ffa9ca8b39b704e91723">view</a>]</li>
+<li>FORTRAN determination string in preprocessing [<a href="https://github.com/doxygen/doxygen/commit/4a7673fed2f28a24e0c7e8bb94621b0e14ac9ed5">view</a>]</li>
+<li>Feature: Translations for german language (changes since 1.8.4) [<a href="https://github.com/doxygen/doxygen/commit/261077497f2bcc3364e182e338d914c470a0a235">view</a>]</li>
+<li>Fix STRIP_FROM_PATH when running from drive root [<a href="https://github.com/doxygen/doxygen/commit/fd808ae3c1e37a8d476d250cf6b4325624a9eccb">view</a>]</li>
+<li>Fix Windows build instructions. [<a href="https://github.com/doxygen/doxygen/commit/eec8d0a31161746041fc94ccbba5a54aecd8cf93">view</a>]</li>
+<li>Fix documentation typos [<a href="https://github.com/doxygen/doxygen/commit/770adb37b2072bbea5412f9cc2058d98d1de60e4">view</a>]</li>
+<li>Fix for HTML output when using server side search and the new menu bar [<a href="https://github.com/doxygen/doxygen/commit/0faf45600c6c640bfaf11b017d43a4b9de193ebf">view</a>]</li>
+<li>Fix for changed references due to different removeRedudantWhiteSpace() implementation [<a href="https://github.com/doxygen/doxygen/commit/f26cc41d0d3d436c809c293a56c66c1f5f953745">view</a>]</li>
+<li>Fix for empty file name [<a href="https://github.com/doxygen/doxygen/commit/0fead5249b8ef2c3c5cbbbd712855bae877aa27b">view</a>]</li>
+<li>Fix for error in travis.yml [<a href="https://github.com/doxygen/doxygen/commit/81cf39f249c58db66368d60d596ac164d886ae90">view</a>]</li>
+<li>Fix issue escaping backslash inside markdown style code span [<a href="https://github.com/doxygen/doxygen/commit/402970f77f961b85b6371c8e53bd69981435c2d7">view</a>]</li>
+<li>Fix linker flags for building with clang on Windows [<a href="https://github.com/doxygen/doxygen/commit/41846b467bea58b904e26ce139394f7371ea5870">view</a>]</li>
+<li>Fix order of member initilaization [<a href="https://github.com/doxygen/doxygen/commit/6b1ebb6bcb345d8997054492c21276dc2dc36416">view</a>]</li>
+<li>Fix return-type warnings with -DNDEBUG [<a href="https://github.com/doxygen/doxygen/commit/f4574baf118da6aa2051b865040a9948bb0d22c9">view</a>]</li>
+<li>Fix search box rendering in HTML when menu bar is disabled [<a href="https://github.com/doxygen/doxygen/commit/ee9a0664c03c306d0aeb127295ced29f8078ae03">view</a>]</li>
+<li>Fix uppercase letters B-Z being unnecessarily escaped in index HTML anchors. [<a href="https://github.com/doxygen/doxygen/commit/0f699ab17cb88beff0ae4aa9b10042c0ccaff937">view</a>]</li>
+<li>Fixed for index.hhp output when using template engine [<a href="https://github.com/doxygen/doxygen/commit/e629fc64d42121e86bf2230a3b515d1d0d868dcd">view</a>]</li>
+<li>Fixed issue escaping ndashes (\--) and mdashes (\---) [<a href="https://github.com/doxygen/doxygen/commit/ef56187f733d946e4df130d9783eadea41ec1c97">view</a>]</li>
+<li>Fixed problem with -w command when no Doxyfile was present and specified [<a href="https://github.com/doxygen/doxygen/commit/7c3126407bbb46717a4e0a09b61ee001702af7bf">view</a>]</li>
+<li>Fixed two regressions found during extensive testing [<a href="https://github.com/doxygen/doxygen/commit/d9166baf589f50e94597829b04d0cabee4573130">view</a>]</li>
+<li>Fixed typos. [<a href="https://github.com/doxygen/doxygen/commit/a787b94d11e9f337570bfab1d36a36b37438ccea">view</a>]</li>
+<li>Fixed wrong &lt;p&gt; nesting issue for call/caller graphs [<a href="https://github.com/doxygen/doxygen/commit/50c78a6f0d720617c5a82045b5b2cd18882a15a9">view</a>]</li>
+<li>Fortran inline source code and crash on Linux [<a href="https://github.com/doxygen/doxygen/commit/661991e55f7ae18e8143733f364d9d7864ec66d9">view</a>]</li>
+<li>Improve output on mobile devices [<a href="https://github.com/doxygen/doxygen/commit/e0dc837a14a466dd4fb58a0a1e6e72b5c400f563">view</a>]</li>
+<li>Improved list of files in htmlhelp.hhp [<a href="https://github.com/doxygen/doxygen/commit/f7a05140593d854955151e4286205ef1f908e07b">view</a>]</li>
+<li>Improved sorting performance for directories and files [<a href="https://github.com/doxygen/doxygen/commit/5475bf2e9a0f1517567186b47595b8dad2b6b3a3">view</a>]</li>
+<li>Include command show line number (e.g. LaTeX) [<a href="https://github.com/doxygen/doxygen/commit/a4bde1e1e71a24d6c714377be4265e95deb1acf3">view</a>]</li>
+<li>Initialization of python variables and type determination [<a href="https://github.com/doxygen/doxygen/commit/46ba7769c4a0600c47f3de6871815398bab7ca91">view</a>]</li>
+<li>Introducing commands includedoc and snippetdoc [<a href="https://github.com/doxygen/doxygen/commit/ba848363081c44c9aa9e91b193054983f562e90c">view</a>]</li>
+<li>Latex page numbering [<a href="https://github.com/doxygen/doxygen/commit/044f2c49882815f58c88b12a0086ad71dd97f071">view</a>]</li>
+<li>Minor build fixes [<a href="https://github.com/doxygen/doxygen/commit/5a7a5477cd60ea7cc10b8132862a4928af788028">view</a>]</li>
+<li>Minor correction for BUILD.txt [<a href="https://github.com/doxygen/doxygen/commit/89ef13dbb6c8ac81a9c118f4f031c45cdc66e3a3">view</a>]</li>
+<li>Minor performance improvement sorting directories [<a href="https://github.com/doxygen/doxygen/commit/67827956351f78516a7c48df366dcf521c51c6eb">view</a>]</li>
+<li>Minor update to the installation instructions [<a href="https://github.com/doxygen/doxygen/commit/840d3d18a172edaf92f7780340b1aee4198846fe">view</a>]</li>
+<li>Missing semicolon in navtree.css [<a href="https://github.com/doxygen/doxygen/commit/360987c61462c185942e5055a345dd777920216a">view</a>]</li>
+<li>Modified (readability) layout for member title in HTML and LaTex [<a href="https://github.com/doxygen/doxygen/commit/a2ae382198092537b6b5c85f9c7e5615046d3c78">view</a>]</li>
+<li>Optimized use of convertNameToFile to improve performance [<a href="https://github.com/doxygen/doxygen/commit/d168f8bfef6aac5a71eccad36dced78d55765ae1">view</a>]</li>
+<li>PDF generation stops when image with caption is included in a table. [<a href="https://github.com/doxygen/doxygen/commit/1d77a4ed407aaa24eae53f501d1a5ce38b352504">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/7b0b7ef746ae15df3894847f5b43a29ae20c9599">view</a>]</li>
+<li>Parse more than 1 size indiction in defaultHandleTitleAndSize [<a href="https://github.com/doxygen/doxygen/commit/2bcf196332084067c3d2409fa07992a6b833473d">view</a>]</li>
+<li>Problem jumping to line number in source code due to wrong hypertarget name [<a href="https://github.com/doxygen/doxygen/commit/ed875603dc42d3a5ebbcfd89540b1f7ecf472ece">view</a>]</li>
+<li>Python strip code comments [<a href="https://github.com/doxygen/doxygen/commit/a19feec4a7864dc17fcb570330ae2f7b9a5c6e45">view</a>]</li>
+<li>Reimplemented node renumbering for dot graph to improve performance [<a href="https://github.com/doxygen/doxygen/commit/fb66cae35cd59d1026fe3c6de46ae3a2ed6f9f91">view</a>]</li>
+<li>Remove unused variables [<a href="https://github.com/doxygen/doxygen/commit/aa61a4b33e2dd5c0f4809dd23f4561bd225270f9">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/e698e53d2c04833143e5ab60f0983e3c683cf85d">view</a>]</li>
+<li>Removed ambiguity in the XML schema definition [<a href="https://github.com/doxygen/doxygen/commit/13946338f9e5fcdb6dca7f8e4c2429ca000455fb">view</a>]</li>
+<li>Revert #291 [<a href="https://github.com/doxygen/doxygen/commit/6ea76e0d89aff8399117e602a3eab1f7d93e466b">view</a>]</li>
+<li>Simplified code of fix for Bug <a href="https://github.com/doxygen/doxygen/issues/5982">5982</a> [<a href="https://github.com/doxygen/doxygen/commit/e70b45fa4398450b588122f9d36b1ed514fc336a">view</a>]</li>
+<li>Sorting in latex index and missing \@ in index [<a href="https://github.com/doxygen/doxygen/commit/558958dca5e5cb50bd33f3344cab151aba9ce076">view</a>]</li>
+<li>Split apt-get install commands in travis config in an attempt to reduce timeouts [<a href="https://github.com/doxygen/doxygen/commit/2f6f48567cb48d21361237a7905e27744e0acf91">view</a>]</li>
+<li>Style fixes and added numbering to overloaded members [<a href="https://github.com/doxygen/doxygen/commit/5af8d5e87657a2d3986783493c618df335b3771c">view</a>]</li>
+<li>Table of contents breaks when documentation spans multiple comment blocks with same @page [<a href="https://github.com/doxygen/doxygen/commit/7f7f7273f816335d556668b86aa99d05f7f09992">view</a>]</li>
+<li>Unified display of enum values across output formats and languages [<a href="https://github.com/doxygen/doxygen/commit/9c915b83bc06babe6f0127f6446143ea50d00b62">view</a>]</li>
+<li>Unify handling of extra packages in formula.cpp and latexgen.cpp so formula.cpp handles package arguments correctly [<a href="https://github.com/doxygen/doxygen/commit/4d2e203a55a2af8f15a3933b86201e6e9b6901b3">view</a>]</li>
+<li>Update LICENSE file to latest from FSF [<a href="https://github.com/doxygen/doxygen/commit/48eb44a00b4b805fda0da82620d7efb135116d23">view</a>]</li>
+<li>Update copyright year in docs [<a href="https://github.com/doxygen/doxygen/commit/b721f6e1707f8cc446c0d7f9956e6d4aa9f17bc9">view</a>]</li>
+<li>Updated README.md to include code docs [<a href="https://github.com/doxygen/doxygen/commit/3911ebdad44a91a6b825051a1ae0f7b280c84567">view</a>]</li>
+<li>Updated stylesheet for the manual to fix layout issue in the navigation tree [<a href="https://github.com/doxygen/doxygen/commit/64597bbe46169c08b591a8714f48d314c5341cc2">view</a>]</li>
+<li>Warnings from CLANG compiler [<a href="https://github.com/doxygen/doxygen/commit/fdfb027f346c30d6cd209b366e6cb879fb11cbcb">view</a>]</li>
+<li>fix ninja build error [<a href="https://github.com/doxygen/doxygen/commit/c4cdfdf65073824d7badb38a1f535310b93d50a9">view</a>]</li>
+<li>fixed rtf subsection [<a href="https://github.com/doxygen/doxygen/commit/17bd813313cf073a437001f2fa550f286458586e">view</a>]</li>
+<li>mangen.h: remove italic in brief member descriptions [<a href="https://github.com/doxygen/doxygen/commit/5716f0aee08bfc9daf7ab7e22566e5acc51446d0">view</a>]</li>
+<li>reimplemented removeRedundantWhiteSpace() to improve performance [<a href="https://github.com/doxygen/doxygen/commit/00ee930a1d73e11885197102c54fd4c8141127da">view</a>]</li>
+<li>sqlite3gen: defnname -&gt; defname [<a href="https://github.com/doxygen/doxygen/commit/79a53cc464ef814adf6b64d45a15fee6676f15d6">view</a>]</li>
+<li>sqlite3gen: export proper memberdef refid [<a href="https://github.com/doxygen/doxygen/commit/918cf6871359da9d14dd6d3e7c4d00d6ca9a496e">view</a>]</li>
+<li>sqlite3gen: insert xrefs using integer refids [<a href="https://github.com/doxygen/doxygen/commit/bac76c1957de71e3e0bddc23ccd46b7b2537c8a1">view</a>]</li>
+<li>sqlite3gen: stripFromPath on all calls to insertFile [<a href="https://github.com/doxygen/doxygen/commit/87222afcfe6089899c8ded60b23692fd40997856">view</a>]</li>
+<li>sqlite3gen: stripWhitespace on bitfield&#39;s text [<a href="https://github.com/doxygen/doxygen/commit/6f4561608adaf8230c2fa015770dfeeab5ce3ba8">view</a>]</li>
+<li>sqlite3gen: sync with xmlgen [<a href="https://github.com/doxygen/doxygen/commit/8208b2d5514a3c29659ae967da544adc21585212">view</a>]</li>
+<li>sqlite3gen: use the refid stored in the refids table [<a href="https://github.com/doxygen/doxygen/commit/9b02db93e7e78aedc0a0ca7fd2701c81dc153487">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -359,153 +359,153 @@
 <a name="1.8.11"></a>
 </p>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1204">1204</a> - Mainpage title has wrong style in RTF [<a href="http://github.com/doxygen/doxygen/commit/021dfd44f2dbeeaac1b9aff95ddc2a3eae173eb4">view</a> and [<a href="http://github.com/doxygen/doxygen/commit/83f23a4f7f7d1351ef89a4e54db6628a9d582dc5">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2059">2059</a> - $line param [<a href="http://github.com/doxygen/doxygen/commit/993972cd242527ddf929756141a68cccfc8ecef9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2258">2258</a> - python: tuple assignment not recognized as variable initialization [<a href="http://github.com/doxygen/doxygen/commit/015955e0badb6082a1e553392acaeb6890734c31">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2653">2653</a> - Fixes angle brackets (&lt; and &gt;) not escaped in HTML formula alt text [<a href="http://github.com/doxygen/doxygen/commit/64adce8b82c332b3855cdfaaa71afc984ffc4ca9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3354">3354</a> - [Python] Add pyw as a valid extension [<a href="http://github.com/doxygen/doxygen/commit/5924acd279f82d8db7ddb33a6ec67937084d7c31">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3499">3499</a> - Python: STRIP_CODE_COMMENTS Doesn&#39;t work within the source code [<a href="http://github.com/doxygen/doxygen/commit/4cad0c9ac3492dd504104b15c9a03ef903950e15">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3515">3515</a> - Python ignores \private tag [<a href="http://github.com/doxygen/doxygen/commit/8782107300b24ac5501d8a5ada9be0859a0ee432">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3621">3621</a> - Deprecated list: Wrong prefix &#39;&lt;globalScope&gt;::&#39; for global functions [<a href="http://github.com/doxygen/doxygen/commit/a5288aca31ccecb78b561b4f382fe6c559bea9f9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3935">3935</a> - Incorrect &quot;References&quot; and &quot;Referenced by&quot; [<a href="http://github.com/doxygen/doxygen/commit/43c415708be4c2d4065ecda9870d361b0beb0f09">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4129">4129</a> - python script with #!/usr/bin/python are not documented correctly [<a href="http://github.com/doxygen/doxygen/commit/322d09de48c07cf7258825e3e7733d5d994e70cf">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4214">4214</a> - htmlonly content appears in generated XML output [<a href="http://github.com/doxygen/doxygen/commit/02ce4f0b2b58ef32dd783b359daf7cc01079462a">view</a>] and [<a href="http://github.com/doxygen/doxygen/commit/6004d659c1ca280acc6588351176be63b55faf70">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4249">4249</a> - PYTHON: stops processing the file after encountering \&quot;&quot;&quot;&quot; [<a href="http://github.com/doxygen/doxygen/commit/59fdba0dd1e3765a2f53b222fdc9455114f720b1">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4433">4433</a> - writeMemberNavIndex template calls static fixSpaces [<a href="http://github.com/doxygen/doxygen/commit/69d5ffaa68210a6e63a618ef304c63462f6e1fac">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4856">4856</a> - Math does not work in LaTeX with custom header and footer. [<a href="http://github.com/doxygen/doxygen/commit/c713984bf6a4c9e8c2ea393b304682ce4a56358f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5503">5503</a> - Markdown backticks not processed within Markdown links. [<a href="http://github.com/doxygen/doxygen/commit/205f7335bca570e87afc0df07bd355848c7af2e3">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5510">5510</a> - doxygen&#39;s \param command is confused by some python default values [<a href="http://github.com/doxygen/doxygen/commit/6447c90acb51807d272ce2f24a94574a413d36e0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5556">5556</a> - Python: Allow undocumented &quot;cls&quot; parameter for class methods [<a href="http://github.com/doxygen/doxygen/commit/0a5dfb77a7d0dfaac2baf8f3e61014a29ba2883b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5715">5715</a> - Unnamed structs gives: QGDict::hashAsciiKey: Invalid null key [<a href="http://github.com/doxygen/doxygen/commit/17b66265ace3418413b5cfab0335b4378e9c176b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5747">5747</a> - PATCH: add option to build latex without timestamps [<a href="http://github.com/doxygen/doxygen/commit/9ef2dc156c37da7fb736c39c3c3fa5074e4d1829">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5755">5755</a> - The table in classes.html has no class attribute [<a href="http://github.com/doxygen/doxygen/commit/0b4b2d76e4cc8fcb85d9b3ad7252e676e5a1d784">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5760">5760</a> - formulas creating invalid HTML code [<a href="http://github.com/doxygen/doxygen/commit/d5905871951cde51c6dcaa01d745de2f884ce9a9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5763">5763</a> - Doxygen thinks C++ class is Objective-C [<a href="http://github.com/doxygen/doxygen/commit/8da86f8adfb826f13321c7d163431f9671ba20b7">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5808">5808</a> - Doxygen don&#39;t support longer key in bibtex [<a href="http://github.com/doxygen/doxygen/commit/b0fc11e4a891e51bb4d982730efecddac2ef807e">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5809">5809</a> - \cite still rejects valid BibTeX keys [<a href="http://github.com/doxygen/doxygen/commit/b1601548308c8a6ec586a406155d24f80d75aafd">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5821">5821</a> - using plantuml cause a popup &quot;openwith&quot; windows when calling java.exe [<a href="http://github.com/doxygen/doxygen/commit/51ee1b0633fbfa935da08c8a13f70da6fc1c074d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5826">5826</a> - PATCH: Honour SOURCE_DATE_EPOCH environment variable for reproducible output [<a href="http://github.com/doxygen/doxygen/commit/b31266c1076c6284116f17241d9e8aa048f88e60">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5830">5830</a> - XML not documenting a class in python [<a href="http://github.com/doxygen/doxygen/commit/288afe7d4fe0953f5717b0ac85f805f78d96afa4">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5831">5831</a> - XML empty &lt;argsstring/&gt; in python [<a href="http://github.com/doxygen/doxygen/commit/a1b3f7b1157b8e7b392bfcd6c6452c664bf5a7c2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5832">5832</a> - last entry missing in a @name group of typedefs [<a href="http://github.com/doxygen/doxygen/commit/21d14b3c7697f8807065070f5850259b1b6550e4">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5833">5833</a> - Non-alphanumeric characters in Markdown links don&#39;t work properly [<a href="http://github.com/doxygen/doxygen/commit/e89eb77b14810649c679dc7d377ddb4e6a942d82">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5839">5839</a> - $file when using @name is wrong [<a href="http://github.com/doxygen/doxygen/commit/790887ea3f63c051954a4cd49f044fa4f536867d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5845">5845</a> - Copy and paste of code fragment from CHM merges all pasted text into single line [<a href="http://github.com/doxygen/doxygen/commit/663544cc0caf9109ea10c33f38b1e07e7a01a575">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5847">5847</a> - class=&quot;current&quot; not applied to &lt;li&gt; for module tab within &#39;group__*.html&#39; module html files [<a href="http://github.com/doxygen/doxygen/commit/0e2e8916f81892c891a33c5435024776ca0f570f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5848">5848</a> - \bug paragraph doesn&#39;t end with a new sectioning command [<a href="http://github.com/doxygen/doxygen/commit/13e2b18c93df1351c4e91d13a7fe224b4841fa73">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5859">5859</a> - Double anchors when using groups [<a href="http://github.com/doxygen/doxygen/commit/e44780a7579ca865cc52801e920b1d20d2a3b438">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5869">5869</a> - xrefitem link to list incorrect when using SHORT_NAMES [<a href="http://github.com/doxygen/doxygen/commit/af5c5b37c5464afb6a2df71edf6f9e82ece75187">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5873">5873</a> - Tree view pane overlaps with content tabs [<a href="http://github.com/doxygen/doxygen/commit/8fc243491cbae2442c1e07faca99a8f6dc6f2e19">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5877">5877</a> - RTF output has incomplete &quot;References&quot; and &quot;Referenced by&quot; sections [<a href="http://github.com/doxygen/doxygen/commit/6184c70c515941212380006a2e6c879e1663daec">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5878">5878</a> - fatal: Cannot open &#39;graph_legend&#39;: No such file or directory [<a href="http://github.com/doxygen/doxygen/commit/08cf278fb80ffb7844b4339458cf4ad03453e827">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5879">5879</a> - Warning refers to incorrect line for undocumented member function (C++) [<a href="http://github.com/doxygen/doxygen/commit/a112c70c7a5d590286e0fad1382b9bb3fd86118b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5883">5883</a> - Race condition in parallel DOT runs [<a href="http://github.com/doxygen/doxygen/commit/f196c9f1d69238a814ff3152103f3bd310efdf0d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5885">5885</a> - Unable to prevent a numbered list [<a href="http://github.com/doxygen/doxygen/commit/3fbb1b66bd5303fa789a36317694bd77eb22ee19">view</a>] and  [<a href="http://github.com/doxygen/doxygen/commit/5487f855ad12d0b7f3ba70aab72fd2debedae16d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5888">5888</a> - Inline markdown links don&#39;t support reference targets that contain ) [<a href="http://github.com/doxygen/doxygen/commit/59a42f974f15fa0154317900ffd9b82babd985ad">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5890">5890</a> - Failed to document nested classes with &quot;reference to array&quot; parameters [<a href="http://github.com/doxygen/doxygen/commit/3bcef269a4fe5bfc1921d7ba934bc09c715eae9c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5893">5893</a> - unclosed tag, c# generics method with where [<a href="http://github.com/doxygen/doxygen/commit/1bb819f5b680d600f010761b21e44df2f5e35ccc">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5894">5894</a> - Doxygen do not support comparison angle bracket in template [<a href="http://github.com/doxygen/doxygen/commit/f836266a4538153a1164642e168bb04c529a4d51">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5897">5897</a> - Brief description of non documented functions [<a href="http://github.com/doxygen/doxygen/commit/7a2164d252a0cb5410ab13b0ca1611a8e94e3c99">view</a>] and [<a href="http://github.com/doxygen/doxygen/commit/1b402f49a0638dd0eec2a123462862c6d4c4084d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5898">5898</a> - Bug in VHDL parser + other fixes [<a href="http://github.com/doxygen/doxygen/commit/4bef27771fec1892331df637dd6184abac36fd8f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5900">5900</a> - C++ templated member-function appears both as public and private [<a href="http://github.com/doxygen/doxygen/commit/bb4e403968dc1ac4deb3b47c0b79b4304f1be288">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5904">5904</a> - Markdown fenced code blocks not parsed properly in comment [<a href="http://github.com/doxygen/doxygen/commit/ae6311ea0855d576a7c4b589dd5f4b994a47fd6c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5910">5910</a> - C++11 unified initializer for array with templates treated as function [<a href="http://github.com/doxygen/doxygen/commit/692544fb47407a3f2c5a5a5e4b80185428adda25">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5913">5913</a> - Doxygen parser confused by C++11 attributes [<a href="http://github.com/doxygen/doxygen/commit/6c005b1e9458430a77bfeba6d08deed4778ad71d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5916">5916</a> - unable to @ref or @link C++ templated operator overloads [<a href="http://github.com/doxygen/doxygen/commit/da09bff6dc9cad40c72b6a858728093cc41dff47">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5919">5919</a> - problems with charset using plantuml [<a href="http://github.com/doxygen/doxygen/commit/165498dc9ea33bc9991c5ab5234b5e51d74569d0">view</a>]</li>
-<li>Actually using value of GROUP_NESTED_COMPOUNDS option [<a href="http://github.com/doxygen/doxygen/commit/3b314b5d856f6f7a25d512737e640a6b7b17c8d4">view</a>]</li>
-<li>Add RPM build for Red Hat [<a href="http://github.com/doxygen/doxygen/commit/7f8f31cb8318e663f2ec145b63fb31278bdd7a76">view</a>]</li>
-<li>Add WARN_AS_ERROR option to stop execution at first warning (equivalent of compilers&#39; -Werror option) [<a href="http://github.com/doxygen/doxygen/commit/38277f1da56c212c9b33f774de412edef1156544">view</a>]</li>
-<li>Add examples to LaTeX / PDF doxygen manual [<a href="http://github.com/doxygen/doxygen/commit/3a236fd01dc23d2d979e06d848f61b002cb4e6ee">view</a> and [<a href="http://github.com/doxygen/doxygen/commit/5e11f885eea694c2ecfeae6ff5774b66eea312e4">view</a>]</li>
-<li>Add mathjax support to template &amp; context. [<a href="http://github.com/doxygen/doxygen/commit/56987af3987f40ac77e70cd39ebbdac3702c1ce2">view</a>]</li>
-<li>Add support for &quot;value&quot; attribute in FORTRAN scanner [<a href="http://github.com/doxygen/doxygen/commit/6dacbd9b22bdd6cd1a8c3e9b5ec8c2f7d15977b8">view</a>]</li>
-<li>Added documentation for creating tables [<a href="http://github.com/doxygen/doxygen/commit/23faa449843eeb4c9e40e650df8844abec024bb7">view</a>]</li>
-<li>Added javascript search engine data to the template context [<a href="http://github.com/doxygen/doxygen/commit/6bb0d2908b4ca7908a8e655a5abcf7615a5f4c77">view</a>]</li>
-<li>Added missing html resources to the html template file [<a href="http://github.com/doxygen/doxygen/commit/43a0883022f64539498b84220d487b16ffd49a7e">view</a>]</li>
-<li>Added missing information to template version of the all members list [<a href="http://github.com/doxygen/doxygen/commit/f16c156065ac8bc6242870c2ae701252b5d4f9b2">view</a>]</li>
-<li>Added support for directory dependency graphs to template engine [<a href="http://github.com/doxygen/doxygen/commit/abe254fbe2235f5b913653acd076d2acd579d5e1">view</a>]</li>
-<li>Adding compilation options for flex/lex and  bison/yacc [<a href="http://github.com/doxygen/doxygen/commit/beb2ff6c39fefbd6aaeecd5de9827d1b1947740b">view</a>]</li>
-<li>Adjusted used option for CLANG usage with CMake in documentation [<a href="http://github.com/doxygen/doxygen/commit/82063c0601b9f7b11c1774a1a42e13295c486467">view</a>]</li>
-<li>Alignment in LaTeX parameter table [<a href="http://github.com/doxygen/doxygen/commit/a0880ff1c41a1c57bc92c1ccf99cf750064e2995">view</a>]</li>
-<li>Avoid using Resource::data as string, as it is not null terminated. [<a href="http://github.com/doxygen/doxygen/commit/15a87a623791bf407b3076960cdd1133c8973357">view</a>]</li>
-<li>Better handling of implicit statement in source code browser [<a href="http://github.com/doxygen/doxygen/commit/404468ac5484d54e47129ce2a00b3ad6e1c2c72a">view</a>]</li>
-<li>Bug&Acirc;&nbsp;149792 - Mainpage title has wrong style in RTF [<a href="http://github.com/doxygen/doxygen/commit/077aeb768767e62407abb4759d44671619bc62fd">view</a>]</li>
-<li>Bump version so that the GIT repo represents the version for the &quot;next&quot; release [<a href="http://github.com/doxygen/doxygen/commit/42c376cdb41db392bd025611ccfcaddb49d05e92">view</a>]</li>
-<li>Cmake tries to remove directory refman.tex instead of file refman.tex [<a href="http://github.com/doxygen/doxygen/commit/63094c8bb34a2e02e8490860660303d849e4a984">view</a>]</li>
-<li>Copy user EXTRA_FILES at the end to overrule files generated by default by doxygen [<a href="http://github.com/doxygen/doxygen/commit/82f08138ad08fa5b8906c162283c4df0e9819d83">view</a>]</li>
-<li>Correct / set types for python variables [<a href="http://github.com/doxygen/doxygen/commit/c47920b217491fc861cdac73d44ab4f93d08423e">view</a>]</li>
-<li>Correcting print format error in config.l [<a href="http://github.com/doxygen/doxygen/commit/9947c11284542a74c56e52b55be032350c6bbc3e">view</a>]</li>
-<li>DO NOT hardcode x86-64 architecture. [<a href="http://github.com/doxygen/doxygen/commit/031780293d2838da2643b46878061598ebb56822">view</a>]</li>
-<li>Don&#39;t show a console when launching doxywizard on Windows. [<a href="http://github.com/doxygen/doxygen/commit/942efcb758977fe95fafc473813528085b56e4ee">view</a>]</li>
-<li>Fix computeCommonDirPrefix sometimes not finding the correct prefix [<a href="http://github.com/doxygen/doxygen/commit/c6bf96520bcff56d3fd67d4277c05b8db9ac2128">view</a>]</li>
-<li>Fix error documentation of in flex debug script [<a href="http://github.com/doxygen/doxygen/commit/09c4e990e4e214900e613343fb9bfbbb08f1bc53">view</a>]</li>
-<li>Fix for broken link in the manual [<a href="http://github.com/doxygen/doxygen/commit/355370151b61f79633b3867634d76eaf8bacce54">view</a>]</li>
-<li>Fix hexChar for inputs 0 &lt;= i &lt; 10 [<a href="http://github.com/doxygen/doxygen/commit/327422d131ed5e6ddf280043b5a56a6fb92d3bbc">view</a> and [<a href="http://github.com/doxygen/doxygen/commit/62da4521880a03b8a92887539eaf76ccad2ee770">view</a>]</li>
-<li>Fix spelling in doc/commands.doc (descriptionm) [<a href="http://github.com/doxygen/doxygen/commit/bd7da008fac074202e3265787907434fbfb40e71">view</a>]</li>
-<li>Fix typo in function name [<a href="http://github.com/doxygen/doxygen/commit/ace0af42e330a96ad691b2d9a08dd3ff4abb2629">view</a> and [<a href="http://github.com/doxygen/doxygen/commit/b890f40d195b9dc5db12aaa398707de138093c66">view</a>]</li>
-<li>Fixed a couple of small memory leaks [<a href="http://github.com/doxygen/doxygen/commit/85ddfc814f33943199928447b4627d05b0920b99">view</a>]</li>
-<li>Fixed a number of memory leaks in the template engine [<a href="http://github.com/doxygen/doxygen/commit/d14bcd1f8f5bd4a2034bae842000630f4e098eb6">view</a>]</li>
-<li>Fixed compiler warning for MacOSX [<a href="http://github.com/doxygen/doxygen/commit/0aa27346b8728f6698dd2b363959e89d02e03ff6">view</a>]</li>
-<li>Fixed link issue for MacOSX 10.11 [<a href="http://github.com/doxygen/doxygen/commit/0918a19225daedfbd5e23388124a5de3860d5420">view</a>]</li>
-<li>Fixed minor typos in comments [<a href="http://github.com/doxygen/doxygen/commit/29c500434d30cd4d9c20f6b295475ed42dba2930">view</a>]</li>
-<li>Fixed preprocessor macros for flex version check [<a href="http://github.com/doxygen/doxygen/commit/a8c73cdbe37cc53c398002d20e94037552a8fb55">view</a>]</li>
-<li>Fixed problem with latex and PDF bookmarks [<a href="http://github.com/doxygen/doxygen/commit/499ecaedf1ee1222535be27f77050ee633595685">view</a>]</li>
-<li>Fixed various issues found by PVS-Studio. [<a href="http://github.com/doxygen/doxygen/commit/48ced3ea8071b3141216482e2821e10250910947">view</a>]</li>
-<li>Fixes bug 485701: Angle brackets (&lt; and &gt;) not escaped in HTML formula alt text [<a href="http://github.com/doxygen/doxygen/commit/08aa01cb0ee9b2dd6403f753156d8b58d8e62145">view</a>]</li>
-<li>Fixes to support nested tables again [<a href="http://github.com/doxygen/doxygen/commit/883989fced827524354297009fde396ca6264a31">view</a>]</li>
-<li>Fortran module private variables and EXTRACT_PRIVATE = NO [<a href="http://github.com/doxygen/doxygen/commit/61820a08200ec62c754cacf8dd3a1121ce6dee69">view</a> and <a href="http://github.com/doxygen/doxygen/commit/8504fc3a06e3430242eab9ac1c1f20319112e6a9">view</a>]</li>
-<li>Improved handling of &lt;caption&gt; in tables for LaTeX output. [<a href="http://github.com/doxygen/doxygen/commit/fa6585b2fc6847c2b242b226b163810c7a6366de">view</a>]</li>
-<li>IncludeInfo class had uninitialized member variable [<a href="http://github.com/doxygen/doxygen/commit/76a9892b190efaeb3c764d824bd285ff3d2c57dc">view</a>]</li>
-<li>Made paragraph spacing more flexible in the LaTeX output to prevent page overflows [<a href="http://github.com/doxygen/doxygen/commit/17b3b41e12e890187f6b7dcc98ed9e2451b14018">view</a>]</li>
-<li>Made several improvements to the performance of template engine [<a href="http://github.com/doxygen/doxygen/commit/ded4e9a92670d0157cdcc5cbf7a4a1e3193e179a">view</a>]</li>
-<li>Make doxywizard compatible with Qt5 [<a href="http://github.com/doxygen/doxygen/commit/333c7c44f1aa3c62f9401b190e45eaff15056d5c">view</a>]</li>
-<li>Make list of default extensions consistent with language mapping list [<a href="http://github.com/doxygen/doxygen/commit/bf35f16863f067286260ad4b68ec4c0ae7febdf1">view</a>]</li>
-<li>Markdown with @cond and @endcond [<a href="http://github.com/doxygen/doxygen/commit/c5a7911741850777b699a63ae5b7702e379a5ada">view</a>]</li>
-<li>Markdown with @cond and @endcond [<a href="http://github.com/doxygen/doxygen/commit/dc26830396970d402ad42d20f1b99bd86f4a5961">view</a>]</li>
-<li>Merge remote-tracking branch &#39;upstream/master&#39; [<a href="http://github.com/doxygen/doxygen/commit/6aba65a4dfaec1aa1131e160ed252d0713403760">view</a>]</li>
-<li>Minor change to pycode.l:codifyLines [<a href="http://github.com/doxygen/doxygen/commit/bbd71be14986e637af9958b2cc18d1d62743ba8e">view</a>]</li>
-<li>Moved creation of inline class documentation to separate template file [<a href="http://github.com/doxygen/doxygen/commit/4bd50c9f0dc1d7b1413a6bda587b8a5999cd7a19">view</a>]</li>
-<li>RTF improvement: Example section was merged with next function title [<a href="http://github.com/doxygen/doxygen/commit/ca617e1e1cd42ee0080c8c13ce3884c8671629dd">view</a>]</li>
-<li>Remove obsolete py files [<a href="http://github.com/doxygen/doxygen/commit/183f36fe97cb95636f1947c2c4be61f7b78f87e0">view</a>]</li>
-<li>Removed BOM marker from greek translator to avoid Visual C warnings [<a href="http://github.com/doxygen/doxygen/commit/9ee8f777f5a4b7a49e644c2da5247fa509038feb">view</a>]</li>
-<li>Repaired breaking @include for LaTeX output [<a href="http://github.com/doxygen/doxygen/commit/ab861c197c596f78c7aea4f45c0e1252de10fc1f">view</a>]</li>
-<li>Revert &quot;Spelling correction for error message with USE_HTAGS usage&quot; [<a href="http://github.com/doxygen/doxygen/commit/a888543ca5f3fd28121f7eea4dbd25898fa7be57">view</a>]</li>
-<li>Revert using container-based infra as sudo is needed :-( [<a href="http://github.com/doxygen/doxygen/commit/f089c3fa4f47dc8bedd25d9d857d004525ee82c0">view</a>]</li>
-<li>Reverted change that caused doxygen to return error code 2 when it produced a warning [<a href="http://github.com/doxygen/doxygen/commit/f9e6fe0bf3886be7e603083b3b200dbd60fbd529">view</a>]</li>
-<li>Rework the generation of packages DEB/RPM/... (CPack) [<a href="http://github.com/doxygen/doxygen/commit/8c0c80e44e1e9cb1ce4e88a3e1d01b65536dc60c">view</a>]</li>
-<li>Right alignment of  in page table of contents [<a href="http://github.com/doxygen/doxygen/commit/a653f7499929f3f0a5b68614dec91242fbc0edf5">view</a>]</li>
-<li>Small correction of errors in case of CSharp XML tags [<a href="http://github.com/doxygen/doxygen/commit/68dd27139e50e048f081549394e6fc6dc04fc699">view</a>]</li>
-<li>Small documentation corrections [<a href="http://github.com/doxygen/doxygen/commit/564c8cd257e0dd1797d94633a0e92ddc5a496540">view</a>]</li>
-<li>Spelling correction for error message with USE_HTAGS usage [<a href="http://github.com/doxygen/doxygen/commit/0d060c455207ab32092e5a7edcd5457bb00f4653">view</a>] and [<a href="http://github.com/doxygen/doxygen/commit/5cc45244002d1d7560233cfae01f9d5d735e1a3f">view</a>]</li>
-<li>Started with generating LaTeX output via the template engine [<a href="http://github.com/doxygen/doxygen/commit/02a0c353a8947290a3191aead59db08dc84766ce">view</a>]</li>
-<li>Stop when doxygen configuration file (&quot;Doxyfile&quot;) cannot be read [<a href="http://github.com/doxygen/doxygen/commit/b8bd3d84590d9adee7084f066f0e3e8c75a99245">view</a>]</li>
-<li>Support flex-2.6.0 [<a href="http://github.com/doxygen/doxygen/commit/8c51120ad55b440b738ef0b96f8169d84a7ae88a">view</a>] and [<a href="http://github.com/doxygen/doxygen/commit/cf936efb8ae99dd297b6afb9c6a06beb81f5b0fb">view</a>]</li>
-<li>Support set in code highlighting [<a href="http://github.com/doxygen/doxygen/commit/1cbcce4ef3460f48ab9c8e9435eec21075dcc788">view</a>]</li>
-<li>Template enhancements and various other small fixes [<a href="http://github.com/doxygen/doxygen/commit/e58fb0a46f73f37d16859f43fda1eb5ba4a15c5d">view</a>]</li>
-<li>Title in case of USE_MDFILE_AS_MAINPAGE [<a href="http://github.com/doxygen/doxygen/commit/09251b805b3c9d96917fedebb3768945d7559b1e">view</a>]</li>
-<li>Tooltip can still contain &lt; and &gt; signs [<a href="http://github.com/doxygen/doxygen/commit/1df28fe4b9a0187f8fa6ed077e4a81002fa50fda">view</a>]</li>
-<li>Tweaked the htmlonly sections in the manual so it produces valid HTML output [<a href="http://github.com/doxygen/doxygen/commit/de03970396e6f7edec359e2b71f3d2aa9d6a6237">view</a>]</li>
-<li>Undo _doxygen to libdoxygen target change [<a href="http://github.com/doxygen/doxygen/commit/940048580f2d61a137e7abbb67b3aed567bfe865">view</a>]</li>
-<li>Updated instructions to toggle debugging flex code [<a href="http://github.com/doxygen/doxygen/commit/368f4f057be0ded4673be826c9a08cd771a023ce">view</a>]</li>
-<li>Updated Italian translation and translator email address [<a href="http://github.com/doxygen/doxygen/commit/a9ad21b4e541d91c804ac39e393cc0c1db4f45f3">view</a>]</li>
-<li>Updated the Greek translation [<a href="http://github.com/doxygen/doxygen/commit/4e0b7f0b9a2a04d0bb5e66871da6d7ffa786836e">view</a>]</li>
-<li>Use CPack to generate rpm/deb packages [<a href="http://github.com/doxygen/doxygen/commit/ba6eb1478d24dc32d4e123951e2f62c75b4b88bd">view</a>]</li>
-<li>Use STATIC libraries to prevent them being shared [<a href="http://github.com/doxygen/doxygen/commit/37a148f6e35523fd2bbbdbc37e6ed838684c6d90">view</a>]</li>
-<li>Using tabu package for LaTeX tables [<a href="http://github.com/doxygen/doxygen/commit/647b6ac8669cd8ba1e8c60eeb3c2de961c7d6a1b">view</a>]</li>
-<li>[Bug <a href="https://github.com/doxygen/doxygen/issues/5872">5872</a>] On Windows, generated layout is with UNIX EOL [<a href="http://github.com/doxygen/doxygen/commit/78a80001223af290c7c7321ad2d210fb3cd16f11">view</a>]</li>
-<li>[Doxygen-users] plugin / filter not behaving as expected [<a href="http://github.com/doxygen/doxygen/commit/0c7f182016c7c2604a484367738e76cb40c0541b">view</a>]</li>
-<li>add spaces like &quot;Doyxgen&quot;CN_SPC-&gt;&quot;Doyxgen&quot; CN_SPC [<a href="http://github.com/doxygen/doxygen/commit/35d1aa8bf9208302601fa96462e246c98aa0b0e5">view</a>]</li>
-<li>allow building with custom iconv on Windows [<a href="http://github.com/doxygen/doxygen/commit/3d684f6d123abdbf630bb19bc6095cc9d69efb68">view</a>]</li>
-<li>doc: generate doxygen&#39;s documentation. [<a href="http://github.com/doxygen/doxygen/commit/3c4a1ea2ee56f2604c2277f13737d53b3a0b0353">view</a>]</li>
-<li>doc: put man pages under share/man/man1 [<a href="http://github.com/doxygen/doxygen/commit/95d28153779810dc95afafa38ed838f32516a1f4">view</a>]</li>
-<li>docparser: warn when finding a documented empty return type [<a href="http://github.com/doxygen/doxygen/commit/10989e2dade3bb35a421787c5315d2630d665842">view</a>]</li>
-<li>docs: add examples as a dependency of docs [<a href="http://github.com/doxygen/doxygen/commit/ec5fde6913935fbe2015220259b611a17a437de3">view</a>]</li>
-<li>doxyapp and CLANG linking [<a href="http://github.com/doxygen/doxygen/commit/a58a2cafbc136f7821b9313bd6c1413eaab3e868">view</a>]</li>
-<li>fixed for travis ci config file [<a href="http://github.com/doxygen/doxygen/commit/ecbb77b40892df8740476023545769ffbda6fd6f">view</a>]</li>
-<li>libpng warning: iCCP: known incorrect sRGB profile [<a href="http://github.com/doxygen/doxygen/commit/c82ac124812dd2f9a5e8b36fcdcf7daf20cfbdda">view</a>]</li>
-<li>rename build target _doxygen to libdoxygen [<a href="http://github.com/doxygen/doxygen/commit/4116648d3c62aee54c385644a4fe754ee7a4261d">view</a>]</li>
-<li>run_translator.cmake is no longer used [<a href="http://github.com/doxygen/doxygen/commit/45e153f2238d0fa031d147cfe207e52b913845eb">view</a>]</li>
-<li>runtests: Simplify dictionary usage [<a href="http://github.com/doxygen/doxygen/commit/95d99a4c857d7d5208d8faf974b01354a798eba4">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1204">1204</a> - Mainpage title has wrong style in RTF [<a href="https://github.com/doxygen/doxygen/commit/021dfd44f2dbeeaac1b9aff95ddc2a3eae173eb4">view</a> and [<a href="https://github.com/doxygen/doxygen/commit/83f23a4f7f7d1351ef89a4e54db6628a9d582dc5">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2059">2059</a> - $line param [<a href="https://github.com/doxygen/doxygen/commit/993972cd242527ddf929756141a68cccfc8ecef9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2258">2258</a> - python: tuple assignment not recognized as variable initialization [<a href="https://github.com/doxygen/doxygen/commit/015955e0badb6082a1e553392acaeb6890734c31">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2653">2653</a> - Fixes angle brackets (&lt; and &gt;) not escaped in HTML formula alt text [<a href="https://github.com/doxygen/doxygen/commit/64adce8b82c332b3855cdfaaa71afc984ffc4ca9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3354">3354</a> - [Python] Add pyw as a valid extension [<a href="https://github.com/doxygen/doxygen/commit/5924acd279f82d8db7ddb33a6ec67937084d7c31">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3499">3499</a> - Python: STRIP_CODE_COMMENTS Doesn&#39;t work within the source code [<a href="https://github.com/doxygen/doxygen/commit/4cad0c9ac3492dd504104b15c9a03ef903950e15">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3515">3515</a> - Python ignores \private tag [<a href="https://github.com/doxygen/doxygen/commit/8782107300b24ac5501d8a5ada9be0859a0ee432">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3621">3621</a> - Deprecated list: Wrong prefix &#39;&lt;globalScope&gt;::&#39; for global functions [<a href="https://github.com/doxygen/doxygen/commit/a5288aca31ccecb78b561b4f382fe6c559bea9f9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3935">3935</a> - Incorrect &quot;References&quot; and &quot;Referenced by&quot; [<a href="https://github.com/doxygen/doxygen/commit/43c415708be4c2d4065ecda9870d361b0beb0f09">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4129">4129</a> - python script with #!/usr/bin/python are not documented correctly [<a href="https://github.com/doxygen/doxygen/commit/322d09de48c07cf7258825e3e7733d5d994e70cf">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4214">4214</a> - htmlonly content appears in generated XML output [<a href="https://github.com/doxygen/doxygen/commit/02ce4f0b2b58ef32dd783b359daf7cc01079462a">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/6004d659c1ca280acc6588351176be63b55faf70">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4249">4249</a> - PYTHON: stops processing the file after encountering \&quot;&quot;&quot;&quot; [<a href="https://github.com/doxygen/doxygen/commit/59fdba0dd1e3765a2f53b222fdc9455114f720b1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4433">4433</a> - writeMemberNavIndex template calls static fixSpaces [<a href="https://github.com/doxygen/doxygen/commit/69d5ffaa68210a6e63a618ef304c63462f6e1fac">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4856">4856</a> - Math does not work in LaTeX with custom header and footer. [<a href="https://github.com/doxygen/doxygen/commit/c713984bf6a4c9e8c2ea393b304682ce4a56358f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5503">5503</a> - Markdown backticks not processed within Markdown links. [<a href="https://github.com/doxygen/doxygen/commit/205f7335bca570e87afc0df07bd355848c7af2e3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5510">5510</a> - doxygen&#39;s \param command is confused by some python default values [<a href="https://github.com/doxygen/doxygen/commit/6447c90acb51807d272ce2f24a94574a413d36e0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5556">5556</a> - Python: Allow undocumented &quot;cls&quot; parameter for class methods [<a href="https://github.com/doxygen/doxygen/commit/0a5dfb77a7d0dfaac2baf8f3e61014a29ba2883b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5715">5715</a> - Unnamed structs gives: QGDict::hashAsciiKey: Invalid null key [<a href="https://github.com/doxygen/doxygen/commit/17b66265ace3418413b5cfab0335b4378e9c176b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5747">5747</a> - PATCH: add option to build latex without timestamps [<a href="https://github.com/doxygen/doxygen/commit/9ef2dc156c37da7fb736c39c3c3fa5074e4d1829">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5755">5755</a> - The table in classes.html has no class attribute [<a href="https://github.com/doxygen/doxygen/commit/0b4b2d76e4cc8fcb85d9b3ad7252e676e5a1d784">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5760">5760</a> - formulas creating invalid HTML code [<a href="https://github.com/doxygen/doxygen/commit/d5905871951cde51c6dcaa01d745de2f884ce9a9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5763">5763</a> - Doxygen thinks C++ class is Objective-C [<a href="https://github.com/doxygen/doxygen/commit/8da86f8adfb826f13321c7d163431f9671ba20b7">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5808">5808</a> - Doxygen don&#39;t support longer key in bibtex [<a href="https://github.com/doxygen/doxygen/commit/b0fc11e4a891e51bb4d982730efecddac2ef807e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5809">5809</a> - \cite still rejects valid BibTeX keys [<a href="https://github.com/doxygen/doxygen/commit/b1601548308c8a6ec586a406155d24f80d75aafd">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5821">5821</a> - using plantuml cause a popup &quot;openwith&quot; windows when calling java.exe [<a href="https://github.com/doxygen/doxygen/commit/51ee1b0633fbfa935da08c8a13f70da6fc1c074d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5826">5826</a> - PATCH: Honour SOURCE_DATE_EPOCH environment variable for reproducible output [<a href="https://github.com/doxygen/doxygen/commit/b31266c1076c6284116f17241d9e8aa048f88e60">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5830">5830</a> - XML not documenting a class in python [<a href="https://github.com/doxygen/doxygen/commit/288afe7d4fe0953f5717b0ac85f805f78d96afa4">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5831">5831</a> - XML empty &lt;argsstring/&gt; in python [<a href="https://github.com/doxygen/doxygen/commit/a1b3f7b1157b8e7b392bfcd6c6452c664bf5a7c2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5832">5832</a> - last entry missing in a @name group of typedefs [<a href="https://github.com/doxygen/doxygen/commit/21d14b3c7697f8807065070f5850259b1b6550e4">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5833">5833</a> - Non-alphanumeric characters in Markdown links don&#39;t work properly [<a href="https://github.com/doxygen/doxygen/commit/e89eb77b14810649c679dc7d377ddb4e6a942d82">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5839">5839</a> - $file when using @name is wrong [<a href="https://github.com/doxygen/doxygen/commit/790887ea3f63c051954a4cd49f044fa4f536867d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5845">5845</a> - Copy and paste of code fragment from CHM merges all pasted text into single line [<a href="https://github.com/doxygen/doxygen/commit/663544cc0caf9109ea10c33f38b1e07e7a01a575">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5847">5847</a> - class=&quot;current&quot; not applied to &lt;li&gt; for module tab within &#39;group__*.html&#39; module html files [<a href="https://github.com/doxygen/doxygen/commit/0e2e8916f81892c891a33c5435024776ca0f570f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5848">5848</a> - \bug paragraph doesn&#39;t end with a new sectioning command [<a href="https://github.com/doxygen/doxygen/commit/13e2b18c93df1351c4e91d13a7fe224b4841fa73">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5859">5859</a> - Double anchors when using groups [<a href="https://github.com/doxygen/doxygen/commit/e44780a7579ca865cc52801e920b1d20d2a3b438">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5869">5869</a> - xrefitem link to list incorrect when using SHORT_NAMES [<a href="https://github.com/doxygen/doxygen/commit/af5c5b37c5464afb6a2df71edf6f9e82ece75187">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5873">5873</a> - Tree view pane overlaps with content tabs [<a href="https://github.com/doxygen/doxygen/commit/8fc243491cbae2442c1e07faca99a8f6dc6f2e19">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5877">5877</a> - RTF output has incomplete &quot;References&quot; and &quot;Referenced by&quot; sections [<a href="https://github.com/doxygen/doxygen/commit/6184c70c515941212380006a2e6c879e1663daec">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5878">5878</a> - fatal: Cannot open &#39;graph_legend&#39;: No such file or directory [<a href="https://github.com/doxygen/doxygen/commit/08cf278fb80ffb7844b4339458cf4ad03453e827">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5879">5879</a> - Warning refers to incorrect line for undocumented member function (C++) [<a href="https://github.com/doxygen/doxygen/commit/a112c70c7a5d590286e0fad1382b9bb3fd86118b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5883">5883</a> - Race condition in parallel DOT runs [<a href="https://github.com/doxygen/doxygen/commit/f196c9f1d69238a814ff3152103f3bd310efdf0d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5885">5885</a> - Unable to prevent a numbered list [<a href="https://github.com/doxygen/doxygen/commit/3fbb1b66bd5303fa789a36317694bd77eb22ee19">view</a>] and  [<a href="https://github.com/doxygen/doxygen/commit/5487f855ad12d0b7f3ba70aab72fd2debedae16d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5888">5888</a> - Inline markdown links don&#39;t support reference targets that contain ) [<a href="https://github.com/doxygen/doxygen/commit/59a42f974f15fa0154317900ffd9b82babd985ad">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5890">5890</a> - Failed to document nested classes with &quot;reference to array&quot; parameters [<a href="https://github.com/doxygen/doxygen/commit/3bcef269a4fe5bfc1921d7ba934bc09c715eae9c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5893">5893</a> - unclosed tag, c# generics method with where [<a href="https://github.com/doxygen/doxygen/commit/1bb819f5b680d600f010761b21e44df2f5e35ccc">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5894">5894</a> - Doxygen do not support comparison angle bracket in template [<a href="https://github.com/doxygen/doxygen/commit/f836266a4538153a1164642e168bb04c529a4d51">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5897">5897</a> - Brief description of non documented functions [<a href="https://github.com/doxygen/doxygen/commit/7a2164d252a0cb5410ab13b0ca1611a8e94e3c99">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/1b402f49a0638dd0eec2a123462862c6d4c4084d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5898">5898</a> - Bug in VHDL parser + other fixes [<a href="https://github.com/doxygen/doxygen/commit/4bef27771fec1892331df637dd6184abac36fd8f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5900">5900</a> - C++ templated member-function appears both as public and private [<a href="https://github.com/doxygen/doxygen/commit/bb4e403968dc1ac4deb3b47c0b79b4304f1be288">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5904">5904</a> - Markdown fenced code blocks not parsed properly in comment [<a href="https://github.com/doxygen/doxygen/commit/ae6311ea0855d576a7c4b589dd5f4b994a47fd6c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5910">5910</a> - C++11 unified initializer for array with templates treated as function [<a href="https://github.com/doxygen/doxygen/commit/692544fb47407a3f2c5a5a5e4b80185428adda25">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5913">5913</a> - Doxygen parser confused by C++11 attributes [<a href="https://github.com/doxygen/doxygen/commit/6c005b1e9458430a77bfeba6d08deed4778ad71d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5916">5916</a> - unable to @ref or @link C++ templated operator overloads [<a href="https://github.com/doxygen/doxygen/commit/da09bff6dc9cad40c72b6a858728093cc41dff47">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5919">5919</a> - problems with charset using plantuml [<a href="https://github.com/doxygen/doxygen/commit/165498dc9ea33bc9991c5ab5234b5e51d74569d0">view</a>]</li>
+<li>Actually using value of GROUP_NESTED_COMPOUNDS option [<a href="https://github.com/doxygen/doxygen/commit/3b314b5d856f6f7a25d512737e640a6b7b17c8d4">view</a>]</li>
+<li>Add RPM build for Red Hat [<a href="https://github.com/doxygen/doxygen/commit/7f8f31cb8318e663f2ec145b63fb31278bdd7a76">view</a>]</li>
+<li>Add WARN_AS_ERROR option to stop execution at first warning (equivalent of compilers&#39; -Werror option) [<a href="https://github.com/doxygen/doxygen/commit/38277f1da56c212c9b33f774de412edef1156544">view</a>]</li>
+<li>Add examples to LaTeX / PDF doxygen manual [<a href="https://github.com/doxygen/doxygen/commit/3a236fd01dc23d2d979e06d848f61b002cb4e6ee">view</a> and [<a href="https://github.com/doxygen/doxygen/commit/5e11f885eea694c2ecfeae6ff5774b66eea312e4">view</a>]</li>
+<li>Add mathjax support to template &amp; context. [<a href="https://github.com/doxygen/doxygen/commit/56987af3987f40ac77e70cd39ebbdac3702c1ce2">view</a>]</li>
+<li>Add support for &quot;value&quot; attribute in FORTRAN scanner [<a href="https://github.com/doxygen/doxygen/commit/6dacbd9b22bdd6cd1a8c3e9b5ec8c2f7d15977b8">view</a>]</li>
+<li>Added documentation for creating tables [<a href="https://github.com/doxygen/doxygen/commit/23faa449843eeb4c9e40e650df8844abec024bb7">view</a>]</li>
+<li>Added javascript search engine data to the template context [<a href="https://github.com/doxygen/doxygen/commit/6bb0d2908b4ca7908a8e655a5abcf7615a5f4c77">view</a>]</li>
+<li>Added missing html resources to the html template file [<a href="https://github.com/doxygen/doxygen/commit/43a0883022f64539498b84220d487b16ffd49a7e">view</a>]</li>
+<li>Added missing information to template version of the all members list [<a href="https://github.com/doxygen/doxygen/commit/f16c156065ac8bc6242870c2ae701252b5d4f9b2">view</a>]</li>
+<li>Added support for directory dependency graphs to template engine [<a href="https://github.com/doxygen/doxygen/commit/abe254fbe2235f5b913653acd076d2acd579d5e1">view</a>]</li>
+<li>Adding compilation options for flex/lex and  bison/yacc [<a href="https://github.com/doxygen/doxygen/commit/beb2ff6c39fefbd6aaeecd5de9827d1b1947740b">view</a>]</li>
+<li>Adjusted used option for CLANG usage with CMake in documentation [<a href="https://github.com/doxygen/doxygen/commit/82063c0601b9f7b11c1774a1a42e13295c486467">view</a>]</li>
+<li>Alignment in LaTeX parameter table [<a href="https://github.com/doxygen/doxygen/commit/a0880ff1c41a1c57bc92c1ccf99cf750064e2995">view</a>]</li>
+<li>Avoid using Resource::data as string, as it is not null terminated. [<a href="https://github.com/doxygen/doxygen/commit/15a87a623791bf407b3076960cdd1133c8973357">view</a>]</li>
+<li>Better handling of implicit statement in source code browser [<a href="https://github.com/doxygen/doxygen/commit/404468ac5484d54e47129ce2a00b3ad6e1c2c72a">view</a>]</li>
+<li>Bug&Acirc;&nbsp;149792 - Mainpage title has wrong style in RTF [<a href="https://github.com/doxygen/doxygen/commit/077aeb768767e62407abb4759d44671619bc62fd">view</a>]</li>
+<li>Bump version so that the GIT repo represents the version for the &quot;next&quot; release [<a href="https://github.com/doxygen/doxygen/commit/42c376cdb41db392bd025611ccfcaddb49d05e92">view</a>]</li>
+<li>Cmake tries to remove directory refman.tex instead of file refman.tex [<a href="https://github.com/doxygen/doxygen/commit/63094c8bb34a2e02e8490860660303d849e4a984">view</a>]</li>
+<li>Copy user EXTRA_FILES at the end to overrule files generated by default by doxygen [<a href="https://github.com/doxygen/doxygen/commit/82f08138ad08fa5b8906c162283c4df0e9819d83">view</a>]</li>
+<li>Correct / set types for python variables [<a href="https://github.com/doxygen/doxygen/commit/c47920b217491fc861cdac73d44ab4f93d08423e">view</a>]</li>
+<li>Correcting print format error in config.l [<a href="https://github.com/doxygen/doxygen/commit/9947c11284542a74c56e52b55be032350c6bbc3e">view</a>]</li>
+<li>DO NOT hardcode x86-64 architecture. [<a href="https://github.com/doxygen/doxygen/commit/031780293d2838da2643b46878061598ebb56822">view</a>]</li>
+<li>Don&#39;t show a console when launching doxywizard on Windows. [<a href="https://github.com/doxygen/doxygen/commit/942efcb758977fe95fafc473813528085b56e4ee">view</a>]</li>
+<li>Fix computeCommonDirPrefix sometimes not finding the correct prefix [<a href="https://github.com/doxygen/doxygen/commit/c6bf96520bcff56d3fd67d4277c05b8db9ac2128">view</a>]</li>
+<li>Fix error documentation of in flex debug script [<a href="https://github.com/doxygen/doxygen/commit/09c4e990e4e214900e613343fb9bfbbb08f1bc53">view</a>]</li>
+<li>Fix for broken link in the manual [<a href="https://github.com/doxygen/doxygen/commit/355370151b61f79633b3867634d76eaf8bacce54">view</a>]</li>
+<li>Fix hexChar for inputs 0 &lt;= i &lt; 10 [<a href="https://github.com/doxygen/doxygen/commit/327422d131ed5e6ddf280043b5a56a6fb92d3bbc">view</a> and [<a href="https://github.com/doxygen/doxygen/commit/62da4521880a03b8a92887539eaf76ccad2ee770">view</a>]</li>
+<li>Fix spelling in doc/commands.doc (descriptionm) [<a href="https://github.com/doxygen/doxygen/commit/bd7da008fac074202e3265787907434fbfb40e71">view</a>]</li>
+<li>Fix typo in function name [<a href="https://github.com/doxygen/doxygen/commit/ace0af42e330a96ad691b2d9a08dd3ff4abb2629">view</a> and [<a href="https://github.com/doxygen/doxygen/commit/b890f40d195b9dc5db12aaa398707de138093c66">view</a>]</li>
+<li>Fixed a couple of small memory leaks [<a href="https://github.com/doxygen/doxygen/commit/85ddfc814f33943199928447b4627d05b0920b99">view</a>]</li>
+<li>Fixed a number of memory leaks in the template engine [<a href="https://github.com/doxygen/doxygen/commit/d14bcd1f8f5bd4a2034bae842000630f4e098eb6">view</a>]</li>
+<li>Fixed compiler warning for MacOSX [<a href="https://github.com/doxygen/doxygen/commit/0aa27346b8728f6698dd2b363959e89d02e03ff6">view</a>]</li>
+<li>Fixed link issue for MacOSX 10.11 [<a href="https://github.com/doxygen/doxygen/commit/0918a19225daedfbd5e23388124a5de3860d5420">view</a>]</li>
+<li>Fixed minor typos in comments [<a href="https://github.com/doxygen/doxygen/commit/29c500434d30cd4d9c20f6b295475ed42dba2930">view</a>]</li>
+<li>Fixed preprocessor macros for flex version check [<a href="https://github.com/doxygen/doxygen/commit/a8c73cdbe37cc53c398002d20e94037552a8fb55">view</a>]</li>
+<li>Fixed problem with latex and PDF bookmarks [<a href="https://github.com/doxygen/doxygen/commit/499ecaedf1ee1222535be27f77050ee633595685">view</a>]</li>
+<li>Fixed various issues found by PVS-Studio. [<a href="https://github.com/doxygen/doxygen/commit/48ced3ea8071b3141216482e2821e10250910947">view</a>]</li>
+<li>Fixes bug 485701: Angle brackets (&lt; and &gt;) not escaped in HTML formula alt text [<a href="https://github.com/doxygen/doxygen/commit/08aa01cb0ee9b2dd6403f753156d8b58d8e62145">view</a>]</li>
+<li>Fixes to support nested tables again [<a href="https://github.com/doxygen/doxygen/commit/883989fced827524354297009fde396ca6264a31">view</a>]</li>
+<li>Fortran module private variables and EXTRACT_PRIVATE = NO [<a href="https://github.com/doxygen/doxygen/commit/61820a08200ec62c754cacf8dd3a1121ce6dee69">view</a> and <a href="https://github.com/doxygen/doxygen/commit/8504fc3a06e3430242eab9ac1c1f20319112e6a9">view</a>]</li>
+<li>Improved handling of &lt;caption&gt; in tables for LaTeX output. [<a href="https://github.com/doxygen/doxygen/commit/fa6585b2fc6847c2b242b226b163810c7a6366de">view</a>]</li>
+<li>IncludeInfo class had uninitialized member variable [<a href="https://github.com/doxygen/doxygen/commit/76a9892b190efaeb3c764d824bd285ff3d2c57dc">view</a>]</li>
+<li>Made paragraph spacing more flexible in the LaTeX output to prevent page overflows [<a href="https://github.com/doxygen/doxygen/commit/17b3b41e12e890187f6b7dcc98ed9e2451b14018">view</a>]</li>
+<li>Made several improvements to the performance of template engine [<a href="https://github.com/doxygen/doxygen/commit/ded4e9a92670d0157cdcc5cbf7a4a1e3193e179a">view</a>]</li>
+<li>Make doxywizard compatible with Qt5 [<a href="https://github.com/doxygen/doxygen/commit/333c7c44f1aa3c62f9401b190e45eaff15056d5c">view</a>]</li>
+<li>Make list of default extensions consistent with language mapping list [<a href="https://github.com/doxygen/doxygen/commit/bf35f16863f067286260ad4b68ec4c0ae7febdf1">view</a>]</li>
+<li>Markdown with @cond and @endcond [<a href="https://github.com/doxygen/doxygen/commit/c5a7911741850777b699a63ae5b7702e379a5ada">view</a>]</li>
+<li>Markdown with @cond and @endcond [<a href="https://github.com/doxygen/doxygen/commit/dc26830396970d402ad42d20f1b99bd86f4a5961">view</a>]</li>
+<li>Merge remote-tracking branch &#39;upstream/master&#39; [<a href="https://github.com/doxygen/doxygen/commit/6aba65a4dfaec1aa1131e160ed252d0713403760">view</a>]</li>
+<li>Minor change to pycode.l:codifyLines [<a href="https://github.com/doxygen/doxygen/commit/bbd71be14986e637af9958b2cc18d1d62743ba8e">view</a>]</li>
+<li>Moved creation of inline class documentation to separate template file [<a href="https://github.com/doxygen/doxygen/commit/4bd50c9f0dc1d7b1413a6bda587b8a5999cd7a19">view</a>]</li>
+<li>RTF improvement: Example section was merged with next function title [<a href="https://github.com/doxygen/doxygen/commit/ca617e1e1cd42ee0080c8c13ce3884c8671629dd">view</a>]</li>
+<li>Remove obsolete py files [<a href="https://github.com/doxygen/doxygen/commit/183f36fe97cb95636f1947c2c4be61f7b78f87e0">view</a>]</li>
+<li>Removed BOM marker from greek translator to avoid Visual C warnings [<a href="https://github.com/doxygen/doxygen/commit/9ee8f777f5a4b7a49e644c2da5247fa509038feb">view</a>]</li>
+<li>Repaired breaking @include for LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/ab861c197c596f78c7aea4f45c0e1252de10fc1f">view</a>]</li>
+<li>Revert &quot;Spelling correction for error message with USE_HTAGS usage&quot; [<a href="https://github.com/doxygen/doxygen/commit/a888543ca5f3fd28121f7eea4dbd25898fa7be57">view</a>]</li>
+<li>Revert using container-based infra as sudo is needed :-( [<a href="https://github.com/doxygen/doxygen/commit/f089c3fa4f47dc8bedd25d9d857d004525ee82c0">view</a>]</li>
+<li>Reverted change that caused doxygen to return error code 2 when it produced a warning [<a href="https://github.com/doxygen/doxygen/commit/f9e6fe0bf3886be7e603083b3b200dbd60fbd529">view</a>]</li>
+<li>Rework the generation of packages DEB/RPM/... (CPack) [<a href="https://github.com/doxygen/doxygen/commit/8c0c80e44e1e9cb1ce4e88a3e1d01b65536dc60c">view</a>]</li>
+<li>Right alignment of  in page table of contents [<a href="https://github.com/doxygen/doxygen/commit/a653f7499929f3f0a5b68614dec91242fbc0edf5">view</a>]</li>
+<li>Small correction of errors in case of CSharp XML tags [<a href="https://github.com/doxygen/doxygen/commit/68dd27139e50e048f081549394e6fc6dc04fc699">view</a>]</li>
+<li>Small documentation corrections [<a href="https://github.com/doxygen/doxygen/commit/564c8cd257e0dd1797d94633a0e92ddc5a496540">view</a>]</li>
+<li>Spelling correction for error message with USE_HTAGS usage [<a href="https://github.com/doxygen/doxygen/commit/0d060c455207ab32092e5a7edcd5457bb00f4653">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/5cc45244002d1d7560233cfae01f9d5d735e1a3f">view</a>]</li>
+<li>Started with generating LaTeX output via the template engine [<a href="https://github.com/doxygen/doxygen/commit/02a0c353a8947290a3191aead59db08dc84766ce">view</a>]</li>
+<li>Stop when doxygen configuration file (&quot;Doxyfile&quot;) cannot be read [<a href="https://github.com/doxygen/doxygen/commit/b8bd3d84590d9adee7084f066f0e3e8c75a99245">view</a>]</li>
+<li>Support flex-2.6.0 [<a href="https://github.com/doxygen/doxygen/commit/8c51120ad55b440b738ef0b96f8169d84a7ae88a">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/cf936efb8ae99dd297b6afb9c6a06beb81f5b0fb">view</a>]</li>
+<li>Support set in code highlighting [<a href="https://github.com/doxygen/doxygen/commit/1cbcce4ef3460f48ab9c8e9435eec21075dcc788">view</a>]</li>
+<li>Template enhancements and various other small fixes [<a href="https://github.com/doxygen/doxygen/commit/e58fb0a46f73f37d16859f43fda1eb5ba4a15c5d">view</a>]</li>
+<li>Title in case of USE_MDFILE_AS_MAINPAGE [<a href="https://github.com/doxygen/doxygen/commit/09251b805b3c9d96917fedebb3768945d7559b1e">view</a>]</li>
+<li>Tooltip can still contain &lt; and &gt; signs [<a href="https://github.com/doxygen/doxygen/commit/1df28fe4b9a0187f8fa6ed077e4a81002fa50fda">view</a>]</li>
+<li>Tweaked the htmlonly sections in the manual so it produces valid HTML output [<a href="https://github.com/doxygen/doxygen/commit/de03970396e6f7edec359e2b71f3d2aa9d6a6237">view</a>]</li>
+<li>Undo _doxygen to libdoxygen target change [<a href="https://github.com/doxygen/doxygen/commit/940048580f2d61a137e7abbb67b3aed567bfe865">view</a>]</li>
+<li>Updated instructions to toggle debugging flex code [<a href="https://github.com/doxygen/doxygen/commit/368f4f057be0ded4673be826c9a08cd771a023ce">view</a>]</li>
+<li>Updated Italian translation and translator email address [<a href="https://github.com/doxygen/doxygen/commit/a9ad21b4e541d91c804ac39e393cc0c1db4f45f3">view</a>]</li>
+<li>Updated the Greek translation [<a href="https://github.com/doxygen/doxygen/commit/4e0b7f0b9a2a04d0bb5e66871da6d7ffa786836e">view</a>]</li>
+<li>Use CPack to generate rpm/deb packages [<a href="https://github.com/doxygen/doxygen/commit/ba6eb1478d24dc32d4e123951e2f62c75b4b88bd">view</a>]</li>
+<li>Use STATIC libraries to prevent them being shared [<a href="https://github.com/doxygen/doxygen/commit/37a148f6e35523fd2bbbdbc37e6ed838684c6d90">view</a>]</li>
+<li>Using tabu package for LaTeX tables [<a href="https://github.com/doxygen/doxygen/commit/647b6ac8669cd8ba1e8c60eeb3c2de961c7d6a1b">view</a>]</li>
+<li>[Bug <a href="https://github.com/doxygen/doxygen/issues/5872">5872</a>] On Windows, generated layout is with UNIX EOL [<a href="https://github.com/doxygen/doxygen/commit/78a80001223af290c7c7321ad2d210fb3cd16f11">view</a>]</li>
+<li>[Doxygen-users] plugin / filter not behaving as expected [<a href="https://github.com/doxygen/doxygen/commit/0c7f182016c7c2604a484367738e76cb40c0541b">view</a>]</li>
+<li>add spaces like &quot;Doyxgen&quot;CN_SPC-&gt;&quot;Doyxgen&quot; CN_SPC [<a href="https://github.com/doxygen/doxygen/commit/35d1aa8bf9208302601fa96462e246c98aa0b0e5">view</a>]</li>
+<li>allow building with custom iconv on Windows [<a href="https://github.com/doxygen/doxygen/commit/3d684f6d123abdbf630bb19bc6095cc9d69efb68">view</a>]</li>
+<li>doc: generate doxygen&#39;s documentation. [<a href="https://github.com/doxygen/doxygen/commit/3c4a1ea2ee56f2604c2277f13737d53b3a0b0353">view</a>]</li>
+<li>doc: put man pages under share/man/man1 [<a href="https://github.com/doxygen/doxygen/commit/95d28153779810dc95afafa38ed838f32516a1f4">view</a>]</li>
+<li>docparser: warn when finding a documented empty return type [<a href="https://github.com/doxygen/doxygen/commit/10989e2dade3bb35a421787c5315d2630d665842">view</a>]</li>
+<li>docs: add examples as a dependency of docs [<a href="https://github.com/doxygen/doxygen/commit/ec5fde6913935fbe2015220259b611a17a437de3">view</a>]</li>
+<li>doxyapp and CLANG linking [<a href="https://github.com/doxygen/doxygen/commit/a58a2cafbc136f7821b9313bd6c1413eaab3e868">view</a>]</li>
+<li>fixed for travis ci config file [<a href="https://github.com/doxygen/doxygen/commit/ecbb77b40892df8740476023545769ffbda6fd6f">view</a>]</li>
+<li>libpng warning: iCCP: known incorrect sRGB profile [<a href="https://github.com/doxygen/doxygen/commit/c82ac124812dd2f9a5e8b36fcdcf7daf20cfbdda">view</a>]</li>
+<li>rename build target _doxygen to libdoxygen [<a href="https://github.com/doxygen/doxygen/commit/4116648d3c62aee54c385644a4fe754ee7a4261d">view</a>]</li>
+<li>run_translator.cmake is no longer used [<a href="https://github.com/doxygen/doxygen/commit/45e153f2238d0fa031d147cfe207e52b913845eb">view</a>]</li>
+<li>runtests: Simplify dictionary usage [<a href="https://github.com/doxygen/doxygen/commit/95d99a4c857d7d5208d8faf974b01354a798eba4">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -516,150 +516,150 @@
 <a name="1.8.10"></a>
 </p>
 <ul>
-<li>change the build system to use cmake [<a href="http://github.com/doxygen/doxygen/commit/2e099b1950eee2c3a0d5d8ae4b25575caeb938b1">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/ba9bb02abf6f6922a83beb2092e7bc270e6f25c1">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/635d8cf30e702bdf83fe5c96452f8f863d57bdee">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/51ee91560a9cbaac41cec536dcdeb3e4c32f139a">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/e775357ae71ecbf02dc93913a923567f31b03681">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/a0cd6a8e0c19a82e9662f96734c7ba21726794d0">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/0dc4eda500e803a65a10445719c97d7e523897da">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/22c0d75d45354979392db5db4e3195570c394e44">view</a>]</li>
-<li>Add support for basic XML syntax highlighting. [<a href="http://github.com/doxygen/doxygen/commit/a418518921ba7a99c7221ba7f40d2e791cb207c4">view</a>]</li>
-<li>Added documentation for ``` style fenced code block and more robust parsing [<a href="http://github.com/doxygen/doxygen/commit/39ba42c3b21d08ec606eee18ee8b64c67ec6a42a">view</a>]</li>
-<li>Added function arguments to the LaTeX toc [<a href="http://github.com/doxygen/doxygen/commit/f5e70723391bacc2d68c19d367ab414e70f786b4">view</a>]</li>
-<li>Added missing files and build instructions [<a href="http://github.com/doxygen/doxygen/commit/39228176c052fd293382dc9bc9b4b69b2a6af277">view</a>]</li>
-<li>Added missing libraries for building doxysearch on Windows [<a href="http://github.com/doxygen/doxygen/commit/84d94779e76681b63cdcbc362bbe0341cd39064d">view</a>]</li>
-<li>Added support for language codes [<a href="http://github.com/doxygen/doxygen/commit/eae07d978b524c787daeab911ca087b47a964577">view</a>]</li>
-<li>Added type constraint relations for Java generics to dot graphs and XML output [<a href="http://github.com/doxygen/doxygen/commit/080a465b1321ff93c05ce398cd18a577e0ebae4b">view</a>]</li>
-<li>Adding commands \hidecallgraph and \hidecallergraph [<a href="http://github.com/doxygen/doxygen/commit/073e9482a516c24a3d045da049941bfd432f3354">view</a>]</li>
-<li>Adjust test script for longer version number [<a href="http://github.com/doxygen/doxygen/commit/c7622971ee485279e8da7634207340ce18b69aaa">view</a>]</li>
-<li>Adjusted version in configure script [<a href="http://github.com/doxygen/doxygen/commit/cbd3fa183815191ac5f172a2bac62991642c0b5e">view</a>]</li>
-<li>Alignment of project name [<a href="http://github.com/doxygen/doxygen/commit/e7b356d2cb9320a363ac024d39b468e98b223b90">view</a>]</li>
-<li>Allow selection of specific translators to compile in at build time [<a href="http://github.com/doxygen/doxygen/commit/faef77a87cecd703e3629a35d2e22efb07e682a0">view</a>]</li>
-<li>Based on the report of Peter D. Barnes in the doxygen forum (http://doxygen.10944.n7.nabble.com/doxygen-1-8-9-1-upgrade-errors-td6990.html) [<a href="http://github.com/doxygen/doxygen/commit/9771b807cd776b37f6538dec085442218a5b6a09">view</a>]</li>
-<li>Better error message in case of IDL inconsistency [<a href="http://github.com/doxygen/doxygen/commit/a7eef85a89d8772b7ab97a4ba378cc7e78c988cc">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4415">4415</a> - EXTRA_PACKAGES can&#39;t handle package options [<a href="http://github.com/doxygen/doxygen/commit/1c47dd436358ffc7bc76901cddc559b2d8ce233d">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/ad53cbab6474e11692f2ca1018a821d042df28e6">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5673">5673</a> - Using HTML entities in PROJECT_NAME [<a href="http://github.com/doxygen/doxygen/commit/8e44571521391403e8d85f893acb926e021e926b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5697">5697</a> - Missing documentation after nested C++11 unified initializer [<a href="http://github.com/doxygen/doxygen/commit/c1789f2e5d8421d6028c836ab66afecacff284ef">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5698">5698</a> - Bogus warning: citelist: Unexpected new line character [<a href="http://github.com/doxygen/doxygen/commit/5c321cbb6359bc1bb875729c08beba2edc084500">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5704">5704</a> - @todo paragraphs incorrectly placed in rtf output [<a href="http://github.com/doxygen/doxygen/commit/600d5859d7bcb94b08ef656fd427914766ae9afe">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5705">5705</a> - Bogus message with addtogroup [<a href="http://github.com/doxygen/doxygen/commit/b75af9180ae53f7c7abb94ccf906333169247785">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5707">5707</a> - Configuring doxyfile to only output docbook produces erroneous warning [<a href="http://github.com/doxygen/doxygen/commit/05fcf8decc25bd2f1a2e7867ee8e5d9da1f08933">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5709">5709</a> - latex compilation: \backmatter incompatible with COMPACT_LATEX=YES [<a href="http://github.com/doxygen/doxygen/commit/c9067c5bb9a1868e0963dc210cf3b7152c4aa79a">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5710">5710</a> - Wrong icons in TOC of CHM help [<a href="http://github.com/doxygen/doxygen/commit/8c97e0cd63bcf942ee5b43c9471055a4ea27551c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5720">5720</a> - &lt;CAPTION&gt; inside &lt;TABLE&gt; no longer works for LaTex output [<a href="http://github.com/doxygen/doxygen/commit/0599f92d06ff433446f34136ffe2f3d65d6bd109">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5726">5726</a> - Duplicate anchors from tagfiles [<a href="http://github.com/doxygen/doxygen/commit/1f21c23c57c91ba6901c0de38bb236f7246e88c9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5727">5727</a> - Tagfile anchors not generated for enumeration values [<a href="http://github.com/doxygen/doxygen/commit/1d4f37cb13a75ca8bdc49be3558438104e7eef19">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5728">5728</a> - Non-ascii characters are not emphasised [<a href="http://github.com/doxygen/doxygen/commit/8f67d4f63efd45b0d38502bdf68987d7fc1e92e9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5744">5744</a> - Using TAGFILES prevents symbol extraction [<a href="http://github.com/doxygen/doxygen/commit/a735498be5a572236755cc3da65bf4774cbac25c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5753">5753</a> - PATCH: please consider making doxygen output byte for byte identical between individual runs by default [<a href="http://github.com/doxygen/doxygen/commit/3f2e8a3067712b025623e4420e6eb161febfd42b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5754">5754</a> - Doxygen generates bad &quot;More...&quot; file links for functions within a namespace [<a href="http://github.com/doxygen/doxygen/commit/ea202be55d68af33917658e3fec169da3a7fa7a8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5756">5756</a> - [PATCH] QT4&#39;s qmake is titled differently on Fedora 21 [<a href="http://github.com/doxygen/doxygen/commit/3bd3ad9f8f4d010e42f0ba8eeab229f44b1ecb1c">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/a883f65ab94973d4c7948623186159f978517851">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5761">5761</a> - last enum member not documented [<a href="http://github.com/doxygen/doxygen/commit/50a329c056a2676608f30321a3207ff17ab20abb">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5764">5764</a> - Nested list in C# XML comments closes outer list prematurely [<a href="http://github.com/doxygen/doxygen/commit/2c679e7d39144dadef2e9fd25772f0e41586e18b">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/7a0522fafde300f36c3d5264f46c1f70cf35b7b9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5768">5768</a> - Bogus warning regarding nested comments [<a href="http://github.com/doxygen/doxygen/commit/e4c0036962d8fa0ea9c1e38dbdb5e91168201f22">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5769">5769</a> - Bogus warnings in case of anonymous namespace and @todo [<a href="http://github.com/doxygen/doxygen/commit/298ab30b2a2aa0936f4683c9366afd44c00adc60">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5772">5772</a> - Don&#39;t warn about missing documentation for deleted functions. [<a href="http://github.com/doxygen/doxygen/commit/796d6585be58d1c9112422a919f49d1998dc672c">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/ac576bd974ac27bc1f395e8ae6c77b19f800b6db">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5774">5774</a> - Table of content incorrect with escaped symbols [<a href="http://github.com/doxygen/doxygen/commit/5cdf62661c88b5f0c135337da4d6e58581aad037">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5777">5777</a> - man output should escape minus signs [<a href="http://github.com/doxygen/doxygen/commit/3608a668b3892eaa4f7b2e4b29b833ede24ceee7">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5779">5779</a> - Bug #313527 regression - Enum in bitfield is not parsed properly. [<a href="http://github.com/doxygen/doxygen/commit/528bb8054ca362843630ec261ca6e6990a206081">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/7b2d77abb73288bdd48ca04720fd6779e0bf94c2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5793">5793</a> - FILE_PATTERNS ignores arbitrary extensions [<a href="http://github.com/doxygen/doxygen/commit/52cb086da66533332962f2bf9cb35772e980c092">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5814">5814</a> - class scoped enum documentation appearing at group level instead of class level [<a href="http://github.com/doxygen/doxygen/commit/e4a9d06d7871f24dd6e37ecac6addae729e6d721">view</a>]</li>
-<li>Build fixes for windows build [<a href="http://github.com/doxygen/doxygen/commit/5446770855a8286092abdd91d9069cb3191c209d">view</a>]</li>
-<li>Bump copyright year [<a href="http://github.com/doxygen/doxygen/commit/e11b48785323017bf1d81e91e8133d7f3ba1f243">view</a>]</li>
-<li>Bump version in configure script [<a href="http://github.com/doxygen/doxygen/commit/97342f92e111d7aa3e423a128379a6018820ce6c">view</a>]</li>
-<li>Cleanup &amp; adapt travis config [<a href="http://github.com/doxygen/doxygen/commit/5f67c67323bff27751ba07c417ba99180fa0d762">view</a>]</li>
-<li>Consistency in handling HTML and LaTeX in respect to header and footer [<a href="http://github.com/doxygen/doxygen/commit/be5cc75ffc2e0a95ecbf0ce8d918b070c276d3e5">view</a>]</li>
-<li>Correct string buffer sizes for RTF output, such that the string is always correctly sized. [<a href="http://github.com/doxygen/doxygen/commit/bc8e705cf90cecdff8a247264c249ffed1d2af4a">view</a>]</li>
-<li>Crash in case of non generic interface in Fortran [<a href="http://github.com/doxygen/doxygen/commit/7d3a2abf0137c5257eeb0a8e0f76381b79f1e7bb">view</a>]</li>
-<li>Documentation HTML Header, Footer, and Stylesheet changes [<a href="http://github.com/doxygen/doxygen/commit/1dded5c92a13f9db60fc630cbe5f2cc5ad9bede0">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/478207365d7f09f0e676a76f654502c084806e4e">view</a>]</li>
-<li>Documenting RESULT variable of Fortran FUNCTION [<a href="http://github.com/doxygen/doxygen/commit/21f9e87db8085fb1b5e0a9a9a25dee159b3fd324">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/4d52beec3760244d959ab4d5528aea1acba505e7">view</a>]</li>
-<li>Doxygen LaTeX / PDF links point to page 1 [<a href="http://github.com/doxygen/doxygen/commit/e34913dcbe0bee2c3e21d6e21b2bcc6970003a5c">view</a>]</li>
-<li>Enable relative paths referenced source files [<a href="http://github.com/doxygen/doxygen/commit/ed178335e8c123b58c4fee24766bceae0fc80aa2">view</a>]</li>
-<li>Escape &quot;@&quot; in names as it is not allowed in XML / Docbook names (coming from anon namespaces) [<a href="http://github.com/doxygen/doxygen/commit/65c35c435ae93d5f39c3ddec93008b2f544544ca">view</a>]</li>
-<li>Fix for bug 746673. [<a href="http://github.com/doxygen/doxygen/commit/effbbcc72295f5843377ddce2794bcf6e7000322">view</a>]</li>
-<li>Fix for building diagram example conditionally [<a href="http://github.com/doxygen/doxygen/commit/f415b624a6cf6b9e577ec6131a23cb4a0e830aaf">view</a>]</li>
-<li>Fix for issue 744670 [<a href="http://github.com/doxygen/doxygen/commit/0d684381ac40574f6a948c56eb2da0445c3ee3bf">view</a>]</li>
-<li>Fix for issue 744671 [<a href="http://github.com/doxygen/doxygen/commit/192f9e8bf78e10c9d97e08264b1c76c8aa4edf2b">view</a>]</li>
-<li>Fix for rendering the template parameters of members of variadic template classes. [<a href="http://github.com/doxygen/doxygen/commit/32093bcca82c7d3a4df4670f52340033e9f16b62">view</a>]</li>
-<li>Fix missing brief documentation for overload and specialization functions [<a href="http://github.com/doxygen/doxygen/commit/c604aef8a6465f38f8f04276194a66a4e044dc84">view</a>]</li>
-<li>Fix nesting of XML tag &quot;literallayout&quot; for docbook output of enums. [<a href="http://github.com/doxygen/doxygen/commit/3abac31c525e6cf6898a1e8deb5c73f2a2ff5a8a">view</a>]</li>
-<li>Fix parsing of ODL-style properties [<a href="http://github.com/doxygen/doxygen/commit/6a8bef8852eb22558b3559ebe96d9e06e6cadfa7">view</a>]</li>
-<li>Fix potential null pointer dereference in src/classdef.cpp [<a href="http://github.com/doxygen/doxygen/commit/5743848928ffaeccaaef24dac051aaa9acf2c4b7">view</a>]</li>
-<li>Fix potential null pointer dereference in src/context.cpp [<a href="http://github.com/doxygen/doxygen/commit/2690774f87b9fcb12b35153de82cde22248b3949">view</a>]</li>
-<li>Fixed a couple of cases where sharing string data could lead to corruption [<a href="http://github.com/doxygen/doxygen/commit/312bef563a5be72f6423377247db1b80044bf711">view</a>]</li>
-<li>Fixed code reachability bug found by coverity in translator_fi.h [<a href="http://github.com/doxygen/doxygen/commit/80d09775da9a99a3bc58704ffd055547c6b03043">view</a>]</li>
-<li>Fixed compilation issue on Windows [<a href="http://github.com/doxygen/doxygen/commit/d75455eef7c91f11c2b9061d9a086ce93c4231b2">view</a>]</li>
-<li>Fixed issue accessing uninitialized buffer under certain conditions. [<a href="http://github.com/doxygen/doxygen/commit/49f6c63aba4d77cd14fa205bee4bf427cefdaa44">view</a>]</li>
-<li>Fixed potential crash while generating dot graphs [<a href="http://github.com/doxygen/doxygen/commit/50f82c94b9bf1ff982f9ddd8b9a88fb91d9e0bec">view</a>]</li>
-<li>Fixed potential string buffer issue for dot graphs [<a href="http://github.com/doxygen/doxygen/commit/6b24aba8fce772d9e46e3174a655281eeb44ad84">view</a>]</li>
-<li>Fixed regression due to buffer resizing while generating RTF. [<a href="http://github.com/doxygen/doxygen/commit/a1f2872ef098cfcc526002b9c9d533da6f2775b5">view</a>]</li>
-<li>Fixed regression in argument processing [<a href="http://github.com/doxygen/doxygen/commit/ae8f618d140b4368045d286a682df3f6de7b2960">view</a>]</li>
-<li>Fixed type in printdocvisitor.h [<a href="http://github.com/doxygen/doxygen/commit/c9465bd210d8250a5439f22bf564c187cd45e968">view</a>]</li>
-<li>Fixed typos in comments. [<a href="http://github.com/doxygen/doxygen/commit/b82320a6f57519443c46e5e3044fef97b1f8f618">view</a>]</li>
-<li>Fixes for showing type constraint relations [<a href="http://github.com/doxygen/doxygen/commit/95375152974fa7e0e4d4cec7007d942dd5e9615e">view</a>]</li>
-<li>Fortran FUNCTION source code [<a href="http://github.com/doxygen/doxygen/commit/25a90990662449808c5ba58c243a7835d13ba750">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/e7a6a682137a82dbdf847b1879f320ece4f3642f">view</a>]</li>
-<li>Fortran: code color GOTO as flow keyword. [<a href="http://github.com/doxygen/doxygen/commit/8090675790ad9265bcffdf07ab4d48fc8c037276">view</a>]</li>
-<li>Fortran: fixed format position 73 and further is comment [<a href="http://github.com/doxygen/doxygen/commit/557ad21ce28d093044101eb8bee2c4df1621da7a">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/eb92c064b33bf9f303233210b9693215b0fb7f9d">view</a>]</li>
-<li>Fortran: warning message about not documented module member [<a href="http://github.com/doxygen/doxygen/commit/dcdd35ce2a0cda024525298a9a20d6c746539e6d">view</a>]</li>
-<li>Guarded debug prints against printing a NULL pointer. [<a href="http://github.com/doxygen/doxygen/commit/0831c71c05c9204839e187759f13303e64783730">view</a>]</li>
-<li>HTML entity &amp;deg; gives problems in LaTeX [<a href="http://github.com/doxygen/doxygen/commit/072383ed1c6fcfff7a7619d92ce3a8cb0b91fff9">view</a>]</li>
-<li>Help message regarding layout file [<a href="http://github.com/doxygen/doxygen/commit/7569f42d95332a5948e9d35e94e88d56d11634a9">view</a>],[<a href="http://github.com/doxygen/doxygen/commit/ad0e5fe14dce093e3b00ca677849cacbc2d657b7">view</a>]</li>
-<li>Internal debug option -d lex is not described [<a href="http://github.com/doxygen/doxygen/commit/00a91ae9fabe7783260c7c3fcdfec5b1ead49350">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/ebe3e8ec4a09edbb8a5b2dde88b6c479b03c0be9">view</a>]</li>
-<li>Internal doxygen docs gives: warning: Unsupported xml/html tag &lt;...&gt; found [<a href="http://github.com/doxygen/doxygen/commit/e366acaf0c27ce43ec80a70c0667c27cd5ef9d29">view</a>]</li>
-<li>Missing cross reference link [<a href="http://github.com/doxygen/doxygen/commit/213e680537303959f29b2424d40d74ecf66cb3f6">view</a>]</li>
-<li>Patch fixing a typo in Pull Request 307 [<a href="http://github.com/doxygen/doxygen/commit/6913c67ff1f9f20a71333f78cacd87a9e0c7756f">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/eac0fd660bffe62ae29a190308bf21b21d49647b">view</a>]</li>
-<li>Prevent example.tag from being regenerated [<a href="http://github.com/doxygen/doxygen/commit/d49604f814ceb22f81571d8ca99540e62cfa979a">view</a>]</li>
-<li>Problem running tests under Windows [<a href="http://github.com/doxygen/doxygen/commit/9bd54df7ba7dd15783f5a9180c85a7137dcdbc08">view</a>]</li>
-<li>Remove the new line after @startuml in generated pu file [<a href="http://github.com/doxygen/doxygen/commit/edf8dbbbc17e65e2eb97b5c9b4763a04969017fe">view</a>]</li>
-<li>Remove unreachable code [<a href="http://github.com/doxygen/doxygen/commit/d3e7b06f3a82780083e27bb83360ed9496df9f8d">view</a>]</li>
-<li>Remove unused local and static global variables [<a href="http://github.com/doxygen/doxygen/commit/d03e4c2ae1864c6f27a4341449ce97133aeb6847">view</a>]</li>
-<li>Remove wrong &lt;/File&gt; [<a href="http://github.com/doxygen/doxygen/commit/e8cef724a1f40896f9c6294d6f410e240b6365ee">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/efd55ae1787f8f7ec35761849dc7cfd3175f8b33">view</a>]</li>
-<li>Removed OS version check for MACOSX (was not used anywhere) [<a href="http://github.com/doxygen/doxygen/commit/1e3e9f03e746d4ac46c9c7b1b80e7e3100ee42f0">view</a>]</li>
-<li>Removed dbus XML parser, various refinements [<a href="http://github.com/doxygen/doxygen/commit/551012f2647c53d8532d638361011d003d5b81f3">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/bf4aee305879406d9057864ab7f8938e01ca8bd0">view</a>]</li>
-<li>Removed old build files, added install targets and other options [<a href="http://github.com/doxygen/doxygen/commit/7bcf8e9a379ec0599160e5562f07b93f8fb9557a">view</a>]</li>
-<li>Repair doxygen generate invalid styleSheetFile and extensionsFile of RTF [<a href="http://github.com/doxygen/doxygen/commit/0d208bc1c9a32718a93eb9911220ba72ad27fb9a">view</a>]</li>
-<li>Replace to_c_cmd by resource compiler [<a href="http://github.com/doxygen/doxygen/commit/2e39e5c7c1427ac6b24c64b7ef01be8d5a20092b">view</a>]</li>
-<li>Restore deleted file [<a href="http://github.com/doxygen/doxygen/commit/dfe93f9fde39167eae2aeeab929641a9c56cc916">view</a>]</li>
-<li>Showing grey/gray in documentation [<a href="http://github.com/doxygen/doxygen/commit/320ebb35dd4a615a7a692d71de4587be9ce8b99b">view</a>]</li>
-<li>Suggestion to use stripPrefix has been implemented for RESULT. For consistency also implemented for arguments. [<a href="http://github.com/doxygen/doxygen/commit/610bdb67c4db775debf26d85091383938d946f3d">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/6720a714461b9454c7cdbae7ceff7eb735feeb3b">view</a>]</li>
-<li>Support diff that returns &quot;No differences encountered&quot; when comparing test results [<a href="http://github.com/doxygen/doxygen/commit/4716f426332d02eb6841c509658b8a709cce9318">view</a>]</li>
-<li>Support generating index-color PNG files [<a href="http://github.com/doxygen/doxygen/commit/a09ffed2f603699955c18c19e0d3e782fb61d93f">view</a>]</li>
-<li>Switched back to version 6.2 of JavaCC for VHDL parser generation. [<a href="http://github.com/doxygen/doxygen/commit/088896f27f460b6ac03c2d64df148e3617c1e519">view</a>]</li>
-<li>Tcl: fix for extra line breaks in source browser introduced by commit 312bef5 [<a href="http://github.com/doxygen/doxygen/commit/3cc116ba2250e6946773ec22c6c7c6557773d28e">view</a>]</li>
-<li>TranslatorSwedish updated [<a href="http://github.com/doxygen/doxygen/commit/eaa19e3a439a4652023b47b0cf47c7303484ef5d">view</a>]</li>
-<li>Update of search from &quot;endless search to &#39;Character search: criterion. [<a href="http://github.com/doxygen/doxygen/commit/a0820f29e60be1555b5b0c92a975bf334b6f5258">view</a>]</li>
-<li>Update translator_cn.h [<a href="http://github.com/doxygen/doxygen/commit/a88d3549373990bfac09f936748577fc5c59d240">view</a>]</li>
-<li>Updated changelog for 1.8.9.1 [<a href="http://github.com/doxygen/doxygen/commit/f8671a4520350fe38f986fdd199c2344452e7a01">view</a>]</li>
-<li>Updated installation section of the manual [<a href="http://github.com/doxygen/doxygen/commit/db6a3ab2761a328e74fdccf243ff148af7623062">view</a>]</li>
-<li>Various VHDL related fixes [<a href="http://github.com/doxygen/doxygen/commit/34b00c442308efe169cc89fad62588fdce1d84e8">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/3eed7a5c5b330736b508c722c9614c774a678ef1">view</a>],
-[<a href="http://github.com/doxygen/doxygen/commit/530647f76a7660a406d102269dc041b00b0e3d4e">view</a>]</li>
-<li>Various minor changes [<a href="http://github.com/doxygen/doxygen/commit/f63d9ed958d2c06717434e1a90e6417cf2d60f6b">view</a>]</li>
-<li>Warning message multiple mainpages [<a href="http://github.com/doxygen/doxygen/commit/17fdd71a0f7a02e8b72eaf86d67bc142210a7059">view</a>]</li>
-<li>Warnings without filename [<a href="http://github.com/doxygen/doxygen/commit/da3faf6b93fd3eb4e751d2c0cbd4ed9ceae7922b">view</a>]</li>
-<li>add support for github flavored fenced code blocks [<a href="http://github.com/doxygen/doxygen/commit/288ea42fc27389160c20912003a7972e21195265">view</a>]</li>
-<li>added HHC.exe own output to the debug output when extcmd flag enabled [<a href="http://github.com/doxygen/doxygen/commit/4438e24b478de1fd97ccc81a3a9f7651124e1c63">view</a>]</li>
-<li>doc/translator.py -- minor updates [<a href="http://github.com/doxygen/doxygen/commit/1ccc93fd699b34b7a89acecf9e59a526a5972bb8">view</a>]</li>
-<li>drop #include &lt;unistd.h&gt; [<a href="http://github.com/doxygen/doxygen/commit/1dd0cf03f5bf173fa4ac3bb8279d12fff1b98eb7">view</a>]</li>
-<li>fix *.l for three backticks [<a href="http://github.com/doxygen/doxygen/commit/bb93db0d60fd4cd123dfc886ecd20167068db6ba">view</a>]</li>
-<li>fix enum brief description in RTF output [<a href="http://github.com/doxygen/doxygen/commit/87429a2609b822d2b08ec17fb2a20464a5043c9e">view</a>]</li>
-<li>fix for CHM TOC &quot;Classes&quot; entry to point to annotated file [<a href="http://github.com/doxygen/doxygen/commit/700a9ac3c177fdef25b9b00ed6bb5e0ea963d236">view</a>]</li>
-<li>fix for src/translator_tw.h by Gary Lee (translation cleaned) [<a href="http://github.com/doxygen/doxygen/commit/d101790db5e64a64f4db0e46391bbb1b0dadc8b1">view</a>]</li>
-<li>increase the size of l when result is modified [<a href="http://github.com/doxygen/doxygen/commit/dd0d738683029f80a42b6673e0b1b1228bebfce3">view</a>]</li>
-<li>move layout_default.xml to templates/html/ [<a href="http://github.com/doxygen/doxygen/commit/45ebb6ff4846255ad7209e3bec7cd4fe0544ffd5">view</a>]</li>
-<li>runtests.pl: mmn version has dash as separator [<a href="http://github.com/doxygen/doxygen/commit/f5efa2f383fe89b53bd8fc27b2116e8636417ebf">view</a>]</li>
-<li>specify that doxygen searches files in INPUT tag [<a href="http://github.com/doxygen/doxygen/commit/0971dc7771be1b386a204c3d11515f7d0f5af427">view</a>]</li>
-<li>sqlite3: add regexp searches to search.py [<a href="http://github.com/doxygen/doxygen/commit/13dd6d635e7ba2beb26a0d2ee8542ac63d1c7973">view</a>]</li>
-<li>sqlite3: add schema comments [<a href="http://github.com/doxygen/doxygen/commit/ef5d48d93f5565ebca9aae4ba9d6633c32719ecc">view</a>]</li>
-<li>sqlite3: fix constness [<a href="http://github.com/doxygen/doxygen/commit/90d89d8a2a2be931742c7291cd70e4a980035ae1">view</a>]</li>
-<li>version.py pass configure file path as parameter [<a href="http://github.com/doxygen/doxygen/commit/75e8f4c80ab5c06a33eaaf7ec587ee35ed9c1b1a">view</a>]</li>
-<li>xml: use STRIP_FROM_PATH on @file attributes. [<a href="http://github.com/doxygen/doxygen/commit/29ae707794042a97412eaa137fa7b30f2367294d">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/5a0379944f8bdf883fdb25e94e0cdb1e5d2f4366">view</a>]</li>
+<li>change the build system to use cmake [<a href="https://github.com/doxygen/doxygen/commit/2e099b1950eee2c3a0d5d8ae4b25575caeb938b1">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/ba9bb02abf6f6922a83beb2092e7bc270e6f25c1">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/635d8cf30e702bdf83fe5c96452f8f863d57bdee">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/51ee91560a9cbaac41cec536dcdeb3e4c32f139a">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/e775357ae71ecbf02dc93913a923567f31b03681">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/a0cd6a8e0c19a82e9662f96734c7ba21726794d0">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/0dc4eda500e803a65a10445719c97d7e523897da">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/22c0d75d45354979392db5db4e3195570c394e44">view</a>]</li>
+<li>Add support for basic XML syntax highlighting. [<a href="https://github.com/doxygen/doxygen/commit/a418518921ba7a99c7221ba7f40d2e791cb207c4">view</a>]</li>
+<li>Added documentation for ``` style fenced code block and more robust parsing [<a href="https://github.com/doxygen/doxygen/commit/39ba42c3b21d08ec606eee18ee8b64c67ec6a42a">view</a>]</li>
+<li>Added function arguments to the LaTeX toc [<a href="https://github.com/doxygen/doxygen/commit/f5e70723391bacc2d68c19d367ab414e70f786b4">view</a>]</li>
+<li>Added missing files and build instructions [<a href="https://github.com/doxygen/doxygen/commit/39228176c052fd293382dc9bc9b4b69b2a6af277">view</a>]</li>
+<li>Added missing libraries for building doxysearch on Windows [<a href="https://github.com/doxygen/doxygen/commit/84d94779e76681b63cdcbc362bbe0341cd39064d">view</a>]</li>
+<li>Added support for language codes [<a href="https://github.com/doxygen/doxygen/commit/eae07d978b524c787daeab911ca087b47a964577">view</a>]</li>
+<li>Added type constraint relations for Java generics to dot graphs and XML output [<a href="https://github.com/doxygen/doxygen/commit/080a465b1321ff93c05ce398cd18a577e0ebae4b">view</a>]</li>
+<li>Adding commands \hidecallgraph and \hidecallergraph [<a href="https://github.com/doxygen/doxygen/commit/073e9482a516c24a3d045da049941bfd432f3354">view</a>]</li>
+<li>Adjust test script for longer version number [<a href="https://github.com/doxygen/doxygen/commit/c7622971ee485279e8da7634207340ce18b69aaa">view</a>]</li>
+<li>Adjusted version in configure script [<a href="https://github.com/doxygen/doxygen/commit/cbd3fa183815191ac5f172a2bac62991642c0b5e">view</a>]</li>
+<li>Alignment of project name [<a href="https://github.com/doxygen/doxygen/commit/e7b356d2cb9320a363ac024d39b468e98b223b90">view</a>]</li>
+<li>Allow selection of specific translators to compile in at build time [<a href="https://github.com/doxygen/doxygen/commit/faef77a87cecd703e3629a35d2e22efb07e682a0">view</a>]</li>
+<li>Based on the report of Peter D. Barnes in the doxygen forum (http://doxygen.10944.n7.nabble.com/doxygen-1-8-9-1-upgrade-errors-td6990.html) [<a href="https://github.com/doxygen/doxygen/commit/9771b807cd776b37f6538dec085442218a5b6a09">view</a>]</li>
+<li>Better error message in case of IDL inconsistency [<a href="https://github.com/doxygen/doxygen/commit/a7eef85a89d8772b7ab97a4ba378cc7e78c988cc">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4415">4415</a> - EXTRA_PACKAGES can&#39;t handle package options [<a href="https://github.com/doxygen/doxygen/commit/1c47dd436358ffc7bc76901cddc559b2d8ce233d">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/ad53cbab6474e11692f2ca1018a821d042df28e6">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5673">5673</a> - Using HTML entities in PROJECT_NAME [<a href="https://github.com/doxygen/doxygen/commit/8e44571521391403e8d85f893acb926e021e926b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5697">5697</a> - Missing documentation after nested C++11 unified initializer [<a href="https://github.com/doxygen/doxygen/commit/c1789f2e5d8421d6028c836ab66afecacff284ef">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5698">5698</a> - Bogus warning: citelist: Unexpected new line character [<a href="https://github.com/doxygen/doxygen/commit/5c321cbb6359bc1bb875729c08beba2edc084500">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5704">5704</a> - @todo paragraphs incorrectly placed in rtf output [<a href="https://github.com/doxygen/doxygen/commit/600d5859d7bcb94b08ef656fd427914766ae9afe">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5705">5705</a> - Bogus message with addtogroup [<a href="https://github.com/doxygen/doxygen/commit/b75af9180ae53f7c7abb94ccf906333169247785">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5707">5707</a> - Configuring doxyfile to only output docbook produces erroneous warning [<a href="https://github.com/doxygen/doxygen/commit/05fcf8decc25bd2f1a2e7867ee8e5d9da1f08933">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5709">5709</a> - latex compilation: \backmatter incompatible with COMPACT_LATEX=YES [<a href="https://github.com/doxygen/doxygen/commit/c9067c5bb9a1868e0963dc210cf3b7152c4aa79a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5710">5710</a> - Wrong icons in TOC of CHM help [<a href="https://github.com/doxygen/doxygen/commit/8c97e0cd63bcf942ee5b43c9471055a4ea27551c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5720">5720</a> - &lt;CAPTION&gt; inside &lt;TABLE&gt; no longer works for LaTex output [<a href="https://github.com/doxygen/doxygen/commit/0599f92d06ff433446f34136ffe2f3d65d6bd109">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5726">5726</a> - Duplicate anchors from tagfiles [<a href="https://github.com/doxygen/doxygen/commit/1f21c23c57c91ba6901c0de38bb236f7246e88c9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5727">5727</a> - Tagfile anchors not generated for enumeration values [<a href="https://github.com/doxygen/doxygen/commit/1d4f37cb13a75ca8bdc49be3558438104e7eef19">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5728">5728</a> - Non-ascii characters are not emphasised [<a href="https://github.com/doxygen/doxygen/commit/8f67d4f63efd45b0d38502bdf68987d7fc1e92e9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5744">5744</a> - Using TAGFILES prevents symbol extraction [<a href="https://github.com/doxygen/doxygen/commit/a735498be5a572236755cc3da65bf4774cbac25c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5753">5753</a> - PATCH: please consider making doxygen output byte for byte identical between individual runs by default [<a href="https://github.com/doxygen/doxygen/commit/3f2e8a3067712b025623e4420e6eb161febfd42b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5754">5754</a> - Doxygen generates bad &quot;More...&quot; file links for functions within a namespace [<a href="https://github.com/doxygen/doxygen/commit/ea202be55d68af33917658e3fec169da3a7fa7a8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5756">5756</a> - [PATCH] QT4&#39;s qmake is titled differently on Fedora 21 [<a href="https://github.com/doxygen/doxygen/commit/3bd3ad9f8f4d010e42f0ba8eeab229f44b1ecb1c">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/a883f65ab94973d4c7948623186159f978517851">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5761">5761</a> - last enum member not documented [<a href="https://github.com/doxygen/doxygen/commit/50a329c056a2676608f30321a3207ff17ab20abb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5764">5764</a> - Nested list in C# XML comments closes outer list prematurely [<a href="https://github.com/doxygen/doxygen/commit/2c679e7d39144dadef2e9fd25772f0e41586e18b">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/7a0522fafde300f36c3d5264f46c1f70cf35b7b9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5768">5768</a> - Bogus warning regarding nested comments [<a href="https://github.com/doxygen/doxygen/commit/e4c0036962d8fa0ea9c1e38dbdb5e91168201f22">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5769">5769</a> - Bogus warnings in case of anonymous namespace and @todo [<a href="https://github.com/doxygen/doxygen/commit/298ab30b2a2aa0936f4683c9366afd44c00adc60">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5772">5772</a> - Don&#39;t warn about missing documentation for deleted functions. [<a href="https://github.com/doxygen/doxygen/commit/796d6585be58d1c9112422a919f49d1998dc672c">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/ac576bd974ac27bc1f395e8ae6c77b19f800b6db">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5774">5774</a> - Table of content incorrect with escaped symbols [<a href="https://github.com/doxygen/doxygen/commit/5cdf62661c88b5f0c135337da4d6e58581aad037">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5777">5777</a> - man output should escape minus signs [<a href="https://github.com/doxygen/doxygen/commit/3608a668b3892eaa4f7b2e4b29b833ede24ceee7">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5779">5779</a> - Bug #313527 regression - Enum in bitfield is not parsed properly. [<a href="https://github.com/doxygen/doxygen/commit/528bb8054ca362843630ec261ca6e6990a206081">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/7b2d77abb73288bdd48ca04720fd6779e0bf94c2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5793">5793</a> - FILE_PATTERNS ignores arbitrary extensions [<a href="https://github.com/doxygen/doxygen/commit/52cb086da66533332962f2bf9cb35772e980c092">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5814">5814</a> - class scoped enum documentation appearing at group level instead of class level [<a href="https://github.com/doxygen/doxygen/commit/e4a9d06d7871f24dd6e37ecac6addae729e6d721">view</a>]</li>
+<li>Build fixes for windows build [<a href="https://github.com/doxygen/doxygen/commit/5446770855a8286092abdd91d9069cb3191c209d">view</a>]</li>
+<li>Bump copyright year [<a href="https://github.com/doxygen/doxygen/commit/e11b48785323017bf1d81e91e8133d7f3ba1f243">view</a>]</li>
+<li>Bump version in configure script [<a href="https://github.com/doxygen/doxygen/commit/97342f92e111d7aa3e423a128379a6018820ce6c">view</a>]</li>
+<li>Cleanup &amp; adapt travis config [<a href="https://github.com/doxygen/doxygen/commit/5f67c67323bff27751ba07c417ba99180fa0d762">view</a>]</li>
+<li>Consistency in handling HTML and LaTeX in respect to header and footer [<a href="https://github.com/doxygen/doxygen/commit/be5cc75ffc2e0a95ecbf0ce8d918b070c276d3e5">view</a>]</li>
+<li>Correct string buffer sizes for RTF output, such that the string is always correctly sized. [<a href="https://github.com/doxygen/doxygen/commit/bc8e705cf90cecdff8a247264c249ffed1d2af4a">view</a>]</li>
+<li>Crash in case of non generic interface in Fortran [<a href="https://github.com/doxygen/doxygen/commit/7d3a2abf0137c5257eeb0a8e0f76381b79f1e7bb">view</a>]</li>
+<li>Documentation HTML Header, Footer, and Stylesheet changes [<a href="https://github.com/doxygen/doxygen/commit/1dded5c92a13f9db60fc630cbe5f2cc5ad9bede0">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/478207365d7f09f0e676a76f654502c084806e4e">view</a>]</li>
+<li>Documenting RESULT variable of Fortran FUNCTION [<a href="https://github.com/doxygen/doxygen/commit/21f9e87db8085fb1b5e0a9a9a25dee159b3fd324">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/4d52beec3760244d959ab4d5528aea1acba505e7">view</a>]</li>
+<li>Doxygen LaTeX / PDF links point to page 1 [<a href="https://github.com/doxygen/doxygen/commit/e34913dcbe0bee2c3e21d6e21b2bcc6970003a5c">view</a>]</li>
+<li>Enable relative paths referenced source files [<a href="https://github.com/doxygen/doxygen/commit/ed178335e8c123b58c4fee24766bceae0fc80aa2">view</a>]</li>
+<li>Escape &quot;@&quot; in names as it is not allowed in XML / Docbook names (coming from anon namespaces) [<a href="https://github.com/doxygen/doxygen/commit/65c35c435ae93d5f39c3ddec93008b2f544544ca">view</a>]</li>
+<li>Fix for bug 746673. [<a href="https://github.com/doxygen/doxygen/commit/effbbcc72295f5843377ddce2794bcf6e7000322">view</a>]</li>
+<li>Fix for building diagram example conditionally [<a href="https://github.com/doxygen/doxygen/commit/f415b624a6cf6b9e577ec6131a23cb4a0e830aaf">view</a>]</li>
+<li>Fix for issue 744670 [<a href="https://github.com/doxygen/doxygen/commit/0d684381ac40574f6a948c56eb2da0445c3ee3bf">view</a>]</li>
+<li>Fix for issue 744671 [<a href="https://github.com/doxygen/doxygen/commit/192f9e8bf78e10c9d97e08264b1c76c8aa4edf2b">view</a>]</li>
+<li>Fix for rendering the template parameters of members of variadic template classes. [<a href="https://github.com/doxygen/doxygen/commit/32093bcca82c7d3a4df4670f52340033e9f16b62">view</a>]</li>
+<li>Fix missing brief documentation for overload and specialization functions [<a href="https://github.com/doxygen/doxygen/commit/c604aef8a6465f38f8f04276194a66a4e044dc84">view</a>]</li>
+<li>Fix nesting of XML tag &quot;literallayout&quot; for docbook output of enums. [<a href="https://github.com/doxygen/doxygen/commit/3abac31c525e6cf6898a1e8deb5c73f2a2ff5a8a">view</a>]</li>
+<li>Fix parsing of ODL-style properties [<a href="https://github.com/doxygen/doxygen/commit/6a8bef8852eb22558b3559ebe96d9e06e6cadfa7">view</a>]</li>
+<li>Fix potential null pointer dereference in src/classdef.cpp [<a href="https://github.com/doxygen/doxygen/commit/5743848928ffaeccaaef24dac051aaa9acf2c4b7">view</a>]</li>
+<li>Fix potential null pointer dereference in src/context.cpp [<a href="https://github.com/doxygen/doxygen/commit/2690774f87b9fcb12b35153de82cde22248b3949">view</a>]</li>
+<li>Fixed a couple of cases where sharing string data could lead to corruption [<a href="https://github.com/doxygen/doxygen/commit/312bef563a5be72f6423377247db1b80044bf711">view</a>]</li>
+<li>Fixed code reachability bug found by coverity in translator_fi.h [<a href="https://github.com/doxygen/doxygen/commit/80d09775da9a99a3bc58704ffd055547c6b03043">view</a>]</li>
+<li>Fixed compilation issue on Windows [<a href="https://github.com/doxygen/doxygen/commit/d75455eef7c91f11c2b9061d9a086ce93c4231b2">view</a>]</li>
+<li>Fixed issue accessing uninitialized buffer under certain conditions. [<a href="https://github.com/doxygen/doxygen/commit/49f6c63aba4d77cd14fa205bee4bf427cefdaa44">view</a>]</li>
+<li>Fixed potential crash while generating dot graphs [<a href="https://github.com/doxygen/doxygen/commit/50f82c94b9bf1ff982f9ddd8b9a88fb91d9e0bec">view</a>]</li>
+<li>Fixed potential string buffer issue for dot graphs [<a href="https://github.com/doxygen/doxygen/commit/6b24aba8fce772d9e46e3174a655281eeb44ad84">view</a>]</li>
+<li>Fixed regression due to buffer resizing while generating RTF. [<a href="https://github.com/doxygen/doxygen/commit/a1f2872ef098cfcc526002b9c9d533da6f2775b5">view</a>]</li>
+<li>Fixed regression in argument processing [<a href="https://github.com/doxygen/doxygen/commit/ae8f618d140b4368045d286a682df3f6de7b2960">view</a>]</li>
+<li>Fixed type in printdocvisitor.h [<a href="https://github.com/doxygen/doxygen/commit/c9465bd210d8250a5439f22bf564c187cd45e968">view</a>]</li>
+<li>Fixed typos in comments. [<a href="https://github.com/doxygen/doxygen/commit/b82320a6f57519443c46e5e3044fef97b1f8f618">view</a>]</li>
+<li>Fixes for showing type constraint relations [<a href="https://github.com/doxygen/doxygen/commit/95375152974fa7e0e4d4cec7007d942dd5e9615e">view</a>]</li>
+<li>Fortran FUNCTION source code [<a href="https://github.com/doxygen/doxygen/commit/25a90990662449808c5ba58c243a7835d13ba750">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/e7a6a682137a82dbdf847b1879f320ece4f3642f">view</a>]</li>
+<li>Fortran: code color GOTO as flow keyword. [<a href="https://github.com/doxygen/doxygen/commit/8090675790ad9265bcffdf07ab4d48fc8c037276">view</a>]</li>
+<li>Fortran: fixed format position 73 and further is comment [<a href="https://github.com/doxygen/doxygen/commit/557ad21ce28d093044101eb8bee2c4df1621da7a">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/eb92c064b33bf9f303233210b9693215b0fb7f9d">view</a>]</li>
+<li>Fortran: warning message about not documented module member [<a href="https://github.com/doxygen/doxygen/commit/dcdd35ce2a0cda024525298a9a20d6c746539e6d">view</a>]</li>
+<li>Guarded debug prints against printing a NULL pointer. [<a href="https://github.com/doxygen/doxygen/commit/0831c71c05c9204839e187759f13303e64783730">view</a>]</li>
+<li>HTML entity &amp;deg; gives problems in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/072383ed1c6fcfff7a7619d92ce3a8cb0b91fff9">view</a>]</li>
+<li>Help message regarding layout file [<a href="https://github.com/doxygen/doxygen/commit/7569f42d95332a5948e9d35e94e88d56d11634a9">view</a>],[<a href="https://github.com/doxygen/doxygen/commit/ad0e5fe14dce093e3b00ca677849cacbc2d657b7">view</a>]</li>
+<li>Internal debug option -d lex is not described [<a href="https://github.com/doxygen/doxygen/commit/00a91ae9fabe7783260c7c3fcdfec5b1ead49350">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/ebe3e8ec4a09edbb8a5b2dde88b6c479b03c0be9">view</a>]</li>
+<li>Internal doxygen docs gives: warning: Unsupported xml/html tag &lt;...&gt; found [<a href="https://github.com/doxygen/doxygen/commit/e366acaf0c27ce43ec80a70c0667c27cd5ef9d29">view</a>]</li>
+<li>Missing cross reference link [<a href="https://github.com/doxygen/doxygen/commit/213e680537303959f29b2424d40d74ecf66cb3f6">view</a>]</li>
+<li>Patch fixing a typo in Pull Request 307 [<a href="https://github.com/doxygen/doxygen/commit/6913c67ff1f9f20a71333f78cacd87a9e0c7756f">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/eac0fd660bffe62ae29a190308bf21b21d49647b">view</a>]</li>
+<li>Prevent example.tag from being regenerated [<a href="https://github.com/doxygen/doxygen/commit/d49604f814ceb22f81571d8ca99540e62cfa979a">view</a>]</li>
+<li>Problem running tests under Windows [<a href="https://github.com/doxygen/doxygen/commit/9bd54df7ba7dd15783f5a9180c85a7137dcdbc08">view</a>]</li>
+<li>Remove the new line after @startuml in generated pu file [<a href="https://github.com/doxygen/doxygen/commit/edf8dbbbc17e65e2eb97b5c9b4763a04969017fe">view</a>]</li>
+<li>Remove unreachable code [<a href="https://github.com/doxygen/doxygen/commit/d3e7b06f3a82780083e27bb83360ed9496df9f8d">view</a>]</li>
+<li>Remove unused local and static global variables [<a href="https://github.com/doxygen/doxygen/commit/d03e4c2ae1864c6f27a4341449ce97133aeb6847">view</a>]</li>
+<li>Remove wrong &lt;/File&gt; [<a href="https://github.com/doxygen/doxygen/commit/e8cef724a1f40896f9c6294d6f410e240b6365ee">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/efd55ae1787f8f7ec35761849dc7cfd3175f8b33">view</a>]</li>
+<li>Removed OS version check for MACOSX (was not used anywhere) [<a href="https://github.com/doxygen/doxygen/commit/1e3e9f03e746d4ac46c9c7b1b80e7e3100ee42f0">view</a>]</li>
+<li>Removed dbus XML parser, various refinements [<a href="https://github.com/doxygen/doxygen/commit/551012f2647c53d8532d638361011d003d5b81f3">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/bf4aee305879406d9057864ab7f8938e01ca8bd0">view</a>]</li>
+<li>Removed old build files, added install targets and other options [<a href="https://github.com/doxygen/doxygen/commit/7bcf8e9a379ec0599160e5562f07b93f8fb9557a">view</a>]</li>
+<li>Repair doxygen generate invalid styleSheetFile and extensionsFile of RTF [<a href="https://github.com/doxygen/doxygen/commit/0d208bc1c9a32718a93eb9911220ba72ad27fb9a">view</a>]</li>
+<li>Replace to_c_cmd by resource compiler [<a href="https://github.com/doxygen/doxygen/commit/2e39e5c7c1427ac6b24c64b7ef01be8d5a20092b">view</a>]</li>
+<li>Restore deleted file [<a href="https://github.com/doxygen/doxygen/commit/dfe93f9fde39167eae2aeeab929641a9c56cc916">view</a>]</li>
+<li>Showing grey/gray in documentation [<a href="https://github.com/doxygen/doxygen/commit/320ebb35dd4a615a7a692d71de4587be9ce8b99b">view</a>]</li>
+<li>Suggestion to use stripPrefix has been implemented for RESULT. For consistency also implemented for arguments. [<a href="https://github.com/doxygen/doxygen/commit/610bdb67c4db775debf26d85091383938d946f3d">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/6720a714461b9454c7cdbae7ceff7eb735feeb3b">view</a>]</li>
+<li>Support diff that returns &quot;No differences encountered&quot; when comparing test results [<a href="https://github.com/doxygen/doxygen/commit/4716f426332d02eb6841c509658b8a709cce9318">view</a>]</li>
+<li>Support generating index-color PNG files [<a href="https://github.com/doxygen/doxygen/commit/a09ffed2f603699955c18c19e0d3e782fb61d93f">view</a>]</li>
+<li>Switched back to version 6.2 of JavaCC for VHDL parser generation. [<a href="https://github.com/doxygen/doxygen/commit/088896f27f460b6ac03c2d64df148e3617c1e519">view</a>]</li>
+<li>Tcl: fix for extra line breaks in source browser introduced by commit 312bef5 [<a href="https://github.com/doxygen/doxygen/commit/3cc116ba2250e6946773ec22c6c7c6557773d28e">view</a>]</li>
+<li>TranslatorSwedish updated [<a href="https://github.com/doxygen/doxygen/commit/eaa19e3a439a4652023b47b0cf47c7303484ef5d">view</a>]</li>
+<li>Update of search from &quot;endless search to &#39;Character search: criterion. [<a href="https://github.com/doxygen/doxygen/commit/a0820f29e60be1555b5b0c92a975bf334b6f5258">view</a>]</li>
+<li>Update translator_cn.h [<a href="https://github.com/doxygen/doxygen/commit/a88d3549373990bfac09f936748577fc5c59d240">view</a>]</li>
+<li>Updated changelog for 1.8.9.1 [<a href="https://github.com/doxygen/doxygen/commit/f8671a4520350fe38f986fdd199c2344452e7a01">view</a>]</li>
+<li>Updated installation section of the manual [<a href="https://github.com/doxygen/doxygen/commit/db6a3ab2761a328e74fdccf243ff148af7623062">view</a>]</li>
+<li>Various VHDL related fixes [<a href="https://github.com/doxygen/doxygen/commit/34b00c442308efe169cc89fad62588fdce1d84e8">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/3eed7a5c5b330736b508c722c9614c774a678ef1">view</a>],
+[<a href="https://github.com/doxygen/doxygen/commit/530647f76a7660a406d102269dc041b00b0e3d4e">view</a>]</li>
+<li>Various minor changes [<a href="https://github.com/doxygen/doxygen/commit/f63d9ed958d2c06717434e1a90e6417cf2d60f6b">view</a>]</li>
+<li>Warning message multiple mainpages [<a href="https://github.com/doxygen/doxygen/commit/17fdd71a0f7a02e8b72eaf86d67bc142210a7059">view</a>]</li>
+<li>Warnings without filename [<a href="https://github.com/doxygen/doxygen/commit/da3faf6b93fd3eb4e751d2c0cbd4ed9ceae7922b">view</a>]</li>
+<li>add support for github flavored fenced code blocks [<a href="https://github.com/doxygen/doxygen/commit/288ea42fc27389160c20912003a7972e21195265">view</a>]</li>
+<li>added HHC.exe own output to the debug output when extcmd flag enabled [<a href="https://github.com/doxygen/doxygen/commit/4438e24b478de1fd97ccc81a3a9f7651124e1c63">view</a>]</li>
+<li>doc/translator.py -- minor updates [<a href="https://github.com/doxygen/doxygen/commit/1ccc93fd699b34b7a89acecf9e59a526a5972bb8">view</a>]</li>
+<li>drop #include &lt;unistd.h&gt; [<a href="https://github.com/doxygen/doxygen/commit/1dd0cf03f5bf173fa4ac3bb8279d12fff1b98eb7">view</a>]</li>
+<li>fix *.l for three backticks [<a href="https://github.com/doxygen/doxygen/commit/bb93db0d60fd4cd123dfc886ecd20167068db6ba">view</a>]</li>
+<li>fix enum brief description in RTF output [<a href="https://github.com/doxygen/doxygen/commit/87429a2609b822d2b08ec17fb2a20464a5043c9e">view</a>]</li>
+<li>fix for CHM TOC &quot;Classes&quot; entry to point to annotated file [<a href="https://github.com/doxygen/doxygen/commit/700a9ac3c177fdef25b9b00ed6bb5e0ea963d236">view</a>]</li>
+<li>fix for src/translator_tw.h by Gary Lee (translation cleaned) [<a href="https://github.com/doxygen/doxygen/commit/d101790db5e64a64f4db0e46391bbb1b0dadc8b1">view</a>]</li>
+<li>increase the size of l when result is modified [<a href="https://github.com/doxygen/doxygen/commit/dd0d738683029f80a42b6673e0b1b1228bebfce3">view</a>]</li>
+<li>move layout_default.xml to templates/html/ [<a href="https://github.com/doxygen/doxygen/commit/45ebb6ff4846255ad7209e3bec7cd4fe0544ffd5">view</a>]</li>
+<li>runtests.pl: mmn version has dash as separator [<a href="https://github.com/doxygen/doxygen/commit/f5efa2f383fe89b53bd8fc27b2116e8636417ebf">view</a>]</li>
+<li>specify that doxygen searches files in INPUT tag [<a href="https://github.com/doxygen/doxygen/commit/0971dc7771be1b386a204c3d11515f7d0f5af427">view</a>]</li>
+<li>sqlite3: add regexp searches to search.py [<a href="https://github.com/doxygen/doxygen/commit/13dd6d635e7ba2beb26a0d2ee8542ac63d1c7973">view</a>]</li>
+<li>sqlite3: add schema comments [<a href="https://github.com/doxygen/doxygen/commit/ef5d48d93f5565ebca9aae4ba9d6633c32719ecc">view</a>]</li>
+<li>sqlite3: fix constness [<a href="https://github.com/doxygen/doxygen/commit/90d89d8a2a2be931742c7291cd70e4a980035ae1">view</a>]</li>
+<li>version.py pass configure file path as parameter [<a href="https://github.com/doxygen/doxygen/commit/75e8f4c80ab5c06a33eaaf7ec587ee35ed9c1b1a">view</a>]</li>
+<li>xml: use STRIP_FROM_PATH on @file attributes. [<a href="https://github.com/doxygen/doxygen/commit/29ae707794042a97412eaa137fa7b30f2367294d">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/5a0379944f8bdf883fdb25e94e0cdb1e5d2f4366">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -670,21 +670,21 @@
 <a name="1.8.9.1"></a>
 </p>
 <ul>
-<li>Fixed a couple of cases where sharing string data could lead to corruption [<a href="http://github.com/doxygen/doxygen/commit/312bef563a5be72f6423377247db1b80044bf711">view</a>]</li>
-<li>Various VHDL related fixes [<a href="http://github.com/doxygen/doxygen/commit/34b00c442308efe169cc89fad62588fdce1d84e8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5698">5698</a> - Bogus warning: citelist: Unexpected new line character [<a href="http://github.com/doxygen/doxygen/commit/5c321cbb6359bc1bb875729c08beba2edc084500">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5704">5704</a> - @todo paragraphs incorrectly placed in rtf output [<a href="http://github.com/doxygen/doxygen/commit/600d5859d7bcb94b08ef656fd427914766ae9afe">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5705">5705</a> - Bogus message with addtogroup [<a href="http://github.com/doxygen/doxygen/commit/b75af9180ae53f7c7abb94ccf906333169247785">view</a>]</li>
-<li>Documentation HTML Header, Footer, and Stylesheet changes [<a href="http://github.com/doxygen/doxygen/commit/478207365d7f09f0e676a76f654502c084806e4e">view</a>]</li>
-<li>Documenting RESULT variable of Fortran FUNCTION [<a href="http://github.com/doxygen/doxygen/commit/4d52beec3760244d959ab4d5528aea1acba505e7">view</a>]</li>
-<li>Fix potential null pointer dereference in src/context.cpp [<a href="http://github.com/doxygen/doxygen/commit/2690774f87b9fcb12b35153de82cde22248b3949">view</a>]</li>
-<li>Fixed compilation issue on Windows [<a href="http://github.com/doxygen/doxygen/commit/d75455eef7c91f11c2b9061d9a086ce93c4231b2">view</a>]</li>
-<li>Fortran FUNCTION source code [<a href="http://github.com/doxygen/doxygen/commit/25a90990662449808c5ba58c243a7835d13ba750">view</a>]</li>
-<li>Fortran: code color GOTO as flow keyword. [<a href="http://github.com/doxygen/doxygen/commit/8090675790ad9265bcffdf07ab4d48fc8c037276">view</a>]</li>
-<li>Help message regarding layout file [<a href="http://github.com/doxygen/doxygen/commit/7569f42d95332a5948e9d35e94e88d56d11634a9">view</a>]</li>
-<li>Remove unused local and static global variables [<a href="http://github.com/doxygen/doxygen/commit/d03e4c2ae1864c6f27a4341449ce97133aeb6847">view</a>]</li>
-<li>Suggestion to use stripPrefix has been implemented for RESULT. For consistency also implemented for arguments. [<a href="http://github.com/doxygen/doxygen/commit/6720a714461b9454c7cdbae7ceff7eb735feeb3b">view</a>]</li>
-<li>Switched back to version 6.2 of JavaCC for VHDL parser generation. [<a href="http://github.com/doxygen/doxygen/commit/088896f27f460b6ac03c2d64df148e3617c1e519">view</a>]</li>
+<li>Fixed a couple of cases where sharing string data could lead to corruption [<a href="https://github.com/doxygen/doxygen/commit/312bef563a5be72f6423377247db1b80044bf711">view</a>]</li>
+<li>Various VHDL related fixes [<a href="https://github.com/doxygen/doxygen/commit/34b00c442308efe169cc89fad62588fdce1d84e8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5698">5698</a> - Bogus warning: citelist: Unexpected new line character [<a href="https://github.com/doxygen/doxygen/commit/5c321cbb6359bc1bb875729c08beba2edc084500">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5704">5704</a> - @todo paragraphs incorrectly placed in rtf output [<a href="https://github.com/doxygen/doxygen/commit/600d5859d7bcb94b08ef656fd427914766ae9afe">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5705">5705</a> - Bogus message with addtogroup [<a href="https://github.com/doxygen/doxygen/commit/b75af9180ae53f7c7abb94ccf906333169247785">view</a>]</li>
+<li>Documentation HTML Header, Footer, and Stylesheet changes [<a href="https://github.com/doxygen/doxygen/commit/478207365d7f09f0e676a76f654502c084806e4e">view</a>]</li>
+<li>Documenting RESULT variable of Fortran FUNCTION [<a href="https://github.com/doxygen/doxygen/commit/4d52beec3760244d959ab4d5528aea1acba505e7">view</a>]</li>
+<li>Fix potential null pointer dereference in src/context.cpp [<a href="https://github.com/doxygen/doxygen/commit/2690774f87b9fcb12b35153de82cde22248b3949">view</a>]</li>
+<li>Fixed compilation issue on Windows [<a href="https://github.com/doxygen/doxygen/commit/d75455eef7c91f11c2b9061d9a086ce93c4231b2">view</a>]</li>
+<li>Fortran FUNCTION source code [<a href="https://github.com/doxygen/doxygen/commit/25a90990662449808c5ba58c243a7835d13ba750">view</a>]</li>
+<li>Fortran: code color GOTO as flow keyword. [<a href="https://github.com/doxygen/doxygen/commit/8090675790ad9265bcffdf07ab4d48fc8c037276">view</a>]</li>
+<li>Help message regarding layout file [<a href="https://github.com/doxygen/doxygen/commit/7569f42d95332a5948e9d35e94e88d56d11634a9">view</a>]</li>
+<li>Remove unused local and static global variables [<a href="https://github.com/doxygen/doxygen/commit/d03e4c2ae1864c6f27a4341449ce97133aeb6847">view</a>]</li>
+<li>Suggestion to use stripPrefix has been implemented for RESULT. For consistency also implemented for arguments. [<a href="https://github.com/doxygen/doxygen/commit/6720a714461b9454c7cdbae7ceff7eb735feeb3b">view</a>]</li>
+<li>Switched back to version 6.2 of JavaCC for VHDL parser generation. [<a href="https://github.com/doxygen/doxygen/commit/088896f27f460b6ac03c2d64df148e3617c1e519">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -695,87 +695,87 @@
 <a name="1.8.9"></a>
 </p>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4011">4011</a> - Fortran: external subroutine as dummy argument not recognized [<a href="http://github.com/doxygen/doxygen/commit/8f78eff7e8b2650f9a8364ff5c5b6925279e6b5a">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4011">4011</a> - Fortran: external subroutine as dummy argument not recognized [<a href="http://github.com/doxygen/doxygen/commit/fabd1194a2e3c2536dddc19945c568a690b17031">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4286">4286</a> - Brief description misplaced in man page output [<a href="http://github.com/doxygen/doxygen/commit/379e3b959a9566571db3c799a8338dd4436881b2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4293">4293</a> - Typedefs in manpages has too few linebreak possiblilities [<a href="http://github.com/doxygen/doxygen/commit/4bbcf71defb2e2be02494b7ff68d475d1a0438ac">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4914">4914</a> - C# &lt;code&gt; tag in an &lt;example&gt; tag does not render as expected. [<a href="http://github.com/doxygen/doxygen/commit/07d5f3f48a497993c525eab9a5ecc0429c317c98">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4941">4941</a> - Add support for LATEX_EXTRA_STYLESHEET [<a href="http://github.com/doxygen/doxygen/commit/fd91442bcc5a20ba298a024ee2cc375ec4f1714d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5237">5237</a> - Allow Class{T}.Method in cref to refer to a generic class in XML comments [<a href="http://github.com/doxygen/doxygen/commit/f9c9edba086f544b813ff036ea9209744da18c44">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5418">5418</a> - classes with same name in different namespace adding to same group [<a href="http://github.com/doxygen/doxygen/commit/73a5a4c48aec0c48353ecb8e5aa6d5ff02463132">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5462">5462</a> - Missing link for item inside the same namespace [<a href="http://github.com/doxygen/doxygen/commit/95aee340bddca0c09c79dc2f137a5ad01eb4fda8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5467">5467</a> - Added HIDE_COMPOUND_REFERENCE config option [<a href="http://github.com/doxygen/doxygen/commit/415ae7021eeee278ad6c95be23e572dc18ff6a32">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5554">5554</a> - QHP toc broken if mainpage with PROJECT_NAME title has sections/subpages [<a href="http://github.com/doxygen/doxygen/commit/745955f576cbd7b5f7601c55937d9c42db8161e8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5558">5558</a> - src/Makefile.libdoxycfg shouldn&#39;t be distributed [<a href="http://github.com/doxygen/doxygen/commit/45cfc44d3670bb9f72a0795d4a9bc07403a29d6d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5559">5559</a> - plantUML requires epstopdf for building PDF files [<a href="http://github.com/doxygen/doxygen/commit/52d216a87451c867c92691a4483cd85d3e5b906f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5560">5560</a> - tag file: Unknown compound attribute `singleton&#39; found! [<a href="http://github.com/doxygen/doxygen/commit/92eb236037e857f38eaf24238815641a48540792">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5562">5562</a> - Fix a resource leak in src/vhdldocgen.cpp [<a href="http://github.com/doxygen/doxygen/commit/22e44853813066e45b483b1b6633199b3d2bf509">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5563">5563</a> - There&#39;s no such thing as a private Q_PROPERTY [<a href="http://github.com/doxygen/doxygen/commit/ff7cc1c73c3d4b3449862055bd08b0f361e5b358">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5564">5564</a> - Same Expression in translator_kr.h [<a href="http://github.com/doxygen/doxygen/commit/32aa9f2a7898b5c43070a5cd0dec8bddcc6b8c39">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5565">5565</a> - Fix a potential null pointer dereference in src/memberdef.cpp [<a href="http://github.com/doxygen/doxygen/commit/7a268f59c0551953fe4e7dde0b1e3804d583a060">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5567">5567</a> - Mismatch in memory allocation/de-allocation function in vhdlparser/vhdlstring.h [<a href="http://github.com/doxygen/doxygen/commit/2038873ce0a9ec90efb28730b3dc787d3d03e964">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5568">5568</a> - Remove a not needed initialization of a local variable in src/mangen.cpp [<a href="http://github.com/doxygen/doxygen/commit/1e8a69902a2cbb3118e6de5959223b9c8d3a843a">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5569">5569</a> - Fix a potential null pointer dereference in src/searchindex.cpp [<a href="http://github.com/doxygen/doxygen/commit/e21aaadb920775f431a27957542da80e39d0c947">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5570">5570</a> - Fix wrong pointer initialization in src/definition.cpp [<a href="http://github.com/doxygen/doxygen/commit/cb5d8e6198fe0d0852fb06d6fa18b8ae2682e2c0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5571">5571</a> - Fix potential modulo by zero in src/template.cpp [<a href="http://github.com/doxygen/doxygen/commit/c4007c3abea9c8494bf32181a1352b5366bede69">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5572">5572</a> - Reached end of file while still inside a (nested) comment in Markdown [<a href="http://github.com/doxygen/doxygen/commit/c7f7c954ec1356e7f361da0d655c72ca0012a0cf">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5573">5573</a> - Fix a terminating null character after fread in src/filedef.cpp [<a href="http://github.com/doxygen/doxygen/commit/a4003db44dfb624c03b7e0a518e368d3e4b8c1ca">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5574">5574</a> - Remove not needed variable initialization in src/classdef.cpp [<a href="http://github.com/doxygen/doxygen/commit/5f01852bbfd3c81320ee4aa8cd45875a80b50ee1">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5575">5575</a> - Remove not needed pointer initialization in src/entry.cpp [<a href="http://github.com/doxygen/doxygen/commit/88832b15f1256846b1228ac411d270c6d092a50b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5576">5576</a> - Provide exit code in case generatePlantUMLOutput fails [<a href="http://github.com/doxygen/doxygen/commit/94ea18e60c50db14f25eda642be020fac5917b3c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5578">5578</a> - Remove not needed variable caching in src/markdown.cpp [<a href="http://github.com/doxygen/doxygen/commit/d6c2464982e5b1c027cdde0400822c3b2fc7fd41">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5580">5580</a> - Do not cache inputSize in src/doxygen.cpp [<a href="http://github.com/doxygen/doxygen/commit/8f3e7fc892f07f32a2c6e0110dab58942f6c20a7">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5581">5581</a> - Expression is always false because &#39;else if&#39; condition matches previous condition [<a href="http://github.com/doxygen/doxygen/commit/98a9b24cd6006b130dd1e56c32f684e159fee2a3">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5583">5583</a> - Fix missing break in switch case statement [<a href="http://github.com/doxygen/doxygen/commit/b59edd279f887e55b162ae1b1c7bce4b2ca29dab">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5584">5584</a> - Spurious ASSERT message [<a href="http://github.com/doxygen/doxygen/commit/fff03ab9adcbdf480929c6a10975cab469eaf17c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5585">5585</a> - Broken man pages due to bad use of autoBreak [<a href="http://github.com/doxygen/doxygen/commit/6aa7f36ce924cf9dc59a951e5727b17c37d0345e">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5586">5586</a> - Fix potential copy and paste issue in vhdlparser/VhdlParser.cc [<a href="http://github.com/doxygen/doxygen/commit/9238e342bc8f1ce3e0aaa2944d77c33e4363cf48">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5587">5587</a> - [Patch] Documentation: Wrong link for \\diafile [<a href="http://github.com/doxygen/doxygen/commit/285221e3d287db083b9377cb5633650fb2a783a1">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5588">5588</a> - [Patch] DocBook: Possible name clash for generated image files [<a href="http://github.com/doxygen/doxygen/commit/8b39158436b740a78166f947de375b5486441c93">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5589">5589</a> - RTF output: \\diafile and \\mscfile do not work [<a href="http://github.com/doxygen/doxygen/commit/7cd2b1f27a03846a8f9bcd1e4489cbfebf56bfa2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5590">5590</a> - Windows: Process exit code is ignored for processes launched using ShellExecuteEx() [<a href="http://github.com/doxygen/doxygen/commit/68aa8c2bd8a5e6a8ad7c46c725c8bb5e61896ba0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5593">5593</a> - Fix potential allocation of huge memory amount due to type overflow in src/lodepng.cpp [<a href="http://github.com/doxygen/doxygen/commit/30870ef90f4a74e7c53a6856b10bcd2f16e4d1bd">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5594">5594</a> - Fix missing unchecked return value in src/dot.cpp [<a href="http://github.com/doxygen/doxygen/commit/be0c23efcb902891e91bed42ab2ac27a6f1460cb">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5595">5595</a> - Fix potential null pointer dereference in src/dbusxmlscanner.cpp [<a href="http://github.com/doxygen/doxygen/commit/46e83b44be0c0aa97ead5ee52e329154c1fb47bc">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5596">5596</a> - Fix identical code for different branches in src/translator_tw.h [<a href="http://github.com/doxygen/doxygen/commit/79dedb65ae1f9306b83a69058dbd2015ef7c3b94">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5597">5597</a> - Fix potential null pointer dereference in src/index.cpp [<a href="http://github.com/doxygen/doxygen/commit/68c063cbffc38c1528dd86232a8b8642fae26b1b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5598">5598</a> - Remove not needed variable initialization in src/cite.cpp [<a href="http://github.com/doxygen/doxygen/commit/23bc555e5483baa6c1a3d0c1ad346bb37348b31b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5599">5599</a> - Remove not needed local variable in src/doxygen.cpp [<a href="http://github.com/doxygen/doxygen/commit/561a996c68f796dccb36fb3eed6150fcc90e5634">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5600">5600</a> - Remove redundant if/else branch in src/lodepng.cpp [<a href="http://github.com/doxygen/doxygen/commit/3026131de3126298863d1a68fe0c747524e26e43">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5601">5601</a> - Remove redundant if/else branch in src/translator_lt.h [<a href="http://github.com/doxygen/doxygen/commit/e7b9f1d16ea2043be068c448676e368e9239314e">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5602">5602</a> - Cleanup redundant if/else branch in src/translator_kr.h [<a href="http://github.com/doxygen/doxygen/commit/3d1343d1c8876d0eb0352eafafe4aa90bc483adf">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5603">5603</a> - Cleanup redundant if/else branch in src/translator_sr.h [<a href="http://github.com/doxygen/doxygen/commit/192aa6590b6ceb264335a5b8a1aed6b6f8b0f350">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5604">5604</a> - Cleanup redundant if/else branch in src/translator_tw.h [<a href="http://github.com/doxygen/doxygen/commit/02b35985cda1a537c45071f1245b2c4a6dc4ffc6">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5605">5605</a> - Cleanup redundant if/else branch in src/translator_vi.h [<a href="http://github.com/doxygen/doxygen/commit/8e47b4bc5084cb00e5bdcdaa4c1bd048b48a4999">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5606">5606</a> - Remove redundant local variable initialization in qtools/qstring.cpp [<a href="http://github.com/doxygen/doxygen/commit/4afe088327ae6780c9c8a73b7b2d3994005f6cca">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5607">5607</a> - Fix wrong member variable initialization in src/define.cpp [<a href="http://github.com/doxygen/doxygen/commit/33daf7a7d9ab9b6c5454acd7a3cff7923d1c4c14">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5611">5611</a> - Fix potential null pointer dereference in src/util.cpp [<a href="http://github.com/doxygen/doxygen/commit/24b5b715929759a7836a3813ef93976b7cc10641">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5612">5612</a> - Fix another potential null pointer dereference in src/util.cpp [<a href="http://github.com/doxygen/doxygen/commit/bc95beac3eca3cda55430e0cde97ba826d3d7400">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5613">5613</a> - Fix a potential null pointer dereference in src/index.cpp [<a href="http://github.com/doxygen/doxygen/commit/c22be34fb79588fa04a9cf9c86438c8eb00d81fc">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5614">5614</a> - Fix a potential null pointer dereference in src/vhdldocgen.cpp [<a href="http://github.com/doxygen/doxygen/commit/7a22d83a1f9665863201ff0e717071e9b7d3a110">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5632">5632</a> - Member functions omitted from tagfile [<a href="http://github.com/doxygen/doxygen/commit/b9ad9a03cf4febeb2aa10ddca22c1c9296c5223b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5643">5643</a> - Java: Annotations with brackets prevent documentation [<a href="http://github.com/doxygen/doxygen/commit/e446e2e044d674ba3609619e3dd95eb340f15e09">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5647">5647</a> - Invalid element name in footer part when GENERATE_TREEVIEW specified [<a href="http://github.com/doxygen/doxygen/commit/5cb961284e89f197406170389e8866bb9c94fe3a">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5649">5649</a> - Fortran attribute contiguous not identified [<a href="http://github.com/doxygen/doxygen/commit/6da2e3fb28f6ed9f219c66d165ac4467fda36148">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5652">5652</a> - Entity references in XML command attributes are incorrectly handled [<a href="http://github.com/doxygen/doxygen/commit/553a7bf7e1b7be2f602e0230ddfc7f882b009cf8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5653">5653</a> - Entity references in XML code command are incorrectly handled [<a href="http://github.com/doxygen/doxygen/commit/30216574cb189a92f27bb0e701ff31aa8cce6b83">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5656">5656</a> - latex: dead links to source code [<a href="http://github.com/doxygen/doxygen/commit/b68a4abcfa22e68fd94487a8f2b48588eda5a1af">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5657">5657</a> - &amp;hellip; is replaced by \cdots rather than \dots in the LaTeX output [<a href="http://github.com/doxygen/doxygen/commit/9ac31f84bd25d320f861e9e194fe5df49f4b212b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5664">5664</a> - Python xml not outputting info of functions inside __init__.py [<a href="http://github.com/doxygen/doxygen/commit/d13908f65b6e745bab14dc610c9f9bc7908c55c5">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5665">5665</a> - Python xml - argsstring is empty, while HTML have arguments [<a href="http://github.com/doxygen/doxygen/commit/89eb624fec44c0f900d9035dfea950ceaf0ba76d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5667">5667</a> - Invalid warning about undocumented C++ function imported from tagfile [<a href="http://github.com/doxygen/doxygen/commit/f1c96033bcea28e3ff4528299459b39488831669">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5668">5668</a> - C++11 scoped enums with same name inside different classes are merged if using tagfile [<a href="http://github.com/doxygen/doxygen/commit/b4fd6ac51fad4f20116194816d4802f616739d1f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5669">5669</a> - Cannot make explicit links to C++ const member functions [<a href="http://github.com/doxygen/doxygen/commit/ad5dfc39bee7a1b3de16f36bc3a20565aa6438fe">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5670">5670</a> - Cannot make unscoped link to C++ conversion operator [<a href="http://github.com/doxygen/doxygen/commit/9f477b87fc492221e1b7109d197fe468cd0ed23d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5671">5671</a> - Using &quot;doxygen.css&quot; for HTML_EXTRA_STYLESHEET fails silently [<a href="http://github.com/doxygen/doxygen/commit/5e962c90d3270612df7363e7cf6bf42646c94fbe">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5674">5674</a> - Regression: Base classes incorrect when using CRTP with default template parameter [<a href="http://github.com/doxygen/doxygen/commit/200b828ead9f6bb5b2f6f99919837d5828a250e4">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5678">5678</a> - Full scope needed when making link inside cross-referenced section [<a href="http://github.com/doxygen/doxygen/commit/c6e41226574c94a869ad0757b53027562ef189e1">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5678">5678</a> - Full scope needed when making link inside cross-referenced section (fixed regression) [<a href="http://github.com/doxygen/doxygen/commit/60abada8b95cc1772996a264065904f408ed32ff">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5680">5680</a> - invalid copydoc target does not result in warning [<a href="http://github.com/doxygen/doxygen/commit/738c0dd829b6e3ae74359a8d92d12b491fa71d1b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5686">5686</a> - Latex to PDF hangs when using Markdown tables [<a href="http://github.com/doxygen/doxygen/commit/089771b5f3c3c3984ae6f352125a001788a62d29">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5690">5690</a> - Crash when building gtkmm documentation [<a href="http://github.com/doxygen/doxygen/commit/050fce2b73d6e4455808ab86da2fddcf2f26e9b5">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5694">5694</a> - \cite confused by labels ending with a dot (improved warning message) [<a href="http://github.com/doxygen/doxygen/commit/78fd02dc41384d81baddf17ff0bb3431267452fc">view</a>]</li>
-<li>fix docbook output [<a href="http://github.com/doxygen/doxygen/commit/1a403d80160458091bab7c442e54f836c0b90bca">view</a>]
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4011">4011</a> - Fortran: external subroutine as dummy argument not recognized [<a href="https://github.com/doxygen/doxygen/commit/8f78eff7e8b2650f9a8364ff5c5b6925279e6b5a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4011">4011</a> - Fortran: external subroutine as dummy argument not recognized [<a href="https://github.com/doxygen/doxygen/commit/fabd1194a2e3c2536dddc19945c568a690b17031">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4286">4286</a> - Brief description misplaced in man page output [<a href="https://github.com/doxygen/doxygen/commit/379e3b959a9566571db3c799a8338dd4436881b2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4293">4293</a> - Typedefs in manpages has too few linebreak possiblilities [<a href="https://github.com/doxygen/doxygen/commit/4bbcf71defb2e2be02494b7ff68d475d1a0438ac">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4914">4914</a> - C# &lt;code&gt; tag in an &lt;example&gt; tag does not render as expected. [<a href="https://github.com/doxygen/doxygen/commit/07d5f3f48a497993c525eab9a5ecc0429c317c98">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4941">4941</a> - Add support for LATEX_EXTRA_STYLESHEET [<a href="https://github.com/doxygen/doxygen/commit/fd91442bcc5a20ba298a024ee2cc375ec4f1714d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5237">5237</a> - Allow Class{T}.Method in cref to refer to a generic class in XML comments [<a href="https://github.com/doxygen/doxygen/commit/f9c9edba086f544b813ff036ea9209744da18c44">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5418">5418</a> - classes with same name in different namespace adding to same group [<a href="https://github.com/doxygen/doxygen/commit/73a5a4c48aec0c48353ecb8e5aa6d5ff02463132">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5462">5462</a> - Missing link for item inside the same namespace [<a href="https://github.com/doxygen/doxygen/commit/95aee340bddca0c09c79dc2f137a5ad01eb4fda8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5467">5467</a> - Added HIDE_COMPOUND_REFERENCE config option [<a href="https://github.com/doxygen/doxygen/commit/415ae7021eeee278ad6c95be23e572dc18ff6a32">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5554">5554</a> - QHP toc broken if mainpage with PROJECT_NAME title has sections/subpages [<a href="https://github.com/doxygen/doxygen/commit/745955f576cbd7b5f7601c55937d9c42db8161e8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5558">5558</a> - src/Makefile.libdoxycfg shouldn&#39;t be distributed [<a href="https://github.com/doxygen/doxygen/commit/45cfc44d3670bb9f72a0795d4a9bc07403a29d6d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5559">5559</a> - plantUML requires epstopdf for building PDF files [<a href="https://github.com/doxygen/doxygen/commit/52d216a87451c867c92691a4483cd85d3e5b906f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5560">5560</a> - tag file: Unknown compound attribute `singleton&#39; found! [<a href="https://github.com/doxygen/doxygen/commit/92eb236037e857f38eaf24238815641a48540792">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5562">5562</a> - Fix a resource leak in src/vhdldocgen.cpp [<a href="https://github.com/doxygen/doxygen/commit/22e44853813066e45b483b1b6633199b3d2bf509">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5563">5563</a> - There&#39;s no such thing as a private Q_PROPERTY [<a href="https://github.com/doxygen/doxygen/commit/ff7cc1c73c3d4b3449862055bd08b0f361e5b358">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5564">5564</a> - Same Expression in translator_kr.h [<a href="https://github.com/doxygen/doxygen/commit/32aa9f2a7898b5c43070a5cd0dec8bddcc6b8c39">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5565">5565</a> - Fix a potential null pointer dereference in src/memberdef.cpp [<a href="https://github.com/doxygen/doxygen/commit/7a268f59c0551953fe4e7dde0b1e3804d583a060">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5567">5567</a> - Mismatch in memory allocation/de-allocation function in vhdlparser/vhdlstring.h [<a href="https://github.com/doxygen/doxygen/commit/2038873ce0a9ec90efb28730b3dc787d3d03e964">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5568">5568</a> - Remove a not needed initialization of a local variable in src/mangen.cpp [<a href="https://github.com/doxygen/doxygen/commit/1e8a69902a2cbb3118e6de5959223b9c8d3a843a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5569">5569</a> - Fix a potential null pointer dereference in src/searchindex.cpp [<a href="https://github.com/doxygen/doxygen/commit/e21aaadb920775f431a27957542da80e39d0c947">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5570">5570</a> - Fix wrong pointer initialization in src/definition.cpp [<a href="https://github.com/doxygen/doxygen/commit/cb5d8e6198fe0d0852fb06d6fa18b8ae2682e2c0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5571">5571</a> - Fix potential modulo by zero in src/template.cpp [<a href="https://github.com/doxygen/doxygen/commit/c4007c3abea9c8494bf32181a1352b5366bede69">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5572">5572</a> - Reached end of file while still inside a (nested) comment in Markdown [<a href="https://github.com/doxygen/doxygen/commit/c7f7c954ec1356e7f361da0d655c72ca0012a0cf">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5573">5573</a> - Fix a terminating null character after fread in src/filedef.cpp [<a href="https://github.com/doxygen/doxygen/commit/a4003db44dfb624c03b7e0a518e368d3e4b8c1ca">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5574">5574</a> - Remove not needed variable initialization in src/classdef.cpp [<a href="https://github.com/doxygen/doxygen/commit/5f01852bbfd3c81320ee4aa8cd45875a80b50ee1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5575">5575</a> - Remove not needed pointer initialization in src/entry.cpp [<a href="https://github.com/doxygen/doxygen/commit/88832b15f1256846b1228ac411d270c6d092a50b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5576">5576</a> - Provide exit code in case generatePlantUMLOutput fails [<a href="https://github.com/doxygen/doxygen/commit/94ea18e60c50db14f25eda642be020fac5917b3c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5578">5578</a> - Remove not needed variable caching in src/markdown.cpp [<a href="https://github.com/doxygen/doxygen/commit/d6c2464982e5b1c027cdde0400822c3b2fc7fd41">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5580">5580</a> - Do not cache inputSize in src/doxygen.cpp [<a href="https://github.com/doxygen/doxygen/commit/8f3e7fc892f07f32a2c6e0110dab58942f6c20a7">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5581">5581</a> - Expression is always false because &#39;else if&#39; condition matches previous condition [<a href="https://github.com/doxygen/doxygen/commit/98a9b24cd6006b130dd1e56c32f684e159fee2a3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5583">5583</a> - Fix missing break in switch case statement [<a href="https://github.com/doxygen/doxygen/commit/b59edd279f887e55b162ae1b1c7bce4b2ca29dab">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5584">5584</a> - Spurious ASSERT message [<a href="https://github.com/doxygen/doxygen/commit/fff03ab9adcbdf480929c6a10975cab469eaf17c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5585">5585</a> - Broken man pages due to bad use of autoBreak [<a href="https://github.com/doxygen/doxygen/commit/6aa7f36ce924cf9dc59a951e5727b17c37d0345e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5586">5586</a> - Fix potential copy and paste issue in vhdlparser/VhdlParser.cc [<a href="https://github.com/doxygen/doxygen/commit/9238e342bc8f1ce3e0aaa2944d77c33e4363cf48">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5587">5587</a> - [Patch] Documentation: Wrong link for \\diafile [<a href="https://github.com/doxygen/doxygen/commit/285221e3d287db083b9377cb5633650fb2a783a1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5588">5588</a> - [Patch] DocBook: Possible name clash for generated image files [<a href="https://github.com/doxygen/doxygen/commit/8b39158436b740a78166f947de375b5486441c93">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5589">5589</a> - RTF output: \\diafile and \\mscfile do not work [<a href="https://github.com/doxygen/doxygen/commit/7cd2b1f27a03846a8f9bcd1e4489cbfebf56bfa2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5590">5590</a> - Windows: Process exit code is ignored for processes launched using ShellExecuteEx() [<a href="https://github.com/doxygen/doxygen/commit/68aa8c2bd8a5e6a8ad7c46c725c8bb5e61896ba0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5593">5593</a> - Fix potential allocation of huge memory amount due to type overflow in src/lodepng.cpp [<a href="https://github.com/doxygen/doxygen/commit/30870ef90f4a74e7c53a6856b10bcd2f16e4d1bd">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5594">5594</a> - Fix missing unchecked return value in src/dot.cpp [<a href="https://github.com/doxygen/doxygen/commit/be0c23efcb902891e91bed42ab2ac27a6f1460cb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5595">5595</a> - Fix potential null pointer dereference in src/dbusxmlscanner.cpp [<a href="https://github.com/doxygen/doxygen/commit/46e83b44be0c0aa97ead5ee52e329154c1fb47bc">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5596">5596</a> - Fix identical code for different branches in src/translator_tw.h [<a href="https://github.com/doxygen/doxygen/commit/79dedb65ae1f9306b83a69058dbd2015ef7c3b94">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5597">5597</a> - Fix potential null pointer dereference in src/index.cpp [<a href="https://github.com/doxygen/doxygen/commit/68c063cbffc38c1528dd86232a8b8642fae26b1b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5598">5598</a> - Remove not needed variable initialization in src/cite.cpp [<a href="https://github.com/doxygen/doxygen/commit/23bc555e5483baa6c1a3d0c1ad346bb37348b31b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5599">5599</a> - Remove not needed local variable in src/doxygen.cpp [<a href="https://github.com/doxygen/doxygen/commit/561a996c68f796dccb36fb3eed6150fcc90e5634">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5600">5600</a> - Remove redundant if/else branch in src/lodepng.cpp [<a href="https://github.com/doxygen/doxygen/commit/3026131de3126298863d1a68fe0c747524e26e43">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5601">5601</a> - Remove redundant if/else branch in src/translator_lt.h [<a href="https://github.com/doxygen/doxygen/commit/e7b9f1d16ea2043be068c448676e368e9239314e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5602">5602</a> - Cleanup redundant if/else branch in src/translator_kr.h [<a href="https://github.com/doxygen/doxygen/commit/3d1343d1c8876d0eb0352eafafe4aa90bc483adf">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5603">5603</a> - Cleanup redundant if/else branch in src/translator_sr.h [<a href="https://github.com/doxygen/doxygen/commit/192aa6590b6ceb264335a5b8a1aed6b6f8b0f350">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5604">5604</a> - Cleanup redundant if/else branch in src/translator_tw.h [<a href="https://github.com/doxygen/doxygen/commit/02b35985cda1a537c45071f1245b2c4a6dc4ffc6">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5605">5605</a> - Cleanup redundant if/else branch in src/translator_vi.h [<a href="https://github.com/doxygen/doxygen/commit/8e47b4bc5084cb00e5bdcdaa4c1bd048b48a4999">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5606">5606</a> - Remove redundant local variable initialization in qtools/qstring.cpp [<a href="https://github.com/doxygen/doxygen/commit/4afe088327ae6780c9c8a73b7b2d3994005f6cca">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5607">5607</a> - Fix wrong member variable initialization in src/define.cpp [<a href="https://github.com/doxygen/doxygen/commit/33daf7a7d9ab9b6c5454acd7a3cff7923d1c4c14">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5611">5611</a> - Fix potential null pointer dereference in src/util.cpp [<a href="https://github.com/doxygen/doxygen/commit/24b5b715929759a7836a3813ef93976b7cc10641">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5612">5612</a> - Fix another potential null pointer dereference in src/util.cpp [<a href="https://github.com/doxygen/doxygen/commit/bc95beac3eca3cda55430e0cde97ba826d3d7400">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5613">5613</a> - Fix a potential null pointer dereference in src/index.cpp [<a href="https://github.com/doxygen/doxygen/commit/c22be34fb79588fa04a9cf9c86438c8eb00d81fc">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5614">5614</a> - Fix a potential null pointer dereference in src/vhdldocgen.cpp [<a href="https://github.com/doxygen/doxygen/commit/7a22d83a1f9665863201ff0e717071e9b7d3a110">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5632">5632</a> - Member functions omitted from tagfile [<a href="https://github.com/doxygen/doxygen/commit/b9ad9a03cf4febeb2aa10ddca22c1c9296c5223b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5643">5643</a> - Java: Annotations with brackets prevent documentation [<a href="https://github.com/doxygen/doxygen/commit/e446e2e044d674ba3609619e3dd95eb340f15e09">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5647">5647</a> - Invalid element name in footer part when GENERATE_TREEVIEW specified [<a href="https://github.com/doxygen/doxygen/commit/5cb961284e89f197406170389e8866bb9c94fe3a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5649">5649</a> - Fortran attribute contiguous not identified [<a href="https://github.com/doxygen/doxygen/commit/6da2e3fb28f6ed9f219c66d165ac4467fda36148">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5652">5652</a> - Entity references in XML command attributes are incorrectly handled [<a href="https://github.com/doxygen/doxygen/commit/553a7bf7e1b7be2f602e0230ddfc7f882b009cf8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5653">5653</a> - Entity references in XML code command are incorrectly handled [<a href="https://github.com/doxygen/doxygen/commit/30216574cb189a92f27bb0e701ff31aa8cce6b83">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5656">5656</a> - latex: dead links to source code [<a href="https://github.com/doxygen/doxygen/commit/b68a4abcfa22e68fd94487a8f2b48588eda5a1af">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5657">5657</a> - &amp;hellip; is replaced by \cdots rather than \dots in the LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/9ac31f84bd25d320f861e9e194fe5df49f4b212b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5664">5664</a> - Python xml not outputting info of functions inside __init__.py [<a href="https://github.com/doxygen/doxygen/commit/d13908f65b6e745bab14dc610c9f9bc7908c55c5">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5665">5665</a> - Python xml - argsstring is empty, while HTML have arguments [<a href="https://github.com/doxygen/doxygen/commit/89eb624fec44c0f900d9035dfea950ceaf0ba76d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5667">5667</a> - Invalid warning about undocumented C++ function imported from tagfile [<a href="https://github.com/doxygen/doxygen/commit/f1c96033bcea28e3ff4528299459b39488831669">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5668">5668</a> - C++11 scoped enums with same name inside different classes are merged if using tagfile [<a href="https://github.com/doxygen/doxygen/commit/b4fd6ac51fad4f20116194816d4802f616739d1f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5669">5669</a> - Cannot make explicit links to C++ const member functions [<a href="https://github.com/doxygen/doxygen/commit/ad5dfc39bee7a1b3de16f36bc3a20565aa6438fe">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5670">5670</a> - Cannot make unscoped link to C++ conversion operator [<a href="https://github.com/doxygen/doxygen/commit/9f477b87fc492221e1b7109d197fe468cd0ed23d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5671">5671</a> - Using &quot;doxygen.css&quot; for HTML_EXTRA_STYLESHEET fails silently [<a href="https://github.com/doxygen/doxygen/commit/5e962c90d3270612df7363e7cf6bf42646c94fbe">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5674">5674</a> - Regression: Base classes incorrect when using CRTP with default template parameter [<a href="https://github.com/doxygen/doxygen/commit/200b828ead9f6bb5b2f6f99919837d5828a250e4">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5678">5678</a> - Full scope needed when making link inside cross-referenced section [<a href="https://github.com/doxygen/doxygen/commit/c6e41226574c94a869ad0757b53027562ef189e1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5678">5678</a> - Full scope needed when making link inside cross-referenced section (fixed regression) [<a href="https://github.com/doxygen/doxygen/commit/60abada8b95cc1772996a264065904f408ed32ff">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5680">5680</a> - invalid copydoc target does not result in warning [<a href="https://github.com/doxygen/doxygen/commit/738c0dd829b6e3ae74359a8d92d12b491fa71d1b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5686">5686</a> - Latex to PDF hangs when using Markdown tables [<a href="https://github.com/doxygen/doxygen/commit/089771b5f3c3c3984ae6f352125a001788a62d29">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5690">5690</a> - Crash when building gtkmm documentation [<a href="https://github.com/doxygen/doxygen/commit/050fce2b73d6e4455808ab86da2fddcf2f26e9b5">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5694">5694</a> - \cite confused by labels ending with a dot (improved warning message) [<a href="https://github.com/doxygen/doxygen/commit/78fd02dc41384d81baddf17ff0bb3431267452fc">view</a>]</li>
+<li>fix docbook output [<a href="https://github.com/doxygen/doxygen/commit/1a403d80160458091bab7c442e54f836c0b90bca">view</a>]
     <ol><li>support other than english</li>
         <li>fix broken example link id</li>
         <li>fix incomplete TOC : no Classe etc.</li>
@@ -783,89 +783,88 @@
         <li>Comply with REPEAT_BRIEF </li>
         <li>Do not output duplicated contents when detailed description is missing.</li>
         <li>set table colwidth for Param/RetVal</li>
-    </ol>
-</li>
-<li>Add missing escape in doxysearch.cpp when result contained a double quote [<a href="http://github.com/doxygen/doxygen/commit/08c9689157d7edc5d8e3369ef96f2ccd4b01c10c">view</a>]</li>
-<li>Add source code possibility for RTF output [<a href="http://github.com/doxygen/doxygen/commit/05eb230757f6510d461bd14df3b190da46edd9dc">view</a>]</li>
-<li>Added Coverity Scan Build Status to Readme [<a href="http://github.com/doxygen/doxygen/commit/394acb6a10dbef10cad3a0a3ff50a05d0efdea9e">view</a>]</li>
-<li>Added clearer range checks for string class to help compiler [<a href="http://github.com/doxygen/doxygen/commit/869ff34828e20e3ec318384d7b0dbf91b6b2d24d">view</a>]</li>
-<li>Added compilation support for MacOSX 10.10 (yosemite) [<a href="http://github.com/doxygen/doxygen/commit/151876a8321204bd2ec08ec6c4de38ba9fb2d034">view</a>]</li>
-<li>Added faster reference counted string implementation with short string optimization [<a href="http://github.com/doxygen/doxygen/commit/9323ae470ad514586706dc8647501361fe208f36">view</a>]</li>
-<li>Added graphical hierarchy support to template engine [<a href="http://github.com/doxygen/doxygen/commit/fe818bf8e3a154788a4a180068cfdfbbadd66ff6">view</a>]</li>
-<li>Added guard to prevent (theoretical) out of bound access [<a href="http://github.com/doxygen/doxygen/commit/060a5cc121be5fd177b5d5c834f2b810dc58b9ec">view</a>]</li>
-<li>Added language attribute to XML output for classes, namespaces, and files [<a href="http://github.com/doxygen/doxygen/commit/e986e0039de21791bd1fbb1f59b13f58c4a46324">view</a>]</li>
-<li>Avoid a (theoretical) memory leak [<a href="http://github.com/doxygen/doxygen/commit/2937e44299a615628c27b0a0a7a95ffdf18249ef">view</a>]</li>
-<li>Better handling of inline Fortran parameter documentation [<a href="http://github.com/doxygen/doxygen/commit/d5546cff5c82157f2dfddd0e1c4fdeeee8e501dd">view</a>]</li>
-<li>Fixed bug for page numbers in the latex indices [<a href="http://github.com/doxygen/doxygen/commit/37ea04c317f9e1e8a09e5944b8c6c2c2ef35b1f6">view</a>]</li>
-<li>Compilation fixes for Windows for new string implementation. [<a href="http://github.com/doxygen/doxygen/commit/a31c9fffec6b5145ac8509d77da826d2e196ed1e">view</a>]</li>
-<li>Convert FORTRAN modules to namespaces [<a href="http://github.com/doxygen/doxygen/commit/be933bfacadaca98aaf4713746201b1fc21177de">view</a>]</li>
-<li>Create an easy possibility to take a snippet from the current file. [<a href="http://github.com/doxygen/doxygen/commit/f8ceac63bdb52cf395207258c98ff0bcba35870a">view</a>]</li>
-<li>Debian Bug 762272: segfault with cyclic subgroups [<a href="http://github.com/doxygen/doxygen/commit/c83db38ea83499be19d9ff242bfa22ae534ee80c">view</a>]</li>
-<li>Disabled enter/exit printing for doctokenizer (produced too much noise) [<a href="http://github.com/doxygen/doxygen/commit/0b615342f0a24fbf02cc9fa94550cf34d230425b">view</a>]</li>
-<li>Empty entry in \tableofcontents in case e.g. section without description. [<a href="http://github.com/doxygen/doxygen/commit/d2acdcf3b1bbd4d3079cf6c4ff5de6ba6716fd06">view</a>]</li>
-<li>Extra empty line in source fragments [<a href="http://github.com/doxygen/doxygen/commit/79b40a437092bccb6589cdb29c0059a4797b771d">view</a>]</li>
-<li>Fix bug with C++11 static_assert [<a href="http://github.com/doxygen/doxygen/commit/7c257bb57562b015b094f109851d914ef232ae2a">view</a>]</li>
-<li>Fix bug: language switch command &quot;\~&quot; failed to detect language id which contains &#39;-&#39; [<a href="http://github.com/doxygen/doxygen/commit/a4cf65dea1371721f07c63c2bb5f9e5085b2618a">view</a>]</li>
-<li>Fix for <a href="https://github.com/doxygen/doxygen/issues/4285">4285</a> [<a href="http://github.com/doxygen/doxygen/commit/e1aa7af27eded7afdf81b688015421d3b3467b2b">view</a>]</li>
-<li>Fix for the second issue in bz 651848 [<a href="http://github.com/doxygen/doxygen/commit/bcd3fbf59f9199470d51938486fecda05006da61">view</a>]</li>
-<li>Fix potential crash when reading tag file which contained nested java classes using generics [<a href="http://github.com/doxygen/doxygen/commit/6d4044ad43ae1424a256eb1c26992301e7c64f4a">view</a>]</li>
-<li>Fix rules for closing FORTRAN module and typedef scopes [<a href="http://github.com/doxygen/doxygen/commit/7ace28eb7bb5f42c3571e5b7be1ab954f4509e17">view</a>]</li>
-<li>Fix to ignore the contents of \verbatim and friends while looking for sections [<a href="http://github.com/doxygen/doxygen/commit/cba0d89fafee3daef31469cbe1cdd24e68c7b56a">view</a>]</li>
-<li>Fix to show relations between C#/Java generic classes [<a href="http://github.com/doxygen/doxygen/commit/9879fddbf8f91c57b258b8e788b5ed8a150a8331">view</a>]</li>
-<li>Fixed a number of issues (resource leaks, uninitialized members, etc) found by coverity [<a href="http://github.com/doxygen/doxygen/commit/41887832b90698df95e8d222cdc0a541ae2f2284">view</a>]</li>
-<li>Fixed bug in new QCString::sprintf for long string. [<a href="http://github.com/doxygen/doxygen/commit/0ec56b7aa2dd39e3cab71c2229d486161566e7f6">view</a>]</li>
-<li>Fixed extension matching issue if path contained a dot. [<a href="http://github.com/doxygen/doxygen/commit/79ed06502c3abca083f2e231f09fc8101862fcf6">view</a>]</li>
-<li>Fixed issue accessing uninitialized data when combining RTF output. [<a href="http://github.com/doxygen/doxygen/commit/e5076edf2c103d262a9e32d57fb40cfe210c9ddf">view</a>]</li>
-<li>Fixed issue parsing @end directly followed by the end of the file [<a href="http://github.com/doxygen/doxygen/commit/fa239ea9a3bba27e4fff84629883ee400f674c1e">view</a>]</li>
-<li>Fixed problem finding \enduml when using /// style comments. [<a href="http://github.com/doxygen/doxygen/commit/4df52916170bb81179697d0fa78c7d81fd95415f">view</a>]</li>
-<li>Fixed refcounting bug in new string implementation [<a href="http://github.com/doxygen/doxygen/commit/a9dcbfe28625673f4d13bc5b3cde694c24062e19">view</a>]</li>
-<li>Fixed several Coverity warnings [<a href="http://github.com/doxygen/doxygen/commit/9b7e4ffb6c5f7534e4ba11d5798b4eb74d4a2a70">view</a>]</li>
-<li>Fixed to small memory leaks [<a href="http://github.com/doxygen/doxygen/commit/b55a5c91d49359f9bbf7c78d9f284be2092bcfaa">view</a>]</li>
-<li>Fixed typos and formatting in Doxyfile (thanks to Armin Mueller) [<a href="http://github.com/doxygen/doxygen/commit/fdd1c3f1527b15f6b0a25c2d99748f6a8adc5fcf">view</a>]</li>
-<li>Fixed typos in C/C++ comments. There are no functional changes. [<a href="http://github.com/doxygen/doxygen/commit/458fb1738f4e59586460daa2a1e3ad2e730306c4">view</a>]</li>
-<li>Fixed typos in comments. [<a href="http://github.com/doxygen/doxygen/commit/8ff67ad01abfe97b43de0ef1799c8b798d725ab9">view</a>]</li>
-<li>Fixed typos in comments. No functional changes. [<a href="http://github.com/doxygen/doxygen/commit/6920d3ec6db21cec32086249a48875cbac957470">view</a>]</li>
-<li>Fortran code color END (regression pull request 259) [<a href="http://github.com/doxygen/doxygen/commit/0ccda478e35eb420d644b6c39923f9c020e69c13">view</a>]</li>
-<li>Fortran color CALL as keyword [<a href="http://github.com/doxygen/doxygen/commit/d3a5f96d07db323ff97fb07766a809769506ef3a">view</a>]</li>
-<li>Fortran color code of END [<a href="http://github.com/doxygen/doxygen/commit/1cfa914cbb4e41f15af1f08517af887d6b241f28">view</a>]</li>
-<li>Fortran continuation character seen as begin of function call [<a href="http://github.com/doxygen/doxygen/commit/b2e9aa362540cae4487e48598fb7e80b8651752f">view</a>]</li>
-<li>Generate error message in case bibtex generation fails [<a href="http://github.com/doxygen/doxygen/commit/f121923bde72ef68616224a3fa1c1fe27eeb385e">view</a>]</li>
-<li>Improved main page rendering via template engine [<a href="http://github.com/doxygen/doxygen/commit/f8a86910e4cd1d98993bd6991eb1b1aff7a86b05">view</a>]</li>
-<li>Initialized potentially uninitialized variable in markdown part [<a href="http://github.com/doxygen/doxygen/commit/c98afa68350ed5cbce5a24bee3b47069789cc411">view</a>]</li>
-<li>Introduce new optimized string implementation (attempt 2) [<a href="http://github.com/doxygen/doxygen/commit/43edc14cd357dcb070402bccc5030507570c22a4">view</a>]</li>
-<li>Introduced template directory for template and resource files and resource compiler &amp; manager [<a href="http://github.com/doxygen/doxygen/commit/0fea3d4ca57187f271d7580ff16f32b7ab4657df">view</a>]</li>
-<li>LaTeX problem with 2 consecutive single quotes [<a href="http://github.com/doxygen/doxygen/commit/0cb39b4cf9f1e89720cb19f58158b90ecf0b75ef">view</a>]</li>
-<li>Last comment of \code{.f90} missing [<a href="http://github.com/doxygen/doxygen/commit/b9145da402cd49c4c4e888a31dc17612387b1321">view</a>]</li>
-<li>Limit images sizes and make more uniform (LaTeX) [<a href="http://github.com/doxygen/doxygen/commit/329a4ddc036ac9dfe72b11d62cb4043bc8488c20">view</a>]</li>
-<li>Package mathptmx gives discrepancy between pdf and HTML formulas [<a href="http://github.com/doxygen/doxygen/commit/418d7f076ffbb1aeaae5f689a5dd46977c456a98">view</a>]</li>
-<li>Portuguese and Brazilian Portuguese translators updated to 1.8.5. [<a href="http://github.com/doxygen/doxygen/commit/7da215a553e19783de60341bd863264ea9393513">view</a>]</li>
-<li>Prevent overly long terms from stopping the search indexer [<a href="http://github.com/doxygen/doxygen/commit/5d266c5d7f7b05dcfa8d3485bc43e268dd8fe90a">view</a>]</li>
-<li>Problem in case of line termination (., a dot) direct after the \cite command [<a href="http://github.com/doxygen/doxygen/commit/f0338dbf3a8770a6120eab83b338e6e3c3427a0e">view</a>]</li>
-<li>Regression class&lt;T extends V&gt; resulted in class&lt;V&gt; as the page title [<a href="http://github.com/doxygen/doxygen/commit/dec53d22986c8d2c44a30806a2c8ed03bbe24768">view</a>]</li>
-<li>Remove bogus argument to avoid compiler warning [<a href="http://github.com/doxygen/doxygen/commit/5bebcfb4a077287c561d2be7b3510d13d4e44a55">view</a>]</li>
-<li>Remove dependency of PlantUML on HAVE_DOT [<a href="http://github.com/doxygen/doxygen/commit/352bac2c21b69d4e33ec0056fe4d2b96fbe1b0b5">view</a>]</li>
-<li>Remove extraneous &#39;README&#39; to allow successful RPM creation [<a href="http://github.com/doxygen/doxygen/commit/fefce473f5cde9fe4db3a86544db2ba41eec8d74">view</a>]</li>
-<li>Remove filtering rule when generating FORTRAN module links [<a href="http://github.com/doxygen/doxygen/commit/238b73322f87614f5753dc0fa6df6c450f81be5e">view</a>]</li>
-<li>Remove redundant code [<a href="http://github.com/doxygen/doxygen/commit/d1ed20c4c9a04f7995b82f8628908e3c34fd054a">view</a>]</li>
-<li>Removed bash specific construct from ./configure script to make it work on Solaris [<a href="http://github.com/doxygen/doxygen/commit/3ebc431569aa6566389f3f3fc00aae7b8a90e58b">view</a>]</li>
-<li>Removed some comment statements. [<a href="http://github.com/doxygen/doxygen/commit/222753a906d42dab63708e074dd289e66dccf091">view</a>]</li>
-<li>Revert &quot;Bug <a href="https://github.com/doxygen/doxygen/issues/4011">4011</a> - Fortran: external subroutine as dummy argument not recognized&quot; [<a href="http://github.com/doxygen/doxygen/commit/8c8120bc3efa6ffa74f5e8cfce9cd6e4cae3de3a">view</a>]</li>
-<li>Reverted back to old string implementation. New one needs more work. [<a href="http://github.com/doxygen/doxygen/commit/7d933a9f99dacb83937534719103218470e2a5ab">view</a>]</li>
-<li>Show tag file name instead of &lt;unknown&gt; for warnings pointing to symbols extracted from tag files. [<a href="http://github.com/doxygen/doxygen/commit/b4b4c9decfacdf77d58490fa2dd81e1e10fe2dd0">view</a>]</li>
-<li>Show the parent-child type specialization relation in Java/C# generics inheritance diagrams [<a href="http://github.com/doxygen/doxygen/commit/7ee743004ac80914bdb66e3c7a8e5c39c0d5bf4a">view</a>]</li>
-<li>Support charset option for PlantUML [<a href="http://github.com/doxygen/doxygen/commit/ed0da5fe85e17eb0f7071fff12e851e92c2d79e6">view</a>]</li>
-<li>Support for INLINE_SOURCES in Fortran [<a href="http://github.com/doxygen/doxygen/commit/940a802a997609105e5be25f6ff576628a51fbda">view</a>]</li>
-<li>Support plantuml !include statement [<a href="http://github.com/doxygen/doxygen/commit/bbb6bb217a2feb7b9b961037072f06ff1024a0ef">view</a>]</li>
-<li>Support visible=no for main page tab. [<a href="http://github.com/doxygen/doxygen/commit/52df7ae7fb9ed9765b0faf922c69a1c57a5cfd69">view</a>]</li>
-<li>Supporting linking for methods bound to FORTRAN classes in source definitions [<a href="http://github.com/doxygen/doxygen/commit/f704342b42b19a857ec42438542221836576287a">view</a>]</li>
-<li>This is the patch attached to bz 651848 by Robin Gareus. [<a href="http://github.com/doxygen/doxygen/commit/f854e1d9f1a60a7e254dcc20a4e6db0aa9172b2c">view</a>]</li>
-<li>Update README.md [<a href="http://github.com/doxygen/doxygen/commit/b3c44e52cf7226b16ebd576ad381c3ee343dfd7e">view</a>]</li>
-<li>Updated configuration script and libdoxygen.pro.in to use llvm-config [<a href="http://github.com/doxygen/doxygen/commit/61e07f8ea2d0d2a2f001b1f657d3d5bbe44e7690">view</a>]</li>
-<li>Use result of vsnprintf [<a href="http://github.com/doxygen/doxygen/commit/84a6f4155659f97d42290494bd21d51f55eda258">view</a>]</li>
-<li>Use substitute() instead of QString conversion [<a href="http://github.com/doxygen/doxygen/commit/7a0f5e6d565db6192f8c22045d7988a0b4e4d8c3">view</a>]</li>
-<li>Various VHDL fixes [<a href="http://github.com/doxygen/doxygen/commit/475b0c51847271b04cb0e58254bd7e420445250b">view</a>]</li>
-<li>various fixes and restructuring [<a href="http://github.com/doxygen/doxygen/commit/223e7de6478019c8eebcfd87085fe22d3bfeec0e">view</a>]</li>
-<li>Various latex problems [<a href="http://github.com/doxygen/doxygen/commit/fb4dad1e1d9774e92d1509d1c2d3f8cb341826a1">view</a>]</li>
+    </ol> </li>
+<li>Add missing escape in doxysearch.cpp when result contained a double quote [<a href="https://github.com/doxygen/doxygen/commit/08c9689157d7edc5d8e3369ef96f2ccd4b01c10c">view</a>]</li>
+<li>Add source code possibility for RTF output [<a href="https://github.com/doxygen/doxygen/commit/05eb230757f6510d461bd14df3b190da46edd9dc">view</a>]</li>
+<li>Added Coverity Scan Build Status to Readme [<a href="https://github.com/doxygen/doxygen/commit/394acb6a10dbef10cad3a0a3ff50a05d0efdea9e">view</a>]</li>
+<li>Added clearer range checks for string class to help compiler [<a href="https://github.com/doxygen/doxygen/commit/869ff34828e20e3ec318384d7b0dbf91b6b2d24d">view</a>]</li>
+<li>Added compilation support for MacOSX 10.10 (yosemite) [<a href="https://github.com/doxygen/doxygen/commit/151876a8321204bd2ec08ec6c4de38ba9fb2d034">view</a>]</li>
+<li>Added faster reference counted string implementation with short string optimization [<a href="https://github.com/doxygen/doxygen/commit/9323ae470ad514586706dc8647501361fe208f36">view</a>]</li>
+<li>Added graphical hierarchy support to template engine [<a href="https://github.com/doxygen/doxygen/commit/fe818bf8e3a154788a4a180068cfdfbbadd66ff6">view</a>]</li>
+<li>Added guard to prevent (theoretical) out of bound access [<a href="https://github.com/doxygen/doxygen/commit/060a5cc121be5fd177b5d5c834f2b810dc58b9ec">view</a>]</li>
+<li>Added language attribute to XML output for classes, namespaces, and files [<a href="https://github.com/doxygen/doxygen/commit/e986e0039de21791bd1fbb1f59b13f58c4a46324">view</a>]</li>
+<li>Avoid a (theoretical) memory leak [<a href="https://github.com/doxygen/doxygen/commit/2937e44299a615628c27b0a0a7a95ffdf18249ef">view</a>]</li>
+<li>Better handling of inline Fortran parameter documentation [<a href="https://github.com/doxygen/doxygen/commit/d5546cff5c82157f2dfddd0e1c4fdeeee8e501dd">view</a>]</li>
+<li>Fixed bug for page numbers in the latex indices [<a href="https://github.com/doxygen/doxygen/commit/37ea04c317f9e1e8a09e5944b8c6c2c2ef35b1f6">view</a>]</li>
+<li>Compilation fixes for Windows for new string implementation. [<a href="https://github.com/doxygen/doxygen/commit/a31c9fffec6b5145ac8509d77da826d2e196ed1e">view</a>]</li>
+<li>Convert FORTRAN modules to namespaces [<a href="https://github.com/doxygen/doxygen/commit/be933bfacadaca98aaf4713746201b1fc21177de">view</a>]</li>
+<li>Create an easy possibility to take a snippet from the current file. [<a href="https://github.com/doxygen/doxygen/commit/f8ceac63bdb52cf395207258c98ff0bcba35870a">view</a>]</li>
+<li>Debian Bug 762272: segfault with cyclic subgroups [<a href="https://github.com/doxygen/doxygen/commit/c83db38ea83499be19d9ff242bfa22ae534ee80c">view</a>]</li>
+<li>Disabled enter/exit printing for doctokenizer (produced too much noise) [<a href="https://github.com/doxygen/doxygen/commit/0b615342f0a24fbf02cc9fa94550cf34d230425b">view</a>]</li>
+<li>Empty entry in \tableofcontents in case e.g. section without description. [<a href="https://github.com/doxygen/doxygen/commit/d2acdcf3b1bbd4d3079cf6c4ff5de6ba6716fd06">view</a>]</li>
+<li>Extra empty line in source fragments [<a href="https://github.com/doxygen/doxygen/commit/79b40a437092bccb6589cdb29c0059a4797b771d">view</a>]</li>
+<li>Fix bug with C++11 static_assert [<a href="https://github.com/doxygen/doxygen/commit/7c257bb57562b015b094f109851d914ef232ae2a">view</a>]</li>
+<li>Fix bug: language switch command &quot;\~&quot; failed to detect language id which contains &#39;-&#39; [<a href="https://github.com/doxygen/doxygen/commit/a4cf65dea1371721f07c63c2bb5f9e5085b2618a">view</a>]</li>
+<li>Fix for <a href="https://github.com/doxygen/doxygen/issues/4285">4285</a> [<a href="https://github.com/doxygen/doxygen/commit/e1aa7af27eded7afdf81b688015421d3b3467b2b">view</a>]</li>
+<li>Fix for the second issue in bz 651848 [<a href="https://github.com/doxygen/doxygen/commit/bcd3fbf59f9199470d51938486fecda05006da61">view</a>]</li>
+<li>Fix potential crash when reading tag file which contained nested java classes using generics [<a href="https://github.com/doxygen/doxygen/commit/6d4044ad43ae1424a256eb1c26992301e7c64f4a">view</a>]</li>
+<li>Fix rules for closing FORTRAN module and typedef scopes [<a href="https://github.com/doxygen/doxygen/commit/7ace28eb7bb5f42c3571e5b7be1ab954f4509e17">view</a>]</li>
+<li>Fix to ignore the contents of \verbatim and friends while looking for sections [<a href="https://github.com/doxygen/doxygen/commit/cba0d89fafee3daef31469cbe1cdd24e68c7b56a">view</a>]</li>
+<li>Fix to show relations between C#/Java generic classes [<a href="https://github.com/doxygen/doxygen/commit/9879fddbf8f91c57b258b8e788b5ed8a150a8331">view</a>]</li>
+<li>Fixed a number of issues (resource leaks, uninitialized members, etc) found by coverity [<a href="https://github.com/doxygen/doxygen/commit/41887832b90698df95e8d222cdc0a541ae2f2284">view</a>]</li>
+<li>Fixed bug in new QCString::sprintf for long string. [<a href="https://github.com/doxygen/doxygen/commit/0ec56b7aa2dd39e3cab71c2229d486161566e7f6">view</a>]</li>
+<li>Fixed extension matching issue if path contained a dot. [<a href="https://github.com/doxygen/doxygen/commit/79ed06502c3abca083f2e231f09fc8101862fcf6">view</a>]</li>
+<li>Fixed issue accessing uninitialized data when combining RTF output. [<a href="https://github.com/doxygen/doxygen/commit/e5076edf2c103d262a9e32d57fb40cfe210c9ddf">view</a>]</li>
+<li>Fixed issue parsing @end directly followed by the end of the file [<a href="https://github.com/doxygen/doxygen/commit/fa239ea9a3bba27e4fff84629883ee400f674c1e">view</a>]</li>
+<li>Fixed problem finding \enduml when using /// style comments. [<a href="https://github.com/doxygen/doxygen/commit/4df52916170bb81179697d0fa78c7d81fd95415f">view</a>]</li>
+<li>Fixed refcounting bug in new string implementation [<a href="https://github.com/doxygen/doxygen/commit/a9dcbfe28625673f4d13bc5b3cde694c24062e19">view</a>]</li>
+<li>Fixed several Coverity warnings [<a href="https://github.com/doxygen/doxygen/commit/9b7e4ffb6c5f7534e4ba11d5798b4eb74d4a2a70">view</a>]</li>
+<li>Fixed to small memory leaks [<a href="https://github.com/doxygen/doxygen/commit/b55a5c91d49359f9bbf7c78d9f284be2092bcfaa">view</a>]</li>
+<li>Fixed typos and formatting in Doxyfile (thanks to Armin Mueller) [<a href="https://github.com/doxygen/doxygen/commit/fdd1c3f1527b15f6b0a25c2d99748f6a8adc5fcf">view</a>]</li>
+<li>Fixed typos in C/C++ comments. There are no functional changes. [<a href="https://github.com/doxygen/doxygen/commit/458fb1738f4e59586460daa2a1e3ad2e730306c4">view</a>]</li>
+<li>Fixed typos in comments. [<a href="https://github.com/doxygen/doxygen/commit/8ff67ad01abfe97b43de0ef1799c8b798d725ab9">view</a>]</li>
+<li>Fixed typos in comments. No functional changes. [<a href="https://github.com/doxygen/doxygen/commit/6920d3ec6db21cec32086249a48875cbac957470">view</a>]</li>
+<li>Fortran code color END (regression pull request 259) [<a href="https://github.com/doxygen/doxygen/commit/0ccda478e35eb420d644b6c39923f9c020e69c13">view</a>]</li>
+<li>Fortran color CALL as keyword [<a href="https://github.com/doxygen/doxygen/commit/d3a5f96d07db323ff97fb07766a809769506ef3a">view</a>]</li>
+<li>Fortran color code of END [<a href="https://github.com/doxygen/doxygen/commit/1cfa914cbb4e41f15af1f08517af887d6b241f28">view</a>]</li>
+<li>Fortran continuation character seen as begin of function call [<a href="https://github.com/doxygen/doxygen/commit/b2e9aa362540cae4487e48598fb7e80b8651752f">view</a>]</li>
+<li>Generate error message in case bibtex generation fails [<a href="https://github.com/doxygen/doxygen/commit/f121923bde72ef68616224a3fa1c1fe27eeb385e">view</a>]</li>
+<li>Improved main page rendering via template engine [<a href="https://github.com/doxygen/doxygen/commit/f8a86910e4cd1d98993bd6991eb1b1aff7a86b05">view</a>]</li>
+<li>Initialized potentially uninitialized variable in markdown part [<a href="https://github.com/doxygen/doxygen/commit/c98afa68350ed5cbce5a24bee3b47069789cc411">view</a>]</li>
+<li>Introduce new optimized string implementation (attempt 2) [<a href="https://github.com/doxygen/doxygen/commit/43edc14cd357dcb070402bccc5030507570c22a4">view</a>]</li>
+<li>Introduced template directory for template and resource files and resource compiler &amp; manager [<a href="https://github.com/doxygen/doxygen/commit/0fea3d4ca57187f271d7580ff16f32b7ab4657df">view</a>]</li>
+<li>LaTeX problem with 2 consecutive single quotes [<a href="https://github.com/doxygen/doxygen/commit/0cb39b4cf9f1e89720cb19f58158b90ecf0b75ef">view</a>]</li>
+<li>Last comment of \code{.f90} missing [<a href="https://github.com/doxygen/doxygen/commit/b9145da402cd49c4c4e888a31dc17612387b1321">view</a>]</li>
+<li>Limit images sizes and make more uniform (LaTeX) [<a href="https://github.com/doxygen/doxygen/commit/329a4ddc036ac9dfe72b11d62cb4043bc8488c20">view</a>]</li>
+<li>Package mathptmx gives discrepancy between pdf and HTML formulas [<a href="https://github.com/doxygen/doxygen/commit/418d7f076ffbb1aeaae5f689a5dd46977c456a98">view</a>]</li>
+<li>Portuguese and Brazilian Portuguese translators updated to 1.8.5. [<a href="https://github.com/doxygen/doxygen/commit/7da215a553e19783de60341bd863264ea9393513">view</a>]</li>
+<li>Prevent overly long terms from stopping the search indexer [<a href="https://github.com/doxygen/doxygen/commit/5d266c5d7f7b05dcfa8d3485bc43e268dd8fe90a">view</a>]</li>
+<li>Problem in case of line termination (., a dot) direct after the \cite command [<a href="https://github.com/doxygen/doxygen/commit/f0338dbf3a8770a6120eab83b338e6e3c3427a0e">view</a>]</li>
+<li>Regression class&lt;T extends V&gt; resulted in class&lt;V&gt; as the page title [<a href="https://github.com/doxygen/doxygen/commit/dec53d22986c8d2c44a30806a2c8ed03bbe24768">view</a>]</li>
+<li>Remove bogus argument to avoid compiler warning [<a href="https://github.com/doxygen/doxygen/commit/5bebcfb4a077287c561d2be7b3510d13d4e44a55">view</a>]</li>
+<li>Remove dependency of PlantUML on HAVE_DOT [<a href="https://github.com/doxygen/doxygen/commit/352bac2c21b69d4e33ec0056fe4d2b96fbe1b0b5">view</a>]</li>
+<li>Remove extraneous &#39;README&#39; to allow successful RPM creation [<a href="https://github.com/doxygen/doxygen/commit/fefce473f5cde9fe4db3a86544db2ba41eec8d74">view</a>]</li>
+<li>Remove filtering rule when generating FORTRAN module links [<a href="https://github.com/doxygen/doxygen/commit/238b73322f87614f5753dc0fa6df6c450f81be5e">view</a>]</li>
+<li>Remove redundant code [<a href="https://github.com/doxygen/doxygen/commit/d1ed20c4c9a04f7995b82f8628908e3c34fd054a">view</a>]</li>
+<li>Removed bash specific construct from ./configure script to make it work on Solaris [<a href="https://github.com/doxygen/doxygen/commit/3ebc431569aa6566389f3f3fc00aae7b8a90e58b">view</a>]</li>
+<li>Removed some comment statements. [<a href="https://github.com/doxygen/doxygen/commit/222753a906d42dab63708e074dd289e66dccf091">view</a>]</li>
+<li>Revert &quot;Bug <a href="https://github.com/doxygen/doxygen/issues/4011">4011</a> - Fortran: external subroutine as dummy argument not recognized&quot; [<a href="https://github.com/doxygen/doxygen/commit/8c8120bc3efa6ffa74f5e8cfce9cd6e4cae3de3a">view</a>]</li>
+<li>Reverted back to old string implementation. New one needs more work. [<a href="https://github.com/doxygen/doxygen/commit/7d933a9f99dacb83937534719103218470e2a5ab">view</a>]</li>
+<li>Show tag file name instead of &lt;unknown&gt; for warnings pointing to symbols extracted from tag files. [<a href="https://github.com/doxygen/doxygen/commit/b4b4c9decfacdf77d58490fa2dd81e1e10fe2dd0">view</a>]</li>
+<li>Show the parent-child type specialization relation in Java/C# generics inheritance diagrams [<a href="https://github.com/doxygen/doxygen/commit/7ee743004ac80914bdb66e3c7a8e5c39c0d5bf4a">view</a>]</li>
+<li>Support charset option for PlantUML [<a href="https://github.com/doxygen/doxygen/commit/ed0da5fe85e17eb0f7071fff12e851e92c2d79e6">view</a>]</li>
+<li>Support for INLINE_SOURCES in Fortran [<a href="https://github.com/doxygen/doxygen/commit/940a802a997609105e5be25f6ff576628a51fbda">view</a>]</li>
+<li>Support plantuml !include statement [<a href="https://github.com/doxygen/doxygen/commit/bbb6bb217a2feb7b9b961037072f06ff1024a0ef">view</a>]</li>
+<li>Support visible=no for main page tab. [<a href="https://github.com/doxygen/doxygen/commit/52df7ae7fb9ed9765b0faf922c69a1c57a5cfd69">view</a>]</li>
+<li>Supporting linking for methods bound to FORTRAN classes in source definitions [<a href="https://github.com/doxygen/doxygen/commit/f704342b42b19a857ec42438542221836576287a">view</a>]</li>
+<li>This is the patch attached to bz 651848 by Robin Gareus. [<a href="https://github.com/doxygen/doxygen/commit/f854e1d9f1a60a7e254dcc20a4e6db0aa9172b2c">view</a>]</li>
+<li>Update README.md [<a href="https://github.com/doxygen/doxygen/commit/b3c44e52cf7226b16ebd576ad381c3ee343dfd7e">view</a>]</li>
+<li>Updated configuration script and libdoxygen.pro.in to use llvm-config [<a href="https://github.com/doxygen/doxygen/commit/61e07f8ea2d0d2a2f001b1f657d3d5bbe44e7690">view</a>]</li>
+<li>Use result of vsnprintf [<a href="https://github.com/doxygen/doxygen/commit/84a6f4155659f97d42290494bd21d51f55eda258">view</a>]</li>
+<li>Use substitute() instead of QString conversion [<a href="https://github.com/doxygen/doxygen/commit/7a0f5e6d565db6192f8c22045d7988a0b4e4d8c3">view</a>]</li>
+<li>Various VHDL fixes [<a href="https://github.com/doxygen/doxygen/commit/475b0c51847271b04cb0e58254bd7e420445250b">view</a>]</li>
+<li>various fixes and restructuring [<a href="https://github.com/doxygen/doxygen/commit/223e7de6478019c8eebcfd87085fe22d3bfeec0e">view</a>]</li>
+<li>Various latex problems [<a href="https://github.com/doxygen/doxygen/commit/fb4dad1e1d9774e92d1509d1c2d3f8cb341826a1">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -876,132 +875,132 @@
 </p>
 <h3>New features</h3>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5505">5505</a> - Support for PlantUML [<a href="http://github.com/doxygen/doxygen/commit/7506404e646f1fcc5a26ca6fca91a7f65154f05a">view</a>]</li>
-<li>Add BREAD_CRUMB_TRAIL. [<a href="http://github.com/doxygen/doxygen/commit/4074da5b83d37dd1c72c5df015fb2b41e7725a7e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5505">5505</a> - Support for PlantUML [<a href="https://github.com/doxygen/doxygen/commit/7506404e646f1fcc5a26ca6fca91a7f65154f05a">view</a>]</li>
+<li>Add BREAD_CRUMB_TRAIL. [<a href="https://github.com/doxygen/doxygen/commit/4074da5b83d37dd1c72c5df015fb2b41e7725a7e">view</a>]</li>
 </ul>
 <h3>Bug fixes</h3>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1527">1527</a> $title doesn&#39;t work in LateX header [<a href="http://github.com/doxygen/doxygen/commit/790000b90944646702ddd3a183ec166669c18f51">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3405">3405</a> Class diagrams and class hierarchy don&#39;t work for java generic classes [<a href="http://github.com/doxygen/doxygen/commit/c3ddf3331239fb3f41e502a8337eee786ceaad06">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3460">3460</a> Flex .rule file for Visual Studio build can&#39;t cope with spaces in filenames [<a href="http://github.com/doxygen/doxygen/commit/eb3ab2452d8a1ef7a85af7a03e1622c12b40400b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3834">3834</a> Fortran: quotation after define causes error [<a href="http://github.com/doxygen/doxygen/commit/f083109de116ee2c6e2a31a15ebc17d2dff008e0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3879">3879</a> FORTRAN: recognition free versus fixed formatted code [<a href="http://github.com/doxygen/doxygen/commit/476d79d31a0534c3d7d07001c47c1212a73d10a5">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5182">5182</a> Bibliography duplicate filenames fails [<a href="http://github.com/doxygen/doxygen/commit/7779bf6d6206bc0f78c22100034c44bfdb7f1bc1">view</a>] and
-                                                                                                                      [<a href="http://github.com/doxygen/doxygen/commit/da029a3c893df22536cb3635e597fd3f5b2a4862">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5215">5215</a> \cite rejects valid BibTeX keys [<a href="http://github.com/doxygen/doxygen/commit/06170de4a166bfad9342f3b957dda82b7fb266b2">view</a>] and
-                                                                                                               [<a href="http://github.com/doxygen/doxygen/commit/69df2f9d1deb87b79c79f9ea1bf20380ff9b71ad">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5259">5259</a> TCL: Documentation of oo::define is not working [<a href="http://github.com/doxygen/doxygen/commit/5ec66c2286d7cedbdbb0930fe0e293b050c91d24">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5445">5445</a> Nested C structures/unions does not work with groups [<a href="http://github.com/doxygen/doxygen/commit/f4388dc4a62e183b7ca4457eba7cb978a35804c2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5459">5459</a> configuration stops with settings.h missing [<a href="http://github.com/doxygen/doxygen/commit/fd4b42ec54cb8d6faf2b0f16e580f376e8cf6982">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5460">5460</a> XML Output: Doxygen doesn't escape &amp; characters (included in a hyperlink) in &lt;detaileddescription&gt; [<a href="http://github.com/doxygen/doxygen/commit/cfde6cdd600b21bba6a2eb0ca0e7e208e014ccaf">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5461">5461</a> function object in member initializer causes documentation loss [<a href="http://github.com/doxygen/doxygen/commit/f4f3e381dba1bc5d46feea3c39e8f076e27463d1">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5472">5472</a> [PATCH] Propagate configure&#39;s perl to makefiles [<a href="http://github.com/doxygen/doxygen/commit/f1a692b019a30f7aa07e0fb3e11402d262af8026">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5483">5483</a> man page extension is incorrect [<a href="http://github.com/doxygen/doxygen/commit/f25d896d4da9b44c23f89bfdd0379fa97ab2c351">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5486">5486</a> No documentation generated for method-less C++ struct [<a href="http://github.com/doxygen/doxygen/commit/21178ab40160abf011fa084a10892b5b7821e44c">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5493">5493</a> [PATCH] Fix potential copy and paste error in inputstring.cpp [<a href="http://github.com/doxygen/doxygen/commit/6f5748e822b009cbe82cc1df8eea43e4769bc44b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5494">5494</a> [PATCH] Fix missing &#39;&amp;&#39; in Boolean operation in qstring.cpp [<a href="http://github.com/doxygen/doxygen/commit/27f1e1e9316addcfd0bbc3321b5614ed14f7a1a5">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5497">5497</a> Dead links in html documentation when using tabs for indentation in c++ [<a href="http://github.com/doxygen/doxygen/commit/2cc3b18da39bde323c5739483e507a133e93ac22">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5500">5500</a> Callgraphs for C# only generated for methods inside the same class [<a href="http://github.com/doxygen/doxygen/commit/7edbf2b2e705eccc0d99cce86149228473bc7f3e">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5506">5506</a> Variadic macros failing to expand if trailing ... is empty [<a href="http://github.com/doxygen/doxygen/commit/070c35549da108695074239be3ab4268f3722261">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5512">5512</a> Two entries for a single member in doxygen XML [<a href="http://github.com/doxygen/doxygen/commit/ed8ce3cf405204916f9832e26797cb15d1490fd1">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5514">5514</a> nested html tables cause pdflatex to hang (1.8.4 and 1.8.6) [<a href="http://github.com/doxygen/doxygen/commit/3cb963061343aa5b3b8a044cdfa62848723a02ee">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5521">5521</a> volatile declaration on member functions is not handled as xml attribute [<a href="http://github.com/doxygen/doxygen/commit/97d12d058a7831adcc8c6f2cfe8c20ddd2ae5bc2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5524">5524</a> Incorrect LaTeX generation for private union member in C++ [<a href="http://github.com/doxygen/doxygen/commit/a36ddbe0ee97c5ee248b7b391b4c30fd4b3c884b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5526">5526</a> XML Output invalid: XML_PROGRAMLISTING=YES copies Unicode form feed character (U+000C) to XML files [<a href="http://github.com/doxygen/doxygen/commit/b272b4b5077873457a0f6b517ac799f4a5f8c951">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5528">5528</a> segfault in QGListIterator while parsing fortran code [<a href="http://github.com/doxygen/doxygen/commit/aac81f8bfe8298aa0839bb2d7c70ea75149cdffb">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5531">5531</a> Explicit links using operator()() not generated. [<a href="http://github.com/doxygen/doxygen/commit/e913d55b2e5a8e37ebd1ffd8fec730886a45fbda">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5534">5534</a> no uniquely matching class member found for inline function definition where parameter argument names don&#39;t match [<a href="http://github.com/doxygen/doxygen/commit/6f0269ef3074bbc4bc16ad63a0e0a8f9b5f0ce31">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5535">5535</a> Add support for non-parsed language [<a href="http://github.com/doxygen/doxygen/commit/0dd59398b3f62288897c8c3405977a27a94fbfee">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5537">5537</a> Q_PROPERTY switches the member access from private to public [<a href="http://github.com/doxygen/doxygen/commit/392b48a25e4315528fbb11a5a1bfc9f2bca791c0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5540">5540</a> Strong enum members listed in containing namespace [<a href="http://github.com/doxygen/doxygen/commit/4766fdba2ab196844a0bd5ec5e0b64d94df4a74f">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5543">5543</a> Sigsegv while generating XML output [<a href="http://github.com/doxygen/doxygen/commit/14f88af12bae98859eafe605ddb5f54029e44076">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5544">5544</a> GENERATE_TAGFILE no longer includes any @*section links [<a href="http://github.com/doxygen/doxygen/commit/7d9d4320f5d183c4e1ebc87a316589c36f0afeed">view</a>] and
-                                                                                                                                       [<a href="http://github.com/doxygen/doxygen/commit/8b279c9bc28c70405e61219a6c2b3c6dbc7426e6">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5548">5548</a> Request: disable building documentation if Python 2.6 or newer not available [<a href="http://github.com/doxygen/doxygen/commit/264ecc9eee1f2b74f0110120574056f0de42a3f9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5550">5550</a> No output for markdown pages with duplicate label title (different anchor) [<a href="http://github.com/doxygen/doxygen/commit/ebb2fe6d73b4aefc6dadab8eec45adc4ee0c9fd5">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5551">5551</a> QGDict::hashAsciiKey: Invalid null key [<a href="http://github.com/doxygen/doxygen/commit/def392bf8d0326733c20504dc36168093e087c95">view</a>]</li>
-<li>Add FORTRAN 2003 keywords and commands [<a href="http://github.com/doxygen/doxygen/commit/4cbfaa8372beff4bd7070dd840924af8d96b0772">view</a>]</li>
-<li>Add type option to FORTRAN select statements [<a href="http://github.com/doxygen/doxygen/commit/db289e2272bfc3b00452cbf7c2a30114fb8b7c58">view</a>]</li>
-<li>Added build support for Python3+ and Python2.6+ [<a href="http://github.com/doxygen/doxygen/commit/98a54c576eec4feda606156ae591854311d9cd0e">view</a>]</li>
-<li>Added class/procedure vardefs to FORTRAN code highlighting [<a href="http://github.com/doxygen/doxygen/commit/dbd1985de07ccd19caf57ffa36c88811048689a4">view</a>]</li>
-<li>Added documentation for some missing HTML commands [<a href="http://github.com/doxygen/doxygen/commit/04c89e604877fa9a4aea160d971c782006872710">view</a>]</li>
-<li>Added flatten, listsort and paginate filters [<a href="http://github.com/doxygen/doxygen/commit/edd056308d04d6f445a48e05105d4d9a0ece80a0">view</a>]</li>
-<li>Added get filter, unified index properties [<a href="http://github.com/doxygen/doxygen/commit/7e3e890fedfb20e7018fadfa87ed97eef7f2b720">view</a>]</li>
-<li>Added groupby filter and some more context info [<a href="http://github.com/doxygen/doxygen/commit/064992b0c901661b49de24ce1a1d9a06e9957a93">view</a>]</li>
-<li>Added import keyword to FORTRAN code highlighting [<a href="http://github.com/doxygen/doxygen/commit/558697792cd062b93e8d7b7904fb9897e5f70750">view</a>]</li>
-<li>Added lists for indices to template context [<a href="http://github.com/doxygen/doxygen/commit/2d35b9a7c0fe70fa894dc266dd0b5ddd54d4014e">view</a>]</li>
-<li>Added mainpage to context and improved page tree [<a href="http://github.com/doxygen/doxygen/commit/2e837e0be05636923ef593c29299ff76c4590a09">view</a>]</li>
-<li>Added member indexes to template context [<a href="http://github.com/doxygen/doxygen/commit/b850eb45e80b348cbe8629c354350b051f7ef2ec">view</a>]</li>
-<li>Added missing links in changelog when multiple bug ids were on one line [<a href="http://github.com/doxygen/doxygen/commit/b752d01fe2de1668c0a247bc3955d7be6987d046">view</a>]</li>
-<li>Added more missing links to the changelog [<a href="http://github.com/doxygen/doxygen/commit/0d50c30becc147918b091c02b41502829b8083a3">view</a>]</li>
-<li>Added namespace info to the context [<a href="http://github.com/doxygen/doxygen/commit/a7c14ac74c43e6b372d866deeed77fe69e2a68e0">view</a>]</li>
-<li>Addition of module data to context and alphaIndex filter [<a href="http://github.com/doxygen/doxygen/commit/e0c3517ff9369387e00dd596b094a4729cfe789c">view</a>]</li>
-<li>Coded coloring of flow statements corrected (regression) [<a href="http://github.com/doxygen/doxygen/commit/ee7194bd73ee3a8142aee6ea59d2e5dc717b18de">view</a>]</li>
-<li>Corrected copyright year [<a href="http://github.com/doxygen/doxygen/commit/7652fc8472ac83e26641fb737539e7c87725ed68">view</a>]</li>
-<li>Correction of typing error [<a href="http://github.com/doxygen/doxygen/commit/81c99d10dbc41feab4a1aca220b27634ca0ff8cd">view</a>]</li>
-<li>Disabled/fixed segments that produced doxygen warnings while running the test [<a href="http://github.com/doxygen/doxygen/commit/3a5e6ac7c6018a7a0da7acd830293da0fcb7a21c">view</a>]</li>
-<li>Docbook output improvements [<a href="http://github.com/doxygen/doxygen/commit/12f5ee8a8c3a287f6bcfe81f79ff4332b3987c7e">view</a>]</li>
-<li>Documentation generator: added support for C# property accessors visibility modifiers. [<a href="http://github.com/doxygen/doxygen/commit/54ac45bd9f535d13b2bf98e4d71b27b4590c3dc7">view</a>]</li>
-<li>Doxywizard: make the Next button on the last page of the expert tab switch to the run tab [<a href="http://github.com/doxygen/doxygen/commit/2277e6e695d785d319cb52a8a8ead2982eac2afa">view</a>]</li>
-<li>Doxywizard: make the Next button on the last page of the wizard switch to the run tab [<a href="http://github.com/doxygen/doxygen/commit/fbc60af2298c2668893e2f7045f66765f8e0c63f">view</a>]</li>
-<li>Error linking 32-bit windows [<a href="http://github.com/doxygen/doxygen/commit/cce307d96a93515d46068cfdcf5e55c1944ae9e5">view</a>]</li>
-<li>Fix FORTRAN code function scope test [<a href="http://github.com/doxygen/doxygen/commit/2030240bc18d32581479306e6fd86211e6f30c73">view</a>]</li>
-<li>Fix after rebase from master [<a href="http://github.com/doxygen/doxygen/commit/57eee1777c18caa6d3215ec162da1fd9b2d14eb2">view</a>]</li>
-<li>Fix description of USE_PDFLATEX [<a href="http://github.com/doxygen/doxygen/commit/c87cceafe203a11e4074b748469e993d13cd8fb3">view</a>]</li>
-<li>Fix highlighting issues [<a href="http://github.com/doxygen/doxygen/commit/be0986e9ab7c1788e3650f1df7e7af70b68f28d8">view</a>]</li>
-<li>Fix typo [<a href="http://github.com/doxygen/doxygen/commit/e32121ab1fb261464356ce2352c08930f942f805">view</a>]</li>
-<li>Fix unnecessary rules for FORTRAN types [<a href="http://github.com/doxygen/doxygen/commit/1e6323e5bb04f49df9d00e82e5db3e8f301dbfc4">view</a>]</li>
-<li>Fix warning about unused functions in qstring.cpp [<a href="http://github.com/doxygen/doxygen/commit/84064ac4db9e487ca4bff9b6c37eb72992050ee3">view</a>]</li>
-<li>Fixed keyword type [<a href="http://github.com/doxygen/doxygen/commit/d8221cb7a73efc8f20068636c3d2fec84ce8cb8b">view</a>]</li>
-<li>Fixed missing include for Linux [<a href="http://github.com/doxygen/doxygen/commit/88468313289c659088be9beece59a82206153ed8">view</a>]</li>
-<li>Fixed test 021 [<a href="http://github.com/doxygen/doxygen/commit/c5c763056535216ccce4bed4892358bf5c8d1fd5">view</a>]</li>
-<li>Fixed typo [<a href="http://github.com/doxygen/doxygen/commit/0bb9b762844a2f88043223a29182dd9e7e524cef">view</a>]</li>
-<li>Fixed typo and used QString for directory [<a href="http://github.com/doxygen/doxygen/commit/5d00fa5862a1724bbe417e33d6c1a260607281ef">view</a>]</li>
-<li>Fixed windows compile issue for is_neutral [<a href="http://github.com/doxygen/doxygen/commit/9278509cf82ed7b0ff37c39e4d6e97f5308f29de">view</a>]</li>
-<li>Fixes for ./configure script on Solaris [<a href="http://github.com/doxygen/doxygen/commit/d234115b6f387ff723cb97a4d47b2bcca7f0bc6d">view</a>]</li>
-<li>Fixes regression due to PR 169 [<a href="http://github.com/doxygen/doxygen/commit/56143a268898249a63bb0a443e09dc2c77ec9ce9">view</a>]</li>
-<li>Language parser: added support for C# property accessors visibility modifiers. [<a href="http://github.com/doxygen/doxygen/commit/f5ff1b8e55b4dad074d2a73f1d003ff2991cf894">view</a>]</li>
-<li>Made INSTALL file version and date independent [<a href="http://github.com/doxygen/doxygen/commit/1781094043eb5f8f7b0f0bbe5f720012346123a2">view</a>]</li>
-<li>Made bread crumb trails enabled unconditionally [<a href="http://github.com/doxygen/doxygen/commit/c7c7d73c184ee2eebf65e83044cf1e325751cffa">view</a>]</li>
-<li>Made setName() virtual so overloading works [<a href="http://github.com/doxygen/doxygen/commit/d1e39098f94487f544a068b7864aa8d1b1f345cd">view</a>]</li>
-<li>Make index for faq [<a href="http://github.com/doxygen/doxygen/commit/38dfdcaba3e9130833cd7b695d5e20fec26f5c3f">view</a>]</li>
-<li>Messages truncated in warnings file [<a href="http://github.com/doxygen/doxygen/commit/cc4f3b454cae7d3e9eaa44342bcbae1061f5e790">view</a>]</li>
-<li>Minor fixes [<a href="http://github.com/doxygen/doxygen/commit/c31a81a85e0396fb276beefd06bb71c2819571ed">view</a>]</li>
-<li>Minor fixes to the template context [<a href="http://github.com/doxygen/doxygen/commit/963e0adfd76e6a59ace5e7318f948632322b1e51">view</a>]</li>
-<li>Missing word after \n command in doxygen rtf output, version 1.8.5 &amp; up [<a href="http://github.com/doxygen/doxygen/commit/ea9f3b1d727b22973c0176b2564304fb160aa70b">view</a>]</li>
-<li>More robust extraction of scope information from tag files [<a href="http://github.com/doxygen/doxygen/commit/6a60477b418e21dbadd3e62dc557a038e319581b">view</a>]</li>
-<li>No warning in case cite definition is missing [<a href="http://github.com/doxygen/doxygen/commit/1f77638174f715f0f2bcf5b2e32ebb329d531f85">view</a>]</li>
-<li>Preparations for release 1.8.8 [<a href="http://github.com/doxygen/doxygen/commit/f16be0113f8d47d4f04e69d0c45ccc4b24e3c426">view</a>]</li>
-<li>Removed not implemented HTML commands from documentation [<a href="http://github.com/doxygen/doxygen/commit/8199b2d105313efd30367c7a03b57bf7a7d2180b">view</a>]</li>
-<li>Removed unsupported HTML commands from the docs [<a href="http://github.com/doxygen/doxygen/commit/16ba4bd5744c2e5fbfabe95b27736b8ca8030390">view</a>]</li>
-<li>Set deployment targets for MacOSX 10.5+ versions [<a href="http://github.com/doxygen/doxygen/commit/28f40b3aea1411488832205fae447f4652125cdc">view</a>]</li>
-<li>Support multiple extra HTML stylesheets. [<a href="http://github.com/doxygen/doxygen/commit/595943c96860425f9086028b00e1e155e8ec434f">view</a>]</li>
-<li>Tcl: add missing file that breaks test 057 [<a href="http://github.com/doxygen/doxygen/commit/73e7c340f555291d4264b2f83caacf59a5a3395f">view</a>]</li>
-<li>Tcl: add test code for Bug <a href="https://github.com/doxygen/doxygen/issues/5463">5463</a> [<a href="http://github.com/doxygen/doxygen/commit/36ce0578065b95cf12b81e5a4edd95dea5707e22">view</a>]</li>
-<li>Tcl: collect XRefs also if INLINE_SOURCES = no [<a href="http://github.com/doxygen/doxygen/commit/6245ef410358f332330195f9f2bfa458cfb6a2b8">view</a>]</li>
-<li>Tcl: correct namespace resolution in case of INLINE_SOURCES = YES [<a href="http://github.com/doxygen/doxygen/commit/470143192d0c8cf90ad84a66226d48060cc713db">view</a>]</li>
-<li>Tcl: recurse for [] [<a href="http://github.com/doxygen/doxygen/commit/9d315a987d7d0ea2f38809aa74e36c92281910df">view</a>]</li>
-<li>Tcl: refactor similar code into tcl_codify_token function [<a href="http://github.com/doxygen/doxygen/commit/06bd53ac6acee5fb83d9f2b5ded1c55c8a069b29">view</a>]</li>
-<li>Tcl: support eval/catch commands [<a href="http://github.com/doxygen/doxygen/commit/9d24b488add8b4c7c689f58a095184a6ed85e9f1">view</a>]</li>
-<li>Tcl: support switch command [<a href="http://github.com/doxygen/doxygen/commit/2984dad86558b4a81e11ce07485057e3903a9304">view</a>]</li>
-<li>Tcl: test 057 additionally tests mutual Xrefs for two files [<a href="http://github.com/doxygen/doxygen/commit/c6aaf0a4c35db27f968a7a6d0b9fa25b5b311bc3">view</a>]</li>
-<li>Template context support for CREATE_SUBDIRS [<a href="http://github.com/doxygen/doxygen/commit/9282aab5ed2a0cca3858df6e62132f959e99edb5">view</a>]</li>
-<li>Update dot.cpp [<a href="http://github.com/doxygen/doxygen/commit/a15c5c89f0b4f97d57474d9ea0e3166709d35534">view</a>]</li>
-<li>Update latexgen.cpp [<a href="http://github.com/doxygen/doxygen/commit/1f877b09262f34e6bad6dbfaee4b04b4be03bd4c">view</a>]</li>
-<li>Update test 058 because commit 9d315a9 fixes also Bug <a href="https://github.com/doxygen/doxygen/issues/5464">5464</a> [<a href="http://github.com/doxygen/doxygen/commit/3486bfc158008da1d69d420e57e7a10f1c0d69c3">view</a>]</li>
-<li>Replaced the VHDL parser with the VHDL scanner from 1.7.5 to avoid potential licensing issues [<a href="http://github.com/doxygen/doxygen/commit/99433b3d2319916f11608c2c818fe35360256d9e">view</a>]</li>
-<li>New VHDL parser implementation [<a href="http://github.com/doxygen/doxygen/commit/36122e49ed1d9e640b1ceca52536ec7c55e10474">view</a>]</li>
-<li>Vhdl fixes [<a href="http://github.com/doxygen/doxygen/commit/3b8fea2f1f7f2e6a83a35626e6dec9d114a78c9e">view</a>]</li>
-<li>\usepackage{fixltx2e} must come before use \usepackage{float} [<a href="http://github.com/doxygen/doxygen/commit/d8a36bbd404bc9c77689f42cc4bfde8ac393cd8c">view</a>]</li>
-<li>cache anonymous into ClassDefImpl::isAnonymous [<a href="http://github.com/doxygen/doxygen/commit/34a5a051a8b91215ae4f93e5541d43c33aa887c1">view</a>]</li>
-<li>changed append filter and added index and path attributes to node [<a href="http://github.com/doxygen/doxygen/commit/47bc520ac8c0dde310dcb1999c622c591b373ffc">view</a>]</li>
-<li>doc/translator.py -- unification for Python 2.6+ and 3.3+ (not finished) [<a href="http://github.com/doxygen/doxygen/commit/8cac977ddfdc1c77546f5d766387f4a57710c8c0">view</a>]</li>
-<li>doc/translator.py unified for Python 2.6+ and Python 3.0+ [<a href="http://github.com/doxygen/doxygen/commit/6212c2d2af12dd9d47459bdecdf79ad106060229">view</a>]</li>
-<li>make.bat: change current directory [<a href="http://github.com/doxygen/doxygen/commit/fc386eb107958b4f3214aa2c0c6caf2a91c83177">view</a>] and
-                                       [<a href="http://github.com/doxygen/doxygen/commit/feb24c82002ced816bc72eb8f2a6a35c71e25ed7">view</a>]</li>
-<li>removeRedundantWhiteSpace micro-optimization [<a href="http://github.com/doxygen/doxygen/commit/d4601735b582b903f1ccb144f59b2030a7797b05">view</a>]</li>
-<li>resolves the error of unbalanced tags opened/closed in docbook output: parser error : Opening and ending tag mismatch: para line 358 and tbody [<a href="http://github.com/doxygen/doxygen/commit/d7b0858e079419bb7ea862e16946218a9352d5b5">view</a>]</li>
-<li>winbuild/pack_the_distribution_for_windows.py minor updates [<a href="http://github.com/doxygen/doxygen/commit/6d969cab51f4c32784966a28b8b9d5fe2d5b2089">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1527">1527</a> $title doesn&#39;t work in LateX header [<a href="https://github.com/doxygen/doxygen/commit/790000b90944646702ddd3a183ec166669c18f51">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3405">3405</a> Class diagrams and class hierarchy don&#39;t work for java generic classes [<a href="https://github.com/doxygen/doxygen/commit/c3ddf3331239fb3f41e502a8337eee786ceaad06">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3460">3460</a> Flex .rule file for Visual Studio build can&#39;t cope with spaces in filenames [<a href="https://github.com/doxygen/doxygen/commit/eb3ab2452d8a1ef7a85af7a03e1622c12b40400b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3834">3834</a> Fortran: quotation after define causes error [<a href="https://github.com/doxygen/doxygen/commit/f083109de116ee2c6e2a31a15ebc17d2dff008e0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3879">3879</a> FORTRAN: recognition free versus fixed formatted code [<a href="https://github.com/doxygen/doxygen/commit/476d79d31a0534c3d7d07001c47c1212a73d10a5">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5182">5182</a> Bibliography duplicate filenames fails [<a href="https://github.com/doxygen/doxygen/commit/7779bf6d6206bc0f78c22100034c44bfdb7f1bc1">view</a>] and
+                                                                                                                      [<a href="https://github.com/doxygen/doxygen/commit/da029a3c893df22536cb3635e597fd3f5b2a4862">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5215">5215</a> \cite rejects valid BibTeX keys [<a href="https://github.com/doxygen/doxygen/commit/06170de4a166bfad9342f3b957dda82b7fb266b2">view</a>] and
+                                                                                                               [<a href="https://github.com/doxygen/doxygen/commit/69df2f9d1deb87b79c79f9ea1bf20380ff9b71ad">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5259">5259</a> TCL: Documentation of oo::define is not working [<a href="https://github.com/doxygen/doxygen/commit/5ec66c2286d7cedbdbb0930fe0e293b050c91d24">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5445">5445</a> Nested C structures/unions does not work with groups [<a href="https://github.com/doxygen/doxygen/commit/f4388dc4a62e183b7ca4457eba7cb978a35804c2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5459">5459</a> configuration stops with settings.h missing [<a href="https://github.com/doxygen/doxygen/commit/fd4b42ec54cb8d6faf2b0f16e580f376e8cf6982">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5460">5460</a> XML Output: Doxygen doesn't escape &amp; characters (included in a hyperlink) in &lt;detaileddescription&gt; [<a href="https://github.com/doxygen/doxygen/commit/cfde6cdd600b21bba6a2eb0ca0e7e208e014ccaf">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5461">5461</a> function object in member initializer causes documentation loss [<a href="https://github.com/doxygen/doxygen/commit/f4f3e381dba1bc5d46feea3c39e8f076e27463d1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5472">5472</a> [PATCH] Propagate configure&#39;s perl to makefiles [<a href="https://github.com/doxygen/doxygen/commit/f1a692b019a30f7aa07e0fb3e11402d262af8026">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5483">5483</a> man page extension is incorrect [<a href="https://github.com/doxygen/doxygen/commit/f25d896d4da9b44c23f89bfdd0379fa97ab2c351">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5486">5486</a> No documentation generated for method-less C++ struct [<a href="https://github.com/doxygen/doxygen/commit/21178ab40160abf011fa084a10892b5b7821e44c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5493">5493</a> [PATCH] Fix potential copy and paste error in inputstring.cpp [<a href="https://github.com/doxygen/doxygen/commit/6f5748e822b009cbe82cc1df8eea43e4769bc44b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5494">5494</a> [PATCH] Fix missing &#39;&amp;&#39; in Boolean operation in qstring.cpp [<a href="https://github.com/doxygen/doxygen/commit/27f1e1e9316addcfd0bbc3321b5614ed14f7a1a5">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5497">5497</a> Dead links in html documentation when using tabs for indentation in c++ [<a href="https://github.com/doxygen/doxygen/commit/2cc3b18da39bde323c5739483e507a133e93ac22">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5500">5500</a> Callgraphs for C# only generated for methods inside the same class [<a href="https://github.com/doxygen/doxygen/commit/7edbf2b2e705eccc0d99cce86149228473bc7f3e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5506">5506</a> Variadic macros failing to expand if trailing ... is empty [<a href="https://github.com/doxygen/doxygen/commit/070c35549da108695074239be3ab4268f3722261">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5512">5512</a> Two entries for a single member in doxygen XML [<a href="https://github.com/doxygen/doxygen/commit/ed8ce3cf405204916f9832e26797cb15d1490fd1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5514">5514</a> nested html tables cause pdflatex to hang (1.8.4 and 1.8.6) [<a href="https://github.com/doxygen/doxygen/commit/3cb963061343aa5b3b8a044cdfa62848723a02ee">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5521">5521</a> volatile declaration on member functions is not handled as xml attribute [<a href="https://github.com/doxygen/doxygen/commit/97d12d058a7831adcc8c6f2cfe8c20ddd2ae5bc2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5524">5524</a> Incorrect LaTeX generation for private union member in C++ [<a href="https://github.com/doxygen/doxygen/commit/a36ddbe0ee97c5ee248b7b391b4c30fd4b3c884b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5526">5526</a> XML Output invalid: XML_PROGRAMLISTING=YES copies Unicode form feed character (U+000C) to XML files [<a href="https://github.com/doxygen/doxygen/commit/b272b4b5077873457a0f6b517ac799f4a5f8c951">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5528">5528</a> segfault in QGListIterator while parsing fortran code [<a href="https://github.com/doxygen/doxygen/commit/aac81f8bfe8298aa0839bb2d7c70ea75149cdffb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5531">5531</a> Explicit links using operator()() not generated. [<a href="https://github.com/doxygen/doxygen/commit/e913d55b2e5a8e37ebd1ffd8fec730886a45fbda">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5534">5534</a> no uniquely matching class member found for inline function definition where parameter argument names don&#39;t match [<a href="https://github.com/doxygen/doxygen/commit/6f0269ef3074bbc4bc16ad63a0e0a8f9b5f0ce31">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5535">5535</a> Add support for non-parsed language [<a href="https://github.com/doxygen/doxygen/commit/0dd59398b3f62288897c8c3405977a27a94fbfee">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5537">5537</a> Q_PROPERTY switches the member access from private to public [<a href="https://github.com/doxygen/doxygen/commit/392b48a25e4315528fbb11a5a1bfc9f2bca791c0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5540">5540</a> Strong enum members listed in containing namespace [<a href="https://github.com/doxygen/doxygen/commit/4766fdba2ab196844a0bd5ec5e0b64d94df4a74f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5543">5543</a> Sigsegv while generating XML output [<a href="https://github.com/doxygen/doxygen/commit/14f88af12bae98859eafe605ddb5f54029e44076">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5544">5544</a> GENERATE_TAGFILE no longer includes any @*section links [<a href="https://github.com/doxygen/doxygen/commit/7d9d4320f5d183c4e1ebc87a316589c36f0afeed">view</a>] and
+                                                                                                                                       [<a href="https://github.com/doxygen/doxygen/commit/8b279c9bc28c70405e61219a6c2b3c6dbc7426e6">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5548">5548</a> Request: disable building documentation if Python 2.6 or newer not available [<a href="https://github.com/doxygen/doxygen/commit/264ecc9eee1f2b74f0110120574056f0de42a3f9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5550">5550</a> No output for markdown pages with duplicate label title (different anchor) [<a href="https://github.com/doxygen/doxygen/commit/ebb2fe6d73b4aefc6dadab8eec45adc4ee0c9fd5">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5551">5551</a> QGDict::hashAsciiKey: Invalid null key [<a href="https://github.com/doxygen/doxygen/commit/def392bf8d0326733c20504dc36168093e087c95">view</a>]</li>
+<li>Add FORTRAN 2003 keywords and commands [<a href="https://github.com/doxygen/doxygen/commit/4cbfaa8372beff4bd7070dd840924af8d96b0772">view</a>]</li>
+<li>Add type option to FORTRAN select statements [<a href="https://github.com/doxygen/doxygen/commit/db289e2272bfc3b00452cbf7c2a30114fb8b7c58">view</a>]</li>
+<li>Added build support for Python3+ and Python2.6+ [<a href="https://github.com/doxygen/doxygen/commit/98a54c576eec4feda606156ae591854311d9cd0e">view</a>]</li>
+<li>Added class/procedure vardefs to FORTRAN code highlighting [<a href="https://github.com/doxygen/doxygen/commit/dbd1985de07ccd19caf57ffa36c88811048689a4">view</a>]</li>
+<li>Added documentation for some missing HTML commands [<a href="https://github.com/doxygen/doxygen/commit/04c89e604877fa9a4aea160d971c782006872710">view</a>]</li>
+<li>Added flatten, listsort and paginate filters [<a href="https://github.com/doxygen/doxygen/commit/edd056308d04d6f445a48e05105d4d9a0ece80a0">view</a>]</li>
+<li>Added get filter, unified index properties [<a href="https://github.com/doxygen/doxygen/commit/7e3e890fedfb20e7018fadfa87ed97eef7f2b720">view</a>]</li>
+<li>Added groupby filter and some more context info [<a href="https://github.com/doxygen/doxygen/commit/064992b0c901661b49de24ce1a1d9a06e9957a93">view</a>]</li>
+<li>Added import keyword to FORTRAN code highlighting [<a href="https://github.com/doxygen/doxygen/commit/558697792cd062b93e8d7b7904fb9897e5f70750">view</a>]</li>
+<li>Added lists for indices to template context [<a href="https://github.com/doxygen/doxygen/commit/2d35b9a7c0fe70fa894dc266dd0b5ddd54d4014e">view</a>]</li>
+<li>Added mainpage to context and improved page tree [<a href="https://github.com/doxygen/doxygen/commit/2e837e0be05636923ef593c29299ff76c4590a09">view</a>]</li>
+<li>Added member indexes to template context [<a href="https://github.com/doxygen/doxygen/commit/b850eb45e80b348cbe8629c354350b051f7ef2ec">view</a>]</li>
+<li>Added missing links in changelog when multiple bug ids were on one line [<a href="https://github.com/doxygen/doxygen/commit/b752d01fe2de1668c0a247bc3955d7be6987d046">view</a>]</li>
+<li>Added more missing links to the changelog [<a href="https://github.com/doxygen/doxygen/commit/0d50c30becc147918b091c02b41502829b8083a3">view</a>]</li>
+<li>Added namespace info to the context [<a href="https://github.com/doxygen/doxygen/commit/a7c14ac74c43e6b372d866deeed77fe69e2a68e0">view</a>]</li>
+<li>Addition of module data to context and alphaIndex filter [<a href="https://github.com/doxygen/doxygen/commit/e0c3517ff9369387e00dd596b094a4729cfe789c">view</a>]</li>
+<li>Coded coloring of flow statements corrected (regression) [<a href="https://github.com/doxygen/doxygen/commit/ee7194bd73ee3a8142aee6ea59d2e5dc717b18de">view</a>]</li>
+<li>Corrected copyright year [<a href="https://github.com/doxygen/doxygen/commit/7652fc8472ac83e26641fb737539e7c87725ed68">view</a>]</li>
+<li>Correction of typing error [<a href="https://github.com/doxygen/doxygen/commit/81c99d10dbc41feab4a1aca220b27634ca0ff8cd">view</a>]</li>
+<li>Disabled/fixed segments that produced doxygen warnings while running the test [<a href="https://github.com/doxygen/doxygen/commit/3a5e6ac7c6018a7a0da7acd830293da0fcb7a21c">view</a>]</li>
+<li>Docbook output improvements [<a href="https://github.com/doxygen/doxygen/commit/12f5ee8a8c3a287f6bcfe81f79ff4332b3987c7e">view</a>]</li>
+<li>Documentation generator: added support for C# property accessors visibility modifiers. [<a href="https://github.com/doxygen/doxygen/commit/54ac45bd9f535d13b2bf98e4d71b27b4590c3dc7">view</a>]</li>
+<li>Doxywizard: make the Next button on the last page of the expert tab switch to the run tab [<a href="https://github.com/doxygen/doxygen/commit/2277e6e695d785d319cb52a8a8ead2982eac2afa">view</a>]</li>
+<li>Doxywizard: make the Next button on the last page of the wizard switch to the run tab [<a href="https://github.com/doxygen/doxygen/commit/fbc60af2298c2668893e2f7045f66765f8e0c63f">view</a>]</li>
+<li>Error linking 32-bit windows [<a href="https://github.com/doxygen/doxygen/commit/cce307d96a93515d46068cfdcf5e55c1944ae9e5">view</a>]</li>
+<li>Fix FORTRAN code function scope test [<a href="https://github.com/doxygen/doxygen/commit/2030240bc18d32581479306e6fd86211e6f30c73">view</a>]</li>
+<li>Fix after rebase from master [<a href="https://github.com/doxygen/doxygen/commit/57eee1777c18caa6d3215ec162da1fd9b2d14eb2">view</a>]</li>
+<li>Fix description of USE_PDFLATEX [<a href="https://github.com/doxygen/doxygen/commit/c87cceafe203a11e4074b748469e993d13cd8fb3">view</a>]</li>
+<li>Fix highlighting issues [<a href="https://github.com/doxygen/doxygen/commit/be0986e9ab7c1788e3650f1df7e7af70b68f28d8">view</a>]</li>
+<li>Fix typo [<a href="https://github.com/doxygen/doxygen/commit/e32121ab1fb261464356ce2352c08930f942f805">view</a>]</li>
+<li>Fix unnecessary rules for FORTRAN types [<a href="https://github.com/doxygen/doxygen/commit/1e6323e5bb04f49df9d00e82e5db3e8f301dbfc4">view</a>]</li>
+<li>Fix warning about unused functions in qstring.cpp [<a href="https://github.com/doxygen/doxygen/commit/84064ac4db9e487ca4bff9b6c37eb72992050ee3">view</a>]</li>
+<li>Fixed keyword type [<a href="https://github.com/doxygen/doxygen/commit/d8221cb7a73efc8f20068636c3d2fec84ce8cb8b">view</a>]</li>
+<li>Fixed missing include for Linux [<a href="https://github.com/doxygen/doxygen/commit/88468313289c659088be9beece59a82206153ed8">view</a>]</li>
+<li>Fixed test 021 [<a href="https://github.com/doxygen/doxygen/commit/c5c763056535216ccce4bed4892358bf5c8d1fd5">view</a>]</li>
+<li>Fixed typo [<a href="https://github.com/doxygen/doxygen/commit/0bb9b762844a2f88043223a29182dd9e7e524cef">view</a>]</li>
+<li>Fixed typo and used QString for directory [<a href="https://github.com/doxygen/doxygen/commit/5d00fa5862a1724bbe417e33d6c1a260607281ef">view</a>]</li>
+<li>Fixed windows compile issue for is_neutral [<a href="https://github.com/doxygen/doxygen/commit/9278509cf82ed7b0ff37c39e4d6e97f5308f29de">view</a>]</li>
+<li>Fixes for ./configure script on Solaris [<a href="https://github.com/doxygen/doxygen/commit/d234115b6f387ff723cb97a4d47b2bcca7f0bc6d">view</a>]</li>
+<li>Fixes regression due to PR 169 [<a href="https://github.com/doxygen/doxygen/commit/56143a268898249a63bb0a443e09dc2c77ec9ce9">view</a>]</li>
+<li>Language parser: added support for C# property accessors visibility modifiers. [<a href="https://github.com/doxygen/doxygen/commit/f5ff1b8e55b4dad074d2a73f1d003ff2991cf894">view</a>]</li>
+<li>Made INSTALL file version and date independent [<a href="https://github.com/doxygen/doxygen/commit/1781094043eb5f8f7b0f0bbe5f720012346123a2">view</a>]</li>
+<li>Made bread crumb trails enabled unconditionally [<a href="https://github.com/doxygen/doxygen/commit/c7c7d73c184ee2eebf65e83044cf1e325751cffa">view</a>]</li>
+<li>Made setName() virtual so overloading works [<a href="https://github.com/doxygen/doxygen/commit/d1e39098f94487f544a068b7864aa8d1b1f345cd">view</a>]</li>
+<li>Make index for faq [<a href="https://github.com/doxygen/doxygen/commit/38dfdcaba3e9130833cd7b695d5e20fec26f5c3f">view</a>]</li>
+<li>Messages truncated in warnings file [<a href="https://github.com/doxygen/doxygen/commit/cc4f3b454cae7d3e9eaa44342bcbae1061f5e790">view</a>]</li>
+<li>Minor fixes [<a href="https://github.com/doxygen/doxygen/commit/c31a81a85e0396fb276beefd06bb71c2819571ed">view</a>]</li>
+<li>Minor fixes to the template context [<a href="https://github.com/doxygen/doxygen/commit/963e0adfd76e6a59ace5e7318f948632322b1e51">view</a>]</li>
+<li>Missing word after \n command in doxygen rtf output, version 1.8.5 &amp; up [<a href="https://github.com/doxygen/doxygen/commit/ea9f3b1d727b22973c0176b2564304fb160aa70b">view</a>]</li>
+<li>More robust extraction of scope information from tag files [<a href="https://github.com/doxygen/doxygen/commit/6a60477b418e21dbadd3e62dc557a038e319581b">view</a>]</li>
+<li>No warning in case cite definition is missing [<a href="https://github.com/doxygen/doxygen/commit/1f77638174f715f0f2bcf5b2e32ebb329d531f85">view</a>]</li>
+<li>Preparations for release 1.8.8 [<a href="https://github.com/doxygen/doxygen/commit/f16be0113f8d47d4f04e69d0c45ccc4b24e3c426">view</a>]</li>
+<li>Removed not implemented HTML commands from documentation [<a href="https://github.com/doxygen/doxygen/commit/8199b2d105313efd30367c7a03b57bf7a7d2180b">view</a>]</li>
+<li>Removed unsupported HTML commands from the docs [<a href="https://github.com/doxygen/doxygen/commit/16ba4bd5744c2e5fbfabe95b27736b8ca8030390">view</a>]</li>
+<li>Set deployment targets for MacOSX 10.5+ versions [<a href="https://github.com/doxygen/doxygen/commit/28f40b3aea1411488832205fae447f4652125cdc">view</a>]</li>
+<li>Support multiple extra HTML stylesheets. [<a href="https://github.com/doxygen/doxygen/commit/595943c96860425f9086028b00e1e155e8ec434f">view</a>]</li>
+<li>Tcl: add missing file that breaks test 057 [<a href="https://github.com/doxygen/doxygen/commit/73e7c340f555291d4264b2f83caacf59a5a3395f">view</a>]</li>
+<li>Tcl: add test code for Bug <a href="https://github.com/doxygen/doxygen/issues/5463">5463</a> [<a href="https://github.com/doxygen/doxygen/commit/36ce0578065b95cf12b81e5a4edd95dea5707e22">view</a>]</li>
+<li>Tcl: collect XRefs also if INLINE_SOURCES = no [<a href="https://github.com/doxygen/doxygen/commit/6245ef410358f332330195f9f2bfa458cfb6a2b8">view</a>]</li>
+<li>Tcl: correct namespace resolution in case of INLINE_SOURCES = YES [<a href="https://github.com/doxygen/doxygen/commit/470143192d0c8cf90ad84a66226d48060cc713db">view</a>]</li>
+<li>Tcl: recurse for [] [<a href="https://github.com/doxygen/doxygen/commit/9d315a987d7d0ea2f38809aa74e36c92281910df">view</a>]</li>
+<li>Tcl: refactor similar code into tcl_codify_token function [<a href="https://github.com/doxygen/doxygen/commit/06bd53ac6acee5fb83d9f2b5ded1c55c8a069b29">view</a>]</li>
+<li>Tcl: support eval/catch commands [<a href="https://github.com/doxygen/doxygen/commit/9d24b488add8b4c7c689f58a095184a6ed85e9f1">view</a>]</li>
+<li>Tcl: support switch command [<a href="https://github.com/doxygen/doxygen/commit/2984dad86558b4a81e11ce07485057e3903a9304">view</a>]</li>
+<li>Tcl: test 057 additionally tests mutual Xrefs for two files [<a href="https://github.com/doxygen/doxygen/commit/c6aaf0a4c35db27f968a7a6d0b9fa25b5b311bc3">view</a>]</li>
+<li>Template context support for CREATE_SUBDIRS [<a href="https://github.com/doxygen/doxygen/commit/9282aab5ed2a0cca3858df6e62132f959e99edb5">view</a>]</li>
+<li>Update dot.cpp [<a href="https://github.com/doxygen/doxygen/commit/a15c5c89f0b4f97d57474d9ea0e3166709d35534">view</a>]</li>
+<li>Update latexgen.cpp [<a href="https://github.com/doxygen/doxygen/commit/1f877b09262f34e6bad6dbfaee4b04b4be03bd4c">view</a>]</li>
+<li>Update test 058 because commit 9d315a9 fixes also Bug <a href="https://github.com/doxygen/doxygen/issues/5464">5464</a> [<a href="https://github.com/doxygen/doxygen/commit/3486bfc158008da1d69d420e57e7a10f1c0d69c3">view</a>]</li>
+<li>Replaced the VHDL parser with the VHDL scanner from 1.7.5 to avoid potential licensing issues [<a href="https://github.com/doxygen/doxygen/commit/99433b3d2319916f11608c2c818fe35360256d9e">view</a>]</li>
+<li>New VHDL parser implementation [<a href="https://github.com/doxygen/doxygen/commit/36122e49ed1d9e640b1ceca52536ec7c55e10474">view</a>]</li>
+<li>Vhdl fixes [<a href="https://github.com/doxygen/doxygen/commit/3b8fea2f1f7f2e6a83a35626e6dec9d114a78c9e">view</a>]</li>
+<li>\usepackage{fixltx2e} must come before use \usepackage{float} [<a href="https://github.com/doxygen/doxygen/commit/d8a36bbd404bc9c77689f42cc4bfde8ac393cd8c">view</a>]</li>
+<li>cache anonymous into ClassDefImpl::isAnonymous [<a href="https://github.com/doxygen/doxygen/commit/34a5a051a8b91215ae4f93e5541d43c33aa887c1">view</a>]</li>
+<li>changed append filter and added index and path attributes to node [<a href="https://github.com/doxygen/doxygen/commit/47bc520ac8c0dde310dcb1999c622c591b373ffc">view</a>]</li>
+<li>doc/translator.py -- unification for Python 2.6+ and 3.3+ (not finished) [<a href="https://github.com/doxygen/doxygen/commit/8cac977ddfdc1c77546f5d766387f4a57710c8c0">view</a>]</li>
+<li>doc/translator.py unified for Python 2.6+ and Python 3.0+ [<a href="https://github.com/doxygen/doxygen/commit/6212c2d2af12dd9d47459bdecdf79ad106060229">view</a>]</li>
+<li>make.bat: change current directory [<a href="https://github.com/doxygen/doxygen/commit/fc386eb107958b4f3214aa2c0c6caf2a91c83177">view</a>] and
+                                       [<a href="https://github.com/doxygen/doxygen/commit/feb24c82002ced816bc72eb8f2a6a35c71e25ed7">view</a>]</li>
+<li>removeRedundantWhiteSpace micro-optimization [<a href="https://github.com/doxygen/doxygen/commit/d4601735b582b903f1ccb144f59b2030a7797b05">view</a>]</li>
+<li>resolves the error of unbalanced tags opened/closed in docbook output: parser error : Opening and ending tag mismatch: para line 358 and tbody [<a href="https://github.com/doxygen/doxygen/commit/d7b0858e079419bb7ea862e16946218a9352d5b5">view</a>]</li>
+<li>winbuild/pack_the_distribution_for_windows.py minor updates [<a href="https://github.com/doxygen/doxygen/commit/6d969cab51f4c32784966a28b8b9d5fe2d5b2089">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -1012,169 +1011,169 @@
 <a name="1.8.7"></a>
 </p>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2479">2479</a> - c-source and h-source missing for latex [<a href="http://github.com/doxygen/doxygen/commit/d5d34325fb9bed776cf2b4facc0c341f701e780b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3879">3879</a> - FORTRAN: recognition free versus fixed formatted code [<a href="http://github.com/doxygen/doxygen/commit/2dec1060623165057628ee678eb3580351922408">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3893">3893</a> - Latex $projectname with &quot;&amp;&quot; gets no escaped [<a href="http://github.com/doxygen/doxygen/commit/586b3b69238fb09d55a03c5d50fc1b7d3e65ed97">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4179">4179</a> - Fortran: variable with name &quot;type&quot; confuses doxygen [<a href="http://github.com/doxygen/doxygen/commit/17c5b6160d013d118296663e133cf8884c74a939">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4683">4683</a> - Percent to prevent auto-linking in page title is not removed for navpath [<a href="http://github.com/doxygen/doxygen/commit/5d44acc0a49bd7b990bfe649efa312f5f0bb594b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4762">4762</a> - Nested \if messes up list items [<a href="http://github.com/doxygen/doxygen/commit/7f4414b92a1c2147b073dd3cf58e0db7c8a88be6">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4762">4762</a> - Nested \if messes up list items [<a href="http://github.com/doxygen/doxygen/commit/de502ca71fc1c20ed93209f6a223c488eee38297">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4870">4870</a> - Command ignored when using umlauts in markdown and also C-comments in markdown didn&#39;t work properly [<a href="http://github.com/doxygen/doxygen/commit/b4b40f4c7ea57655d1264e8f72c754526e3a9209">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5052">5052</a> - Notes in xml output are not correctly separated [<a href="http://github.com/doxygen/doxygen/commit/bc61f00f142792dfbe97c361d9fecd3ea2850f5e">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5254">5254</a> - Enables using unicode (non ASCII) to name output files [<a href="http://github.com/doxygen/doxygen/commit/d5fb69739a1b2facf32a63ca94c12d097f8278cc">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5258">5258</a> - Nested namespace causes incorrect display when referenced via .tag file [<a href="http://github.com/doxygen/doxygen/commit/1bdbbc60982f2f61f4e0423c9fc8c4a24cfb2e94">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5348">5348</a> - Documentation for enumeration not generated [<a href="http://github.com/doxygen/doxygen/commit/1bb36723a522b371810606c2f6504d0374a7b027">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5383">5383</a> - Code coloring in case of file without extension [<a href="http://github.com/doxygen/doxygen/commit/45934e88fa961686c00be1ad272a088f4e7eac0b">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5387">5387</a> - Trouble with /cond /endcond [<a href="http://github.com/doxygen/doxygen/commit/2912829ca5bced897a2c063d1883b9cfd39d3bd9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5388">5388</a> - Wrong call graph in simple situation [<a href="http://github.com/doxygen/doxygen/commit/e12d6b506862c8ad843b7853bc1c9ceb5d0ccb4d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5389">5389</a> - [Latex/PDF] Merging brief and detailed description in file section [<a href="http://github.com/doxygen/doxygen/commit/a99c33838057acba20768ca32681e1f379f36ca0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5390">5390</a> - Parsing problem with C++11 empty initializer lists [<a href="http://github.com/doxygen/doxygen/commit/1bfacc3b8e589907352eff923b7b3aa73cfc5138">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5393">5393</a> - Move constructors and move assignment operators of embedded classes of template classes cannot be matched. [<a href="http://github.com/doxygen/doxygen/commit/1d0c9b6fefb6c2e0a9a2b7a7ea3192ccace33710">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5396">5396</a> - Dia diagrams not displayed by Firefox [<a href="http://github.com/doxygen/doxygen/commit/5ea2f2a123e473d5964435369fd925d7f103b456">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5404">5404</a> - regression referencing namespaced type [<a href="http://github.com/doxygen/doxygen/commit/9b76c1a9bb7039962933aeef398bb7aa2f59c3a5">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5408">5408</a> - doxygen nested \if \endif sample not working [<a href="http://github.com/doxygen/doxygen/commit/cc78b12b0019fbcb17692b231d38ba75d0952201">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5410">5410</a> - doxygen 1.8.6 sorts the contents of a namespace by group within the Class List [<a href="http://github.com/doxygen/doxygen/commit/f9b80aff6d20524dd0838aff12033fe3df66ba98">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5414">5414</a> - Link refs with no title swallow an extra newline [<a href="http://github.com/doxygen/doxygen/commit/60ea06a68f2e355e34b61bf45babc6405bfbfe84">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5415">5415</a> - Documentation for derived classes no longer has an &quot;Additional Inherited Members&quot; section after upgrading doxygen from 1.8.3.1 to 1.8.6 [<a href="http://github.com/doxygen/doxygen/commit/0e9da9fb27147c5685088019afd428a0aaa901fa">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5416">5416</a> - configure --prefix=/opt/foo not accepted [<a href="http://github.com/doxygen/doxygen/commit/bc7e6301e2d1474592f6cd6cc07624852d1b5016">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5417">5417</a> - Command \| not working when last character in markdown table line [<a href="http://github.com/doxygen/doxygen/commit/8309fbd9e639eaf9e763e83ca7a228c659450a57">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5421">5421</a> - Last line of code block lost if it is only one character and there is no text afterward [<a href="http://github.com/doxygen/doxygen/commit/4d1951ebb648bbc92464904305cafc7fc0dba557">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5422">5422</a> - Doxygen crashes on incorrect end group /**&lt; @} */ [<a href="http://github.com/doxygen/doxygen/commit/b4d5ef176eced8315523baea464cfda733ecb9aa">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5424">5424</a> - star is not printed in \code environment [<a href="http://github.com/doxygen/doxygen/commit/0eaf1cd5d2eac57666b5ffea9e0f948b7a3e6b3a">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5425">5425</a> - Internal inconsistency: namespace in IDL [<a href="http://github.com/doxygen/doxygen/commit/b0456fbefa864b33611f289818deeaaf791c17c9">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5428">5428</a> - Server side (PHP) search broke in 1.8.3 [<a href="http://github.com/doxygen/doxygen/commit/1d2bb19e394850ecb37bea06ef4e5d15fe06e7b0">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5436">5436</a> - python3 import style causes doxygen to ignore some inheritances [<a href="http://github.com/doxygen/doxygen/commit/513ce9aafd05add9b5c1e67e843e540f8937cf63">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5437">5437</a> - Markdown Extra - fenced code block: &#39;&gt;&#39; before tab width parsed as block quote [<a href="http://github.com/doxygen/doxygen/commit/3598e8fdf7ee61a281480fec09f63669710ac35d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5438">5438</a> - Tilde sign in combination with &lt;pre&gt; and MARKDOWN_SUPPORT disabled [<a href="http://github.com/doxygen/doxygen/commit/721764a1b3c63c77ff0792beb6c37fbfee0f87bb">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5439">5439</a> - Blockquote followed by text inserts an extra paragraph [<a href="http://github.com/doxygen/doxygen/commit/518fccbbadba3136a29c895f3606f40fa220fe47">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5440">5440</a> - alignment of blockquotes in pdf [<a href="http://github.com/doxygen/doxygen/commit/9059295fd6e178804f2f2d95ffe3764645ecc026">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5449">5449</a> - Build fails when --with-libclang on Fedora [<a href="http://github.com/doxygen/doxygen/commit/837d63319a7b014412cb3cb2b5d27d2474a932c2">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5456">5456</a> - Crash on \addindex \term [<a href="http://github.com/doxygen/doxygen/commit/653a2a8b123b79835af9f684f8b92ef7f88712aa">view</a>]</li>
-<li>A new files have been added but is not incorporated in the windows build part [<a href="http://github.com/doxygen/doxygen/commit/d9dd873e25fba968ddcbcc79d6643f5df669b626">view</a>]</li>
-<li>Add docbook directory to be removed as well [<a href="http://github.com/doxygen/doxygen/commit/08ea10029e705a388ab14ee29544d496a203f23f">view</a>]</li>
-<li>Add extra (documenattion) directories to ignore pattern [<a href="http://github.com/doxygen/doxygen/commit/db358b1f219fecf0d7df96d8c70b47b245471c66">view</a>]</li>
-<li>Add index support to context [<a href="http://github.com/doxygen/doxygen/commit/12cd22f4c32ed8b92da7b5a03181aa6735018a5b">view</a>]</li>
-<li>Add line numbers in case comment is not closed properly. [<a href="http://github.com/doxygen/doxygen/commit/b1d513b2ac65fe26ceec2fa494867713efa01cd5">view</a>]</li>
-<li>Add template context for annotated class index [<a href="http://github.com/doxygen/doxygen/commit/9434ecb13e1f3e2901b78d3e41e7f1d7d9469434">view</a>]</li>
-<li>Add validation of internal consistency to html entity mapper [<a href="http://github.com/doxygen/doxygen/commit/d96458ce99b92590a8fec0aba46c67b6816fa632">view</a>]</li>
-<li>Add warning when encountering a nested comment start (/*) without matching end (*/). [<a href="http://github.com/doxygen/doxygen/commit/7f30d0afbeb9565bced1439f86ce9f862de5282e">view</a>]</li>
-<li>Added \latexinclude command (thanks to Juan Zaratiegui for the patch) [<a href="http://github.com/doxygen/doxygen/commit/1134237afe25f86fcf7c7e2a76a3542eee8acc79">view</a>]</li>
-<li>Added basic arithmetic operations to the template expressions, and made the expression lexer faster [<a href="http://github.com/doxygen/doxygen/commit/5af2b7c0aef5cd6a0dc6ceddcffba16f623d920a">view</a>]</li>
-<li>Added dir tree nodes to the context [<a href="http://github.com/doxygen/doxygen/commit/762ee821bb0bef125d5406572963ce32c748e227">view</a>]</li>
-<li>Added directory info to the context [<a href="http://github.com/doxygen/doxygen/commit/47adeb82d67208db88a4aaae5c3427291462611a">view</a>]</li>
-<li>Added doc/config.doc to .gitignore [<a href="http://github.com/doxygen/doxygen/commit/fa400a0252d12db3ffd30eb083e5185f11264112">view</a>]</li>
-<li>Added language update for Swedish (thanks to Bj&ouml;rn Palmqvist) [<a href="http://github.com/doxygen/doxygen/commit/eec2140f577431915ed087727093c5bf381500ba">view</a>]</li>
-<li>Added last and first attributes to index tree node [<a href="http://github.com/doxygen/doxygen/commit/ff5ec803a39b225e03edcd1bf2df3198dafcc16e">view</a>]</li>
-<li>Added missing \+ command to build LaTeX manual [<a href="http://github.com/doxygen/doxygen/commit/c096119b0c0bfc567058538b6225ca26eb191a3a">view</a>]</li>
-<li>Added new language maintainer for Swedish, removed generated file language.doc [<a href="http://github.com/doxygen/doxygen/commit/f3172cf19514fc05588878d3fabfffe479495cca">view</a>]</li>
-<li>Added optional [block] option to \htmlonly [<a href="http://github.com/doxygen/doxygen/commit/842c816a31537e32cec376c85c0a4363f74d7a54">view</a>]</li>
-<li>Added reference counting for all context objects [<a href="http://github.com/doxygen/doxygen/commit/ff00706a18b6e57419796ffd6f1448cb2ccb9436">view</a>]</li>
-<li>Added stricter URL filtering to prevent DOM Based XSS when the tree view is enabled [<a href="http://github.com/doxygen/doxygen/commit/8ba739ad1ecde1036bfe2e364aee378e137f6dff">view</a>]</li>
-<li>Added support for \-- and \--- to prevent interpretation as ndash and mdash [<a href="http://github.com/doxygen/doxygen/commit/385b87e08c23b1392d0e6d6fbdb6ef463fa28477">view</a>]</li>
-<li>Added support for elif to the template language [<a href="http://github.com/doxygen/doxygen/commit/ae3a22ba276a2e446a460274e0bff8a9bdf4af7d">view</a>]</li>
-<li>Added support for range tag in the template language [<a href="http://github.com/doxygen/doxygen/commit/b98846d0b57b78cd45d34e0962a8bcdc2e643e18">view</a>]</li>
-<li>Alternative way to get rules information from flex [<a href="http://github.com/doxygen/doxygen/commit/224fa96dd9c9245bfdf68ee6f92160b7aa05f8d1">view</a>]</li>
-<li>Better message in case doxygen -u is used [<a href="http://github.com/doxygen/doxygen/commit/cfd8c2415e7d0744a00bf1990f26aab538940f20">view</a>]</li>
-<li>Changed &quot;See Also&quot; back to &quot;See also&quot; [<a href="http://github.com/doxygen/doxygen/commit/0754c968a4a06c8217c9301a5ca82c6212c228ec">view</a>]</li>
-<li>Chm don&#39;t add images multiple times [<a href="http://github.com/doxygen/doxygen/commit/3b339813794390bdce59fa1009cf71506e0cec2b">view</a>]</li>
-<li>Command \&lt; and \&gt; are not properly shown in section headers (and consequently in index) [<a href="http://github.com/doxygen/doxygen/commit/04a8ce9a8e2f022c21a5728ffdfb029258fa54e9">view</a>]</li>
-<li>Consistency of usage of the word LaTeX in the documentation [<a href="http://github.com/doxygen/doxygen/commit/d63a7d8812c7f748a48d76bfc39ce57f79f6f667">view</a>]</li>
-<li>Context enhancement [<a href="http://github.com/doxygen/doxygen/commit/92d53a473074a78735d25bbef02715b3caced569">view</a>]</li>
-<li>Corrected some definitions for some Fortran keywords [<a href="http://github.com/doxygen/doxygen/commit/d4aa05e171d27cc17b177078d3ff481441087da4">view</a>]</li>
-<li>Disabled config dependency check to avoid regression [<a href="http://github.com/doxygen/doxygen/commit/904ad3fbdc5e1615fdb052ba8562fc9b1329cd81">view</a>]</li>
-<li>Documentation corrections [<a href="http://github.com/doxygen/doxygen/commit/4b51e6113f1e9e20a5700840d83f1c3928d84825">view</a>]</li>
-<li>Enable Previous and Next buttons in chm output file [<a href="http://github.com/doxygen/doxygen/commit/e6a78b6b2573388353bdb5dcd7a13dcc11959d13">view</a>]</li>
-<li>Enabling possibility to have { and } in (latex) index items [<a href="http://github.com/doxygen/doxygen/commit/dd2c137847e16d0a7c6086053f55bce501d84a0c">view</a>]</li>
-<li>Error message is given for make distclean as generated_src is a directory [<a href="http://github.com/doxygen/doxygen/commit/76701e2bfb688ac22a751c4f03b28fa9d5f594f7">view</a>]</li>
-<li>Extension in config.xml if type=string with format=image [<a href="http://github.com/doxygen/doxygen/commit/025cc9def72002d4ab6da7bfee8a73c03ca7c331">view</a>]</li>
-<li>Extension specific filtering [<a href="http://github.com/doxygen/doxygen/commit/425e64e2ee52b92a2c0c8f6fb5457bf95b95e5bf">view</a>]</li>
-<li>Fix id parsing for atx markdown headers [<a href="http://github.com/doxygen/doxygen/commit/ee830bb8888535ac48c0c4fd90580542e7f70481">view</a>]</li>
-<li>Fix segfault on invalid bounding FIG when patching dot [<a href="http://github.com/doxygen/doxygen/commit/1bd2e38a2ce2d0823557381c48fe47cb53d6fba8">view</a>]</li>
-<li>Fix to VHDL scanner. [<a href="http://github.com/doxygen/doxygen/commit/5ca7d423a11337d5c31082f52a287a3dc0986642">view</a>]</li>
-<li>Fix typos in russian translation [<a href="http://github.com/doxygen/doxygen/commit/8ce2b0d7aec1d4398b5b4f365a7d3abbe75daf5f">view</a>]</li>
-<li>Fixed Tidy&#39;s &#39;empty span&#39; warning in HTML output [<a href="http://github.com/doxygen/doxygen/commit/8cfac90d6c8632436db1a6b650a05a8dfcfab5d0">view</a>]</li>
-<li>Fixed compiler warnings in section.h [<a href="http://github.com/doxygen/doxygen/commit/683ef76f7bf1ba929f9c263064bb5f6c8e377275">view</a>]</li>
-<li>Fixed difference between generated XML schema and XML files for HTML entities [<a href="http://github.com/doxygen/doxygen/commit/836af2f9510d10f2dd7d832025f214983387b3c6">view</a>]</li>
-<li>Fixed issues with @parblock and added regression test case [<a href="http://github.com/doxygen/doxygen/commit/2ed3d33a92dbcdf0a0149c5f06909926e44cdebd">view</a>]</li>
-<li>Fixed issues with SEPARATE_MEMBER_PAGES and INLINE_SIMPLE_STRUCTS [<a href="http://github.com/doxygen/doxygen/commit/a9f93437b6b2b9686e1b4f2e691782c6ebe99c26">view</a>]</li>
-<li>Fixed memory leak in nested comment administration [<a href="http://github.com/doxygen/doxygen/commit/2514ba72e53473f8dd424efdbef34287c8a3fd56">view</a>]</li>
-<li>Fixed off-by one error for last character in compound.xsd [<a href="http://github.com/doxygen/doxygen/commit/61b00c0061eda805696fe6f90db15136811e1ed7">view</a>]</li>
-<li>Fixed potential crash caused by overloading the variadic warn function [<a href="http://github.com/doxygen/doxygen/commit/31505eb34565b2e39d113b7f5460645d02ad6d2e">view</a>]</li>
-<li>Fixed problem handling Obj-C protocol list when proceeded by a newline [<a href="http://github.com/doxygen/doxygen/commit/09a5fc198a98d697d3e50c1c76392b8373f1af12">view</a>]</li>
-<li>Fixed problem with ending a paragraph when htmlonly was at the end of a comment block [<a href="http://github.com/doxygen/doxygen/commit/8d03b3f35e404abfd0ed31022a687fc1eab07fd5">view</a>]</li>
-<li>Fixed typo in changelog [<a href="http://github.com/doxygen/doxygen/commit/8f58d6dd7c3d0f6004d127bf111f76e4a4478516">view</a>]</li>
-<li>Fixed typo in doxyindexer.vcproj [<a href="http://github.com/doxygen/doxygen/commit/2bc8a820b3e2fefaedb10a3129eed35581a1ea5b">view</a>]</li>
-<li>Fixes for missing build dependencies [<a href="http://github.com/doxygen/doxygen/commit/62379ff8fdb13d95c7651419d92db47150e15bcc">view</a>]</li>
-<li>Give message when PROJECT_LOGO cannot be found or cannot be converted [<a href="http://github.com/doxygen/doxygen/commit/164864d9bc8ea7e32a69fbc0e47cff54dc678a48">view</a>]</li>
-<li>Handlingh of -- by \c and &lt;code&gt; results in - adjusted documentation [<a href="http://github.com/doxygen/doxygen/commit/73d12cc5cf0656e94125baea62cdb19b67908b3d">view</a>]</li>
-<li>Improve rendering of sub and superscripts in LaTeX [<a href="http://github.com/doxygen/doxygen/commit/a7c7f36ea2a67969bf3916c7600fe487e34438c0">view</a>]</li>
-<li>Improved handling of percent symbol [<a href="http://github.com/doxygen/doxygen/commit/0e080f486f67008ef427c834f6ab6ebca7578124">view</a>]</li>
-<li>Improved performance of rendering large index pages, by replacing images in the tables by spans [<a href="http://github.com/doxygen/doxygen/commit/956a7fb004e72923f737e387d053812f99b7bda2">view</a>]</li>
-<li>In case of sections with the same name they are not reported. [<a href="http://github.com/doxygen/doxygen/commit/ac611be473c2d9bf65bcafb53b0577274c4ae706">view</a>]</li>
-<li>Inconsistency in usage of simplesecr versus simplesectsep corrected [<a href="http://github.com/doxygen/doxygen/commit/bc46b90c42470e238a6e038f49a7423796a8c2e3">view</a>]</li>
-<li>Inconsistency in usage of simplesecr versus simplesectsep corrected [<a href="http://github.com/doxygen/doxygen/commit/c5bedcdc2e3b6c519aae62ff1a08d4ec808cce6b">view</a>]</li>
-<li>Incorrect handling dependencies [<a href="http://github.com/doxygen/doxygen/commit/bfcfa6fc73942b80cb22e2900438dc99d844a78e">view</a>]</li>
-<li>Items XML_SCHEMA and XML_DTD declared obsolete [<a href="http://github.com/doxygen/doxygen/commit/ba31ee73aad3bdc6b3854add2db01c302c9cf19c">view</a>]</li>
-<li>List only the project pages in &quot;Related Pages&quot; [<a href="http://github.com/doxygen/doxygen/commit/a2c7f91d6320f72951f1e3ef092e077a89562670">view</a>]</li>
-<li>Made documentation more consistent [<a href="http://github.com/doxygen/doxygen/commit/b81fe14c7fe8b3eaafa4ce8ddcd0f1815c2c7ff0">view</a>]</li>
-<li>Make sure all ids in g_linkRefs are lower case [<a href="http://github.com/doxygen/doxygen/commit/3df31762585075033a04e40c3cdfb52781aa258f">view</a>]</li>
-<li>Make the MAN_SUBDIR setting override the name of the directory the man pages are placed in. [<a href="http://github.com/doxygen/doxygen/commit/83b344db49b27bf68994eb8ec6be87d6d0f24e86">view</a>]</li>
-<li>Meta tag in the HTML search page was not closed properly [<a href="http://github.com/doxygen/doxygen/commit/4ccfb9efa8382de50dfc5b176cb147fd1b05870c">view</a>]</li>
-<li>Minor fixes for the new build locations [<a href="http://github.com/doxygen/doxygen/commit/d86520ef4920a9a47a4d6e33eadfc62b8b983748">view</a>]</li>
-<li>Missing &amp; and chars after &quot; in tree of chm documentation [<a href="http://github.com/doxygen/doxygen/commit/89638fbc9961bd9a1e9cb7bc25e5f739936e8a43">view</a>]</li>
-<li>More context changes [<a href="http://github.com/doxygen/doxygen/commit/196f39515ec5f9fdcbda68046f48a1d1a8250854">view</a>]</li>
-<li>More work on the template and context mechanisms [<a href="http://github.com/doxygen/doxygen/commit/744d1ca52e25dfa9e3d656056d87ed7cb6320585">view</a>]</li>
-<li>On windows citelist.doc remains [<a href="http://github.com/doxygen/doxygen/commit/3c941f24ee93687c197363fa2d4b787512878eab">view</a>]</li>
-<li>Place where dot executable is found [<a href="http://github.com/doxygen/doxygen/commit/90ecc2487146e0cdd392047342a30fd13453b233">view</a>]</li>
-<li>Properly escape the XCODE path. [<a href="http://github.com/doxygen/doxygen/commit/0cc8f6b2a14fdeb6d6769d34edb035b755d1299f">view</a>]</li>
-<li>Pull out property names in Objective-C. [<a href="http://github.com/doxygen/doxygen/commit/f4ff0ea8b11560ce718bb41b63bdf793cd333f27">view</a>]</li>
-<li>Recognize all HTML4 special character entities [<a href="http://github.com/doxygen/doxygen/commit/1bd64ac0e925ba2ff069ec64c026ea3c32f85600">view</a>]</li>
-<li>Reduced and improved functionality of QList [<a href="http://github.com/doxygen/doxygen/commit/6e51abf63021dc9fe32c05f003232fe68a08591d">view</a>]</li>
-<li>Removed config.doc as it is generated by configgen.py [<a href="http://github.com/doxygen/doxygen/commit/a642629761d43d53f3ade41c78530d0c7228a84d">view</a>]</li>
-<li>Removed generated file src/settings.h from source repository [<a href="http://github.com/doxygen/doxygen/commit/43461e44d49200fd1564c4e416db7384e7e5eab8">view</a>]</li>
-<li>Removed message, minor restructuring [<a href="http://github.com/doxygen/doxygen/commit/ea436bd659e022d6375dd37f651d4bb18a1c01db">view</a>]</li>
-<li>Removed remark about installdox from the FAQ [<a href="http://github.com/doxygen/doxygen/commit/68080883535bb146e2e4f65943c8b836da6b68e0">view</a>]</li>
-<li>Restructured html entity handling [<a href="http://github.com/doxygen/doxygen/commit/dfa20277697fe904a0846b60a01cc388fc13c933">view</a>]</li>
-<li>Reverted #132 after submitter reported that it did not work [<a href="http://github.com/doxygen/doxygen/commit/fdc81edcd47ce176648d7507d0597294098ae8aa">view</a>]</li>
-<li>Showing error message on windows in case on error on startup [<a href="http://github.com/doxygen/doxygen/commit/6a0651d9328262271ade2b733c125aae4415e3c3">view</a>]</li>
-<li>Simplified LaTeX header/footer escaping [<a href="http://github.com/doxygen/doxygen/commit/3337add3a6e05e26800c9e269b23fff272a9534c">view</a>]</li>
-<li>Some restructuring and some compiler warning fixes [<a href="http://github.com/doxygen/doxygen/commit/941eea998d6b9608b8fc586069ef90e805d771f5">view</a>]</li>
-<li>Spitting generated files better from source files [<a href="http://github.com/doxygen/doxygen/commit/8885016b2a3bbeb6045a3e71d508939e0a7bd773">view</a>]</li>
-<li>Superfluous &lt; sign [<a href="http://github.com/doxygen/doxygen/commit/599700e6e72d687b6597cfbe2453474b231640ea">view</a>]</li>
-<li>Superfluous backslash in documentation [<a href="http://github.com/doxygen/doxygen/commit/be5f9c70bcf38f9bce58e4b8e293dab6aea754fd">view</a>]</li>
-<li>Superfluous include removed [<a href="http://github.com/doxygen/doxygen/commit/0e12f6bfa938b675f827074eb3693eff362e6b96">view</a>]</li>
-<li>Undo previous commit [<a href="http://github.com/doxygen/doxygen/commit/1b5d5e53a7fce8136f9ab0ce82c95a8f9d479574">view</a>]</li>
-<li>Unified DirFileContext and NestingContext [<a href="http://github.com/doxygen/doxygen/commit/df839603204979113b96678e2ab21b3eba64476c">view</a>]</li>
-<li>Update doctokenizer.l [<a href="http://github.com/doxygen/doxygen/commit/68cf977ee72f8914678e30e3a88f0e9d90703418">view</a>]</li>
-<li>Update doctokenizer.l [<a href="http://github.com/doxygen/doxygen/commit/ea1ee635fccbba4273a922dab3d092dd75b195e0">view</a>]</li>
-<li>Updated copyright [<a href="http://github.com/doxygen/doxygen/commit/a28ff2331d8e228d901cd6f0b038f76e1cee630a">view</a>]</li>
-<li>Use \newline i.s.o. \par for linebreaks in LaTeX [<a href="http://github.com/doxygen/doxygen/commit/7e719d1ad5da33ccb3f54a90ae11dee58828b6ab">view</a>]</li>
-<li>Use hook arrow for hyphens in symbol names in the LaTeX output. [<a href="http://github.com/doxygen/doxygen/commit/ac813134a85ba9bd999fb4cf8271c74e02cd4ebb">view</a>]</li>
-<li>Wrong UTF 8 codes [<a href="http://github.com/doxygen/doxygen/commit/fd4beb272e5f1a760a71ab8d85463b8356c6f786">view</a>]</li>
-<li>Fix broken links to subpages in LaTeX output [<a href="http://github.com/doxygen/doxygen/commit/10189681dcb46e543a287827e2096cef3dbc42ae">view</a>]</li>
-<li>\xmlonly aoppeared twice in see also section of \htmlonly and \docbookonly [<a href="http://github.com/doxygen/doxygen/commit/f1cdb27194dd180f1bff1fbdd87874bb0d15758d">view</a>]</li>
-<li>add css-escape to avoid jquery based xss [<a href="http://github.com/doxygen/doxygen/commit/7fea82094723ecfb4e9b3ea6819137b99d7dfa9c">view</a>]</li>
-<li>add parameter [<a href="http://github.com/doxygen/doxygen/commit/c5bc9fc8c407aac845d594b2685d0c92699727d8">view</a>]</li>
-<li>add search.py, a client for doxygen_sqlite3.db [<a href="http://github.com/doxygen/doxygen/commit/697ac97aad7fa045b6cc205050b69cf3f22408ad">view</a>]</li>
-<li>add space between br and / for better compatibility [<a href="http://github.com/doxygen/doxygen/commit/2a40448c3855da250561fa4bac01179311831307">view</a>]</li>
-<li>added option to have numbers in the bookmark pane (PDF output) [<a href="http://github.com/doxygen/doxygen/commit/62cf79095c4d02ff1c737e02f91f8dcea2175b9e">view</a>]</li>
-<li>config.l: dependency checks for booleans [<a href="http://github.com/doxygen/doxygen/commit/5d64c0e2f39730bb5decd86a483a5b0823a67958">view</a>]</li>
-<li>detect python2 as Python 2 binary [<a href="http://github.com/doxygen/doxygen/commit/3754cd80cae41b23dc1069245ad5acdc460b8809">view</a>]</li>
-<li>fixed compile issue on Linux [<a href="http://github.com/doxygen/doxygen/commit/e3c636337323ba6e3f21bf1e8cfe2a899a8890c1">view</a>]</li>
-<li>pass libclang header file location; add paths for Ubuntu&#39;s llvm-3.4 [<a href="http://github.com/doxygen/doxygen/commit/2613bf77ccbeee4721a17a8168dead071e41b45e">view</a>]</li>
-<li>sqlite3: SQLITE_TRANSIENTs [<a href="http://github.com/doxygen/doxygen/commit/6f38dd245d56aaa9b6c8e966a4ccebe2f66ceb7d">view</a>]</li>
-<li>sqlite3: add new searches to search.py [<a href="http://github.com/doxygen/doxygen/commit/c99422b0c7919e953811a3a06e18c7cacbacd7c6">view</a>]</li>
-<li>sqlite3: clear bindings on errors and more care with return [<a href="http://github.com/doxygen/doxygen/commit/1a708967ba0c4a5604c1ac7d8f3c8112ec3e7044">view</a>]</li>
-<li>sqlite3: extract more info [<a href="http://github.com/doxygen/doxygen/commit/cd4bdf6708194228434bed1f71d1cd698863aaaf">view</a>]</li>
-<li>sqlite3: fedora has libsqlite3.so in /usr/lib64 [<a href="http://github.com/doxygen/doxygen/commit/49f65d1ee1c9005e019ec95a933ec5fcf02556c9">view</a>]</li>
-<li>sqlite3: leave out insertMemberReference until xref location is valid [<a href="http://github.com/doxygen/doxygen/commit/2349f4b3ff931e334b3d3e09b3e03861a7630f86">view</a>]</li>
-<li>sqlite3: remove some debug messages [<a href="http://github.com/doxygen/doxygen/commit/f76ec80dc8d1d7910951b34582ac25ce6f0efe4d">view</a>]</li>
-<li>sqlite3: speedup the SELECTs [<a href="http://github.com/doxygen/doxygen/commit/d7f9bbedaa4b4fcc0253470d522149a2307d1020">view</a>]</li>
-<li>sqlite3: updates [<a href="http://github.com/doxygen/doxygen/commit/2b80c416671220315a11287b6e10d5b3b2f852cc">view</a>]</li>
-<li>sqlite3: use the new qtools API [<a href="http://github.com/doxygen/doxygen/commit/54fbd99c753e09b1c3850af6b8b4457d339b6e84">view</a>]</li>
-<li>testsqlite3: a test for sqlite3gen [<a href="http://github.com/doxygen/doxygen/commit/733aaaa073a92a316ba888b6992f1172550dd469">view</a>]</li>
-<li>util/patternMatch: break when pattern is found [<a href="http://github.com/doxygen/doxygen/commit/6d8c3184fadb1834223236b13471797089e4a004">view</a>]</li>
-<li>util/patternMatch: don&#39;t extract a QCString(QFileInfo) each time we QRegExp.match [<a href="http://github.com/doxygen/doxygen/commit/8991d11cc824f40c11a28ccc38c09e9b10f722c3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2479">2479</a> - c-source and h-source missing for latex [<a href="https://github.com/doxygen/doxygen/commit/d5d34325fb9bed776cf2b4facc0c341f701e780b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3879">3879</a> - FORTRAN: recognition free versus fixed formatted code [<a href="https://github.com/doxygen/doxygen/commit/2dec1060623165057628ee678eb3580351922408">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3893">3893</a> - Latex $projectname with &quot;&amp;&quot; gets no escaped [<a href="https://github.com/doxygen/doxygen/commit/586b3b69238fb09d55a03c5d50fc1b7d3e65ed97">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4179">4179</a> - Fortran: variable with name &quot;type&quot; confuses doxygen [<a href="https://github.com/doxygen/doxygen/commit/17c5b6160d013d118296663e133cf8884c74a939">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4683">4683</a> - Percent to prevent auto-linking in page title is not removed for navpath [<a href="https://github.com/doxygen/doxygen/commit/5d44acc0a49bd7b990bfe649efa312f5f0bb594b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4762">4762</a> - Nested \if messes up list items [<a href="https://github.com/doxygen/doxygen/commit/7f4414b92a1c2147b073dd3cf58e0db7c8a88be6">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4762">4762</a> - Nested \if messes up list items [<a href="https://github.com/doxygen/doxygen/commit/de502ca71fc1c20ed93209f6a223c488eee38297">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4870">4870</a> - Command ignored when using umlauts in markdown and also C-comments in markdown didn&#39;t work properly [<a href="https://github.com/doxygen/doxygen/commit/b4b40f4c7ea57655d1264e8f72c754526e3a9209">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5052">5052</a> - Notes in xml output are not correctly separated [<a href="https://github.com/doxygen/doxygen/commit/bc61f00f142792dfbe97c361d9fecd3ea2850f5e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5254">5254</a> - Enables using unicode (non ASCII) to name output files [<a href="https://github.com/doxygen/doxygen/commit/d5fb69739a1b2facf32a63ca94c12d097f8278cc">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5258">5258</a> - Nested namespace causes incorrect display when referenced via .tag file [<a href="https://github.com/doxygen/doxygen/commit/1bdbbc60982f2f61f4e0423c9fc8c4a24cfb2e94">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5348">5348</a> - Documentation for enumeration not generated [<a href="https://github.com/doxygen/doxygen/commit/1bb36723a522b371810606c2f6504d0374a7b027">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5383">5383</a> - Code coloring in case of file without extension [<a href="https://github.com/doxygen/doxygen/commit/45934e88fa961686c00be1ad272a088f4e7eac0b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5387">5387</a> - Trouble with /cond /endcond [<a href="https://github.com/doxygen/doxygen/commit/2912829ca5bced897a2c063d1883b9cfd39d3bd9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5388">5388</a> - Wrong call graph in simple situation [<a href="https://github.com/doxygen/doxygen/commit/e12d6b506862c8ad843b7853bc1c9ceb5d0ccb4d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5389">5389</a> - [Latex/PDF] Merging brief and detailed description in file section [<a href="https://github.com/doxygen/doxygen/commit/a99c33838057acba20768ca32681e1f379f36ca0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5390">5390</a> - Parsing problem with C++11 empty initializer lists [<a href="https://github.com/doxygen/doxygen/commit/1bfacc3b8e589907352eff923b7b3aa73cfc5138">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5393">5393</a> - Move constructors and move assignment operators of embedded classes of template classes cannot be matched. [<a href="https://github.com/doxygen/doxygen/commit/1d0c9b6fefb6c2e0a9a2b7a7ea3192ccace33710">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5396">5396</a> - Dia diagrams not displayed by Firefox [<a href="https://github.com/doxygen/doxygen/commit/5ea2f2a123e473d5964435369fd925d7f103b456">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5404">5404</a> - regression referencing namespaced type [<a href="https://github.com/doxygen/doxygen/commit/9b76c1a9bb7039962933aeef398bb7aa2f59c3a5">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5408">5408</a> - doxygen nested \if \endif sample not working [<a href="https://github.com/doxygen/doxygen/commit/cc78b12b0019fbcb17692b231d38ba75d0952201">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5410">5410</a> - doxygen 1.8.6 sorts the contents of a namespace by group within the Class List [<a href="https://github.com/doxygen/doxygen/commit/f9b80aff6d20524dd0838aff12033fe3df66ba98">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5414">5414</a> - Link refs with no title swallow an extra newline [<a href="https://github.com/doxygen/doxygen/commit/60ea06a68f2e355e34b61bf45babc6405bfbfe84">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5415">5415</a> - Documentation for derived classes no longer has an &quot;Additional Inherited Members&quot; section after upgrading doxygen from 1.8.3.1 to 1.8.6 [<a href="https://github.com/doxygen/doxygen/commit/0e9da9fb27147c5685088019afd428a0aaa901fa">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5416">5416</a> - configure --prefix=/opt/foo not accepted [<a href="https://github.com/doxygen/doxygen/commit/bc7e6301e2d1474592f6cd6cc07624852d1b5016">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5417">5417</a> - Command \| not working when last character in markdown table line [<a href="https://github.com/doxygen/doxygen/commit/8309fbd9e639eaf9e763e83ca7a228c659450a57">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5421">5421</a> - Last line of code block lost if it is only one character and there is no text afterward [<a href="https://github.com/doxygen/doxygen/commit/4d1951ebb648bbc92464904305cafc7fc0dba557">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5422">5422</a> - Doxygen crashes on incorrect end group /**&lt; @} */ [<a href="https://github.com/doxygen/doxygen/commit/b4d5ef176eced8315523baea464cfda733ecb9aa">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5424">5424</a> - star is not printed in \code environment [<a href="https://github.com/doxygen/doxygen/commit/0eaf1cd5d2eac57666b5ffea9e0f948b7a3e6b3a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5425">5425</a> - Internal inconsistency: namespace in IDL [<a href="https://github.com/doxygen/doxygen/commit/b0456fbefa864b33611f289818deeaaf791c17c9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5428">5428</a> - Server side (PHP) search broke in 1.8.3 [<a href="https://github.com/doxygen/doxygen/commit/1d2bb19e394850ecb37bea06ef4e5d15fe06e7b0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5436">5436</a> - python3 import style causes doxygen to ignore some inheritances [<a href="https://github.com/doxygen/doxygen/commit/513ce9aafd05add9b5c1e67e843e540f8937cf63">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5437">5437</a> - Markdown Extra - fenced code block: &#39;&gt;&#39; before tab width parsed as block quote [<a href="https://github.com/doxygen/doxygen/commit/3598e8fdf7ee61a281480fec09f63669710ac35d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5438">5438</a> - Tilde sign in combination with &lt;pre&gt; and MARKDOWN_SUPPORT disabled [<a href="https://github.com/doxygen/doxygen/commit/721764a1b3c63c77ff0792beb6c37fbfee0f87bb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5439">5439</a> - Blockquote followed by text inserts an extra paragraph [<a href="https://github.com/doxygen/doxygen/commit/518fccbbadba3136a29c895f3606f40fa220fe47">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5440">5440</a> - alignment of blockquotes in pdf [<a href="https://github.com/doxygen/doxygen/commit/9059295fd6e178804f2f2d95ffe3764645ecc026">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5449">5449</a> - Build fails when --with-libclang on Fedora [<a href="https://github.com/doxygen/doxygen/commit/837d63319a7b014412cb3cb2b5d27d2474a932c2">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5456">5456</a> - Crash on \addindex \term [<a href="https://github.com/doxygen/doxygen/commit/653a2a8b123b79835af9f684f8b92ef7f88712aa">view</a>]</li>
+<li>A new files have been added but is not incorporated in the windows build part [<a href="https://github.com/doxygen/doxygen/commit/d9dd873e25fba968ddcbcc79d6643f5df669b626">view</a>]</li>
+<li>Add docbook directory to be removed as well [<a href="https://github.com/doxygen/doxygen/commit/08ea10029e705a388ab14ee29544d496a203f23f">view</a>]</li>
+<li>Add extra (documenattion) directories to ignore pattern [<a href="https://github.com/doxygen/doxygen/commit/db358b1f219fecf0d7df96d8c70b47b245471c66">view</a>]</li>
+<li>Add index support to context [<a href="https://github.com/doxygen/doxygen/commit/12cd22f4c32ed8b92da7b5a03181aa6735018a5b">view</a>]</li>
+<li>Add line numbers in case comment is not closed properly. [<a href="https://github.com/doxygen/doxygen/commit/b1d513b2ac65fe26ceec2fa494867713efa01cd5">view</a>]</li>
+<li>Add template context for annotated class index [<a href="https://github.com/doxygen/doxygen/commit/9434ecb13e1f3e2901b78d3e41e7f1d7d9469434">view</a>]</li>
+<li>Add validation of internal consistency to html entity mapper [<a href="https://github.com/doxygen/doxygen/commit/d96458ce99b92590a8fec0aba46c67b6816fa632">view</a>]</li>
+<li>Add warning when encountering a nested comment start (/*) without matching end (*/). [<a href="https://github.com/doxygen/doxygen/commit/7f30d0afbeb9565bced1439f86ce9f862de5282e">view</a>]</li>
+<li>Added \latexinclude command (thanks to Juan Zaratiegui for the patch) [<a href="https://github.com/doxygen/doxygen/commit/1134237afe25f86fcf7c7e2a76a3542eee8acc79">view</a>]</li>
+<li>Added basic arithmetic operations to the template expressions, and made the expression lexer faster [<a href="https://github.com/doxygen/doxygen/commit/5af2b7c0aef5cd6a0dc6ceddcffba16f623d920a">view</a>]</li>
+<li>Added dir tree nodes to the context [<a href="https://github.com/doxygen/doxygen/commit/762ee821bb0bef125d5406572963ce32c748e227">view</a>]</li>
+<li>Added directory info to the context [<a href="https://github.com/doxygen/doxygen/commit/47adeb82d67208db88a4aaae5c3427291462611a">view</a>]</li>
+<li>Added doc/config.doc to .gitignore [<a href="https://github.com/doxygen/doxygen/commit/fa400a0252d12db3ffd30eb083e5185f11264112">view</a>]</li>
+<li>Added language update for Swedish (thanks to Bj&ouml;rn Palmqvist) [<a href="https://github.com/doxygen/doxygen/commit/eec2140f577431915ed087727093c5bf381500ba">view</a>]</li>
+<li>Added last and first attributes to index tree node [<a href="https://github.com/doxygen/doxygen/commit/ff5ec803a39b225e03edcd1bf2df3198dafcc16e">view</a>]</li>
+<li>Added missing \+ command to build LaTeX manual [<a href="https://github.com/doxygen/doxygen/commit/c096119b0c0bfc567058538b6225ca26eb191a3a">view</a>]</li>
+<li>Added new language maintainer for Swedish, removed generated file language.doc [<a href="https://github.com/doxygen/doxygen/commit/f3172cf19514fc05588878d3fabfffe479495cca">view</a>]</li>
+<li>Added optional [block] option to \htmlonly [<a href="https://github.com/doxygen/doxygen/commit/842c816a31537e32cec376c85c0a4363f74d7a54">view</a>]</li>
+<li>Added reference counting for all context objects [<a href="https://github.com/doxygen/doxygen/commit/ff00706a18b6e57419796ffd6f1448cb2ccb9436">view</a>]</li>
+<li>Added stricter URL filtering to prevent DOM Based XSS when the tree view is enabled [<a href="https://github.com/doxygen/doxygen/commit/8ba739ad1ecde1036bfe2e364aee378e137f6dff">view</a>]</li>
+<li>Added support for \-- and \--- to prevent interpretation as ndash and mdash [<a href="https://github.com/doxygen/doxygen/commit/385b87e08c23b1392d0e6d6fbdb6ef463fa28477">view</a>]</li>
+<li>Added support for elif to the template language [<a href="https://github.com/doxygen/doxygen/commit/ae3a22ba276a2e446a460274e0bff8a9bdf4af7d">view</a>]</li>
+<li>Added support for range tag in the template language [<a href="https://github.com/doxygen/doxygen/commit/b98846d0b57b78cd45d34e0962a8bcdc2e643e18">view</a>]</li>
+<li>Alternative way to get rules information from flex [<a href="https://github.com/doxygen/doxygen/commit/224fa96dd9c9245bfdf68ee6f92160b7aa05f8d1">view</a>]</li>
+<li>Better message in case doxygen -u is used [<a href="https://github.com/doxygen/doxygen/commit/cfd8c2415e7d0744a00bf1990f26aab538940f20">view</a>]</li>
+<li>Changed &quot;See Also&quot; back to &quot;See also&quot; [<a href="https://github.com/doxygen/doxygen/commit/0754c968a4a06c8217c9301a5ca82c6212c228ec">view</a>]</li>
+<li>Chm don&#39;t add images multiple times [<a href="https://github.com/doxygen/doxygen/commit/3b339813794390bdce59fa1009cf71506e0cec2b">view</a>]</li>
+<li>Command \&lt; and \&gt; are not properly shown in section headers (and consequently in index) [<a href="https://github.com/doxygen/doxygen/commit/04a8ce9a8e2f022c21a5728ffdfb029258fa54e9">view</a>]</li>
+<li>Consistency of usage of the word LaTeX in the documentation [<a href="https://github.com/doxygen/doxygen/commit/d63a7d8812c7f748a48d76bfc39ce57f79f6f667">view</a>]</li>
+<li>Context enhancement [<a href="https://github.com/doxygen/doxygen/commit/92d53a473074a78735d25bbef02715b3caced569">view</a>]</li>
+<li>Corrected some definitions for some Fortran keywords [<a href="https://github.com/doxygen/doxygen/commit/d4aa05e171d27cc17b177078d3ff481441087da4">view</a>]</li>
+<li>Disabled config dependency check to avoid regression [<a href="https://github.com/doxygen/doxygen/commit/904ad3fbdc5e1615fdb052ba8562fc9b1329cd81">view</a>]</li>
+<li>Documentation corrections [<a href="https://github.com/doxygen/doxygen/commit/4b51e6113f1e9e20a5700840d83f1c3928d84825">view</a>]</li>
+<li>Enable Previous and Next buttons in chm output file [<a href="https://github.com/doxygen/doxygen/commit/e6a78b6b2573388353bdb5dcd7a13dcc11959d13">view</a>]</li>
+<li>Enabling possibility to have { and } in (latex) index items [<a href="https://github.com/doxygen/doxygen/commit/dd2c137847e16d0a7c6086053f55bce501d84a0c">view</a>]</li>
+<li>Error message is given for make distclean as generated_src is a directory [<a href="https://github.com/doxygen/doxygen/commit/76701e2bfb688ac22a751c4f03b28fa9d5f594f7">view</a>]</li>
+<li>Extension in config.xml if type=string with format=image [<a href="https://github.com/doxygen/doxygen/commit/025cc9def72002d4ab6da7bfee8a73c03ca7c331">view</a>]</li>
+<li>Extension specific filtering [<a href="https://github.com/doxygen/doxygen/commit/425e64e2ee52b92a2c0c8f6fb5457bf95b95e5bf">view</a>]</li>
+<li>Fix id parsing for atx markdown headers [<a href="https://github.com/doxygen/doxygen/commit/ee830bb8888535ac48c0c4fd90580542e7f70481">view</a>]</li>
+<li>Fix segfault on invalid bounding FIG when patching dot [<a href="https://github.com/doxygen/doxygen/commit/1bd2e38a2ce2d0823557381c48fe47cb53d6fba8">view</a>]</li>
+<li>Fix to VHDL scanner. [<a href="https://github.com/doxygen/doxygen/commit/5ca7d423a11337d5c31082f52a287a3dc0986642">view</a>]</li>
+<li>Fix typos in russian translation [<a href="https://github.com/doxygen/doxygen/commit/8ce2b0d7aec1d4398b5b4f365a7d3abbe75daf5f">view</a>]</li>
+<li>Fixed Tidy&#39;s &#39;empty span&#39; warning in HTML output [<a href="https://github.com/doxygen/doxygen/commit/8cfac90d6c8632436db1a6b650a05a8dfcfab5d0">view</a>]</li>
+<li>Fixed compiler warnings in section.h [<a href="https://github.com/doxygen/doxygen/commit/683ef76f7bf1ba929f9c263064bb5f6c8e377275">view</a>]</li>
+<li>Fixed difference between generated XML schema and XML files for HTML entities [<a href="https://github.com/doxygen/doxygen/commit/836af2f9510d10f2dd7d832025f214983387b3c6">view</a>]</li>
+<li>Fixed issues with @parblock and added regression test case [<a href="https://github.com/doxygen/doxygen/commit/2ed3d33a92dbcdf0a0149c5f06909926e44cdebd">view</a>]</li>
+<li>Fixed issues with SEPARATE_MEMBER_PAGES and INLINE_SIMPLE_STRUCTS [<a href="https://github.com/doxygen/doxygen/commit/a9f93437b6b2b9686e1b4f2e691782c6ebe99c26">view</a>]</li>
+<li>Fixed memory leak in nested comment administration [<a href="https://github.com/doxygen/doxygen/commit/2514ba72e53473f8dd424efdbef34287c8a3fd56">view</a>]</li>
+<li>Fixed off-by one error for last character in compound.xsd [<a href="https://github.com/doxygen/doxygen/commit/61b00c0061eda805696fe6f90db15136811e1ed7">view</a>]</li>
+<li>Fixed potential crash caused by overloading the variadic warn function [<a href="https://github.com/doxygen/doxygen/commit/31505eb34565b2e39d113b7f5460645d02ad6d2e">view</a>]</li>
+<li>Fixed problem handling Obj-C protocol list when proceeded by a newline [<a href="https://github.com/doxygen/doxygen/commit/09a5fc198a98d697d3e50c1c76392b8373f1af12">view</a>]</li>
+<li>Fixed problem with ending a paragraph when htmlonly was at the end of a comment block [<a href="https://github.com/doxygen/doxygen/commit/8d03b3f35e404abfd0ed31022a687fc1eab07fd5">view</a>]</li>
+<li>Fixed typo in changelog [<a href="https://github.com/doxygen/doxygen/commit/8f58d6dd7c3d0f6004d127bf111f76e4a4478516">view</a>]</li>
+<li>Fixed typo in doxyindexer.vcproj [<a href="https://github.com/doxygen/doxygen/commit/2bc8a820b3e2fefaedb10a3129eed35581a1ea5b">view</a>]</li>
+<li>Fixes for missing build dependencies [<a href="https://github.com/doxygen/doxygen/commit/62379ff8fdb13d95c7651419d92db47150e15bcc">view</a>]</li>
+<li>Give message when PROJECT_LOGO cannot be found or cannot be converted [<a href="https://github.com/doxygen/doxygen/commit/164864d9bc8ea7e32a69fbc0e47cff54dc678a48">view</a>]</li>
+<li>Handlingh of -- by \c and &lt;code&gt; results in - adjusted documentation [<a href="https://github.com/doxygen/doxygen/commit/73d12cc5cf0656e94125baea62cdb19b67908b3d">view</a>]</li>
+<li>Improve rendering of sub and superscripts in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/a7c7f36ea2a67969bf3916c7600fe487e34438c0">view</a>]</li>
+<li>Improved handling of percent symbol [<a href="https://github.com/doxygen/doxygen/commit/0e080f486f67008ef427c834f6ab6ebca7578124">view</a>]</li>
+<li>Improved performance of rendering large index pages, by replacing images in the tables by spans [<a href="https://github.com/doxygen/doxygen/commit/956a7fb004e72923f737e387d053812f99b7bda2">view</a>]</li>
+<li>In case of sections with the same name they are not reported. [<a href="https://github.com/doxygen/doxygen/commit/ac611be473c2d9bf65bcafb53b0577274c4ae706">view</a>]</li>
+<li>Inconsistency in usage of simplesecr versus simplesectsep corrected [<a href="https://github.com/doxygen/doxygen/commit/bc46b90c42470e238a6e038f49a7423796a8c2e3">view</a>]</li>
+<li>Inconsistency in usage of simplesecr versus simplesectsep corrected [<a href="https://github.com/doxygen/doxygen/commit/c5bedcdc2e3b6c519aae62ff1a08d4ec808cce6b">view</a>]</li>
+<li>Incorrect handling dependencies [<a href="https://github.com/doxygen/doxygen/commit/bfcfa6fc73942b80cb22e2900438dc99d844a78e">view</a>]</li>
+<li>Items XML_SCHEMA and XML_DTD declared obsolete [<a href="https://github.com/doxygen/doxygen/commit/ba31ee73aad3bdc6b3854add2db01c302c9cf19c">view</a>]</li>
+<li>List only the project pages in &quot;Related Pages&quot; [<a href="https://github.com/doxygen/doxygen/commit/a2c7f91d6320f72951f1e3ef092e077a89562670">view</a>]</li>
+<li>Made documentation more consistent [<a href="https://github.com/doxygen/doxygen/commit/b81fe14c7fe8b3eaafa4ce8ddcd0f1815c2c7ff0">view</a>]</li>
+<li>Make sure all ids in g_linkRefs are lower case [<a href="https://github.com/doxygen/doxygen/commit/3df31762585075033a04e40c3cdfb52781aa258f">view</a>]</li>
+<li>Make the MAN_SUBDIR setting override the name of the directory the man pages are placed in. [<a href="https://github.com/doxygen/doxygen/commit/83b344db49b27bf68994eb8ec6be87d6d0f24e86">view</a>]</li>
+<li>Meta tag in the HTML search page was not closed properly [<a href="https://github.com/doxygen/doxygen/commit/4ccfb9efa8382de50dfc5b176cb147fd1b05870c">view</a>]</li>
+<li>Minor fixes for the new build locations [<a href="https://github.com/doxygen/doxygen/commit/d86520ef4920a9a47a4d6e33eadfc62b8b983748">view</a>]</li>
+<li>Missing &amp; and chars after &quot; in tree of chm documentation [<a href="https://github.com/doxygen/doxygen/commit/89638fbc9961bd9a1e9cb7bc25e5f739936e8a43">view</a>]</li>
+<li>More context changes [<a href="https://github.com/doxygen/doxygen/commit/196f39515ec5f9fdcbda68046f48a1d1a8250854">view</a>]</li>
+<li>More work on the template and context mechanisms [<a href="https://github.com/doxygen/doxygen/commit/744d1ca52e25dfa9e3d656056d87ed7cb6320585">view</a>]</li>
+<li>On windows citelist.doc remains [<a href="https://github.com/doxygen/doxygen/commit/3c941f24ee93687c197363fa2d4b787512878eab">view</a>]</li>
+<li>Place where dot executable is found [<a href="https://github.com/doxygen/doxygen/commit/90ecc2487146e0cdd392047342a30fd13453b233">view</a>]</li>
+<li>Properly escape the XCODE path. [<a href="https://github.com/doxygen/doxygen/commit/0cc8f6b2a14fdeb6d6769d34edb035b755d1299f">view</a>]</li>
+<li>Pull out property names in Objective-C. [<a href="https://github.com/doxygen/doxygen/commit/f4ff0ea8b11560ce718bb41b63bdf793cd333f27">view</a>]</li>
+<li>Recognize all HTML4 special character entities [<a href="https://github.com/doxygen/doxygen/commit/1bd64ac0e925ba2ff069ec64c026ea3c32f85600">view</a>]</li>
+<li>Reduced and improved functionality of QList [<a href="https://github.com/doxygen/doxygen/commit/6e51abf63021dc9fe32c05f003232fe68a08591d">view</a>]</li>
+<li>Removed config.doc as it is generated by configgen.py [<a href="https://github.com/doxygen/doxygen/commit/a642629761d43d53f3ade41c78530d0c7228a84d">view</a>]</li>
+<li>Removed generated file src/settings.h from source repository [<a href="https://github.com/doxygen/doxygen/commit/43461e44d49200fd1564c4e416db7384e7e5eab8">view</a>]</li>
+<li>Removed message, minor restructuring [<a href="https://github.com/doxygen/doxygen/commit/ea436bd659e022d6375dd37f651d4bb18a1c01db">view</a>]</li>
+<li>Removed remark about installdox from the FAQ [<a href="https://github.com/doxygen/doxygen/commit/68080883535bb146e2e4f65943c8b836da6b68e0">view</a>]</li>
+<li>Restructured html entity handling [<a href="https://github.com/doxygen/doxygen/commit/dfa20277697fe904a0846b60a01cc388fc13c933">view</a>]</li>
+<li>Reverted #132 after submitter reported that it did not work [<a href="https://github.com/doxygen/doxygen/commit/fdc81edcd47ce176648d7507d0597294098ae8aa">view</a>]</li>
+<li>Showing error message on windows in case on error on startup [<a href="https://github.com/doxygen/doxygen/commit/6a0651d9328262271ade2b733c125aae4415e3c3">view</a>]</li>
+<li>Simplified LaTeX header/footer escaping [<a href="https://github.com/doxygen/doxygen/commit/3337add3a6e05e26800c9e269b23fff272a9534c">view</a>]</li>
+<li>Some restructuring and some compiler warning fixes [<a href="https://github.com/doxygen/doxygen/commit/941eea998d6b9608b8fc586069ef90e805d771f5">view</a>]</li>
+<li>Spitting generated files better from source files [<a href="https://github.com/doxygen/doxygen/commit/8885016b2a3bbeb6045a3e71d508939e0a7bd773">view</a>]</li>
+<li>Superfluous &lt; sign [<a href="https://github.com/doxygen/doxygen/commit/599700e6e72d687b6597cfbe2453474b231640ea">view</a>]</li>
+<li>Superfluous backslash in documentation [<a href="https://github.com/doxygen/doxygen/commit/be5f9c70bcf38f9bce58e4b8e293dab6aea754fd">view</a>]</li>
+<li>Superfluous include removed [<a href="https://github.com/doxygen/doxygen/commit/0e12f6bfa938b675f827074eb3693eff362e6b96">view</a>]</li>
+<li>Undo previous commit [<a href="https://github.com/doxygen/doxygen/commit/1b5d5e53a7fce8136f9ab0ce82c95a8f9d479574">view</a>]</li>
+<li>Unified DirFileContext and NestingContext [<a href="https://github.com/doxygen/doxygen/commit/df839603204979113b96678e2ab21b3eba64476c">view</a>]</li>
+<li>Update doctokenizer.l [<a href="https://github.com/doxygen/doxygen/commit/68cf977ee72f8914678e30e3a88f0e9d90703418">view</a>]</li>
+<li>Update doctokenizer.l [<a href="https://github.com/doxygen/doxygen/commit/ea1ee635fccbba4273a922dab3d092dd75b195e0">view</a>]</li>
+<li>Updated copyright [<a href="https://github.com/doxygen/doxygen/commit/a28ff2331d8e228d901cd6f0b038f76e1cee630a">view</a>]</li>
+<li>Use \newline i.s.o. \par for linebreaks in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/7e719d1ad5da33ccb3f54a90ae11dee58828b6ab">view</a>]</li>
+<li>Use hook arrow for hyphens in symbol names in the LaTeX output. [<a href="https://github.com/doxygen/doxygen/commit/ac813134a85ba9bd999fb4cf8271c74e02cd4ebb">view</a>]</li>
+<li>Wrong UTF 8 codes [<a href="https://github.com/doxygen/doxygen/commit/fd4beb272e5f1a760a71ab8d85463b8356c6f786">view</a>]</li>
+<li>Fix broken links to subpages in LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/10189681dcb46e543a287827e2096cef3dbc42ae">view</a>]</li>
+<li>\xmlonly aoppeared twice in see also section of \htmlonly and \docbookonly [<a href="https://github.com/doxygen/doxygen/commit/f1cdb27194dd180f1bff1fbdd87874bb0d15758d">view</a>]</li>
+<li>add css-escape to avoid jquery based xss [<a href="https://github.com/doxygen/doxygen/commit/7fea82094723ecfb4e9b3ea6819137b99d7dfa9c">view</a>]</li>
+<li>add parameter [<a href="https://github.com/doxygen/doxygen/commit/c5bc9fc8c407aac845d594b2685d0c92699727d8">view</a>]</li>
+<li>add search.py, a client for doxygen_sqlite3.db [<a href="https://github.com/doxygen/doxygen/commit/697ac97aad7fa045b6cc205050b69cf3f22408ad">view</a>]</li>
+<li>add space between br and / for better compatibility [<a href="https://github.com/doxygen/doxygen/commit/2a40448c3855da250561fa4bac01179311831307">view</a>]</li>
+<li>added option to have numbers in the bookmark pane (PDF output) [<a href="https://github.com/doxygen/doxygen/commit/62cf79095c4d02ff1c737e02f91f8dcea2175b9e">view</a>]</li>
+<li>config.l: dependency checks for booleans [<a href="https://github.com/doxygen/doxygen/commit/5d64c0e2f39730bb5decd86a483a5b0823a67958">view</a>]</li>
+<li>detect python2 as Python 2 binary [<a href="https://github.com/doxygen/doxygen/commit/3754cd80cae41b23dc1069245ad5acdc460b8809">view</a>]</li>
+<li>fixed compile issue on Linux [<a href="https://github.com/doxygen/doxygen/commit/e3c636337323ba6e3f21bf1e8cfe2a899a8890c1">view</a>]</li>
+<li>pass libclang header file location; add paths for Ubuntu&#39;s llvm-3.4 [<a href="https://github.com/doxygen/doxygen/commit/2613bf77ccbeee4721a17a8168dead071e41b45e">view</a>]</li>
+<li>sqlite3: SQLITE_TRANSIENTs [<a href="https://github.com/doxygen/doxygen/commit/6f38dd245d56aaa9b6c8e966a4ccebe2f66ceb7d">view</a>]</li>
+<li>sqlite3: add new searches to search.py [<a href="https://github.com/doxygen/doxygen/commit/c99422b0c7919e953811a3a06e18c7cacbacd7c6">view</a>]</li>
+<li>sqlite3: clear bindings on errors and more care with return [<a href="https://github.com/doxygen/doxygen/commit/1a708967ba0c4a5604c1ac7d8f3c8112ec3e7044">view</a>]</li>
+<li>sqlite3: extract more info [<a href="https://github.com/doxygen/doxygen/commit/cd4bdf6708194228434bed1f71d1cd698863aaaf">view</a>]</li>
+<li>sqlite3: fedora has libsqlite3.so in /usr/lib64 [<a href="https://github.com/doxygen/doxygen/commit/49f65d1ee1c9005e019ec95a933ec5fcf02556c9">view</a>]</li>
+<li>sqlite3: leave out insertMemberReference until xref location is valid [<a href="https://github.com/doxygen/doxygen/commit/2349f4b3ff931e334b3d3e09b3e03861a7630f86">view</a>]</li>
+<li>sqlite3: remove some debug messages [<a href="https://github.com/doxygen/doxygen/commit/f76ec80dc8d1d7910951b34582ac25ce6f0efe4d">view</a>]</li>
+<li>sqlite3: speedup the SELECTs [<a href="https://github.com/doxygen/doxygen/commit/d7f9bbedaa4b4fcc0253470d522149a2307d1020">view</a>]</li>
+<li>sqlite3: updates [<a href="https://github.com/doxygen/doxygen/commit/2b80c416671220315a11287b6e10d5b3b2f852cc">view</a>]</li>
+<li>sqlite3: use the new qtools API [<a href="https://github.com/doxygen/doxygen/commit/54fbd99c753e09b1c3850af6b8b4457d339b6e84">view</a>]</li>
+<li>testsqlite3: a test for sqlite3gen [<a href="https://github.com/doxygen/doxygen/commit/733aaaa073a92a316ba888b6992f1172550dd469">view</a>]</li>
+<li>util/patternMatch: break when pattern is found [<a href="https://github.com/doxygen/doxygen/commit/6d8c3184fadb1834223236b13471797089e4a004">view</a>]</li>
+<li>util/patternMatch: don&#39;t extract a QCString(QFileInfo) each time we QRegExp.match [<a href="https://github.com/doxygen/doxygen/commit/8991d11cc824f40c11a28ccc38c09e9b10f722c3">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly
@@ -1298,7 +1297,8 @@
 <li> Space missing in error message. the word 'in' and the vale of filesOption were concatenated</li>
 <li> This patch contains changes regarding the build system so that the *nix and Windows systems use the same information (consistency). Some use names routine names have been changed (from .l files with -P option) to reflect the file name that generated the routines, this makes it easier to create a general procedure. A number of include / header files are files are generated from different file types (html, xml, js), due some limitations of the windows build system the generated file names had to be changed (the extension in the windows build system is only available including the '.' so e.g. the file jquery_fx.js generates now jquery_fx.js.h instead of jquery_fx_js.h) In the windows version the creation of .cpp files from .l files has been adjusted to correct for the YY_BUF_SIZE problems. Furthermore on windows (and also used on *nix) some commands have been replaced with python scripts so that on windows only python is need (besides flex and bison). On *nix also perl is required for the generation using tmake.</li>
 <li> Updated Visual Studio project files to include new source files</li>
-<li> Usage of the -d option corrected Giving an error when a wrong -d option is given. Made some error messages more consistent. Corrected usage of the exit call, in case of an error: exit(1) otherwise exit(0). A closer look should be made on exitDoxygen as it does not contain any exit statements and it is unclear (to me) when it is used.</li> <li> VHDL-2008 and arrays on unconstrained elements</li>
+<li> Usage of the -d option corrected Giving an error when a wrong -d option is given. Made some error messages more consistent. Corrected usage of the exit call, in case of an error: exit(1) otherwise exit(0). A closer look should be made on exitDoxygen as it does not contain any exit statements and it is unclear (to me) when it is used.</li>
+<li> VHDL-2008 and arrays on unconstrained elements</li>
 <li> consider currentFile when searching for global symbols</li>
 <li> doc/language.doc generated from the updated sources (bgcolored)</li>
 <li> doc/language.tpl -- UTF-8 reflected in the langhowto template</li>
@@ -2037,8 +2037,7 @@ make sure you add the following:
 &lt;script type="text/javascript" src="$relpath$jquery.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript" src="$relpath$dynsections.js"&gt;&lt;/script&gt;</pre><p>
        Otherwise the interactivity of the trees does not work.
-       </p>
-</li>
+       </p> </li>
 <li>   Included a couple of performance improvements (thanks to Dirk Reiners)</li>
 <li>   Changed the way member attributes (like protected, virtual, and static)
        are rendered in the HTML output.</li>
@@ -2206,7 +2205,7 @@ make sure you add the following:
             Note that doxygen uses a relative indent of 4 spaces, not an
             absolute indent like Markdown does. </li>
        <li> Markdown style hyperlinks and hyperlink references.</li>
-       <li> Simple tables can be created using the <a href="http://michelf.com/projects/php-markdown/extra/#table">Markdown Extra format</a>.</li>
+       <li> Simple tables can be created using the <a href="https://michelf.ca/projects/php-markdown/extra/#table">Markdown Extra format</a>.</li>
        <li> <a href="http://freewisdom.org/projects/python-markdown/Fenced_Code_Blocks">Fenced code blocks</a> are also supported, include language selection.</li>
        <li> files with extension .md or .markdown are converted to related pages.</li>
        </ul>
@@ -2317,7 +2316,7 @@ make sure you add the following:
 <a name="1.7.6.1"></a>
 </p>
 <h1>Doxygen Release 1.7.6.1</h1>
-<h2>(release date 10-12-2011)</h2>
+<b>(release date 10-12-2011)</b>
 <h3>Changes</h3>
 <ul>
 <li>   Doxygen now reports its cache usage (for the symbol and the 
@@ -2346,7 +2345,7 @@ make sure you add the following:
 </ul>
 <a name="1.7.6"></a>
 <h1>Doxygen Release 1.7.6</h1>
-<h2>(release date 03-12-2011)</h2>
+<b>(release date 03-12-2011)</b>
 <h3>Changes</h3>
 <ul>
 <li>   To improve the performance of loading the navigation tree,
@@ -2437,7 +2436,7 @@ make sure you add the following:
 </ul>
 <a name="1.7.5.1"></a>
 <h1>Doxygen Release 1.7.5.1</h1>
-<h2>(release date 21-08-2011)</h2>
+<b>(release date 21-08-2011)</b>
 <h3>New features</h3>
 <ul>
 <li>Update of the French translation.</li>
@@ -2453,7 +2452,7 @@ make sure you add the following:
 </ul>
 <a name="1.7.5"></a>
 <h1>Doxygen Release 1.7.5</h1>
-<h2>(release date 14-08-2011)</h2>
+<b>(release date 14-08-2011)</b>
 <h3>Changes</h3>
 <ul>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4145">4145</a>: Function in the call graphs are now shown based on first 
@@ -2490,7 +2489,7 @@ make sure you add the following:
 <li>   PHP namespaces are now shown as A\B in the output.</li>
 <li>   Added new \snippet command that can be used to include marked 
        sections from a source file. See 
-       http://www.doxygen.org/commands.html#cmdsnippet for more info.</li>
+       <a href="commands.html#cmdsnippet">\snippet</a> for more info.</li>
 <li>   Added translation support for Armenian, thank to Armen Tangamyan.
        and included translation updates for a number of languages.</li>
 </ul>
@@ -2596,7 +2595,7 @@ make sure you add the following:
 </ul>
 <a name="1.7.4"></a>
 <h1>Doxygen Release 1.7.4</h1>
-<h2>(release date 28-03-2011)</h2>
+<b>(release date 28-03-2011)</b>
 <h3>Changes</h3>
 <ul>
 <li>   doxygen -w html now reads the default Doxyfile even if not specified
@@ -2683,7 +2682,7 @@ make sure you add the following:
 </ul>
 <a name="1.7.3"></a>
 <h1>Doxygen Release 1.7.3</h1>
-<h2>(release date 03-01-2011)</h2>
+<b>(release date 03-01-2011)</b>
 <h3>Changes</h3>
 <ul>
 <li>   Added a header for each HTML page above the navigation menu, 
@@ -2769,7 +2768,7 @@ make sure you add the following:
 </ul>
 <a name="1.7.2"></a>
 <h1>Doxygen Release 1.7.2</h1>
-<h2>(release date 09-10-2010)</h2>
+<b>(release date 09-10-2010)</b>
 
 <h3>Changes</h3>
 <ul>
@@ -2869,14 +2868,14 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3963">3963</a>: Inconsistent behaviour when a brief description was given 
        following by a detailed comment block with JAVADOC_AUTOBRIEF enabled.</li>
 <li>   Fixed a number of typos in the documentation 
-       (thanks to Albert van der Meer)</li>
+       (thanks to Albert)</li>
 <li>   Fixed potential hangup when scanning directories defined as 
        symlinks to absolute paths.</li>
 <li>   HTML attributes other than src were not copied for the &lt;img&gt; tag.</li>
 </ul>
 <a name="1.7.1"></a>
 <h1>Doxygen Release 1.7.1</h1>
-<h2>(release date 25-06-2010)</h2>
+<b>(release date 25-06-2010)</b>
 <h3>Changes</h3>
 <ul>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3803">3803</a>: Made warning and error messages appear with lower case 
@@ -2928,7 +2927,7 @@ make sure you add the following:
 
 <a name="1.7.0"></a>
 <h1>Doxygen Release 1.7.0</h1>
-<h2>(release date 15-06-2010)</h2>
+<b>(release date 15-06-2010)</b>
 <h3>Changes</h3>
 <ul>
 <li>   Changed the look of the HTML output.</li>
@@ -3062,7 +3061,7 @@ make sure you add the following:
 <a name="1.6.3"></a>
 </p>
 <h1>Doxygen Release 1.6.3</h1>
-<h2>(release date 21-02-2010)</h2>
+<b>(release date 21-02-2010)</b>
 <h3>New features</h3>
 <ul>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3654">3654</a>: Using \dir without argument will create directory 
@@ -3124,7 +3123,7 @@ make sure you add the following:
 
 <a name="1.6.2"></a>
 <h1>Doxygen Release 1.6.2</h1>
-<h2>(release date 30-12-2009)</h2>
+<b>(release date 30-12-2009)</b>
 <h3>Changes</h3>
 <ul>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3513">3513</a>: Autolinking to all-lower case words has been disabled,
@@ -3144,7 +3143,7 @@ make sure you add the following:
        to generate an index file that can be used to embed doxygen's HTML 
        output into Eclipse as a help plugin 
        (thanks to a patch by Ondrej Starek).</li>
-<li>   Wrote new <a href="http://www.doxygen.org/searching.html">documentation</a> 
+<li>   Wrote new <a href="searching.html">documentation</a> 
        regarding the methods of searching in the HTML output.</li>
 <li>   Included patch by Ed Rosten to render formulas with 
        proper anti-aliasing on non-white backgrounds using transparency.</li>
@@ -3230,7 +3229,7 @@ make sure you add the following:
 
 <a name="1.6.1"></a>
 <h1>Doxygen Release 1.6.1</h1>
-<h2>(release date 25-08-2009)</h2>
+<b>(release date 25-08-2009)</b>
 <h3>Bug fixes</h3>
 <ul>
 <li>   Fixed file handle leak when parsing include files. Also fixed
@@ -3246,8 +3245,9 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3489">3489</a>: xrefitems (like @todo) did not appear in the list when
        found in comments marked with @enum or @name.</li>
 </ul>
+<a name="1.6.0"></a>
 <h1>Doxygen Release 1.6.0</h1>
-<h2>(release date 20-08-2009)</h2>
+<b>(release date 20-08-2009)</b>
 <h3>Changes</h3>
 <ul>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3372">3372</a>, <a href="https://github.com/doxygen/doxygen/issues/3012">3012</a>: Replaced the PHP based search engine by a 
@@ -3326,7 +3326,6066 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3477">3477</a>: @optional/@required attributes for Objective-C were missing
        from the XML output.</li>
 </ul>
-<h1><a href="http://www.doxygen.org/changelog_1.5.html">Doxygen Release 1.5 and earlier</a></h1>
+<p>
+\endhtmlonly
+\section log_1_5 1.5 Series
+\htmlonly
+</p>
+<h1>Doxygen Release 1.5.9</h1>
+<b>(release date 30-04-2009)</b>
+<a name="1.5.9"></a>
+<h3>New features</h3>
+<ul>
+<li>   Added new option LATEX_SOURCE_CODE, which when enabled adds
+       source code also to the latex output (typically to be used in
+       combination with SOURCE_BROWSER)</li>
+<li>   Included updates for the Finnish, Romanian, Korean, German, Japanese,
+       and Hungarian translation.</li>
+<li>   Added translation support for Esperanto.</li>
+<li>   id 579630: Added class attribute to the \todo and \bug HTML code so they
+       can be customized via CSS.</li>
+<li>   id 578740: Added support for &AElig; and &aelig; characters.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 395169: Some links via tagfiles were not correct in 
+       combination with CREATE_SUBDIRS=YES</li>
+<li>   id 539080: Having the same comment for the declaration and definition
+       of a function could result in duplicate documentation in case the 
+       indentation level was different.</li>
+<li>   id 566713: Dot font was not removed even though DOT_CLEANUP was YES.</li>
+<li>   id 566925: Fixed problem resolving symbolic links.</li>
+<li>   id 567044: Fully qualified name was not shown correctly for nested 
+       classes.</li>
+<li>   id 567375: Fixed parse problem for typedefs with redundant braces.</li>
+<li>   id 567535: Fixed problem when parsing operator%= for CLI/C++ code.</li>
+<li>   id 567777: Fixed problem with latex output when using enums.</li>
+<li>   id 567990: Doxygen could crash when there was a symlink in project.</li>
+<li>   id 568237: Non-ascii values entered where not saved according to the
+       INPUT_ENCODING.</li>
+<li>   id 568505: Fixed build problem for old Linux distributions.</li>
+<li>   id 569478: Fixed line continuation issue with the Fortran parser.</li>
+<li>   id 570960: C++ class defined in a .mm file was sometimes parsed as
+       Objective-C code.</li>
+<li>   id 571013: In the wizard, editing a text field in the middle of the 
+       text in the expert tab caused the cursor to jump to the end of the line.</li>
+<li>   id 571096: Fixed Objective-C parsing problem when multiple protocol
+       forward declarations are put on one line.</li>
+<li>   id 571990: Fixed compiler issue with portable_iconv by moving the
+       function to a C file.</li>
+<li>   id 572560: Fixed parse issue when a #define is inside an enum.</li>
+<li>   id 572740: Fixed problem parsing C++ comments using line continuation.</li>
+<li>   id 573057: Included update for Swedish translator and changed
+       the language code from SE to SV to comply with ISO 639.</li>
+<li>   id 578382: When referring to a static variable or function
+       doxygen will now look at the file context in case of ambiguity.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.8</h1>
+<b>(release date 27-12-2008)</b>
+<a name="1.5.8"></a>
+<h3>Changes</h3>
+<ul>
+<li>   Completely rewrote the doxywizard. Main changes: 
+       <ul>
+       <li> It is now based on Qt version 4. (4.3 or higher is required) </li>
+       <li> Different layout that allows easy switching between wizard 
+            and expert mode, without losing settings.</li>
+       <li> Running doxygen can be done without first having to save 
+            the configuration file.</li>
+       <li> For HTML output, there is a button to show the results in 
+            the default browser.</li>
+       <li> Option to change the default configuration that is used 
+            when you first start the wizard.</li>
+       <li> Non-default options are shown with red label, and there is
+            context menu to reset them back to the default.</li>
+       </ul></li>
+<li>   Included Qt help update by Sebastian Pipping introducing 
+       three new options to define custom filter sections and attributes:
+       <code>QHP_CUST_FILTER_NAME</code>, 
+       <code>QHP_CUST_FILTER_ATTRS</code>, 
+       <code>QHP_SECT_FILTER_ATTRS</code>.
+       Doxygen now directly generates the indices needed 
+       by the qthelpgenerator.
+       Qt customers can have a look at issue 28 of the Qt Quarterly for
+       more information.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   id 131496, 522488, 541649, 554800: 
+       Add new option EXTENSION_MAPPING, which can be used to 
+       change the 
+       mapping of file extension to language parser, e.g. defining
+       <code>
+       EXTENSION_MAPPING = f=C 
+       </code>
+       will make doxygen parse files with the <code>.f</code>
+       extension as if it were C files.</li>
+<li>   Added support for Vietnamese (thanks to Dang Minh Tuan)</li>
+<li>   Thanks to Emin Ilker Cetinbas doxygen can now also produce Turkish
+       documentation.</li>
+<li>   id 143218: It is now possible to add the direction attributes 
+       normally used with the @param command to document parameters 
+       inline, e.g.
+       <code>
+       void foo(int v /**&lt; [in] input parameter docs */);
+       </code></li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   TYPEDEF_HIDES_STRUCT did not work correctly if the typedef did a
+       forward declaration of the struct/union.</li>
+<li>   id 153222: Fixed issue following recursive symbolic links.</li>
+<li>   id 423223: Detailed description was not visible for group functions
+       when SEPARATE_MEMBER_PAGES was enabled.</li>
+<li>   id 437346: Fixed issue handling multibyte characters in the RTF output.</li>
+<li>   id 475377: Improved error handling in case of character encoding
+       problems.</li>
+<li>   id 486747: Inherited typedefs were not resolved propertly.</li>
+<li>   id 508752: Add support for BLOCK DATA to the fortran parser.</li>
+<li>   id 532695: included documentation update about the use of \public
+       and friends for object-oriented programming in C.</li>
+<li>   id 532808: References to class variables in PHP code did not already work.</li>
+<li>   id 536394: Warning "no matching file member found" was given for a static 
+       variables in multiple anonymous namespaces.</li>
+<li>   id 537686: Fixed invalid empty section for enum in a member group.</li>
+<li>   id 539590: C# generics with the same name but different template 
+       parameters where merged.</li>
+<li>   id 540321: A using declaration in a header file was not taken into
+       account in the source file that included it.</li>
+<li>   id 540520: Have two C# enum values with the same name in different enums
+       was not handled properly.</li>
+<li>   id 543036: //## comments were extracted even if they were not part of
+       Rose documentation.</li>
+<li>   id 547436: Fixed issue combining Python docstrings and doxygen comments.</li>
+<li>   id 551615: A multiline C# comment with @ was not shown correctly in the
+       source browser.</li>
+<li>   id 544598: A multiline comment as part of a #define could case
+       wrong line counting and missing cross-references.</li>
+<li>   id 545128: \overload didn't work if it was the last statement in a
+       comment and not followed by a newline.</li>
+<li>   id 553380: Removed bogus warning refering to a namespace member from
+       with a brief description that was converted to a tooltip.</li>
+<li>   id 553968: Added support for JavaDoc command {@code ... }</li>
+<li>   id 554444: Bullet lists were no longer correctly indented when using
+       IE6.</li>
+<li>   id 554674: Fixed index rendering bug in the RTF output.</li>
+<li>   id 555174: The .qch file didn't include generated images.</li>
+<li>   id 555200: Fixed potential crash bug when parsing special comment
+       inside an if at global scope level of a PHP code fragment.</li>
+<li>   id 556240: Tree view in HTML output was not encoded correctly.</li>
+<li>   id 557001: VHDL Parser got confused when -- is in a string literal.</li>
+<li>   id 557014: Undocumented VHDL record member's internal record prefix 
+       was not removed.</li>
+<li>   id 557026: Obj-C Protocols and interfaces had wrong 
+       type/name in DocSets.</li>
+<li>   id 557031: Obj-C methods no longer require a space after the 
+       initial - or +.</li>
+<li>   id 557034: Fixed problem parsing property in Objective-C code.</li>
+<li>   id 557038: Items in tabs.css could not be overridden by custom
+       style sheet.</li>
+<li>   id 557419: $relpath$ was no longer expanded in custom HTML headers.</li>
+<li>   id 557735: Summary for member groups was missing for groups and files.</li>
+<li>   id 558078: collaboration graph of a class using std::list of another class
+       was not correct if the classes where inside a namespace.</li>
+<li>   id 558460: When using \subpage, any section in the sub page was
+       missing from the LaTeX output.</li>
+<li>   id 558525: Template classes produced invalid HTML in the tree view.</li>
+<li>   id 559338: PHP Parser could get confused when there was a comment inside 
+       an array initializer.</li>
+<li>   id 559650: Obj-C @interface without body was handle correctly.</li>
+<li>   id 560623: Mixin template classes where not shown properly in the inheritance
+       diagram if the classes where inside a namespace.</li>
+<li>   id 563136: The brief sentence is not shown for groups with no children.</li>
+<li>   id 563384: call graphs were not generated for Qt signals and slots</li>
+<li>   Included VHDL fix by Martin Kreis.</li>
+<li>   grouping of multiple @todo's (and friends) didn't work anymore, 
+       causing duplicate sections and labels.</li>
+<li>   Some issues related to the Qt help output were fixed.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.7.1</h1>
+<b>(release date 5-10-2008)</b>
+<a name="1.5.7.1"></a>
+<h3>Changes</h3>
+<ul>
+<li> The dot tool is no longer part of the doxygen package for MacOSX.
+     Please install GraphViz separately and set the dot path 
+     to /usr/local/bin</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li> Added option DOT_FONTSIZE which allows to set the size of
+     the fonts used in dot generated graphs.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li> id 554432: Re-added ALPHABETICAL_INDEX option.</li>
+<li> id 554379: Fixed internal error for GENERATE_INDEXLOG when
+     GENERATE_HTML was set to NO.</li>
+<li> id 554546: Included fix for handling relative includes in the 
+     preprocessor.</li>
+<li> Included several VHDL fixes related to syntax highlighting, finding
+     class members, and mixing upper and lower case.</li>
+<li> Included patch to allow setting DEST_DIR environment variable
+     to determine where to install doxygen.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.7</h1>
+<b>(release date 28-9-2008)</b>
+<a name="1.5.7"></a>
+<h3>Changes</h3>
+<ul>
+<li>   The default CSS style sheet has been cleaned up and simplified, thanks 
+       to the work done by Quinn Taylor.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added new config options <code>GENERATE_QHP</code>
+       which enables generating .qch (Qt compiled help) file via 
+       the Qt's qthelpgenerator tool (part of Qt 4.4+).
+       This type of files can be read with Qt's Assisant to browse the 
+       documentation in a similar way as is possible with Microsoft's 
+       compiled HTML help (.chm). To further customize the output and run the
+       help generator from within doxygen, the following options
+       are available: <code>QCH_FILE</code>, <code>QHP_NAMESPACE</code>, 
+       <code>QHP_VIRTUAL_FOLDER</code>, <code>QHG_LOCATION</code>. 
+       Thanks to Sebastian Pipping for the patch.</li>
+<li>   Add new option <code>SYMBOL_CACHE_SIZE</code> to allow a different 
+       trade off between doxygen's memory usage and the amount of disk 
+       accesses.</li>
+<li>   id 532695: Added 3 new commands: \extends, \implements, and \memberof
+       that allow object oriented constructs to be documented as such
+       for languages that do not support it natively (e.g. C)</li>
+<li>   Added better support for one line comments after VHDL types.</li>
+<li>   Added new option <code>LAYOUT_FILE</code> which can be used to 
+       specify a layout
+       template file that tells doxygen in which order to generate the
+       output and which titles to use for headings and how 
+       the navigation index will look;
+       Read <a href="customize.html">this</a> for more info.
+       As a result the following options are now obsolete since they can
+       now only be controlled via the layout file:
+       <code>DETAILS_AT_TOP</code>, <code>ALPHABETICAL_INDEX</code>.
+       The following options can also be set via the layout file, but
+       for convenience and backward compatibility reasons they are still
+       also part of the configuration file:
+       <code>SHOW_INCLUDE_FILES</code>, <code>SHOW_USED_FILES</code>, 
+       <code>CLASS_GRAPH</code>, <code>COLLABORATION_GRAPH</code>, 
+       <code>GROUP_GRAPHS</code>, <code>INCLUDE_GRAPH</code>, 
+       <code>INCLUDED_BY_GRAPH</code>.
+       Run doxygen with the -l option to generate the default layout file.</li>
+<li>   Included update for the Macedonian, Catalan, Brazilian, and Serbian 
+       translation and also support for Serbian with Cyrilic characters.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 140264, 332187, 541924: Sections inside a \subpage where not shown as
+       subsection in the LaTeX/RTF output. </li>
+<li>   id 155098,156188: Added support for UTF-8 special characters in identifiers (which is 
+       allowed by e.g. C#).</li>
+<li>   id 304598: operator-- caused invalid HTML output.</li>
+<li>   id 324047: parameter type [in or out] were not generated in RTF document</li>
+<li>   id 363499: @todo and friends did not work in a comment marked with @dir.</li>
+<li>   id 445485: HTML commands in a comment block with attribute values without 
+                  quotes were not handled properly.</li>
+<li>   id 533855: Processes were always documented as anonymous in VHDL code.</li>
+<li>   id 535379: Added support for %{...%} blocks in XPCOM's IDL.</li>
+<li>   id 536298: Last port in a VHDL port list was not correctly put in a
+       member group.</li>
+<li>   id 536385: Fixed problem matching function prototype and implementation
+       under certain conditions.</li>
+<li>   id 536629: Fixed compilation issue on NetBSD.</li>
+<li>   id 537393: Properties in Python were not properly handled.</li>
+<li>   id 538065: Added support for @optional and @required in Objective C 2.0
+       protocols.</li>
+<li>   id 538239: Some unlabeled VHDL processes were not corrected detected.</li>
+<li>   id 538515: Deriving a Objective-C interface from a protocol caused
+       parsing problems if the interface also has a body.</li>
+<li>   id 539057: Part of an Objective-C expression could be missing in the 
+       source browser under certain conditions.</li>
+<li>   id 539590: Generic C# classes with the same name but different 
+       template arguments were no longer treated as different classes.</li>
+<li>   id 539712: Fixed code parser issue for parameter indices of procedures
+       and functions.</li>
+<li>   id 540058: Creator code was wrong in the MacOSX application bundle.</li>
+<li>   id 540372: Fixed problem parsing large table by increasing
+       YY_READ_BUF_SIZE in the generated parser files.</li>
+<li>   id 540247: Fixed potential memory corruption issue parsing VHDL.</li>
+<li>   id 541113: Fixed locale for ctype, to avoid stripping of 0xA0 
+       from multi-byte UTF-8 characters.</li>
+<li>   id 544479: <code>SORT_MEMBER_DOCS</code> did not work for class members.</li>
+<li>   id 546621: Fixed makefile so that .svn stuff is removed from the 
+       tarball when doing "make archive".</li>
+<li>   id 546812: Using a table with row span greater than 1 did not 
+       produce correct LaTeX output.</li>
+<li>   id 545098: Fixed problem parsing where clauses in combination with C#
+       generics.</li>
+<li>   id 545503: Nameless parameters of type "struct A" could end up wrongly
+       in the XML output.</li>
+<li>   id 545970: Refering to the main page did not work as advertised.</li>
+<li>   id 546158: The variable defined inside a foreach statement in C# code 
+       was not considered for source linking, cause potentially incomplete call
+       graphs.</li>
+<li>   id 547361: Linking to specialized template functions did not work.</li>
+<li>   id 548175: Fixed problem parsing class members within a class X, 
+       inside a namespace that is also named X.</li>
+<li>   id 548443: Documenting a nested namespace/classes with @namespace X.Y
+       did not work for C# (only X::Y worked).</li>
+<li>   id 548489: C++/CLI classes of type sealed abstract were not 
+       processed correctly.</li>
+<li>   id 549318: Some headings in the user manual where wrongly formatted. </li>
+<li>   id 549581: Fixed potential buffer overflow in preprocessor.</li>
+<li>   id 550058: Obj-C: properties for private fields did not appear in the
+       output unless <code>EXTRACT_PRIVATE</code> was enabled. </li>
+<li>   id 550156: Corrected typo in the documentation for 
+       <code>GENERATE_TREEVIEW</code>.</li>
+<li>   id 550247: Fixed problem parsing octal character literals in 
+       the preprocessing phase.</li>
+<li>   id 551739: Related function with explicit namespace scope was not
+       properly placed if the function also existed in the global namespace.</li>
+<li>   id 552115: Anonymous structs and unions could produce invalid links in
+       the html help index.</li>
+<li>   id 552361: Fixed problem with operators in the LaTeX output.</li>
+<li>   id 552600: \copybrief ended a brief description instead of appending 
+       to it.</li>
+<li>   id 553469: Removed bogus warning about internal inconsistency when
+       importing items via a tagfiles that are inside an undocumented scope.</li>
+<li>   id 553616: One can now remove the automatic line breaks in the type 
+       part of a declaration by using a custom stylesheet with
+       BR.typebreak { display: none; }</li>
+<li>   id 553663: Aliases did not work in Fortan comments.</li>
+<li>   id 549022: Reimplemented in links could be wrong in case of 
+       overloaded members.</li>
+<li>   id 553225: Parser was confused by arrays inside an Obj-C message.</li>
+<li>   Finnish translation was disabled.    </li>
+<li>   A collaboration graph with multiple edge labels with not written to
+       the XML output correctly.</li>
+<li>   sub pages of a \mainpage were not shown in the Latex/RTF output.</li>
+<li>   Included some fixed for the VHDL parser.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.6</h1>
+<b>(release date 18-5-2008)</b>
+<a name="1.5.6"></a>
+<h3>Changes</h3>
+<ul>
+<li>   The GENERATE_TREEVIEW option is not longer a boolean, but can now
+       have 4 values, NONE (was NO), FRAME (was YES), HIERARCHIES, and ALL.
+       Thanks to Jake Colman for the patch.</li>
+<li>   a page marked as a sub page (\subpage) is now shown in the LaTeX and 
+       RTF output as a section of its parent page. So the top level pages are 
+       shown a chapters, subpages as sections, subpages of a subpage as 
+       subsections, etc. </li>
+<li>   Included spec file updates by Kenneth Porter.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   id 514810: Added DOT_FONTNAME and DOT_FONTPATH options which allow
+       instructing dot to use a different font than FreeSans.ttf which doxygen
+       put in the output directory.</li>
+<li>   id 517242: Added option CHM_INDEX_ENCODING to specify the encoding
+       to be used for the CHM index files. Needed because CHM index files 
+       cannot handle UTF-8 encoding.</li>
+<li>   id 519573: Included patch to make the font-size button visible in the
+       CHM output.</li>
+<li>   id 521288: Added new options SHOW_NAMESPACES and SHOW_FILES to 
+       Suppress Namepace and Files Pages.</li>
+<li>   id 521495: Included a patch that makes it easy to modify the root of
+       the html treeview with an image using style sheets.</li>
+<li>   id 522300: Added option IDL_PROPERTY_SUPPORT to enable/disable special 
+       propget/propput handling in IDL files.</li>
+<li>   Translation support for Finnish has been updated.</li>
+<li>   Added option FORMULA_FONTSIZE which can be used to change the font size
+       of the formulas included in the HTML documentation.</li>
+<li>   included update for Russian translation.</li>
+<li>   included patch to fixed some issues with VHDL code and add support
+       for some VHDL-93 constructs.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Regression: fixed problem handling STL classes 
+       when BUILTIN_STL_SUPPORT was enabled</li>
+<li>   id 142866,377976: Added new \copybrief and \copydetails commands, 
+       which work as \copydoc but then only copy either the brief or the 
+       detailed part of a comment block.</li>
+<li>   id 312655: DISTRIBUTE_GROUP_DOC didn't always work in combination
+       with SORT_BRIEF_DOCS enabled.</li>
+<li>   id 352234: The search index could contain invalid references when
+       SOURCE_BROWSER=NO and CALL_GRAPHS=YES.</li>
+<li>   id 402447: Added support for C# method declarations with where clauses.</li>
+<li>   id 425029: WARN_FORMAT does no longer require all of
+       $file, $line, $text to be valid.</li>
+<li>   id 495687: Replaced MAX_DOT_GRAPH_MAX_NODES with DOT_GRAPH_MAX_NODES 
+       in the docs &amp; config file.</li>
+<li>   id 508694 Fixed problem with mixed simple and double quotes in 
+       fortran format declaration</li>
+<li>   id 508752: Fixed problem where the fortran scanner didn't recognize END</li>
+<li>   id 510971: Fortran: parser was confused by double REAL() in processed 
+       statements.</li>
+<li>   id 514488: Fixed problem matching argument lists with const qualifiers.</li>
+<li>   id 514891: PDF generation failed with a LaTeX error when tocdepth
+       was set to a value higher than 2.</li>
+<li>   id 515518: Links in member group documentation was broken when
+       CREATE_SUBDIRS was enabled.</li>
+<li>   id 516086: Fixed division by zero when producing RTF output for the 
+       comment /** &lt;table&gt;&lt;tr&gt;&lt;/tr&gt;&lt;/table&gt; */</li>
+<li>   id 516536: Fixed build issues on OSX 10.4 and earlier.</li>
+<li>   id 516070: Added support for simple events without accessors in C#.</li>
+<li>   id 516387: replace 0xA0 character in perlmodgen.cpp by a space to
+       avoid compilation problems with the Chinese version of Visual Studio.</li>
+<li>   id 517112: Regression: examples with the same name but different paths
+       cause "file not found" warning.</li>
+<li>   id 518334: Fixed problem parsing Objective-C protocol definitions.</li>
+<li>   id 518537: Hiding an enum with an undocumented typedef with the same
+       name caused explicit referencing of the enum to fail.</li>
+<li>   id 519661: In some cases a function prototype could incorrectly be 
+       flagged as a variable with constructor.</li>
+<li>   id 520325: Fixed parse problem when comment was after an extern "C" 
+       block and before the opening bracket.</li>
+<li>   id 521234: Fortran: fixed problem causing 
+       "stack empty! when parsing code"</li>
+<li>   id 522225: PDF Latex output did not produce proper hyperlinks for \page
+       and \subpage comment blocks.</li>
+<li>   id 522248: Page header were wrongly displayed in the RTF output.</li>
+<li>   id 522415: Fixed compile errors in addon/doxmlparser.</li>
+<li>   id 522600: Added additional warnings to signal invalid configurations.</li>
+<li>   id 523138: Removed redundant paragraph in navigation section of the
+       HTML output. </li>
+<li>   id 523326: Namespace name was prepended twice to template 
+       specializations classes.</li>
+<li>   id 524357: Default mentioned for REFERENCED_BY_RELATION relation 
+       was not correct.</li>
+<li>   id 524359: Default mentioned for REFERENCES_RELATION relation was 
+       not correct.</li>
+<li>   id 524473: Removed incorrect warnings about parameters in VHDL.</li>
+<li>   id 525140: Improved handling of Objective-C 2.0 properties.</li>
+<li>   id 525143: Properties are now listed as attributes in the UML diagrams.</li>
+<li>   id 525144: GENERATE_DOCSET option greyed out in doxywizard.</li>
+<li>   id 526155: Removed warning about QFile::setName when parsing VHDL files.</li>
+<li>   id 527781: Template arguments for bases class not shown in a consistent
+       way.</li>
+<li>   id 528023: Inheritance relations were not correctly displayed for
+       C# generics.</li>
+<li>   id 528424: Fixed rendering bug in HTML output when used with Opera.</li>
+<li>   id 528584: Using enum and enum value with the same name in C# code
+       caused crash.</li>
+<li>   id 528620: Fixed typo in French translation.</li>
+<li>   id 528815: Fixed problem parsing define() statements in PHP code.</li>
+<li>   id 528989: Leading C comment could prevent preprocessor expansion for
+       the rest of the line.</li>
+<li>   id 529803: Doxygen didn't find call(er) relations for C# when using
+       this.Method() calls;</li>
+<li>   id 529554: Putting defined() inside a macro caused the preprocessor
+       to get confused.</li>
+<li>   id 529758: C++/CLI: default inheritance is now public, nested templates
+       ending with &gt;&gt; are now handled properly as well as indexed properties.</li>
+<li>   id 530201: Avoided warning for undocumented self parameter in Python.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.5</h1>
+<b>(release date 10-2-2008)</b>
+<a name="1.5.5"></a>
+<h3>Changes</h3>
+<ul>
+<li>   Pages created with @page are now chapters in the LaTeX and RTF output
+       and treeviews, and directly follow the mainpage. Also the project name
+       is not longer repeated for each chapter.
+       This should make it more convenient to create normal, printable 
+       documentation with doxygen.</li>
+<li>   For dot graphs with an edge with more than ten labels, only the first
+       ten are shown followed by an ellipsis; done to prevent very long
+       dot runs resulting in unreadable graphs.</li>
+<li>   Use of pdflatex with hyperlinks is now the default.</li>
+<li>   id 511116: C++ preprocessor macro names are now replaced in the
+       comments as well. For example, S and m are replaced in the comments for:
+       <code>
+       #define C(S,m) /** container S */ struct S { /** value m */ int m; }
+       </code></li>
+<li>   id 493923: The options SOURCE_BROWSER, CALL_GRAPH, CALLER_GRAPH, 
+       REFERENCES_RELATION, and REFERENCED_BY_RELATION can now be indepently
+       enabled and disabled. By default the relations are now disabled.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for VHDL (.vhd or .vhdl extension) based on a patch by
+       Martin Kreis. Use OPTIMIZE_OUTPUT_VHDL when parsing VHDL code. </li>
+<li>   id 374699: Added support for Objective-C 2.0 properties.</li>
+<li>   Added compilation support for MacOSX 10.5 (Leopard) incombination with 
+       Xcode 3</li>
+<li>   Added support for docsets, which allow integration of doxygen generated 
+       API documentation in Xcode 3. new options: 
+       <ul>
+       <li> GENERATE_DOCSET: enables/disables the feature</li>
+       <li> DOCSET_FEEDNAME: sets the provider/suite name under which the set is
+                          listed.</li>
+       <li> DOCSET_BUNDLE_ID: A unique name for the docset.</li>
+       </ul>
+       See the configuration file or manual for more details.</li>
+<li>   id 493467: Added compilation support 64bit Solaris machines in 
+       combination with Sun's own compiler (thanks to Heiko Jansen).</li>
+<li>   id 153376: Added support for the \tparam command, which works similar to \param
+       but is meant for documenting template parameters.</li>
+<li>   id 140104: Added \headerfile command which can be used to specify
+       the second and third argument of a \class command, when
+       the documentation is already in front of a class definition.</li>
+<li>   Added translator support for Macedonian.</li>
+<li>   Added language updates for German, Perian, Spanish, Taiwanese,  
+       and Chinese, Korean, Croatian.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed potential crash bug due to wrong pointer check.</li>
+<li>   Using @param as the first word in a comment block did not work properly
+       in combination with JAVADOC_AUTOBRIEF set to YES.</li>
+<li>   Some character's could be missing from IDL properties.</li>
+<li>   Automatic abbreviations did not work for nested classes or classes
+       in a namespace.</li>
+<li>   Fixed a preprocessor bug where the line numbers of a definition could 
+       get out of sync with the source code.</li>
+<li>   id 142023: Putting Qt signals or slots in a group did not
+       make them appear in the group documentation.</li>
+<li>   id 318668: Comments in Python function argument lists got messed up.</li>
+<li>   id 325359: Added support for C# XML-doc commands typeparam and 
+       typeparamref.</li>
+<li>   id 331674: Aliases did not work in Python code.</li>
+<li>   id 356399: Fixed strange warning when specifying a tag file with an
+       anchor twice.</li>
+<li>   id 363828: Docstrings found at the top of a python file are handled
+                  as module documentation again.</li>
+<li>   id 429437: A #include outside the input files was not searched
+       in the current directory of the file containing the include.</li>
+<li>   id 451299: Sometimes the wrong include file chosen when ambiguous</li>
+<li>   id 460585: @cond did not work in Python code.</li>
+<li>   id 477377: Function in undocumented anonymous namespace cause broken
+                  link if EXTRACT_ALL was set to NO.</li>
+<li>   id 484731: Additional fixes for parsing Fortran.</li>
+<li>   id 488125: <code>operator-&gt;*</code> was not displayed properly in the output.</li>
+<li>   id 490766: Fixed compile error in fortranscanner.l which occurred for
+       some compilers.</li>
+<li>   id 492027: Ampersand (&amp;) in front of parameter stops documenting 
+       of PHP source</li>
+<li>   id 493249: using a namespace (or fortran module) caused the namespace
+       to appear in the documentation as if it was defined.</li>
+<li>   id 493434: Nested C# style XML lists in a comment block were not
+       handled correctly.            </li>
+<li>   id 494187: Doxygen could crash due to an infinite recursion when
+       using tag files.</li>
+<li>   id 494599: When updating a config file an extra space was added just 
+       before the end of a quoted string.</li>
+<li>   id 494760: Putting a # in a path name using Doxywizard, caused the
+       # to interpreted as the start of a comment in the Doxyfile.</li>
+<li>   id 495656: Description of default used for DOT_TRANSPARENT was wrong.</li>
+<li>   id 495687: Fixed typo in the description of DOT_GRAPH_MAX_NODES.</li>
+<li>   id 496392: Putting character entities like &eacute; in section/group
+       titles resulted in &amp;acute; in the output.</li>
+<li>   id 498049: Improvements to .spec files for RPM creation.</li>
+<li>   id 498680: Callgraphs for functions in anonymous namespaces generated 
+       invalid labels for 'dot' when EXTRACT_ANON_NSPACES was set to YES.</li>
+<li>   id 498711: Reference parameters in PHP were not properly parsed.</li>
+<li>   id 499577: Collaboration diagrams not working with typedef</li>
+<li>   id 500227: Wrong output generated for Objective-C methods with 
+       multiple arguments for LaTeX or RTF output.</li>
+<li>   id 500635: Project name is no longer placed before each top level 
+       item in the treeview and other indices.</li>
+<li>   id 500465: Fixed some issues compiling for AIX.</li>
+<li>   id 500928: Fixed parser issue handling a tripple quoted 
+                  string when used to initialize a Python variable.</li>
+<li>   id 500944: Python variables with package scope were only extracted if
+       EXTRACT_STATIC was enabled.</li>
+<li>   id 501704: Line numbering was wrong when a #include was placed inside
+       an array/struct initializer list.</li>
+<li>   id 502213: Combining a brief and detailed description in an alias
+       produced the warning "unknown command \_&zwj;linebr".</li>
+<li>   id 502447: Single quoted PHP strings were not handled correctly
+       by the source code parser.</li>
+<li>   id 503939: Variable was checked before initialized.</li>
+<li>   id 504120: TYPEDEF_HIDES_STRUCT now also works for enums.</li>
+<li>   id 504439: Assert when marshaling a member which had an associated 
+                  example.</li>
+<li>   id 504650: Generated LaTeX code injected hyperlinks into section titles.</li>
+<li>   id 507052: Fortran function named x_function was not properly handled.</li>
+<li>   id 507603: Enabling FILTER_SOURCE_FILES caused strange warnings when
+       INPUT_FILTER is empty.</li>
+<li>   id 508740: Using upper case port mode specifiers did not work correctly.</li>
+<li>   id 508753: Fortran: Added .f as allowed fortran extension.</li>
+<li>   id 508759: Fortran: fixed potential memory corruption while scanning 
+       parameter lists.</li>
+<li>   id 507528: XML output was not correct for pointer arrays.</li>
+<li>   id 508752: Fortran scanner didn't recognize lonely END</li>
+<li>   id 509278: Spaced before the \internal command where treated as 
+       documentation.</li>
+<li>   id 509582: Fortran: Spaces in function return type were not parsed 
+       properly.</li>
+<li>   id 510387: Fortran scanner didn't parse initialisation of complex type
+       correctly. </li>
+<li>   id 511921: @file command ended brief description even when
+       JAVADOC_AUTOBRIEF was enabled.</li>
+<li>   id 512620: \copydoc of a comment with @param commands could result in
+       warnings that parameters were not documented.</li>
+<li>   id 513570: Fixed cross site scripting vulnerability in the 
+       search.php script.</li>
+<li>   id 514814: Included missing fromUtf8 calls to translator decoder to
+       prevent potential language encoding issues.</li>
+<li>   id 513885: Using <code>this-&gt;</code> inside a function could result in incomplete
+       call graph.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.4</h1>
+<b>(release date 27-10-2007)</b>
+<a name="1.5.4"></a>
+<h3>Changes</h3>
+<ul>
+<li>   id 469260: When setting SOURCE_BROWSER to YES, all undocumented classes also ended
+       up in the documentation. Now this will only happen if EXTRACT_ALL is also
+       enabled.</li>
+<li>   Upgraded included third party libs libpng and zlib to version 1.2.21 and 1.2.3
+       respectively.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Included support for parsing Fortran 90, thanks to a patch by 
+       Anke Visser and Oleg Batrashev (source: http://dougdevel.org/index.php?page=doxygen)</li>
+<li>   id 477548: Added config option SIP_SUPPORT to support handling SIP sources
+       (used for Python to C++ bindings).</li>
+<li>   id 475828: Added support for CLI/C++ style indexed properties.</li>
+<li>   Added config option TYPEDEF_HIDES_STRUCT which when enabled treats a typedef
+       of a struct as a struct with the name of the typedef. This behavious was
+       coupled to OPTIMIZE_OUTPUT_FOR_C in the previous version and is now an independent
+       option.</li>
+<li>   Included updates for the Korean, Brazilian and Chinese translations.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 314541: Fixed wrong DOCTYPE in HTML output when GENERATE_TREEVIEW was set to YES</li>
+<li>   id 321784: Changed scope resolution algorithm to avoid lookup failures on using
+                  directives (thanks to Christoph Schulz for the patch).</li>
+<li>   id 415866: Fixed bug in preprocessor causing "More #endif's than #if's found" warning.</li>
+<li>   id 426971,465020: A brief description would in some cases be treated as a 
+                  detailed one.</li>
+<li>   id 430148: Doxygen reported "Internal Inconsistency" for class member inside 
+                  anonymous namespaces.</li>
+<li>   id 433449,363010: Removed Internal inconsistency when referencing enum values found 
+                  in a tag file.</li>
+<li>   id 438282: Line numbers were displayed when using \include inside \example.</li>
+<li>   id 443942,461433: mscgen was not called correctly on Windows when 
+                  generating .map files.</li>
+<li>   id 457346: increased the threshold for adding line breaks to the type part of a
+                  declaration.</li>
+<li>   id 460294: Missing references in source browser when using the "register" keyword.</li>
+<li>   id 461889: Fixed bogus "no matching class member found" case.       </li>
+<li>   id 462051: In certain cases doxygen failed to find the proper inheritance relation.</li>
+<li>   id 462077: Error in LaTeX index generation due to unescaped characters.</li>
+<li>   id 462159, 143250: Added support for parsing functions/methods returning a 
+                  pointer or reference to an array, e.g. a function of the 
+                  form: "int (*f(int))[];"</li>
+<li>   id 462436: Inheritance from an unknown template class was not handled consistently.</li>
+<li>   id 462439: Adjusted \author documentation.</li>
+<li>   id 462757: Fixed Latex output bug for members of anonymous struct or unions. </li>
+<li>   id 462861: Members references via tagfiles were sometimes broken.</li>
+<li>   id 463139: Doxygen failed to detect duplicate variable declarations in the same file.</li>
+<li>   id 465138: HTML entities in page title (such as &uuml;) where not displayed 
+                  correctly in the HTML output.</li>
+<li>   id 465170: Wrong line numbers reported for errors when using multiline formulas.</li>
+<li>   id 465172: Fixed issues parsing &lt;code&gt;operator&lt;/code&gt;.</li>
+<li>   id 466803: Fixed crash when parsing Java enum with empty field.</li>
+<li>   id 466890: Handling of CVS/RCS keywords was broken.</li>
+<li>   id 466910: When UML_LOOK is set to YES, the graph orientation is always top to bottom.</li>
+<li>   id 466991: Template argument using '?' operator breaks file generation.</li>
+<li>   id 468858,472310: C++ casting operator with templates was displayed wrong.</li>
+<li>   id 468937: .hhc and .hhk was missing the &lt;/body&gt; and &lt;/html&gt; tags.</li>
+<li>   id 469269: When HTML_DYNAMIC_SECTIONS was enabled, index.hhp missed
+                  open.gif and closed.gif.</li>
+<li>   id 470029: Fixed crash while parsing a particular piece of PHP code.</li>
+<li>   id 471185: The word "property" was stripped from functions that started with it.</li>
+<li>   id 471495: Objective C category documentation was ignored in some cases.</li>
+<li>   id 472193: Fixed issue expanding multiple occurrences of the same alias command 
+                  argument.</li>
+<li>   id 472201: Removed spurious warning introduced by the fix for bug 465170.</li>
+<li>   id 473105: Auto link to nested class inside a base class was missing. </li>
+<li>   id 473140: Anonymous scope ended up wrongly in the XML output.</li>
+<li>   id 473402: context dependent \ref's inside a dot or msc graph did not work anymore.</li>
+<li>   id 473679: Doxygen skipped function if return type contained round parenthesis.</li>
+<li>   id 474529: index entries in LaTeX could be wrong on some platforms.</li>
+<li>   id 476035: Externally referenced links obtained via a tag file had an extra g in 
+                  the anchor</li>
+<li>   id 476562: argument of copydoc appears in XML output without proper escaping.</li>
+<li>   id 476766: Type of a virtual destructor was "virtual" in the XML output.</li>
+<li>   id 479113: Automatic links were not generated when next word started with "const".</li>
+<li>   id 479762: Wrong character encoding was used for dot files.</li>
+<li>   id 480722: File tooltips incorrect for the include dependency graph.</li>
+<li>   id 481168: Allow \f{environment}{ .... \f} so the number of braces matches.</li>
+<li>   id 481107: Using HTML_FILE_EXTENSION to set a non-default extension did not work
+                  for the "no frames" link to main.html when GENERATE_TREEVIEW was enabled.</li>
+<li>   id 481827: Macro expansion removed the @ character when it appear in a C comment.</li>
+<li>   id 482964: The "template" word was a little too close to the rounded border in 
+                  the html output when rendered by Firefox.</li>
+<li>   id 484277: Adjusted the instructions to report a bug in the hope this will result
+                  in less duplicate bugs.</li>
+<li>   id 484731: Fixed issue parsing unindented interface (Fortran).</li>
+<li>   id 486159: Fixed problem parsing \xrefitem commands in joined comment blocks.</li>
+<li>   id 488760: Added support for Trigraphs to doxygen's C-preprocessor.</li>
+<li>   id 488800: Fixed problem in perlmod generation.</li>
+<li>   id 488837: abstract class in PHP was not properly parsed.</li>
+<li>   id 489049: Setting MUTLILINE_CPP_IS_BRIEF to YES could cause wrong line number 
+       references.</li>
+<li>   Call graphs were not properly synced between function declaration and definition.</li>
+<li>   Fixed bug in doxygen's internal caching mechanism which could make doxygen
+       forget enum lists for large projects. </li>
+</ul>
+
+<h1>Doxygen Release 1.5.3</h1>
+<b>(release date 27-7-2007)</b>
+<a name="1.5.3"></a>
+<h3>Changes</h3>
+<ul>
+<li>   When <code>OPTIMIZE_OUTPUT_FOR_C</code> is enabled then a struct definition of the
+       form <code>typedef struct _S { ... } S_t</code> will be shown in the output as a
+       struct of type <code>S_t</code> and the typedef itself is omitted 
+       (previousily <code>_S</code> was shown
+       as well as a typedef of the form <code>typedef _S S_t</code>). </li>
+<li>   Improved the line-breaking rules for members whose return types have many characters
+       (for example a function returning a pointer to a template class).</li>
+<li>   Multiple brief and detailed descriptions are now possible. It is still not
+       recommended to make use of them, but at least no documentation is silently hidden
+       when there are two brief or two detailed descriptions for the same entity.</li>
+<li>   Improved dot layout control and page sizing to better fit images on the screen
+       and paper.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for aliases with arguments, 
+       see <a href="custcmd.html">the manual</a>
+       for more information.</li>
+<li>   Added <code>HTML_DYNAMIC_SECTIONS</code> option which, when enabled, 
+       will produce sections 
+       in the HTML output that can be expanded/collapsed. Currently used for
+       diagrams and graphs.</li>
+<li>   Added support for type constraints as available in the C# language ("where" clause)</li>
+<li>   id 332263: Added new option <code>EXTRACT_ANON_NSPACES</code> that when set to <code>YES</code> will extract
+                  the contents of anonymous namespaces and show then in the output.</li>
+<li>   id 423765: Added support for &lt;see cref="SomeSymbol"/&gt; style XML comments. </li>
+<li>   id 426971: Added <code>QT_AUTOBRIEF</code> config option, which has the same meaning
+       as <code>JAVADOC_AUTOBRIEF</code> only now for /&zwj;*! .. *&zwj;/ style comment blocks.</li>
+<li>   id 435108: Reintroduced the <code>MAX_DOT_GRAPH_DEPTH</code> option as a means to further
+                  reduce the size of a graph.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 137644: Fixed issue with "const" parsing of a typedef'ed struct where the "const"
+                  is placed after the struct definition.</li>
+<li>   id 153362: A typedef of a function pointer was not shown correctly in the output.</li>
+<li>   id 156003: Wrong template arguments when using @related for a (template) function
+                  with a template class.</li>
+<li>   id 170004: The check for PDF or DVI in the generated latex output 
+                  was not always reliable.</li>
+<li>   id 300022: PHP code with unknown extension was parsed as C/C++ code. Added a
+                  detection rule for &lt;?php to switch to PHP parsing.</li>
+<li>   id 317967: Setting <code>USE_PDFLATEX</code> to <code>YES</code> now generates a 
+                  Makefile with a "pdf" target,
+                  to be consistent with the documentation.</li>
+<li>   id 397099: Fixed several cases where "referenced by" relation was unresolved.</li>
+<li>   id 423776: XML style see tag resulted in messed up documentation.</li>
+<li>   id 426852: \hideinitializer was sometimes ignored when using structural commands.</li>
+<li>   id 426977: Included a patch allow building under recent versions of Cygwin</li>
+<li>   id 427991: Doxygen failed to call mscgen.exe properly on Win32 platforms.</li>
+<li>   id 430962: struct keyword was stripped from typedefs even for C code.</li>
+<li>   id 431049: Fixed potential crash when <code>GENERATE_PERLMOD</code> was enabled.</li>
+<li>   id 431202, 333607: Quotes inside strings caused the Pythons parser to get off track.</li>
+<li>   id 431763: doxygen crashes when using unsupported tags in the config file.</li>
+<li>   id 432420: Last enum value of a Java 1.5 style enum with constructor did not appear.</li>
+<li>   id 432743: The "std" namespace appeared in the output when 
+                  <code>BUILTIN_STL_SUPPORT</code> was enabled.</li>
+<li>   id 432757: Setting <code>INLINE_INHERITED_MEMBERS</code> to <code>YES</code>, 
+                  did not inherit the group of grouped members of a base class.</li>
+<li>   id 433630: Using double-quotes (") inside a brief description could lead to
+                  errors in dot files when the brief description was used as a tooltip.</li>
+<li>   id 434079: The number of graph nodes could still be too large despite a 
+                  conservative <code>DOT_GRAPH_MAX_NODES</code> setting.</li>
+<li>   id 436648: List of class members was no longer complete under certain conditions.</li>
+<li>   id 437218: Special characters in \brief string cause problems HTML/XML in source 
+                  listings.</li>
+<li>   id 438300: Fixed two cases where doxygen could access memory outside array 
+                  boundaries under certain conditions.</li>
+<li>   id 441114: Add support for &lt;term&gt; inside &lt;list&gt; to conform to 
+                  C# XML comments.</li>
+<li>   id 442313: Casing of special commands was not handled consistently.</li>
+<li>   id 443942: Fixed problems running mscgen.</li>
+<li>   id 444823: No newline after the error message when hhc failed with return code &gt;0</li>
+<li>   id 445105: Fixed some issues and wrong spacing for the RTF generation.</li>
+<li>   id 446585: Doxygen could crash when producing a warning for undocumented C++/CLI
+                  arguments of the type "T%".</li>
+<li>   id 447133: Replaced occurrences of &apos; by &#39; in the HTML output.</li>
+<li>   id 448210: Make rule to install manpages was broken.</li>
+<li>   id 451297: Fixed more issues where using double-quotes (") inside a brief 
+                  description could lead to errors in dot files when the brief 
+                  description was used as a tooltip.</li>
+<li>   id 452824: In the source browser linking of a local variable did not work
+                  after a sizeof() of the variable.</li>
+<li>   id 452828: Missing reference to struct member in the source browser due to 
+                  incorrect bracket count.</li>
+<li>   id 453366: Removed bogus warning for unresolved references in brief descriptions. </li>
+<li>   id 453918: The __init__.py files were incorrectly treated as modules causing 
+                  scoping issues for symbols defined inside such file.</li>
+<li>   id 456471: Changing the installation location (--prefix) did not affect the
+                  location were the documentation was installed. --docdir can still
+                  be used to overrule the location for the documentation.</li>
+<li>   id 456475: Added support for C++/CLI style finalizers.</li>
+<li>   id 457857: Leading "struct" keyword is no longer stripped from the documentation of
+                  functions that return a pointer to a struct.</li>
+<li>   id 458710: Expanding environment variables in the config file to a
+                  file or path name with spaces (e.g. "$(VCInstallDir)include") was
+                  incorrectly interpreted as a list when used with for instance <code>INPUT</code>.</li>
+<li>   id 458749: Undocumented constructors/destructors inside an undocumented member group
+                  were not visible in the output.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.2</h1>
+<b>(release date 4-4-2007)</b>
+<a name="1.5.2"></a>
+<h3>Changes</h3>
+<ul>
+<li>   The options <code>MAX_DOT_GRAPH_WIDTH</code>, <code>MAX_DOT_GRAPH_HEIGHT</code>, and <code>MAX_DOT_GRAPH_DEPTH</code> have
+       been replaced by a single option <code>DOT_GRAPH_MAX_NODES</code>, which can be used to 
+       limit the size of a graph indirectly, by specifying the maximum amount of nodes in 
+       the graph. The main advantage is that this can be computed much faster; dot has 
+       to be run only once per graph and never on graphs with more than the specified 
+       amount of nodes. Note that doxygen will always render the root node and its 
+       direct children even when <code>DOT_GRAPH_MAX_NODES = 0</code>.</li>
+<li>   Parameters names are now copied to reimplemented functions, avoiding warnings about
+       missing or wrong parameter names when <code>INHERIT_DOCS = YES</code>.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   id 150916,159291,166209,330109,396316 
+       Doxygen now uses UTF-8 internally for all strings and uses 
+       iconv to recode the input to UTF-8. For HTML, LaTeX and man pages
+       the output is now always UTF-8. For RTF the encoding is local and 
+       depends on the code page specified in the translator.
+       The config option <code>USE_WINDOWS_ENCODING</code> has been removed.
+       A new config option <code>INPUT_ENCODING</code> has been added which can be used to
+       specify the encoding of the input. Another config option <code>DOXYFILE_ENCODING</code>
+       can be used to specify the encoding of the config file itself.</li>
+<li>   Added support for message sequence charts (using mscgen).
+       For this two new commands have been added: \msc and \endmsc (similar 
+       to \dot..\enddot), and a new config option <code>MSCGEN_PATH</code> (similar to DOT_PATH)
+       See the manual and <a href="http://www.mcternan.me.uk/mscgen/index.html">website</a> for more info.</li>
+<li>   Added support for C++/CLI. To enable it set <code>CPP_CLI_SUPPORT</code> to <code>YES</code> in the 
+       config file (thanks to Ben Voigt for doing a lot of the work).</li>
+<li>   <code>IGNORE_PREFIX</code> now also works for function/members names when shown in the various
+       indices.</li>
+<li>   Doxygen will show a tooltip in the HTML output for links to classes, namespaces, 
+       and members with the brief description (including dot graphs and source code).</li>
+<li>   id 321575: Added a new config option <code>EXCLUDE_SYMBOLS</code> which can be used to 
+       exclude certain namespaces/classes/functions from the output by specifying
+       their name (which may include wildcards).</li>
+<li>   id 364536: Included patch by Ben Voigt which adds syntax highlight 
+       support for several (managed) C++ keywords.</li>
+<li>   id 419349: Added two LaTeX layout enhancements provided by Stefan Pawig. </li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 132886: Included patch to fix an issue with using a sequence of xrefitems</li>
+<li>   id 134792: Added configure script for Cygwin autodetection.</li>
+<li>   id 162006: Doxygen now uses the default search path of dot for user defined
+                  dot graphs (defined with @dot and @dotfile).</li>
+<li>   id 306231: Include fix for Japanese translation.</li>
+<li>   id 315543: htmlinclude didn't work as part of a description of a param.</li>
+<li>   id 322806: Doxygen now does not treat &gt;&gt; in a template list as a shift operator
+                  for Java and C#.</li>
+<li>   id 332815: Legend generated with <code>GENERATE_LEGEND</code> did have typo.</li>
+<li>   id 345820: Included patch to make doxygen handle config files with 
+                  <code>@INCLUDE</code> with absolute paths correctly.</li>
+<li>   id 364780: Included patch to improve scope handling of nested classes/namespaces by
+                  the code parser (thanks to Ben Voigt).</li>
+<li>   id 366113: Fixed configure script issue under Solaris.</li>
+<li>   id 367233: Non-class functions were duplicated in the xml index file.</li>
+<li>   id 367495: Windows build files had only support for English by default.</li>
+<li>   id 369499: In some cases variable names were duplicated in python source code output.</li>
+<li>   id 369200: Fixed parse problem when a single quote appeared in a Python comment line.</li>
+<li>   id 373229: Doxygen now gives a warning when it cannot inline a #include inside a body </li>
+<li>   id 374486: Inheriting from a template argument via an intermediate typedef could 
+                  result in invalid output.</li>
+<li>   id 375073: \ref could cause wrong XML output.</li>
+<li>   id 375753: Added missing new line to error message.</li>
+<li>   id 377911: Fixed problem with end of formula.</li>
+<li>   id 380516: Fixed line number issue in the Python parser.</li>
+<li>   id 381450: Tabs in the HTML output redefined the value of an "id" attribute, 
+                  which is not legal HTML.</li>
+<li>   id 374592: Member grouping didn't work properly for constructors.</li>
+<li>   id 381608: Initializer values of class variables and constants did no longer
+                  appear in the documentations.</li>
+<li>   id 382274: Scanning files with <code>RECURSIVE</code> enabled ignored <code>EXCLUDE_PATTERNS</code>.</li>
+<li>   id 383377: C# code was not passed though the C-preprocessor.</li>
+<li>   id 383493: Improved the warning message for unterminated code/verbatim blocks.</li>
+<li>   id 384439: Made comment block parser more robust against HTML errors.</li>
+<li>   id 385384: <code>SEPARATE_MEMBER_PAGES=YES</code> caused broken links in Html Help index.</li>
+<li>   id 387781: Parsing #import statements was broken for Objective-C.</li>
+<li>   id 387848: Included patch to avoid LaTeX compilation issues.</li>
+<li>   id 389656: For C# enums in the same scope can have the same values, but doxygen's
+                  parser got confused.</li>
+<li>   id 389750: Fixed alignment bug in the default html footer generated by doxygen.</li>
+<li>   id 390821: Fixed problem parsing Java 1.5 enums with initializers.</li>
+<li>   id 391619: When dot produces an non-zero return code, doxygen now prints the
+                  return code and the command it tried to execute.</li>
+<li>   id 407815: Doxygen's got confused by certain combinations of " and ' s in PHP code.</li>
+<li>   id 409935: Fixed bug in qcstring.cpp</li>
+<li>   id 411300: PDF/Latex output was broken for operator[] documentation.</li>
+<li>   id 411328: Fixed Accessibility/Section 508 Compliance issue.</li>
+<li>   id 413071: Added support for Java 1.5 annotations.</li>
+<li>   id 415683: Two typedefs of function pointers with different names could still
+                  resolve to the same type if the only difference was the argument list
+                  and as a result cause "Undocumented function" warnings.</li>
+<li>   id 418920: Doxygen stripped leading comment chars from C# code blocks.</li>
+<li>   id 421131: Character encoding was not consistent for all HTML files.</li>
+<li>   The "list of all members" was not shown for a class with no members that derived 
+                  from a class with members.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.1</h1>
+<b>(release date 29-10-2006)</b>
+<a name="1.5.1"></a>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 148567: @todo at the end of a comment block caused problem when copied by @copydoc</li>
+<li>   id 352420: Fixed bug in LaTeX output (missing space after \bf).</li>
+<li>   id 363227: missing output for instance variables defined in a Python function 
+       that has a doc string</li>
+<li>   id 363397: Member groups did not appear in a class when SUBGROUPING was set to YES.</li>
+<li>   id 364341: Parsing could become really slow if often included header files contained
+       using statements.</li>
+<li>   id 364673: The values of two enums with the same name (both in difference scopes)
+       where merged.</li>
+<li>   The version of dot shipped with the Mac binary had some non-standard dependencies.</li>
+<li>   Doxywizard didn't work on PC's where no Visual Studio 2005 was present, when build
+       with the project files (I'm now using /MT instead of /MD which fixes this issue). </li>
+<li>   Running 2 instances of doxygen on the same output directory caused corruption of
+       the temporary files generated by doxygen.</li>
+</ul>
+
+<h1>Doxygen Release 1.5.0</h1>
+<b>(release date 16-10-2006)</b>
+<a name="1.5.0"></a>
+<h3>Changes</h3>
+<ul>
+<li>   cleaned up the internal structures to make them smaller, and made doxygen use
+       a temporary file to store the parse results (instead of keeping them in memory), 
+       which will further reduce the memory usage, especially for large projects, and is a 
+       first step towards incremental parsing.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added example application that shows how to configure and run doxygen from 
+       within an application and use the information collected by doxygen without
+       also generating the output (see addon/doxyapp).</li>
+<li>   id 322467: Sections produces by \note, \warning, \remarks etc, now have a
+       class label in the generated HTML (&lt;dl&gt; tag) so you can give them a 
+       distinct style using a non-default stylesheet (i.e. using HTML_STYLESHEET). </li>
+<li>   Added project files for building doxygen from Visual Studio 2005 (see winbuild dir). </li>
+<li>   added translator updates for Czech, Danish, German, Catalan, Croatian, French, 
+       Japanese, and Italian.</li>
+<li>   added translator support for Arabic (thanks to Moaz Reyad)</li>
+<li>   added translator support for Persian (thanks to Ali Nadalizadeh)</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 131445: Fixed autolinking for related functions.</li>
+<li>   id 137236: Updated documentation to make it clear that a lower-case only word
+       is not a candidate for autolinking.</li>
+<li>   id 141758: Fixed a problem parsing &lt;?=...?&gt; contructs outside of functions in PHP.</li>
+<li>   id 319169: Second level index not shown when DISABLE_INDEX=YES.</li>
+<li>   id 325337: Added "optimize output for C#" option to Doxywizard.</li>
+<li>   id 325426: Partial C# class inside a namespace where not handled properly.</li>
+<li>   id 327358: Fixed wrong link to the search engine when CREATE_SUBDIRS was set to YES.</li>
+<li>   id 326885: Leading ///'s ended up in code fragments when using indented 
+       /// comments.</li>
+<li>   id 330513: For file documentation, the scope not stripped for namespace members 
+       even if HIDE_SCOPE_NAMES was set to YES.</li>
+<li>   id 335131: Fixed "internal inconsistency" warning related to use of nested
+       classes defined outside a used namespace.</li>
+<li>   id 338475: Added support for Q_SIGNALS and Q_SLOTS macros (thanks to Thomas
+       Zander for the patch). </li>
+<li>   id 340973: Improved performance of "Computing template instances" step
+       significantly in case of (large) Java projects.</li>
+<li>   id 342090: Fixed missing cross-reference to "m" for code of the form f(a[s.f]-&gt;m) </li>
+<li>   id 344443: Code font commands where not treated properly in C# style comments.</li>
+<li>   id 344445: Made it more clear in the documentation where the XML commands in the
+       comment blocks are for, and how &lt;code&gt; works in C#.</li>
+<li>   id 345322: DOTFONTPATH was corrupted in mingw builds.</li>
+<li>   id 345519: Fixed problem parsing attributes in C#.</li>
+<li>   id 345660: Python class members that spanned multiple lines could confuse the parser.</li>
+<li>   id 345742: enum values were shown twice in some cases.</li>
+<li>   is 346095: Forced a newline before \normalsize in the LaTeX to avoid
+       font size issues.</li>
+<li>   id 346848: Under certain conditions nesting of groups did not work properly.</li>
+<li>   id 347444: paramref XML command did not render properly.</li>
+<li>   id 348259: Doxygen now keeps the _formulas.log file when there is a problem
+       generating bitmaps for formulas. This can help to identify the problem quicker.</li>
+<li>   id 348481: friend class in unnamed namespace produced bogus error.</li>
+<li>   id 348537: Fixed internal inconsistency warning that could occur when reopening 
+       an anonymous namespace  </li>
+<li>   id 349867: Fixed issue handling brief and detailed description when
+       both are positioned after an item. </li>
+<li>   id 350168: Doxygen didn't parse C# type contraints properly.</li>
+<li>   id 351890: In some cases C# attributes were treated as properties.</li>
+<li>   id 353044: C99 style variadic macros were not handled properly by doxygen.</li>
+<li>   id 353195: Member grouping with SUBGROUPING = YES now works the same for files
+       and namespaces as it does for classes.</li>
+<li>   id 354765: A command like \ingroup now ends a brief description as was the case
+       in the pre 1.4.x series.</li>
+<li>   id 355922: When a function was found in a namespace but also in the global 
+       namespace, doxygen could make the wrong cross-reference.</li>
+<li>   id 356204: Setting HIDE_UNDOC_RELATIONS to NO could result in
+       argument mismatches in certain cases.</li>
+<li>   id 357092: Spurious doxygen warning when using a class that ends with 'const'
+       or 'volatile'.</li>
+<li>   id 357438: tabs and newlines were not parsed properly for html attributes inside
+       a comment block.</li>
+<li>   id 357646: objcache.cpp did not compile cleanly on a system with 64 bit pointers.</li>
+<li>   id 361812: whitespace after the colon at the end of a Python definition caused
+       parsing issues.</li>
+<li>   "struct Foo operator+()" was not parsed properly due to the "struct" keyword.</li>
+<li>   As a side-effect of bug 329861 Obj-C protocols and categories were no longer
+       extracted. </li>
+<li>   Fixed an problem with cross-referencing Obj-C code.</li>
+<li>   Removed the memory leaks reported by valgrind and tuned some data structures
+       to reduce the memory usage.</li>
+<li>   enums in a used namespace could cause arguments not to match.</li>
+<li>   fixed several cases where arguments of function/method declaration and definition
+       did not match while they should.</li>
+</ul>
+<p>
+\endhtmlonly
+\section log_1_4 1.4 Series
+\htmlonly
+</p>
+<h1>Doxygen Release 1.4.7</h1>
+<b>(release date 11-06-2006)</b>
+<a name="1.4.7"></a>
+<h3>Changes</h3>
+<ul>
+<li>   The stylesheet has changed, so if you use your own, you will need to
+       update it or the output will look ugly.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for universal binaries on MacOSX (only the non-GUI part).</li>
+<li>   Added CALLER_GRAPH config option and \callergraph command to add
+       a caller (or called-by) graph to a function or all functions.
+       (thanks to Daniel Sherwood for the patch)</li>
+<li>   Added REFERENCES_LINK_SOURCE config option which allows to selected
+       if reference relations should point to the source or to the 
+       documentation (thanks to Daniel Sherwood for the patch).</li>
+<li>   Included patch by Christoph Pesch to mention the member type in the 
+       warning "Member ... of ... is not documented".</li>
+<li>   included update for Spanish, Italian, Norwegian, and Czech translations.</li>
+<li>   Added support for get/set properties in IDL (thanks to a patch by
+       Sander Stoks).</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 151959: incremental "using" of nested namespaces could prevent 
+       that doxygen matched function declaration against definition.</li>
+<li>   id 310521: HIDE_IN_BODY_DOCS was longer working.</li>
+<li>   id 315039: Improved handling of members in an anonymous scope. </li>
+<li>   id 322415: Under certain conditions a scrollbar appeared in a HTML page
+       while this was not needed.</li>
+<li>   id 325845: Documentation parser was confused when starting a HTML list 
+       directly after a \b command.</li>
+<li>   id 325866: SORT_BY_SCOPE_NAME=YES did not always work if SORT_BRIEF_DOCS
+       was also enabled.</li>
+<li>   id 326023: CHM files had @ signs in CHM index for anonymous class enums</li>
+<li>   id 326250: Fixed incorrect regular expression in constexp.l</li>
+<li>   id 326688: Added better support for PHP5 style constructors 
+       and destructors.</li>
+<li>   id 326885: Using multi-line //!-blocks did not work nicely together with
+       @code...@endcode blocks anymore.</li>
+<li>   id 327242: Python: Methods starting with _ are now marked private,
+       except for special method names (i.e. starting and ending with __).</li>
+<li>   id 327666: Fixed parse issue that resulted in a missing call graph.</li>
+<li>   id 328435: When enabling USE_PDFLATEX a blank line appeared in the 
+       makefile</li>
+<li>   id 328849: Added clarification to the manual about the use of //!&lt;
+       comments.</li>
+<li>   id 328635: Text of the HTML output didn't always wrap properly anymore
+       after "fixing" bug 322415.</li>
+<li>   id 329343: Fixed segment in Python parser caused by @var or @fn with
+       a missing argument.</li>
+<li>   id 329530: An apostrophe in ##-comments inside a Python class confused
+       the parser.</li>
+<li>   id 329534: Fixed problem resolving inheritance relations for nested 
+       Python classes.</li>
+<li>   id 329537: Corrected the Python example to show how modules should be
+       documented.</li>
+<li>   id 329719: # comment in PHP containing a ' caused doxygen to ignore 
+       rest of input.</li>
+<li>   id 329861: Fixed problem parsing embedded structs in an Objective-C
+       interface.</li>
+<li>   id 329905: PDF manual produced a LaTeX error because style sheet 
+       was not up to date.</li>
+<li>   id 330209: A typedef in an Obj-C implementation file could obscure 
+       class implementation later in the file</li>
+<li>   id 331511: no matching class member found error for class template 
+       instance in combination with "using" of said class.</li>
+<li>   id 331751: Fixed problem parsing a function typedef.</li>
+<li>   id 332110: method matching failed for equivalent template instance 
+       types.</li>
+<li>   id 332178: Fixed malformed XML output for readable properties.</li>
+<li>   id 333270: Fixed BoundingBox problem with PostScript graphs generated
+       with dot using graphviz-2.9.20060302.0540 and later (thanks to 
+       John Ellison for the patch)</li>
+<li>   id 332875: Enabling SEPARATE_MEMBER_PAGES could lead to bogus warning
+       messages about undocumented parameters if only the HTML output was 
+       enabled.</li>
+<li>   id 333330: Patch the reorganizes the treeview.</li>
+<li>   id 333831: "typedef const struct { } NAME" construction was not 
+       properly parsed.</li>
+<li>   id 334716: Doxygen could hang when calling latex with invalid formulas.</li>
+<li>   id 336467: Latex formula could prevent /// comment blocks to be properly 
+       converted to /** */ blocks.</li>
+<li>   id 336782: Prevented crash when providing code with illegal/redundant 
+       class scope.</li>
+<li>   id 337344: Configure now accept system's /usr/bin/install on FreeBSD.</li>
+<li>   id 341365: @endcode comment was skipped in a specific case.</li>
+<li>   id 341453: Under certain conditions @cond did not stop at @endcond</li>
+<li>   id 341456: Fixed crash when feeding doxygen /dev/null as config file</li>
+<li>   id 342329: Text such as "dir/file.cpp" was not auto-linked.</li>
+<li>   id 342946: Anonymous enums couldn't be grouped using separate @var block</li>
+<li>   id 344118: Inbody documentation could hide the detailed description.</li>
+<li>   id 344172: Class Hierarchy appeared in a C-Code-Documentation.</li>
+<li>   Protection level of inner classes was not written to the XML output
+       (thanks to Shachar Itzhaky for the patch)</li>
+<li>   Included patch by Ernst Giessmann, which prevents most of the underfull
+       hbox warnings that are produced when compiling doxygen's LaTeX output.</li>
+<li>   Fixed potential crash during preprocessing if C-macros are defined 
+       with /* (thanks to Günther Haslauer for the patch).</li>
+<li>   Anonymous struct members could end up in the wrong scope 
+       (thanks to Bruno Andrillon for the patch).</li>
+<li>   saving to an existing file in doxywizard now requires a confirmation.</li>
+<li>   Fixed potential crash in case a template class with a redundant
+       namespace qualifier was used: 
+       e.g. "namespace N { template&lt;&gt; class N::C&lt;G::H&gt; {}; }"</li>
+</ul>
+
+<h1>Doxygen Release 1.4.6</h1>
+<b>(release date 30-12-2005)</b>
+<a name="1.4.6"></a>
+<h3>New features</h3>
+<ul>
+<li>   id 317773: Improved .spec file and better support for building rpms
+       (thanks to Kevin McBride)</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 145294: Boolean expression with '&lt;' as template argument confused 
+       doxygen.</li>
+<li>   id 303297: The class hierarchy was sometimes incorrectly shown.</li>
+<li>   id 317819: Updated the documentation concerning the creation of PDF
+       output.</li>
+<li>   id 317967: @&zwj;htmlonly..@&zwj;endhtmlonly type of blocks (including formulas)
+       were not always working properly if used in inline parameter
+       documentation.</li>
+<li>   id 318008: The base class name was missing from the XML output.</li>
+<li>   id 318208: Enabling SUBDIRS resulted in the tabs at the top of certain
+       pages not be styled as tabs. Also, links to include dependency graphs
+       had wrong links or were incomplete.</li>
+<li>   id 318564: Python: parser skipped comment blocks in some cases.</li>
+<li>   id 318565: Python: single quote doc strings did not get parsed properly 
+       if there was no space before the closing '''.</li>
+<li>   id 318567: Python: parse problem when () appear in default value of a
+       function parameter.</li>
+<li>   id 318618: If INLINE_INHERITED_MEMB = YES constructors of a 
+       template class were shown in the derived class.</li>
+<li>   id 318678: Python: A referenced variable that
+       was not found using docstring could lead to memory corruption.</li>
+<li>   id 319170: The CHM file did not include the stylesheet material needed
+       to properly render the tabs at the top of each page.</li>
+<li>   id 319341: Doxygen crashed while generating call graph under certain
+       circumstances.</li>
+<li>   id 319539: Fixed parse problem with Python/Objective-C code.</li>
+<li>   id 319586: tabs.css not correctly included with CREATE_SUBDIRS option 
+                  set.</li>
+<li>   id 318460: Multiply-defined labels if two function specializations 
+       differ only on the name of a template parameter.</li>
+<li>   id 319219: Spurious space was inserted after inlined math formulae.</li>
+<li>   id 319826: The file name for template classes could become too 
+       long causing files that cannot be created by some file systems.</li>
+<li>   id 320026: undocumented "typedef struct foo baz" causes subsequent 
+       variables appear as typedefs.</li>
+<li>   id 320543: If enabled the alphabetical class list is now the default
+       item under the classes tab.</li>
+<li>   id 320587: Links in brief file descriptions shown in directory pages 
+       were broken if CREATE_SUBDIRS was enabled.</li>
+<li>   id 320693: First sentence in mainpage was missing with 
+       JAVADOC_AUTOBRIEF enabled.</li>
+<li>   id 320740: Added support for documenting individual elements of an
+       associative array in PHP.</li>
+<li>   id 320813: The if() statement with space after the if confused the
+       code parser and resulted in partial call graphs.</li>
+<li>   id 320960: redundant line continuation characters were not removed 
+       by doxygen's C-preprocessor.</li>
+<li>   id 321165: Doxygen choked on Qt properties with namespaced types</li>
+<li>   id 321197: using a namespace that contains a nested class, where the
+       inner class was forward defined, could introduce a bogus namespace
+       with the name of the outer class.</li>
+<li>   id 321256: Installation path mentioned in the documentation was wrong.</li>
+<li>   id 321349: In typedefs like "typedef struct {} T, *pT, the pT typedef
+       appeared wrongly in the documentation.</li>
+<li>   id 321540: An array of type an anonymous struct was not parsed
+       properly if there was a space between the name and the size, i.e.
+       struct {} Var [10];</li>
+<li>   id 321682: Fixed typo in the HTML output of the search page.</li>
+<li>   id 321743: Cross-references were missing to members of 
+       anonymous structs.</li>
+<li>   id 311833: A template specialization of a private class member was 
+       marked as public.</li>
+<li>   id 312329: @link label @endlink, i.e without link text now shows 
+       the label as text, and space after label is omitted.</li>
+<li>   id 312624: \verbatim block could cause wrong line numbers while 
+       parsing the source code.</li>
+<li>   id 322752: Fixed specific case where aliases were incorrectly expanded 
+       inside environment formulas</li>
+<li>   id 322997: Putting function-style macros in a parameter of a 
+       template return type of a function confused doxygen's parser.</li>
+<li>   id 323320: An enum name that also appears as a typedef 
+       (i.e. typedef T {} T; }) is now linked as an enum and the typedef is 
+       omitted from the output.</li>
+<li>   id 323557: Bit field information was missing from the XML output.</li>
+<li>   id 323627: Fixed compiler warning when using gcc 4.x.</li>
+<li>   id 323628: Improved warning when documenting #defines while the
+       preprocessor is disabled.</li>
+<li>   id 323988: FILE_VERSION_FILTER incorrectly handled command parameters</li>
+<li>   id 324076: Fixed some typos in the documentation.</li>
+<li>   id 324153: The configure script didn't work for SunOS 5.8.</li>
+<li>   id 324163: \todo paragraph did not end at \author (or similar commands).</li>
+<li>   id 324313: Added support for having a Linux system where libraries are 
+       located in lib64 by adding a new platform to tmake: linux-64</li>
+<li>   id 324521: Autolinking to classes in a group which itself was in a
+       namespace didn't work without explicit scoping.</li>
+<li>   id 324558: Null pointer dereference in namespacedef.cpp</li>
+<li>   id 324565: References and callgraphs missing for some functions 
+       (thanks to a patch by Dave Dodge).</li>
+<li>   id 324566: Fixed problem matching 
+       f(unsigned long const a) against f(unsigned long)</li>
+<li>   id 324568: Fixed problem were some function prototypes were detected 
+       as variable constructor calls (thanks to Dave Dodge for the patch).</li>
+<li>   id 324601: Cross referencing and call graphs were broken by 
+       certain bracket positions for functions.</li>
+<li>   id 324823: Doxygen's code parser lost track in some cases, causing
+       function definitions not being found in some cases.</li>
+<li>   id 324891: Doxygen crashed on circular python imports.</li>
+</ul>
+<h1>Doxygen Release 1.4.5</h1>
+<b>(release date 4-10-2005)</b>
+<a name="1.4.5"></a>
+<h3>Changes</h3>
+<ul>
+<li>   Changed to way the index looks (I hope you like it!). 
+       It now is a list of items styled (with CSS) as a row of tabs.
+       Also class/namespace/file related items are now grouped together and 
+       presented as a second row of tabs to prevent clutter (the latter is
+       based on the suggestions/patch in bug report 162968).
+       Note that if you use a custom HTML header you need to add
+       &lt;link href="tabs.css" rel="stylesheet" type="text/css"&gt;
+       to the head section!</li>
+<li>   Copydoc now copies the brief description as well.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   id 306889: Added new config option BUILTIN_STL_SUPPORT. When enabled,
+       doxygen will assume that STL classes exist (without the need to include
+       the STL headers as INPUT).
+       This helps with matching of argument lists for function declarations and
+       definitions and also helps to improve the collaboration and inheritance
+       diagrams that involve STL classes.</li>
+<li>   id 317010: Added support for the following new HTML entities: 
+       &amp;lsquo; &amp;rsquo; &amp;ldquo; &amp;rdquo; &amp;ndash; 
+       &amp;mdash; (thanks to a patch by madalexonline)</li>
+<li>   Included update for Chinese translation.</li>
+<li>   included update for the VC++ project files (in wintools dir), thanks
+       to Johan Eriksson.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 304339: Using \dot in latex formulas conflicted with the doxygen's
+       \dot command.</li>
+<li>   id 306076: Using a namespace inside an example listed with 
+       @example did not work.</li>
+<li>   id 306069: Search engine required lower case names in order to find
+       something, which made pasting of names difficult.</li>
+<li>   id 308395: Doxygen could crash when producing a warning that included
+       a %s sequence.</li>
+<li>   id 311191: Default values for parameters weren't shown in the detailed 
+       documentation.</li>
+<li>   id 311198: If JAVADOC_AUTOBRIEF was set to YES, a \todo or \bug like
+       command always ended at the first dot.</li>
+<li>   id 311207: The /* and */ inside a \code ... \endcode code fragment 
+       were stipped.</li>
+<li>   id 311577: Putting a documentated class name in the title of the main
+       page caused a LaTeX error if pdf hyperlinks were enabled.</li>
+<li>   id 311665: Fixed compile issue for Solaris.</li>
+<li>   id 312688: Typedefs of arrays were auto-linked to the base type 
+       i.s.o the typedef.</li>
+<li>   id 312678: Fixed excessive memory usage for @fn commands 
+       due to a memory leak of the scanner buffer 256K of memory was leaked 
+       for each command!</li>
+<li>   id 312791: Undocumentated members did not result in warnings if 
+       SOURCE_BROWSER was enable and the member's definition was part of
+       the INPUT.</li>
+<li>   A C-comment inside a \code block could lead to parse problems in the
+       preprocessor, resulting in #defines that are not found.</li>
+<li>   Fixed problem documenting Python code using docstrings where the module
+       documentation was not picked up. Also fixed several other Python
+       related issues. Also included Python examples in the documentation.</li>
+<li>   id 312805: Using BUILTIN_STL_SUPPORT could result in dead links for
+       STL classes.</li>
+<li>   id 312807: Added support for STL exceptions (when BUILTIN_STL_SUPPORT
+       is enabled).</li>
+<li>   id 313011: Item after the closing of a nested group was ignored in
+       some cases.</li>
+<li>   id 313103: Member groups within other nested groups did not work 
+       anymore.</li>
+<li>   id 313298: Code parser didn't handle function-try-blocks correctly.</li>
+<li>   id 313572: Fixed lockup issue when generation code for Python files.</li>
+<li>   id 313695: Fixed parsing issues for the constructs 
+       "\f$n\f$" and "operator &lt;CODE&gt;". </li>
+<li>   id 313805: '@' characters in a string literal were lost during 
+       macro expansion.</li>
+<li>   id 313906: added support for "import" and "from ... import" to the
+       Python parser so cross module inheritance works.</li>
+<li>   id 313908: Fixed python parser problem: If there are two classes 
+       defined in one module there needed to be a comment between them.</li>
+<li>   id 314165: Python functions starting with _ are not marked as public,
+       whereas variables starting with _ are marked private.</li>
+<li>   id 314194: Brief description containing 'i.e., ' ended after the
+       comma.</li>
+<li>   id 314237: You can now also use \ref on directories documented with
+       \dir.</li>
+<li>   id 314288: Using \ref with an ambiguous filename didn't work.</li>
+<li>   id 315006: C++ comments at the start of a line and 
+       inside a &lt;pre&gt;..&lt;/pre&gt; block were stripped.</li>
+<li>   id 316264: Fixed typo in the inline config file documentation.</li>
+<li>   id 316266: Included update for the Japanese translation (thanks to 
+       Katsuhiro Hermit Endo)</li>
+<li>   id 316759: Fixed problem in the Makefile of doxywizard so that the
+       right version appears in the about box.</li>
+<li>   id 316944: An inline formula (or other special command) did not get 
+       executed if it was within an inline documentation block and 
+       put after a parameter.</li>
+<li>   id 317052: The alphabetical class index was not sorted properly if
+       multiple prefixes were specified using IGNORE_PREFIX. </li>
+<li>   id 317105: Latex output expanded &amp;szlig; as "s instead of {\ss} which
+       only worked if german.sty was included. Thanks to Stefan Pawig for the
+       patch)</li>
+<li>   id 317397: Copying of images from subdirectory within the IMAGE_PATH 
+       didn't work properly since doxygen didn't remove the subdirectory
+       from the destination path.</li>
+<li>   id 317446: Documenting an enum with \enum while there is also a function
+       with the same name in the same scope could make the enum documentation
+       appear at the wrong spot or the enum in the wrong member group.</li>
+<li>   id 317490: A variable of a nested class, forward declared in a template
+       class, which in turn was in a namespace, caused the variable to end 
+       up in the global scope. </li>
+       
+</ul>
+
+<h1>Doxygen Release 1.4.4</h1>
+<b>(release date 21-7-2005)</b>
+<a name="1.4.4"></a>
+<h3>New features</h3>
+<ul>
+<li>   Added support for parsing Python code.
+       Special comment blocks in Python are of the 
+       <pre>
+         ##
+         #  Some comment
+         #
+       </pre>
+       or you can rely on Python docstrings.
+       This code uses the new parser interface and was based on the work done
+       by a group of students as part of a compiler design project.</li>
+<li>   Added support for C# style XML tags in the comments.
+       See the manual or the C# language specification for more details.
+       Thanks to Talin for doing most of the work.</li>
+<li>   Added support for the JavaDoc command {@inheritDoc}.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 166254: SORT_BY_SCOPE_NAME didn't work anymore.</li>
+<li>   id 304380: New argument matching algorithm didn't handle the case 
+                  where "const int" needed to be matched against 
+                  "const int a" correctly.</li>
+<li>   id 304435: Superfluous backslash in the makefile caused problems for
+                  Japanese locale.</li>
+<li>   id 304476: A #define directly after a //!&lt; style comment block was not
+                  parsed properly.</li>
+<li>   id 304598: Using operator-- in resulted in broken HTML output due to the
+                  embedded doxytag that include the end of a HTML comment.</li>
+<li>   id 304623: Spreading a @fn command over multiple lines didn't work
+                  anymore without using line-contination characters.</li>
+<li>   id 304666: Attributes of the same class appeared separated with \n in 
+                  collaboration diagrams</li>
+<li>   id 304751: A define "foo()" was indisguishable from a define "foo" in
+                  the XML output.</li>
+<li>   id 304752: XML location tag attribute "file" could have the
+                  syntactially wrong value "&lt;generated&gt;" in some cases.</li>
+<li>   id 305334: INPUT_FILTER tag did not work properly anymore due to
+                  additional quotes.</li>
+<li>   id 305364: Improved argument matching routine to avoid cases where
+                  declaration and definition of functions/methods could not
+                  be matched.</li>
+<li>   id 305439: @link command did not work if the link text started with
+                  "const" as part of a longer word.  </li>
+<li>   id 305638: operator&amp; was only usable with @copydoc if the method was
+                  fully qualified.</li>
+<li>   id 305672: Title of a paragraph was not properly rendered for the
+                  RTF output when using \par in ALIASES.</li>
+<li>   id 305740: When putting a \b command in a HTML table cell, doxygen got
+                  confused by the cell end tag, causing the rest of the table
+                  to be displayed wrongly.</li>
+<li>   id 305768: @todo, @bug, @deprecated, etc, did not always end at the
+                  next paragraph.</li>
+<li>   id 305770: For overloaded global functions only the first appeared
+                  in the file documentation.</li>
+<li>   id 306028: The text after /*@{ and //@{ was treated as source code 
+                  instead of a comment block.</li>
+<li>   id 306136: Structural commands were executed even though they appeared
+                  within quoted text.</li>
+<li>   id 306200: Putting a command like \author before \brief caused the
+                  long description to be glued to the \author command.</li>
+<li>   id 306235: Punctuation is not automatically added to brief 
+                  descriptions for Japanese, Chinese, and Korean anymore. </li>
+<li>   id 306637: @endcond did not properly end a conditional section 
+                  when @cond was used without label.</li>
+<li>   id 306711: Brief descriptions ended at a new paragraph even if no
+                  content was found and @name didn't work without explicit
+                  @{ ... @} block commands.</li>
+<li>   id 306851: Under certain conditions bogus argument documentation could
+                  appear.</li>
+<li>   id 306943: Certain constructs could get the code parser off track and
+                  could lead to memory corruption.</li>
+<li>   id 307579: Fixed argument matching problem where "unsigned int"
+                  did not match "unsigned int i".</li>
+<li>   id 307613: Documented struct fields declared as a comma separated list
+                  caused the documentation of all fields to be appended.</li>
+<li>   id 307618: Reference in the source file did not appear if a variable was
+                  documented with \var and also had a brief description.</li>
+<li>   id 307954: Parse problem when a /* was nested inside a C-style comment.</li>
+<li>   id 308053: It is now possible to put multiple structural commands into
+                  a single comment block. Doxygen will treat them as 
+                  separate comment blocks internally. Example:
+                  <pre>
+                  /** @file
+                   *  File documentation.
+                   *  @defgroup grp A Group
+                   *  Group documentation.
+                   */
+                  </pre></li>
+<li>   id 308059: &amp;nbsp; was written as "\ " to the LaTeX output instead 
+                  of ~.</li>
+<li>   id 308400: The parameter names are now used based on whether the
+                  documentation is in front of the declaration or definition.</li>
+<li>   id 309022: Conversion operators inherited from a template class 
+                  did not appear with the proper type substitution.</li>
+<li>   id 309148: The search index page was not correct if DISABLE_INDEX was
+                  set to YES.</li>
+<li>   id 309446: Files beginning with one or more digits were not autolinked.</li>
+<li>   id 309461: Made the configure script look for qt in places like
+                  /usr/share/qt3 (debian) and /usr/qt/3/ (gentoo)</li>
+<li>   id 309711: Aliases were expanded inside formulas.</li>
+<li>   id 310012: Made the allowed suffixes for constants in the constant
+                  expression evaluator of the C-preprocessor more strict.</li>
+<li>   id 310025: Added explicit type conversion to avoid problems with 
+                  compiler bugs in Sun's Forte 6.1 and Studio 10 compiler.</li>
+<li>   Fixed argument matching issue exposed by the template example in the
+                  examples directory.</li>
+</ul>
+
+<h1>Doxygen Release 1.4.3</h1>
+<b>(release date 16-5-2005)</b>
+<a name="1.4.3"></a>
+<h3>Changes</h3>
+<ul>
+<li>   For Developers: Added an abstract interface for language parsers 
+       (see src/parserintf.h), which can be used implement new programming 
+       language parsers. There is also a manager class, where a parser 
+       instance can be bound to a certain file extension.</li>
+<li>   Changed the algorithm for matching function/method declarations against
+       their definitions. The new algorithm should be faster, more powerful,
+       and more accurate.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>   Included new config option HTAGS. When enabled in combination with 
+       SOURCE_BROWSER=YES, the source browser of GNU's Global source 
+       system (via htags) is used instead of doxygen's own (thanks to
+       Shigio Yamaguchi for the patch).</li>
+<li>   Added language updates for Indonesian, Catalan, Russian, Korean,
+       German, Hungarian, Polish, and Lithuanian.</li>
+<li>   Included update of the .spec file (thanks to Stephane Gourichon).</li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 163705: Using \image for latex without caption but with size 
+                  parameter "width=\textwidth" did not work.</li>
+<li>   id 163783: Items of an autolist could be wrongly indented if put 
+                  directly after @name.</li>
+<li>   id 163928: Class section was missing in the file documentation.</li>
+<li>   id 164072: When using tag files unneeded external
+                  classes could appear in the class hierarchy in some cases.</li>
+<li>   id 169755: page title was omitted in the XML output if 
+                  CASE_SENSE_NAME was set to NO.</li>
+<li>   id 170592: Using \ref for Objective-C methods did not work if the
+                  name contained a colon.</li>
+<li>   id 171795: Refering to Objective-C methods now follows Apple's
+                  conventions. </li>
+<li>   id 171878: When JAVADOC_AUTOBRIEF = YES and there was no blank line 
+                  after a page command, the first sentence did not appear in
+                  the documentation.</li>
+<li>   id 171923: Doxygen failed to match arguments for a function documentated
+                  out-of-line with @fn and using @relatesalso.</li>
+<li>   id 172118: Doxywizard now shows the version of doxygen it is for.</li>
+<li>   id 172133: Doxygen did not longer ignore preceding C++ comments inside a
+                  comment block.</li>
+<li>   id 172217: 'using namespace' declarations with spaces resulted 
+                  in duplicate namespaces.</li>
+<li>   id 172329: The index of the CHM did not always link to groups correctly.</li>
+<li>   id 172456: Fixed case where doxygen had problems differentiating const 
+                  and non-const member functions.</li>
+<li>   id 172494: @code blocks were not poperly ignored by the preprocessor 
+                  in some cases.</li>
+<li>   id 172622: Fixed parse problem for Objective-C method implementations 
+                  whole declaration part ended with a semicolon.</li>
+<li>   id 172723: Namespace members appeared in the file documentation without
+                  proper links to the namespace.</li>
+<li>   id 172778: A single colon after retval caused a crash.</li>
+<li>   id 172783: Doxygen will now put quotes around a filter name before
+                  calling it so it will work with filters with spaces in the
+                  name or path.</li>
+<li>   id 172818: Improved translation of Todo List to German.</li>
+<li>   id 172937: FILE_VERSION_FILTER failed for filenames containing spaces.</li>
+<li>   id 173034: The \elseif command was not handled properly.</li>
+<li>   id 173110: \ingroup did not work with multiple group labels anymore.</li>
+<li>   id 300204: Doxygen disobeyed Cygwin's 'text/binary mount mode'
+                  (thanks to Max Bowsher for the patch).</li>
+<li>   id 300466: Improved the documentation for FILTER_SOURCE_FILES.</li>
+<li>   is 300473: Added a browse button for several of Doxywizard's 
+                  fields of the expert dialog where a file was expected.</li>
+<li>   id 300532: consecutive @todo items were joined together even if they
+                  are in different sections.</li>
+<li>   id 300745: A disabled @cond section did not omit #define documentation.</li>
+<li>   is 301409: autolinks to undocumented files did not work correctly when
+                  SOURCE_BROWSER was enabled.</li>
+<li>   id 301437: Fixed a typo in an example that is part of the preprocessor 
+                  documentation.</li>
+<li>   id 301478: Fixed some cases where cross-references were not properly
+                  detected anymore.</li>
+<li>   id 301616: Added "+" or "-" to the Objective-C method lists in the
+                  summary section of a class.</li>
+<li>   id 302100: An enum could not be grouped by grouping out of line 
+                  documentation.</li>
+<li>   id 302158: When enabling SEPARATE_MEMBER_PAGES and CREATE_SUBDIRS
+                  the member index contained invalid links.</li>
+<li>   id 302160: list directly after @brief not parsed properly if there
+                  were spaces before the @brief command.</li>
+<li>   id 302713: Updated doxytag so it works better with recent versions 
+                  of Qt3 and the Qt4 beta versions.</li>
+<li>   id 303305: When using \subpage the page hierarchy wasn't reflected 
+                  in the tree view or .chm index.</li>
+<li>   id 303511: Documenting a class in a namespace with a comment block 
+                  inside the namespace containing a @class command did
+                  not work properly.</li>
+<li>   id 303911: Links from todo list items to Objective-C categories were 
+                  broken.</li>
+<li>   id 304026: A class/struct/interface can now be turned into something
+                  else of the same kind using the proper command (i.e. 
+                  @interface could by used to turn a class into an interface).</li>
+<li>   Doxygen did not honor the "All members of an interface in Java are 
+       implicitly public" rule.</li>
+<li>   An enum of a class could not be documented with @enum from inside a 
+       namespace.</li>
+<li>   Fixed problem handling unname member groups (useful in combination
+       with DISTRIBUTE_GROUP_DOC = YES, which didn't work anymore).</li>
+<li>   Updated Doxygen.dsp (thanks to Gerik Rhoden).</li>
+<li>   For a word marked with a #, the # is now also removed when no link 
+       could be generated.</li>
+<li>   Using '&lt;' (or '\&lt;') in a &lt;pre&gt; section cause '$&lt;$' 
+       to appear in the Latex output.</li>
+</ul>
+
+<h1>Doxygen Release 1.4.2</h1>
+<b>(release date 28-3-2005)</b>
+<a name="1.4.2"></a>
+<h3>Changes</h3>
+<ul>
+<li>If the class/namespace/file member indexes get too long they are now
+    automatically split over multiple pages (one page per index letter).</li>
+<li>Internal: I've split the input scanner (scanner.l) in a part that scans
+    the supported programming languages and passes the comment blocks to a 
+    second scanner. This should clean up the code a lot and make
+    the handling of structural commands (like \class and \section) 
+    more consistent. It is also a first step towards supporting dedicated
+    scanners for other programming languages. </li>
+<li>Made doxygen parse .as files (Action Script) as Java code.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>Added a new option SEPARATE_MEMBER_PAGES. When enabled doxygen will
+    generate a separate page for each documented member, instead of putting
+    all members on the class/file/namespace page. An index for other members
+    of the same compound is rendered on the left hand side of the page.</li>
+<li>Added new command \subpage that can be used to build a hierarchy of
+    pages. For pages this is more convenient than using \defgroup 
+    and \ingroup.  See the documentation more details and an example.</li>
+<li>Included man pages for doxygen and doxywizard.</li>
+<li>Language updates for Czech, Swedish, Russian, Italian, Catalan, 
+    German, Brazilian, Korean, Ukrainian, Romanian, Croatian and Chinese,</li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>id 124214: #'s inside a single quoted PHP string could lead to parse
+                problems.</li>
+<li>id 142339: Doxygen did not using the LATEX_CMD_NAME setting when
+               generating formulas.</li>
+<li>id 163180: Extension specific filters did not work.</li>
+<li>id 163940: Labels in dot graphs containing quotes where 
+               not escaped properly.</li>
+<li>id 164198: \overload text was always English, it is now translatable.</li>
+<li>id 164498: Fixed problem where doxygen ignored the documentation for 
+               members of Objective C class categories when put in the 
+               implementation section.</li>
+<li>id 164563: \anchor didn't work inside a &lt;pre&gt;...&lt;/pre&gt; section.</li>
+<li>id 164812: fix compile problem for certain language selections.</li>
+<li>id 165097: Fixed problem with wrong syntax color in \code section.</li>
+<li>id 165188: in index.xsd the refid attribute type (xsd:Name) was 
+               not broad enough and has been replaced by xsd:string.</li>
+<li>id 165339: Fixed some issues in the code parser causing missed 
+               cross-referencing relations and/or call graphs.</li>
+<li>id 165428: ALIASES containing @section commands where not 
+               handled properly.</li>
+<li>id 165503: grouped classes did not appear as such in the XML output.</li>
+<li>id 165793: input filter was applied to \verbinclude.</li>
+<li>id 165816: Grouped functions referenced via tag files had broken links</li>
+<li>id 165821: Tag file parser produced bogus errors for nested classes and
+               namespaces and no line number was reported.</li>
+<li>id 166043: static initializer block in Java made doxygen ignore the 
+               rest of the file.</li>
+<li>id 166161: More documentation to make the \code command more clear.</li>
+<li>id 166756: Fixed a number of issues with the new comment scanner. 
+               It should be much more usable now.</li>
+<li>id 166782: XML output: Simple types in a namespace are also 
+               listed at file scope in index.xml</li>
+<li>id 166863: @class required fully qualified name even if the comment
+               block was in the right scope already.</li>
+<li>id 166898: Forward declaring a template class added the template 
+               argument to next class defined</li>
+<li>id 167037: The method names were non-informative in the todo like 
+               lists when HIDE_SCOPE_NAMES was set to YES (thanks to Luigi Ballabio
+               for the fix).</li>
+<li>id 167040: Related functions were listed as members in the todo list.</li>
+<li>id 167462: Doxygen doesn't recognize references to methods of classes 
+               that come as parameter</li>
+<li>id 168159: Sometimes enums don't have hyperlinks in the source code.</li>
+<li>id 168243: Doxygen produced an unclear warning when putting multiple 
+               @page commands in one comment block.</li>
+<li>id 168693: A C-style comment ending with a brief description (including dot)
+               and a **/ as end marker, caused strange warning.</li>
+<li>id 168734: Nested C comments in a \code block confused the preprocessor.</li>
+<li>id 168754: //@{ was not working with the new comment block scanner.</li>
+<li>id 168871: \~ did not work in C++ style documentation and aliases.</li>
+<li>id 168961: Fixed problem parsing arrays of unnamed structs.</li>
+<li>id 169003: cross-references were make to global variables even if the
+               global variables were hidden by local ones or 
+               undocumented/private member variables.</li>
+<li>id 169069: static C++ variables with initializers were detected as 
+               functions.</li>
+<li>id 169188: static functions were not extracted from PHP classes even 
+               though EXTRACT_STATIC was set to YES.</li>
+<li>id 169495: const Qt properties were not parsed properly.</li>
+<li>id 169535: spaces after \ref command were not preserved 
+               in &lt;pre&gt; context when the command had only one argument.</li>
+<li>id 169547: Removed bogus warning for friend classes inside classes in
+               an anonymous namespace.</li>
+<li>id 169549: Previous fixes introduced flattening of the class hierarchy.</li>
+<li>id 169640: File suffix check for the D language was broken.</li>
+<li>id 169641: D contructors and destructors were not detected.</li>
+<li>is 169657: Fixed the way import is treated in D to prevent recursive
+               lockup.</li>
+<li>id 169784: Objective-C methods with a variable number of arguments were
+               are not parsed properly.</li>
+<li>id 169789: Images specified via \image are now also copied to the
+               XML output.</li>
+<li>id 170612: documenting members of nested anonymous compounds did no
+               longer work.</li>
+<li>id 170833: &lt;code&gt; ended a brief description.</li>
+<li>id 170835: doxygen didn't match members of classes in unnamed 
+               namespaces with their definitions</li>
+<li>id 170846: template instance friend classes could not be documented 
+               externally. </li>
+<li>id 171260: In some cases doxygen produced an incorrect warning about 
+               duplicate detailed descriptions.</li>
+<li>id 171295: It now possible again to link to a (enum)value of a @retval using
+               #name.</li>
+<li>id 171376: \else command was not properly parsed if the corresponding 
+               \if was disabled. </li>
+<li>id 171749: Using @relatesalso for functions in a namespace didn't work
+               correctly.</li>
+<li>It is now possible again to use Thing%s to auto-link to a class 
+    Thing and put a non-linked "s" after it.</li>
+<li>Nested anonymous namespaces appeared as @&lt;num&gt; in the 
+    documentation of the parent namespace.</li>
+<li>aliases containing @brief were not handled correctly.</li>
+<li>The class name in the HtmlHelp index was linked to the
+    first member function of that class instead of the class itself.</li>
+</ul>
+
+<h1>Doxygen Release 1.4.1</h1>
+<b>(release date 11-1-2005)</b>
+<a name="1.4.1"></a>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 163058,163401: Due to a memory corruption bug doxygen could crash under certain conditions
+       (the Windows binary was the most sensitive to this).</li>
+<li>   id 163003,163495: Doxygen crashed when GROUP_GRAPH and UML_LOOK were enabled.</li>
+<li>   Book icon in the treeview is now clickable and has the appropriate action (thanks to
+       Will Bateman).</li>
+<li>   Entering the expert dialog in doxywizard now only requires saving the config file
+       if actual changes were made.</li>
+</ul>
+<h1>Doxygen Release 1.4.0</h1>
+<b>(release date 31-12-2004)</b>
+<a name="1.4.0"></a>
+<h3>Changes</h3>
+<ul>
+<li>   In the HTML help output (.chm files) the index items with only one 
+       subitem are now collapsed into one item (thanks to Antony Pranata for 
+       the patch).</li>
+<li>   Some minor tweaks to the style sheet.</li>
+<li>   @relates can now not only be used for functions, but also for
+       other members (i.e. enums, types and variables).</li>
+<li>   Static members do have have explicit "static" in the declaration 
+       part of the documentation. This is useful for grouping where it 
+       is otherwise not obvious that a member is static.</li>
+<li>   typedefs and enumeration are no longer shown in the "referenced by"
+       list as these are types (based on patch by Antoine Tandin).  </li>
+<li>   Make configure script use solaris-g++ by default (Sun's own compiler
+       generates faulty code for doxygen).</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Included language update for Serbian, German, and Korean.</li>
+<li>   For directories dependency graphs are now generated (controlled
+       by the DIRECTORY_GRAPH switch). For a given directory, the graph will
+       show its parent directory and the sub directories as nested boxes. 
+       For the directory and its sub directories it will show the relations 
+       with other directories. Relations are based on #include relations of 
+       the files contained in the directories. Each dependency arrow has an 
+       associated number. This number indicates the number of 
+       different #include relations. Clicking on the number will show a page 
+       with the exact #include relations (the latter is for the HTML output 
+       only). </li>
+<li>   Added \cond and \endcond commands, which can be used to
+       (conditionally) exclude a part of a file. See the manual for an
+       example.</li>
+<li>   Added "-d ExtCmd" debug option, which when used shows what doxygen
+       will execute when invoking an external command (such as dot). </li>
+<li>   New option WARN_NO_PARAMDOC that warns about the absence of function
+       parameter or return type documentation.</li>
+<li>   Nested classes are now listed in their containing class.</li>
+<li>   Extended the \f command to support different environments, i.e.
+        \f{eqnarray*} for equation arrays. The end command is \f}. The 
+        documentation has an example.</li>
+<li>   Added support for group dependency graphs 
+       (thanks to a patch by Antoine Tandin): New option: GROUP_GRAPHS</li>
+<li>   New option DOT_TRANSPARENT to enable dot graph with a transparent
+       background. Thanks to Maik Hinrichs for the patch.</li>
+<li>   New option FILE_VERSION_FILTER which allows an external tool to
+       provide version information per file, which is then used in the
+       file documentation. Thanks to Maik Hinrichs for the patch.</li>
+<li>   id 162295: New option DOT_MULTI_TARGETS which when set to YES, 
+       will run dot with multiple output files if possible. This was added 
+       to support older version of dot (&lt;=1.8.10) which do not support multiple 
+       output targets. If you use a recent version of dot, you probably want 
+       to enable this (default is NO).</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 119868: Removed warning when &lt;/li&gt; ended a @c or similar command.</li>
+<li>   id 120367: \~lang didn't work correctly around brief descriptions
+       and certain commands. It is now implemented as an early filter
+       operation like \cond.</li>
+<li>   id 135311: Recursive ALIAS definitions now work again.</li>
+<li>   id 151012: &lt;td&gt; tag in HTML function documentation missed 'class="md"'</li>
+<li>   id 154689: Wrong link to members of namespaces imported from tag 
+       files when CASE_SENSE_NAMES is set to NO.</li>
+<li>   id 154700: anchors in pages imported via tag files could not be
+       linked to.</li>
+<li>   id 154755: Files were missing from Doxygen.dsp project file.
+       (thanks to Gerik Rhoden).</li>
+<li>   id 154758: Fixed typedef resolution bug that could crash doxygen 
+       (thanks to Gerik Rhoden for the analysis and fix).</li>
+<li>   id 154862: Fixed problem matching array parameters that include 
+                  template parameters as the array size.</li>
+<li>   id 154863: Fixed parsing problem in the preprocessor when an
+                  expression contained the division operator.</li>
+<li>   id 154469: Referring to Objective-C messages was broken if the full
+                  scope was used.</li>
+<li>   id 155086: Typedef for member-function pointers of template classes 
+                  not recognized</li>
+<li>   id 155272: Image filenames in RTF output were not quoted causing problem
+                  with custom images whose name contained spaces.</li>
+<li>   id 155322: Fixed parse problem for php code containing '#'.  </li>
+<li>   id 155224: Java interfaces did't resolve across packages w/o FQN.</li>
+<li>   id 156411: Return type of a function was not hyperlinked in some cases 
+                  (typical with nested namespaces or Java packages).</li>
+<li>   id 156445: function seen first in header and doc'ed in 
+                  source broke autolinking depending on the order of the input.</li>
+<li>   id 157085: Autolinks for const/volatile operators didn't work.</li>
+<li>   id 157229: Upper case letters in \page "&lt;name&gt;" breaks title on page.</li>
+<li>   id 157433: Multi-variable declarations were not parsed properly.</li>
+<li>   id 157485: @todo's inside the body of a function were not handled
+       properly.</li>
+<li>   id 158961: Set EXTRACT_ALL to NO resulted in no directory information
+       unless the directory and files were documented. This is now controlled
+       by SHOW_DIRECTORIES.</li>
+<li>   id 158481: I did some memory usage analysis with valgrind's massif tool, 
+       which indicated that a lot of memory was used by QCString objects. 
+       This made me decide to reimplement the class and optimize it for 
+       memory usage. The resulting class saves a "new" operation of 12 bytes 
+       per string object, which seems to reduce the overall amount of  
+       memory used by doxygen by a factor 2 to 3! The implementation seemed 
+       more expense to use (as it always copies the content instead of sharing
+       it), but the performance has improved nevertheless (probably because 
+       "new" is much more expensive operation than copying small strings).</li>
+<li>   id 158637: Links to classes in brief description in index pages were
+       wrong when CREATE_SUBDIRS was set to YES.</li>
+<li>   id 158884: "typedef [something] enum" in IDL was not handled properly.</li>
+<li>   id 159487: @ref's to Objective-C class categories were not possible.</li>
+<li>   id 159973: @todo item in anonymous enum resulted in broken link.</li>
+<li>   id 160642: Fixed problem parsing multi-dimensional C arrays.</li>
+<li>   id 160673: Borland's __property keyword was not handled correctly.</li>
+<li>   id 160824: UML Collab diagram did't show fields in user defined groups.</li>
+<li>   id 160931: Made configure script use /bin/bash as it apparently didn't 
+       work with /bin/sh anyway.</li>
+<li>   id 161048: Latex output for directories could contain unescaped 
+       underscores when SHOW_DIRECTORIES was set to YES.</li>
+<li>   id 161167: /// \file was not parsed properly.</li>
+<li>   id 161247: If CALL_GRAPH was enabled references were shown even if
+       REFERENCES_RELATION was set to NO.</li>
+<li>   id 161320: An incorrect line number was given for inherited comments 
+                  which have an error.</li>
+<li>   id 161321: Fixed problem parsing '"' in PHP code.</li>
+<li>   id 161394: Fixed problem with inheritance tree showing the same
+       undocumented base class multiple times.</li>
+<li>   id 161556: Fixed two parse bugs related to member specializations.</li>
+<li>   id 162149: URLs with commas were not handled properly.</li>
+<li>   id 162271: Doxygen was confused by read-only Qt properties.</li>
+<li>   id 162434: void function gave rise to warnings when WARN_NO_PARAMDOC
+       was set to YES.</li>
+<li>   id 162446: Fixed parse problem in code.l, causing it to get off track.</li>
+<li>   id 162517: A @ref command was not parsed properly if the argument 
+       between quotes was found on the next line.</li>
+<li>   Dot would not run if doxygen was installed in a path which contained
+       spaces (Mac OS X).</li>
+<li>   Functions inside inline methods were not always cross-referenced anymore.</li>
+<li>   Latex output was broken in some cases where anonymous structs were used.</li>
+<li>   Fixed bug in doxywizard: if the wizard was used some settings
+       were not remembered.</li>
+<li>   Using \n inside an ALIAS definition caused line numbers for
+       source browsing to become misaligned.</li>
+<li>   For included-by graphs files with the same name all had the same
+       node label.</li>
+<li>   The following typedef was not parsed properly:
+       typedef function&lt;void (int,int)&gt; ptr_t;</li>
+<li>   Fixed problems with the WARN_NO_PARAMDOC command.</li>
+<li>   Struct members of the form "enum a b;" where not properly parsed.</li>
+<li>   Fixed a couple of memory leaks.</li>
+<li>   Fixed crash problem on Windows related to the new string implementation.</li>
+<li>   Fixed problem with Visual Studio project files (in wintools).</li>
+<li>   Included patch by Antoine Tandin to fix problem with GROUP_GRAPHS 
+       in combination with CREATE_SUBDIRS = YES.</li>
+<li>   Included patch by Mikhail Glushenkov to make HTML look prettier.</li>
+<li>   Parsing operator[]s was broken.</li>
+<li>   Referencing constants via #CONST did not work anymore.</li>
+<li>   Fixed problem handing multiline ALIASES containing @defgroup and 
+       @ingroup.</li>
+<li>   Fixed problem handling \n in ALIASES.</li>
+<li>   @section's in non-page documentation blocks did not work.</li>
+<li>   Referencing a group label in a @see section, now shows the group's
+       title i.s.o. the label name (this was already done for @ref).</li>
+</ul>
+<p>
+\endhtmlonly
+\section log_1_3 1.3 Series
+\htmlonly
+</p>
+<h1>Doxygen Release 1.3.9.1</h1>
+<h3>Bug fixes</h3>(ids refer to the old buzilla issue, just use it in the search box of the <a href="https://github.com/doxygen/doxygen/issues">issue tracker</a>)<br/>
+<ul>
+<li>   Due to an error in the packaging script, an old version of doxywizard 
+       was bundled with the Mac OS X version of doxygen.</li>
+<li>   Dot would not run if doxygen was installed in a path which contained
+       spaces (Mac OS X).</li>
+<li>   id 151012: &lt;td&gt; tag in HTML function documentation 
+       missed 'class="md"'</li>
+<li>   id 154689: Wrong link to members of namespaces imported from tag 
+       files when CASE_SENSE_NAMES is set to NO.</li>
+<li>   id 154700: anchors in pages imported via tag files could not be
+       linked to.</li>
+<li>   id 154755: Files were missing from Doxygen.dsp project file.
+                  (thanks to Gerik Rhoden for sending an update).</li>
+<li>   id 154758: Fixed typedef resolution bug that could crash doxygen 
+       (thanks to Gerik Rhoden for the analysis and fix).</li>
+<li>   id 154862: Fixed problem matching array parameters that include 
+                  template parameters as the array size.</li>
+<li>   id 154863: Fixed parsing problem in the preprocessor when an
+                  expression contained the division operator.</li>
+</ul>
+<h1>Doxygen Release 1.3.9</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Changed the stylesheet so font usage is more uniform and consistent.</li>
+<li>   Changed the colors of the doxygen logo at the bottom of a HTML page.
+       Let me know if you prefer this one or the old one.</li>
+<li>   Improved rendering of template functions and methods in the HTML output
+       (previously these could push the method names to the right side of the page).</li>
+<li>   id 149899: A macro defined in the config file (see PREDEFINED) can now
+       prevented from being undefined (via a #undef in the code) when its
+       value is assigned via the := operator (e.g. PREDEFINED = A(x):=x ).</li>
+<li>   id 150631: if HIDE_SCOPE_NAMES is enabled the scope of a method in a 
+                  call graph is only shown when the method is of a different 
+                  class.</li>
+<li>   id 151911: Stylesheet is generated earlier in the process.</li>
+<li>   id 152164, 152166: Improved the way search results are sorted.</li>
+<li>   Changed the way function pointer arguments are represented in the
+       detailed description.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Directory information is now extracted by doxygen. Files are 
+       automatically grouped by directory. You can use 
+       the SHOW_DIRECTORIES option to enable/disable this feature.
+       Added a new command \dir which can be used to document directories.</li>
+<li>   Language updates for Czech, Swedish, Hungarian, Danish, Russian, Italian, 
+       German, Chinese, Croatian, and Polish.</li>
+<li>   Applied a patch by Arend van Beelen which adds support for the
+       new features introduced in PHP5.</li>
+<li>   Applied a patch by Ferdinand Wess for better handling of #import 
+       statements in Obj-C code.</li>
+<li>   Applied a patch by Adam Treat to add read and write accessors 
+       of a Q_PROPERY to the XML output.</li>
+<li>   Arnaud Bercegeay has added platform support for the Atari MiNT OS. </li>
+<li>   Included patch by James Ahlborn which improves the way nested numbered
+       lists are layouted in the HTML output.</li>
+<li>   Included update for Hungarian translation.</li>
+<li>   Added patch to improve support for Debian
+       (http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=263542)</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 123772: putting an example inside a group caused broken links to
+                  in the example list.</li>
+<li>   id 125737: Fixed link error when a @todo item was placed in the
+                  documentation of a variable inside a anonymous union/struct.</li>
+<li>   id 126344: Added initial support for member template specializations.</li>
+<li>   id 126448: Argument passed to input filter was not always quoted.</li>
+<li>   id 126745: Anchors of grouped members were wrong in some cases.</li>
+<li>   id 128585: Lists were not always rendered properly in the man page 
+       output format.</li>
+<li>   id 128809: Hidden files (starting with a dot) could not be included
+                  with for instance \verbinclude.</li>
+<li>   id 130431: Prevented recursive loop in the call graph when a function 
+                  declares a local variable with the name of the function.</li>
+<li>   id 131299: \copydoc with argument A#func() didn't work.</li>
+<li>   id 131354: Fixed bug matching function declaration/implementation with 
+                  using declarations.</li>
+<li>   id 135448: Improved autodetection of Qt by the configure script 
+                  some more (thanks to Michael Henry).</li>
+<li>   id 135808: Removed reference to doxysearch.cpp from Doxyfile included
+                  with the source distribution.</li>
+<li>   id 138629: Included patch to make the HTML output more conformant to 
+                  the XHTML standard (thanks to Jan Nijtmans).</li>
+<li>   id 144865: Variables in anonymous unions/structs did not appear as
+                  data fields.</li>
+<li>   id 148547: Added a workaround for a compile problem in pngrutils.c 
+       on AIX 5.2.</li>
+<li>   id 148671: Using "publicsomething" as a name for a base class resulted
+       in the "public" part being stripped.</li>
+<li>   id 148707: &lt;a href&gt; and &lt;br&gt; tags are now allowed inside html headings.</li>
+<li>   id 149023: Fixed template inheritance through typedefs problem.</li>
+<li>   id 149045: Fixed several small problems related to template handling.</li>
+<li>   id 149106: Fixed problem parsing enum declarations.</li>
+<li>   id 149164: Fixed problem in the configure script when used with perl 
+       version 5.6 (thanks to a patch by Joerg Schlichenmaier)</li>
+<li>   id 149258: Example sources could be wrongly indented.</li>
+<li>   id 149263: Fixed copy/paste error in HTML_FOOTER documentation.</li>
+<li>   id 149698: Multiple lines of //!&lt; comments were not handle correctly.</li>
+<li>   id 149711: Title of a namespace page/section was not generated.</li>
+<li>   id 149797: Forgot to turn off debug mode for the RTF output.</li>
+<li>   id 149880: Brief description of one variable could appear in the 
+                  the description of the next under certain circumstances.</li>
+<li>   id 150264: linking to Obj-C protocols did not work.</li>
+<li>   id 150427: "virtual" and "const" were not nicely formatted when 
+                  followed by unary scope resolution operator (e.g "const ::A")</li>
+<li>   id 150629: Enabling OPTIMIZE_OUTPUT_JAVA did not help for call graphs.</li>
+<li>   id 151457: Fixed compile problem on Solaris 4.2.</li>
+<li>   id 151452: Bug in LaTeX output for anonymous structs/unions whose 
+       members have brief descriptions.</li>
+<li>   id 151246: Parse error when using in-body comment blocks.</li>
+<li>   id 152005: Objective-C string constants appear in output with @"@"</li>
+<li>   id 152182: Spaces mess up type in Objective C functions.</li>
+<li>   id 152184: label-less parameters in Objective C functions were not 
+                  parsed properly.</li>
+<li>   id 152383: Objective-C categories showed methods twice.</li>
+<li>   id 152572: \brief inside an argument description caused a bogus warning.</li>
+<li>   id 152681: Call-graphs were generated inside a table environment in 
+       the HTML output.</li>
+<li>   #include after a @file comment made the #include appear on the same line
+       when DETAILED_AT_TOP was enabled.</li>
+<li>   User specified images &amp; stylesheets did not work with 
+       CREATE_SUBDIR.</li>
+<li>   Nested using directives did not work for C#.</li>
+<li>   Grouped classes did not always appear in the modules section of the
+       navigation tree.</li>
+<li>   "internal" classes appeared in the XML output.</li>
+<li>   friend classes did no longer appear in the output even when 
+       HIDE_FRIEND_COMPOUNDS was set to NO.</li>
+<li>   Fixing bug in code parser when encountering arrays and some other
+       related problems.</li>
+<li>   Array initializers did not show up regardless of the 
+       MAX_INITIALIZER_LINES setting.</li>
+<li>   Improved support for classes with the same name but in different
+       namespaces in combination with "using" of namespaces.</li>
+</ul>
+<h1>Doxygen Release 1.3.8</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Rewrote doxywizard. It should be more easy to use and has much better
+       support for running doxygen from the GUI. Feedback is welcomed!</li>
+<li>   Members of a namespace are now also added to the file in which they
+       appear (thanks to Mike Morearty for the patch).</li>
+<li>   Included patch by Mikhail Glushenkov that fixed item 5 on the todo list
+       (titles of html pages are now internationalized).</li>
+<li>   A macro defined in the config file can now be undefined in the
+       source code via a #undef.</li>
+<li>   Optimized calling of dot using multiple -T flags at a couple of places
+       (note that doxygen now requires graphviz &gt;=1.9)</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   New option FILTER_PATTERNS which can be used to specify multiple 
+       input filters, and let doxygen select the right one based on
+       matching the source file name with a specified pattern (thanks to
+       a patch by James Ahlborn).</li>
+<li>   id 142939: New commands \protocol and \category which can be used
+       to document Objective-C protocols and categories in the same way 
+       the \class command does for classes.</li>
+<li>   Included patch that removes some cosmetic annoyances in the man page 
+       output (thanks to Chris Croughton).</li>
+<li>   Added internationalization support for Afrikaans and
+       Lithanian.  Included language updates for Dutch, 
+       Czech, Italian, Brazilian, Croatian, Japanese, Norwegian and
+       Russian.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 120810: \code fragment has links first time, but then no more.</li>
+<li>   id 124214: Fixed parse problems with single quoted strings in PHP.</li>
+<li>   id 135508: Using a namespace in C# did not get interpreted correctly.</li>
+<li>   id 137842: Using @todo/@bug/... and disabling the generation of the
+       list, still caused a colon to appear in the output.</li>
+<li>   id 138075: A comment block containing a \code block with C style
+       comments was not properly parsed.</li>
+<li>   id 138307: Fixed parse problems with single quoted strings in PHP.</li>
+<li>   id 138394: C style comments placed on the same line after a macro 
+       definition appeared as part of the macro's value.</li>
+<li>   id 138429: Fixed language setting for HTML output when using 
+       traditional chinese.</li>
+<li>   id 140259: Using @dotfile in a comment block could cause broken @refs
+       to sections defined after the @dotfile command.</li>
+<li>   id 141915: Fixed a couple of problems with the RTF output.</li>
+<li>   id 141918: Fixed a couple of problems with the RTF output.</li>
+<li>   id 142118: Fixed compile issue with the mingw compiler.</li>
+<li>   id 142288: Doxywizard crashed when started (fix was applied to version
+       1.3.7 as well).</li>
+<li>   id 142741: Links in todo/bug/... lists were broken if CREATE_SUBDIRS 
+       was enabled.  Same was true for the built-in diagrams.</li>
+<li>   id 142925: Autolinking to a member of a class from a page inside a 
+       namespace did not work.</li>
+<li>   id 142940: Due to a misplaced break statement a examples included 
+       with \example was shown twice in the output.</li>
+<li>   id 143107: Made some cosmetic changes to the HTML and HTML output, 
+                  (thanks to David Baird for the patch).</li>
+<li>   id 143340: Fixed autolink problem for names ending with a colon or
+                  a &lt;br&gt; tag.</li>
+<li>   id 143412: Fixed problem parsing Objective C class methods.</li>
+<li>   id 143413: Fixed problem parsing Objective C root classes.</li>
+<li>   id 143593: Under certain conditions the XML output could contain a
+                  reference to a non-existing class.</li>
+<li>   id 145295: Variable of a templated type was mistaken for a function.</li>
+<li>   id 145583: Fixed problems handing formulas and graphs defined using
+       @dot in combination with CREATE_SUBDIRS = YES.</li>
+<li>   id 147253: Quotes in a class initializer could confuse the source
+       code parser.</li>
+<li>   id 147425: The class diagram did not show the relation to the template
+       specialization when inheritance was done via one or more typedefs.</li>
+<li>   Fixed case where template classes "used" via typedefs were not 
+       properly shown in the collaboration diagram.</li>
+<li>   Variables explicitly declared external were reported being defined
+       at the place they were actually declared external.</li>
+<li>   Fixed bug in the XML schema for enum values with initializers.</li>
+<li>   Documentation of a member group did not appear in the XML output
+       (thanks to Chris Croughton for the patch).</li>
+<li>   Command line build process failed under windows if the name of the 
+       directory in which sources are located contained spaces (thanks to 
+       Mikhail Glushenkov for the patch).</li>
+<li>   Improved cross-referencing to methods of a template instance variables
+       (thanks to a patch by Jeff Apple).</li>
+<li>   Included a patch by Enrico Schnepel that puts the same output files
+       in the same subdirectories (with SUBDIRS = YES) for subsequent runs 
+       (on slightly modified input files) and also renumbers the dot nodes 
+       so they are only regenerated when actually changed.</li>
+<li>   Unsupported HTML end tags and unsupported begin tags with attributes
+       are now copied to the output as is.</li>
+</ul>
+
+<h1>Doxygen Release 1.3.7</h1>
+<h3>Changes</h3>
+<ul>
+<li>   The \param command now has an optional input and/or output attribute. 
+       The syntax for an input &amp; output parameter is for example: 
+       \param[in,out] name Description.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added new option CREATE_SUBDIRS which when enabled makes doxygen
+       distribute the generated output evenly over 100 subdirectories.</li>
+<li>   Added support for Qt's properties (i.e. Q_PROPERTY) which can be 
+       documented by putting a documentation block in front of the macro or 
+       by using a comment block with the new \property command. </li>
+<li>   Added new commands \manonly and \endmanonly to enter man page specific
+       text and commands in the generated man pages (thanks to Carsten Stiborg).</li>
+<li>   Included new python based translation report script, which now 
+       replaces the old perl based version (thanks to Petr Prikryl).</li>
+<li>   Improved parser to also support parsing of Objective-C implementation 
+       files.</li>
+<li>   Added new config option EXTRACT_LOCAL_METHODS which can be used for
+       Objective-C code to extract methods definition in the implementation
+       section that are not present in the interface.</li>
+<li>   Added new config option STRIP_FROM_INC_PATH which allows to 
+       specify a list of paths that, if matched, will be striped from the 
+       #include statement in the generated documentation of a class.</li>
+<li>   Added new command \includelineno with works as \include except it will
+       add line numbers to the code (thanks to Giancarlo Niccolai for the patch).</li>
+<li>   Added BeOS support, thanks to a patch by Mark Hellegers.</li>
+<li>   Included update for the French translation, thanks to Jacques Bouchard.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 133388: Fixed problem parsing '"' inside multi-line C++ style 
+       comment blocks</li>
+<li>   id 134265: Doxygen now outputs unrecognized HTML tags instead of 
+       removing them (thanks to Éric Malenfant for the patch).</li>
+<li>   id 134869: When HIDE_SCOPE_NAMES was set to NO, the methods of an
+       Objective-C class did not have the right name.</li>
+<li>   id 134876: Fixed problem with forward declaration of a protocol in 
+       Objective-C.</li>
+<li>   id 134647: using a parameter name ending with "const" was not 
+       accepted by doxygen.</li>
+<li>   id 134639: Fixed parse problem in the preprocessor.</li>
+<li>   id 137398: add \% command to the documentation.</li>
+<li>   id 137730: Fixed problem for man pages with non numeric extension
+       (thanks to a patch by Joe Schirmer).</li>
+<li>   id 138652: Line numbers for defines with /* */ comments were wrong
+       (thanks to J. Noack for the patch).</li>
+<li>   id 139591: Fixed problem parsing nested template arguments with 
+       comments.</li>
+<li>   id 140012: a variable could appear in a group twice if it was
+       declared externally somewhere.</li>
+<li>   id 140540: Fixed problem parsing "@" in the source code parser.</li>
+<li>   id 141133: Spaces were stripped in default arguments such as 
+       f(const char *t=" \t")</li>
+<li>   id 141364: Members of an anonymous nested structure had no brief 
+       comment and no link to the detailed description if available.</li>
+<li>   Fixed recursive lockup problem that was caused by two or more 
+       namespaces using each other (i.e. a cycle in the usage relation).</li>
+<li>   Included patch by Erik Zeek to allow the explicit setting of QTDIR to
+       override the "search for Qt" algorithm in the configure script.</li>
+<li>   Parsing of tag files produced for Objective-C code now works.</li>
+<li>   Objective-C: Improved hyperlinking of source code, handling of 
+       prototypes and the list of all members of a class now also contains the 
+       members of class categories.</li>
+<li>   Third argument of @class was ignored (thanks to Mahadevan for the patch).</li>
+<li>   Fixed problem with collaboration diagrams for template instances
+       whose template parameter list contained qualified scope names
+       (e.g A&lt;B::C&gt;).</li>
+<li>   Removed bogus warning about undefined documented function for 
+       classes that were made friends of other classes.</li>
+<li>   Spaces where not preserved for @code block inside a @example block.</li>
+<li>   Undocumented dependency relations where not shown in some cases
+       even though HIDE_UNDOC_RELATIONS was set to NO.</li>
+<li>   Fixed two bugs that resulted in invalid HTML output. </li>
+<li>   For Unix the default FILE_PATTERNS did not include upper case versions
+       such as .C and .H</li>
+<li>   Fixed incorrect character encoding problem for the generated tag files.</li>
+<li>   Fixed problem that could lead to memory corruption/crashes.</li>
+<li>   Included a patch by Bernhard Rosenk to fix a compile problem with
+       doxywizard using a recent Qt version.</li>
+<li>   Call-graphs were missing if a file name ended with ".C" and K&amp;R
+       function definitions were used.</li>
+<li>   Improved source code generation performance when there are many 
+       typedefs with the same name in different scopes.</li>
+<li>   Linking to a section resulted in the wrong label in the XML output.</li>
+</ul>
+<h1>Doxygen Release 1.3.6</h1>
+<h3>Changes</h3>
+<ul>
+<li>   For projects with many nested classes, namespaces, typedefs and using
+       statements, doxygen could become very slow. This should
+       now be improved significantly.</li>
+<li>   Made some cosmetic changes to the HTML output (thanks to Ben Harper).</li>
+<li>   STRIP_FROM_PATH now by default strips the path from which doxygen is
+       run (i.e. $(PWD)/ on Unix)</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Make a start with adding support for Objective-C. Doxygen can now
+       parse Objective-C header files (including protocols and categories).
+       Thanks to Apple for donating hardware.</li>
+<li>   Include a patch by Hauke Duden which adds preliminary support for 
+       the D programming language (see http://www.digitalmars.com/d).</li>
+<li>   C Comments inside #defines are now preserved. This could be useful
+       to document boilerplate code.</li>
+<li>   Included patch to replace tabs by the proper amount of spaced inside
+       code fragments in the XML output (thanks to Alexandr for the patch). </li>
+<li>   Included Gerik Rhoden's fixes for the .dsp/.dsw files found in the
+       wintools dir.</li>
+<li>   Examples (documented via \example) are now included in the XML output.</li>
+<li>   New option SORT_BRIEF_DOCS which when enabled will list the
+       declaration section of the documentation (with the brief descriptions)
+       in alpabetical order, instead of declaration order (thanks to 
+       Akos Kiss for the patch).</li>
+<li>   Included patch for Hungarian translation (thanks to Akos Kiss)
+       and for the Serbian language. Added support for mixed Korean/english 
+       (thanks to Jihoon Chung).
+       The translator report script was also updated (thanks to Petr Prikryl)</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 120070: Included workaround for build problems with RedHat 9
+       (thanks to Tim van Holder)</li>
+<li>   id 128054: Fixed rare case where doxygen crashed due to a recursive
+       lock-up.</li>
+<li>   id 131404: Fixed problem cross-referencing PHP member functions.</li>
+<li>   id 131434: Clarified confusing warning message.</li>
+<li>   id 131446: Extra attributes of a &lt;a href&gt; tag (like target) are now 
+       copied to the HTML output.</li>
+<li>   id 132535: Fixed problem with generating man page output for groups 
+       with brief descriptions.</li>
+<li>   id 132772: Fixed compile problems on HP-UX using acc compiler
+       (thanks to Clyde Gerber).</li>
+<li>   id 133300: Fixed missing cross-reference to "c" in constructs such as
+       "a[b].c"</li>
+<li>   id 133482: Fixed spurious cross-references to member function which
+       was shadowed by a parameter name.</li>
+<li>   id 133986: Attributes of the &lt;img&gt; tag where not written to the
+       HTML output.</li>
+<li>   id 134123: Fixed problem with multiple arrows between nodes 
+       in the graphical class hierarchy.</li>
+<li>   \ref in dot graphs was not working correctly (thanks to 
+       Eoin MacDonell for the fix).</li>
+<li>   Grouped pages in the XML output did have the same id as their group.</li>
+<li>   Fixed problem handling environment variables inside a
+       quoted string in the config file (e.g. "$(HOME)/My Path/").</li>
+<li>   Using "\mainpage notitle" caused the "notitle" to appear in the treeview.</li>
+<li>   Page references where wrong in the latex output when PDF_HYPERLINKS
+       was disabled.</li>
+<li>   Words inside a hyperlink could be hyperlinked, resulting in invalid
+       HTML.</li>
+<li>   Fixed parse error handling function pointer arguments in K&amp;R-style code.</li>
+<li>   Doxygen could crash when it failed to enter a directory.</li>
+</ul>
+<h1>Doxygen Release 1.3.5</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Doxygen now only regenerates a dot image if it has actually changed! 
+       This could significantly reduce the time of any run after the first. 
+       Checking if a graph has changed is done by computing an md5 hash for 
+       the graph description which is then stored along with the 
+       image generated by dot and compared in subsequent runs.</li>
+<li>   Improved the way lists look in the man pages (thanks to Silke Reimer).</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for parsing K&amp;R style function prototypes. 
+       Please try it on your favourite legacy C project and report any 
+       problems.</li>
+<li>   Included languages updates for Traditional Chinese, 
+       Danish, German, Korian translation.</li>
+<li>   id 120464: doxygen's XML output does now assign a prot="..." 
+       attribute for nested classes (thanks to Paul Ross for the patch).</li>
+<li>   Added new configuration switch XML_PROGRAMLISTING to enable/disable 
+       generating source code listings as part of the XML output (thanks to
+       Paul Ross for the patch).  </li>
+<li>   Added new config option ABBREVIATE_BRIEF which makes the
+       abbration process of brief descriptions configurable and language
+       independent (thanks to Jake Colman for the patch).</li>
+<li>   The alphabetical class list now comes with a quick index
+       (thanks to Marcin Zukowski for the patch).</li>
+<li>   An XSLT script "combine.xslt" is now generated in the XML output 
+       directory. It can be used to combine XML files into one big file.</li>
+<li>   The source code is now indexed and thus searchable when the source 
+       browser and search engine options are enabled.</li>
+<li>   Added "dist" target to the makefile (thanks to Erik Zeek)</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   id 119778, 123385: Documentation in the body of a function could not be
+                  combined with a detailed description before the declaration.</li>
+<li>   id 122852: References to grouped functions were wrong in certain cases.</li>
+<li>   id 123031: problem matching f(const char) with f(const char cc).</li>
+<li>   id 123140: typedef'ed enums whose tag name was the same as the typedef
+       name did not appear in a group.</li>
+<li>   id 123145: Under certain circumstances an assertion failed message
+       was produced.</li>
+<li>   id 123206: Fixed problem in qtools when opening files in text mode.</li>
+<li>   id 123322: The search page did not honor DISABLE_INDEX.</li>
+<li>   id 123420: Functions with a brief description caused bugus &lt;/em&gt; tags 
+                  in the HTML output.</li>
+<li>   id 124114: typo in the generated PHP search script could cause errors
+       in the search result page.</li>
+<li>   id 124187: Setting EXTRACT_LOCAL_CLASSES to NO, could result in a 
+       broken "More..." link in documented local classes inside a namespace.</li>
+<li>   id 124214: Fixed problem in search indexer, which could crash doxygen 
+       (thanks to Daniel Koebbing for the patch).</li>
+<li>   id 124545: fixed a number of problems in the generated search script.</li>
+<li>   id 124815: Fixed compile problem in filedef.h for aCC on HP-UX.</li>
+<li>   id 125369: Fixed inconsistency of showing files in the tree view
+       (thanks to a patch by Alexey Neyman).</li>
+<li>   id 125424: Font size was not reset after @endcode or verbatim block
+       in the latex output.</li>
+<li>   id 125654: Character encoding was not correct for html help treeview
+       (thanks to Sawada Kentaro for the fix).</li>
+<li>   id 125367: Fixed problem with producing links in case files with
+       the same name (but in different directories).</li>
+<li>   id 126968: Fixed problem parsing verbatim string literals such as
+       @"\" in C#.</li>
+<li>   id 127094: Fixed character encoding problem in the XML output.</li>
+<li>   id 131364: Fixed parse problem when initializing a function pointer.</li>
+<li>   Links to classes, files, namespaces and groups in the search results
+       were broken (missing file extension).</li>
+<li>   Doxygen logo is now transparent even when viewed with IE.</li>
+<li>   Using a character with ascii code 0x06 in a comment block could crash 
+       doxygen if the preprocessor was enabled.</li>
+<li>   Fixed problem handling conditional commands and grouping (thanks to
+       Silke Reimer for the patch).</li>
+<li>   Fixed problem using \dotfile in combination with RTF output 
+       (thanks to Vegard Larsen).</li>
+<li>   Fixed several problems related to the new md5 hash feature.</li>
+<li>   Undocumented functions referenced in a comment block were linked to 
+       anyway.</li>
+<li>   Fixed a number of typos in the config file documentation (thanks to
+       Boaz Kelmer)</li>
+<li>   Workaround for toupper() bug for Russian (thanks to cav@cryptopro.ru)</li>
+<li>   Fixed problem that HTML image maps ended up in the RTF output.</li>
+<li>   Fixed bug in code fragment parser that could cause memory corruption
+       in certain cases.</li>
+<li>   Fixed problem matching definition and declation of functions, which
+       could cause bogus warnings for functions with the same name but in 
+       different namespaces.</li>
+<li>   Using "/// @file" to document a file quickly was not possible, while
+       "/** @file */" did work. Now both work.</li>
+</ul>
+<h1>Doxygen Release 1.3.4</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Rewrote the search engine. The doxysearch CGI binary has been 
+       replaced by a PHP script which is generated by doxygen. Also the 
+       index file is now generated by doxygen and requires way less memory. 
+       This should make it much easier to use the search facility. 
+       All that is required is a web server with PHP 4.1 or higher.
+       Please report any problems you find.</li>
+<li>   Changed the way class names are resolved. This can result in
+       a significant speedup for projects that use namespaces and typedefs
+       (including Java projects). Thanks to Edmund Green for the performance 
+       analysis and ideas.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for the &amp;oslash;, and &amp;Oslash; character entities.</li>
+<li>   Added language updates for Korean, Swedish, German, Russian, 
+       Croatian, Brazilian, Spanish, Japanese, French and Italian.</li>
+<li>   Added new \relatesalso command, which can be used to put a file member
+       also in the documentation of a class (thanks to Ian Scott for the patch).</li>
+<li>   Added support for pseudo IDL files with the .pidl extension 
+       (as used in TAO). Thanks to Éric Malenfant for the patch.</li>
+<li>   Added new commands \dot ... \enddot to include a dot graph in a
+       comment block (thanks to a patch by Eoin MacDonell). Inside the
+       URL attribute of a node you can use \ref to make links to documented
+       items. See the documentation of the \dot command for an example.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed recursive lock-up problem handling "using" of namespaces.</li>
+<li>   Doxygen incorrectly translated \\htmlonly and \\latexonly to
+       \verbatim in the output. </li>
+<li>   Using the -d Time option caused:
+       message.cpp&lt;100&gt;: Internal error: Requested unknown option QUIET
+       at the end of the run.</li>
+<li>   Static members appeared in the todo list even if EXTRACT_STATIC was
+       set to NO.</li>
+<li>   Fixed problem matching f(const int *i) with f(const int * const i),</li>
+<li>   Fixed case where a variable could get by assigned a bogus "()" in the
+       heading of the detailed description.</li>
+<li>   Fixed problem handling extern"C" (without the space). </li>
+<li>   \ref file.c ended up as file::c in the output.</li>
+<li>   Special characters in generated texts were not always translated into 
+       proper LaTeX commands in the LaTeX output.</li>
+<li>   Fixed problem parsing "const ::Class *func()" and "static ::Class *func()".
+       The keywords were seen as namespaces.
+       due to the use of more than one const keyword.</li>
+<li>   Fixed two bugs in compound.xsd schema, thanks to Ademar Aguiar.</li>
+<li>   Fixed some more problems linking typedefs in combination with namespaces.</li>
+<li>   id 120637: Fixed parse problem handing character literals such 
+       as '"' inside the initializer list of a constructor.</li>
+<li>   Fixed file handle leak when INLINE_SOURCES was set to YES.</li>
+<li>   Fixed problem handling Java packages (Internal inconsistency warnings).</li>
+<li>   Fixed problem preprocessing @verbatim blocks containing C comments.</li>
+<li>   Fixed problem handling preprocessor statement just before a function
+       body when ENABLE_PREPROCESSING was set to NO.</li>
+<li>   id 122457: INLINE_SOURCES feature was broken (only showed the 
+       first line)</li>
+</ul>
+<h1>Doxygen Release 1.3.3</h1>
+<h3>New features</h3>
+<ul>
+<li>   Included update for VC++ 6.0 project/workspace files (can be found
+       in wintools). Thanks to Simon Goodwin &amp; Johan Eriksson.</li>
+<li>   Added new debug flag "-d Time" which will report the elapsed time
+       for each message printed, and will also show the total running time
+       along with the time spend on external tools such as dot.
+       Note: If you have a project that takes doxygen a long time to process, 
+       please send me the output so I get a global idea where to optimize.</li>
+<li>   New option SUBGROUPING which can be set to NO to have \nosubgrouping
+       for all classes (thanks to Torben Koch for the patch).</li>
+<li>   Added XML schemas for validating the XML output, and to help 
+       writing XSLT files.
+       The generated index.xml now has a complete schema, the compounds
+       not yet.  Thanks go to Alexej Humbach for doing a lot of the work.  
+       Note that a couple of "id" attributes in the XML output have been 
+       changed to "refid", and section tags are now nested.</li>
+<li>   Included language updates for Traditional Chinese and Japanese.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Doxygen crashed when parsing a comment block with only a \mainpage 
+       command.</li>
+<li>   Fixed problem matching namespace members.</li>
+<li>   Fixed scanner push back error for ALIASES with long definitions.</li>
+<li>   Default main page was wrong if DISABLE_INDEX was set to YES.</li>
+<li>   Argument of type array were not properly parsed in Java, causing
+       problems when documenting them with @param.</li>
+<li>   \image with "" as caption didn't work.</li>
+<li>   If the last \section in a comment block was empty, doxygen produced
+       warnings.</li>
+<li>   Call graphs were only generated if REFERENCES_RELATION was set to YES.</li>
+<li>   Link could be wrong if a member's name was found in multiple namespaces. </li>
+<li>   A function returning "struct s *" caused a bogus recursion relation 
+       in the call graph.</li>
+<li>   Improved handling backslashes for the perlmodgen (thanks to Miguel 
+       Lobo).</li>
+<li>   Page anchors did not appear in the tag files.</li>
+<li>   \ref's to grouped pages were not generated correctly.</li>
+<li>   Fixed parse bug when putting \image inside a HTML table. </li>
+<li>   Made the documentation parser more tollerant to spaces inside HTML
+       commands.</li>
+<li>   Doxygen now issues a warning if invalid commands are used inside
+       a single-line C++ comment (such a @see and @image).</li>
+<li>   Fixed parse problem for the semicolon in the following: 
+       Class A : a(";") {};</li>
+<li>   Doxygen now resolves links to classes imported in a namespace 
+       via using declarations or directives.</li>
+<li>   Doxygen now issues a warning when @code, @verbatim, @htmlonly, or
+       @latexonly are not properly terminated.</li>
+<li>   Fixed "Internal inconsistency" messages when parsing Java packages.</li>
+<li>   A member did not appear in its group if it was first declared without
+       documentation and then defined with documentation (with \ingroup).</li>
+<li>   The &lt;caption&gt; tag was put at the end of a &lt;table&gt; 
+       in the HTML output, while it should be the first tag 
+       after &lt;table&gt;. This is now corrected.</li>
+<li>   In the LaTeX output, the page references were missing for the links 
+       in the documentation when PDF_HYPERLINK was set to NO.</li>
+</ul>
+<h1>Doxygen Release 1.3.2</h1>
+<h3>Changes</h3>
+<ul>
+<li>   The main page (\mainpage) can now be completely customized, by using
+       no project name or using "notitle" as argument for \mainpage.</li>
+<li>   Changed the look of the quick index on top of each page using CSS.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added new command \callgraph which can be put in the documentation
+       of a function to get a callgraph. In the config file a
+       new option CALL_GRAPH is added which can be set to YES to enable
+       callgraphs for all functions (note that this will slow doxygen down!).</li>
+<li>   Added new boolean config option UML_LOOK which can be enabled to give 
+       class and collaboration diagrams a more UML conformant look 
+       (thanks to Dominick Paniscotti).</li>
+<li>   Added new commands \xmlonly and \endxmlonly which can be paired
+       to form blocks of text that only appear in the XML output.</li>
+<li>   Added sub-indices for the lists of all class/file/namespace members
+       to filter out just of type of members.</li>
+<li>   Included language update for Czech, Italian, Portuguese, and French.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Doxygen could crash if a namespace and a class with the same 
+       name were found in the global scope.</li>
+<li>   Fixed problem handling multiple \xrefitem's in one comment block 
+       (could crash doxygen).</li>
+<li>   Added check for recursive group relations to prevent lock-up/crash while 
+       generating the group index.</li>
+<li>   Doxygen could crash if a group contained only undocumented members.</li>
+<li>   Putting a #include inside a function body would cause the
+       line numbering to be off.</li>
+<li>   Fixed cause of a failed assertion when @retval or @param was the last
+       text in a comment block.</li>
+<li>   Improved scope detection for code parser when dealing with examples
+       (imported via \example).</li>
+<li>   Fixed preprocessor bug handling "#if!defined(VALUE)" (note the lack of
+       a space).</li>
+<li>   Added warning if @subsection, @subsubsection or @paragraph were found
+       in the page context.</li>
+<li>   French translation was broken (probably due to a dos2unix accident).</li>
+<li>   Underscores inside a &lt;pre&gt; section did not appear correctly in the
+       LaTeX output.</li>
+<li>   Fixed several typos in the generated config file (thanks to a patch
+       by Justin Zaglio)</li>
+<li>   Formula's inside comments directly in front or behind function arguments
+       did not work.</li>
+<li>   Fixed code parser problem when //&lt;! was nested in a normal C comment.</li>
+<li>   Included a number of fixes for typos found and corrected by Justin 
+       Zaglio.</li>
+<li>   For #define values that were constant strings, doxygen tried to link 
+       the text inside the string when shown in the documentation.</li>
+<li>   The source-browse parser did not link to class variables used in 
+       inline function if the variables were defined before the functions. </li>
+<li>   The first paragraph after a &lt;h1&gt; or similar heading was not put in 
+       a paragraph context in the generated output.</li>
+</ul>
+
+<h1>Doxygen Release 1.3.1</h1>
+<h3>Changes</h3>
+<ul>
+<li>   A multi-line C++ comment block now has to be aligned in order to
+       make doxygen treat it is one block. As a result the
+       following is treated as one comment block:
+       <pre>
+           int var; //!&lt; variable.
+                    //!  more info about var.
+           int anotherVar;
+       </pre>
+       while this results in two comment blocks:
+       <pre>
+           int var; //!&lt; variable.
+                    //! info about second variable
+           int anotherVar;
+       </pre>
+       Hopefully this will give more intuitive results. Tabs are replaced
+       by spaces according to the value of TAB_SIZE in the config file.</li>
+<li>   Modified the CSS to change the look of the HTML output, and made the
+       stylesheet a little more powerful (thanks to a patch by Ben Harper).</li>
+<li>   Formula alignment in the HTML output is now controlled via CSS
+       (thanks to a patch by Vassilii Khachaturov).</li>
+<li>   The option TEMPLATE_RELATIONS now defaults to NO.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added new command \xrefitem which enables user-defined commands
+       that act like \todo and \bug, i.e. produces a related page containing
+       all items, which is cross-referenced with the documentation blocks 
+       where the items are placed.</li>
+<li>   Added support for package scope in Java.</li>
+<li>   Added alt attributes to user included images in the HTML output
+       (thanks to patch by Vassilii Khachaturov)</li>
+<li>   Added XML_OUTPUT option to allow a user defined location for
+       generating XML output (thanks to a patch by Emmanuel Guerin).</li>
+<li>   Included language updates for French, German, Czech, Italian, and
+       Brazilian.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Occurrences of &lt;span&gt; and &lt;div&gt; tags in the documentation 
+       were not properly handled.</li>
+<li>   Fixed problem parsing the following pattern 
+       "namespace { .... } typedef ....", which could crash doxygen if
+       IGNORE_PREFIX was used.</li>
+<li>   The project name is now put in front of each title of a HTML page
+       for easier bookmarking.</li>
+<li>   In C# enums, classes and structs without (optional) ; were not 
+       properly parsed.</li>
+<li>   Though still not perfect, I Improved the way namespace aliasing is 
+       handled. It should now work inside other namespaces and for 
+       computing class and usage relations.</li>
+<li>   Fixed problem documenting typedefs of function pointers using
+       \typedef.</li>
+<li>   Links to groups imported via tag files were broken.</li>
+<li>   Fixed problem resolving class relations for nested classes within
+       namespaces.</li>
+<li>   Static members can now be documentated in a separate file using \fn
+       as long as they have unique names. If the names are not unique the 
+       documentation must be located in the same file (as was required before).</li>
+<li>   In arguments and return types of the form NA::A were not linked if NA 
+       was a namespace alias to a documentation namespace and A a documented 
+       class name.</li>
+<li>   Matching a declaration f(NA::C c) with f(C c) did not work if NA was
+       a namespace alias.</li>
+<li>   Undocumented classes had wrong links in the treeview frame.</li>
+<li>   Pages whose title contained &lt; or &gt;'s were not written correctly to the
+       tag file.</li>
+<li>   Fixed preprocessor bug: "a##b" was not correctly expanded if
+       argument "a" or "b" was empty.</li>
+<li>   Putting \todo and friends inside the documentation of enum values 
+       did not result in an entry on the todo list page.</li>
+<li>   Fixed some problems compiling with versions of flex &gt;2.5.4, but
+       also added a #error if these are used, since they produce incompatible
+       parsers (a bug report has been filed, but no feedback was received).</li>
+<li>   Characters &gt;=128 are now written as &amp;#nnn; to the XML output.
+       (thanks to a patch by Michiel Ouwehand).</li>
+<li>   The table row backgroup color of the "all member" list was hard-coded
+       in the HTML output. This is now controlled by the stylesheet.</li>
+<li>   Fixed problem handling omission of the optional arguments of 
+       the \image command.</li>
+<li>   Enabling HIDE_IN_BODY_DOCS did not work properly if C++-style special
+       comments were used inside the body of a fucntion.</li>
+<li>   Fixed problem cross-referencing variables used as a
+       guard (i.e. if (var) ...) </li>
+<li>   Setting ENUM_VALUES_PER_LINE to 0 caused a division by 0 error.</li>
+<li>   Autolinking did not work for members that were grouped and imported
+       via tag files.</li>
+<li>   The divide symbol "/" did not appear in the output for array/define 
+       initializers</li>
+<li>   Fixed paring problem parsing "operator &lt;b&gt;new&lt;/b&gt;" 
+       in the documentation.</li>
+<li>   Fixed problem with resolving template relations (as reported by 
+       Kris Thielemans).</li>
+<li>   Members in the todo list were not shown correctly (with dot separators) 
+       if OPTIMIZE_OUTPUT_JAVA was set to YES.</li>
+<li>   Fixed problem handing "class A { public: A::f(); };" which is accepted
+       as valid C++ by a number of compilers.</li>
+<li>   Putting a /* inside a C-comment without matching */ caused the 
+       preprocessor to ignore the rest of the file.</li>
+<li>   Improved the way typedefs are resolved.</li>
+<li>   Fixed parse problem for the following PHP code: $color='#FFFFFF'</li>
+<li>   Using @dontinclude could cause broken LaTeX output.</li>
+<li>   Links to examples (using \example) were broken.</li>
+<li>   Class members appeared twice in the index of the latex output.</li>
+<li>   Fixed problem putting \if..\else..\endif around a pair of \defgroup's</li>
+</ul>
+
+<h1>Doxygen Release 1.3</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Increased internal buffer size from 16K to 256K for a number of 
+       scanners, so the "input buffer overflow, can't enlarge buffer because 
+       scanner uses REJECT" error should occur less easily.</li>
+<li>   Style commands like \e, \a or \c will now be terminated when
+       one of the characters in the following string is 
+       found: ".,()[]:;?", example: "a point (consisting of @a x and @a y)"</li>
+<li>   Setting OPTIMIZE_OUTPUT_JAVA to YES, will automatically set INLINE_INFO
+       to NO.</li>
+<li>   Quotes strings (like "\0" or "%H.%d.%Y") are now considered to be
+       words (hence the \ and % do not have to be escaped).</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added new configuration option USE_WINDOWS_ENCODING which can be
+       used to select windows specific character encodings for some languages.
+       (thanks to Piotr Kaminski).</li>
+<li>   Added new configuration option LATEX_HIDE_INDICES which can be
+       used to suppress the various indices that are normally generated in 
+       the LaTeX output (thanks to Ken Yarnall for the patch).</li>
+<li>   Added new option MAX_DOT_GRAPH_DEPTH to set the maximum distance
+       from a root node after which the class or include graph will be 
+       truncated. Setting this to a low value should considerably reduce the
+       time doxygen needs on large projects.</li>
+<li>   Included updates for French, Korean, Polish, Croatian, and 
+       Danish translations.</li>
+<li>   Access to title of user defined user defined sections is now
+       possible from the doxmlparser.</li>
+<li>   &lt;div&gt; and &lt;span&gt; commands can now by used in the 
+       documentation. Their effect is limited to the HTML output though 
+       (thanks to Frank Schimmel for the patch)</li>
+<li>   Added inline, virtual, explicit and mutable attributes to XML output
+       (thanks to patch by Michiel Ouwehand).</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed out-of-memory bug for files containing using directives and 
+       including themselves (indirectly).</li>
+<li>   Doxygen could crash if two \todo-like commands appeared on the
+       same line.</li>
+<li>   Non-inline cast operator was not properly parsed.</li>
+<li>   Fixed preprocessor problem with parsing /*//*/</li>
+<li>   URL's in the docs using &lt;a href=""&gt; caused a nested link. </li>
+<li>   "using namespace A::B;" confused the code parser.</li>
+<li>   Interface keyword was not recognised in C# (thanks to Onorio Catenacci
+       for the patch).</li>
+<li>   Line counting was incorrect when parsing multi-line formulas.</li>
+<li>   \section's in a \mainpage are now correctly numbered in the LaTeX
+       output (nesting level was one too deep).</li>
+<li>   \ref to lower case names did not work 
+       (thanks to Herman ten Brug for the patch)</li>
+<li>   escaped quotes (") were not preserved in the config file when it was
+       updated (thanks to Herman ten Brug for the patch).</li>
+<li>   PHP related fixes contributed by Vaclav Dvorak: 
+       <ul>
+       <li> #-style comment handling, </li>
+       <li> adds (problematic) support for define() constants, </li>
+       <li> adds ".phtml" as a supported file extension for PHP code 
+         (not very common, but still...), </li>
+       <li> fixes handling of code like "include 'file.inc';" (was parsed 
+         as a variable definition), </li>
+       <li> removes the variable insidePHPCode (was not needed), </li>
+       <li> fixes spaces in function argument lists (the '$' was the problem).</li>
+       </ul></li>
+<li>   Functions documented with \fn did not get transferred to declaration or
+       definition (depending on where the comment block was put).</li>
+<li>   If a function definition was documented and grouped the declaration 
+       was not even if the same documentation block was used for it. </li>
+<li>   Fixed bug in code parser that could crash doxygen under 
+       certain conditions.</li>
+<li>   Fixed some spacing problems in the LaTeX output 
+       (thanks to patches by Roberto Bagnara).</li>
+<li>   Mail address containing the '+' character were not properly parsed
+       (thanks to Jon Parise for the patch).</li>
+<li>   Fixed duplicate/wrong id's of grouped members in the XML output.</li>
+<li>   Docparser reported wrong error if unknown command was found inside
+       \c (or similar command).</li>
+<li>   Preprocessor got confused when parsing a special comment as
+       part of a #define and containing a ' or ".</li>
+<li>   subgroups defined with @defgroup could be reordered if 
+       @addtogroup was used.</li>
+<li>   Projects name was not shown as the root of the treeview anymore.</li>
+<li>   Links to pages imported via tag files were broken in the treeview
+       frame.</li>
+<li>   removed leading and trailing whitespace within a \code ... \endcode
+       block.</li>
+<li>   Constant class variables with constructor were parsed as functions.</li>
+<li>   Autolinks of the form class#member were not shown as class::member or
+       class.member in the documentation.</li>
+<li>   Fixed problem parsing things like echo('!$tar' . '"'); (PHP).</li>
+<li>   Fixed problem distinguishing f(__true_type) and f(__false_type)</li>
+<li>   Fixed lack of translation of some latin2 characters in the latex output
+       (thanks to Aleksander Kupiec for the patch).</li>
+<li>   Group members appeared in the treeview or html help index regardless
+       if they were documented.</li>
+<li>   The treeview page was not rendered with the right character set (it was
+       always English).</li>
+<li>   Explicit template instantations appeared as a variable in the output.</li>
+<li>   Java instance and static initializer blocks are now correctly parsed
+       and can be documented.</li>
+<li>   Fixed bug in the LATEX_HIDE_INDICES option.</li>
+<li>   Fixed bug parsing simple lists (last word or token could get repeated).</li>
+<li>   \section titles did not appear in the RTF output.</li>
+<li>   Tables were not correctly rendered in the RTF output.</li>
+<li>   Verbatim fragments were not properly rendered in the RTF output.</li>
+<li>   Fixed some cases where collaboration relations were not visible due
+       to typedefs.</li>
+<li>   Fixed some compiler warnings that occurred with more recent versions 
+       of gcc.</li>
+<li>   Auto-links to files were shown with as file::c instead of file.c. </li>
+<li>   @ref namespace::class was not parsed correctly.</li>
+<li>   Undocumented enums could appear in the declaration part of the output
+       even though HIDE_UNDOC_MEMBERS was set to YES.</li>
+<li>   \anchor tags now appear in the tagfiles as &lt;docanchor&gt; again.</li>
+<li>   Hyperlinks in the LaTeX were broken in some cases.</li>
+<li>   Fixed case where a global variable was not linked from within a function
+       body.</li>
+<li>   Include dependencies graph was shown at the place where the 
+       "included by" graph should have appeared.</li>
+<li>   A // comment following by a //! comment was not handled properly by
+       the source browser.</li>
+<li>   If the definition of nested class was found before the definition of the
+       outer class, its name was displayed without scope.</li>
+<li>   If a parameter of a prototype was documented (with a separate
+       documentation block) and the name of the parameter in the definition 
+       was different, the wrong name could be shown in the documentation.</li>
+<li>   Fixed bug handling \line, \skipline, and \until</li>
+</ul>
+<h1>Doxygen Release 1.3-rc3</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Rewrote the implementation of the tree view feature 
+       (see GENERATE_TREEVIEW). The new implementation should be much faster,
+       but does require a browser that supports JavaScript, DHTML, and CSS.
+       Please report any problems you find.</li>
+<li>   Changed the way dot is launched under Linux/Unix (vfork i.s.o. fork)
+       so less memory is required (thanks to a patch by Thorsten Behrens).</li>
+<li>   Changed "Methods" to "Member Functions" in the output (thanks to patch
+       by Tom Emerson).</li>
+<li>   STRIP_FROM_PATH now ignores the exact casing of characters, which
+       makes things simpler on Windows.</li>
+<li>   Style modifiers such as &lt;b&gt;, &lt;em&gt; and &lt;pre&gt; are now 
+       capable of spanning multiple paragraphs.</li>
+<li>   Made some improvements to the documentation, including a diagram
+       showing the information flow between the doxygen and various other 
+       tools (see the getting started section).</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for comment blocks generated by 
+       Rational Rose's ANSI C++ code generator (thanks to a patch by 
+       Martin Beaudoin).</li>
+<li>   Included language update for the Serbian and Japanese.</li>
+<li>   Included patch by Ryunosuke Satoh to reduce size of the executable when
+       building for Cygwin.</li>
+<li>   Tables in the docs were ended with a bogus row in the LaTeX output.</li>
+<li>   A \link to a member variable that is grouped using \defgroup can
+       now be done from another member without specifying the full scope.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   @addindex now works on the whole line instead of a single word (as
+       was already suggested in the docs).</li>
+<li>   source code line in the XML output didn't escape special characters 
+       like &amp; anymore.</li>
+<li>   Fixed small bug in german translation (thanks to Jens Seidel).</li>
+<li>   e-mail addresses with multiple dots got truncated when linked.</li>
+<li>   Attributes of html commands with value "" where not properly parsed
+       causing the image in the legend page not to appear.</li>
+<li>   Fixed excessive memory usage in the "Building member list" phase while
+       using todo/test/bug items (thanks to Gerik Rhoden).</li>
+<li>   Fixed parsing problem in PHP. Doxygen was expecting classes to end with
+       a semicolon (thanks to Jaime Uriel Torres for the patch).</li>
+<li>   Using &lt;dt&gt; with also adding a &lt;dd&gt; caused a parse error while it is
+       legal HTML.</li>
+<li>   The identifier "package" in C/C++ code was wrongly interpreted as 
+       a Java keyword.</li>
+<li>   \todo item at the end of a comment block caused "unexpected character"
+       error while generating the XML output.</li>
+<li>   \ref did not work when the argument was a file name.</li>
+<li>   \ref and \link are now allowed inside a &lt;td&gt;..&lt;/td&gt; section.</li>
+<li>   Argument matching routine was not able to distinguish between
+       f(long n) and f(long long n).</li>
+<li>   Classes were listed in the alphabetical index with full scope.</li>
+<li>   \copydoc did not work recursively for members.</li>
+<li>   Fixed a number of small memory leaks (I used ccmalloc to detect them).</li>
+<li>   The HTML command &lt;SUP&gt; was not parsed correctly if it was prefixed
+       with an identifier (i.e. blah&lt;SUP&gt;).</li>
+<li>   HTML tags were not properly parsed if there was a linebreak after
+       the tag name.</li>
+<li>   The \~id command was not working properly. The section was always
+       generated regardless of the OUTPUT_LANGUAGE setting.</li>
+<li>   id attribute was missing from the sect tag in the XML output.</li>
+<li>   Links to files or file members could be wrong if SHORT_NAMES was set
+       to YES and the file was imported via a tag file.</li>
+<li>   Attribute lists inside an enum in an IDL file were not properly parsed.</li>
+<li>   Fixed problem in code browser that prevented linking to global 
+       variables defined in other files.</li>
+<li>   When putting a "using namespace X" in a header file doxygen did not
+       recognise this in files that included the header file.</li>
+<li>   Fixed bug in parsing sections without title.</li>
+<li>   doxytag did not include anchor in the search index. Thanks to 
+       Joerg Schlichenmaier for the fix.</li>
+<li>   Using an auto-list as an argument of @todo and friends did not work.</li>
+<li>   A class with all members in a section grouped could result in broken
+       LaTeX output (empty CompactItemize list).</li>
+</ul>
+<h1>Doxygen Release 1.3-rc2</h1>
+<h3>New features</h3>
+<ul>
+<li>   Added support for importing members via using declarations.</li>
+<li>   Anchors and sections (and references to them) are now supported in 
+       all comment blocks, not just \page blocks.</li>
+<li>   Dot files imported via @dotfile now produce images maps in the
+       HTML output. Use the URL node attribute in the dot file to make a link
+       (thanks to Marco Dalla Gasperina for the patch).</li>
+<li>   New config option WARN_IF_DOC_ERROR which allows documentation problems
+       to be shown, while other warnings (such as warnings about 
+       undocumented members) can be hidden (thanks to Miguel for the patch).</li>
+<li>   Included language update for German and Italian.</li>
+<li>   Added support for &amp;tm; (trademark) and &amp;reg; (registered). </li>
+<li>   Added "static" attribute to methods in the XML output to ease parsing.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   A &lt;pre&gt; .. &lt;/pre&gt; section with included blank lines 
+       causes warning about missing &lt;/pre&gt; marker.</li>
+<li>   "typedef enum { a };" confused doxygen's parser, while most compilers
+       seem to accept it without warnings.</li>
+<li>   \deprecated item alone in a comment block caused a crash.</li>
+<li>   Putting @todo (and similar commands) inside a function body
+       did not result in correct cross-references with the todo list.</li>
+<li>   Java interfaces were not detected as such.</li>
+<li>   Fixed some localization problems in the XML output.</li>
+<li>   Fixed problem handling multiple \par commands (headings were wrong).</li>
+<li>   Fixed array out of bounds assert that was triggered while parsing.</li>
+<li>   Links to pages were not properly resolved in hyperlinked PDF.</li>
+<li>   Using a \name command without //@{ .. //@} scoping could cause
+       a segmentation fault. </li>
+<li>   Including images with @dotfile caused problems in the LaTeX output.</li>
+<li>   Local variables and parameters now properly hide globals with the
+       same name in the source browser, reducing wrong references.</li>
+<li>   Verbatim blocks in the documentation could break the RTF output.</li>
+<li>   RCS/CVS tags did not appear in the output.</li>
+<li>   @note section result in section with type "bug" in the XML output.</li>
+<li>   Dot graphs were truncated too quickly in some cases.</li>
+<li>   Files with a .php4 extension are now recognised as PHP files.</li>
+<li>   Source browser could get out of sync causing wrong cross references.</li>
+<li>   Text after @} could end up in another documentation block.</li>
+<li>   Putting a style command such as \c or \b at the end of a line, before
+       a auto list item, caused the list item to be ignored.</li>
+<li>   Autolinks to files did not work anymore.</li>
+<li>   @copydoc of a target without documentation could cause a crash.</li>
+</ul>
+<h1>Doxygen Release 1.3-rc1</h1>
+<h3>Changes</h3>
+<ul>
+<li>   New validating parser for documentation blocks that replaces the 
+       old parser (which was actually only a lexical scanner).</li>
+<li>   The new documentation parser will now pass attributes of html tags
+       to the html output. Example:
+       <pre>
+       /*! \mainpage A Dutch Table
+        * &lt;table bgcolor="black" border="0" cellspacing="2" 
+        *        cellpadding="2" align="center"&gt;
+        * &lt;tr&gt;&lt;td bgcolor="red"&gt;red
+        * &lt;tr&gt;&lt;td bgcolor="white"&gt;white
+        * &lt;tr&gt;&lt;td bgcolor="blue"&gt;blue
+        * &lt;/table&gt;
+        */
+       </pre></li>
+<li>   Doxywizard will now run doxygen from the directory where the
+       config file is found, so paths can be made relative 
+       in the config file. This will now also work if the config file's
+       path or name contains spaces.</li>
+<li>   Doxygen style comment blocks found in the body of functions are
+       now appended to the function's documentation block.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added rudimentary support for C#. Parsing should work,
+       but not all attributes are handled correctly.</li>
+<li>   Included perl module generator by Miguel Lobo. Setting
+       GENERATE_PERLMOD to YES in the config file will produce 
+       a perl module in the output dir.</li>
+<li>   Included language updates for French, Czech, and Russian.</li>
+<li>   Included a number of enhancements to the xml parser (thanks to 
+       a patch by Tree).</li>
+<li>   Locally documentated parameters now appear in the XML output
+       (thanks to Cormac Twomey for the patch). </li>
+<li>   The preprocessor now inserts line control commands where appropriate.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Aliased \if .. \endif commands around a \brief section were not handled
+       properly.</li>
+<li>   Warnings for undocumentation members were not generated anymore
+       in certain cases.</li>
+<li>   A member of a group linked with \ref showed the group's title 
+       as link text instead of the member's name.</li>
+<li>   Using aliased commands whose definition contained \n's caused the
+       code browser to put definition links at the wrong line numbers.</li>
+<li>   Todo items inside related pages appeared in tag files, causing warnings
+       about duplicated labels.</li>
+<li>   Included a patch by Ryunosuke Satoh that fixes some issues when
+       compiling in a cygwin environment.</li>
+<li>   The presence of using declarations could result bogus entries in the 
+       class hierarchy.</li>
+<li>   Links in the hyperlinked sources could point to the wrong global 
+       function depending on the order in which files were parsed.</li>
+<li>   Using \retval in combination with parameters that are documented 
+       on the spot, caused bogus warnings about undocumented parameters.</li>
+<li>   id attributes of references/referencedby relations are wrong in 
+       the XML output.</li>
+<li>   Links could wrongly point to a class in an outer scope instead of a 
+       typedef with the same name in the inner scope.</li>
+<li>   A reference in the code to a member of a derived class that is defined 
+       in a base class is now resolved properly even if both classes are 
+       imported via tag files.</li>
+<li>   Language codes were wrong in the html help output for some languages
+       (thanks to Erwin Hoffmann for the patch).</li>
+<li>   Fixed case where function was detected as a variable.</li>
+<li>   if HIDE_UNDOC_CLASSES is set YES, doxygen will not complain about
+       undocumented classes.</li>
+<li>   Included RTF output fixes by Gorden Machel.</li>
+<li>   Global variables of complex types were not properly cross-referenced.</li>
+<li>   Fixed argument matching bug for nested template classes;
+       matching <code>"f(A::B&lt;T&gt;::C c)"</code> with 
+       <code>"f(C c)"</code> within context <code>A::B&lt;T&gt;</code></li>
+<li>   Fixed preprocessor bug handling nested comment blocks 
+       (the */ of the inner block was eaten).</li>
+</ul>
+<p>
+\endhtmlonly
+\section log_1_2 1.2 Series
+\htmlonly
+</p>
+<h1>Doxygen Release 1.2.18</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Running doxygen with the "-d Validate" option will activate a
+       new documentation parser. The parser will produce output for 
+       Html, Latex, XML and RTF output (man page output still needs to be done). 
+       For XML output this new parser will <em>always</em> be used.
+       Please try it and let me know if you see unexpected errors or 
+       invalid output. This parser will replace the old one in the
+       next release.
+       <p>
+       The main advantages of the new parser are that it actually checks the
+       syntax of the documentation blocks and will produce valid output
+       by design. </p>
+       <p>
+       For debugging purposes, adding "-d PrintTree" along 
+       with "-d Validate" will let doxygen dump the abstract syntax tree of 
+       each documentation block to the output in a pretty printed way 
+       (this reflects the structure built-up by the parser).</p> </li>
+<li>   A number of new XML tags are introduced along with the new parser,
+       these include: umlaut, acute, grave, circ, tilde, szlig, cedil, ring
+       nonbreakablespace, toclist, tocitem, xrefsect, xrefdescription, 
+       and xreftitle.</li>
+<li>   Changed the way code fragments are represented in XML to simplify
+       validation.</li>
+<li>   Changed the way \page, \section, and \subsection are handled in LaTeX
+       (and RTF).
+       <ul>
+       <li>
+       \page now results in a section in latex (of the related pages chapter)</li>
+       <li>
+       \section is now a subsection within that page section (used to be a 
+                section, so at the same level as \page)</li>
+       <li>
+       \subsection is now a subsubsection within a subsection (used to be a
+                subsection).</li>
+       </ul></li>
+<li>   Included a number of patches by Kristian Ede:
+       <ul>
+       <li> Undocumented private friend classes no longer cause warnings</li>
+       <li> Undocumented private classes no longer cause warnings</li>
+       <li> Undocumented members are now hidden if they are 
+            default constuctors, destructors or reimplemented.</li>
+       </ul></li>
+<li>   Pages introduced via \page are now context aware. This means that
+       if you put them inside a class or namespace, names do not have
+       to be prefixed with a full scope to create a link in the documentation.</li>
+<li>   Boolean values in doxywizard can no longer be toggled by clicking
+       anywhere on the line on which they appear, but only by clicking on
+       the name or checkbox.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   @deprecated is now treated as @todo, @test, and @bug, which means
+       that a list of all deprecated items is generated.
+       Thanks to Angela Marshall for the patch.</li>
+<li>   Enum value documentation was added to the XML output.</li>
+<li>   Files ending with ".inc" are now recognised as PHP files
+       (thanks to Marcus Ahlfors).</li>
+<li>   Included updated documentation for language translators 
+       (thanks to Petr Prikryl).</li>
+<li>   Included language updates for Czech, Slovak, Brazillan, Croatian,
+       Portuguese, Russian, Polish, Japanese and Serbian. 
+       Include language support for Catalan (thanks to Albert Mora)</li>
+<li>   Included .dsp update by Simon Goodwin (already needs to be updated 
+       again :-( )</li>
+<li>   Added new configuration options XML_DTD and XML_SCHEMA to set the
+       DTD or Schema used in the XML output.</li>
+<li>   Include new commands \subsubsection and \paragraph which add two
+       section level below \section and \subsection (thanks to 
+       Dirk Reiners for the patch) </li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed lock-up bug in RTF output when using tables.</li>
+<li>   The internal comment conversion routine was confused by lines of the 
+       form //*************</li>
+<li>   Fixed recursive lockup for template arguments of the form
+       "typename A = ::A"</li>
+<li>   Description part of @name did not (always) appear in the resulting
+       documentation.</li>
+<li>   Alphabetic index showed package scope using "::" even when
+       OPTIMIZE_OUTPUT_JAVA was set to YES. The same happened for class and 
+       namespace HTML page titles.</li>
+<li>   New versions of dot (graphviz &gt;=1.8.8) broke clickable images
+       for versions of doxygen &lt;=1.2.17. Now fixed for newer doxygen 
+       releases in a backwards compatible way thanks to a patch by John Ellson.</li>
+<li>   Fixed compile problem for 64 bit machines (pointer to int cast).</li>
+<li>   Included patch to build Doxygen 1.2.17 on AIX 4.3 by Russ Allbery</li>
+<li>   \if ... \else ... \endif blocks now also work in //!&lt; style comments.</li>
+<li>   Fixed a couple of memory leaks in the code parser.</li>
+<li>   Fixed case where member function was put in the member variable
+       section (thanks to Mahadevan R)</li>
+<li>   Fixed bug causing link targets not to appear in the output.</li>
+<li>   Setting BRIEF_MEMBER_DESC set to NO for a member that did not have
+       a detailed description while setting ALWAYS_DETAILED to YES caused the
+       documentation not to appear in the output at all.</li>
+<li>   Fixed todo list linking problems for hyperlinked pdf output and
+       grouped pages.</li>
+<li>   Putting a function declaration and its definition in the same group 
+       could lead to wrong links using @ref.</li>
+<li>   Undocumented but grouped members did not appear in the output.</li>
+<li>   The declaration and definition of overloaded global functions
+       was not always properly matched, causing functions not to appear
+       in the documentation.</li>
+<li>   Nested C-comments were confusing the preprocessor, causing it to
+       incorrectly skip comment blocks.</li>
+<li>   An empty line was not always being recognized as a paragraph break
+       (thanks to Stephen Pope for the fix).</li>
+<li>   An aliased \endif in a skipped section was not handled properly. </li>
+</ul>
+<h1>Doxygen Release 1.2.17</h1>
+<h3>Changes</h3>
+<ul>
+<li>   XML: The index of the XML output now has @refid instead of @id's, 
+       and includes a "kind" attribute for the compounds and members for easier
+       filtering.</li>
+<li>   Improved dot image generation speed for large projects by changing 
+       the way the best-fitting graph is computed (thanks to Philip Bergen
+       for the suggestion).</li>
+<li>   @name now automatically starts a member group section (previously
+       a @{ command was needed). The member group continues until a new @name 
+       command is found or until the end of a compound is reached. @{ ... @} 
+       commands can still be used for backward compatibility or to end a member 
+       group before the end of a compound. @defgroup and friends still require 
+       explicit @{ ... @} blocks.</li>
+<li>   Changed the way \todo, \bug, and \test are handled internally.
+       This should have no visible effect on the outside, but makes it much
+       easier to add similar commands and also saves a bit of memory on average.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added initial support for parsing PHP code (thanks to a patch by 
+       Jan Borsodi). For a PHP file the following additional commands are 
+       available:
+       <dl>
+       <dt>\private          </dt><dd> makes the current item private</dd>
+       <dt>\protected        </dt><dd> makes the current item protected</dd>
+       <dt>\public           </dt><dd> makes the current item public</dd>
+       <dt>\privatesection   </dt><dd> changes to private section(same as private: in C++)</dd>
+       <dt>\protectedsection </dt><dd> changes to protected section(same as protected: in C++)</dd>
+       <dt>\publicsection    </dt><dd> changes to public section(same as public: in C++)</dd>
+       <dt>\static           </dt><dd> changes the current item to static</dd>
+       <dt>\pure             </dt><dd> changes the current item to pure virtual</dd>
+       </dl></li>
+<li>   New command @copydoc that can be used to copy a documentation block
+       of some item and paste it in another documentation block.</li>
+<li>   i18n: Added support for the Serbian language (thanks to Dejan Milosavljevic).
+       Included a new language option Japanese-en for combined Japanese 
+       and english.</li>
+<li>   Included patch for dealing with variable argument macros in @param 
+       (thanks to Alfred Heggestad).</li>
+<li>   Added new option MULTILINE_CPP_IS_BRIEF to make doxygen treat
+       a multi-line brief comment block as a brief description. Set this to
+       YES to obtain the behaviour of version 1.2.15 and earlier. Default as
+       of version 1.2.16 is to treat multi-line C++ comment block as a 
+       detailed description.</li>
+<li>   New option CHM_FILE to set the .chm file (and path) to use for
+       Html Help output.</li>
+<li>   New option HHC_LOCATION to set the location of the Html Help compiler.
+       If given doxygen will automatically run the compiler to create the
+       .chm file.</li>
+<li>   Included .dsp &amp; .dsw files to build doxygen from DevStudio in the
+       wintools dir. Thanks to Simon Goodwin for providing these.</li>
+<li>   Included new command $year that can be use in header and footer
+       files to produce the current year (thanks to Michael Beck for the patch).</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed lock-up bug when writing RTF output with verbatim sections.</li>
+<li>   The tree view showed entries in C++ style even if OPTIMIZE_OUTPUT_JAVA
+       was set to YES.</li>
+<li>   Documentation blocks for function arguments in a documented header
+       file did not show up if the function definition was parsed first.</li>
+<li>   Inheritance relations in Java where not always correctly resolved if 
+       the base class was explicitly scoped.</li>
+<li>   Fixed some non-standard conformance issues in the HTML output (thanks to
+       John Levon for the patch).</li>
+<li>   Usage relations for variables whose type was a qualified typedef were
+       not properly resolved.</li>
+<li>   Fixed potential crash bug (null-pointer dereference) in source browser 
+       parser.</li>
+<li>   Comment blocks ending with an empty /// comment line were not 
+       properly handled by the comment conversion code.</li>
+<li>   @relates is no longer needed for a friend function documented in 
+       the source file (thanks to Johan Eriksson for the fix).</li>
+<li>   Doxygen could link include files to non-existing source files, if they
+       pointed to external files but were also found in the include path.</li>
+<li>   "make install_docs" was broken.</li>
+<li>   Fixed parse bug for conversion operators of the form "operator ::X*()"</li>
+<li>   XML output fixes: 
+       <ul>
+       <li> derivedcompoundref was not terminated properly. </li>
+       <li> innerpage and innergroup were closed twice.</li>
+       <li> Removed auto-generated section titles from the detailed descriptions
+            in the XML output.</li>
+       <li> para tags in simple section in the XML output were not properly matched</li>
+       </ul></li>
+<li>   PDF output fixes: 
+       <ul>
+       <li> Fixed pdflatex reruns in the Makefile when USE_PDFLATEX was YES. It
+         should now run the proper amount of times (thanks to Simon Goodwin
+         for the fix).</li>
+       <li> Links to items in the bug list were broken for the PDF output.</li>
+       <li> Fixed bug in PDF output that resulted in links to non-existing 
+         source pages.</li>
+       <li> Fixed bug in URL parsing that caused invalid PDF output for the 
+         doxygen manual.</li>
+       <li> Doxygen logo did not appear in the PDF manual.</li>
+       </ul></li>
+<li>   RTF output fixes/improvements by Janet Swisher, 
+       Gordon Machel &amp; Martin Vuille: 
+       <ul>
+       <li> Included fix for loading RTF style-sheets</li>
+       <li> reference list and title were merged</li>
+       <li> First word of company name was lost.</li>
+       <li> Main page title was not substituted.</li>
+       <li> There were two pages numbered "i" in the document.</li>
+       <li> Added a heading to the table of contents page.</li>
+       <li> Depending on the order in which things are
+         documented, there were extra, empty paragraphs
+         thrown in.</li>
+       <li> Added a number of debugging comments
+         and changed some existing ones to make it easier
+         to relate the comment in the RTF to the name of
+         the method that generates it.</li>
+       </ul></li>
+<li>   operator|() caused invalid entries in the latex index.</li>
+<li>   Fixed bug parsing URLs with curly braces in documentation blocks.</li>
+<li>   Html help output now uses the correct language code if non english
+       language is selected.</li>
+<li>   Fixed bug in generate makefile for latex output (thanks to Petr 
+       Prikryl)</li>
+<li>   Fixed source browser bug: a comment just before a function body 
+       confused the parser.</li>
+<li>   Fixed problem handling function typedefs.</li>
+<li>   \endif appeared in output when used via ALIASES in a brief description.</li>
+<li>   Included heuristic to distiguish between a variable definition 
+       with initialization via a constructor and a function prototype 
+       (e.g. "Test var(initVal);", v.s. "Test func(SomeType);").</li>
+<li>   Fixed lock-up problem when to @brief were put after each other in a
+       comment block.</li>
+<li>   Images for include dependency graphs were unclickable.</li>
+<li>   Members in source fragments and examples were not linked to their
+       member group documentation if available.</li>
+<li>   For initializers of the form ' ', the space was removed in the output. </li>
+<li>   \dotfile generated files did not get generated correctly because dot 
+       could not find the specified font.</li>
+<li>   Third argument of \class did not always work.</li>
+<li>   The pattern argument for the @skip, @skipline, @until and @line commands
+       now extents until the end of the line (as suggested by the documentation) 
+       instead of just the first word.  </li>
+</ul>
+
+<h1>Doxygen Release 1.2.16</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Verbatim and preformatted sections 
+       are now represented with a new "preformatted" tag in the XML output.</li>
+<li>   The HIDE_UNDOC_RELATIONS option is no longer depending on
+       HAVE_DOT being set to YES.</li>
+<li>   A dot is only added after a brief description if it starts
+       with a capital (thanks to Ondrej Jombik for the patch).</li>
+<li>   Doxygen now treats blocks of C++ comments such as
+       //! Detailed
+       //! Description
+       as a detailed description
+       (such blocks used to be treated as brief descriptions!). 
+       A single line C++ comments still represents a brief description,
+       for multiline brief description an explicit @brief can be used.
+       See the updated documentation for more examples.</li>
+<li>   XML: Added class name to inheritance relations that are written to the 
+       XML output.</li>
+<li>   Images included with \dotfile are now centered in the latex output
+       (thanks to Nils Strom for the patch).</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Included language update for Slovene.</li>
+<li>   CGI_URL now allows URLs that start with cgi: (for KDE KIO slave support)</li>
+<li>   Made include dependency graphs available from the XML parser API.</li>
+<li>   Added patch to support multi-byte RTF output (thanks to Sato Ryunosuke)</li>
+<li>   Gary Lee added language support for Chinese-Traditional. </li>
+<li>   Thanks to a patch by Loïc the RTF output now supports (non-nested) 
+       tables.</li>
+<li>   Added compilation support for cygwin (win32-g++ target). 
+       Thanks to Ryunosuke Sato for the patch.</li>
+<li>   Added new option DETAILS_AT_TOP to put the detailed documentation
+       at the top of a documentation page where normally only the brief
+       descriptions would be shown (based on a patch by Elliott Hughes).</li>
+<li>   XML: Added member template parameters to the XML output.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Improved portability of the png code: updated zlib to version 1.1.4, 
+       replaced K&amp;R style code by ansi code, fixed compile problem with 
+       pngenc.cpp on some platforms.</li>
+<li>   Fixed recursive lock-up problem that could occur for certain cases
+       in which recursive template inheritance was used.</li>
+<li>   The cross-package inheritance relations were broken for Java code.
+       I fixed this by treating Java import statement as C++ using statements.
+       Please report any problems that remain.</li>
+<li>   Alias commands put in separate parameter documentation blocks 
+       were not resolved.</li>
+<li>   The documentation for arguments, documented with a seperate 
+       documentation block, was not consistently shown in source and header 
+       files, depending on the order of the input files. </li>
+<li>   The characters '(', ')', '$', ''', and ';' were not recognised 
+       as part of an URL.</li>
+<li>   Grouped enum values could not share the same documentation block
+       even when DISTRIBUTE_GROUP_DOC is YES. </li>
+<li>   The end caption tag was missing a closing &gt; in the XML output.</li>
+<li>   Fixed bug with table captions in XML output.</li>
+<li>   Removed warning when documenting include guard-like defines.  </li>
+<li>   The \package command was broken. Fixed cases where :: appeared in
+       the output when OPTIMIZE_OUTPUT_JAVA was set to YES.</li>
+<li>   Fixed scoping problem using \class for documenting nested classes inside 
+       template classes.</li>
+<li>   Fixed invalid output bug when putting "-" items inside @arg or @li 
+       lists.</li>
+<li>   Fixed problem referencing functions using {@link ... } with explicit
+       argument lists.</li>
+<li>   Fixed bug when parsing "typedef struct{}TypeName;" (i.e. without
+       a space before the struct).</li>
+<li>   Fixed argument matching bug for global functions having undocumented
+       classes, imported via using declarations, as their parameter type.</li>
+<li>   Fixed bug in conditional section handling for cases like:
+       @if guard text @else more text @endif</li>
+<li>   The html help files did not honour the HTML_FILE_EXTENSION settings.</li>
+<li>   Removed bogus warning when using @param for function-type 
+       parameters.</li>
+<li>   Include statements in the source browser output now link to the 
+       right include file in case of ambiguities. </li>
+<li>   The include lines in the file documentation didn't link to files that
+       were imported from tag files. </li>
+<li>   The include dependency graph did not show include files if they
+       were directly or indirectly imported from tag files. Existing tag
+       files need to be regenerated to make use of this.</li>
+<li>   XML: The refid of members in listofallmembers section in the XML output 
+       was wrong. The ulink tag did not end properly in the XML output.
+       The Value of ambiguityscope in the XML output was not properly escaped.
+       LaTeX page reference texts appeared in the XML output.</li>
+<li>   Included language update for Brazilian.</li>
+<li>   Doxygen now treats "const int *" and "int const *" (i.e. with
+       reordered const) as equivalent types.</li>
+<li>   The preprocessor now avoids recursive includes, which helps
+       to parse files that do not have proper #ifndef-#define .. #endif guards.</li>
+<li>   Matching arguments with types "unsigned long int" and 
+       "unsigned long int blah" removed argument name. 
+       Same for "int" and "const int blah".</li>
+<li>   Fixed LaTeX output bug that occurs when using \dotfile in combination 
+       with USE_PDFLATEX = YES (thanks to Nils Strom for the patch).</li>
+<li>   Links to static functions in the documentation, now point to the
+       local file in case of ambiguities.</li>
+<li>   Comments of the form /*/**/ confused the source browser.</li>
+<li>   Fixed bug parsing "class C : public ::C {};" inside a namespace.</li>
+<li>   Fixed bug in tag file reader when parsing includes.</li>
+<li>   The include dependencies were wrong if an include file name was part of
+       the input but the #include specifically asked for another file 
+       not part of the input but with the same name.</li>
+</ul>
+<h1>Doxygen Release 1.2.15</h1>
+<h3>Changes</h3>
+<ul>
+<li>   On request of Richard Stallman and others I replaced all 
+       generated GIF images with PNG images. 
+       See <a href="http://www.burnallgifs.org">http://www.burnallgifs.org</a> 
+       for the motivation.</li>
+<li>   The Documentation of function definitions and declarations are now 
+       always merged. References/Referenced by relations are now equal 
+       for function declarations and definitions.</li>
+<li>   When @retval commands are used to document parameters, doxygen will
+       no longer produce a warning message for that parameter. @retval can
+       still be used to document non parameters such as the return values
+       of a function.</li>
+<li>   <pre>#define A(x) x /**&lt; a define */</pre>  
+       will document a define, while
+       <pre>#define A(x) /** an argument */ x</pre>
+       will document the argument of the define</li>
+<li>   Links in the documentation to const/volatile members are now 
+       possible by explicitly specifying "f() const" or "f() volatile"
+       in case a non-const/volatile "f()" also exists.</li>
+<li>   Doxygen now warns about undocumented compounds (thanks to Itai Frenkel
+       for the patch).</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Included language update for Russian and Romanian translations.</li>
+<li>   EPS images included with "\image latex" are automatically converted 
+       to pdf's when USE_PDFLATEX is set to YES.</li>
+<li>   Added two new commands: LATEX_CMD_NAME and MAKEINDEX_CMD_NAME to 
+       set the name of the latex and makeindex tools to be used for latex
+       output (thanks to Konno Akihisa for the patch).</li>
+<li>   Improved support for Java. Packages are now treated like
+       C++ namespaces and there is a new option OPTIMIZE_OUTPUT_JAVA 
+       that, when enabled, provides more Java-oriented output. Please
+       report any Java-related problems that remain.</li>
+<li>   Extended XML parser API (see addon/doxmlparser/include/doxmlintf.h)
+       with full access to documentation blocks. 
+       Made inheritance/collaboration diagrams accessible via the
+       XML parser API (see addon/doxmlparser/include/doxmlintf.h).
+       Reorganised the internals of the XML parser so the API does
+       not require destructors. Made the parser more portable (it should
+       compile with gcc and M$ visual C++ now).</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Using "@param x,y,z" resulted bogus warnings about undocumented 
+       parameters.</li>
+<li>   "doxygen -w latex header.tex doxygen.sty Doxyfile" caused a segmentation
+       fault (thanks to Aric Cyr for the patch).</li>
+<li>   Fixed argument matching problem that occurred in some rare cases 
+       that involved "using" of namespaces.</li>
+<li>   Using /**&lt; Brief.\ more brief. Details. */ with ENABLE_JAVADOC = YES,
+       now removes the slash just like it did with /**...*/ style comments. </li>
+<li>   Using an ordered, html-style list inside a @param command
+       resulted in invalid output if list item contained blank lines.</li>
+<li>   STRIP_FROM_PATH now also works with Windows style paths 
+       (e.g. C:\MyPath\)</li>
+<li>   A module can now appear more than once in the module tree
+       (thanks to Itai Frenkel for the patch).</li>
+<li>   In some cases the tree view showed leaf elements as non-leafs. </li>
+<li>   Fixed a number of cases where illegal characters could end up in 
+       the XML output.</li>
+<li>   If a function in a base class was (re)implemented by serveral classes
+       only one of them appeared in the "(re)implemented in" list. </li>
+<li>   graph_legend.gif was hardcoded in translator_*.h files. 
+       Note to translators: this has affected all translator files, so please
+       update your local translator file!</li>
+<li>   In some cases a grouped member within a namespace did not appear
+       in the group's documentation.</li>
+<li>   Namespace members were not properly cross-referenced with in the
+       source browser output.</li>
+<li>   Using directives inside anonymous namespaces had no effect.</li>
+<li>   Fixed bug in the preprocessor when parsing '"' as the argument to
+       a function macro.</li>
+<li>   The argument of commands like \c did not produce a link to 
+       external documentation if possible, while links to local 
+       documentation were generated.</li>
+</ul>
+
+<h1>Doxygen Release 1.2.14</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Split up the XML output into an index (index.xml) and one page per
+       compound. This allows for faster processing and less memory consumption,
+       when using DOM style parsers.</li>
+<li>   Include files are now shown in the class documentation if 
+       and only if SHOW_INCLUDE_FILES is YES. </li>
+<li>   Doxygen-style C comments inside macro definitions are now preserved 
+       in the output. Example: 
+       <pre>
+         #define INIT(x) /*! Initializes x. */ void Init() { x = 0; }
+       </pre></li>
+<li>   When deriving from pure virtual members or IDL interfaces, doxygen will
+       now put an "implements/implemented in" list in the documentation instead
+       of "reimplements/reimplemented by".</li>
+<li>   Doxygen now filters out duplicate input files.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added a very simple metrics utility 
+       (see addon/doxmlparser/examples/metrics) which can compute some 
+       figures based on the XML output generated by doxygen.</li>
+<li>   Added autodetection for Darwin (MacOSX) to the configure script.</li>
+<li>   Added option EXCLUDE_SYMLINKS.
+       The EXCLUDE_SYMLINKS tag can be used to select whether or not files or 
+       directories that are symbolic links (a Unix filesystem feature) are 
+       excluded. </li>
+<li>   Added option EXTERNAL_GROUPS. 
+       If the EXTERNAL_GROUPS tag is set to YES all external groups 
+       will be listed in the modules index. If set to NO, only the 
+       current project's groups will be listed. (thanks to Darren Oldag
+       for the patch).</li>
+<li>   Included update for translator.pl (thanks to Petr Prikryl)</li>
+<li>   updated .spec file (thanks to Emilio Riva).</li>
+<li>   Included patch by Jochen Hanff to make the index headings configurable 
+       via style-sheets.</li>
+<li>   If a comment block contains at least one @param command, doxygen now 
+       produces warnings if not all parameters of a function are documented or
+       if the names of the parameters do not match the argumentlist.  
+       (Please report any false alarms).</li>
+<li>   Added new command \~language_id to create sections that 
+       are outputted for the language &gt;language_id&gt; only:
+       Example: 
+       <pre>
+       /** \~czech Cesky komentar \~english English comment text \~dutch 
+            Nederlands commentaar \~ Common comment for all languages, 
+            this tag switches off the language filter...
+       */
+       </pre>
+       Which of the language specific fragments is outputed depends
+       on the setting of OUTPUT_LANGUAGE (Thanks to Milan Rusek for the patch).</li>
+<li>   Added build support for Cygwin (thanks to Ryunosuke Sato).        </li>
+<li>   Added new option HTML_FILE_EXTENSION to allow different file extension
+       for the html file outputted by doxygen (like .php). Thanks to 
+       Rob Olsthoorn for the patch.</li>
+<li>   Added option DOT_IMAGE_FORMAT that can be used to set the image
+       format of images generated by dot (possible formats: gif, png, jpg).</li>
+<li>   In the documentation of class, namespace, file and group items a 
+       list of groups to which the item belongs is put between brackets ([..])
+       under the title (HTML only).</li>
+<li>   Added "list of all members" and template parameter lists for 
+       classes to the XML output.</li>
+<li>   Included language updates for Chinese, Czech, French, Italian, 
+       Brazilian, Japanese, Russian and German.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   The start of a comment (/*) embedded in a page or example block 
+       caused parse problems.</li>
+<li>   operator%= member caused latex error when in pdf hyperlink mode.</li>
+<li>   fixed parse problem for global function typedefs like "typedef int f()"</li>
+<li>   Qt slots weren't included in the reference/referenced by relations 
+       (thanks to Gordon Machel for the patch).</li>
+<li>   Fixed parse problem that occurred when the &lt;SUP&gt; tag was used in
+       a brief description. </li>
+<li>   Private members sometimes showed up in the all member list even though
+       EXTRACT_PRIVATE was NO.</li>
+<li>   Doxygen now exits with code 0 if there is no error (previously it
+       returned 1 in some cases were no error occurred).</li>
+<li>   Calling "doxygen -g -" now writes the config file to stdout 
+       (this already worked when using "doxygen -g-").</li>
+<li>   Undocumented classes exposed when setting EXTRACT_ALL to YES, could
+       result in broken links in the class hierarchy.</li>
+<li>   Exception specifications in Java were not parsed properly.</li>
+<li>   If INLINE_INHERITED_MEMB was YES, pure vitual members of base classes
+       reachable via multiple paths appeared more than once in the 
+       documentation.</li>
+<li>   Removed potential recursive loop when computing reimplements relations
+       for template instances.</li>
+<li>   Fixed argument matching problem when matching "a&lt;int *&gt;" with 
+       a&lt;int * &gt;"</li>
+<li>   Links in the documentation of grouped namespace members were not 
+       pointing to the group but to the namespace.</li>
+<li>   For template specializations the title of an html page contained 
+       plain &lt; and &gt; characters.</li>
+<li>   When computing source references undocumented members could introduce
+       non-existing relations for documented members in front of it.</li>
+<li>   Fixed escaping problem in Makefile generated for latex output.</li>
+<li>   File names were sometimes prefixed for undocumented classes in the
+       class hierarchy.</li>
+<li>   When computing the list of all members, interface members are now
+       treated as virtual.</li>
+<li>   Protected members of a base class did not appear as such in the list of
+       all members of derived classes.</li>
+<li>   Fixed problem with ending itemized lists before paragraph commands 
+       (like @see), which resulted in invalid output.</li>
+<li>   The version number in config files generated by doxywizard was 
+       always 0.1.</li>
+<li>   Having a macro function and typedef with the same name confused doxygen.</li>
+<li>   An \endverbatim command at the end of a \name section was not parsed.</li>
+<li>   Stars (*) at the start of a line in /**&lt; ... */ style comments 
+       after a parameter were included in the result.</li>
+<li>   Putting a C-style comment in a @code block was not handled properly.</li>
+</ul>
+
+<h1>Doxygen Release 1.2.13.1</h1>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Links to grouped members were broken.</li>
+<li>   The Module index was broken in HTML and subgroups were still not
+       sorted properly.</li>
+<li>   Selecting a non-default language was not possible in doxywizard
+       (thanks to Heiko Schaefer for the patch).</li>
+<li>   Ending a dash-style list was not possible by starting a new paragraph
+       anymore.</li>
+<li>   Fixed "exceptions" tag mismatch in the XML output.</li>
+<li>   extern "C" blocks inside source files incorrectly included header files
+       during preprocessing.</li>
+<li>   Compiling doxywizard on Unix with Qt-3.x didn't work because
+       libdoxycfg was linked with qtools from Qt-2.x.</li>
+<li>   Fixed potential memory corruption when generation the graphical class
+       hierarchy (nodes were deleted more than once).</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for multi-method declarations such as: int func1(),func2();</li>
+<li>   Included updated DTD for validating the XML output produced by doxygen,
+       thanks to Angelo Hulshout.</li>
+<li>   Included support for Japanese-ShiftJIS translation,
+       thanks to Ryunosuke Sato.</li>
+<li>   Included update for Slovak translator, thanks to Stanislav Kudlac.</li>
+<li>   Thanks to a patch by Pascal Flammant tables in the documentation
+       can now have captions using &lt;caption&gt; ... &lt;/caption&gt; 
+       within a table definition.</li>
+<li>   A dash-style list can now be ended without ending the paragraph.
+       See the list-section of the documentation for an example.</li>
+</ul>
+<h1>Doxygen Release 1.2.13</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Changed the way @internal works. The "For internal use only" message,
+       now appears (along with the internal documentation) 
+       if and only if INTERNAL_DOCS = YES. </li>
+<li>   Subgroups are no longer sorted but presented in declaration order.</li>
+<li>   Members inside todo/test/bug lists are now shown with qualified 
+       names again. </li>
+<li>   Reorganized the XML parser. It is now structured as a library,
+       a header file, and a test application. See addon/doxmlparser for
+       details.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Included languages updates for French, Portuguese, 
+       Korean, Italian, Dutch, Slovene, Brazil, German and Portuguese.
+       Thanks to Harry Kalogirou doxygen now has support for output in 
+       the Greek language.</li>
+<li>   Included patch by Adam Doppelt to make doxysearch work 
+       better with windows/IIS.</li>
+<li>   Added more info to the XML output: include dependencies,
+       member groups, re-implement relations, const/volatile specifiers,
+       namespace info, related pages, inner classes, inner namespaces.</li>
+<li>   Added some logic to deal with member specializations.
+       They should now be added as additional members to a class instead of
+       being ignored and producing a warning.</li>
+<li>   Thanks to a patch by Bruce Korb, author of 
+       <a href="http://autogen.sourceforge.net/">autogen</a>, doxygen now
+       has output support for producing autogen definition files. To do
+       this set GENERATE_AUTOGEN_DEF to YES in the config file. </li>
+<li>   The \relates command can now be used for macros as well.</li>
+<li>   New option INLINE_INHERITED_MEMB which can be enabled to include all
+       directly and indirectly inherited members inside the
+       documentation of a class as if they were real members (inspired by
+       a patch sent by Ted Drain). </li>
+<li>   Added option EXTRACT_LOCAL_CLASSES which can be used to show
+       or hide classes and structs defined in source files.</li>
+<li>   Thanks to an install script written by David Greig, the windows
+       version of doxygen now comes with a windows installer based on
+       Jordan Russell's 
+       <a href="http://www.jrsoftware.org/isinfo.htm">Inno Setup</a>.</li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed potential bogus link in the references list.</li>
+<li>   Auto detection of idl files was broken.</li>
+<li>   Preprocessor did not parse hexadecimal values correctly.</li>
+<li>   Fixed XML output problem (too many &lt;/highlight&gt; tags).</li>
+<li>   Documentation for nested classes inside other nested classes was 
+       not written to the output.</li>
+<li>   Fixed problem mixing paragraph commands (like \param) with 
+       hyphen-style lists.</li>
+<li>   Modules index in LaTeX was broken.</li>
+<li>   STRIP_FROM_PATH now works for windows-style paths as well.
+       Thanks to Joël Conraud for the patch.</li>
+<li>   For functions whose declaration was grouped and whose definition 
+       contained a documentation block with a todo/test/bug item, 
+       the item did not appear in the todo/test/bug list.</li>
+<li>   In the source browser output, the "=" in variable initializers
+       was outputted as "==".  </li>
+<li>   Fixed parse problem for typedefs of function pointers returning 
+       a template instance.</li>
+<li>   Fixed bug in parsing method pointer function arguments of the
+       form "void f(void (C::*m)() const)"</li>
+</ul>
+<h1>Doxygen Release 1.2.12</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Improved the speed of the todo/test/bug list generation considerably.</li>
+<li>   The list of all members of a class now shows for each member, 
+       the class in which the member is defined.</li>
+<li>   Rewrote a substantial part of the source code parser 
+       (SOURCE_BROWSER = YES). It is now more context sensitive and 
+       will generate more/better links.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>   Added new option HIDE_UNDOC_RELATIONS that can be set to NO to show
+       any undocumented inheritance and usage relations from the various 
+       graphs.</li>
+<li>   Included updates for translations to Chinese (thanks to Charlie Liu)
+       Slovene (thanks to Matjaz Ostroversnik), Russian
+       (thanks to Alexandr Chelpanov), Czech (thanks to Petr Prikryl)
+       and Croatian (thanks to Boris Bralo). Included Petr's translator 
+       adapter simplifications. Included Latin2 patch by Mitja Udovc.</li>
+<li>   Updated the graph legend page.</li>
+<li>   Added option REFERENCES_RELATION that can be enabled in combination
+       with SOURCE_BROWSER to produce for each function 
+       a list of all called/used members/functions/variables. 
+       The reverse list can now be enabled/disabled using the 
+       new REFERENCED_BY_RELATION option.</li>
+<li>   Added native support for typedefs of the form 
+       "typedef void (__stdcall *name)()", where __stdcall can be any
+       identifier.</li>
+<li>   Included a patch by Stephen Goudge which adds an option 
+       EXAMPLE_RECURSIVE to indicate whether or not example files should
+       be searched recursively.</li>
+<li>   Included patch by Erik Zeek to add EOL translation to the 
+       config file output.</li>
+<li>   Doxygen now searches the current directory for source files if
+       the INPUT and FILE_PATTERNS are empty (thanks to Johan Eriksson
+       for ideas and code)</li>
+<li>   Reference to/referenced by information is now included in the XML
+       output.</li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed more RTF problems and added an RTF integrity check that
+       is performed on the generated RTF output (bracket matching).</li>
+<li>   Refined the macro detection in the preprocessor a little, so it does 
+       not match constructors and functions so easily.</li>
+<li>   the % prefix didn't work for scoped items.</li>
+<li>   References to groups defined in tag files did not work.</li>
+<li>   documentation for classes inside namespaces was generated multiple
+       times.</li>
+<li>   Running doxytag on qt-3.0.0 resulted in a tag file containing 
+       non-breakable spaces.</li>
+<li>   The \package statement did not work correctly for packages whose name
+       contained a dot.</li>
+<li>   Fixed Parser bug for java initializers of the form = "\"/*";</li>
+<li>   Fixed LaTeX output problem when using \par followed by a (-) list.</li>
+<li>   Fixed LaTeX output bug in the related page index.</li>
+<li>   Commands inside a conditional section would still appear in the 
+       result even if the section was disabled.</li>
+<li>   Included idea by Roberto Bagnara to make running "make" in the LaTeX
+       output autodetect how many times latex has to be run.</li>
+<li>   Included a patch by Johan Eriksson to fix a link problem in the
+       "list of all member" for grouped members.</li>
+<li>   Fixed potential crash when \todo was used without arguments.</li>
+<li>   The HIDE_UNDOC_CLASSES option did not work correctly for template
+       instances when set to YES.</li>
+<li>   \line, \skipline and \until introduced too many new lines.</li>
+<li>   Doxygen did not parse "struct {} typedef S;" correctly.</li>
+</ul>
+
+<h1>Doxygen Release 1.2.11.1</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Included update for Slovak translation (thanks to Stanislav Kudlac)</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed RTF output bugs.</li>
+<li>   When preprocessing was disabled, the input was truncated for sources
+       containing CR's (i.e. sources edited on Windows).</li>
+<li>   Syntax highlighting C-style comments was broken.</li>
+<li>   Links to members in undocumented groups were broken.</li>
+<li>   Deep class hierarchies caused "nested too deep" error in LaTeX output.</li>
+<li>   providing one documentation block for grouped, related members did
+       not work.</li>
+<li>   Documentation pages for documented classes nested inside
+       undocumented classes or namespaces were not generated.</li>
+</ul>
+<h1>Doxygen Release 1.2.11</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Undocumented friend class declarations now link to their class
+       if documented.</li>
+<li>   Undocumented template classes (and other "used" types)
+       are now shown in the collaboration diagram.</li>
+<li>   Changed the look of the various indices (file/class/namespace/...)
+       in the HTML output.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   The source browser option now generates links to (documented)
+       globals and fields. Especially useful for C code.</li>
+<li>   Input containing CR+LF (DOS/Windows) or CR only (Mac) are now 
+       automatically converted to LF. </li>
+<li>   New config option SKIP_FUNCTION_MACROS that when set to YES
+       (the default) makes doxygen's preprocessor automatically remove all 
+       function macros that are alone on a line and do not end with a 
+       semicolon. These are typically used as boiler-plate code and 
+       confuse the parser if not removed.</li>
+<li>   Added class collaboration and inheritance diagram descriptions 
+       to the XML output. Also added source browser output for each file.</li>
+<li>   Added a developers part to the manual, with some information on
+       how doxygen is structured internally.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Using HIDE_UNDOC_MEMBERS=YES and ENUM_VALUES_PER_LINE=1 resulted in
+       blank lines in the HTML-output.</li>
+<li>   "friend class A::B" caused a bogus warning.</li>
+<li>   Fixed problem generating tag files for the Qt-3.0.0 beta releases.</li>
+<li>   Fixed parameter list layout problem in the HTML output.</li>
+<li>   Fixed some (all?) compile problems on Solaris.</li>
+<li>   Class hierarchy was not correct if a template class inherited from
+       a template argument, which was also a documented class.</li>
+<li>   When substituting template arguments, default values of
+       template arguments were not substituted themselves.</li>
+<li>   Fixed a number of XML output bugs (thanks to Christian Hammond).</li>
+<li>   Fixed bug parsing character literals.</li>
+<li>   Fixed bug in RTF output (bracket mismatch).</li>
+<li>   Inializer of the last enum value of an enum did not always appear.</li>
+<li>   Dots were removed from return types in Java.</li>
+<li>   In some cases a broken "More..." link was generated after 
+       a brief class description.</li>
+<li>   Text of a section title containing was truncated if it contained an
+       asterix.</li>
+<li>   Fixed crash bug when filtering CR+LF's from input (thanks to Petr
+       Prykril).</li>
+<li>   Fixed generated makefile dependencies for USE_PDFLATEX = YES
+       (thanks to Marcus Holland-Moritz)</li>
+<li>   "\retval #VALUE" now links to VALUE if documented. The same works
+       for \exception and \throws 
+       (and since the argument is a class no # is needed).</li>
+<li>   Sorting the alphabetical list was broken for nested classes.</li>
+</ul>
+<h1>Doxygen Release 1.2.10</h1>
+<h3>New features</h3>
+<ul>
+<li>   Relations between templates and their instances are now visualized
+       in the inheritance and collaboration graphs. Can be disabled
+       by setting TEMPLATE_RELATIONS to NO in the config file.</li>
+<li>   A Java package can now be documented using a comment block containing a 
+       @package command or by putting a documentation block in front of a 
+       package statement.</li>
+<li>   Added new command \dotfile which can be used to include a user
+       specified dot file as an image in the documentation. The new config
+       option DOTFILE_DIRS should be used to specify directories in which 
+       doxygen should look for dot files (thanks to Samit Basu for the patch).</li>
+<li>   Added new build target macosx-c++ to build doxygen for Mac OS X
+       (Thanks to Jason Harris for telling me what needed to be changed).</li>
+<li>   Added --enable-langs option to the configure script which can be used
+       to compile-in support for a specified set of languages (thanks to
+       Vitaly Repin for the patch).</li>
+<li>   Included update for Russian &amp; Italian translation.</li>
+<li>   Included translator.pl update received from Petr.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fix compile problem for the Irix compiler (thanks to Dirk Reiners)</li>
+<li>   Some generated &amp;nsbp; entities where missing a ; in the HTML output.
+       For some browsers this resulted in argument types &amp; names being 
+       glued together.</li>
+<li>   The heading of parameter and return value lists was not bold anymore in
+       the HTML output. </li>
+<li>   "Reimplemented to/from" member links now work between template base
+       classes and their derived classes.</li>
+<li>   Not all documented templates class were regarded as documented 
+       (unless EXTRACT_ALL was set to YES).</li>
+<li>   Fixed recursive lock-up problem for recursive templates of the form:
+       template&lt;class T&gt; class A : public A&lt;typename T::B&gt; {}</li>
+<li>   The labels in the alphabetical list were broken when namespaces were 
+       used.</li>
+<li>   An error was given for import statements in Java sources.</li>
+<li>   The "list of all members" was no longer generated for nested classes.</li>
+<li>   Fixed bug in XML output causing mis matched &lt;para&gt; tags.</li>
+<li>   Fixed parse problem for enum initializers like: "enumVal = A&lt;T,C&gt;::val" </li>
+<li>   \hideinitializer did not hide the initializer of enum values.</li>
+<li>   Undocumented enums and enum values now behave correctly when 
+       HIDE_UNDOC_MEMBERS is set to YES.</li>
+<li>   Fixed a problem with using \if inside alias definitions.</li>
+<li>   Fixed &amp; changed the layout of function arguments a little.</li>
+<li>   Typedef struct{}Name was not parsed properly without adding more spaces.</li>
+<li>   Static initializer blocks were not properly parsed in Java classes.</li>
+<li>   Members of an unnamed namespace are now treated as static, and will
+       only appear in the documentation if EXTRACT_STATIC is set to YES.</li>
+<li>   Classes are sorted by their name, i.s.o. full scope again.</li>
+<li>   Improved argument matching for members defined within (nested) 
+       namespaces.</li>
+</ul>
+
+<h1>Doxygen Release 1.2.9.1</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Bug/test/todo items of members are now grouped 
+       together with their compound.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added three new conditional commands: \ifnot, \else and \elseif
+       (thanks to Fabian Cenedese).</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   The .spec file still assumed the --with-xmlgen switch was available.</li>
+<li>   Template instances caused double entries in the class list 
+       (in LaTeX) and broke RTF output.</li>
+<li>   \if and \endif can now be used to make structural commands like
+       \brief, \ingroup, and \defgroup conditional.</li>
+<li>   The "const" in "func(B * const)" was parsed as a variable name.</li>
+<li>   Template specializations of the form A&lt;N::C&gt; where not handled
+       properly.</li>
+<li>   Putting \relates in a function documentation block that was 
+       within a namespace, while referring to another namespace did not work.</li>
+<li>   Doxywizard always complained it could not read the config file.</li>
+<li>   Doxywizard did not properly update boolean and integer values.</li>
+<li>   Fixed recursive lock-up problem when recursive templates were used.</li>
+<li>   LaTeX output was broken when PDF_HYPERLINKS was enabled and templates
+       were used.</li>
+<li>   Private friends were hidden even though friends have no access control.</li>
+<li>   Argument matching was sensitive to spaces in some cases.</li>
+<li>   Bug/test/todo item in class members did not always result in the
+       generation of the list. </li>
+</ul>
+
+<h1>Doxygen Release 1.2.9</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Friend class declarations are now treated as normal members.</li>
+<li>   Completely rewrote the way templates are handled. 
+       Doxygen now (internally) computes all template instances it encounters. 
+       This has the following advantages:
+       <ul>
+       <li>Template instances are now shown in the hierarchical index
+           and in all class diagrams in a uniform way.</li>
+       <li>The list of all members is now correct for classes deriving
+           from a template.</li>
+       </ul>
+       Since there is a lot of new code, some more testing won't hurt
+       to mature the code. If you are using templates, please try this
+       version for me and report any problems.</li>
+<li>   Started moving the XML output generator back into doxygen. 
+       As a result the GENERATE_XML option has reappeared.</li>
+<li>   Function arguments names are now nicely aligned in the generated
+       HTML output. Thanks to Joe Bester for doing most of the work. </li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added GNU install tool auto detection to the configure script.</li>
+<li>   Included update for French translation (thanks to Xavier Outhier)
+       Olexij Tkatchenko has added support for the Ukrainian language.
+       Included update for Portuguese and Brazillian.</li>
+<li>   Added --docdir option to the configure script.</li>
+<li>   Using the non-commercial version of Qt for windows, it is now
+       possible to build doxywizard for windows.</li>
+<li>   Made preprocessor parse error messages somewhat more informative.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Image references to dot images were broken in the RTF output
+       (thanks to Henning Moll for the fix).</li>
+<li>   Linebreaks are now done with \par instead of \line in the RTF
+       output (thanks to Henning Moll).</li>
+<li>   Removed bogus warnings when parsing tag files.</li>
+<li>   The detailed description in a @name block can now be more than 
+       plain text.</li>
+<li>   Included fix for the tree view script for the mozilla browser
+       (thanks to Alec Panovici).</li>
+<li>   Grouping members with the same signature but with a different scopes
+       is now possible.</li>
+<li>   Related functions could not be grouped.</li>
+<li>   MAN_LINKS option was broken (fixed by Patrick Ohly).</li>
+<li>   Including a file with \include in LaTeX caused the leading text
+       to appear in a smaller font size.</li>
+<li>   Improved the documentation and spec file (thanks to Jens Seidel).
+       Fixed some typos in the docs. Thanks to Wouter Slegers.</li>
+<li>   JavaDoc style links such as @{link #var} and @{link #var label}
+       now work.</li>
+<li>   "doxygen -g -s" now creates a file named Doxyfile i.s.o "-s" </li>
+<li>   Fixed a null pointer referencing problem (thanks to Nick Pratt)</li>
+<li>   8-bits characters are now correctly handled within the argument 
+       of \b, \c or \e.</li>
+<li>   Reimplemented links were broken for grouped members (thanks to
+       Johan Eriksson for the fix).</li>
+<li>   Enabling the Tree view didn't result in proper RTF and LaTeX output 
+       (thanks to Paul Sydney for the fix).</li>
+<li>   Merged patches by Joe Bester:
+       <ul>
+       <li>Could not link to @anchors in the main page on external packages.</li>
+       <li> All external modules and pages were linked to or appended 
+          (even the TODO page, etc), even when EXTRACT_ALL is set to NO.</li>
+       <li> The section containing structs and unions is labeled 
+          "Class Documentation" (in the English translation) even when 
+           the OPTIMIZE_OUTPUT_FOR_C was set to YES.</li>
+       </ul></li>
+<li>   using the IDL keyword "import" in other languages did not work 
+       correctly.</li>
+<li>   members of a privately inherited base class were not shown in the
+       list of all members, while they were accessible from the derived class.</li>
+<li>   Reworked part of the template handling. Doxygen should now be
+       capable of handling nested template classes correctly. Please test
+       this if you are using these contructs. Thanks to Christoph Koegl
+       for providing some difficult test cases.</li>
+<li>   Fixed parse problem when parsing &lt;&lt; as part of the first 
+       argument of a typedef.</li>
+<li>   Further improved typedef resolution.</li>
+<li>   The LATEX_HEADER-config option disabled the \mainpage-output
+       (thanks to Eric Reinhart for the fix).</li>
+<li>   Merged a patch by Erik Zeek, to allow compilation under BCB5</li>
+<li>   Spaces in arguments of preprocessor macros were not treated properly.</li>
+<li>   Fixed argument matching bug that caused doxygen to treat
+       f(type t) and f(type_t t) as the same function.
+       "void func(const ::A)" was interpreted as "void func(const::A)",
+       where "const" would have to be a class name.</li>
+<li>   static file members were not auto-linked even if EXTRACT_STATIC was set
+       to YES.</li>
+</ul>
+
+<h1>Doxygen Release 1.2.8.1</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Enum values of a grouped (with @ingroup) enum are now automatically
+       added to the same group.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Included update for Brazilian translation.</li>
+<li>   Add support for &amp;lt; &amp;gt; &amp;amp; &amp;apos; &amp;quot; 
+       in the documentation,
+       since these commands after occur in Java documentation.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Parameters appeared in the documentation for undocumented
+       arguments (and twice if they were also documented with @param). </li>
+<li>   Specifying boolean tags twice in the config file resulted in
+       an invalid value (both boolean values were appended).</li>
+<li>   Fixed a number of typos (thanks to Jens Seidel).</li>
+<li>   When a paragraph header was directly followed by an
+       item list doxygen did not render the first item properly.</li>
+<li>   The "More..." link was often omitted for grouped members. </li>
+<li>   "dangerous" characters like ":" are now escaped from man page 
+       file names</li>
+</ul>
+<h1>Doxygen Release 1.2.8</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Doxygen now uses a more natural naming scheme for man pages.</li>
+<li>   Man page and rtf output are now disabled by default.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   The dot generated inheritance and collaboration graphs for classes
+       should now show the proper template instantation for the derived/used
+       classes. For instance it should show that class S uses class V 
+       (indirectly) in the following example:
+       <pre>
+           class V {};
+           template&lt;class T&gt; class U1 { T *m_t; };
+           template&lt;class T&gt; class U2 { U1&lt;T&gt; *m_t; };
+           template&lt;class T&gt; class B1 { U2&lt;T&gt; *m_t; };
+           template&lt;class T&gt; class B2 : public B1&lt;T&gt; {};
+           class S : public B2&lt;V&gt; {};
+       </pre>
+       Please report any example of class hierarchies that are not shown 
+       properly.</li>
+<li>   Added doc/translator.pl script created by Petr Prikryl.
+       Its main purpose is to extract information from doxygen's sources
+       related to internationalization (i.e. the translator classes), to
+       avoid duplication of information (i.e. doc/language.doc is now 
+       generated) and to generate reports about the status of the translations
+       (e.g. missing methods). </li>
+<li>   Stanislav Kudlac added support for Slovak language and
+       Erik Søe Sørensen added support for Danish.
+       Applied language updates for 
+       Italian, Croatian, Spanish, Czech, German &amp; Russian.</li>
+<li>   Added support for "KBD" HTML tags (thanks to Albin Wu).</li>
+<li>   Added man patch by Patrick Ohly which allows to create freestyle 
+       man pages using \page and puts man page with non-default extension 
+       in the correct directory.</li>
+<li>   Added MAN_LINKS option (thanks to Patrick Ohly for the patch).</li>
+<li>   Added grouping patches by Patrick Ohly:
+
+       There are now three commands to define a group:
+       <pre>
+         \defgroup name title
+         \addtogroup name [title]
+         \weakgroup name [title]
+       </pre>
+
+       \defgroup must be used exactly once for a group, so you should
+       provide a title. Without the title you will get a warning and
+       doxygen will use the name as title (this is the old behaviour).
+       <pre>
+       /** \addtogroup name */
+       </pre> 
+       can be used to add documentation or
+       members to a group (as in 1.2.7), but the group is created if
+       it doesn't exist yet. You can provide the title later
+       with another block:
+       <pre>
+       /**
+        * \addgroup name title
+        * documentation
+        */
+       </pre>
+       <p>
+       Setting different titles will trigger a warning without overwriting
+       the title once more.
+       </p>
+       <p>
+       \weakgroup is exactly the same as \addtogroup, but if a member
+       is put into such a group with <code>\weakgroup name @{ @}</code> 
+       and into
+       another group with <code>\[def|addto]group @{ @}</code>, then it will be
+       placed into the other group without issuing a warning.
+       </p>
+       <p>
+       Actually there is a four-level hierarchy for grouping with
+       (from strongest to weakest) \ingroup, \defgroup, \addtogroup,
+       \weakgroup. You will get warnings when putting members into
+       groups with commands of the same level, but only when you really
+       document this member. This will not trigger a warning and put
+       variable a into Group1:
+       </p>
+       <pre>
+       /** \addtogroup Group1 */
+       /*@{*/
+       /** this is the real group */
+       extern int a;
+       /*@}*/
+
+       /** \addtogroup Group2 */
+       /*@{*/
+       extern int a;
+       /*@}*/
+       </pre></li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed a bug in the LaTeX output generation (empty lists).</li>
+<li>   Doxygen can now distiguishing f(const A) from f(const B)
+       even though they match from a syntactical point of view.</li>
+<li>   A template base class that is actually an inherited template 
+       argument of the derived class is no longer shown in the output 
+       indices and hierarchies.</li>
+<li>   TOC_EXPAND could result in a broken tree view
+       (patch by Alexandr Chalpanov).</li>
+<li>   If a base class had member names which has the same name as enumerator 
+       values in a derived class, the enumerator values did not show up in 
+       the documentation (thanks to John Harris for reporting this).</li>
+<li>   Applied a number of patches sent by Jens Seidel.</li>
+<li>   Fixed compiler limit problem on Windows (thanks to Trevor Robinson).</li>
+<li>   Add -dBATCH in system calls to ghostscipt (needed for formulas) 
+       to avoid a command prompt for newer versions of ghostscript 
+       (thanks to Marvin Wolfthal).</li>
+<li>   In some situations doxygen wanted to write a files containing a \n.</li>
+<li>   Environment variables can now also be used for non-string values
+       in the config file, like for example QUIET = $(QUIET_ON)</li>
+<li>   Fixed a number of typo's in the docs (thanks to Philippe Lhoste &amp;
+       Jens Seidel).</li>
+<li>   Inheritance through typedefs within a namespace did not yield the
+       correct inheritance diagram.</li>
+<li>   References to anchors in grouped members or pages were not
+       correctly resolved.</li>
+<li>   Fixed a problem with argument matching for arguments that contained
+       classes imported via a using declaration.</li>
+</ul>
+<h1>Doxygen Release 1.2.7</h1>
+<h3>Changes</h3>
+<ul>
+<li>   The configgen tool is now replaced by a more dynamic parser. This 
+       will allow future output generators to add specific options without 
+       changing or recompiling the doxygen engine. Doxywizard has also been 
+       updated to use this new parser. Developers that wish to add new 
+       configuration options, please look at Config::create() in src/config.l</li>
+<li>   Changed the way the translators work internally (thanks to Petr
+       Prikryl for ideas and code) and updated the documentation regarding 
+       language support and maintenance.  Users of languages other than 
+       English will get a warning message if the translation for their 
+       language is not up to date.</li>
+<li>   Did some internal cleaning up to make things 
+       more consistent and easier to maintain.  Please let me know if you 
+       think something has been broken in the process. </li>
+<li>   Doxygen now uses a more unique output file name mangling scheme, which
+       generates unique file names even if entity names (like class names) 
+       only differ in case.</li>
+<li>   Setting ALLEXTERNALS = NO now hides external pages in the page index.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>   \image is now supported for RTF output (thanks to Joe Ninety).</li>
+<li>   New RTF_EXTENSIONS_FILE that can be used to configure the RTF output
+       (thanks to Joe Ninety for the patch).</li>
+<li>   Added new command \htmlinclude that can be used to include a 
+       HTML file as is in the HTML documentation. 
+       (thanks to Uwe Wojak for the patch)</li>
+<li>   &amp;nbsp; can now be put in the documentation to force a 
+       non-breakable space.</li>
+<li>   Included support for the gcc extension #include_next
+       (thanks to Jac Goudsmit for the patch). </li>
+<li>   Included translation for Brazilian Portuguese sent by Fabio Jun 
+       Takada Chino. Add update for the Czech translation 
+       (thanks to Petr Prikryl). Also included updates for German 
+       (thanks to Jens Seidel), Russian (thanks to Alexandr Chelpanov) and 
+       Croatian (thanks to Boris Bralo).</li>
+<li>   Added RPM spec file update by Jens Seidel.</li>
+<li>   Added SHORT_NAMES option which can be set to YES to make doxygen
+       generate short (but non-informative) output file names.</li>
+<li>   Added new command \addtogroup that can be used to extend a group
+       defined with \defgroup with extra members and/or documentation.</li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>   Inline sources weren't appearing for undocumented non-inline members.</li>
+<li>   Doxygen did not subgroup in case the parent group was
+       found after the child group. (thanks to Johan Eriksson for the patch
+       that fixes this).</li>
+<li>   Specifying a directory at the INPUT that ends with a \ did not
+       make doxygen recurse the down the directory tree in Windows.</li>
+<li>   Fixed two small bugs that caused segfaults on 
+       NetBSD and Linux on 64bit Alpha's (thanks to Rex McMaster
+       and Ovidiu Toader).</li>
+<li>   "Referenced by" section now starts at a new paragraph 
+       (thanks to Joe Ninety).</li>
+<li>   Setting OPTIMIZE_OUTPUT_FOR_C still produced some C++-ish 
+       sentences for the list of all struct/union fields.</li>
+<li>   Undocumented friend functions were listed as friend classes.</li>
+<li>   A CORBA IDL union with a switch was not always recognised correctly.  </li>
+<li>   doxygen did not handle try-function-blocks with multiple catch clauses
+       properly.</li>
+<li>   \bug and co. were not working for static members.</li>
+<li>   Formulas weren't correctly re-generated when changed.</li>
+<li>   relative include paths containing /../ were not linked, since they
+       were not normalized.</li>
+<li>   Locally included files where not searched in the directory containing
+       the file that did the inclusion, only in the paths specified with
+       INCLUDE_PATH. </li>
+<li>   Fixed problem with numbers in the generated eps file for non-english
+       systems (thanks to Vsevolod Novikov).</li>
+<li>   Generated bookmarks in the RTF output not starting with a letter caused
+       problems (thanks to Jonathan Beaupre for the fix).</li>
+<li>   Putting &amp;aring; in the docs wasn't working as expected.</li>
+<li>   Fixed a number of typo's in the docs (thanks to Jens Seidel and 
+       Philippe Lhoste).</li>
+<li>   Autolinking could create links inside user defined HTML links.</li>
+<li>   Email addresses in the docs starting with an "a" and put inside sharp 
+       brackets were not properly displayed (thanks to Abramo Bagnara for 
+       the fix).</li>
+<li>   Fix several man page output bugs (thanks a patch by Patrick Ohly). </li>
+</ul>
+
+<h1>Doxygen Release 1.2.6</h1>
+<h3>Changes</h3>
+<ul>
+<li>   The \bug command now works like the \todo and \test commands; each item
+       documented with \bug will be cross-referenced with a bug list. The list
+       can be disabled by setting GENERATE_BUGLIST to NO in the config file.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>   Included updates for Croatian, Czech and German,
+       Japanese, Italian and Russian translations.</li>
+<li>   Added option GENERATE_CHI that can be used to control whether
+       or not an .chi file should be generated by the HtmlHelp compiler
+       (default is NO).</li>
+<li>   Added option DOT_CLEANUP that when set to NO leaves the intermediate
+       dot files in the output directory.</li>
+<li>   Added option BINARY_TOC to enable/disable use of a binary table of 
+       contents in a .chm file (thanks to Martin Slater for the patch).</li>
+<li>   Added option TOC_EXPAND to when enabled shows the members of a
+       group in the treeview and HTML help table of contents (thanks again
+       to Martin Slater).</li>
+<li>   Included group support for man page output (thanks to Joe Bester for
+       the patch).</li>
+<li>   Added option SHOW_USED_FILES that can be used to disable the
+       list of used files normally generated at bottom of the documentation 
+       of classes and structs (thanks to Joe Bester).</li>
+<li>   Updated the doxbar tool: 
+       <ul>
+       <li> the addin no longer requires administrator privileges to work 
+         (thanks to Michael Beck)</li>
+       <li> the existance of files is now checked (thanks to Pekka Pessi).</li>
+       <li> .odl and .inl files are recognised (thanks to Pekka Pessi).</li>
+       </ul></li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>   doxygen.css was also used by the treeview even if the user specified
+       his/her own stylesheet.</li>
+<li>   Inline source blocks (INLINE_SOURCES=YES) were sometimes truncated
+       at the wrong closing bracket (thanks to Jac Goudsmit for the fix).</li>
+<li>   Some references to subsections were not correctly generated
+       (thanks to Stefan Ruppert for the fix).</li>
+<li>   Fixed IDL union parse problem (thanks to Richard Hash).</li>
+<li>   Latex output sometimes contained $\ast$ for code fragments.</li>
+<li>   lonely *'s were not removed inside a &lt;pre&gt; and &lt;code&gt; blocks. </li>
+<li>   Applied patch sent by Joe Bester to make the treeview 
+       javascript work with Mozilla. Still has some problems though.</li>
+<li>   Fixed a bug in code parser regarding string detection, inside
+       the argument list of a function.</li>
+<li>   Using a command alias starting with \class (or other structural
+       commands) did not give the expected result.</li>
+<li>   A function pointer returned as the template argument of a template 
+       class that itself is the return type of a function was not 
+       parsed properly.</li>
+<li>   In IDL, typedef's followed by an attribute list where not parsed
+       properly. </li>
+<li>   The list of all members now shows all privately accessible members 
+       if EXTRACT_PRIVATE is set to YES, instead of just the non-inherited
+       private members.</li>
+<li>   Fixed autolink problem for grouped members.</li>
+<li>   Mutliple static global functions with the same name (but in different
+       files), which were forward declared, could make doxygen put 
+       the wrong documentation block at the wrong global function.</li>
+<li>   Support for Norwegian was not enabled.</li>
+<li>   The correct charset is now set when the treeview is used (thanks to
+       Boris Bralo).</li>
+<li>   For inline source fragments of member functions, the types
+       of the arguments are now also taken into account for 
+       cross-referencing.</li>
+<li>   A sentence ending with a dot, directly followed by a \n was not
+       handled correctly.</li>
+<li>   File reference extracted from a tag file could something cause
+       doxygen to generate a bogus warning. </li>
+<li>   Parsing large arrays of hex numbers took very long when the source
+       browser was enabled.</li>
+<li>   Fixed install rule in the Makefile</li>
+<li>   Doxygen now parses try-function-blocks correctly.</li>
+<li>   A zero initialized function pointer inside a namespace was
+       misinterpreted as a pure virtual function.</li>
+<li>   Applied Joe Bester's patch that fixes some LaTeX output problems.</li>
+<li>   Java Package info was not correctly read from a tag file.</li>
+<li>   Todo items in the documentation of grouped members were not
+       correctly referenced from the todo list.</li>
+<li>   Removed bogus "a" entries from appearing in doxysearch's search results.</li>
+<li>   Putting &lt;a href="..."&gt;&lt;img src="..."&gt;&lt;/a&gt; in the 
+       docs will now work as expected for HTML.</li>
+<li>   Fixed problems with &gt;pre&gt;...&gt;/pre&gt; block in LaTeX.</li>
+<li>   Putting &amp;ccedil; in the docs now preduces a c-cedille.</li>
+</ul>
+
+
+
+<h1>Doxygen Release 1.2.5</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Split up doxygen into a library and an executable part,
+       and moved the XML generation part to a separate front-end
+       (see addon/xmlgen).</li>
+<li>   Having SOURCE_BROWSER set to YES does not automatically
+       imply that a member is documented.</li>
+<li>   Typedefs of classes are now shown in (dot) inheritance graphs with 
+       their typedef name instead of the resolved name.</li>
+<li>   Upgraded Qt files to 2.2.3 to fix some compile issues.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>   Added initial support for Java. The parsing of Java code
+       should be ok. There is a new "packages" index, with a list
+       of all parsed Java packages, each of which can be documented 
+       (but not yet in the Java way using package.html) and contains 
+       links to the interfaces and classes in the package. The code 
+       parser still needs work (It doesn't do much cross-referencing yet). 
+       Also any explicit package scope for classes is basically ignored,
+       so you cannot have two classes with the same name in different 
+       packages.
+       Let me know if you know of other improvements.</li>
+<li>   Added support for the Java style of linking (using
+       {@link package.object#item()} as syntax)</li>
+<li>   Added file, compound and namespace members to the treeview index.</li>
+<li>   New configuration option MAX_INITIALIZER_LINES that can be
+       used to control when/if the initial values of variable and defines
+       are shown in the documentation.</li>
+<li>   OPTIMIZE_OUTPUT_FOR_C flag that when set to YES makes doxygen produce
+       output that looks more natural for C programmers.</li>
+<li>   Included Czech language update sent by Petr Prikryl. </li>
+<li>   Added "Binary TOC=YES" and "Create CHI file=YES" to the HtmlHelp 
+       project file for better integration with MSDN.</li>
+<li>   I've updated the doxbar tool:
+       <ul>
+       <li> sources are appended to the INPUT line of the template config file</li>
+       <li> sources mentioned in the .dsp with quotes (i.e. "c:\bla.cpp") are now
+            handled properly (thanks to Robert Radtke for the fix).</li>
+       </ul></li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed 0-pointer bug that could crash doxygen in some cases.</li>
+<li>   Starting a list in a brief JavaDoc-style description splitted
+       the list into two invalid parts if a list item ended with a dot.</li>
+<li>   Fixed a problem with linking to grouped class members.</li>
+<li>   Indenting of code fragment in LaTeX output was not always correct.
+       Also for code lines starting with a * the * was removed.</li>
+<li>   Typedefs where not properly extracted from tag files.</li>
+<li>   Links to operators in a "See also" section did only work if the
+       arguments list was given.</li>
+<li>   Fixed parse bug in the code parser for the case where "&lt;"
+       and "&gt;" were found on a line but couldn't possibly be a 
+       template scope.</li>
+<li>   The "More..." links was incorrect for members of class grouped
+       with @ingroup.</li>
+<li>   Fixed preprocessor parse bug that occurred when parsing string
+       literal "...\\" as an macro argument.</li>
+<li>   Fixed buffer overflow problems when parsing very long input lines
+       (thanks to Arnault Bonafos).</li>
+<li>   References to pages and anchors imported via tag files did not work.</li>
+<li>   Local references to page anchors did not work.</li>
+<li>   Windows only: doxygen leaked process handles while running dot
+       (thanks to Jeroen ter Hofstede for the fix).</li>
+<li>   Undefining (with #undef) a define set using PREDEFINED now 
+       longer has an effect.</li>
+<li>   Functions appeared twice in modules if the prototype and definition
+       did not match exactly.</li>
+<li>   the word "operator" in todo items caused problems.</li>
+<li>   Fixed some more problems with references to external pages, 
+       local references to sections, and naming conflicts with multiple 
+       todo/test lists.</li>
+<li>   "char a:1, b:2" resulting in output including both bitfields for b.</li>
+<li>   The protection level of the members in the all-member list was not 
+       always correct.</li>
+<li>   Fixed some typos in the Dutch and German translations.</li>
+<li>   \todo's in the docs of #define did not end up on the todo list.</li>
+<li>   "typedef volatile struct {} name;" was not handled properly.</li>
+<li>   HTML header and footer file are now read only once.</li>
+<li>   Fixed 2 memory leaks.</li>
+</ul>
+
+
+<h1>Doxygen Release 1.2.4</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   New XML-based tag file format. <p>
+       <b>Note:</b> If you are already using tag files, you need
+       to regenerate them, because the old format is no longer supported!</p></li>
+<li>   Removed the "No description available" for classes without brief
+       description in the compound list. </li>
+<li>   User defined groups (a.k.a. modules) are now shown in a hierarchy.</li>
+<li>   If a function and its prototype are both inside different documented
+       files then they may both be documented separately and will appear 
+       as such in their file documentation 
+       If you only document the header file and not the source
+       file you can still put your documentation in front of the function 
+       definition as before.</li>
+<li>   For unresolved base classes of a class inside a namespace, doxygen
+       now guesses they are defined outside the namespace (was inside).</li>
+<li>   Performance: replaced O(n^2) sort routines for member lists
+       with O(nlog(n)) versions.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>   There is now an HTML Help like tree view, that can be enabled
+       by setting GENERATE_TREEVIEW to YES. 
+       This feature requires a browser that supports frames and javascript.
+       Note that frame/page-resizing requires a manual reload with 
+       Netscape 4.x at the moment (it is a known netscape bug).
+       (thanks to Ken Wong for providing the code to generate the tree
+       in the proper format).</li>
+<li>   Added new option TREEVIEW_WIDTH that can be used to set the initial
+       with of the treeview frame.</li>
+<li>   A warning is now generated for invalid \link targets 
+       (again thanks to Ken Wong).</li>
+<li>   Wang Weihan sent an update for the Chinese translation which is now
+       included. Included update for the Russian and Italian language as well.</li>
+<li>   Support for Borland C++ and MINGW compilers for Windows 
+       (thanks to Oliver Brandt for the patch). </li>
+<li>   Groups and pages defined in external documentation (i.e. with tag files)
+       can now be referenced using \ref.</li>
+<li>   Pages can now be put into groups using \ingroup (thanks to Ken Wong).
+       A group with only pages is rendered as a page (the group itself) 
+       with subsections (the inserted pages). </li>
+<li>   \ingroup can now be put in a one line comments (thanks to Patrick Ohly)</li>
+<li>   \ingroup in a comment block before a comma separated list of  
+       variables is now applied to all variables (as is the documentation 
+       itself). (thanke to Patrick Ohly for the patch)</li>
+<li>   @{ .. @} blocks can now be used for normal groups as well
+       (thanks to Trevor Robinson for the patch). Here is an example:
+       <pre>
+       /** @defgroup mygrp My Own Group
+        *  @brief My brief group description.
+        *  @{
+        */
+
+       /** @name My member group 
+        *  @{
+        */
+       /** This is a function */
+       void func1();
+
+       /** Another function */
+       void func2();
+
+       /** This is a typedef */
+       typedef int Int;
+
+       /** @} */
+
+       /** This is a variable */
+       int var;
+
+       /** This is a define */
+       #define DEF def
+
+       /** @} */
+       </pre></li>
+<li>   Normal groups can now also be nested using /*@{*/ ... /*@}*/ blocks
+       (thanks to Patrick Ohly for the patch)</li>
+</ul>
+
+<h3>Bug fixes</h3>
+
+<ul>
+<li>   If source files were put in the input before header files, the
+       declaration against definition matching did not work for  
+       global functions (thanks to Frank Warmerdam for reporting this). </li>
+<li>   The template argument type and name of template functions 
+       were not separated by a space.</li>
+<li>   A comma separated list of member reference variables (like int &amp;i,&amp;j;)
+       was not parsed correctly.</li>
+<li>   Removed bogus warning when excluding non-existent files or directories </li>
+<li>   Fixed problem parsing nameless bit padding fields.</li>
+<li>   Fixed a pointer bug in the XML generation that could crash doxygen.</li>
+<li>   The code parser did not cross-reference functions inside namespaces
+       and nested classes.</li>
+<li>   Only the first member of a member group was shown in a group
+       definition.</li>
+<li>   REPEAT_BRIEF = NO now works for class, namespace and file documentation
+       as well.</li>
+<li>   No macro-expansion was done on a file that was #include'd in a body 
+       of a class or enum.</li>
+<li>   Fixed macro concatenation bug in the preprocessor.</li>
+<li>   Global functions that were \ingroup'd could appear twice in a group
+       in some cases.</li>
+<li>   % and &amp; can now be used in the URL in the documentation.</li>
+<li>   \c,\e and \b now also generate a link if they have the name of a
+       documented file as their argument.</li>
+<li>   Made the FILTER_SOURCE_FILES actually do something 
+       (it was always treated as enabled).</li>
+<li>   Fixed two bugs in the autolist feature (thanks to Ken Wong)</li>
+<li>   Fix macro expansion bug in the preprocessor, when macro's
+       where used as the argument of an #include.</li>
+<li>   // did not work inside the argument of a \todo or \test command. </li>
+<li>   Doxygen did not parse arrays of function pointers properly.</li>
+<li>   Fixed parse bug for templates with nested template arguments.</li>
+<li>   Fixed parsing problem for template arguments 
+       containing &lt;&lt; or &gt;&gt; operators</li>
+<li>   Fixed some problems with the DOT_PATH config option on windows.</li>
+<li>   Group title and file names are now shown in the latex index instead
+       of the label names.</li>
+<li>   Portability: Added workaround for SGI MipsPro compiler, that 
+       (hopefully) prevents it from crashing while compiling doxygen. 
+       Worked around a number of compile problems with HP's C++ compiler.</li>
+<li>   Fixed problem with doxygen calling epstopdf.bat in Windows.</li>
+<li>   Fixed some problems that occurred when regenerating the 
+       doxygen manual on Windows.</li>
+<li>   Fixed some output formatting problems regarding templates. </li>
+<li>   Global functions, typedefs, and enums did not get linked when
+       were read in via a tag file.</li>
+<li>   Using /* inside an \code ... \endcode block confused the parser.</li>
+</ul>
+
+<h1>Doxygen Release 1.2.3</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   enum values are now packed in groups of 4 in the declaration part
+       of the HTML docs.</li>
+<li>   <code>JAVADOC_AUTOBRIEF</code> is now set to NO by default, because too many
+       people expect the JavaDoc-style to behave as the Qt-style and
+       not in the way described in the JavaDoc spec.</li>
+<li>   The distribution now includes the part of Qt-2.2.0 that is needed for 
+       compilation of doxygen, doxytag, and doxysearch. I've also created the 
+       missing files for Windows. This allows compilation of doxygen on systems 
+       without X11 or the full Qt. For doxywizard Qt-2.2.x is still required 
+       however.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Support for the Slovene language (thanks to Matjaz Ostroversnik)</li>
+<li>   Bit fields for struct members are now shown in the documentation.</li>
+<li>   Enabled "favourites" and "Full text-search" for the generated
+       HTML Help browser files. </li>
+<li>   Added support for M$-IDL properties. The "methods:" section
+       now also works.</li>
+<li>   Added support for Borland C++ builder "__published:" and "__property:"
+       sections. (__published: is just treated as public:).</li>
+<li>   Included update for the Czech language. Thanks to Wang Weihan there is
+       also support for Chinese output now.</li>
+<li>   Added a config option <code>WARN_LOGFILE</code> to log warnings to a 
+       file for those
+       people that have to use certain "operating systems" that do not support 
+       redirection of stderr to file.</li>
+<li>   Added a config option <code>GENERATE_LEGEND</code> that can be used to disable the
+       legend page normally generated for explaining dot graphs.</li>
+<li>   Thanks to a patch send by Micha Bieber, doxygen can now be run from
+       inside doxywizard.</li>
+<li>   Environment variables can now be used in the <code>@INCLUDE_PATH</code> 
+       and <code>@INCLUDE</code> tags in the config file (thanks to Stephen 
+       Goudge).</li>
+<li>   Windows compilation/installation instructions are updated (thanks to
+       Petr Prikryl)</li>
+<li>   New config tag <code>ENUM_VALUES_PER_LINE</code> to set the number of 
+       enum values
+       that are grouped on one line (default=4).</li>
+<li>   #include's inside the body of a class are now expanded. </li>
+<li>   The source browser files can now by filtered using the 
+       <code>INPUT_FILTER</code> if <code>FILTER_SOURCE_FILES</code> is set 
+       to YES (thanks to Paul Strauss).</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   For #foo in member documentation doxygen was trying to find
+       a global variable named foo instead of a member. Use ::foo
+       to make an explicit link to a global variable in case there is 
+       also a member named foo. </li>
+<li>   A bullet list ending with a \par sometimes caused the paragraph to
+       be indented.</li>
+<li>   When <code>STRIP_CODE_COMMENTS</code> was set to NO, and /*!&lt; .. */ style
+       comments were used, the code parser got out of sync with the
+       documentation parser.</li>
+<li>   (Hopefully) fixed some Solaris compile problems 
+       (thanks to John Sturton).</li>
+<li>   documentation for private slots appeared in the documentation even
+       though <code>EXTRACT_PRIVATE</code> was set to NO.</li>
+<li>   \relates was not working for nested classes or classes defined 
+       within a namespace.</li>
+<li>   namespace alias support was broken with respect to inheritance
+       relations containing aliased namespace names.</li>
+<li>   The documentation of members that are put into a 
+       group (with \ingroup) is now removed from the natural 
+       container of the member. Also the links are now corrected.</li>
+<li>   Links from the code parser to static global functions are
+       now always pointing to the correct file (thanks to Bill Soudan
+       for the patch).</li>
+<li>   Fixed HTML bug in non-indexed namespace member lists. </li>
+<li>   Using `:' inside ID's caused problems for some
+       XML parsers. I'm now using "__" instead. Also removed @ from appearing
+       in the output when annonymous compounds were used.</li>
+<li>   Fixed output bug that is caused by nesting paragraph commands
+       inside autolists.</li>
+<li>   Doxygen no longer generates source files for input files that
+       end with .doc or .txt</li>
+<li>   Fixed argument matching problem that could result in parameter name
+       changes for overloaded functions.  Also fixed buglet for 
+       matching things like "unsigned int" against "unsigned int name"</li>
+<li>   Fixed qtools compile problem with ./configure --english-only problem</li>
+<li>   Putting documentation between the class and its body now also works
+       if the class has base classes.</li>
+<li>   Fixed parse problem for const function pointers like 
+       "int* (* const name)(long);"</li>
+<li>   Slightly changed the HTML output to work around display "bugs" in 
+       Konquerer and Opera (thanks to Achim Spangler).</li>
+<li>   Examples in compress HTML help of doxygen's manual has absolute links.</li>
+</ul>
+
+<h1>Doxygen Release 1.2.2</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Verbatim headers are now also created if a documented header
+       file does not contain a struct or class (unless VERBATIM_HEADERS = NO 
+       of course).</li>
+<li>   For member groups, where only the first member is documented, that
+       documentation is no longer automatically copied to all other
+       members of the group. You can still enble this by setting
+       DISTRIBUTE_GROUP_DOC to YES in the config file.</li>
+<li>   The \mainpage block now gets its own chapter in Latex/RTF</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added support for KDE-2 IDL (more specific: k_dcop member sections).</li>
+<li>   New ALIASES config option which allows you to add one or more user 
+       defined aliases (a.k.a. macros) that can be used as commands in the 
+       documentation. For instance:
+       <pre>
+       ALIASES = "sideeffect=\par Side Effects:\n"
+       </pre>
+       allows you to put @sideeffect in the documentation, which doxygen
+       will replace by "\par Side Effects:", before parsing. As a result 
+       a formatted paragraph with a "Side Effects" header will appear. 
+       Note that the \n's are replaced by real newlines, so in the example
+       you can put your paragraph text directly after the sideeffect command.</li>
+<li>   Added language support for Hungarian (Thanks to György Földvári),
+       Korean (thanks to Richard Kim), and Romanian (thanks to Alexandru Iosup).
+       Received language updates for Italian, Polish, Croatian, Czech,
+       Hungarian and Russian.</li>
+<li>   Added support for namespace aliases.</li>
+<li>   Added RTF patch from Alexander Bartolich. Here is his description of
+       the changes:
+       "The following patch of rtgen.cpp allows to read *complete* style 
+        definitions from rtfstyle. This includes \sbasedon, \snext, \additive 
+        and actual style names.
+
+        If this data is missing the default value is used.
+        This means old rtfstyle-files can be used without change, with one
+        exception:
+          Reset is no longer considered a style. Since unknown style names 
+          are simply ignored I don't consider this a big problem.
+        There is no means to write rtfstyle in old format, however.
+       "</li>
+<li>   Documentation can now also be put after the initializer of a constructor
+       but before the body. </li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   RTF output was broken w.r.t. dot generated images.  </li>
+<li>   Spacing and blanks inside &lt;pre&gt; ... &lt;/pre&gt; block were not 
+       properly preserved.</li>
+<li>   Fixed lock-up when parsing "enum A { A };"</li>
+<li>   If INLINE_INFO was set to NO an empty property list could be put after
+       the function definitions.</li>
+<li>   Fixed source code linking for the following cases: 
+       <code>A::func().func2()</code>
+       and <code>a[2]-&gt;func()</code>.</li>
+<li>   \em %className did not remove the %</li>
+<li>   In some cases namespace members ended up multiple times in the
+       documentatation.</li>
+<li>   Fixed a bug in the auto list generation.</li>
+<li>   \latexonly inside brief description did not work properly.</li>
+<li>   "Referenced By" list did not include constructors with 
+       inline initializers.</li>
+<li>   &amp;auml; and such were not parsed when used as the argument of a section.</li>
+<li>   A struct inheriting from a base class was marked as private inheritance
+       while it should be public inheritance.</li>
+<li>   The autobreak routine for long return types was sometimes skipping
+       characters. </li>
+<li>   Class usage relations should now also appear in the collaboration
+       diagrams for classes within the same namespace, without explicitly 
+       having to mention the namespace.</li>
+</ul>
+
+
+
+
+<h1>Doxygen Release 1.2.1</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   I have completely rewritten the \todo code. Now a \todo command have a
+       paragraph as argument. The todo list has a header for each
+       item indicating where the todo item was found. The todo list (and
+       all todo items) can be disabled by setting GENERATE_TODOLIST to NO.</li>
+<li>   &lt;pre&gt; ... &lt;/pre&gt; blocks now behave as in plain HTML instead of
+       \code ... \endcode blocks. This also works for LaTeX ofcourse. 
+       These blocks differ from \verbatim ... \endverbatim blocks in that 
+       commands can be used inside these blocks.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added rudimentary support for XML output. Still very much work in 
+       progress... You can enable it by setting GENERATE_XML to YES.
+       There is a small utility (based on Qt &amp; Xerces-C) in addon/xmlread 
+       that uses the SAX interface to read a generated XML file and then dumps 
+       the class hierarchy contained in it.</li>
+<li>   Thanks to a patch sent by Christophe Prud'homme, doxygen now has a new
+       option USE_PDFLATEX that when set to YES makes doxygen use
+       pdflatex instead of latex to generate refman.pdf. The
+       result is a document with higher quality fonts.</li>
+<li>   Added a \test command that works similar to \todo and can be used to 
+       describe test cases. Doxygen will generate a page containing a list 
+       of all test cases. To disable the list set GENERATE_TESTLIST to NO.
+       Thanks to Dave Murrell for the idea and the initial code.</li>
+<li>   For each list option in the config file += can now be used to append
+       something to a list. Thanks to Joerg Baumann for adding this.</li>
+<li>   Numbered items are now supported like this:
+       <pre>
+       /*!
+         This is nested list:
+          - It can be either one of following:
+            -# An apple
+              - Green or
+              - Red
+            -# An orange
+          - Or one of the following:
+            -# A plane
+            -# A bird
+
+         More text follows.
+       */
+       </pre>
+       Credits go to Joerg Baumann.</li>
+<li>   Included French and Czech language updates from Mathieu Despriée and
+       Petr Prikryl. Also included a language update for german from 
+       Raimund Klein.</li>
+<li>   Doxygen will now do give proper warnings for formulas that do not 
+       end properly.</li>
+<li>   Improved error reporting for illegal list combinations (thanks to
+       Joerg Baumann for the patch)</li>
+<li>   Comments from the code example in the dot graph "legend page" was 
+       stripped if STRIP_CODE_COMMENTS was set to YES.</li>
+<li>   In the config file "@INCLUDE = file" can now be used to include
+       part of a configuration file. "@INCLUDEPATH = dir1 dir2 ..." can
+       be put in front of it to add search paths (default is $PWD).
+       Thanks to Joerg Baumann for the patch.</li>
+<li>   Added alphabetical quick indices for compound, file and namespace 
+       member lists.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Running ghostscript on Windows for generating formulas was done
+       asynchronously, resulting in ghostscript trying to access temporary
+       files that may already have been deleted by doxygen. Thanks to Robert 
+       Golias for the code to fix this.</li>
+<li>   Include dependency graphs failed to get included in LaTeX because
+       \includegraphics did not like the dots in the generated file names. 
+       Those dots are now escaped by underscores.</li>
+<li>   The \remark did not end a brief description in JavaDoc comments, 
+       resulting in a error in the generated LaTeX.</li>
+<li>   "<code>operator &gt;&gt;</code>" was not matched against 
+       "<code>operator&gt;&gt;</code>" </li>
+<li>   the (required) space after \addindex ended up in the LaTeX index,
+       causing all generated entries to be placed after the user added entries.</li>
+<li>   "<code>typedef class A&lt;B&gt; a;</code>" is now correctly handled in inheritance 
+       relations. </li>
+<li>   Fixed some typos in the manual</li>
+<li>   <code>\c Class::func(arg)</code> was not autolinked.</li>
+<li>   Doxygen stopped reading from stdin after 4096 bytes.</li>
+<li>   In code fragments no autolinks for local variables or 
+       dereferenced arguments were generated for template classes.</li>
+<li>   autolinking to a namespace member foo from within a class scope also
+       having a member foo did not work.  </li>
+<li>   The brief description was prepended before \todo and \test.
+       The reference from the todo and test lists back to the documentation
+       did not work for overloaded members.</li>
+<li>   specifying width or height for \images was not handled properly.
+       (width and height were repeated). Now you can also use commands like
+       \textwidth as the width or height.  </li>
+<li>   After expanding an environment variable in the config file, the
+       next environment variable was searched starting at the wrong position.</li>
+<li>   Fixed LaTeX/RTF labelname collisions between members of files and 
+       groups, and between classes and groups with the same name.</li>
+<li>   HTML image map partly appeared in RTF output when built-in class 
+       diagrams were used causing the RTF file to be truncated.</li>
+<li>   Inheritance relation was not determined correctly in case a base
+       class was imported from another namespace via a using declaration.</li>
+<li>   Todo and test items defined with \class or related block, where 
+       sometimes missing from The todo &amp; test</li>
+<li>   Preprocessor: Multi-line #define's where not properly parsed &amp; colored 
+       on windows due to \r's</li>
+<li>   Preprocessor: expansion of <code>M(x)A</code>, where M is a macro 
+       that expands to mx, resulted in 
+       "<code>mxA</code>", instead of "<code>mx A</code>"</li>
+<li>   Fixed compile problem with Qt-2.2.0beta1</li>
+</ul>
+
+<h1>Doxygen Release 1.2.0</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   <code>CASE_SENSE_NAMES</code> is now enabled by default.</li>
+<li>   In LaTeX <code>.eps</code> images are now included using the 
+       graphicx package instead of epsfig to simplify the use of pdflatex 
+       (thanks to Pier Giorgio for showing me how that works).</li>
+<li>   Reimplemented the <code>system()</code> call for Unix, so doxygen becomes
+       interruptable when calling external tools such as dot.</li>
+<li>   Changed the way <code>-w</code> works. It can now also be used to generate
+       template header and footers.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Grzegorz Kowal added support for the Polish language. His patch
+       is now included. </li>
+<li>   A <code>\par</code> command without title argument can now be used to 
+       add a new paragraph with the same indent under the heading of
+       another command (such as <code>\par</code>, <code>\param</code>, 
+       <code>\note</code>, etc...) </li>
+<li>   Added a legend page explaining the various arrows and box colorings
+       for the class diagrams generated by dot.</li>
+<li>   Merged update for Croatian language.</li>
+<li>   Relative paths are now also allowed for the 
+       <code>STRIP_FROM_PATH</code> tag.</li>
+<li>   Added a new section to the manual explaining the use of tag files
+       in more detail. Also move the contents of the INSTALL file into 
+       the "installation" section of the manual.</li>
+<li>   Added <code>ps_2on1</code> and <code>pdf_2on1</code> targets to the 
+       Makefile generated in the
+       LaTeX directory. These can be used to generate manual with 2 
+       logical pages on 1 physical pages (Thanks to Onno).</li>
+<li>   Merged Czech language update from Petr Prikryl. Merged Spanish
+       language update sent by Lucas Cruz. </li>
+<li>   Added standard GNU long options <code>--help</code> and 
+       <code>--version</code>.</li>
+<li>   Added a <code>-w</code> option that can be used to generate template 
+       style sheet files for RTF, HTML, Latex. Thanks to Alexander Bartolich
+       for the idea and part of the implementation.</li>
+<li>   Merged patch from Steve Hespelt, which adds a new configuration
+       option: <code>INCLUDE_FILE_PATTERNS</code>. This tag can be used to 
+       set the file patterns for the include files (if left empty the 
+       <code>FILE_PATTERNS</code> will be used, which was also the old 
+       behaviour). </li>
+<li>   Added a couple of commands for kdoc compatability: <code>@p</code>, 
+       <code>@li</code>, <code>@em</code>.
+       Also made @ref a bit less strict.</li>
+<li>   Portuguese translation by Rui Lopes.  </li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Documenting member function pointers with \var like this:
+
+       <pre>
+       /*! class B */
+       class B
+       {
+         public:
+           void (B::*pmf)();       
+       };
+
+       /*! \var void (B::*B::pmf)()
+        *  docs for this class member.
+        */
+       </pre>
+      
+       did not work.</li>
+<li>   Library blocks inside M$-IDL files are now also processed
+       (a library is treated as a namespace at the moment). </li>
+<li>   Argument matching did not work for array argument with different
+       amounts of whitespace. </li>
+<li>   If a namespace definition was found before its documentation than
+       grouping it (with @ingroup) did not work.</li>
+<li>   Global functions within anonymous namespace scopes did appear
+       in the documentation with the anonymous scope marker used internally
+       by doxygen.</li>
+<li>   "namespace{}",so without space was not recognised as a namespace.</li>
+<li>   If the search engine was used then running installdox on the generated
+       html resulted in bogus links to the search engine.</li>
+<li>   Fixed some compiler warning on Solaris.</li>
+<li>   Changed grey by grey50 in dot.cpp to avoid PDF conversion problems.</li>
+<li>   A &lt;/pre&gt; that was not preceeded by a whitespace was ignored </li>
+<li>   The methods operator&lt;() and operator&lt;&lt;() were not 
+       automatically linked anymore.</li>
+<li>   Some special characters in LaTeX were eating up the blanks that 
+       followed them.</li>
+<li>   The built-in C preprocessor did not evaluate the following to TRUE:
+       <pre>
+       #define A
+       #define TO_BE_EVALUATED defined A
+       #if TO_BE_EVALUATED
+         ...
+       #endif
+       </pre></li>
+<li>   Improved code parsing a bit: things like 
+       <code>getClass()-&gt;func()</code> and 
+       <code>(*pb)-&gt;func()</code> should now work. Also the scope of the 
+       body is correctly detected in case of inline constructor initializers 
+       like: <code>A() : m_a(10) { ... }</code></li>
+<li>   File index is now in (path,name) lexical order, instead of (name,path) 
+       order. The file index is also only generated once instead of twice ;-)</li>
+<li>   Typedefs to structs in C-style did (still) not get resolved as "usage" 
+       relations for the collaboration diagrams.</li>
+<li>   Fixed some HTML output typos reported by Onno Kortmann (who used
+       the tool "html tidy" on the generated output).</li>
+<li>   Merged a patch from Paul Lieverse that should solve the empty image
+       map problems on Solaris.</li>
+<li>   If the title of a <code>\defgroup</code> contained a documented class, a 
+       nested (and thus broken) link was generated. </li>
+<li>   Externally defined variable were treated as variable definitions. </li>
+<li>   If a file only had a verbatim header but no documentation, a
+       link broken link was added to the HTML help TOC.</li>
+<li>   Fixed "member with no name" warning that occurred when a enum's 
+       last value ended with a comma and the enum was inside a member group.</li>
+<li>   A &lt;dl&gt; type of list with multiple &lt;dd&gt;'s did not give 
+       the correct output in LaTeX.</li>
+<li>   <code>SORT_MEMBER_DOCS</code> is <code>NO</code> only worked for 
+       class members.</li>
+<li>   Both the prototype and the definition of a global function 
+       appeared in a <code>\defgroup</code>.</li>
+<li>   Fixed some visual problems with operator links in source code
+       fragments.</li>
+<li>   Code parser got confused by template specifiers. Also improved
+       linking of typedef'ed classes. </li>
+<li>   A warning was generated if the same function was defined both inside
+       and outside a namespace.</li>
+</ul>
+<p>
+\endhtmlonly
+\section log_1_1 1.1 Series
+\htmlonly
+</p>
+<h1>Doxygen Release 1.1.5</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   If DISABLE_INDEX = YES and a user defined main was specified
+       (with \mainpage), then no index will be generated anymore.</li>
+<li>   RTF output is now enabled by default.</li>
+<li>   LaTeX output now uses fancyhdr instead of fancyheader.</li>
+<li>   If the search engine is enabled, the default config values will be
+       put into the generated HTML files, so you do not need to run
+       the installdox script, if the initial values are ok.  </li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Added a new config option HIDE_SCOPE_NAMES that can be set to YES
+       to hide the namespace and class scopes that are put in the
+       documentation and diagrams.</li>
+<li>   added a new type of graph, that can be used to visualize 
+       which files #include (i.e. depend on) a given file. This graph is 
+       enabled by setting HAVE_DOT and INCLUDED_BY_GRAPH to YES.</li>
+<li>   added new configuration option EXTRACT_STATIC that can be used
+       to enable/disable the extraction of static file members. The behaviour
+       of this option used to be linked with EXTRACT_PRIVATE.</li>
+<li>   Added two new configuration options MAX_DOT_GRAPH_WIDTH and 
+       MAX_DOT_GRAPH_HEIGHT that let the user configure how big the
+       generated dot graph may become.</li>
+<li>   Added a new configuration option EXPAND_AS_DEFINED that can
+       be used in combination with PREPROCESSING = YES, MACRO_EXPANSION = YES, 
+       and EXPAND_PREDEF_ONLY = YES, to expand a given list of macro names,
+       as they are defined in the sources.</li>
+<li>   Merged Alexander Bartolich's RTF style sheet patch. 
+       A new config option RTF_STYLESHEET_FILE is now available with which you
+       can specify a style sheet file. The style sheet file should contain
+       a list of assignments. The assignments can be used to overwrite the
+       definitions of the various styles with user defined settings. </li>
+<li>   Added a new command @since for JavaDoc compatibility.</li>
+<li>   Added two new commands: \remarks and \attention that work in a
+       similar way as \warning, \pre, \post, et al.</li>
+<li>   If SOURCE_BROWSER = YES, each member function documentation 
+       now includes a list of member functions that call the member 
+       somewhere in their body. </li>
+<li>   RCS/CVS tags of the form $word:text$ are now nicely typeset in the 
+       documentation.</li>
+<li>   Providing all members of an enum with the same documentation can
+       now be done with member grouping like this:
+       <pre>
+       /*!
+        * Rotation values
+        */
+       enum
+       {
+         //@{ rotation value
+         Up=0,
+         Left=-90,
+         Right=90,
+         Down=180,
+         //@}
+       };
+       </pre></li>
+<li>   Member grouping can by denoted more compactly like this:
+       <pre>
+       //@{ Same documentation for each function
+       int getFunc1();
+       int getFunc2();
+       //@}
+
+       /*@{ @name Set functions 
+        *   Functions for setting values.
+        */
+       void setFunc1(int v);
+       void setFunc2(int v);
+       /*@}*/
+       </pre></li>
+<li>   Merged Czech language support patches send by Petr Prikryl. Also
+       removed some obsolete methods from the translator files.</li>
+<li>   Call chains like <code>a-&gt;b()-&gt;c()</code> are now followed 
+       by the code parser so <code>c()</code> is linked if documented.  </li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   the warning message in case of ambigous file matches was containing
+       a bogus <code>%s</code>, which could even crash doxygen.</li>
+<li>   An autolist followed by a \retval, \param, or \exception did 
+       produced invalid output, resulting in a compile error in LaTeX. </li>
+<li>   " has a special meaning in LaTeX when the german babel package
+       is loaded. Doxygen now produces proper output for text containing
+       quotes.</li>
+<li>   The title of a related page was not properly parsed, causing
+       HTML special characters to end up in the output for some languages 
+       (German for instance). </li>
+<li>   The hierarchy shown in the "Contents" part of the html help
+       browser did not properly show the hierarchy when it contained
+       undocumented classes. </li>
+<li>   explict compound specifiers in the return type could lead to 
+       parse problems. Example:
+       <pre>
+       enum SomeEnumType_e Func()
+       {
+         ...
+       }
+       </pre>
+       This was parsed as an enum definition.</li>
+<li>   A user defined style sheet did not get included properly, if it
+       was specified with a (partial) path in HTML_STYLESHEET. </li>
+<li>   Linking in code fragments now works with nested classes
+       and links to the correct reimplemented member are generated.</li>
+<li>   \ingroup did not work when grouping enums</li>
+<li>   members of a module were not cross-referenced with the sources.</li>
+<li>   Function pointers like <code>void ( *func )()</code> where not c
+       orrectly parsed because of the extra spacing between 
+       the `(' and the `*'. </li>
+<li>   The const in void <code>func(int * const val /*&lt; a value. */);</code>
+       was named part of the name, instead of the type.</li>
+<li>   Removed bogus warning in case of global function pointer variables.
+       Function pointers inside namespaces and member function pointers 
+       did also produce bogus warnings.</li>
+<li>   Fixed a misalignment problem with inline source fragments.
+       Also the initializer list after a colon is now included in an inline
+       source fragment.</li>
+<li>   Case sensitivity of file names was set before the configuration file
+       was parsed, causing the default value of CASE_SENSE_NAMES to
+       be used in any case.</li>
+<li>   added a space after "file" in the groupdef docs (thanks Hauke)</li>
+<li>   Documentation blocks can now also be put just after a class name, like
+       in:
+       <pre>
+          class C
+          /*! documentation here */
+          {
+            ...
+          };
+       </pre>
+       This was already possible for functions.</li>
+<li>   Due to a bracket counting bug, throw clauses where not always
+       parsed properly.</li>
+<li>   Fixed a parse bug for the following code-pattern: 
+       <pre>
+         void Class::
+         // Comment
+         method() {}
+       </pre></li>
+<li>   With the newer Qt versions (2.1.x), passing a null string as the first 
+       argument of <code>QRegExp::match</code> seems no longer be allowed, 
+       so I added some extra checks to avoid potential crashes.</li>
+<li>   The title of the documentation of a template class now explicitly
+       states that it is a template. (For non-English languages,
+       this still requires a change to trCompoundReference() in 
+       translator_xx.h).</li>
+<li>   Fixed a problem with matching methods of template classes.</li>
+<li>   commenting out a section or subsection with <code>&lt;!-- --&gt;</code> 
+       did not work.</li>
+<li>   Fixed some inconsistencies in the configuration page of 
+       the documentation.</li>
+<li>   Some operators like <code>operator[]()</code>, 
+       <code>operator|()</code> and <code>operator!()</code>
+       did not appear correctly in the LaTeX index.</li>
+<li>   If an include file name matched a directory name, then the
+       directory could be found first in the INCLUDE_PATH. This resulted in a 
+       scanner error.</li>
+<li>   Fixed parse problems that occurred when &lt;&lt; or &gt;&gt; was 
+       part of a template argument list.</li>
+<li>   Fixed some more parse problems that occurred when parsing base classes
+       that were nested templates.</li>
+<li>   variables whose name started 
+       with an _ like <code>struct {int x; } _var;</code> 
+       where not properly parsed.</li>
+<li>   LaTeX formulas did not work in the brief description of a JavaDoc 
+       style block that was put after an item.</li>
+<li>   Empty group definitions were not properly handled.</li>
+<li>   References to pages using \ref did not work in LaTeX.</li>
+<li>   Members that are typedef's to classes are now shown in the 
+       collaboration diagram.</li>
+</ul>
+
+
+<h1>Doxygen Release 1.1.4</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   The member definition that is put before the detailed 
+       documentation section should now be layouted a bit better for members
+       of classes with lots of template arguments.</li>
+<li>   The HTML pages now have a new doxygen logo at the bottom. This logo has
+       a transparent background and no shadow or anti-aliasing, so it looks 
+       equally nice on all backgrounds.</li>
+<li>   If the first member of a member group is documented, this documentation
+       is now repeated for all undocumented members of that group. </li>
+<li>   The following is now treated as one parameter list with two
+       parameters, instead of two lists with one parameter each. 
+       <pre>
+       /*!
+        * @param a the first parameter
+        *
+        * @param b the second parameter
+        */
+       </pre>
+       The same goes for the @retval and @exception commands.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   In code fragments: added different colors for keywords that are
+       types, and for keywords that deal with the flow control.
+       Also added colors for string and character literals.</li>
+<li>   Added a new command \nosubgrouping that can be put in the documentation
+       of a class. It can be used in combination with member-grouping
+       to avoid that doxygen puts a member group as a subgroup of a
+       Public/Protected/Private/... section.
+
+       Example:
+       <pre>
+         /*! A class.
+          *  \nosubgrouping
+          */
+         class Test
+         {
+           public:
+             /*! \name A member group
+              */
+             //@{
+             /*! Docs for both members in the group. */
+             void Member1();
+             void Member2();
+             //@}
+             /*! A member outside of the group. */
+             void Member3();
+         };
+       </pre></li>
+<li>   Added three new configuration options: 
+       <ul>
+       <li>WARN_IF_UNDOCUMENTED which can be used to turn on or off warning
+           message related to undocumented entities. This works independently
+           of the WARNING tag, which is there to enable/disable all 
+           other warning messages.</li>
+       <li>WARN_FORMAT which can be used to specify the format of the warnings
+           produced by doxygen. The argument is a free form string
+           that must contain a $file, $line and $text marker. 
+           The $file and $line markers will be replaced by the file name and line 
+           number from where the warning originated. 
+           The $text marker will be replaced by the actual warning text.
+           The default argument format string is: <code>"$file:$line: $text"</code>.</li>
+       <li>DOT_PATH that can be used to specify the path
+           where the dot tool is to be found, in case it is not in the
+           default search path.</li>
+       </ul></li>
+<li>   Added rudimentary support for using declarations. The following
+       now works:
+       <pre>
+         /*! Docs for the namespace. */
+         namespace N
+         {
+           /*! Docs for class Test. */
+           class Test
+           {
+             public:
+               void func();
+           };
+         };
+
+         using N::Test;
+
+         /*! The documentation for func is here */
+         void Test::func() {}
+       </pre>
+       Using of individual functions remains unsupported.</li>
+<li>   collaboration and include dependency graph are now also included
+       in the LaTeX documentation.</li>
+<li>   Thanks to Tim Mensch, doxygen has now has a \todo command, which 
+       can be used put todo items in the documentation. 
+       All items will automatically be cross-referenced with a 
+       (generated) todo list. Here is an example:
+       <pre>
+       /*! \mainpage 
+        * \todo write something useful here.
+        */
+
+       /*! A class
+        * \todo Add more comments here 
+        */
+       class Test
+       {
+         public:
+           //! \todo implement this function
+           void func();
+
+           /*! Computes stuff.
+            *  \todo can we combine this with Test::func()?
+            *  More docs.
+            */
+           void func2();
+       };
+       </pre>
+
+       Note that the arguments of the \todo command ends at the end of the
+       line.</li>
+<li>   membergroups in files can now also be header-less. Example:
+       <pre>
+       /*! @file */
+
+       /*! A macro */
+       #define AMACRO 11
+
+       //@{ 
+       /*! F1 macros */
+       #define F1_0 0                                   
+       #define F1_1 (F1_0 + 1)   
+       #define F1_2 (F1_1 + 2)
+       //@}
+
+       /*! Yet another macro */
+       #define YAMACRO 10
+       </pre> </li>
+<li>   The `explicit' and `mutable' keywords are now recognized as
+       member attributes instead of return types.</li>
+<li>   the index page is now added to the HTML help contents.</li>
+<li>   In case "no matching member" is found, a list of possible
+       (but non-matching) candidates is generated along with the warning. 
+       This makes it much easier to see what's wrong. </li>
+<li>   added two new commands: 
+       <ul>
+       <li>\hideinitializer which can be put in the documentation to 
+           a variable or the define to hide the initializer or define value.</li>
+       <li>\showinitializer which can be used to explicitly show the
+         initializer of a variable or the value of a define even if it
+         is longer than 30 lines.</li>
+       </ul></li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed a lock-up problem, that occurred when 
+       parsing a code fragment containing something like:
+       <pre>
+       //
+       /*!
+        blah
+       */
+       </pre>
+       while STRIP_CODE_COMMENTS was set to NO       </li>
+<li>   The auto list feature was still broken. 
+       Due to a bad scanner rule, things like -1 at the start of a line 
+       were treated as a list items (again) and a list at the end of a 
+       comment block did not always work either.</li>
+<li>   If an non-existent config file was specified, the directories
+       "html", "man" and "latex" were created anyway.</li>
+<li>   A fragment like: os <code>&lt;&lt; "&gt;"</code> was misinterpreted 
+       by doxygen's code parser.</li>
+<li>   Parameter declarations that differ only in the presence or absence
+       of const and/or volatile are now treated as equivalent, as is
+       dictated by the C++ standard.</li>
+<li>   The inline function body was wrong in the following example:
+       <pre>
+        void f(                                               
+           int i    ///&lt; Parameter                                          
+        )   
+        {                                                            
+            return 1;                            
+        }  
+       </pre>
+       Thanks to Alexander Gidon for the fix.</li>
+<li>   typedef'ed classes are now also resolved in code fragments
+       (again thanks to Alexander).</li>
+<li>   Fixed a bug related to base classes with nested template specifiers,
+       like class SB in the following:
+       <pre>
+         template &lt;class T&gt; class C  {};
+         template &lt;class T&gt; class S  {};
+         template &lt;class T&gt; class SB {};
+         template &lt;class T&gt; class S&lt;C&lt;T&gt; &gt; : public SB&lt;C&lt;T&gt; &gt; {};
+       </pre> </li>
+<li>   #includes in code fragments where not hyperlinked. Operator
+       methods were also not correctly recognised.</li>
+<li>   C/C++ comments inside initializers where not handled properly.</li>
+<li>   If the type of an argument of a member definition was prefixed 
+       with a (redudant) scope name of an indirect base class, 
+       then it was not matched against the member declaration if that
+       omitted the scope.</li>
+<li>   \name did not work within //! comments</li>
+<li>   When FULL_PATH_NAMES was set to YES, doxygen did no longer
+       distinguish between files with the same name (but in 
+       different directories). </li>
+<li>   The file match routine now does an case-insensitive lookup
+       if CASE_SENSE_NAMES = NO. Hopefully this is enough to 
+       let doxygen ignore case differences in file names on Windows.</li>
+<li>   The constructors and destructors of classes inside namespaces
+       or other classes did not end up in the constructor/destructor
+       section of the documentation.</li>
+<li>   If an environment variable in the config file starts with a space 
+       followed by a list of words, the space ends up in the first word 
+       after expansion.</li>
+<li>   A &lt;table&gt; inside a JavaDoc style comment block caused a bogus
+       warning.</li>
+<li>   Using member groups could result in an empty list generated in
+       LaTeX, causing a error while compiling the documentation.</li>
+<li>   Fixed a missing stdlib.h problem in doxywizard, which occurred
+       on non-Linux systems.</li>
+<li>   The generation of dot include graphs did not work properly in 
+       case file names with space were used.</li>
+<li>   back-references from source-lines to documentation only worked for
+       those members of a member group that were explicitly documented.</li>
+<li>   doxygen did not distriguish between func(int a) and func(int a[])
+       which could cause documentation to end up at the wrong member
+       in case over overloading. </li>
+</ul>
+
+
+
+<h1>Doxygen Release 1.1.3</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   Changed the way anonymous enums are handled: they are now handled
+       just like named enums, which makes the "Enumeration Values" section
+       obsolete.</li>
+<li>   If 
+       <pre>
+         /*! \file */ 
+       </pre>
+       is put into a file (thus without further documentation) then the
+       file is treated as being documented.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Doxygen now has a GUI frontend to create and edit the configuration
+       file. It is called doxywizard. To build it from sources use:
+       <pre>
+         ./configure --with-doxywizard
+       </pre>
+       The front-end requires Qt 2.x to build. I've only tested with Qt-2.1.
+       Sources can be found in the addon directory.</li>
+<li>   To make it very easy to add new configuration options, doxygen 
+       now has an additional tool called configgen. All options supported
+       by doxygen are now located in one place (in configgen.cpp).
+       From this the configuration parser and part of the GUI are 
+       generated. You only need configgen if you want to add new options
+       to doxygen. Thanks go to Joerg Baumann for providing the ideas
+       and part of the code.</li>
+<li>   Added a bit of syntax highlighting to the generated source
+       fragments in HTML (only keywords, comments and preprocessor directives 
+       are colored for now). The font color &amp; style is determined by 
+       the style sheet, so it is easy to customize :-)</li>
+<li>   Typedefs of classes are now resolved when the inheritance
+       and usage relation of classes is determined.</li>
+<li>   Waechter Parker made the following improvements on the RTF generator:
+       <ol>
+       <li>Now it uses the translator for the table of contents entry names
+          for the sections.</li>
+       <li>writeSection now puts braces around the entry so the formatting              
+          doesn't get messed up so easily.                                       </li>
+       <li>removed extra newline in startDescList                    </li>
+       <li>writeSectionRef now writes out "title (p.pagnum)" like it should.</li>
+       <li>writeSectionRefAnchor now just calls writeSectionRef.  </li>
+       </ol></li>
+<li>   Doxygen's preprocessor now supports the non-ANSI "#else if" 
+       preprocessor construction, which some other preprocessors seem to 
+       accept as well.</li>
+<li>   Boris Bralo added language support for the Croatian language.
+       Nickolay Semyonov has finished the translation to Russian, which is
+       now included.</li>
+<li>   Added documentation for the commands \if and \endif, the
+       configuration tag ENABLED_SECTIONS, and the ways to groups
+       things together.</li>
+<li>   In the brief part of a JavaDoc style comment block,
+       putting a backslash after a space, prevents switching to the
+       detailed description. Example: <code>i.e.\ this</code>.</li>
+<li>   Class diagrams can now also be rendered with dot by setting
+       CLASS_GRAPH to YES (this will disable the build-in class graphs).
+       The advantages:
+       <ul>
+       <li>More compact diagrams.</li>
+       <li>Correctly looking diagrams in case of virtual inheritance.</li>
+       <li>A more consistent look w.r.t. the other graphs.</li>
+       </ul></li>
+<li>   Groups can now contain namespaces and other groups.</li>
+<li>   operator% caused problems with LaTeX when PDF_HYPERLINKS was set to YES.</li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   <code>\c func()</code> did not autolink to function "func" anymore.  </li>
+<li>   template members with multiple arguments were misaligned
+       in the HTML output. </li>
+<li>   Since 1.1.2, environment variable expansion in the config 
+       file always resulted in a single string for each expanded variable
+       (just as if quotes were put around the environment variable).
+       The old behaviour is restored again.</li>
+<li>   removed redundant spaces in the man page output and fixed the
+       tab alignment in code fragments.</li>
+<li>   <code>typedef ( bla::*proc)();</code> was not properly parsed because of the
+       space after the first opening bracket.</li>
+<li>   fixed a problem in the namespace strip routine that could potentially
+       lock up doxygen.</li>
+<li>   Long pre-initialized arrays ended up in the documentation.</li>
+<li>   Friend functions that were documented at the declaration were 
+       cross-referenced to the wrong file when using SOURCE_BROWSER=YES.</li>
+<li>   When EXTRACT_ALL=YES was used, classes that were 
+       documented with \class appeared twice in the namespace documentation.</li>
+<li>   Setting HIDE_UNDOC_CLASS=YES could result in an incorrectly
+       indented textual class hierarchy. This should now be fixed.</li>
+<li>   Members with very long return types caused all member names to
+       be pushed to the right in the HTML documentation 
+       (if HTML_ALIGN_MEMBERS was YES). Now some line breaks are inserted
+       at the proper places.</li>
+<li>   A couple of people reported that doxygen crashed while it was generating 
+       dot graphs. The cause was likely to be multiple frees of the same 
+       pointer (but I have not been able to reproduce the crash myself). 
+       I've now reimplemented the deletion routine of the dot graph
+       respresentation, which hopefully fixes this problem.</li>
+<li>   Elements of the configuration options in lists, which used quotes 
+       were broken up into smaller pieces anyway. This most notably broke
+       PREDEFINED in some cases that worked before.</li>
+<li>   Detailed description was present for classes, files and namespaces
+       even if there was only a brief description and REPEAT_BRIEF was NO.</li>
+<li>   LaTeX: For German output "deutsch" was used as an option for the babel
+       package, while it should be "german". For Russian output an encoding
+       option is added.</li>
+<li>   The inheritance relation was incorrect for the inner class of B in the
+       following situation:
+       <pre>
+       template &lt;class T&gt; class A { public: class inner { }; };
+       template &lt;class T&gt; class B : public A&lt;T&gt; 
+              { public: class inner : public A&lt;T&gt;::inner { }; }; 
+       </pre> </li>
+<li>   Fixed a bug that prevented the header links of the search engine 
+       from working.</li>
+<li>   Undocumented classes &amp; enums made it in the file documentation even if
+       HIDE_UNDOC_MEMBERS was set to YES.</li>
+<li>   Backslashes in includes like
+       <pre>
+       #include "..\blah.h" 
+       </pre>
+       did not end up in the include dependency graph.</li>
+<li>   If ALPHABETICAL_INDEX=YES but there were no documented classes, part
+       of the LaTeX output (doxygen.sty a.o.) was not generated 
+       (Thanks to Markus Lepper for reporting this).</li>
+<li>   Doxygen can now match arguments containing an explicit namespace
+       qualifier against arguments containing an implicit qualitifier 
+       (i.e. imported via a using directive). 
+       An example (thanks to Karl Stroetmann):
+       <pre>
+       /*! a class */
+       class Test
+       {
+         public:
+           void resolve(const std::vector&lt;int&gt;&amp;);
+       };                                                                              
+       using namespace std;                 
+       /*! a member */
+       void Test::resolve(const vector&lt;int&gt;&amp;) {}                                
+       </pre> </li>
+<li>   Template specifiers are now shown in dot generated
+       collaboration graphs.</li>
+</ul>
+
+<h1>Doxygen Release 1.1.2</h1>
+
+<h3>Changes</h3>
+<ul>
+<li> Having the source browser set to YES does not longer imply that
+     a member with a reference to the sources is automatically documented.</li>
+<li> Base classes are shown in declaration order in the class diagrams</li>
+<li> The arguments of a function now each get their own
+     line in the header above the detailed description. This makes
+     function with lots of argument much more readable.</li>
+<li> Changed the look of the LaTeX output a bit. </li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   Thanks to Joerg Baumann, doxygen now has two new commands:
+       <ul>
+       <li>\if label </li>
+       <li>\endif</li>
+       </ul>
+       These commands can be used to create conditional documentation blocks.
+       Sections are disabled by default. To enable them add a guarding
+       "label" to the <code>ENABLED_SECTIONS</code> tag in the config file.
+       Conditional blocks can be nested.
+       Example:
+       <pre>
+       /*! Normal docs.
+        *  \if Cond1
+        *    Only included if Cond1 is set.
+        *  \endif
+        *  \if Cond2
+        *    Only included if Cond2 is set.
+        *    \if Cond3
+        *      Only included if Cond2 and Cond3 are set.
+        *    \endif
+        *    More text.
+        *  \endif
+        *  Unconditional text.
+        */
+        </pre></li>
+<li>   Again thanks to Joerg Baumann, URLs and mail addresses are now
+       hyperlinked in the PDF output 
+       (=latex with <code>PDF_HYPERLINKS = YES</code>).</li>
+<li>   Added support for member grouping. I reimplemented this
+       from scratch. I decided to follow the doc++ syntax for the member 
+       grouping. Here are two examples. 
+       <p>
+       <b>Usage:</b> A group is defined by a <code>//@{ .. //@}</code> block 
+       (or <code>/*@{*/../*@}*/</code> if 
+       you're addited to C style comments :-) Nesting of groups is not 
+       allowed. Before the opening marker of a block a separate comment 
+       block should be placed. This block should contain the @name 
+       (or \name) command to specify the header of the group.
+       </p>
+       <p>
+       If all members of a user defined member group are in same section
+       (for instance all are public methods), then the group as a whole
+       will be listed as subsection of that section.
+       </p>
+       <p>
+       <b>Example1:</b> Two ways to grouping member of a class
+       </p>
+       <pre>
+       /** A class. Details */
+       class Test
+       {
+         public:
+           /** @name Group1
+            *  Description of group 1. Details.
+            */
+           //@{
+           /** Function 1 in group 1. Details. */
+           void func1InGroup1();
+           /** Function 2 in group 1. Details. */
+           void func2InGroup1();
+           //@}
+
+           void func1InGroup2();
+           void func2InGroup2();
+           /** Function without group. Details. */
+           void ungroupedFunction();
+       };
+
+       void Test::func1InGroup1() {}
+       void Test::func2InGroup1() {}
+
+       /** @name Group2 */
+       //@{
+       /** Function 2 in group 2. Details. */
+       void Test::func2InGroup2() {}
+       /** Function 1 in group 2. Details. */
+       void Test::func1InGroup2() {}
+       //@}
+       </pre>
+       <p>
+       <b>Example2:</b> Combining member groups with @defgroup.
+       </p>
+       <pre>
+       /** @defgroup globals Global Functions 
+        *  Functions that may be used in any translation unit.
+        */
+
+       /** @name Debug Functions */
+       /*@{*/
+
+       /** @ingroup globals
+        *  debug printf function.
+        */
+       void debugPrint(const char *s /**&lt; the message to print. */
+                      );
+
+       /** @ingroup globals
+        *  assert function.
+        */
+       void my_assert(const char *f, /**&lt; current file. */
+                      int l,         /**&lt; current line. */
+                      BOOL e         /**&lt; expression to evaluate. */
+                     );
+       /*@}*/
+
+       /** @name Test Functions */
+       /*@{*/
+
+       /** @ingroup globals
+        *  test on-board memory.
+        *  @returns TRUE if successful.
+        */
+       bool testRam();
+
+       /** @ingroup globals
+        *  perform CPU self-test.
+        *  @returns TRUE if successful.
+        */
+       bool testCPU();
+
+       /*@}*/
+       </pre></li>
+<li>   Documented variables (e.g. constants) that are used as initializers
+       of function parameters are now also cross-referenced. </li>
+<li>   Lucas Cruz sent an update for the Spanish translation. This is now
+       included. Jens Breitenstein sent an update for the German translation.
+       Philippe Lhoste sent some bug fixes for the French translation.
+       Alessandro Falappa sent an updated of the Italian translation, which
+       is now included. Nickolay Semyonov added initial support for the 
+       Russian language. I updated the Dutch translation.</li>
+<li>   Thanks to Matthias Andree, the doxygen source package 
+       now contains a .spec file. This can be used to build an .rpm package 
+       for doxygen.
+       doing:
+       <pre>
+         rpm -ta doxygen-x.y.z.src.tar.gz
+       </pre>
+       will create the rpm (in /usr/src/packages/RPMS/i386/ on my machine).
+       Running <code>rpm -Uhv</code> as root on the .rpm file will 
+       install/update doxygen. 
+       After that you can use <code>rpm -e doxygen</code> to uninstall it again.</li>
+<li>   Umlauts and other accents in the documentation now appear properly in 
+       generated RTF output.  </li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   Fixed bug in the generated config file (LATEX_BATCHMODE)</li>
+<li>   When updating the config file, <code>TAB_SIZE</code> and 
+       <code>COLS_IN_ALPHA_INDEX</code>
+       were reset to their default values. Environment variables in 
+       the config file are no longer replaced by their value when updating 
+       the config file. </li>
+<li>   The version.cpp file is now automatically updated when creating
+       a source/cvs package.</li>
+<li>   The types of arguments that are prefixed with a namespace scope 
+       are now be matched against non-prefixed names. Example:
+       <pre>
+       namespace std { class string {}; }
+       //! A class
+       class Test { 
+         public:
+           void test(std::string a);
+       };
+       using std::string;
+       //! A member
+       void Test::test(string a);
+       </pre>
+       <b>Note:</b> The namespace definition has to be part of the 
+       input sources for this to work!</li>
+<li>   Fixed a bug in structure of the graphical class hierarchy
+       (thanks to Paul Bohme for pointing me at this bug)</li>
+<li>   Non-function members can now also be documented if they
+       are inside annonymous namespaces, which themselves are nested in 
+       named namespaces.</li>
+<li>   #defines can now grouped with \defgroup and \ingroup as well.</li>
+<li>   fixed a bug in the latex output of groups (thanks to Gregory Kurz
+       for reporting this)</li>
+<li>   Doing a \ref to a \anchor in an example did not work.</li>
+<li>   static file &amp; namespace members were cross-referenced even though
+       they were not visible if EXTRACT_PRIVATE is set to NO.</li>
+<li>   The following code fragment made doxygen crash, because the
+       table was split between the brief and detailed section:
+       <pre>
+       /** &lt;table&gt;&lt;tr&gt;&lt;td&gt;a. &lt;/td&gt;&lt;tr&gt;&lt;/table&gt; */
+       class Test {};
+       </pre>
+       Doxygen now ends the brief description when a &lt;table&gt; tag is encountered.</li>
+<li>   \c and \b now also accept numbers and other printable characters, 
+       instead of only identifiers.</li>
+<li>   Autolinking did not work if a member with arguments was specified
+       in the documentation and that member had a const or volatile postfix
+       in the code. Autolinking did not also not work if a member with 
+       arguments contained digits (thanks to Fred Labrosse for pointing me
+       at this bug).</li>
+<li>   The first line was missed if @code was used for generating man pages.
+       (Thanks to Joe Bester for the patch). </li>
+<li>   <code>\link create_link(long,int&amp;) bla \endlink</code> 
+       now works (doxygen was confused by the arguments before).</li>
+<li>   A brief description after a function definition, followed by a detailed
+       description now works as expected. Example:
+       <pre>
+         bool func()
+         {
+         }
+         //!&lt; Brief.
+         /*!&lt; Details. */
+       </pre></li>
+<li>   Multi-line brief descriptions after a function declaration or definition
+       now work as excepted. Example:
+       <pre>
+         bool func()
+         //!&lt; Brief.
+         //!&lt; More brief.
+       </pre></li>
+<li>   \latexonly fragments were put on a single line causing problems 
+       when latex comments (%'s) are used. </li>
+<li>   The license file that came with doxygen was of LGPL, while it
+       should be GPL. The correct license file is included now.</li>
+<li>   The heading of the alphabetical index was duplicated if 
+       classes were present in both upper and lower case.</li>
+<li>   If ENABLE_PREPROCESSING=NO and the INPUT_FILTER was used, doxygen
+       did not filter properly can could even block on input!</li>
+<li>   Internationalization should now output proper characters with qt-2.1x.</li>
+<li>   If namespace contained a function prototype &amp; a function definition
+       they both ended up in the documentation.</li>
+<li>   &lt;table&gt; without &lt;/table&gt; could cause doxygen to crash. Now a 
+       warning is given.</li>
+<li>   Multiline variable and enum initializers with lots of spaces were 
+       shown in an ugly way.</li>
+</ul>
+
+
+
+<h1>Doxygen Release 1.1.1</h1>
+
+<h3>Changes</h3>
+<ul>
+<li>   "Reimplements" for a member now points to the most direct
+       base class that overrides the member instead of the base 
+       class containing the vtable.</li>
+<li>   classes, namespaces, and members are now sorted 
+       in a case insensitive way (like in a dictionary).
+       Was case sensitive.</li>
+<li>   Kenji Nagamatsu has send me an update for the Japanese translation
+       which is now included.</li>
+</ul>
+<h3>New features</h3>
+<ul>
+<li>   new option SHOW_INCLUDE_FILES, which can be set to NO to turn of the
+       list of include files that is generated for each documented file.</li>
+<li>   new option STRIP_CODE_COMMENTS, which can be set to NO to keep any
+       special comment blocks in the generated code fragments.</li>
+<li>   Added a new tag to the configuration file: SORT_MEMBER_DOCS. If this
+       is set to NO the member documentation will appear in declaration
+       order (as was the case with version 1.0.0 and older). </li>
+<li>   Corba IDL exceptions are now also supported by doxygen.
+       If you do not want to put the documentation in front of the 
+       exception you can use \idlexcept command which behaves like \class.</li>
+<li>   Local file:/// URLs are now automatically linked when put in the
+       documentation.</li>
+<li>   For \class and other structural commands you can now use 
+       a backslash (\) at the end of a line to continue the command on 
+       the next line. 
+       Example:
+       <pre>
+         \class Abstract_Server_Session_Implementation  \
+                Abstract_Server_Session_Implementation.h \
+                ATD/Abstract_Server_Session_Implementation.h     
+       </pre></li>
+<li>   "make distclean" now removes all generated stuff and results in a
+       package that is more clean than a normal source package 
+       (i.e. the generated flex &amp; bison code is removed).  </li>
+<li>   Added command \note (and @note) for a "Note:" paragraph.</li>
+<li>   Multi arguments can now be given as a comma separated list 
+       after a \param or \retval command. Example:
+       <pre>
+       void Zoom( int aX1, int aY1, int aX2, int aY2 );  
+       /*! Zoom into the data.                                        
+        *  \param aX1, aY1 Upper left corner.                         
+        *  \param aX2, aY2 Lower right corner. 
+        */
+       </pre></li>
+<li>   Added 9 new class declaration sections: 
+       Public/Protected/Private Types, for member typedefs &amp; variables.
+       [Static] Public/Protected/Private Attributes, for member variables.</li>
+<li>   Doxygen now has a new command line option -u, that can be used
+       to upgrade an old configuration file without losing the values that 
+       where edited. In combination with the -s option this can also be used
+       to strip comments from or add comments to a configuration file.</li>
+<li>   Added a new tag LATEX_BATCHMODE that makes latex run in batch mode.
+       This will run latex non-interactively, and not stop at the first
+       problem encountered. If the tag is enabled this mode will also be 
+       used when generation formulas for inclusion in the HTML documentation.</li>
+<li>   The \ingroup command can now also be used to group a number of
+       members. The only limitation is that a member can currently be in
+       one group only (classes, files &amp; namespaces do 
+       not have this limitation). </li>
+</ul>
+<h3>Bug fixes</h3>
+<ul>
+<li>   The graphical class hierarchy was not properly generated when
+       template classes were used.</li>
+<li>   Template specialization could not be documented using the 
+       \class command. This is now fixed. Example:
+       <pre>
+       /*!
+        * \class T&lt;A,int&gt;
+        * My template specialization of template T.
+        */
+       </pre></li>
+<li>   Fixed a bug when parsing M$-IDL code, containing 
+       helpstring("bla") attributes. The attributes of a method are no longer
+       shown in the documentation (the attributes of method arguments 
+       still visible however).</li>
+<li>   Improved the search algorithm that tries to connect classes with their
+       base classes. It should now (hopefully) work correct in all cases 
+       where nested classes and/or namespaces are used.       </li>
+<li>   Fixed a scanner problem that could cause doxygen to get
+       confused after parsing struct initializers.</li>
+<li>   the DOTFONTPATH environment variable is now automatically set
+       for Windows. This should make any "missing doxfont.ttf" 
+       messages disappear.</li>
+<li>   the extra LaTeX packages specified with EXTRA_PACKAGES can now
+       also be used when generating formulas for HTML. </li>
+<li>   The documentation of a parameters that is part of a member definition,
+       is now used in the documentation as well.</li>
+<li>   Fixed a HTML output bug in the class/file group-pages.</li>
+<li>   Links to example files generated with \link ... \endlink where not
+       correct. </li>
+<li>   made the bullet list generation more robust. A space is now required 
+       after the - sign. A list can now start a paragraph.</li>
+<li>   the configure script now detects whether or not dot is installed.</li>
+<li>   The VERBATIM_HEADERS option didn't have any effect any more.
+       It should now work again as advertised.</li>
+<li>   The IGNORE_PREFIX option can now also deal with a list of prefixes.</li>
+<li>   @verbatim ... @endverbatim blocks did not work. </li>
+<li>   removed some \n's from the systems calls that run dot. This appears to 
+       cause problems for some people and was not what I intended anyway :^)</li>
+<li>   The following construct was not working:
+       <pre>
+       namespace foo { class bar; }
+       /*! let's go to the bar */
+       class foo::bar { };
+       </pre></li>
+<li>   Members inside annonymous namespaces nested inside named namespaces 
+       were not properly handled. </li>
+<li>   When documenting template specializations with the \class command,
+       the second argument was not interpreted correctly.</li>
+<li>   Interface inheritance relations are now always public for IDL 
+       interfaces.</li>
+<li>   Templetized related functions showed a double `template' line.</li>
+<li>   Related function that had a declaration and a definition 
+       also appeared in file documentation but without documentation. </li>
+<li>   Links to files of the include dependency graph were
+       non existent in some situations.</li>
+<li>   Removed warning generated for undocumented friend classes.</li>
+<li>   Class reference in the main page ended up in refman.tex</li>
+<li>   Source files were generated for files mentioned in tag files.</li>
+<li>   The graphical class hierarchy always contained all external class,
+       regardless of the ALLEXTERNALS flag.</li>
+<li>   operator~() was grouped with the constructor/destructors.</li>
+<li>   In a number of cases, documented include files, that were 
+       shown in the include dependency diagram where not found to be
+       documented. As a result the diagram was often not clickable and
+       incomplete.</li>
+<li>   Fixed the graphical class hierarchy. Sometimes classes were missing.</li>
+<li>   Added support for the cpp_quote hack inside M$-IDL code.</li>
+<li>   The typedef in:
+       <pre>
+         struct MyStruct { int i; };
+         typedef struct MyStruct * MyStructPtr;
+       </pre>
+       was mistaken for a variable.</li>
+<li>   <pre>
+        /** @file
+        *  @brief
+        *  Brief.
+        *
+        *  Details.
+        */
+       </pre>
+       was not properly handled.</li>
+<li>   Corba IDL unions now work. Example:
+       <pre>
+       /** \union XYZ
+        *  \brief The XYZ union.
+        */                       
+       union XYZ switch ( ABC ) 
+       {
+         case A: D_VAR m_d; ///&lt; Docs for a member in case A
+         case B: E_VAR m_e; ///&lt; Docs for a member in case B
+       };
+       </pre></li>
+<li>   Classes documented with \class and using \ingroup where not always
+       put into the group.</li>
+<li>   In Latex &amp; RTF references to undocumented files where put in the
+       index.  </li>
+</ul>
+
+<h1>Doxygen Release 1.1.0</h1>
+<h3>Changes</h3>
+<ul>
+<li>   Static file members are now hidden if EXTRACT_PRIVATE is set to NO.</li>
+<li>   the documentation of members in the class/file descriptions are now
+       alphabetically sorted by member name for each section. There is a new
+       section for constructors &amp; destructors.</li>
+<li>   merged file, header and source indices into one file index.
+       As a result, doxygen will generate a hyperlinked source code only
+       once. This should greatly increase speed and reduce memory usage
+       for large projects.</li>
+</ul>
+
+<h3>New features</h3>
+<ul>
+<li>   Thanks to Parker Waechter, doxygen now has a new output format: RTF. 
+       This is Microsoft's "portable" document format. Due to the great 
+       "portability" of this format the output produced by doxygen will 
+       probably only look nice with Microsoft's Word 97.
+       <p>
+       RTF is currently disabled by default. You can set GENERATE_RTF to 
+       YES to enable it. The directory where the RTF output is put, can
+       be specified using the RTF_OUTPUT tag in the configuration file.
+       COMPACT_RTF can be enabled to generate more compact RTF.
+       RTF_HYPERLINKS can be used to generate HTML like cross references
+       in the document. </p></li>
+<li>   Doxygen can now use the "dot" tool from graphviz 1.5, which is an 
+       open-sourced, cross-platform graph drawing toolkit from AT&amp;T and 
+       Lucent Bell Labs.
+       <p>
+       Graphviz can be found at 
+       <a href="https://www.graphviz.org/">https://www.graphviz.org/</a>
+       If you have the "dot" tool available in the path, you can set
+       HAVE_DOT to YES in the configuration file to let doxygen use it.
+       </p><p>
+       Doxygen uses the "dot" tool to generate the following graphs:
+       </p>
+       <ul>
+       <li>if GRAPHICAL_HIERARCHY is set to YES, a graphical representation
+           of the overall inheritance diagram will be drawn, 
+           along with the textual one (currently supported for HTML only).</li>
+       <li>if INCLUDE_GRAPH is set to YES, an include dependency graph
+           is generated for each documented file that includes at least one
+           other file (currently supported for HTML and RTF only).</li>
+       <li>if COLLABORATION_GRAPH is set to YES, a graph is drawn for each
+           documented class and struct that shows:
+           <ul>
+           <li> the inheritance relation with base classes 
+              (using solid blue/green/red arrows, for public,protected,private
+              inheritance).</li>
+           <li> the containment relations with other structs 
+              and class (using purple dashed arrows with variable names as labels)
+              (currently supported for HTML and RTF only)</li>
+           </ul></li>
+       </ul>
+       <p>
+       For the include dependency graph and the collaboration graph, 
+       doxygen will render a transitive closure of the relation. If
+       the diagram becomes too large (currently wider than 1024 pixels),
+       only the maximum graph depth (as seen from the root of the 
+       graph) that still fits will be drawn. (the nodes that can still be 
+       expanded are shown with a red border in this case).
+       </p><p>
+       For HTML all graphs are drawn as client side clickable image maps.</p></li>
+<li>   Each file now has a list the files it includes 
+       (with links to the sources if available)</li>
+<li>   For class documentation it is now possible to choose how the
+       <code>#include</code> statement should look like 
+       (i.e. like "stdio.h" or &lt;stdio.h&gt;). 
+       This can be done using the third argument of 
+       the <code>\class</code> command.
+       Example: <pre>\class myclass myclass.h "mydir/myclass.h"</pre></li>
+<li>   If the - character is used as the first character in a comment line
+       it is interpreted as an item of a bullet list. Subitems are also
+       possible. Here is an example:
+       <pre>
+       /*!
+        * A list:
+        *      - item 1
+        *        - subitem 1
+        *      - item 2
+        *        - subitem 1
+        *          - subsubitem
+        *        - subitem 2
+        *      - item 3
+        *      - item 4
+        *
+        * Starting a new paragraph in a top level item ends the list!
+        */
+       </pre>
+
+       Notice: tabs can be used for indenting, but the TAB_SIZE tag in the 
+       configuration file must be set correctly!</li>
+<li>   Function/member arguments can now be documented, like this
+       <pre>
+       /*! This function finds the first occurrence of a 
+        *  substring in a string.  
+        */
+       char *strstr(const char *haystack, /*!&lt; the string to search in. */
+                    const char *needle)   /*!&lt; the substring to search for. */                  
+       {
+       }
+       </pre></li>
+<li>   Three new section commands <code>\pre</code>, <code>\post</code> and 
+       <code>\invariant</code> are added to describe
+       preconditions, postcondictions and invariants respectively.</li>
+<li>   Variable/enum initializers and define definitions are 
+       now included in documentation (unless the initializer/definition 
+       is more than 30 lines long)</li>
+<li>   Added new configuration option IGNORE_PREFIX that can be
+       used to ignore a specified prefix while generating the alphabetical
+       class index.</li>
+</ul>
+
+<h3>Bug fixes</h3>
+<ul>
+<li>   All defines were shown as function macros in the documentation section.</li>
+<li>   Fixed bug with parsing multi-line defines on Windows (\r problem). </li>
+<li>   Protection level of members inside nested anonymous compounds was not 
+       set correctly.</li>
+<li>   Class diagram was not correct in case the same class was inherited
+       via two different paths (bug introduced in 1.0.0).</li>
+<li>   If a tag is specified two times in the config file, then the second
+       definition will correctly overwrite the value of the first occurrence.</li>
+<li>   For multiple defines with comments after them only the first was
+       cross-referenced with the sources.</li>
+<li>   Autolinks to #defines looked like function macro even if they weren't.</li>
+<li>   Members that were hidden deep in an inheritance tree, got multiple
+       scope prefixes in the "all members list", while a scope prefix to
+       the member in the base class was enough to use it unambiguishly.</li>
+<li>   <code>\latexonly ... \endlatexonly</code> in the main page produced 
+       erroneous text in refman.tex</li>
+<li>   The keywords in header and footer were only evaluated once.</li>
+<li>   Formulas now also work in documentation blocks that are put after an
+       item.</li>
+<li>   The source code could produce links to the wrong class for
+       a code fragment like <code>a.f()</code> in 
+       case two classes have the same member variable `a', but with a
+       different class types and those classes both had the member 
+       function `f'.</li>
+<li>   array type arguments (like int a[2]) where not matched if the argument
+       name of declaration and definition were different. </li>
+<li>   memory in code.l is now returned at the appropriate times.</li>
+</ul>
 <hr/>
 Go <a href="index.html">back</a> to the main page.
 <p>


### PR DESCRIPTION
- integrating older versions of the changelog (i.e. version 1.5 and older, so no external references to doxygen changelog pages)
- correcting permanent redirects
- consistency