### PR TITLE
Prevent empty page list table (XHTML)

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -828,10 +828,13 @@ void FTVHelp::generateTreeViewInline(FTextStream &t)
   }
   //printf("preferred depth=%d\n",preferredDepth);
 
-  t << "<table class=\"directory\">\n";
-  int index=0;
-  generateTree(t,m_indentNodes[0],0,preferredDepth,index);
-  t << "</table>\n";
+  if (m_indentNodes[0].count())
+  {
+    t << "<table class=\"directory\">\n";
+    int index=0;
+    generateTree(t,m_indentNodes[0],0,preferredDepth,index);
+    t << "</table>\n";
+  }
 
   t << "</div><!-- directory -->\n";
 }


### PR DESCRIPTION
The table (tag) should only be written in case a table has at least one row, otherwise a non valid table is generated (XHTML)