### PR TITLE
issue #6692 XML TOC generation is not backwards-compatible with 1.8.14

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2110,7 +2110,7 @@ Make sure you have first read \ref intro "the introduction".
   this range are considered to be 5. In case no `level` is specified `level` is
   set to 5 (show all)
   In case no `option`. is specified \c \\tableofcontents acts as if just the
-  `option` `HTML` was specified. In case of multiple \c \\tableofcontents
+  `option` `HTML` and `XML` was specified. In case of multiple \c \\tableofcontents
   commands in a page the `option`(s) will be used additional to the already
   specified `option`(s), but only the last `level` of an `option` is valid.
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3005,7 +3005,9 @@ static bool handleToc(const QCString &, const QCStringList &optList)
     }
     if (current->localToc.nothingEnabled())
     {
-      current->localToc.enableHtml(5); // for backward compatibility
+      // for backward compatibility
+      current->localToc.enableHtml(5);
+      current->localToc.enableXml(5);
     }
   }
   return FALSE;


### PR DESCRIPTION
In case no options specified with the `\tableofcontents` `Html` and `XML` should be generated and not only `Html` (compatibility).