### PR TITLE
Create possibility of a dynamic in page table of contents

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2109,10 +2109,18 @@ Make sure you have first read \ref intro "the introduction".
   that is shown. The value of `level` should be in the range 1..5, values outside
   this range are considered to be 5. In case no `level` is specified `level` is
   set to 5 (show all)
-  In case no `option`. is specified \c \\tableofcontents acts as if just the
+
+  In case none of the `option`s `HTML`, `LaTeX`, `XML` or `DocBook`, is specified
+  \c \\tableofcontents acts as if just the
   `option` `HTML` was specified. In case of multiple \c \\tableofcontents
   commands in a page the `option`(s) will be used additional to the already
   specified `option`(s), but only the last `level` of an `option` is valid.
+
+  In case of `HTML` output the default is a static table of contents. To have
+  a dynamic table of contents one has to specify besides the `HTML` `option`
+  the `option` `dyn` or `dync`. In case the `option` `dyn` is used an expanded
+  table of contents is shown in case of `dync` a collapsed but expandable
+  table of contents showing the highest level is shown.
 
   \warning This command only works inside related page documentation and
            \e not in other documentation blocks and only has effect in the

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2958,6 +2958,7 @@ static bool handleToc(const QCString &, const QCStringList &optList)
   if (current->section==Entry::PAGEDOC_SEC || 
       current->section==Entry::MAINPAGEDOC_SEC)
   {
+    current->localToc.setDynamicHtml(LocalToc::HtmlStatic); // default setting
     QCStringList::ConstIterator it;
     for ( it = optList.begin(); it != optList.end(); ++it )
     {
@@ -2996,6 +2997,14 @@ static bool handleToc(const QCString &, const QCStringList &optList)
         else if (opt == "docbook")
         {
           current->localToc.enableDocbook(level);
+        }
+        else if (opt == "dyn")
+        {
+          current->localToc.setDynamicHtml(LocalToc::HtmlDynamicExpanded);
+        }
+        else if (opt == "dync")
+        {
+          current->localToc.setDynamicHtml(LocalToc::HtmlDynamicCollapsed);
         }
         else
         {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -748,6 +748,7 @@ void HtmlGenerator::init()
   {
     mgr.copyResourceAs("fixed_tabs.css",dname,"tabs.css");
   }
+  mgr.copyResource("dyntoc.js",dname);
   mgr.copyResource("jquery.js",dname);
   if (Config_getBool(INTERACTIVE_SVG))
   {

--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -351,6 +351,7 @@ void marshalLocalToc(StorageIntf *s,const LocalToc &lt)
   marshalInt(s,lt.latexLevel());
   marshalInt(s,lt.xmlLevel());
   marshalInt(s,lt.docbookLevel());
+  marshalInt(s,lt.dynamicHtml());
 }
 
 void marshalEntry(StorageIntf *s,Entry *e)
@@ -744,7 +745,8 @@ LocalToc unmarshalLocalToc(StorageIntf *s)
   int htmlLevel  = unmarshalInt(s);
   int latexLevel = unmarshalInt(s);
   int xmlLevel   = unmarshalInt(s);
-  int docbookLevel   = unmarshalInt(s);
+  int docbookLevel = unmarshalInt(s);
+  int dynHtml      = unmarshalInt(s);
   if ((mask & (1<<LocalToc::Html))!=0)
   {
     result.enableHtml(htmlLevel);
@@ -761,6 +763,7 @@ LocalToc unmarshalLocalToc(StorageIntf *s)
   {
     result.enableDocbook(docbookLevel);
   }
+  result.setDynamicHtml(dynHtml);
   return result;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -230,6 +230,11 @@ enum FortranFormat
 class LocalToc
 {
   public:
+    enum HtmlDynamic {
+      HtmlStatic           = 0,
+      HtmlDynamicCollapsed = 1,
+      HtmlDynamicExpanded  = 2
+    };
     enum Type {
       None                   = 0, // initial value
       Html                   = 0, // index / also to be used as bit position in mask (1 << Html)
@@ -238,7 +243,7 @@ class LocalToc
       Docbook                = 3, // ...
       numTocTypes            = 4  // number of enum values
     };
-    LocalToc() : m_mask(None) { memset(m_level,0,sizeof(m_level)); }
+    LocalToc() : m_mask(None), m_htmldyn(HtmlStatic) { memset(m_level,0,sizeof(m_level)); }
 
     // setters
     void enableHtml(int level)
@@ -262,6 +267,11 @@ class LocalToc
       m_level[Docbook]=level;
     }
 
+    void setDynamicHtml(int dyn)
+    {
+      m_htmldyn=dyn;
+    }
+
     // getters
     bool isHtmlEnabled()  const { return (m_mask & (1<<Html))!=0;  }
     bool isLatexEnabled() const { return (m_mask & (1<<Latex))!=0; }
@@ -273,10 +283,12 @@ class LocalToc
     int xmlLevel()        const { return m_level[Xml]; }
     int docbookLevel()    const { return m_level[Docbook]; }
     int mask()            const { return m_mask; }
+    int dynamicHtml()     const { return m_htmldyn; }
 
   private:
     int m_mask;
     int m_level[numTocTypes];
+    int m_htmldyn;
 };
 
 #endif

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1358,6 +1358,7 @@ dl.citelist dd {
         padding:5px 0;
 }
 
+div.dyntoc,
 div.toc {
         padding: 14px 25px;
         background-color: ##F6;
@@ -1369,25 +1370,34 @@ div.toc {
         width: 200px;
 }
 
+.PageDocRTL-title div.dyntoc,
 .PageDocRTL-title div.toc {
   float: left !important;
   text-align: right;
 }
 
+div.dyntoc li,
 div.toc li {
-        background: url("bdwn.png") no-repeat scroll 0 5px transparent;
         font: 10px/1.2 Verdana,DejaVu Sans,Geneva,sans-serif;
         margin-top: 5px;
-        padding-left: 10px;
         padding-top: 2px;
 }
+div.dyntoc li {
+        padding-left: 2px;
+}
+div.toc li {
+        background: url("bdwn.png") no-repeat scroll 0 5px transparent;
+        padding-left: 10px;
+}
 
+.PageDocRTL-title div.dyntoc li,
 .PageDocRTL-title div.toc li {
   background-position-x: right !important;
   padding-left: 0 !important;
   padding-right: 10px;
 }
 
+div.dyntoc h3,
 div.toc h3 {
         font: bold 12px/1.2 Arial,FreeSans,sans-serif;
 	color: ##60;
@@ -1395,46 +1405,85 @@ div.toc h3 {
         margin: 0;
 }
 
+div.dyntoc ul,
 div.toc ul {
         list-style: none outside none;
         border: medium none;
         padding: 0px;
 }       
 
+div.dyntoc li.level1,
 div.toc li.level1 {
         margin-left: 0px;
 }
 
+div.dyntoc li.level2,
 div.toc li.level2 {
         margin-left: 15px;
 }
 
+div.dyntoc li.level3,
 div.toc li.level3 {
         margin-left: 30px;
 }
 
+div.dyntoc li.level4,
 div.toc li.level4 {
         margin-left: 45px;
 }
 
+.PageDocRTL-title div.dyntoc li.level1,
 .PageDocRTL-title div.toc li.level1 {
   margin-left: 0 !important;
   margin-right: 0;
 }
 
+.PageDocRTL-title div.dyntoc li.level2,
 .PageDocRTL-title div.toc li.level2 {
   margin-left: 0 !important;
   margin-right: 15px;
 }
 
+.PageDocRTL-title div.dyntoc li.level3,
 .PageDocRTL-title div.toc li.level3 {
   margin-left: 0 !important;
   margin-right: 30px;
 }
 
+.PageDocRTL-title div.dyntoc li.level4,
 .PageDocRTL-title div.toc li.level4 {
   margin-left: 0 !important;
   margin-right: 45px;
+}
+
+.caret {
+  cursor: pointer;
+  -webkit-user-select: none; /* Safari 3.1+ */
+  -moz-user-select: none; /* Firefox 2+ */
+  -ms-user-select: none; /* IE 10+ */
+  user-select: none;
+}
+
+.caret::before {
+  content: "\25B6";
+  color: black;
+  display: inline-block;
+  margin-right: 2px;
+}
+
+.caret-down::before {
+  -ms-transform: rotate(90deg); /* IE 9 */
+  -webkit-transform: rotate(90deg); /* Safari */
+  transform: rotate(90deg);
+}
+
+
+.nested {
+  display: none;
+}
+
+.active {
+  display: block;
 }
 
 .inherit_header {

--- a/templates/html/dyntoc.js
+++ b/templates/html/dyntoc.js
@@ -1,0 +1,8 @@
+  var toggler = document.getElementsByClassName("caret");
+  var i;
+  for (i = 0; i < toggler.length; i++) {
+    toggler[i].addEventListener("click", function() {
+      this.parentElement.querySelector(".nested").classList.toggle("active");
+      this.classList.toggle("caret-down");
+    });
+  };

--- a/templates/html/htmllayout.tpl
+++ b/templates/html/htmllayout.tpl
@@ -27,6 +27,7 @@
 {% resource 'navtree.js' %}
 {% resource 'resize.js' %}
 {% resource 'menu.js' %}
+{% resource 'dyntoc.js' %}
 {% resource 'doc.luma' %}
 {% resource 'folderopen.luma' %}
 {% resource 'folderclosed.luma' %}


### PR DESCRIPTION
The current HTML in page table of contents is static. To have the possibility to have a more "navigation tree" like table of contents 2 new options have been introduced with the `\tableofcontents` command:
- dyn   a dynamic expanded  table of contents is shown
- dync a collapsed but expandable  dynamic table of contents showing the highest level is shown.

the default is still to have a 'static' table of contents