### PR TITLE
Incorrect closing tags for in page table of contents (XHTML)

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1837,6 +1837,7 @@ void Definition::writeToc(OutputList &ol, const LocalToc &localToc)
         level = nextLevel;
       }
     }
+    if (level > maxLevel) level = maxLevel;
     while (level>1 && level <= maxLevel)
     {
       if (inLi[level]) ol.writeString("</li>\n");


### PR DESCRIPTION
In case of using the levels in the in page table of contents in XHTML some closing tags were missing.