### PR TITLE
Incorrect XHTML of changelog for 1.8.15

### DIFF
--- a/doc/changelog.doc
+++ b/doc/changelog.doc
@@ -8,397 +8,397 @@
 <a name="1.8.15"></a>
 </p>
 <ul>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/851">851</a> - A function cannot be documented as related to two classes. [<a href="https://github.com/doxygen/doxygen/commit/e8661c343a4e8ebeaf82b2f926d68167e41be284">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1041">1041</a> - &lt;a href&gt; doesn&#39;t allow &lt;img&gt; as visible part? [<a href="https://github.com/doxygen/doxygen/commit/6c80429e303c89a9cba83569d65d118f8d48f97c">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1601">1601</a> - Missing warning of undocumented member in member group [<a href="https://github.com/doxygen/doxygen/commit/fe7e597a172fa08a075ac10bbefc572a785e4c0d">view</a>]
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/851">851</a> - A function cannot be documented as related to two classes. [<a href="https://github.com/doxygen/doxygen/commit/e8661c343a4e8ebeaf82b2f926d68167e41be284">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1041">1041</a> - &lt;a href&gt; doesn&#39;t allow &lt;img&gt; as visible part? [<a href="https://github.com/doxygen/doxygen/commit/6c80429e303c89a9cba83569d65d118f8d48f97c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/1601">1601</a> - Missing warning of undocumented member in member group [<a href="https://github.com/doxygen/doxygen/commit/fe7e597a172fa08a075ac10bbefc572a785e4c0d">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/2274">2274</a> - Tooltips are not shown in dot-generated graphs [<a href="https://github.com/doxygen/doxygen/commit/56f6398447407a3826285e527cee547588e2e517">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/1419dca75d33aaf96919ae7a1fc77137d22db14f">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/dbb7838937e7bcbe129dd246438aeabfafc6be32">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2354">2354</a> - caller graph can be improved by having caller on left &amp; callee on right [<a href="https://github.com/doxygen/doxygen/commit/af7dfbdda302e55fb8a62ab224184abccab3d167">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2478">2478</a> - Handling of unnamed parameters (C/C++) unclear [<a href="https://github.com/doxygen/doxygen/commit/7ef7b137d38d7ddcbcef787704317531b44c2baf">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2655">2655</a> - cond/endcond cannot be used in aliases [<a href="https://github.com/doxygen/doxygen/commit/be8465e89496d9b5e0d219d0e3f21aafb70dc299">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2859">2859</a> - Unnamed parameters parsed incorrectly [<a href="https://github.com/doxygen/doxygen/commit/657a6b5348d453fd1351b8c3238426e25acdbbb9">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3206">3206</a> - Fortran: Does not recognize backslash at end of documentation line [<a href="https://github.com/doxygen/doxygen/commit/ad244059b3ffc896905f1000ad40b435d8bbe823">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3361">3361</a> - Merging of consecutive repeated commands creates poorly-structured HTML [<a href="https://github.com/doxygen/doxygen/commit/d9b93a377237efd3f60186c5ba2ba344d4439173">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3677">3677</a> - &lt;![CDATA[ is not handled inside C# comments [<a href="https://github.com/doxygen/doxygen/commit/f2b6959dff5b5d3d2bbbe8204b1fc32905003ad3">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3691">3691</a> - C# keywords &#39;get&#39; and &#39;set&#39; are highlighted as reserved words in C++ documentation source browser. [<a href="https://github.com/doxygen/doxygen/commit/0bdaf4541c2495b3166386992666f842c38642c1">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3892">3892</a> - @var in php is not documented [<a href="https://github.com/doxygen/doxygen/commit/d83265914607c6556fefa852a90b6a16821b0634">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3958">3958</a> - \cond after @string literal containing backslash fails in C# [<a href="https://github.com/doxygen/doxygen/commit/179f80e666d6c017f7130b6b26e687f2b5ea54d9">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4013">4013</a> - Automatic links don&#39;t work correctly with operator&lt; and operator&lt;= [<a href="https://github.com/doxygen/doxygen/commit/7508151230301113cf6531bfe631472fa4513d19">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4064">4064</a> - Support for C# nullable type [<a href="https://github.com/doxygen/doxygen/commit/98eb981dba723ed1d71fdcbcd7ca2de0e086b1e0">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4244">4244</a> - Fortran: tagfile.tag:789: warning: Unknown compound attribute `type&#39; found! [<a href="https://github.com/doxygen/doxygen/commit/5088fb700cd0bb4a9ce676ae235d48586229e1ba">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4316">4316</a> - Can&#39;t use pound sign in alias command, escaped or unescaped [<a href="https://github.com/doxygen/doxygen/commit/e15c80cbf1c0f35c2d2ddc950e3d653bc24aac4e">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4458">4458</a> - @todo in @param leads to strange confusing message [<a href="https://github.com/doxygen/doxygen/commit/59781ae4ee1937f51836c03bd7c67e1e7be13bfc">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/dbb7838937e7bcbe129dd246438aeabfafc6be32">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2354">2354</a> - caller graph can be improved by having caller on left &amp; callee on right [<a href="https://github.com/doxygen/doxygen/commit/af7dfbdda302e55fb8a62ab224184abccab3d167">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2478">2478</a> - Handling of unnamed parameters (C/C++) unclear [<a href="https://github.com/doxygen/doxygen/commit/7ef7b137d38d7ddcbcef787704317531b44c2baf">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2655">2655</a> - cond/endcond cannot be used in aliases [<a href="https://github.com/doxygen/doxygen/commit/be8465e89496d9b5e0d219d0e3f21aafb70dc299">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/2859">2859</a> - Unnamed parameters parsed incorrectly [<a href="https://github.com/doxygen/doxygen/commit/657a6b5348d453fd1351b8c3238426e25acdbbb9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3206">3206</a> - Fortran: Does not recognize backslash at end of documentation line [<a href="https://github.com/doxygen/doxygen/commit/ad244059b3ffc896905f1000ad40b435d8bbe823">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3361">3361</a> - Merging of consecutive repeated commands creates poorly-structured HTML [<a href="https://github.com/doxygen/doxygen/commit/d9b93a377237efd3f60186c5ba2ba344d4439173">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3677">3677</a> - &lt;![CDATA[ is not handled inside C# comments [<a href="https://github.com/doxygen/doxygen/commit/f2b6959dff5b5d3d2bbbe8204b1fc32905003ad3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3691">3691</a> - C# keywords &#39;get&#39; and &#39;set&#39; are highlighted as reserved words in C++ documentation source browser. [<a href="https://github.com/doxygen/doxygen/commit/0bdaf4541c2495b3166386992666f842c38642c1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3892">3892</a> - @var in php is not documented [<a href="https://github.com/doxygen/doxygen/commit/d83265914607c6556fefa852a90b6a16821b0634">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/3958">3958</a> - \cond after @string literal containing backslash fails in C# [<a href="https://github.com/doxygen/doxygen/commit/179f80e666d6c017f7130b6b26e687f2b5ea54d9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4013">4013</a> - Automatic links don&#39;t work correctly with operator&lt; and operator&lt;= [<a href="https://github.com/doxygen/doxygen/commit/7508151230301113cf6531bfe631472fa4513d19">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4064">4064</a> - Support for C# nullable type [<a href="https://github.com/doxygen/doxygen/commit/98eb981dba723ed1d71fdcbcd7ca2de0e086b1e0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4244">4244</a> - Fortran: tagfile.tag:789: warning: Unknown compound attribute `type&#39; found! [<a href="https://github.com/doxygen/doxygen/commit/5088fb700cd0bb4a9ce676ae235d48586229e1ba">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4316">4316</a> - Can&#39;t use pound sign in alias command, escaped or unescaped [<a href="https://github.com/doxygen/doxygen/commit/e15c80cbf1c0f35c2d2ddc950e3d653bc24aac4e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4458">4458</a> - @todo in @param leads to strange confusing message [<a href="https://github.com/doxygen/doxygen/commit/59781ae4ee1937f51836c03bd7c67e1e7be13bfc">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/4529">4529</a> - HTML tags &lt;u&gt; and &lt;/u&gt; not supported [<a href="https://github.com/doxygen/doxygen/commit/9eec9866fcdab896b53d44056c5afbc0b6a6373d">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/b4e535197890521306d30e0713ca8b88a98f7bf7">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4725">4725</a> - single quote in HTML section of PHP breaks doxygen [<a href="https://github.com/doxygen/doxygen/commit/53d89156855079fcf2f25fe516e6493e42e35f1e">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4771">4771</a> - Not warning of undocumented function parameters [<a href="https://github.com/doxygen/doxygen/commit/2a61c8542284261e74e5d6720ee6165b8202ed99">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4878">4878</a> - Value from enumeration followed with semicolon is not present in java docs [<a href="https://github.com/doxygen/doxygen/commit/e2b0f27d6fca5dacfedc79a1a4eff32d5e9254e9">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4954">4954</a> - JavaDoc @linkplain is not recognized [<a href="https://github.com/doxygen/doxygen/commit/a06b1020839f36e3b2ea73c09d9ead7f75983549">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5032">5032</a> - Line numbers for examples [<a href="https://github.com/doxygen/doxygen/commit/0b4b3698b29436b299d4e4a315d610bc1ab98acb">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5068">5068</a> - The &#39;Examples:&#39; section; bad/missing style and incorrect spelling [<a href="https://github.com/doxygen/doxygen/commit/12eaf6afe565ae1f7d440080205ddb76585bd31d">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/b4e535197890521306d30e0713ca8b88a98f7bf7">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4725">4725</a> - single quote in HTML section of PHP breaks doxygen [<a href="https://github.com/doxygen/doxygen/commit/53d89156855079fcf2f25fe516e6493e42e35f1e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4771">4771</a> - Not warning of undocumented function parameters [<a href="https://github.com/doxygen/doxygen/commit/2a61c8542284261e74e5d6720ee6165b8202ed99">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4878">4878</a> - Value from enumeration followed with semicolon is not present in java docs [<a href="https://github.com/doxygen/doxygen/commit/e2b0f27d6fca5dacfedc79a1a4eff32d5e9254e9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/4954">4954</a> - JavaDoc @linkplain is not recognized [<a href="https://github.com/doxygen/doxygen/commit/a06b1020839f36e3b2ea73c09d9ead7f75983549">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5032">5032</a> - Line numbers for examples [<a href="https://github.com/doxygen/doxygen/commit/0b4b3698b29436b299d4e4a315d610bc1ab98acb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5068">5068</a> - The &#39;Examples:&#39; section; bad/missing style and incorrect spelling [<a href="https://github.com/doxygen/doxygen/commit/12eaf6afe565ae1f7d440080205ddb76585bd31d">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5213">5213</a> - Generated Doxyfile differs from result of doxygen -u [<a href="https://github.com/doxygen/doxygen/commit/406b442fc3d0360e387324ff1c08251d86a1d035">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/58d4ad3cd25569f09b31c4b80bc145477c6d61cb">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5327">5327</a> - &lt;img&gt; on a \page does not copy the image to the html output folder [<a href="https://github.com/doxygen/doxygen/commit/4fcf0ebe7f8b5040fa6b8cca72de6cfa774d4b15">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5366">5366</a> - Error with inserting images to PDF with Markdown [<a href="https://github.com/doxygen/doxygen/commit/7ef3ba54570275a423ce52f65437607446c15b12">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5442">5442</a> - Misparsed comments leading to missing call graph [<a href="https://github.com/doxygen/doxygen/commit/ec8a1a465ef6b4cbcba9b7b9b9cbdf87e39c7bba">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5539">5539</a> - Error message when using memberof in a C macro [<a href="https://github.com/doxygen/doxygen/commit/65a3129eea3d3f807fa6a641087c26c3d0100eac">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5547">5547</a> - &quot;remove&quot; is treated as a keyword (green) in the source browser for C++ [<a href="https://github.com/doxygen/doxygen/commit/55e020ce14abfa2dc2ee395fefd7b1da33180e70">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5677">5677</a> - Negative sign in -Foo::Bar ruins hyperlink in generated output [<a href="https://github.com/doxygen/doxygen/commit/5a9bfc176eb3da266f44bd5cb0b38975c812e49c">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5725">5725</a> - Field with name &quot;internal&quot; confuses documentation builder. [<a href="https://github.com/doxygen/doxygen/commit/89f808f75f7d39962a0b9dba4f479b5c6d6d9a24">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5765">5765</a> - \todo at end of C# XML comment breaks following todo&#39;s [<a href="https://github.com/doxygen/doxygen/commit/c6adc51933fcb58970bbcf89465d57edc2d19c0d">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5783">5783</a> - Navigation incorrect with escaped symbols [<a href="https://github.com/doxygen/doxygen/commit/09af3e03a55a5b02ebb6254c39a09877c8bd671b">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5784">5784</a> - Doxygen not creating call graphs for C# methods if namespace contains the classname [<a href="https://github.com/doxygen/doxygen/commit/5f9be083471dad47a9b3ad59d85bf04d3a855001">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5818">5818</a> - Main page absent in TOC of CHM, if PROJECT_NAME is empty [<a href="https://github.com/doxygen/doxygen/commit/887db516c1b0163139db971c5aa720804cc23f37">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5853">5853</a> - Can&#39;t suppress @author, @date and @copyright information in the detailed file description [<a href="https://github.com/doxygen/doxygen/commit/39232901e3577f6e548353b89c4338cc8ba11016">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5901">5901</a> - Macros (@test, @todo, etc) used with PHP namespaces causes illegal command warning [<a href="https://github.com/doxygen/doxygen/commit/bf793310d5d493d19b6cb8840151ab38659dd58f">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5929">5929</a> - \internal stops all parsing if used inside a section [<a href="https://github.com/doxygen/doxygen/commit/4e71a72e6c826bee54f2aba55a329c2032a83c66">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6025">6025</a> - Make maxLineLen of latex output configurable [<a href="https://github.com/doxygen/doxygen/commit/ee1ea269e1c684cf5ff39ed836fd8af288837275">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6041">6041</a> - PHP: New array syntax not supported when parsing initial value [<a href="https://github.com/doxygen/doxygen/commit/7d325579b7b38a898d3766d186f9358d899dc304">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6104">6104</a> - EXTERNAL_GROUPS lose hierarchy [<a href="https://github.com/doxygen/doxygen/commit/730b7827a8e6dd4ef82d91b6ac6c3d58f95313e3">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6118">6118</a> - Title in rtf file is incorrect when overridden by user in extension file [<a href="https://github.com/doxygen/doxygen/commit/67a22b2d5b9c14a325374dd8857e066b11abb7ca">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6153">6153</a> - Build of PDF with LaTEX breaks [<a href="https://github.com/doxygen/doxygen/commit/bf4c90ae6e433922b011d51401db8eb23a83f294">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6160">6160</a> - Python List as Default Parameter not parsed correctly [<a href="https://github.com/doxygen/doxygen/commit/e5e75b7f713251dd6caa472f9c5fb8d49e36ff5a">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6172">6172</a> - CREATE_SUBDIRS breaks SERVER_BASED_SEARCH [<a href="https://github.com/doxygen/doxygen/commit/c95b50542c519a66d6adbdc7031c5a5bafb75929">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6175">6175</a> - plantuml:an unwanted newline is generated after @startuml [<a href="https://github.com/doxygen/doxygen/commit/032d8fd0cd8bd33448186081c54168889e25d55e">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6197">6197</a> - Czech/Slovak language documentation with tables from LaTeX to PDF is not possible [<a href="https://github.com/doxygen/doxygen/commit/509cf2db2304ee74e3fa1a580f33dbea3cdfca30">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6208">6208</a> - Annotated function parameter generates &lt;dt&gt; warning in todo list [<a href="https://github.com/doxygen/doxygen/commit/9277e1466f91d7b2d4190b4e55d6e7b9b5e3962d">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6213">6213</a> - rtf generation [<a href="https://github.com/doxygen/doxygen/commit/be4fb2753c2f028a53d657a7920267a4191cd566">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/58d4ad3cd25569f09b31c4b80bc145477c6d61cb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5327">5327</a> - &lt;img&gt; on a \page does not copy the image to the html output folder [<a href="https://github.com/doxygen/doxygen/commit/4fcf0ebe7f8b5040fa6b8cca72de6cfa774d4b15">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5366">5366</a> - Error with inserting images to PDF with Markdown [<a href="https://github.com/doxygen/doxygen/commit/7ef3ba54570275a423ce52f65437607446c15b12">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5442">5442</a> - Misparsed comments leading to missing call graph [<a href="https://github.com/doxygen/doxygen/commit/ec8a1a465ef6b4cbcba9b7b9b9cbdf87e39c7bba">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5539">5539</a> - Error message when using memberof in a C macro [<a href="https://github.com/doxygen/doxygen/commit/65a3129eea3d3f807fa6a641087c26c3d0100eac">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5547">5547</a> - &quot;remove&quot; is treated as a keyword (green) in the source browser for C++ [<a href="https://github.com/doxygen/doxygen/commit/55e020ce14abfa2dc2ee395fefd7b1da33180e70">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5677">5677</a> - Negative sign in -Foo::Bar ruins hyperlink in generated output [<a href="https://github.com/doxygen/doxygen/commit/5a9bfc176eb3da266f44bd5cb0b38975c812e49c">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5725">5725</a> - Field with name &quot;internal&quot; confuses documentation builder. [<a href="https://github.com/doxygen/doxygen/commit/89f808f75f7d39962a0b9dba4f479b5c6d6d9a24">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5765">5765</a> - \todo at end of C# XML comment breaks following todo&#39;s [<a href="https://github.com/doxygen/doxygen/commit/c6adc51933fcb58970bbcf89465d57edc2d19c0d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5783">5783</a> - Navigation incorrect with escaped symbols [<a href="https://github.com/doxygen/doxygen/commit/09af3e03a55a5b02ebb6254c39a09877c8bd671b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5784">5784</a> - Doxygen not creating call graphs for C# methods if namespace contains the classname [<a href="https://github.com/doxygen/doxygen/commit/5f9be083471dad47a9b3ad59d85bf04d3a855001">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5818">5818</a> - Main page absent in TOC of CHM, if PROJECT_NAME is empty [<a href="https://github.com/doxygen/doxygen/commit/887db516c1b0163139db971c5aa720804cc23f37">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5853">5853</a> - Can&#39;t suppress @author, @date and @copyright information in the detailed file description [<a href="https://github.com/doxygen/doxygen/commit/39232901e3577f6e548353b89c4338cc8ba11016">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5901">5901</a> - Macros (@test, @todo, etc) used with PHP namespaces causes illegal command warning [<a href="https://github.com/doxygen/doxygen/commit/bf793310d5d493d19b6cb8840151ab38659dd58f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5929">5929</a> - \internal stops all parsing if used inside a section [<a href="https://github.com/doxygen/doxygen/commit/4e71a72e6c826bee54f2aba55a329c2032a83c66">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6025">6025</a> - Make maxLineLen of latex output configurable [<a href="https://github.com/doxygen/doxygen/commit/ee1ea269e1c684cf5ff39ed836fd8af288837275">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6041">6041</a> - PHP: New array syntax not supported when parsing initial value [<a href="https://github.com/doxygen/doxygen/commit/7d325579b7b38a898d3766d186f9358d899dc304">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6104">6104</a> - EXTERNAL_GROUPS lose hierarchy [<a href="https://github.com/doxygen/doxygen/commit/730b7827a8e6dd4ef82d91b6ac6c3d58f95313e3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6118">6118</a> - Title in rtf file is incorrect when overridden by user in extension file [<a href="https://github.com/doxygen/doxygen/commit/67a22b2d5b9c14a325374dd8857e066b11abb7ca">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6153">6153</a> - Build of PDF with LaTEX breaks [<a href="https://github.com/doxygen/doxygen/commit/bf4c90ae6e433922b011d51401db8eb23a83f294">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6160">6160</a> - Python List as Default Parameter not parsed correctly [<a href="https://github.com/doxygen/doxygen/commit/e5e75b7f713251dd6caa472f9c5fb8d49e36ff5a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6172">6172</a> - CREATE_SUBDIRS breaks SERVER_BASED_SEARCH [<a href="https://github.com/doxygen/doxygen/commit/c95b50542c519a66d6adbdc7031c5a5bafb75929">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6175">6175</a> - plantuml:an unwanted newline is generated after @startuml [<a href="https://github.com/doxygen/doxygen/commit/032d8fd0cd8bd33448186081c54168889e25d55e">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6197">6197</a> - Czech/Slovak language documentation with tables from LaTeX to PDF is not possible [<a href="https://github.com/doxygen/doxygen/commit/509cf2db2304ee74e3fa1a580f33dbea3cdfca30">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6208">6208</a> - Annotated function parameter generates &lt;dt&gt; warning in todo list [<a href="https://github.com/doxygen/doxygen/commit/9277e1466f91d7b2d4190b4e55d6e7b9b5e3962d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6213">6213</a> - rtf generation [<a href="https://github.com/doxygen/doxygen/commit/be4fb2753c2f028a53d657a7920267a4191cd566">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6214">6214</a> - LaTeX output for \tparam block fails to compile when it contains a \code block [<a href="https://github.com/doxygen/doxygen/commit/8afcb87097c92fd124282a998dad61ea2b16c7ec">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/d59ed22f114398d74d5c3fd1445a7901d26ff93a">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6224">6224</a> - .tex file is wrong when generating a function whose name includes an underline [<a href="https://github.com/doxygen/doxygen/commit/1c55b572b345bf124daaa33d436d2e822b5f6eee">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6269">6269</a> - Disabled controls when `HAVE_DOT` is already set to `YES` [<a href="https://github.com/doxygen/doxygen/commit/8bf975ea2861def50f9b7d4cca0fb4002c991ec0">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6270">6270</a> - Bad handling of Python class members when a class declaration line contains a comment [<a href="https://github.com/doxygen/doxygen/commit/eb72534ade8b9598806fc7e7b08374bd43bb44f3">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6295">6295</a> - doxygen has problem with operator&amp;=() [<a href="https://github.com/doxygen/doxygen/commit/1e935dc5b1a7f01fe1f3545f773eca52629dad09">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6305">6305</a> - XHTML pages are broken several ways [<a href="https://github.com/doxygen/doxygen/commit/5bae9d9ec8e5a253d6f5e8f15be43b85cd7ae0ff">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/ceedc1b7c0e9c2ea6e00d44fae2c0f8f477def69">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6308">6308</a> - When generating xhtml, async attribute on script tags need a value [<a href="https://github.com/doxygen/doxygen/commit/1b8afc8802f7ac40614e95a47ffd3ae152b57987">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6310">6310</a> - Table markdown produces invalid xhtml code [<a href="https://github.com/doxygen/doxygen/commit/eb4af56797a4bd5396c4ecda76196de61e709f56">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6311">6311</a> - Blank rows on class page when using external tag file [<a href="https://github.com/doxygen/doxygen/commit/44960da16786f6fe769b2c45d9be309568c3c1a8">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6312">6312</a> - markdown plantuml use of graphviz fail if plantuml work i code file [<a href="https://github.com/doxygen/doxygen/commit/a50c7551d3e8cb18514f517d36b6ba343596a426">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6316">6316</a> - unescaped double quote in searchdata.js breaks search box functionality [<a href="https://github.com/doxygen/doxygen/commit/ed642b1cabdd2f3f52906a75cae7c477eb1c0378">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6322">6322</a> - incorrect parsing of markdown table [<a href="https://github.com/doxygen/doxygen/commit/efcc4d035e4ecdb3ecc449770a5fd26694717efa">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6323">6323</a> - error: Could not open file .../doc/html/functions_ .html for writing [<a href="https://github.com/doxygen/doxygen/commit/2609f6f49763fd75e5c529788795a07f6559b954">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6324">6324</a> - C#: Incorrect parsing of property definitions containing &quot;//&quot; symbols in one line with &quot;} [<a href="https://github.com/doxygen/doxygen/commit/098bc86187295a77b08c1e5c061ed5788aaa73ae">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6325">6325</a> - Segmentation fault when generating graphical class hierarchy [<a href="https://github.com/doxygen/doxygen/commit/17338710275948c23e0f0b312d004b84976f68bc">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6339">6339</a> - Examples of TCL files fail to display [<a href="https://github.com/doxygen/doxygen/commit/05bec28930831888b6dfb610307a04da2d345924">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6340">6340</a> - Missed warning opportunity: duplicated arguments [<a href="https://github.com/doxygen/doxygen/commit/d39cdf826f15470def2ca36bc636868a62c42bbf">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6345">6345</a> - c# see langword broken [<a href="https://github.com/doxygen/doxygen/commit/7e041a6f5bf32637ebb71589d471586db1d0f7fd">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6346">6346</a> - Doxygen crash when using \code{.markdown}...\endcode in VHDL source [<a href="https://github.com/doxygen/doxygen/commit/1431d16ca2a8a20a72f029b48e4b178aa59009e3">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6350">6350</a> - Broken extension test in FileDef::generateSourceFile() [<a href="https://github.com/doxygen/doxygen/commit/b1792d19afd245f33667e6170b9f08a8528e07f8">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6352">6352</a> - &quot;unexpected token TK_EOF as the argument of ref&quot; when target starts with a digit [<a href="https://github.com/doxygen/doxygen/commit/07ae32a61e779647bace1efdbf8d15b35871fcca">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6362">6362</a> - Adjacent xrefitems always added to first list present on page [<a href="https://github.com/doxygen/doxygen/commit/a6b0a7fe237c5eb6e76073d366f281c8413eb0dd">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6363">6363</a> - Backslashes in default values confuse the parser (and cause params to be ignored) [<a href="https://github.com/doxygen/doxygen/commit/b33c0e0274ee25b1a414a79c13521ef8defecbda">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6368">6368</a> - LaTeX: Class scrbook Error: undefined old font command `\tt&#39; [<a href="https://github.com/doxygen/doxygen/commit/52c0b2e25fc3bb15be1d240d86701a5827630db0">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6370">6370</a> - Invalid 3-byte UTF8 found in input of graph [<a href="https://github.com/doxygen/doxygen/commit/21ce6ed9d2a37df2de846d48398261bb087c0a09">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6373">6373</a> - Collapsed treeview arrow displays as emoji in Microsoft Edge [<a href="https://github.com/doxygen/doxygen/commit/293e5c9ba4b88924e0cc4b513318cf822f5c63eb">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6378">6378</a> - @cond does not stop at @endcond Fortran [<a href="https://github.com/doxygen/doxygen/commit/a0db6fdbff2e21502bb2ac7437c5bd57d515d83b">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/d59ed22f114398d74d5c3fd1445a7901d26ff93a">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6224">6224</a> - .tex file is wrong when generating a function whose name includes an underline [<a href="https://github.com/doxygen/doxygen/commit/1c55b572b345bf124daaa33d436d2e822b5f6eee">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6269">6269</a> - Disabled controls when `HAVE_DOT` is already set to `YES` [<a href="https://github.com/doxygen/doxygen/commit/8bf975ea2861def50f9b7d4cca0fb4002c991ec0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6270">6270</a> - Bad handling of Python class members when a class declaration line contains a comment [<a href="https://github.com/doxygen/doxygen/commit/eb72534ade8b9598806fc7e7b08374bd43bb44f3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6295">6295</a> - doxygen has problem with operator&amp;=() [<a href="https://github.com/doxygen/doxygen/commit/1e935dc5b1a7f01fe1f3545f773eca52629dad09">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6305">6305</a> - XHTML pages are broken several ways [<a href="https://github.com/doxygen/doxygen/commit/5bae9d9ec8e5a253d6f5e8f15be43b85cd7ae0ff">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/ceedc1b7c0e9c2ea6e00d44fae2c0f8f477def69">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6308">6308</a> - When generating xhtml, async attribute on script tags need a value [<a href="https://github.com/doxygen/doxygen/commit/1b8afc8802f7ac40614e95a47ffd3ae152b57987">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6310">6310</a> - Table markdown produces invalid xhtml code [<a href="https://github.com/doxygen/doxygen/commit/eb4af56797a4bd5396c4ecda76196de61e709f56">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6311">6311</a> - Blank rows on class page when using external tag file [<a href="https://github.com/doxygen/doxygen/commit/44960da16786f6fe769b2c45d9be309568c3c1a8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6312">6312</a> - markdown plantuml use of graphviz fail if plantuml work i code file [<a href="https://github.com/doxygen/doxygen/commit/a50c7551d3e8cb18514f517d36b6ba343596a426">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6316">6316</a> - unescaped double quote in searchdata.js breaks search box functionality [<a href="https://github.com/doxygen/doxygen/commit/ed642b1cabdd2f3f52906a75cae7c477eb1c0378">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6322">6322</a> - incorrect parsing of markdown table [<a href="https://github.com/doxygen/doxygen/commit/efcc4d035e4ecdb3ecc449770a5fd26694717efa">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6323">6323</a> - error: Could not open file .../doc/html/functions_ .html for writing [<a href="https://github.com/doxygen/doxygen/commit/2609f6f49763fd75e5c529788795a07f6559b954">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6324">6324</a> - C#: Incorrect parsing of property definitions containing &quot;//&quot; symbols in one line with &quot;} [<a href="https://github.com/doxygen/doxygen/commit/098bc86187295a77b08c1e5c061ed5788aaa73ae">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6325">6325</a> - Segmentation fault when generating graphical class hierarchy [<a href="https://github.com/doxygen/doxygen/commit/17338710275948c23e0f0b312d004b84976f68bc">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6339">6339</a> - Examples of TCL files fail to display [<a href="https://github.com/doxygen/doxygen/commit/05bec28930831888b6dfb610307a04da2d345924">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6340">6340</a> - Missed warning opportunity: duplicated arguments [<a href="https://github.com/doxygen/doxygen/commit/d39cdf826f15470def2ca36bc636868a62c42bbf">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6345">6345</a> - c# see langword broken [<a href="https://github.com/doxygen/doxygen/commit/7e041a6f5bf32637ebb71589d471586db1d0f7fd">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6346">6346</a> - Doxygen crash when using \code{.markdown}...\endcode in VHDL source [<a href="https://github.com/doxygen/doxygen/commit/1431d16ca2a8a20a72f029b48e4b178aa59009e3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6350">6350</a> - Broken extension test in FileDef::generateSourceFile() [<a href="https://github.com/doxygen/doxygen/commit/b1792d19afd245f33667e6170b9f08a8528e07f8">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6352">6352</a> - &quot;unexpected token TK_EOF as the argument of ref&quot; when target starts with a digit [<a href="https://github.com/doxygen/doxygen/commit/07ae32a61e779647bace1efdbf8d15b35871fcca">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6362">6362</a> - Adjacent xrefitems always added to first list present on page [<a href="https://github.com/doxygen/doxygen/commit/a6b0a7fe237c5eb6e76073d366f281c8413eb0dd">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6363">6363</a> - Backslashes in default values confuse the parser (and cause params to be ignored) [<a href="https://github.com/doxygen/doxygen/commit/b33c0e0274ee25b1a414a79c13521ef8defecbda">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6368">6368</a> - LaTeX: Class scrbook Error: undefined old font command `\tt&#39; [<a href="https://github.com/doxygen/doxygen/commit/52c0b2e25fc3bb15be1d240d86701a5827630db0">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6370">6370</a> - Invalid 3-byte UTF8 found in input of graph [<a href="https://github.com/doxygen/doxygen/commit/21ce6ed9d2a37df2de846d48398261bb087c0a09">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6373">6373</a> - Collapsed treeview arrow displays as emoji in Microsoft Edge [<a href="https://github.com/doxygen/doxygen/commit/293e5c9ba4b88924e0cc4b513318cf822f5c63eb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6378">6378</a> - @cond does not stop at @endcond Fortran [<a href="https://github.com/doxygen/doxygen/commit/a0db6fdbff2e21502bb2ac7437c5bd57d515d83b">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6517">6517</a> - Emoji support [<a href="https://github.com/doxygen/doxygen/commit/47fee387821113956e10fffa79ea22062de8c817">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/e7fde5d604faf27dec989c8894e949d48676e0c1">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6524">6524</a> - Markdown formats missing in doxygen outputs. [<a href="https://github.com/doxygen/doxygen/commit/dee50d6921e2f6fe2a0dd2e9b50fa51cd1fc4c60">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6533">6533</a> - PHP: Namespaced typehints in deprecated methods not handled correctly [<a href="https://github.com/doxygen/doxygen/commit/97f2d220240a1f6692627171398a06a3fa238639">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/e7fde5d604faf27dec989c8894e949d48676e0c1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6524">6524</a> - Markdown formats missing in doxygen outputs. [<a href="https://github.com/doxygen/doxygen/commit/dee50d6921e2f6fe2a0dd2e9b50fa51cd1fc4c60">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6533">6533</a> - PHP: Namespaced typehints in deprecated methods not handled correctly [<a href="https://github.com/doxygen/doxygen/commit/97f2d220240a1f6692627171398a06a3fa238639">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6547">6547</a> - Call graph missing due to ALIASES [<a href="https://github.com/doxygen/doxygen/commit/0077ab48f682cca9caf99b2d92a8448d1d66cb98">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/93b085e465a42eb26ef8305edfc6d61ba6ce858f">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6566">6566</a> - INHERIT_DOCS not working for python [<a href="https://github.com/doxygen/doxygen/commit/f56ce241a09dff819c194be4585aae99f35d85f1">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6580">6580</a> - xrefitems not listed if the page is referenced multiple times [<a href="https://github.com/doxygen/doxygen/commit/50d47c3383becb7ba7cedc53bb43b99898df7481">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6589">6589</a> - anchor after test command in a namespace produces duplicate tests [<a href="https://github.com/doxygen/doxygen/commit/cc3cb095a035db0037604dca2109c927e3ba7df3">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6594">6594</a> - using ingroup and anchor causes tests to disappear [<a href="https://github.com/doxygen/doxygen/commit/ebbb2ca96a23951dbd82b976ace0d01470e8a9d6">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6597">6597</a> - SIGSEGV presumably caused by C++ &quot;using&quot; declaration [<a href="https://github.com/doxygen/doxygen/commit/efc33490c36cb7c21955901ce0abccc343c0c7b3">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6601">6601</a> - tparam HTML gobbles up lines after the tparam comment [<a href="https://github.com/doxygen/doxygen/commit/3b95f4936ce8841f88fdaebdfe80da8eb0504cd3">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6612">6612</a> - Issue with handling of emoji [<a href="https://github.com/doxygen/doxygen/commit/d748615666f7fac43880f0d3ec859d11ad304deb">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6632">6632</a> - References to Objective C protocols by name broken in 1.8.12 [<a href="https://github.com/doxygen/doxygen/commit/c0b367ecd4a2f48cde85d4f5aed416892d3fa775">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6657">6657</a> - &quot;QGDict::hashAsciiKey: Invalid null key&quot; when using anonymous union/struct [<a href="https://github.com/doxygen/doxygen/commit/62f8c5346b2f3ea492404ae85942a0de4b091c71">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6690">6690</a> - Regression in handling of shorthand signed/unsigned types in function parameters (with bisect and test case) [<a href="https://github.com/doxygen/doxygen/commit/6833f142284376d256688511c5111dda6df9d79d">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6691">6691</a> - Multiple issues with emoji matching [<a href="https://github.com/doxygen/doxygen/commit/a06e660406d655568635521f6df161e3a7e5734b">view</a>]
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6692">6692</a> - XML TOC generation is not backwards-compatible with 1.8.14 [<a href="https://github.com/doxygen/doxygen/commit/15541e75816673fdc51d90820d6620e98b8fcd4b">view</a>]
-<li>&#39;self&#39; keyword in PHP documentation [<a href="https://github.com/doxygen/doxygen/commit/7e591135c56c3679c5ee63aa78f6baeae2cde63f">view</a>]
-<li>Added: support RTL for DocXRefItem in html - Removed: support RTL form Return section in html, for consistency with parameter sections [<a href="https://github.com/doxygen/doxygen/commit/08be7a8ef12518736b2530504a28904eec3e47ab">view</a>]
-<li>Fixed: list item bullets overlap floating elements in html - Fixed: fragment lines overlap floating elements in html [<a href="https://github.com/doxygen/doxygen/commit/dda245dbab60bddab4e7593cccbf59117d00a812">view</a>]
-<li>Fixed: text-align of rtl toc [<a href="https://github.com/doxygen/doxygen/commit/2ad516fef49f95b9edafe7ade6d1ed6d35cb75f7">view</a>]
-<li>Fixed: last line underline overlap border in html fragment [<a href="https://github.com/doxygen/doxygen/commit/1245145d6710abbb58057dc555fccac08ac8a3fa">view</a>]
-<li>A few more language updates [<a href="https://github.com/doxygen/doxygen/commit/9d35bd4f5865a63f3daacc8d4ab613fb4743bb72">view</a>]
-<li>Add VHDL strings to Translator class and add german translations. [<a href="https://github.com/doxygen/doxygen/commit/f1fea3603fa3e561d8f1efff5bc685e4484e7998">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/93b085e465a42eb26ef8305edfc6d61ba6ce858f">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6566">6566</a> - INHERIT_DOCS not working for python [<a href="https://github.com/doxygen/doxygen/commit/f56ce241a09dff819c194be4585aae99f35d85f1">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6580">6580</a> - xrefitems not listed if the page is referenced multiple times [<a href="https://github.com/doxygen/doxygen/commit/50d47c3383becb7ba7cedc53bb43b99898df7481">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6589">6589</a> - anchor after test command in a namespace produces duplicate tests [<a href="https://github.com/doxygen/doxygen/commit/cc3cb095a035db0037604dca2109c927e3ba7df3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6594">6594</a> - using ingroup and anchor causes tests to disappear [<a href="https://github.com/doxygen/doxygen/commit/ebbb2ca96a23951dbd82b976ace0d01470e8a9d6">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6597">6597</a> - SIGSEGV presumably caused by C++ &quot;using&quot; declaration [<a href="https://github.com/doxygen/doxygen/commit/efc33490c36cb7c21955901ce0abccc343c0c7b3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6601">6601</a> - tparam HTML gobbles up lines after the tparam comment [<a href="https://github.com/doxygen/doxygen/commit/3b95f4936ce8841f88fdaebdfe80da8eb0504cd3">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6612">6612</a> - Issue with handling of emoji [<a href="https://github.com/doxygen/doxygen/commit/d748615666f7fac43880f0d3ec859d11ad304deb">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6632">6632</a> - References to Objective C protocols by name broken in 1.8.12 [<a href="https://github.com/doxygen/doxygen/commit/c0b367ecd4a2f48cde85d4f5aed416892d3fa775">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6657">6657</a> - &quot;QGDict::hashAsciiKey: Invalid null key&quot; when using anonymous union/struct [<a href="https://github.com/doxygen/doxygen/commit/62f8c5346b2f3ea492404ae85942a0de4b091c71">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6690">6690</a> - Regression in handling of shorthand signed/unsigned types in function parameters (with bisect and test case) [<a href="https://github.com/doxygen/doxygen/commit/6833f142284376d256688511c5111dda6df9d79d">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6691">6691</a> - Multiple issues with emoji matching [<a href="https://github.com/doxygen/doxygen/commit/a06e660406d655568635521f6df161e3a7e5734b">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6692">6692</a> - XML TOC generation is not backwards-compatible with 1.8.14 [<a href="https://github.com/doxygen/doxygen/commit/15541e75816673fdc51d90820d6620e98b8fcd4b">view</a>]</li>
+<li>&#39;self&#39; keyword in PHP documentation [<a href="https://github.com/doxygen/doxygen/commit/7e591135c56c3679c5ee63aa78f6baeae2cde63f">view</a>]</li>
+<li>Added: support RTL for DocXRefItem in html - Removed: support RTL form Return section in html, for consistency with parameter sections [<a href="https://github.com/doxygen/doxygen/commit/08be7a8ef12518736b2530504a28904eec3e47ab">view</a>]</li>
+<li>Fixed: list item bullets overlap floating elements in html - Fixed: fragment lines overlap floating elements in html [<a href="https://github.com/doxygen/doxygen/commit/dda245dbab60bddab4e7593cccbf59117d00a812">view</a>]</li>
+<li>Fixed: text-align of rtl toc [<a href="https://github.com/doxygen/doxygen/commit/2ad516fef49f95b9edafe7ade6d1ed6d35cb75f7">view</a>]</li>
+<li>Fixed: last line underline overlap border in html fragment [<a href="https://github.com/doxygen/doxygen/commit/1245145d6710abbb58057dc555fccac08ac8a3fa">view</a>]</li>
+<li>A few more language updates [<a href="https://github.com/doxygen/doxygen/commit/9d35bd4f5865a63f3daacc8d4ab613fb4743bb72">view</a>]</li>
+<li>Add VHDL strings to Translator class and add german translations. [<a href="https://github.com/doxygen/doxygen/commit/f1fea3603fa3e561d8f1efff5bc685e4484e7998">view</a>]</li>
 <li>Add commands to handle referenced by relation and references relation [<a href="https://github.com/doxygen/doxygen/commit/0697535ad38ed122964c4673b102a8e30ad4369f">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/6c0436303d76a3df4c323bf6ca1e5716b6027ec0">view</a>]
-<li>Add formula (images) to RTF output [<a href="https://github.com/doxygen/doxygen/commit/79ac5232cf029f3d40543641e92daa8aaa1c9f7c">view</a>]
-<li>Add function annotations support [<a href="https://github.com/doxygen/doxygen/commit/72c5c25695273c96f30f118cb8270a037e28eb7a">view</a>]
-<li>Add possibility for adding doxygen configuration items to, all, tests during runtime. [<a href="https://github.com/doxygen/doxygen/commit/bb23893d5d5267942092bb93fd22b14dea9c1135">view</a>]
-<li>Add support for std::shared_ptr [<a href="https://github.com/doxygen/doxygen/commit/6c380ba91ae41c6d5c409a5163119318932ae2a3">view</a>]
-<li>Add support of dict/set in annotations and default values [<a href="https://github.com/doxygen/doxygen/commit/ec98b6f662024fc3d5bf47e33630fc8d06bde6c6">view</a>]
-<li>Add variadic arguments support to @link and @ref, aka &#39;...&#39; arguments, fixes [<a href="https://github.com/doxygen/doxygen/commit/dd88186b18613388902e4921e5203375458783b6">view</a>]
-<li>Add variadic function arguments &#39;...&#39; regression tests [<a href="https://github.com/doxygen/doxygen/commit/fce142b4282d80f16fff53ba1cbd2572119b17ef">view</a>]
-<li>Add variadic template function regression tests [<a href="https://github.com/doxygen/doxygen/commit/818f0458205a2965f0a676265e2454450a4c3455">view</a>]
-<li>Added *.ice files as a recognized file type. Added a Slice-optimized output mode. [<a href="https://github.com/doxygen/doxygen/commit/3a97099d5e6afd298486f219694a7fb5eff67fea">view</a>]
-<li>Added French translation [<a href="https://github.com/doxygen/doxygen/commit/7d058fe977db011e35cbfd0247bfa8d7f9435998">view</a>]
-<li>Added missing #include for util.h to portable.cpp [<a href="https://github.com/doxygen/doxygen/commit/74c9b5f67758ad21f014f6447d55e8aea6722cb5">view</a>]
-<li>Added not for usage of [TOC] together with Markdown headers [<a href="https://github.com/doxygen/doxygen/commit/19e2abe877cafbe4ab56cbc50d913dfaf249e450">view</a>]
-<li>Added some VHDL code  coloring [<a href="https://github.com/doxygen/doxygen/commit/cb331331f7b09aa44376596e83d29b3191a55b43">view</a>]
-<li>Added some missing default types for argument matching [<a href="https://github.com/doxygen/doxygen/commit/72f1b53bb5aebfebf829a684a7f16de1c07873c7">view</a>]
-<li>Added substitution variant for character substitution [<a href="https://github.com/doxygen/doxygen/commit/bd6c93b2d26a9a80df66a25404613e285ef35815">view</a>]
-<li>Added support for RTL(right to left) languages like Arabic and Persian in HTML output [<a href="https://github.com/doxygen/doxygen/commit/5885c89d6b30ca607f84794d0de6800f49dd327b">view</a>]
-<li>Added test case for \ref, and fixed representation of operator-&gt;*() [<a href="https://github.com/doxygen/doxygen/commit/2b4257860046b3863b7c478d7f6ad5bdfcab757b">view</a>]
-<li>Adding debug options to vhdl parser generator [<a href="https://github.com/doxygen/doxygen/commit/6ad7854e72abda652bdf034d7cf355dcb136a7fe">view</a>]
-<li>Adjustment of xhtml1-transitional.dtd [<a href="https://github.com/doxygen/doxygen/commit/2427e160d2299d72813f52f0862d504956c6c209">view</a>]
-<li>Automatic detection of UCS-2 based on BOM corrected [<a href="https://github.com/doxygen/doxygen/commit/f3b423989086728ded99492e61a0a5c127f21f69">view</a>]
-<li>Better HTML output for VHDL Ports [<a href="https://github.com/doxygen/doxygen/commit/36afe5e25c10dfd5a6208df7c8892eb2bb7498c5">view</a>]
-<li>Bold text terminated by plus sign [<a href="https://github.com/doxygen/doxygen/commit/5ddb9f02b9fdaf6e3e25f0281d11e6d516ab4aad">view</a>]
-<li>Bug fix for plantuml [<a href="https://github.com/doxygen/doxygen/commit/cbb0ae9a02305e0464737b316abd35e8e6d7c1a2">view</a>]
-<li>Bump minimal deployment target for OSX to 10.9 to avoid deprecation warning while linking [<a href="https://github.com/doxygen/doxygen/commit/58f9985ba779cbf733f78a720060ff0225f0156d">view</a>]
-<li>C++11 features used in Doxygen [<a href="https://github.com/doxygen/doxygen/commit/e2b07563dd9cc21f8472570d2cc8d6cd69d536b8">view</a>]
-<li>Cannot Generate Layout File using -l [<a href="https://github.com/doxygen/doxygen/commit/5c3bcaadff1a693dab41ee49701dc12df7d6b09a">view</a>]
-<li>Cannot properly jump from brief to detailed function description [<a href="https://github.com/doxygen/doxygen/commit/edfa0d2a95dacfea8c2cddc1da1e37728d1cc608">view</a>]
-<li>Change german translation of trClassDocumentation() for VHDL output. [<a href="https://github.com/doxygen/doxygen/commit/fe88231028cc137b9e97ae1024ce8781244f3103">view</a>]
-<li>Changed implementation, added test case [<a href="https://github.com/doxygen/doxygen/commit/0a384496099569c2a675a94c5af06ad83cccb247">view</a>]
-<li>Changed mail address and removed obsolete files [<a href="https://github.com/doxygen/doxygen/commit/92aae074ff9115e13295dcc9eb1515ed1d62319c">view</a>]
-<li>Changed refiltering to forced use of insideTabbing [<a href="https://github.com/doxygen/doxygen/commit/8deca51e0c8cca7873d40d5670edbea36ea38ee3">view</a>]
-<li>Changed state guard instead of adding pattern check+reject [<a href="https://github.com/doxygen/doxygen/commit/510f342b4d6f61f4ea6f0e7cab5531895bc86a20">view</a>]
-<li>Close last code line properly. [<a href="https://github.com/doxygen/doxygen/commit/ef9c151c86073f107ec6556b779cd7b8da3154eb">view</a>]
-<li>Combined lrRank and rank parameters for computeMd5Signature [<a href="https://github.com/doxygen/doxygen/commit/cbca2bdcd77ce0ab6b907cf2d4bab65340a57f00">view</a>]
-<li>Consistency between &#39;generate&#39; and &#39;update&#39; startup option [<a href="https://github.com/doxygen/doxygen/commit/c17bfe7f9ee46c9cf41bbf16ef72607793c80036">view</a>]
-<li>Consistency between preprocessor and handling of \cond and \if [<a href="https://github.com/doxygen/doxygen/commit/50019481eb64142248d74bb89ad2c6e2b50e69f2">view</a>]
-<li>Consistency for &quot;group&quot; commands [<a href="https://github.com/doxygen/doxygen/commit/3514452268bf860ac7516185adc0907817ccda97">view</a>]
-<li>Consistency in headings and layout for template parameters (tparam) [<a href="https://github.com/doxygen/doxygen/commit/626e56ee5c6d6d2f6c51bd64855c70500b28472e">view</a>]
-<li>Consistency of Index name in LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/84c791d75dd1e9026cbbc1a338316656b0c03896">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/6c0436303d76a3df4c323bf6ca1e5716b6027ec0">view</a>]</li>
+<li>Add formula (images) to RTF output [<a href="https://github.com/doxygen/doxygen/commit/79ac5232cf029f3d40543641e92daa8aaa1c9f7c">view</a>]</li>
+<li>Add function annotations support [<a href="https://github.com/doxygen/doxygen/commit/72c5c25695273c96f30f118cb8270a037e28eb7a">view</a>]</li>
+<li>Add possibility for adding doxygen configuration items to, all, tests during runtime. [<a href="https://github.com/doxygen/doxygen/commit/bb23893d5d5267942092bb93fd22b14dea9c1135">view</a>]</li>
+<li>Add support for std::shared_ptr [<a href="https://github.com/doxygen/doxygen/commit/6c380ba91ae41c6d5c409a5163119318932ae2a3">view</a>]</li>
+<li>Add support of dict/set in annotations and default values [<a href="https://github.com/doxygen/doxygen/commit/ec98b6f662024fc3d5bf47e33630fc8d06bde6c6">view</a>]</li>
+<li>Add variadic arguments support to @link and @ref, aka &#39;...&#39; arguments, fixes [<a href="https://github.com/doxygen/doxygen/commit/dd88186b18613388902e4921e5203375458783b6">view</a>]</li>
+<li>Add variadic function arguments &#39;...&#39; regression tests [<a href="https://github.com/doxygen/doxygen/commit/fce142b4282d80f16fff53ba1cbd2572119b17ef">view</a>]</li>
+<li>Add variadic template function regression tests [<a href="https://github.com/doxygen/doxygen/commit/818f0458205a2965f0a676265e2454450a4c3455">view</a>]</li>
+<li>Added *.ice files as a recognized file type. Added a Slice-optimized output mode. [<a href="https://github.com/doxygen/doxygen/commit/3a97099d5e6afd298486f219694a7fb5eff67fea">view</a>]</li>
+<li>Added French translation [<a href="https://github.com/doxygen/doxygen/commit/7d058fe977db011e35cbfd0247bfa8d7f9435998">view</a>]</li>
+<li>Added missing #include for util.h to portable.cpp [<a href="https://github.com/doxygen/doxygen/commit/74c9b5f67758ad21f014f6447d55e8aea6722cb5">view</a>]</li>
+<li>Added not for usage of [TOC] together with Markdown headers [<a href="https://github.com/doxygen/doxygen/commit/19e2abe877cafbe4ab56cbc50d913dfaf249e450">view</a>]</li>
+<li>Added some VHDL code  coloring [<a href="https://github.com/doxygen/doxygen/commit/cb331331f7b09aa44376596e83d29b3191a55b43">view</a>]</li>
+<li>Added some missing default types for argument matching [<a href="https://github.com/doxygen/doxygen/commit/72f1b53bb5aebfebf829a684a7f16de1c07873c7">view</a>]</li>
+<li>Added substitution variant for character substitution [<a href="https://github.com/doxygen/doxygen/commit/bd6c93b2d26a9a80df66a25404613e285ef35815">view</a>]</li>
+<li>Added support for RTL(right to left) languages like Arabic and Persian in HTML output [<a href="https://github.com/doxygen/doxygen/commit/5885c89d6b30ca607f84794d0de6800f49dd327b">view</a>]</li>
+<li>Added test case for \ref, and fixed representation of operator-&gt;*() [<a href="https://github.com/doxygen/doxygen/commit/2b4257860046b3863b7c478d7f6ad5bdfcab757b">view</a>]</li>
+<li>Adding debug options to vhdl parser generator [<a href="https://github.com/doxygen/doxygen/commit/6ad7854e72abda652bdf034d7cf355dcb136a7fe">view</a>]</li>
+<li>Adjustment of xhtml1-transitional.dtd [<a href="https://github.com/doxygen/doxygen/commit/2427e160d2299d72813f52f0862d504956c6c209">view</a>]</li>
+<li>Automatic detection of UCS-2 based on BOM corrected [<a href="https://github.com/doxygen/doxygen/commit/f3b423989086728ded99492e61a0a5c127f21f69">view</a>]</li>
+<li>Better HTML output for VHDL Ports [<a href="https://github.com/doxygen/doxygen/commit/36afe5e25c10dfd5a6208df7c8892eb2bb7498c5">view</a>]</li>
+<li>Bold text terminated by plus sign [<a href="https://github.com/doxygen/doxygen/commit/5ddb9f02b9fdaf6e3e25f0281d11e6d516ab4aad">view</a>]</li>
+<li>Bug fix for plantuml [<a href="https://github.com/doxygen/doxygen/commit/cbb0ae9a02305e0464737b316abd35e8e6d7c1a2">view</a>]</li>
+<li>Bump minimal deployment target for OSX to 10.9 to avoid deprecation warning while linking [<a href="https://github.com/doxygen/doxygen/commit/58f9985ba779cbf733f78a720060ff0225f0156d">view</a>]</li>
+<li>C++11 features used in Doxygen [<a href="https://github.com/doxygen/doxygen/commit/e2b07563dd9cc21f8472570d2cc8d6cd69d536b8">view</a>]</li>
+<li>Cannot Generate Layout File using -l [<a href="https://github.com/doxygen/doxygen/commit/5c3bcaadff1a693dab41ee49701dc12df7d6b09a">view</a>]</li>
+<li>Cannot properly jump from brief to detailed function description [<a href="https://github.com/doxygen/doxygen/commit/edfa0d2a95dacfea8c2cddc1da1e37728d1cc608">view</a>]</li>
+<li>Change german translation of trClassDocumentation() for VHDL output. [<a href="https://github.com/doxygen/doxygen/commit/fe88231028cc137b9e97ae1024ce8781244f3103">view</a>]</li>
+<li>Changed implementation, added test case [<a href="https://github.com/doxygen/doxygen/commit/0a384496099569c2a675a94c5af06ad83cccb247">view</a>]</li>
+<li>Changed mail address and removed obsolete files [<a href="https://github.com/doxygen/doxygen/commit/92aae074ff9115e13295dcc9eb1515ed1d62319c">view</a>]</li>
+<li>Changed refiltering to forced use of insideTabbing [<a href="https://github.com/doxygen/doxygen/commit/8deca51e0c8cca7873d40d5670edbea36ea38ee3">view</a>]</li>
+<li>Changed state guard instead of adding pattern check+reject [<a href="https://github.com/doxygen/doxygen/commit/510f342b4d6f61f4ea6f0e7cab5531895bc86a20">view</a>]</li>
+<li>Close last code line properly. [<a href="https://github.com/doxygen/doxygen/commit/ef9c151c86073f107ec6556b779cd7b8da3154eb">view</a>]</li>
+<li>Combined lrRank and rank parameters for computeMd5Signature [<a href="https://github.com/doxygen/doxygen/commit/cbca2bdcd77ce0ab6b907cf2d4bab65340a57f00">view</a>]</li>
+<li>Consistency between &#39;generate&#39; and &#39;update&#39; startup option [<a href="https://github.com/doxygen/doxygen/commit/c17bfe7f9ee46c9cf41bbf16ef72607793c80036">view</a>]</li>
+<li>Consistency between preprocessor and handling of \cond and \if [<a href="https://github.com/doxygen/doxygen/commit/50019481eb64142248d74bb89ad2c6e2b50e69f2">view</a>]</li>
+<li>Consistency for &quot;group&quot; commands [<a href="https://github.com/doxygen/doxygen/commit/3514452268bf860ac7516185adc0907817ccda97">view</a>]</li>
+<li>Consistency in headings and layout for template parameters (tparam) [<a href="https://github.com/doxygen/doxygen/commit/626e56ee5c6d6d2f6c51bd64855c70500b28472e">view</a>]</li>
+<li>Consistency of Index name in LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/84c791d75dd1e9026cbbc1a338316656b0c03896">view</a>]</li>
 <li>Consistency of environment variables between config and code [<a href="https://github.com/doxygen/doxygen/commit/35b7de3e692b127f8192900e1ae1152221afe76b">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/b1a7c9f513fd7c15d86d536cad64338dfd2b617c">view</a>]
-<li>Consistent warning messages [<a href="https://github.com/doxygen/doxygen/commit/1a16a1be6eff7c32795455e47c09b9452f7c3a4e">view</a>]
-<li>Correct list of not used translator functions [<a href="https://github.com/doxygen/doxygen/commit/ca68fbb7cb8937b0a90fcd1b326c00e6e413e70c">view</a>]
-<li>Correct typing error in test 5 [<a href="https://github.com/doxygen/doxygen/commit/a705a7a3f3cd0689e0185d92c4f0542c83b9dcb6">view</a>]
-<li>Correct typing error in test 51 [<a href="https://github.com/doxygen/doxygen/commit/03fad37f3bd695d0a30333e8cecc3931c4f870ba">view</a>]
-<li>Correct typing error in warning message. [<a href="https://github.com/doxygen/doxygen/commit/bae4bd915ac018c4a3ce681067e0a1a51017e418">view</a>]
-<li>Corrected description of XML output for emoji characters [<a href="https://github.com/doxygen/doxygen/commit/7d86cf4c84221696cbd2879809dba1e85d2dbaa6">view</a>]
-<li>Corrected warning in case of a not supported output format with \image command. [<a href="https://github.com/doxygen/doxygen/commit/e570fd61c6975ef067efbf6a9c09b79cc58d96f5">view</a>]
-<li>Correcting &quot;Definition at line @0 of file @1.&quot; [<a href="https://github.com/doxygen/doxygen/commit/afecea64c225ec3c8ef9c84235d9fe091af588ca">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/b1a7c9f513fd7c15d86d536cad64338dfd2b617c">view</a>]</li>
+<li>Consistent warning messages [<a href="https://github.com/doxygen/doxygen/commit/1a16a1be6eff7c32795455e47c09b9452f7c3a4e">view</a>]</li>
+<li>Correct list of not used translator functions [<a href="https://github.com/doxygen/doxygen/commit/ca68fbb7cb8937b0a90fcd1b326c00e6e413e70c">view</a>]</li>
+<li>Correct typing error in test 5 [<a href="https://github.com/doxygen/doxygen/commit/a705a7a3f3cd0689e0185d92c4f0542c83b9dcb6">view</a>]</li>
+<li>Correct typing error in test 51 [<a href="https://github.com/doxygen/doxygen/commit/03fad37f3bd695d0a30333e8cecc3931c4f870ba">view</a>]</li>
+<li>Correct typing error in warning message. [<a href="https://github.com/doxygen/doxygen/commit/bae4bd915ac018c4a3ce681067e0a1a51017e418">view</a>]</li>
+<li>Corrected description of XML output for emoji characters [<a href="https://github.com/doxygen/doxygen/commit/7d86cf4c84221696cbd2879809dba1e85d2dbaa6">view</a>]</li>
+<li>Corrected warning in case of a not supported output format with \image command. [<a href="https://github.com/doxygen/doxygen/commit/e570fd61c6975ef067efbf6a9c09b79cc58d96f5">view</a>]</li>
+<li>Correcting &quot;Definition at line @0 of file @1.&quot; [<a href="https://github.com/doxygen/doxygen/commit/afecea64c225ec3c8ef9c84235d9fe091af588ca">view</a>]</li>
 <li>Correcting labels for citations [<a href="https://github.com/doxygen/doxygen/commit/e2306e7ff24e72d49893eb9ebc568b468298e236">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/fcb7d9fb380b714e1db9a279ceeba5af4cf59965">view</a>]
-<li>Correcting tag example and uniform calling all examples [<a href="https://github.com/doxygen/doxygen/commit/dfdf4323434ec466613e9c358da98a4be868986c">view</a>]
-<li>Correcting tag in printdocvisitor [<a href="https://github.com/doxygen/doxygen/commit/6ea7d92e56c929af29aafc7ea072ce465d5961d9">view</a>]
-<li>Correcting warning messages and echoing unknown command [<a href="https://github.com/doxygen/doxygen/commit/a68e6c0724f99dfa6cea25f7d56fb6077100fc85">view</a>]
-<li>Correction for `doxygen -g` [<a href="https://github.com/doxygen/doxygen/commit/f5e25bba9c01e473991ea6c7d8622a40e5c8f92d">view</a>]
-<li>Correction in example of FILE_VERSION_FILTER [<a href="https://github.com/doxygen/doxygen/commit/b278c8f658a2507076840f37287e7fe1e3357b54">view</a>]
-<li>Correction in title of FAQ [<a href="https://github.com/doxygen/doxygen/commit/f1148cc406d6e1eefd146f35e766b62bd376cdc3">view</a>]
-<li>Correction internal documentation [<a href="https://github.com/doxygen/doxygen/commit/55bdda94dc8661dc740e26e6fb91beb7e2bb7ec7">view</a>]
-<li>Correction of some coloring of code comments in VHDL, adding data type &#39;positive&#39; [<a href="https://github.com/doxygen/doxygen/commit/fdd10f2415c65a9a34d64c985ea5ff0a6f4b6654">view</a>]
-<li>Create command for escaped equal sign [<a href="https://github.com/doxygen/doxygen/commit/8292eeebd57aea339ea4ebad2267402d1183b097">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/fcb7d9fb380b714e1db9a279ceeba5af4cf59965">view</a>]</li>
+<li>Correcting tag example and uniform calling all examples [<a href="https://github.com/doxygen/doxygen/commit/dfdf4323434ec466613e9c358da98a4be868986c">view</a>]</li>
+<li>Correcting tag in printdocvisitor [<a href="https://github.com/doxygen/doxygen/commit/6ea7d92e56c929af29aafc7ea072ce465d5961d9">view</a>]</li>
+<li>Correcting warning messages and echoing unknown command [<a href="https://github.com/doxygen/doxygen/commit/a68e6c0724f99dfa6cea25f7d56fb6077100fc85">view</a>]</li>
+<li>Correction for `doxygen -g` [<a href="https://github.com/doxygen/doxygen/commit/f5e25bba9c01e473991ea6c7d8622a40e5c8f92d">view</a>]</li>
+<li>Correction in example of FILE_VERSION_FILTER [<a href="https://github.com/doxygen/doxygen/commit/b278c8f658a2507076840f37287e7fe1e3357b54">view</a>]</li>
+<li>Correction in title of FAQ [<a href="https://github.com/doxygen/doxygen/commit/f1148cc406d6e1eefd146f35e766b62bd376cdc3">view</a>]</li>
+<li>Correction internal documentation [<a href="https://github.com/doxygen/doxygen/commit/55bdda94dc8661dc740e26e6fb91beb7e2bb7ec7">view</a>]</li>
+<li>Correction of some coloring of code comments in VHDL, adding data type &#39;positive&#39; [<a href="https://github.com/doxygen/doxygen/commit/fdd10f2415c65a9a34d64c985ea5ff0a6f4b6654">view</a>]</li>
+<li>Create command for escaped equal sign [<a href="https://github.com/doxygen/doxygen/commit/8292eeebd57aea339ea4ebad2267402d1183b097">view</a>]</li>
 <li>Create test possibilities for xhtml and pdf output [<a href="https://github.com/doxygen/doxygen/commit/4575eef95039149eb19c4f5e5bf99e67e36afb5a">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/95a6451107f8964b1c2290e2f4e9761a64be124b">view</a>]
-<li>Debug output commentcnv independent of QUIET setting [<a href="https://github.com/doxygen/doxygen/commit/3c0327c1f8461a029c83b744d076617e28cd26bf">view</a>]
-<li>Difference between standard and used Doxyfile [<a href="https://github.com/doxygen/doxygen/commit/ed1fb80b55bab16443b211ebeb1cd45bb630b08b">view</a>]
-<li>Difference between standard and used Doxyfile (list) [<a href="https://github.com/doxygen/doxygen/commit/c6ec3a813f61b1a5c15d959b923c4f26dd2f62c5">view</a>]
-<li>Disabled Appveyor documentation build due to unreliability of MikTeX download [<a href="https://github.com/doxygen/doxygen/commit/8c7b1352474e4da5024cfc3ecc25a486b1d4ef2a">view</a>]
-<li>Disabled debug print [<a href="https://github.com/doxygen/doxygen/commit/200353a0886f5ee20101b7af4b55af498adc495f">view</a>]
-<li>Documentation EXTENSION_MAPPING [<a href="https://github.com/doxygen/doxygen/commit/967be1c5a03c4e80149c984e5a6b208c9f65f824">view</a>]
-<li>Documentation correction [<a href="https://github.com/doxygen/doxygen/commit/f1274b44ad4cb7b4c1a04893b5ad17f830600af4">view</a>]
-<li>Documentation correction CLANG option usage [<a href="https://github.com/doxygen/doxygen/commit/0e80abeb4c0966ef66a616c21ecb71583465955a">view</a>]
-<li>Documentation correction include command with options [<a href="https://github.com/doxygen/doxygen/commit/731758537f45b602b000cb081d8b642fc54141da">view</a>]
-<li>Documentation corrections [<a href="https://github.com/doxygen/doxygen/commit/17c8c0ee8c0dd06938f3b85db6361de24c1bbe58">view</a>]
-<li>Documentation internet addresses [<a href="https://github.com/doxygen/doxygen/commit/78a73c52935396f0158ed9dd58909424981bee7e">view</a>]
-<li>Documentation update regarding right font usage in architecture chapter [<a href="https://github.com/doxygen/doxygen/commit/824025bdec187c07b744e4a1fa0837b932d13679">view</a>]
-<li>Does not generate TOC for markdown [<a href="https://github.com/doxygen/doxygen/commit/ea361e255efa1286566fef7f38c1ce5a01a44f33">view</a>]
-<li>Don&#39;t link to non existing / not accessible namespaces , in CSharp, in the source code [<a href="https://github.com/doxygen/doxygen/commit/28fe14198cf1da1f6bef42d4cba4cfbec35c7155">view</a>]
-<li>Doxygen creates empty image titles for Docbook output [<a href="https://github.com/doxygen/doxygen/commit/2e3c07357f208033b502bb6cc5ae015ff76668de">view</a>]
-<li>Doxygen manual doesn&#39;t have lines around markdown tables / cells. [<a href="https://github.com/doxygen/doxygen/commit/2c5a80f301032ab4653736f767037f2cd6c0ef61">view</a>]
-<li>Doxygen manual is not XHTML compliant [<a href="https://github.com/doxygen/doxygen/commit/565c21b260ca58c9d6b845ecc64f8c4aaa9a9a96">view</a>]
-<li>Drop down lists in menu bar missing [<a href="https://github.com/doxygen/doxygen/commit/09ae56fcfc540ab79378ba83fdb95ff28401786c">view</a>]
-<li>Enable comma as separator in configuration lists [<a href="https://github.com/doxygen/doxygen/commit/7c76f37c452ad49f1b19a661525ceebafc036a6e">view</a>]
-<li>Enable in page table of contents for LaTeX [<a href="https://github.com/doxygen/doxygen/commit/ba30b13cfd4910a5913f080a039fc429ec8a7e3f">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/95a6451107f8964b1c2290e2f4e9761a64be124b">view</a>]</li>
+<li>Debug output commentcnv independent of QUIET setting [<a href="https://github.com/doxygen/doxygen/commit/3c0327c1f8461a029c83b744d076617e28cd26bf">view</a>]</li>
+<li>Difference between standard and used Doxyfile [<a href="https://github.com/doxygen/doxygen/commit/ed1fb80b55bab16443b211ebeb1cd45bb630b08b">view</a>]</li>
+<li>Difference between standard and used Doxyfile (list) [<a href="https://github.com/doxygen/doxygen/commit/c6ec3a813f61b1a5c15d959b923c4f26dd2f62c5">view</a>]</li>
+<li>Disabled Appveyor documentation build due to unreliability of MikTeX download [<a href="https://github.com/doxygen/doxygen/commit/8c7b1352474e4da5024cfc3ecc25a486b1d4ef2a">view</a>]</li>
+<li>Disabled debug print [<a href="https://github.com/doxygen/doxygen/commit/200353a0886f5ee20101b7af4b55af498adc495f">view</a>]</li>
+<li>Documentation EXTENSION_MAPPING [<a href="https://github.com/doxygen/doxygen/commit/967be1c5a03c4e80149c984e5a6b208c9f65f824">view</a>]</li>
+<li>Documentation correction [<a href="https://github.com/doxygen/doxygen/commit/f1274b44ad4cb7b4c1a04893b5ad17f830600af4">view</a>]</li>
+<li>Documentation correction CLANG option usage [<a href="https://github.com/doxygen/doxygen/commit/0e80abeb4c0966ef66a616c21ecb71583465955a">view</a>]</li>
+<li>Documentation correction include command with options [<a href="https://github.com/doxygen/doxygen/commit/731758537f45b602b000cb081d8b642fc54141da">view</a>]</li>
+<li>Documentation corrections [<a href="https://github.com/doxygen/doxygen/commit/17c8c0ee8c0dd06938f3b85db6361de24c1bbe58">view</a>]</li>
+<li>Documentation internet addresses [<a href="https://github.com/doxygen/doxygen/commit/78a73c52935396f0158ed9dd58909424981bee7e">view</a>]</li>
+<li>Documentation update regarding right font usage in architecture chapter [<a href="https://github.com/doxygen/doxygen/commit/824025bdec187c07b744e4a1fa0837b932d13679">view</a>]</li>
+<li>Does not generate TOC for markdown [<a href="https://github.com/doxygen/doxygen/commit/ea361e255efa1286566fef7f38c1ce5a01a44f33">view</a>]</li>
+<li>Don&#39;t link to non existing / not accessible namespaces , in CSharp, in the source code [<a href="https://github.com/doxygen/doxygen/commit/28fe14198cf1da1f6bef42d4cba4cfbec35c7155">view</a>]</li>
+<li>Doxygen creates empty image titles for Docbook output [<a href="https://github.com/doxygen/doxygen/commit/2e3c07357f208033b502bb6cc5ae015ff76668de">view</a>]</li>
+<li>Doxygen manual doesn&#39;t have lines around markdown tables / cells. [<a href="https://github.com/doxygen/doxygen/commit/2c5a80f301032ab4653736f767037f2cd6c0ef61">view</a>]</li>
+<li>Doxygen manual is not XHTML compliant [<a href="https://github.com/doxygen/doxygen/commit/565c21b260ca58c9d6b845ecc64f8c4aaa9a9a96">view</a>]</li>
+<li>Drop down lists in menu bar missing [<a href="https://github.com/doxygen/doxygen/commit/09ae56fcfc540ab79378ba83fdb95ff28401786c">view</a>]</li>
+<li>Enable comma as separator in configuration lists [<a href="https://github.com/doxygen/doxygen/commit/7c76f37c452ad49f1b19a661525ceebafc036a6e">view</a>]</li>
+<li>Enable in page table of contents for LaTeX [<a href="https://github.com/doxygen/doxygen/commit/ba30b13cfd4910a5913f080a039fc429ec8a7e3f">view</a>]</li>
 <li>Enable in page table of contents for XML and add maximum level to in page table of contents [<a href="https://github.com/doxygen/doxygen/commit/5b735d5118581e3bca686f79de341b8b2e76691f">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/956342ae0b2e09f5e398778c255006f9d26e7b52">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/956342ae0b2e09f5e398778c255006f9d26e7b52">view</a>]</li>
 <li>Enable possibility of CLANG for Cygwin [<a href="https://github.com/doxygen/doxygen/commit/9e29820e9f0207230ac05facb93f414cb5239ae5">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/b0f638cb3a63ba4e73657ed5fd6276e1814391d7">view</a>]
-<li>Enable possibility to run single tests [<a href="https://github.com/doxygen/doxygen/commit/a34987da94ea06a53bf4841e09436db1748bf306">view</a>]
-<li>Ensure all language files are reset [<a href="https://github.com/doxygen/doxygen/commit/4663bed1653e1009bf06a6e21907e93ad74f281f">view</a>]
-<li>Expand sqlite3gen&#39;s breadth, depth, and quality [<a href="https://github.com/doxygen/doxygen/commit/61cddaf2d440aff48868fc3a50185a2788917914">view</a>]
-<li>Extending \cite command with &#39;-&#39; and &#39;?&#39; characters. [<a href="https://github.com/doxygen/doxygen/commit/8ef2c893f372d44225f9536bac379387e8d2bc44">view</a>]
-<li>Extending tests with extra possibilities [<a href="https://github.com/doxygen/doxygen/commit/8176639e13357f74d317c631a5bf01a60bb543af">view</a>]
-<li>Fix French lang build [<a href="https://github.com/doxygen/doxygen/commit/e36d06860e9e1441a402ec8c9a7e03742eb85e9a">view</a>]
-<li>Fix HTTPS links [<a href="https://github.com/doxygen/doxygen/commit/4cda8f612403c6feb6b596c101ddf1e5d6fe35e0">view</a>]
-<li>Fix VHDL Latex documentation having two chapters with the same name. [<a href="https://github.com/doxygen/doxygen/commit/efd2921d1e3a3f9b7f994673d0af6d70b1888b98">view</a>]
-<li>Fix Windows build failure [<a href="https://github.com/doxygen/doxygen/commit/e2bbd54c5eb915c6dfecef1895b336d4b16c9df3">view</a>]
-<li>Fix annotation with default value parsing [<a href="https://github.com/doxygen/doxygen/commit/03894677569451502c4bbc0b5f656244357dd907">view</a>]
-<li>Fix building with Visual Studio 2013 [<a href="https://github.com/doxygen/doxygen/commit/dcd7390a61abc1da656c10dde282191e651a36fb">view</a>]
-<li>Fix for &#39;Definition at line&#39; points to end of multiple-lined definition for Python #6706 [<a href="https://github.com/doxygen/doxygen/commit/babfc33370e28963f890a5f05355aa7778700ca6">view</a>]
-<li>Fix for module quicklinks [<a href="https://github.com/doxygen/doxygen/commit/109bd64ceb2fbe41cd1f94011edd51f03b28fbdb">view</a>]
-<li>Fix for unbounded memory usage due to a bug in \ref const matching #6689 [<a href="https://github.com/doxygen/doxygen/commit/f30a5fa78d9460550c7e921e73e11087f90b7db3">view</a>]
-<li>Fix potential hangup when merging scopes [<a href="https://github.com/doxygen/doxygen/commit/c506514a32991918e06ec75ebaad3f6eaea1dc9b">view</a>]
-<li>Fix regression due to move of markdown processing [<a href="https://github.com/doxygen/doxygen/commit/48e838a1d15c5feb2247f9c93bebc971b871800c">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/b0f638cb3a63ba4e73657ed5fd6276e1814391d7">view</a>]</li>
+<li>Enable possibility to run single tests [<a href="https://github.com/doxygen/doxygen/commit/a34987da94ea06a53bf4841e09436db1748bf306">view</a>]</li>
+<li>Ensure all language files are reset [<a href="https://github.com/doxygen/doxygen/commit/4663bed1653e1009bf06a6e21907e93ad74f281f">view</a>]</li>
+<li>Expand sqlite3gen&#39;s breadth, depth, and quality [<a href="https://github.com/doxygen/doxygen/commit/61cddaf2d440aff48868fc3a50185a2788917914">view</a>]</li>
+<li>Extending \cite command with &#39;-&#39; and &#39;?&#39; characters. [<a href="https://github.com/doxygen/doxygen/commit/8ef2c893f372d44225f9536bac379387e8d2bc44">view</a>]</li>
+<li>Extending tests with extra possibilities [<a href="https://github.com/doxygen/doxygen/commit/8176639e13357f74d317c631a5bf01a60bb543af">view</a>]</li>
+<li>Fix French lang build [<a href="https://github.com/doxygen/doxygen/commit/e36d06860e9e1441a402ec8c9a7e03742eb85e9a">view</a>]</li>
+<li>Fix HTTPS links [<a href="https://github.com/doxygen/doxygen/commit/4cda8f612403c6feb6b596c101ddf1e5d6fe35e0">view</a>]</li>
+<li>Fix VHDL Latex documentation having two chapters with the same name. [<a href="https://github.com/doxygen/doxygen/commit/efd2921d1e3a3f9b7f994673d0af6d70b1888b98">view</a>]</li>
+<li>Fix Windows build failure [<a href="https://github.com/doxygen/doxygen/commit/e2bbd54c5eb915c6dfecef1895b336d4b16c9df3">view</a>]</li>
+<li>Fix annotation with default value parsing [<a href="https://github.com/doxygen/doxygen/commit/03894677569451502c4bbc0b5f656244357dd907">view</a>]</li>
+<li>Fix building with Visual Studio 2013 [<a href="https://github.com/doxygen/doxygen/commit/dcd7390a61abc1da656c10dde282191e651a36fb">view</a>]</li>
+<li>Fix for &#39;Definition at line&#39; points to end of multiple-lined definition for Python #6706 [<a href="https://github.com/doxygen/doxygen/commit/babfc33370e28963f890a5f05355aa7778700ca6">view</a>]</li>
+<li>Fix for module quicklinks [<a href="https://github.com/doxygen/doxygen/commit/109bd64ceb2fbe41cd1f94011edd51f03b28fbdb">view</a>]</li>
+<li>Fix for unbounded memory usage due to a bug in \ref const matching #6689 [<a href="https://github.com/doxygen/doxygen/commit/f30a5fa78d9460550c7e921e73e11087f90b7db3">view</a>]</li>
+<li>Fix potential hangup when merging scopes [<a href="https://github.com/doxygen/doxygen/commit/c506514a32991918e06ec75ebaad3f6eaea1dc9b">view</a>]</li>
+<li>Fix regression due to move of markdown processing [<a href="https://github.com/doxygen/doxygen/commit/48e838a1d15c5feb2247f9c93bebc971b871800c">view</a>]</li>
 <li>Fix scanner.l for Slice [<a href="https://github.com/doxygen/doxygen/commit/d5fd75574bc816e95f1bcdcdb8e2121949d484d8">view</a>]
 , [<a href="https://github.com/doxygen/doxygen/commit/d0f90ba4a1b7a8e2b5a15e7d8a05d0f484e8f3b5">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/e78925a2142bb254dfc8ffc993a21f54ee4cf461">view</a>]
-<li>Fix/New: add variadic function args &#39;...&#39; support to @link [<a href="https://github.com/doxygen/doxygen/commit/6b29c4e55009771545305fe3ec3ba92e8d0ba38e">view</a>]
-<li>Fix/New: add variadic function args &#39;...&#39; support to @ref [<a href="https://github.com/doxygen/doxygen/commit/037f465e934ce122c8412b55548a153ad517aba0">view</a>]
-<li>Fixed bug in URL [<a href="https://github.com/doxygen/doxygen/commit/fbabed9704a0d9876676122515be2651ab696cf1">view</a>]
-<li>Fixed compile errors in clang and gcc [<a href="https://github.com/doxygen/doxygen/commit/2a539e12679a244389c781f6146d7f6bd9c82048">view</a>]
-<li>Fixed compiler warning for nested /* in scanner.l [<a href="https://github.com/doxygen/doxygen/commit/c78c338fffbdbb9b2379b1896e647f7cc697da57">view</a>]
-<li>Fixed differently by changing root cause for introducing the space [<a href="https://github.com/doxygen/doxygen/commit/890e3567470b0767c5ebe52207d1c75a96e888aa">view</a>]
-<li>Fixed documentation to point to GitHub issue tracker [<a href="https://github.com/doxygen/doxygen/commit/d72bfbd272669f22bfa615549dc737199a48dc95">view</a>]
-<li>Fixed incorrect XHTML output for test 021 [<a href="https://github.com/doxygen/doxygen/commit/d33a129d784f2b0f823f14a008e929513b302ad3">view</a>]
-<li>Fixed logic error [<a href="https://github.com/doxygen/doxygen/commit/301425d57d422431037779e52e0ffcc93e509a35">view</a>]
-<li>Fixed merge problem [<a href="https://github.com/doxygen/doxygen/commit/c4b853d749fcaffb2f2c142dcd14e48ab049013e">view</a>]
-<li>Fixed one remained compile error in clang [<a href="https://github.com/doxygen/doxygen/commit/3977359bd3fb5527a237c2c0cdb61407f2d85464">view</a>]
-<li>Fixed problems with emoji handling and added a test case for it [<a href="https://github.com/doxygen/doxygen/commit/348a8cc72dd481fa9e65e6209946bfeef5716914">view</a>]
-<li>Fixed some more small memory leaks [<a href="https://github.com/doxygen/doxygen/commit/b6662b61dd83be32481a1c83e092082e9d797f0a">view</a>]
-<li>Fixed two small memory leaks [<a href="https://github.com/doxygen/doxygen/commit/0591146bb406c8601c452f7a8a9e6e24823ce8d9">view</a>]
-<li>Fixing coverity messages [<a href="https://github.com/doxygen/doxygen/commit/99f948c038b763028fcb95ef2a65fdbc1d5f9520">view</a>]
-<li>Fixing coverity messages  (Namespace tag) [<a href="https://github.com/doxygen/doxygen/commit/b7cdfc8d47dc7a7f86605bbbc74aa78501d2bc33">view</a>]
-<li>Fixing problem with possible not initialized variable (endless loop in VS 2017 debug) [<a href="https://github.com/doxygen/doxygen/commit/0a4b995cdd7735aaf42c423eed2889db5b8617ef">view</a>]
-<li>Fortran code coloring improvements (REAL and comment lines) [<a href="https://github.com/doxygen/doxygen/commit/2e570d3762a412f87fff19ea4a30d60b171a6ea4">view</a>]
-<li>Fortran improvements [<a href="https://github.com/doxygen/doxygen/commit/5f11678370f55e491fa9a04b7fd03cd473f8982f">view</a>]
-<li>Fortran improvements (2) [<a href="https://github.com/doxygen/doxygen/commit/4013e52ba0f87eb12f8a1c8cb3b2714c0d519a81">view</a>]
-<li>Fortran scanner abort message [<a href="https://github.com/doxygen/doxygen/commit/ee12e104e1f43aa4e5301b314f7c620dbbf58ecc">view</a>]
-<li>French translation for VHDL additions [<a href="https://github.com/doxygen/doxygen/commit/76098e99ae17ed2bf69e3ac17d97b496d3d706f8">view</a>]
-<li>Further simplified the fix [<a href="https://github.com/doxygen/doxygen/commit/f194a3165042428359ec5b5af7e9bad7878c0536">view</a>]
-<li>Generating doxygen documentation on Windows (with MikTex) [<a href="https://github.com/doxygen/doxygen/commit/df9a47bd2080ce6385f2a21c6d868755ba7b1f67">view</a>]
-<li>Handling Fortran functions in call graphs [<a href="https://github.com/doxygen/doxygen/commit/58cf0414b9bfc5d7216e75e00beb115d91e36245">view</a>]
-<li>Heading in rtf. #6522 https://github.com/doxygen/doxygen/issues/6522 [<a href="https://github.com/doxygen/doxygen/commit/b90d628a80179f2a2c82f7d43bbec1df3f8190bb">view</a>]
-<li>Ignore build* directories and not just build [<a href="https://github.com/doxygen/doxygen/commit/bad04c77bd626e5badf7654136b6a5dfa20c6b93">view</a>]
-<li>Implementation Fortran ENUM / ENUMERATION [<a href="https://github.com/doxygen/doxygen/commit/f5ffd481a44fa5eae225ce728d1777070c4143e1">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/e78925a2142bb254dfc8ffc993a21f54ee4cf461">view</a>]</li>
+<li>Fix/New: add variadic function args &#39;...&#39; support to @link [<a href="https://github.com/doxygen/doxygen/commit/6b29c4e55009771545305fe3ec3ba92e8d0ba38e">view</a>]</li>
+<li>Fix/New: add variadic function args &#39;...&#39; support to @ref [<a href="https://github.com/doxygen/doxygen/commit/037f465e934ce122c8412b55548a153ad517aba0">view</a>]</li>
+<li>Fixed bug in URL [<a href="https://github.com/doxygen/doxygen/commit/fbabed9704a0d9876676122515be2651ab696cf1">view</a>]</li>
+<li>Fixed compile errors in clang and gcc [<a href="https://github.com/doxygen/doxygen/commit/2a539e12679a244389c781f6146d7f6bd9c82048">view</a>]</li>
+<li>Fixed compiler warning for nested /* in scanner.l [<a href="https://github.com/doxygen/doxygen/commit/c78c338fffbdbb9b2379b1896e647f7cc697da57">view</a>]</li>
+<li>Fixed differently by changing root cause for introducing the space [<a href="https://github.com/doxygen/doxygen/commit/890e3567470b0767c5ebe52207d1c75a96e888aa">view</a>]</li>
+<li>Fixed documentation to point to GitHub issue tracker [<a href="https://github.com/doxygen/doxygen/commit/d72bfbd272669f22bfa615549dc737199a48dc95">view</a>]</li>
+<li>Fixed incorrect XHTML output for test 021 [<a href="https://github.com/doxygen/doxygen/commit/d33a129d784f2b0f823f14a008e929513b302ad3">view</a>]</li>
+<li>Fixed logic error [<a href="https://github.com/doxygen/doxygen/commit/301425d57d422431037779e52e0ffcc93e509a35">view</a>]</li>
+<li>Fixed merge problem [<a href="https://github.com/doxygen/doxygen/commit/c4b853d749fcaffb2f2c142dcd14e48ab049013e">view</a>]</li>
+<li>Fixed one remained compile error in clang [<a href="https://github.com/doxygen/doxygen/commit/3977359bd3fb5527a237c2c0cdb61407f2d85464">view</a>]</li>
+<li>Fixed problems with emoji handling and added a test case for it [<a href="https://github.com/doxygen/doxygen/commit/348a8cc72dd481fa9e65e6209946bfeef5716914">view</a>]</li>
+<li>Fixed some more small memory leaks [<a href="https://github.com/doxygen/doxygen/commit/b6662b61dd83be32481a1c83e092082e9d797f0a">view</a>]</li>
+<li>Fixed two small memory leaks [<a href="https://github.com/doxygen/doxygen/commit/0591146bb406c8601c452f7a8a9e6e24823ce8d9">view</a>]</li>
+<li>Fixing coverity messages [<a href="https://github.com/doxygen/doxygen/commit/99f948c038b763028fcb95ef2a65fdbc1d5f9520">view</a>]</li>
+<li>Fixing coverity messages  (Namespace tag) [<a href="https://github.com/doxygen/doxygen/commit/b7cdfc8d47dc7a7f86605bbbc74aa78501d2bc33">view</a>]</li>
+<li>Fixing problem with possible not initialized variable (endless loop in VS 2017 debug) [<a href="https://github.com/doxygen/doxygen/commit/0a4b995cdd7735aaf42c423eed2889db5b8617ef">view</a>]</li>
+<li>Fortran code coloring improvements (REAL and comment lines) [<a href="https://github.com/doxygen/doxygen/commit/2e570d3762a412f87fff19ea4a30d60b171a6ea4">view</a>]</li>
+<li>Fortran improvements [<a href="https://github.com/doxygen/doxygen/commit/5f11678370f55e491fa9a04b7fd03cd473f8982f">view</a>]</li>
+<li>Fortran improvements (2) [<a href="https://github.com/doxygen/doxygen/commit/4013e52ba0f87eb12f8a1c8cb3b2714c0d519a81">view</a>]</li>
+<li>Fortran scanner abort message [<a href="https://github.com/doxygen/doxygen/commit/ee12e104e1f43aa4e5301b314f7c620dbbf58ecc">view</a>]</li>
+<li>French translation for VHDL additions [<a href="https://github.com/doxygen/doxygen/commit/76098e99ae17ed2bf69e3ac17d97b496d3d706f8">view</a>]</li>
+<li>Further simplified the fix [<a href="https://github.com/doxygen/doxygen/commit/f194a3165042428359ec5b5af7e9bad7878c0536">view</a>]</li>
+<li>Generating doxygen documentation on Windows (with MikTex) [<a href="https://github.com/doxygen/doxygen/commit/df9a47bd2080ce6385f2a21c6d868755ba7b1f67">view</a>]</li>
+<li>Handling Fortran functions in call graphs [<a href="https://github.com/doxygen/doxygen/commit/58cf0414b9bfc5d7216e75e00beb115d91e36245">view</a>]</li>
+<li>Heading in rtf. #6522 https://github.com/doxygen/doxygen/issues/6522 [<a href="https://github.com/doxygen/doxygen/commit/b90d628a80179f2a2c82f7d43bbec1df3f8190bb">view</a>]</li>
+<li>Ignore build* directories and not just build [<a href="https://github.com/doxygen/doxygen/commit/bad04c77bd626e5badf7654136b6a5dfa20c6b93">view</a>]</li>
+<li>Implementation Fortran ENUM / ENUMERATION [<a href="https://github.com/doxygen/doxygen/commit/f5ffd481a44fa5eae225ce728d1777070c4143e1">view</a>]</li>
 <li>Implementation of standard generator for docbook output [<a href="https://github.com/doxygen/doxygen/commit/7340b1c0e767b0ee88ce389df653d3d2a77801cd">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/d198c549fb88769912761d75277680438d88d69b">view</a>]
-<li>Improved robustness of the emoji feature [<a href="https://github.com/doxygen/doxygen/commit/c3ee766d0ad5721c753581e7f87026614c0730e1">view</a>]
-<li>Improvement LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/66a728cdcf50baeef45f78a1180c5ce86fe734af">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/496ebe413b20d406ef4a3b6b2a5966461c30af6c">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/4c7ed9016d24482cb2b46363537c95954a809012">view</a>]
-<li>Improvement regarding width and title for docbook [<a href="https://github.com/doxygen/doxygen/commit/f5390468388b80c1f0279f5942d05cb325744b28">view</a>]
-<li>Improvements in handling special characters in Latex [<a href="https://github.com/doxygen/doxygen/commit/0f8902275a4c02196d4eb1398e621a349355410a">view</a>]
-<li>Include &quot;empty&quot; directories in the documentation if they contain a `.dox` file (or similar) documenting the directory itself. [<a href="https://github.com/doxygen/doxygen/commit/5d79d65df3b66554c8e9630fd3bea322c3e36f0d">view</a>]
-<li>Include header for CompilationDatabase [<a href="https://github.com/doxygen/doxygen/commit/9606604a18ac78165b92099bc822ccbddda32bb7">view</a>]
-<li>Include height item in XML output [<a href="https://github.com/doxygen/doxygen/commit/43e606f185c7fb334062521eff4905d047f78503">view</a>]
-<li>Inconsistency in respect to tgroup in docbook [<a href="https://github.com/doxygen/doxygen/commit/529244ed7be4c289c46c66f0d7aa248e80fbacdf">view</a>]
-<li>Incorrect  tag sequence for xhtml with class diagram possible [<a href="https://github.com/doxygen/doxygen/commit/2bcda330add9279f777990b450f182be16b67e80">view</a>]
-<li>Incorrect closing tags for in page table of contents (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/9ef709e59187f18229fce1f9443547ad93f17be0">view</a>]
-<li>Incorrect closing tags for in page table of contents (docbook) [<a href="https://github.com/doxygen/doxygen/commit/71b0a3ab98690e20208280c1715807786d56cbc2">view</a>]
-<li>Incorrect number of start / end paragraph tags for xhtml with htmlonly [<a href="https://github.com/doxygen/doxygen/commit/f923f26d602fd991577b7a6676d129bd1642f453">view</a>]
-<li>Incorrect number of start / end paragraph tags for xhtml with image command [<a href="https://github.com/doxygen/doxygen/commit/5998b139855faba0e089338b6f53e8c1a6eee814">view</a>]
-<li>Incorrect number tag sequence for xhtml with htmlinclude command possible [<a href="https://github.com/doxygen/doxygen/commit/1c0a565a28582d0bc0776988ffef16565563e950">view</a>]
-<li>Incorrect tag sequence for xhtml with latexinclude command possible [<a href="https://github.com/doxygen/doxygen/commit/f4a16c46b29817ab0847555a2a51e4fa556e4f16">view</a>]
-<li>Incorrect tag sequence possible for images possible in case of xhtml [<a href="https://github.com/doxygen/doxygen/commit/400de444ef9b0569b2803dc4a8e5497c181384ce">view</a>]
-<li>Index bugfix [<a href="https://github.com/doxygen/doxygen/commit/846cde72cbd7b3f69393391adca19d009fecb8c3">view</a>]
-<li>Index list cannot contain special characters in ids for XHTML [<a href="https://github.com/doxygen/doxygen/commit/6f836989966863932e10678bbcfc4dc5ccbf0ea9">view</a>]
-<li>Inline images [<a href="https://github.com/doxygen/doxygen/commit/4682b91364247aafe66b6af472e321511e115e7c">view</a>]
-<li>Invalid warnings regarding todos when source file name contains a &#39;-&#39; [<a href="https://github.com/doxygen/doxygen/commit/ee97be448f7adc1285b38bae5adb7e7d48d4c29e">view</a>]
-<li>Issue #6631 Code blocks incorrectly formatted in Latex [<a href="https://github.com/doxygen/doxygen/commit/75f2cfcffbd0e4667d668e80b9c69ce56e9bd438">view</a>]
-<li>Issue 6411: CSS for Markdown tables do not use HTML_COLORSTYLE_HUE, HTML_COLORSTYLE_SAT config variables [<a href="https://github.com/doxygen/doxygen/commit/359e09007d056646bfe4e3bccf64c0a36ac3ccc1">view</a>]
-<li>Issue 6469: Java method calls are ignored in generating call/caller graph with Graphviz [<a href="https://github.com/doxygen/doxygen/commit/f0cf6f2324a2f27214b0216be9f9f0d03d32f401">view</a>]
-<li>Issue 6494: asterisks before args and kwargs are ignored in python [<a href="https://github.com/doxygen/doxygen/commit/eef433c0531f8f5321f3034bcc5bed02c006f2cf">view</a>]
-<li>Issue_6456 Using # in links causes errors in PDF generation [<a href="https://github.com/doxygen/doxygen/commit/1f849a16671e1c9afff4ee30a5b5a33d271e8684">view</a>]
-<li>Issue_6585: Unexpected anchor tags in tag-files [<a href="https://github.com/doxygen/doxygen/commit/fcc956dcd48be631a88df8ffbb7fbe160b7250f2">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/d198c549fb88769912761d75277680438d88d69b">view</a>]</li>
+<li>Improved robustness of the emoji feature [<a href="https://github.com/doxygen/doxygen/commit/c3ee766d0ad5721c753581e7f87026614c0730e1">view</a>]</li>
+<li>Improvement LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/66a728cdcf50baeef45f78a1180c5ce86fe734af">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/496ebe413b20d406ef4a3b6b2a5966461c30af6c">view</a>] and [<a href="https://github.com/doxygen/doxygen/commit/4c7ed9016d24482cb2b46363537c95954a809012">view</a>]</li>
+<li>Improvement regarding width and title for docbook [<a href="https://github.com/doxygen/doxygen/commit/f5390468388b80c1f0279f5942d05cb325744b28">view</a>]</li>
+<li>Improvements in handling special characters in Latex [<a href="https://github.com/doxygen/doxygen/commit/0f8902275a4c02196d4eb1398e621a349355410a">view</a>]</li>
+<li>Include &quot;empty&quot; directories in the documentation if they contain a `.dox` file (or similar) documenting the directory itself. [<a href="https://github.com/doxygen/doxygen/commit/5d79d65df3b66554c8e9630fd3bea322c3e36f0d">view</a>]</li>
+<li>Include header for CompilationDatabase [<a href="https://github.com/doxygen/doxygen/commit/9606604a18ac78165b92099bc822ccbddda32bb7">view</a>]</li>
+<li>Include height item in XML output [<a href="https://github.com/doxygen/doxygen/commit/43e606f185c7fb334062521eff4905d047f78503">view</a>]</li>
+<li>Inconsistency in respect to tgroup in docbook [<a href="https://github.com/doxygen/doxygen/commit/529244ed7be4c289c46c66f0d7aa248e80fbacdf">view</a>]</li>
+<li>Incorrect  tag sequence for xhtml with class diagram possible [<a href="https://github.com/doxygen/doxygen/commit/2bcda330add9279f777990b450f182be16b67e80">view</a>]</li>
+<li>Incorrect closing tags for in page table of contents (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/9ef709e59187f18229fce1f9443547ad93f17be0">view</a>]</li>
+<li>Incorrect closing tags for in page table of contents (docbook) [<a href="https://github.com/doxygen/doxygen/commit/71b0a3ab98690e20208280c1715807786d56cbc2">view</a>]</li>
+<li>Incorrect number of start / end paragraph tags for xhtml with htmlonly [<a href="https://github.com/doxygen/doxygen/commit/f923f26d602fd991577b7a6676d129bd1642f453">view</a>]</li>
+<li>Incorrect number of start / end paragraph tags for xhtml with image command [<a href="https://github.com/doxygen/doxygen/commit/5998b139855faba0e089338b6f53e8c1a6eee814">view</a>]</li>
+<li>Incorrect number tag sequence for xhtml with htmlinclude command possible [<a href="https://github.com/doxygen/doxygen/commit/1c0a565a28582d0bc0776988ffef16565563e950">view</a>]</li>
+<li>Incorrect tag sequence for xhtml with latexinclude command possible [<a href="https://github.com/doxygen/doxygen/commit/f4a16c46b29817ab0847555a2a51e4fa556e4f16">view</a>]</li>
+<li>Incorrect tag sequence possible for images possible in case of xhtml [<a href="https://github.com/doxygen/doxygen/commit/400de444ef9b0569b2803dc4a8e5497c181384ce">view</a>]</li>
+<li>Index bugfix [<a href="https://github.com/doxygen/doxygen/commit/846cde72cbd7b3f69393391adca19d009fecb8c3">view</a>]</li>
+<li>Index list cannot contain special characters in ids for XHTML [<a href="https://github.com/doxygen/doxygen/commit/6f836989966863932e10678bbcfc4dc5ccbf0ea9">view</a>]</li>
+<li>Inline images [<a href="https://github.com/doxygen/doxygen/commit/4682b91364247aafe66b6af472e321511e115e7c">view</a>]</li>
+<li>Invalid warnings regarding todos when source file name contains a &#39;-&#39; [<a href="https://github.com/doxygen/doxygen/commit/ee97be448f7adc1285b38bae5adb7e7d48d4c29e">view</a>]</li>
+<li>Issue #6631 Code blocks incorrectly formatted in Latex [<a href="https://github.com/doxygen/doxygen/commit/75f2cfcffbd0e4667d668e80b9c69ce56e9bd438">view</a>]</li>
+<li>Issue 6411: CSS for Markdown tables do not use HTML_COLORSTYLE_HUE, HTML_COLORSTYLE_SAT config variables [<a href="https://github.com/doxygen/doxygen/commit/359e09007d056646bfe4e3bccf64c0a36ac3ccc1">view</a>]</li>
+<li>Issue 6469: Java method calls are ignored in generating call/caller graph with Graphviz [<a href="https://github.com/doxygen/doxygen/commit/f0cf6f2324a2f27214b0216be9f9f0d03d32f401">view</a>]</li>
+<li>Issue 6494: asterisks before args and kwargs are ignored in python [<a href="https://github.com/doxygen/doxygen/commit/eef433c0531f8f5321f3034bcc5bed02c006f2cf">view</a>]</li>
+<li>Issue_6456 Using # in links causes errors in PDF generation [<a href="https://github.com/doxygen/doxygen/commit/1f849a16671e1c9afff4ee30a5b5a33d271e8684">view</a>]</li>
+<li>Issue_6585: Unexpected anchor tags in tag-files [<a href="https://github.com/doxygen/doxygen/commit/fcc956dcd48be631a88df8ffbb7fbe160b7250f2">view</a>]</li>
 <li>Keyword register (in code) is deprecated since C++11 [<a href="https://github.com/doxygen/doxygen/commit/24e97b9b61e3fb87fc1b9fbc5362ad24cc40b780">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/b6101af96fb793d9e9bdc0c34f0690545f3a1e56">view</a>]
-<li>LaTeX with verbatim part inside a table [<a href="https://github.com/doxygen/doxygen/commit/7a8e1182ba11369f11325d75af552ad7467b1e81">view</a>]
-<li>Large CALL / CALLER graphs cannot be processed in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/49079853fc4670c11b46e12eba7cb519608be8b0">view</a>]
-<li>Make conanfile creation more readable [<a href="https://github.com/doxygen/doxygen/commit/9fa511f6a7080ce19036088078105fc4e01d3f35">view</a>]
-<li>Make it possible to list namespace members in file scope for XML output. [<a href="https://github.com/doxygen/doxygen/commit/f5ed5051c0754f9c7e0e5556114e173016d7f984">view</a>]
-<li>Making VHDL error messages more doxygen like [<a href="https://github.com/doxygen/doxygen/commit/12ea0367d27b47280e8d768d04c8c332e9657491">view</a>]
-<li>Making the &#39;tex&#39; part of \makeindex available to the user [<a href="https://github.com/doxygen/doxygen/commit/9b52da49cb544fb0a676e9d12fdbafaf0c1db8cb">view</a>]
-<li>Markdown list wrong displayed [<a href="https://github.com/doxygen/doxygen/commit/ed562f3ed5e3208a1351387441028c7831ad14fd">view</a>]
-<li>Minor documentation fix [<a href="https://github.com/doxygen/doxygen/commit/ae25f5c41545e17b37d67ab7dabf422f0eb757aa">view</a>]
-<li>Minor fixes to local toc logic after feedback [<a href="https://github.com/doxygen/doxygen/commit/b6c724e8ab5caeef1e3d065e4c2fa05740d87859">view</a>]
-<li>Minor restructuring [<a href="https://github.com/doxygen/doxygen/commit/f0cc0f5da51faddd490c2cf358614b4ab70cc8ac">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/b6101af96fb793d9e9bdc0c34f0690545f3a1e56">view</a>]</li>
+<li>LaTeX with verbatim part inside a table [<a href="https://github.com/doxygen/doxygen/commit/7a8e1182ba11369f11325d75af552ad7467b1e81">view</a>]</li>
+<li>Large CALL / CALLER graphs cannot be processed in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/49079853fc4670c11b46e12eba7cb519608be8b0">view</a>]</li>
+<li>Make conanfile creation more readable [<a href="https://github.com/doxygen/doxygen/commit/9fa511f6a7080ce19036088078105fc4e01d3f35">view</a>]</li>
+<li>Make it possible to list namespace members in file scope for XML output. [<a href="https://github.com/doxygen/doxygen/commit/f5ed5051c0754f9c7e0e5556114e173016d7f984">view</a>]</li>
+<li>Making VHDL error messages more doxygen like [<a href="https://github.com/doxygen/doxygen/commit/12ea0367d27b47280e8d768d04c8c332e9657491">view</a>]</li>
+<li>Making the &#39;tex&#39; part of \makeindex available to the user [<a href="https://github.com/doxygen/doxygen/commit/9b52da49cb544fb0a676e9d12fdbafaf0c1db8cb">view</a>]</li>
+<li>Markdown list wrong displayed [<a href="https://github.com/doxygen/doxygen/commit/ed562f3ed5e3208a1351387441028c7831ad14fd">view</a>]</li>
+<li>Minor documentation fix [<a href="https://github.com/doxygen/doxygen/commit/ae25f5c41545e17b37d67ab7dabf422f0eb757aa">view</a>]</li>
+<li>Minor fixes to local toc logic after feedback [<a href="https://github.com/doxygen/doxygen/commit/b6c724e8ab5caeef1e3d065e4c2fa05740d87859">view</a>]</li>
+<li>Minor restructuring [<a href="https://github.com/doxygen/doxygen/commit/f0cc0f5da51faddd490c2cf358614b4ab70cc8ac">view</a>]</li>
 <li>Misc. typos [<a href="https://github.com/doxygen/doxygen/commit/436ba3423e9a7d9b482bb4b35ae2fce2249dc762">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/99a836218ca4e20862d3f816361c4586b45560ee">view</a>]
-<li>Missing opening round bracket in case of an exception [<a href="https://github.com/doxygen/doxygen/commit/a9f1c59479e316ab277521faa2a629f25fde25ba">view</a>]
-<li>More typos [<a href="https://github.com/doxygen/doxygen/commit/03a9454f2b748b3c9b7f5e12b921b25a9c8c98cb">view</a>]
-<li>Moved #include &quot;config.h&quot; back to the original place [<a href="https://github.com/doxygen/doxygen/commit/d4b5fa51ec2ad9dd2ba59e16fa85c53f9015755f">view</a>]
-<li>Moved duplicated code into dedicated function skipLanguageSpecificKeyword [<a href="https://github.com/doxygen/doxygen/commit/2b6fd3bd70795c1c1cf0accb1a991015ad6b2ba9">view</a>]
-<li>Moved local toc data into a separate type for better encapsulation [<a href="https://github.com/doxygen/doxygen/commit/185d6abdc832e7dd66183a2154a13a546414b96f">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/99a836218ca4e20862d3f816361c4586b45560ee">view</a>]</li>
+<li>Missing opening round bracket in case of an exception [<a href="https://github.com/doxygen/doxygen/commit/a9f1c59479e316ab277521faa2a629f25fde25ba">view</a>]</li>
+<li>More typos [<a href="https://github.com/doxygen/doxygen/commit/03a9454f2b748b3c9b7f5e12b921b25a9c8c98cb">view</a>]</li>
+<li>Moved #include &quot;config.h&quot; back to the original place [<a href="https://github.com/doxygen/doxygen/commit/d4b5fa51ec2ad9dd2ba59e16fa85c53f9015755f">view</a>]</li>
+<li>Moved duplicated code into dedicated function skipLanguageSpecificKeyword [<a href="https://github.com/doxygen/doxygen/commit/2b6fd3bd70795c1c1cf0accb1a991015ad6b2ba9">view</a>]</li>
+<li>Moved local toc data into a separate type for better encapsulation [<a href="https://github.com/doxygen/doxygen/commit/185d6abdc832e7dd66183a2154a13a546414b96f">view</a>]</li>
 <li>Multiple `\xreflist` in one page with same key [<a href="https://github.com/doxygen/doxygen/commit/00dff76126039629de0595f76260e94ddc189cbe">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/2e03d23d0385dbbe39f5b6a67ab480734f285e76">view</a>]
-<li>Multiple addindex commands in HTML with same name [<a href="https://github.com/doxygen/doxygen/commit/2e072c9e3cbc748ac2cdf6453c16d95cbfabf9d7">view</a>]
-<li>Namespace with name docstrings_linebreak [<a href="https://github.com/doxygen/doxygen/commit/ab80e5dff5e3f3f1e9ce473ea25894ca08d1f739">view</a>]
-<li>Not showing external project in HTML hierarchy class pages [<a href="https://github.com/doxygen/doxygen/commit/12aeab904791c514325d8ef0e230c13893b0b41a">view</a>]
-<li>Numbers in comment disappear [<a href="https://github.com/doxygen/doxygen/commit/e91f7a173e00db8ccb6d217728ccfc71981c4d7b">view</a>]
-<li>Numbers overlap the titles in TOC of PDF [<a href="https://github.com/doxygen/doxygen/commit/abca136aa24db05c5a3bcbac3e4708cb01aac2c2">view</a>]
-<li>Order resources not only on filename but also dirname [<a href="https://github.com/doxygen/doxygen/commit/dc90259bb67126a6f3e016db2a67499945d6224f">view</a>]
-<li>PATCH -- updates reference link with no closing [<a href="https://github.com/doxygen/doxygen/commit/30362ecc6da4123a9d87e9c74a6918aa23cc1403">view</a>]
-<li>Path for external commands on windows [<a href="https://github.com/doxygen/doxygen/commit/67375f4cf2dc12ad1445d6b02863954c1c11ee97">view</a>]
-<li>Possibility to have a \image command inside a &lt;A&gt; tag [<a href="https://github.com/doxygen/doxygen/commit/fb7592546b89471e62f68892c945ab7db98875b6">view</a>]
-<li>Possible fix for the build [<a href="https://github.com/doxygen/doxygen/commit/5c4ee43f13433a0c1de63805cc139b61e9a4d872">view</a>]
-<li>Prevent &lt;center&gt; and &lt;div&gt; inside brief descriptions to avoid broken XHTML output [<a href="https://github.com/doxygen/doxygen/commit/bed8623159191e65997b34dba80a804bfd4ea85b">view</a>]
-<li>Prevent empty list [<a href="https://github.com/doxygen/doxygen/commit/30299da719fea492d07cf56b37537c45c52c52f0">view</a>]
-<li>Prevent empty member list table (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/052fea7e9e03fe2fde177cf6c1a788a58a8f392f">view</a>]
-<li>Prevent empty page list table (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/f2e96034620007f7ef2e2c66845237814e80d356">view</a>]
-<li>Prevent possible &#39;QGDict::hashAsciiKey: Invalid null key&#39; warning [<a href="https://github.com/doxygen/doxygen/commit/c94a53eefb4159d238cb5714b6732e145aaeb582">view</a>]
-<li>Prevent potential race condition [<a href="https://github.com/doxygen/doxygen/commit/cd9c5bb4ceb6bf9ce48c2861bdf72d5c1ff79752">view</a>]
-<li>Print emoji text in case of unknown emoji [<a href="https://github.com/doxygen/doxygen/commit/427d2df4b2d7fc35abac519c646b52a1285aab9f">view</a>]
-<li>Problem with TEST_FLAGS when using CMake for Visual Studio [<a href="https://github.com/doxygen/doxygen/commit/33f574a534239b9d9e713b8d4c9d1d1dedf4d177">view</a>]
-<li>Problem with \cond in normal comment of test 015 [<a href="https://github.com/doxygen/doxygen/commit/f7663cf300375b4ec8d8fe052f3da48782743919">view</a>]
-<li>Problem with code inside a Doxy table in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/ed86c707318c1cb005702ef88dbdaa3a2bee5581">view</a>]
-<li>Problems and some enhancements for LaTeX tables [<a href="https://github.com/doxygen/doxygen/commit/d984f7dd21863fc01a1a6ede0878d3dd14af157a">view</a>]
-<li>RTF layout regarding References and Referenced by [<a href="https://github.com/doxygen/doxygen/commit/c90505681054d51da05fd476d08c610d3e20ca38">view</a>]
-<li>RTF lists more levels and removing extra paragraphs [<a href="https://github.com/doxygen/doxygen/commit/8fc23878b4375546bfb6a9149f009fbe0f7da42f">view</a>]
-<li>Readded missing &quot;Span&quot; case to DocStyleChange::styleString [<a href="https://github.com/doxygen/doxygen/commit/6a3d1b3d12e353d0c6ebd642b691e5e2608f8df2">view</a>]
-<li>Redundant whitespace removal breaks some C++ links [with test case and Git bisect] (Origin: bugzilla #791942) [<a href="https://github.com/doxygen/doxygen/commit/449a7e2b4ff114a72be573013558bae19672ebbc">view</a>]
-<li>Refactored code a bit [<a href="https://github.com/doxygen/doxygen/commit/4ed08b969b575d6dc1a49bca936a43eb43d337e2">view</a>]
-<li>Refactored code a bit (use const references and made global functions members) [<a href="https://github.com/doxygen/doxygen/commit/3820f6a841115bd66ed409221c73824ec41ae6ab">view</a>]
-<li>Reference text in reference list seen as emoji [<a href="https://github.com/doxygen/doxygen/commit/3540365053d32741b0caab83dbdc79b83a7da1cf">view</a>]
-<li>Remove debug statement [<a href="https://github.com/doxygen/doxygen/commit/c8ff40b37ca811e207968b70b7c60cbb7dd58596">view</a>]
-<li>Remove debug statements [<a href="https://github.com/doxygen/doxygen/commit/51ab08fa5bded3db613d06909fc6d3109c0a9a4c">view</a>]
-<li>Remove default assignment from Translator::trVhdlType() declaration [<a href="https://github.com/doxygen/doxygen/commit/da7ff05881501450be84bc870fdb1931b7e57af2">view</a>]
-<li>Remove double line with documented argument from addContentsItem in ftvhelp.cpp [<a href="https://github.com/doxygen/doxygen/commit/8c838d66fae65187692ec5fc04389d0811860a7f">view</a>]
-<li>Remove non-english translations [<a href="https://github.com/doxygen/doxygen/commit/1a8ea5cd42a1a7c397c21eb8410244608769be46">view</a>]
-<li>Remove obsolete definitions from scanner [<a href="https://github.com/doxygen/doxygen/commit/8e6a8c7c396748051a8cb3bbe5dbe0def92e82cc">view</a>]
-<li>Remove obsolete line from README.md [<a href="https://github.com/doxygen/doxygen/commit/69092a59ad04016f2423776425140c3190db6a01">view</a>]
-<li>Remove old obsolete docbook generator [<a href="https://github.com/doxygen/doxygen/commit/55063c91fa74921d0c5c7c84d1784ce617f0d53b">view</a>]
-<li>Remove some dead code [<a href="https://github.com/doxygen/doxygen/commit/279f5286ecd3f1e7a35bbfedab774d9d93b80f99">view</a>]
-<li>Renamed (start/end)SimpleSect to (start/end)Examples. [<a href="https://github.com/doxygen/doxygen/commit/a2ea725e1b0070ee8bcf55683157e67f5f727254">view</a>]
-<li>Renamed command and moved duplicated code into a macro [<a href="https://github.com/doxygen/doxygen/commit/dff7c1af885ceb0210f6c529df4e16b0ebf19164">view</a>]
-<li>Renamed option and test case numbers [<a href="https://github.com/doxygen/doxygen/commit/63931be561ab140b558418cffdd9b63b522c0e0d">view</a>]
-<li>Replace &#39;&#39;printf&#39; with appropriate warn &#39;message&#39; [<a href="https://github.com/doxygen/doxygen/commit/21021ce13919d19ce5434a3db868c2d4f5a4a53c">view</a>]
-<li>Replace calls to trTypeString with trVhdlType in single mode, which is the default. [<a href="https://github.com/doxygen/doxygen/commit/6caac96a48e055807920f724d7de68f764e06441">view</a>]
-<li>Replaced replace(QRegExp(..)) by substitute [<a href="https://github.com/doxygen/doxygen/commit/5caff305e828e98939c87191342ea6c33b17e96c">view</a>]
-<li>Replaced replace(QRegExp..) by substitute [<a href="https://github.com/doxygen/doxygen/commit/fbca3f69cf0e98a8269c86567c7d24d25723bb82">view</a>]
-<li>Resolve inconsistency in formula repositories. [<a href="https://github.com/doxygen/doxygen/commit/5d89de25fa5aa146ab65a88f09a7cc729dea3e51">view</a>]
-<li>Restructured code to avoid the need for global state [<a href="https://github.com/doxygen/doxygen/commit/f91bf62416c80cbe3bce8c428e0d3da2afa0d55f">view</a>]
-<li>Return VHDL specific text in trClassHierarchyDescription() [<a href="https://github.com/doxygen/doxygen/commit/9f7406d151e4f5d021558e97f5d87a0d9cacecf9">view</a>]
-<li>Section label with minus sign not recognized properly. [<a href="https://github.com/doxygen/doxygen/commit/7e185a2e25e4bdbac422299f029a68d1c0c70d6e">view</a>]
-<li>Small clarification for REFERENCED_BY_RELATION [<a href="https://github.com/doxygen/doxygen/commit/f69d501429f12a2027bb2dfc100a69a30ca1c7f9">view</a>]
-<li>Small correction installation / build procedure [<a href="https://github.com/doxygen/doxygen/commit/44278f94827cf772b9f679a6d9f5ea9d3a663b49">view</a>]
-<li>Small corrections in distributed man pages [<a href="https://github.com/doxygen/doxygen/commit/c546894fc6c2af3ff81789893a5fb816c697ab73">view</a>]
-<li>Small documentation corrections [<a href="https://github.com/doxygen/doxygen/commit/ec0e5078b3a9db1f24079257287f7aee9e721093">view</a>]
-<li>Small problems when displaying python code [<a href="https://github.com/doxygen/doxygen/commit/48817487de116ee526714587900380e53b195f5e">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/2e03d23d0385dbbe39f5b6a67ab480734f285e76">view</a>]</li>
+<li>Multiple addindex commands in HTML with same name [<a href="https://github.com/doxygen/doxygen/commit/2e072c9e3cbc748ac2cdf6453c16d95cbfabf9d7">view</a>]</li>
+<li>Namespace with name docstrings_linebreak [<a href="https://github.com/doxygen/doxygen/commit/ab80e5dff5e3f3f1e9ce473ea25894ca08d1f739">view</a>]</li>
+<li>Not showing external project in HTML hierarchy class pages [<a href="https://github.com/doxygen/doxygen/commit/12aeab904791c514325d8ef0e230c13893b0b41a">view</a>]</li>
+<li>Numbers in comment disappear [<a href="https://github.com/doxygen/doxygen/commit/e91f7a173e00db8ccb6d217728ccfc71981c4d7b">view</a>]</li>
+<li>Numbers overlap the titles in TOC of PDF [<a href="https://github.com/doxygen/doxygen/commit/abca136aa24db05c5a3bcbac3e4708cb01aac2c2">view</a>]</li>
+<li>Order resources not only on filename but also dirname [<a href="https://github.com/doxygen/doxygen/commit/dc90259bb67126a6f3e016db2a67499945d6224f">view</a>]</li>
+<li>PATCH -- updates reference link with no closing [<a href="https://github.com/doxygen/doxygen/commit/30362ecc6da4123a9d87e9c74a6918aa23cc1403">view</a>]</li>
+<li>Path for external commands on windows [<a href="https://github.com/doxygen/doxygen/commit/67375f4cf2dc12ad1445d6b02863954c1c11ee97">view</a>]</li>
+<li>Possibility to have a \image command inside a &lt;A&gt; tag [<a href="https://github.com/doxygen/doxygen/commit/fb7592546b89471e62f68892c945ab7db98875b6">view</a>]</li>
+<li>Possible fix for the build [<a href="https://github.com/doxygen/doxygen/commit/5c4ee43f13433a0c1de63805cc139b61e9a4d872">view</a>]</li>
+<li>Prevent &lt;center&gt; and &lt;div&gt; inside brief descriptions to avoid broken XHTML output [<a href="https://github.com/doxygen/doxygen/commit/bed8623159191e65997b34dba80a804bfd4ea85b">view</a>]</li>
+<li>Prevent empty list [<a href="https://github.com/doxygen/doxygen/commit/30299da719fea492d07cf56b37537c45c52c52f0">view</a>]</li>
+<li>Prevent empty member list table (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/052fea7e9e03fe2fde177cf6c1a788a58a8f392f">view</a>]</li>
+<li>Prevent empty page list table (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/f2e96034620007f7ef2e2c66845237814e80d356">view</a>]</li>
+<li>Prevent possible &#39;QGDict::hashAsciiKey: Invalid null key&#39; warning [<a href="https://github.com/doxygen/doxygen/commit/c94a53eefb4159d238cb5714b6732e145aaeb582">view</a>]</li>
+<li>Prevent potential race condition [<a href="https://github.com/doxygen/doxygen/commit/cd9c5bb4ceb6bf9ce48c2861bdf72d5c1ff79752">view</a>]</li>
+<li>Print emoji text in case of unknown emoji [<a href="https://github.com/doxygen/doxygen/commit/427d2df4b2d7fc35abac519c646b52a1285aab9f">view</a>]</li>
+<li>Problem with TEST_FLAGS when using CMake for Visual Studio [<a href="https://github.com/doxygen/doxygen/commit/33f574a534239b9d9e713b8d4c9d1d1dedf4d177">view</a>]</li>
+<li>Problem with \cond in normal comment of test 015 [<a href="https://github.com/doxygen/doxygen/commit/f7663cf300375b4ec8d8fe052f3da48782743919">view</a>]</li>
+<li>Problem with code inside a Doxy table in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/ed86c707318c1cb005702ef88dbdaa3a2bee5581">view</a>]</li>
+<li>Problems and some enhancements for LaTeX tables [<a href="https://github.com/doxygen/doxygen/commit/d984f7dd21863fc01a1a6ede0878d3dd14af157a">view</a>]</li>
+<li>RTF layout regarding References and Referenced by [<a href="https://github.com/doxygen/doxygen/commit/c90505681054d51da05fd476d08c610d3e20ca38">view</a>]</li>
+<li>RTF lists more levels and removing extra paragraphs [<a href="https://github.com/doxygen/doxygen/commit/8fc23878b4375546bfb6a9149f009fbe0f7da42f">view</a>]</li>
+<li>Readded missing &quot;Span&quot; case to DocStyleChange::styleString [<a href="https://github.com/doxygen/doxygen/commit/6a3d1b3d12e353d0c6ebd642b691e5e2608f8df2">view</a>]</li>
+<li>Redundant whitespace removal breaks some C++ links [with test case and Git bisect] (Origin: bugzilla #791942) [<a href="https://github.com/doxygen/doxygen/commit/449a7e2b4ff114a72be573013558bae19672ebbc">view</a>]</li>
+<li>Refactored code a bit [<a href="https://github.com/doxygen/doxygen/commit/4ed08b969b575d6dc1a49bca936a43eb43d337e2">view</a>]</li>
+<li>Refactored code a bit (use const references and made global functions members) [<a href="https://github.com/doxygen/doxygen/commit/3820f6a841115bd66ed409221c73824ec41ae6ab">view</a>]</li>
+<li>Reference text in reference list seen as emoji [<a href="https://github.com/doxygen/doxygen/commit/3540365053d32741b0caab83dbdc79b83a7da1cf">view</a>]</li>
+<li>Remove debug statement [<a href="https://github.com/doxygen/doxygen/commit/c8ff40b37ca811e207968b70b7c60cbb7dd58596">view</a>]</li>
+<li>Remove debug statements [<a href="https://github.com/doxygen/doxygen/commit/51ab08fa5bded3db613d06909fc6d3109c0a9a4c">view</a>]</li>
+<li>Remove default assignment from Translator::trVhdlType() declaration [<a href="https://github.com/doxygen/doxygen/commit/da7ff05881501450be84bc870fdb1931b7e57af2">view</a>]</li>
+<li>Remove double line with documented argument from addContentsItem in ftvhelp.cpp [<a href="https://github.com/doxygen/doxygen/commit/8c838d66fae65187692ec5fc04389d0811860a7f">view</a>]</li>
+<li>Remove non-english translations [<a href="https://github.com/doxygen/doxygen/commit/1a8ea5cd42a1a7c397c21eb8410244608769be46">view</a>]</li>
+<li>Remove obsolete definitions from scanner [<a href="https://github.com/doxygen/doxygen/commit/8e6a8c7c396748051a8cb3bbe5dbe0def92e82cc">view</a>]</li>
+<li>Remove obsolete line from README.md [<a href="https://github.com/doxygen/doxygen/commit/69092a59ad04016f2423776425140c3190db6a01">view</a>]</li>
+<li>Remove old obsolete docbook generator [<a href="https://github.com/doxygen/doxygen/commit/55063c91fa74921d0c5c7c84d1784ce617f0d53b">view</a>]</li>
+<li>Remove some dead code [<a href="https://github.com/doxygen/doxygen/commit/279f5286ecd3f1e7a35bbfedab774d9d93b80f99">view</a>]</li>
+<li>Renamed (start/end)SimpleSect to (start/end)Examples. [<a href="https://github.com/doxygen/doxygen/commit/a2ea725e1b0070ee8bcf55683157e67f5f727254">view</a>]</li>
+<li>Renamed command and moved duplicated code into a macro [<a href="https://github.com/doxygen/doxygen/commit/dff7c1af885ceb0210f6c529df4e16b0ebf19164">view</a>]</li>
+<li>Renamed option and test case numbers [<a href="https://github.com/doxygen/doxygen/commit/63931be561ab140b558418cffdd9b63b522c0e0d">view</a>]</li>
+<li>Replace &#39;&#39;printf&#39; with appropriate warn &#39;message&#39; [<a href="https://github.com/doxygen/doxygen/commit/21021ce13919d19ce5434a3db868c2d4f5a4a53c">view</a>]</li>
+<li>Replace calls to trTypeString with trVhdlType in single mode, which is the default. [<a href="https://github.com/doxygen/doxygen/commit/6caac96a48e055807920f724d7de68f764e06441">view</a>]</li>
+<li>Replaced replace(QRegExp(..)) by substitute [<a href="https://github.com/doxygen/doxygen/commit/5caff305e828e98939c87191342ea6c33b17e96c">view</a>]</li>
+<li>Replaced replace(QRegExp..) by substitute [<a href="https://github.com/doxygen/doxygen/commit/fbca3f69cf0e98a8269c86567c7d24d25723bb82">view</a>]</li>
+<li>Resolve inconsistency in formula repositories. [<a href="https://github.com/doxygen/doxygen/commit/5d89de25fa5aa146ab65a88f09a7cc729dea3e51">view</a>]</li>
+<li>Restructured code to avoid the need for global state [<a href="https://github.com/doxygen/doxygen/commit/f91bf62416c80cbe3bce8c428e0d3da2afa0d55f">view</a>]</li>
+<li>Return VHDL specific text in trClassHierarchyDescription() [<a href="https://github.com/doxygen/doxygen/commit/9f7406d151e4f5d021558e97f5d87a0d9cacecf9">view</a>]</li>
+<li>Section label with minus sign not recognized properly. [<a href="https://github.com/doxygen/doxygen/commit/7e185a2e25e4bdbac422299f029a68d1c0c70d6e">view</a>]</li>
+<li>Small clarification for REFERENCED_BY_RELATION [<a href="https://github.com/doxygen/doxygen/commit/f69d501429f12a2027bb2dfc100a69a30ca1c7f9">view</a>]</li>
+<li>Small correction installation / build procedure [<a href="https://github.com/doxygen/doxygen/commit/44278f94827cf772b9f679a6d9f5ea9d3a663b49">view</a>]</li>
+<li>Small corrections in distributed man pages [<a href="https://github.com/doxygen/doxygen/commit/c546894fc6c2af3ff81789893a5fb816c697ab73">view</a>]</li>
+<li>Small documentation corrections [<a href="https://github.com/doxygen/doxygen/commit/ec0e5078b3a9db1f24079257287f7aee9e721093">view</a>]</li>
+<li>Small problems when displaying python code [<a href="https://github.com/doxygen/doxygen/commit/48817487de116ee526714587900380e53b195f5e">view</a>]</li>
 <li>Small problems when having code in LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/7bb6b4792a95626685df5750a6ab79b675c9fd60">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/f4544b7508bde732dacb1172e8200e88ac07c82b">view</a>]
-<li>Sorting of index in case of LaTex [<a href="https://github.com/doxygen/doxygen/commit/080389ee153981831ea36e14726b49f756e081bf">view</a>]
-<li>Spanish translation for VHDL additions [<a href="https://github.com/doxygen/doxygen/commit/8daabeb2d8650e215b9cfd3e242f687a6f06289c">view</a>]
-<li>Spelling of the word Javadoc [<a href="https://github.com/doxygen/doxygen/commit/d42f1d1bbb3cd73f71ee2c57791d31ff37d5d0f1">view</a>]
-<li>Synchronize chapter names of doxygen&#39;s own documentation. [<a href="https://github.com/doxygen/doxygen/commit/35f3081a603c4e2a8fb95f50a9e8a3593e9ca2b6">view</a>]
-<li>Syntax highlighting / code coloring in RTF [<a href="https://github.com/doxygen/doxygen/commit/d05562bb395d0e83be29c8ff5ad76ddbe2a794bc">view</a>]
-<li>Tag sequence incorrect for svg image (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/57633468f2f0cfb7d4f93bf58c3e8801824dca8d">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/f4544b7508bde732dacb1172e8200e88ac07c82b">view</a>]</li>
+<li>Sorting of index in case of LaTex [<a href="https://github.com/doxygen/doxygen/commit/080389ee153981831ea36e14726b49f756e081bf">view</a>]</li>
+<li>Spanish translation for VHDL additions [<a href="https://github.com/doxygen/doxygen/commit/8daabeb2d8650e215b9cfd3e242f687a6f06289c">view</a>]</li>
+<li>Spelling of the word Javadoc [<a href="https://github.com/doxygen/doxygen/commit/d42f1d1bbb3cd73f71ee2c57791d31ff37d5d0f1">view</a>]</li>
+<li>Synchronize chapter names of doxygen&#39;s own documentation. [<a href="https://github.com/doxygen/doxygen/commit/35f3081a603c4e2a8fb95f50a9e8a3593e9ca2b6">view</a>]</li>
+<li>Syntax highlighting / code coloring in RTF [<a href="https://github.com/doxygen/doxygen/commit/d05562bb395d0e83be29c8ff5ad76ddbe2a794bc">view</a>]</li>
+<li>Tag sequence incorrect for svg image (XHTML) [<a href="https://github.com/doxygen/doxygen/commit/57633468f2f0cfb7d4f93bf58c3e8801824dca8d">view</a>]</li>
 <li>Test renumbering [<a href="https://github.com/doxygen/doxygen/commit/1c3317e72f7845f121009c10add4d209d607ce48">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/80ec5521ebee6072f6c43946cb5ef3e812ee777a">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/80ec5521ebee6072f6c43946cb5ef3e812ee777a">view</a>]</li>
 <li>Tooltip was twice &#39;HTML escaped&#39; [<a href="https://github.com/doxygen/doxygen/commit/1de4faf17a4b5de11839220d95e08264303924c5">view</a>]
-, [<a href="https://github.com/doxygen/doxygen/commit/80c321c6856e7923e99c2ece878da5625566712c">view</a>]
-<li>Translators updated to version 1.8.15. [<a href="https://github.com/doxygen/doxygen/commit/fc2d26714142033dfec24f846c439464bda65dca">view</a>]
-<li>Truncated split bar in HTML output between treeview and normal text area [<a href="https://github.com/doxygen/doxygen/commit/5b11346a3620a0788bd0b9106c159e2f1e6356df">view</a>]
-<li>Typos [<a href="https://github.com/doxygen/doxygen/commit/c9f7e5073163ede0a1ca071030d6b3746b943b94">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/2f2c2d79d4104b25d87df86d0843d017b125fcdb">view</a>] , [<a href="https://github.com/doxygen/doxygen/commit/a40b6623967d2ab9817d674b0c13c746784bb020">view</a>]
-<li>Unbalanced start of lists resulting in not creatable pdf of rtf document [<a href="https://github.com/doxygen/doxygen/commit/b3838c5b58fc224f2638530694f9b3210d5d49d2">view</a>]
-<li>Update Dutch translation for new Slice implementation [<a href="https://github.com/doxygen/doxygen/commit/b85c68bd1ea21c2a5b537fbdd2fe64f440f901d8">view</a>]
-<li>Update Dutch translation in respect to new VHDL entries. [<a href="https://github.com/doxygen/doxygen/commit/5b2c378d1932bc548d6b3fcc1841b6c7778c4a97">view</a>]
-<li>Updated Hungarian translation [<a href="https://github.com/doxygen/doxygen/commit/992204b8a0d8cd509d8da9f17366054a2b7ffa37">view</a>]
-<li>Upgrade to jQuery 1.7.2 to get rid of security scan violations. [<a href="https://github.com/doxygen/doxygen/commit/a9471149d84c618f307f8b3970720d38d01a07a9">view</a>]
-<li>Usage of &#39;{&#39;, &#39;}&#39; and &#39;,&#39; in ALIAS [<a href="https://github.com/doxygen/doxygen/commit/9766554d63dd85ba8857fe18eb7064c84b0231f6">view</a>]
-<li>Use QCStringList::split i.s.o. QStringList::split [<a href="https://github.com/doxygen/doxygen/commit/d0852053693f3f56741657f2a5167950e4d000d5">view</a>]
-<li>Version bump for next release [<a href="https://github.com/doxygen/doxygen/commit/27731a36c182f672fe4486c4a9ae390c4ee8a10f">view</a>]
-<li>Warning  running  xmllint for xhtml [<a href="https://github.com/doxygen/doxygen/commit/b851ef73be5ea01726bca0b6d686508e54a4191d">view</a>]
-<li>Wrong counting of lines during VHDL code output [<a href="https://github.com/doxygen/doxygen/commit/9447c47c5f569dec436e0facef8c0d99fd12943f">view</a>]
-<li>Wrong determination of begin / end tag of formula in markdown. [<a href="https://github.com/doxygen/doxygen/commit/39118ed6cef251d1dbdca98801960eab49154128">view</a>]
-<li>Wrong link generated for inherited members when tag files are used. [<a href="https://github.com/doxygen/doxygen/commit/135412e4e9af74cda860205b4c8104098c2b65aa">view</a>]
-<li>Wrong separator in index for a.o. Python, C# [<a href="https://github.com/doxygen/doxygen/commit/3e6447119d64b492ed55c3baad17b04dd57f4821">view</a>]
-<li>Wrong spelling of word doxygen [<a href="https://github.com/doxygen/doxygen/commit/ea4af8a8579f3a1a9712e13b01a725c61773432b">view</a>]
-<li>XHTML image tag mandatory alt attribute [<a href="https://github.com/doxygen/doxygen/commit/66f9f6ec07f29fb737b0d0fe11072ea156581576">view</a>]
-<li>XHTML incorrect attribute values for align and valign [<a href="https://github.com/doxygen/doxygen/commit/7db371ebe9d770cb1bd977b5698fd698ab0e399b">view</a>]
-<li>XHTML problem with class index table [<a href="https://github.com/doxygen/doxygen/commit/a4c2fd0e8f367531b78683ba920a853e23d101ec">view</a>]
-<li>XHTML problem with multiple use of node numbers in id attribute [<a href="https://github.com/doxygen/doxygen/commit/36adf08f19b7c6bce53b42a5de577d578bbd0bea">view</a>]
-<li>XHTML problem with name attribute with VHDL name attribute [<a href="https://github.com/doxygen/doxygen/commit/889a302661db7eba47b70a4a61827a5971dbe75e">view</a>]
-<li>XML output: avoid warnings with scoped enum values in anonymous namespaces. [<a href="https://github.com/doxygen/doxygen/commit/5db858953001c534341562cfaeba39782abc5ca6">view</a>]
-<li>[ImgBot] Optimize images [<a href="https://github.com/doxygen/doxygen/commit/ddfe40a3834f63a2705739c19dc9ab637ecb40df">view</a>]
-<li>added PHP7 support for the search engine on HTML output. See: http://php.net/manual/en/language.basic-syntax.phptags.php [<a href="https://github.com/doxygen/doxygen/commit/22b67836d678cea695b977ec648c0aa013339c55">view</a>]
-<li>addindex supports also DocBook and RTF [<a href="https://github.com/doxygen/doxygen/commit/5fe01a8548f0ac7f9f7eafdc7d0fc614222267ba">view</a>]
-<li>correct typo in comment [<a href="https://github.com/doxygen/doxygen/commit/c15e0f7a41510e89145b0562833821a7a4245c77">view</a>]
-<li>declares XMLCodeGenerator in xmlgen.h [<a href="https://github.com/doxygen/doxygen/commit/172016e3d3b5cfe6f51470d43669f794b993da65">view</a>]
-<li>doxyparse bugfixes and minor improvements [<a href="https://github.com/doxygen/doxygen/commit/b4ec5e1442ec24b0345ba4362cf202014d8371cf">view</a>]
-<li>fix build with qt 5.11, deprecated qt5_use_modules macro was removed, patch by Christophe Giboudeaux [<a href="https://github.com/doxygen/doxygen/commit/a74e24784f4d5b6be5cd2167340a7572d869e220">view</a>]
-<li>perlmod syntax correction [<a href="https://github.com/doxygen/doxygen/commit/6a0f531d104d80fb1ab220ea952d3c45d3474f57">view</a>]
-<li>redundant input_filter runs significantly reduce performance when FILTER_SOURCE_FILES and INLINE_SOURCES are both enabled #6395 [<a href="https://github.com/doxygen/doxygen/commit/608b5c375a3ea265afe96dd8b921b4b81d6b354d">view</a>]
-<li>sqlite3: fix missing external_file view schema col [<a href="https://github.com/doxygen/doxygen/commit/eec2d3b6a9f80715fb590b0fb67b7fe87ba5fee7">view</a>]
-<li>sqlite3: require sqlite &gt;= 3.9.0 [<a href="https://github.com/doxygen/doxygen/commit/e4f408eb4aad7fb035847616debe68fe115e2ae4">view</a>]
+, [<a href="https://github.com/doxygen/doxygen/commit/80c321c6856e7923e99c2ece878da5625566712c">view</a>]</li>
+<li>Translators updated to version 1.8.15. [<a href="https://github.com/doxygen/doxygen/commit/fc2d26714142033dfec24f846c439464bda65dca">view</a>]</li>
+<li>Truncated split bar in HTML output between treeview and normal text area [<a href="https://github.com/doxygen/doxygen/commit/5b11346a3620a0788bd0b9106c159e2f1e6356df">view</a>]</li>
+<li>Typos [<a href="https://github.com/doxygen/doxygen/commit/c9f7e5073163ede0a1ca071030d6b3746b943b94">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/2f2c2d79d4104b25d87df86d0843d017b125fcdb">view</a>] , [<a href="https://github.com/doxygen/doxygen/commit/a40b6623967d2ab9817d674b0c13c746784bb020">view</a>]</li>
+<li>Unbalanced start of lists resulting in not creatable pdf of rtf document [<a href="https://github.com/doxygen/doxygen/commit/b3838c5b58fc224f2638530694f9b3210d5d49d2">view</a>]</li>
+<li>Update Dutch translation for new Slice implementation [<a href="https://github.com/doxygen/doxygen/commit/b85c68bd1ea21c2a5b537fbdd2fe64f440f901d8">view</a>]</li>
+<li>Update Dutch translation in respect to new VHDL entries. [<a href="https://github.com/doxygen/doxygen/commit/5b2c378d1932bc548d6b3fcc1841b6c7778c4a97">view</a>]</li>
+<li>Updated Hungarian translation [<a href="https://github.com/doxygen/doxygen/commit/992204b8a0d8cd509d8da9f17366054a2b7ffa37">view</a>]</li>
+<li>Upgrade to jQuery 1.7.2 to get rid of security scan violations. [<a href="https://github.com/doxygen/doxygen/commit/a9471149d84c618f307f8b3970720d38d01a07a9">view</a>]</li>
+<li>Usage of &#39;{&#39;, &#39;}&#39; and &#39;,&#39; in ALIAS [<a href="https://github.com/doxygen/doxygen/commit/9766554d63dd85ba8857fe18eb7064c84b0231f6">view</a>]</li>
+<li>Use QCStringList::split i.s.o. QStringList::split [<a href="https://github.com/doxygen/doxygen/commit/d0852053693f3f56741657f2a5167950e4d000d5">view</a>]</li>
+<li>Version bump for next release [<a href="https://github.com/doxygen/doxygen/commit/27731a36c182f672fe4486c4a9ae390c4ee8a10f">view</a>]</li>
+<li>Warning  running  xmllint for xhtml [<a href="https://github.com/doxygen/doxygen/commit/b851ef73be5ea01726bca0b6d686508e54a4191d">view</a>]</li>
+<li>Wrong counting of lines during VHDL code output [<a href="https://github.com/doxygen/doxygen/commit/9447c47c5f569dec436e0facef8c0d99fd12943f">view</a>]</li>
+<li>Wrong determination of begin / end tag of formula in markdown. [<a href="https://github.com/doxygen/doxygen/commit/39118ed6cef251d1dbdca98801960eab49154128">view</a>]</li>
+<li>Wrong link generated for inherited members when tag files are used. [<a href="https://github.com/doxygen/doxygen/commit/135412e4e9af74cda860205b4c8104098c2b65aa">view</a>]</li>
+<li>Wrong separator in index for a.o. Python, C# [<a href="https://github.com/doxygen/doxygen/commit/3e6447119d64b492ed55c3baad17b04dd57f4821">view</a>]</li>
+<li>Wrong spelling of word doxygen [<a href="https://github.com/doxygen/doxygen/commit/ea4af8a8579f3a1a9712e13b01a725c61773432b">view</a>]</li>
+<li>XHTML image tag mandatory alt attribute [<a href="https://github.com/doxygen/doxygen/commit/66f9f6ec07f29fb737b0d0fe11072ea156581576">view</a>]</li>
+<li>XHTML incorrect attribute values for align and valign [<a href="https://github.com/doxygen/doxygen/commit/7db371ebe9d770cb1bd977b5698fd698ab0e399b">view</a>]</li>
+<li>XHTML problem with class index table [<a href="https://github.com/doxygen/doxygen/commit/a4c2fd0e8f367531b78683ba920a853e23d101ec">view</a>]</li>
+<li>XHTML problem with multiple use of node numbers in id attribute [<a href="https://github.com/doxygen/doxygen/commit/36adf08f19b7c6bce53b42a5de577d578bbd0bea">view</a>]</li>
+<li>XHTML problem with name attribute with VHDL name attribute [<a href="https://github.com/doxygen/doxygen/commit/889a302661db7eba47b70a4a61827a5971dbe75e">view</a>]</li>
+<li>XML output: avoid warnings with scoped enum values in anonymous namespaces. [<a href="https://github.com/doxygen/doxygen/commit/5db858953001c534341562cfaeba39782abc5ca6">view</a>]</li>
+<li>[ImgBot] Optimize images [<a href="https://github.com/doxygen/doxygen/commit/ddfe40a3834f63a2705739c19dc9ab637ecb40df">view</a>]</li>
+<li>added PHP7 support for the search engine on HTML output. See: http://php.net/manual/en/language.basic-syntax.phptags.php [<a href="https://github.com/doxygen/doxygen/commit/22b67836d678cea695b977ec648c0aa013339c55">view</a>]</li>
+<li>addindex supports also DocBook and RTF [<a href="https://github.com/doxygen/doxygen/commit/5fe01a8548f0ac7f9f7eafdc7d0fc614222267ba">view</a>]</li>
+<li>correct typo in comment [<a href="https://github.com/doxygen/doxygen/commit/c15e0f7a41510e89145b0562833821a7a4245c77">view</a>]</li>
+<li>declares XMLCodeGenerator in xmlgen.h [<a href="https://github.com/doxygen/doxygen/commit/172016e3d3b5cfe6f51470d43669f794b993da65">view</a>]</li>
+<li>doxyparse bugfixes and minor improvements [<a href="https://github.com/doxygen/doxygen/commit/b4ec5e1442ec24b0345ba4362cf202014d8371cf">view</a>]</li>
+<li>fix build with qt 5.11, deprecated qt5_use_modules macro was removed, patch by Christophe Giboudeaux [<a href="https://github.com/doxygen/doxygen/commit/a74e24784f4d5b6be5cd2167340a7572d869e220">view</a>]</li>
+<li>perlmod syntax correction [<a href="https://github.com/doxygen/doxygen/commit/6a0f531d104d80fb1ab220ea952d3c45d3474f57">view</a>]</li>
+<li>redundant input_filter runs significantly reduce performance when FILTER_SOURCE_FILES and INLINE_SOURCES are both enabled #6395 [<a href="https://github.com/doxygen/doxygen/commit/608b5c375a3ea265afe96dd8b921b4b81d6b354d">view</a>]</li>
+<li>sqlite3: fix missing external_file view schema col [<a href="https://github.com/doxygen/doxygen/commit/eec2d3b6a9f80715fb590b0fb67b7fe87ba5fee7">view</a>]</li>
+<li>sqlite3: require sqlite &gt;= 3.9.0 [<a href="https://github.com/doxygen/doxygen/commit/e4f408eb4aad7fb035847616debe68fe115e2ae4">view</a>]</li>
 </ul>
 <p>
 \endhtmlonly


### PR DESCRIPTION
Checking for valid XNHTM results in:
`html/changelog.html:365: parser error : Excessive depth in document: 256`
due to missing `</li>`