### PR TITLE
Don't crash or generate invalid XML for empty TOC

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -1818,10 +1818,10 @@ static void generateXMLForPage(PageDef *pd,FTextStream &ti,bool isExample)
     }
   }
   writeInnerPages(pd->getSubPages(),t);
-  if (pd->localToc().isXmlEnabled())
+  SectionDict *sectionDict = pd->getSectionDict();
+  if (pd->localToc().isXmlEnabled() && sectionDict)
   {
     t << "    <tableofcontents>" << endl;
-    SectionDict *sectionDict = pd->getSectionDict();
     SDict<SectionInfo>::Iterator li(*sectionDict);
     SectionInfo *si;
     int level=1,l;

--- a/testing/079/empty.xml
+++ b/testing/079/empty.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="empty" kind="page">
+    <compoundname>empty</compoundname>
+    <title>An empty page</title>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+<para>With an empty TOC. </para>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/079/levels.xml
+++ b/testing/079/levels.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="levels" kind="page">
+    <compoundname>levels</compoundname>
+    <title>A page with two-level TOC</title>
+    <tableofcontents>
+      <tocsect>
+        <name>A section that's in TOC</name>
+        <reference>levels_1first</reference>
+        <tableofcontents>
+          <tocsect>
+            <name>A subsection that's in TOC</name>
+            <reference>levels_1first2</reference>
+          </tocsect>
+        </tableofcontents>
+      </tocsect>
+      <tocsect>
+        <name>A section that's in TOC again</name>
+        <reference>levels_1second</reference>
+      </tocsect>
+    </tableofcontents>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+      <sect1 id="levels_1first">
+        <title>A section that's in TOC</title>
+        <sect2 id="levels_1first2">
+          <title>A subsection that's in TOC</title>
+          <sect3 id="levels_1first3">
+            <title>A subsubsection that's not in TOC</title>
+            <para>Nay!</para>
+          </sect3>
+        </sect2>
+      </sect1>
+      <sect1 id="levels_1second">
+        <title>A section that's in TOC again</title>
+        <para>Yay! </para>
+      </sect1>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/079_tableofcontents.dox
+++ b/testing/079_tableofcontents.dox
@@ -1,0 +1,9 @@
+// objective: test TOC generation for an empty page
+// check: empty.xml
+/**
+@page empty An empty page
+
+@tableofcontents
+
+With an empty TOC.
+*/

--- a/testing/079_tableofcontents.dox
+++ b/testing/079_tableofcontents.dox
@@ -1,9 +1,26 @@
 // objective: test TOC generation for an empty page
 // check: empty.xml
+// check: levels.xml
 /**
 @page empty An empty page
 
 @tableofcontents
 
 With an empty TOC.
+*/
+
+/**
+@page levels A page with two-level TOC
+
+@tableofcontents{xml:2}
+
+@section first A section that's in TOC
+@subsection first2 A subsection that's in TOC
+@subsubsection first3 A subsubsection that's not in TOC
+
+Nay!
+
+@section second A section that's in TOC again
+
+Yay!
 */


### PR DESCRIPTION
The new XML TOC implementation from https://github.com/doxygen/doxygen/pull/736 is not handling TOC on pages without `@section`s correctly, accessing a null pointer. This adds a corresponding test and a fix. Interestingly enough, the docbook and XHTML generators are already handling this case properly.

I also added a test for TOC levels that could lead to bugs like those fixed in #6696 and #6697. The XML output is not affected by these but having an explicit test for it certainly won't hurt.

What concerns me and what I *would like to have fixed in additon to merging this PR* is that on a larger project ([Magnum](https://magnum.graphics)), `doxygen` didn't crash on this but rather exited with a success return code and generated empty XML for given page and truncated `index.xml`. That's similar to the issue with a fix for  https://github.com/doxygen/doxygen/issues/6277 that I reported a year ago (also accessing a null pointer, fixed in https://github.com/doxygen/doxygen/commit/1a1fdbed64de6ce01959b2e4d0988be823fb6bad). My question/request is:

- Why `doxygen` executed by `runtests.py` crashes in this case and why `doxygen` executed on a larger project fails silently, making the error much more confusing and harder to spot? Is it because threads are involved?
- Is it possible to propagate the aborted operation (from the thread?) all the way to the return code of the `doxygen` executable, so the crash is never silent?