### PR TITLE
issue #6716 mainpage notitle causes notitle to appear in index bar

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1739,7 +1739,8 @@ QCString Definition::navigationPathAsString() const
     }
     else if (definitionType()==Definition::TypePage && !((const PageDef*)this)->title().isEmpty())
     {
-      result+="<a class=\"el\" href=\"$relpath^"+getOutputFileBase()+Doxygen::htmlFileExtension+"\">"+
+      if ((this==Doxygen::mainPage && mainPageHasTitle()) || this!=Doxygen::mainPage)
+        result+="<a class=\"el\" href=\"$relpath^"+getOutputFileBase()+Doxygen::htmlFileExtension+"\">"+
               convertToHtml(((const PageDef*)this)->title())+"</a>";
     }
     else if (definitionType()==Definition::TypeClass)


### PR DESCRIPTION
The "notitle" was still shown at the botton page index bar in case of TreeView and in other cases in the top index bar.