### PR TITLE
issue #6708 Invalid UTF-8 characters in hover title

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -377,7 +377,6 @@ static bool convertMapFile(FTextStream &t,const char *mapName,
                            const QCString &context=QCString())
 {
   QFile f(mapName);
-  static QRegExp re("id=\"node[0-9]*\"");
   if (!f.open(IO_ReadOnly)) 
   {
     err("problems opening map file %s for inclusion in the docs!\n"
@@ -396,7 +395,17 @@ static bool convertMapFile(FTextStream &t,const char *mapName,
 
       if (buf.left(5)=="<area")
       {
-        t << replaceRef(buf,relPath,urlOnly,context).replace(re,"");
+	QCString replBuf = replaceRef(buf,relPath,urlOnly,context);
+        int indexS = replBuf.find("id=\""), indexE;
+        indexE=replBuf.find('"',indexS+4);
+        if (indexS>=0 && (indexE=buf.find('"',indexS))!=-1)
+	{
+	  t << replBuf.left(indexS-1) << replBuf.right(replBuf.length() - indexE - 1);
+	}
+	else
+	{
+          t << replBuf;
+	}
       }
     }
   }


### PR DESCRIPTION
The replace function has as side effect that it affect UTF-8 characters as well.
Removing   `id="node[0-9]*"` no by searching its start and end.