### PR TITLE
Make var & function declaration/definition location parsing not order-dependent

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -56,6 +56,7 @@ class DefinitionImpl
   public:
     DefinitionImpl();
    ~DefinitionImpl();
+    void setDefFileName(const QCString &df);
     void init(const char *df, const char *n);
 
     SectionDict *sectionDict;  // dictionary of all sections, not accessible
@@ -112,7 +113,7 @@ DefinitionImpl::~DefinitionImpl()
   delete inbodyDocs;
 }
 
-void DefinitionImpl::init(const char *df, const char *n)
+void DefinitionImpl::setDefFileName(const QCString &df)
 {
   defFileName = df;
   int lastDot = defFileName.findRev('.');
@@ -120,6 +121,11 @@ void DefinitionImpl::init(const char *df, const char *n)
   {
     defFileExt = defFileName.mid(lastDot);
   }
+}
+
+void DefinitionImpl::init(const char *df, const char *n)
+{
+  setDefFileName(df);
   QCString name = n;
   if (name!="<globalScope>") 
   {
@@ -395,6 +401,13 @@ Definition::~Definition()
   }
   delete m_cookie;
   m_cookie=0;
+}
+
+void Definition::setDefFile(const QCString& df, int defLine, int defColumn)
+{
+  m_impl->setDefFileName(df);
+  m_defLine = defLine;
+  m_defColumn = defColumn;
 }
 
 void Definition::setName(const char *name)

--- a/src/definition.h
+++ b/src/definition.h
@@ -282,6 +282,9 @@ class Definition : public DefinitionIntf
     // ----  setters -----
     //-----------------------------------------------------------------------------------
 
+    /*! Set a new file name and position */
+    void setDefFile(const QCString& df,int defLine,int defColumn);
+
     /*! Sets a new \a name for the definition */
     virtual void setName(const char *name);
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2597,6 +2597,15 @@ static MemberDef *addVariableToFile(
               "    variable already found: scope=%s\n",qPrint(md->getOuterScope()->name()));
           addMemberDocs(rootNav,md,def,0,FALSE);
           md->setRefItems(root->sli);
+
+          // If md is not external and current is, update declaration location
+          // to current. In case md is external and current isn't, declaration
+          // and definition location is already correct.
+          if(root->explicitExternal && !md->isExternal())
+          {
+            md->setDefFile(root->fileName,root->startLine,root->startColumn);
+          }
+
           return md;
         }
       }
@@ -3748,10 +3757,22 @@ static void buildFunctionList(EntryNav *rootNav)
                 }
 
                 // if md is a declaration and root is the corresponding
-                // definition, then turn md into a definition.
+                // definition, then turn md into a definition. Declaration
+                // location and definition location is already correct in this
+                // case.
                 if (md->isPrototype() && !root->proto)
                 {
                   md->setPrototype(FALSE);
+                }
+                // If md is a definition and we are merging it with a
+                // declaration, update declaration location. Definition
+                // location is already correct. This is a bit random when there
+                // are multiple declarations for a single definition, but such
+                // behavior is still better than conflating everything to a
+                // single location.
+                else if(!md->isPrototype() && root->proto)
+                {
+                  md->setDefFile(root->fileName,root->startLine,root->startColumn);
                 }
               }
             }

--- a/testing/080/namespace_foo.xml
+++ b/testing/080/namespace_foo.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespace_foo" kind="namespace" language="C++">
+    <compoundname>Foo</compoundname>
+    <innerclass refid="struct_foo_1_1_struct" prot="public">Foo::Struct</innerclass>
+      <sectiondef kind="var">
+      <memberdef kind="variable" id="namespace_foo_1a2c8abbc84bb41d8ddb8a5a57e3191e28" prot="public" static="no" mutable="no">
+        <type>int</type>
+        <definition>int Foo::Var</definition>
+        <argsstring/>
+        <name>Var</name>
+        <initializer>= 1337</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A var, declared at 080_declaration_definition_order.cpp:44 and defined at 080_declaration_definition_order.cpp:16 </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_declaration_definition_order.cpp" line="44" column="1" bodyfile="080_declaration_definition_order.cpp" bodystart="16" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="namespace_foo_1aece4ee53bd9801f9d8fd41257afbb25e" prot="public" static="no" mutable="no">
+        <type>int</type>
+        <definition>int Foo::War</definition>
+        <argsstring/>
+        <name>War</name>
+        <initializer>= 0</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A war, declared at 080_declaration_definition_order.cpp:17 and defined at 080_declaration_definition_order.cpp:50 </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_declaration_definition_order.cpp" line="17" column="1" bodyfile="080_declaration_definition_order.cpp" bodystart="50" bodyend="-1"/>
+      </memberdef>
+      </sectiondef>
+      <sectiondef kind="func">
+      <memberdef kind="function" id="namespace_foo_1a1d0dde98446ce72fbaebef84c86efe1a" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void Foo::foo</definition>
+        <argsstring>()</argsstring>
+        <name>foo</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A foo, declared at 080_declaration_definition_order.cpp:32 and defined at 080_declaration_definition_order.cpp:11 </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_declaration_definition_order.cpp" line="32" column="1" bodyfile="080_declaration_definition_order.cpp" bodystart="11" bodyend="11"/>
+      </memberdef>
+      <memberdef kind="function" id="namespace_foo_1a809d062bb88fcd3bd6cf38be250aa348" prot="public" static="no" const="no" explicit="no" inline="yes" virt="non-virtual">
+        <type>void</type>
+        <definition>void Foo::bar</definition>
+        <argsstring>()</argsstring>
+        <name>bar</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A bar, declared at 080_declaration_definition_order.cpp:13 and defined at 080_declaration_definition_order.cpp:38 </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_declaration_definition_order.cpp" line="13" column="1" bodyfile="080_declaration_definition_order.cpp" bodystart="38" bodyend="38"/>
+      </memberdef>
+      </sectiondef>
+    <briefdescription>
+      <para>A namespace. </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_declaration_definition_order.cpp" line="9" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/080/struct_foo_1_1_struct.xml
+++ b/testing/080/struct_foo_1_1_struct.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="struct_foo_1_1_struct" kind="struct" language="C++" prot="public">
+    <compoundname>Foo::Struct</compoundname>
+      <sectiondef kind="public-static-attrib">
+      <memberdef kind="variable" id="struct_foo_1_1_struct_1afcc2cc5f3a13fcf5ed68a1a2942984c0" prot="public" static="yes" mutable="no">
+        <type>int</type>
+        <definition>int Foo::Struct::Var</definition>
+        <argsstring/>
+        <name>Var</name>
+        <initializer>= 42</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A var, declared at 080_declaration_definition_order.cpp:64 and defined at 080_declaration_definition_order.cpp:15 </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_declaration_definition_order.cpp" line="64" column="1" bodyfile="080_declaration_definition_order.cpp" bodystart="64" bodyend="-1"/>
+      </memberdef>
+      </sectiondef>
+      <sectiondef kind="public-func">
+      <memberdef kind="function" id="struct_foo_1_1_struct_1a03020a9929d0639af8b9b117e92f84f1" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>Foo::Struct::foo</definition>
+        <argsstring>()</argsstring>
+        <name>foo</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A foo, declared at 080_declaration_definition_order.cpp:58 and defined at 080_declaration_definition_order.cpp:12 </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_declaration_definition_order.cpp" line="58" column="1" bodyfile="080_declaration_definition_order.cpp" bodystart="12" bodyend="12"/>
+      </memberdef>
+      </sectiondef>
+    <briefdescription>
+      <para>A struct. </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_declaration_definition_order.cpp" line="53" column="1" bodyfile="080_declaration_definition_order.cpp" bodystart="53" bodyend="65"/>
+    <listofallmembers>
+      <member refid="struct_foo_1_1_struct_1a03020a9929d0639af8b9b117e92f84f1" prot="public" virt="non-virtual">
+        <scope>Foo::Struct</scope>
+        <name>foo</name>
+      </member>
+      <member refid="struct_foo_1_1_struct_1afcc2cc5f3a13fcf5ed68a1a2942984c0" prot="public" virt="non-virtual">
+        <scope>Foo::Struct</scope>
+        <name>Var</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/080_declaration_definition_order.cpp
+++ b/testing/080_declaration_definition_order.cpp
@@ -1,0 +1,67 @@
+// objective: test that declaration/definition location is parsed properly independently of order in which they are seen
+// check: namespace_foo.xml
+// check: struct_foo_1_1_struct.xml
+
+/* the code below should be in 080_declaration_definition_order.cpp but I
+   haven't found a way to have two input files for a test, so this has to
+   suffice */
+
+namespace Foo {
+
+void foo() {}
+Struct::foo() {}
+void bar();
+
+int Struct::Var = 42;
+int Var = 1337;
+extern int War;
+
+}
+
+/* the code below should be in 080_declaration_definition_order.h but I
+   haven't found a way to have two input files for a test, so this has to
+   suffice */
+
+/** @brief A namespace */
+namespace Foo {
+
+/**
+ * A foo, declared at 080_declaration_definition_order.cpp:32 and defined at
+ * 080_declaration_definition_order.cpp:11
+ */
+void foo();
+
+/**
+ * A bar, declared at 080_declaration_definition_order.cpp:13 and defined at
+ * 080_declaration_definition_order.cpp:38
+ */
+inline void bar() {}
+
+/**
+ * A var, declared at 080_declaration_definition_order.cpp:44 and defined at
+ * 080_declaration_definition_order.cpp:16
+ */
+extern int Var;
+
+/**
+ * A war, declared at 080_declaration_definition_order.cpp:17 and defined at
+ * 080_declaration_definition_order.cpp:50
+ */
+int War = 0;
+
+/** @brief A struct */
+struct Struct {
+  /**
+   * A foo, declared at 080_declaration_definition_order.cpp:58 and defined at
+   * 080_declaration_definition_order.cpp:12
+   */
+  void foo();
+
+  /**
+   * A var, declared at 080_declaration_definition_order.cpp:64 and defined at
+   * 080_declaration_definition_order.cpp:15
+   */
+  static int Var;
+};
+
+}


### PR DESCRIPTION
The [m.css Doxygen theme](https://mcss.mosra.cz/doxygen/) provides include information also for free functions, variables and typedefs (instead of just classes), as [can be seen for example here](https://doc.magnum.graphics/magnum/namespaceMagnum_1_1Primitives.html#a5687268cfce168ff39376d0be228eab7):

![image](https://user-images.githubusercontent.com/344828/50566943-8eb77800-0d3f-11e9-8cd7-04c40e7fd5fb.png)

To do that, the script is extracting the `<location>` information from the XML files. Previously, if a definition was processed before declaration, both the declaration and definition location was set to the definition. It was working correctly only when declaration was found before definition, but due to the fact that C/C++ files are named like this:

    foo.cpp
    foo.h  

And thus when globbing the filesystem, the definition is always seen before the declaration. Note that this affects only functions inside namespaces, (in my testing) functions in global scope were reported
twice, once for each file (which can be considered okay, as it doesn't exhibit this bug).

For variables, I'm distinguishing definitions and declarations based on presence of the `extern` keyword -- declarations have it, definitions not.

In case it's not clear what this PR does -- there's a test in the first commit, run it with current Doxygen `master` to see the difference. Oh, also -- I'm not well aware of all the interactions in Doxygen internals, so hopefully changing the source location this way doesn't lead to any inconsistencies in the internal state.