### PR TITLE
issue #6710 xml summary tag not identical to brief with < marker

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1002,7 +1002,7 @@ void ClassDef::writeDetailedDocumentationBody(OutputList &ol)
     ol.generateDoc(briefFile(),briefLine(),this,0,briefDescription(),FALSE,FALSE);
   }
   if (!briefDescription().isEmpty() && repeatBrief &&
-      !documentation().isEmpty())
+      !documentation().stripWhiteSpace().isEmpty())
   {
     ol.pushGeneratorState();
     ol.disable(OutputGenerator::Html);
@@ -1010,7 +1010,7 @@ void ClassDef::writeDetailedDocumentationBody(OutputList &ol)
     ol.popGeneratorState();
   }
   // write documentation
-  if (!documentation().isEmpty())
+  if (!documentation().stripWhiteSpace().isEmpty())
   {
     ol.generateDoc(docFile(),docLine(),this,0,documentation(),TRUE,FALSE);
   }
@@ -1038,7 +1038,7 @@ bool ClassDef::hasDetailedDescription() const
   static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   static bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
   return ((!briefDescription().isEmpty() && repeatBrief) ||
-          !documentation().isEmpty() ||
+          !documentation().stripWhiteSpace().isEmpty() ||
           (sourceBrowser && getStartBodyLine()!=-1 && getBodyDef()));
 }
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -721,7 +721,7 @@ static void stripTrailingWhiteSpace(QCString &s)
 }
 
 // selects the output to write to
-static inline void setOutput(OutputContext ctx)
+static inline void setOutput(OutputContext ctx, bool force = false)
 {
   bool xrefAppendToPrev = xrefAppendFlag;
   // determine append flag for the next item (i.e. the end of this item)
@@ -816,7 +816,7 @@ static inline void setOutput(OutputContext ctx)
 	  current->briefLine = yyLineNr;
 	}
       }
-      if (current->brief.stripWhiteSpace().isEmpty()) // we only want one brief
+      if (force || current->brief.stripWhiteSpace().isEmpty()) // we only want one brief
 	                                              // description even if multiple
 	                                              // are given...
       {
@@ -1055,7 +1055,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           REJECT;
 					}
 <Comment>"<summary>"			{ // start of a .NET XML style brief description
-					  setOutput(OutputBrief);
+					  setOutput(OutputBrief, true);
                                           addOutput(yytext);
   					}
 <Comment>"<remarks>"            	{ // start of a .NET XML style detailed description
@@ -1063,7 +1063,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           addOutput(yytext);
   					}
 <Comment>"</summary>"	                { // start of a .NET XML style detailed description
-					  setOutput(OutputBrief);
+					  setOutput(OutputBrief, true);
                                           addOutput(yytext);
 					  setOutput(OutputDoc);
   					}
@@ -3019,7 +3019,7 @@ static bool handleExtends(const QCString &, const QCStringList &)
 
 static bool handleCopyBrief(const QCString &, const QCStringList &)
 {
-  if (current->brief.isEmpty() && current->doc.isEmpty())
+  if (current->brief.isEmpty() && current->doc.stripWhiteSpace().isEmpty())
   { // if we don't have a brief or detailed description yet,
     // then the @copybrief should end up in the brief description.
     // otherwise it will be copied inline (see bug691315 & bug700788)
@@ -3166,7 +3166,7 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
 
   current->doc=stripLeadingAndTrailingEmptyLines(current->doc,current->docLine);
 
-  if (current->section==Entry::FILEDOC_SEC && current->doc.isEmpty())
+  if (current->section==Entry::FILEDOC_SEC && current->doc.stripWhiteSpace().isEmpty())
   {
     // to allow a comment block with just a @file command.
     current->doc="\n\n";
@@ -3369,7 +3369,7 @@ static void groupAddDocs(Entry *e)
   {
     g_memberGroupDocs=e->brief.stripWhiteSpace();
     e->doc = stripLeadingAndTrailingEmptyLines(e->doc,e->docLine);
-    if (!g_memberGroupDocs.isEmpty() && !e->doc.isEmpty())
+    if (!g_memberGroupDocs.isEmpty() && !e->doc.stripWhiteSpace().isEmpty())
     {
       g_memberGroupDocs+="\n\n";
     }

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -588,7 +588,7 @@ void Definition::_setDocumentation(const char *d,const char *docFile,int docLine
     {
       m_impl->details = new DocInfo;
     }
-    if (m_impl->details->doc.isEmpty()) // fresh detailed description
+    if (m_impl->details->doc.stripWhiteSpace().isEmpty()) // fresh detailed description
     {
       m_impl->details->doc = doc;
     }
@@ -657,7 +657,7 @@ void Definition::_setBriefDescription(const char *b,const char *briefFile,int br
 
   if (!_docsAlreadyAdded(brief,m_impl->briefSignatures))
   {
-    if (m_impl->brief && !m_impl->brief->doc.isEmpty())
+    if (m_impl->brief && !m_impl->brief->doc.stripWhiteSpace().isEmpty())
     {
        //printf("adding to details\n");
        _setDocumentation(brief,briefFile,briefLine,FALSE,TRUE);
@@ -700,7 +700,7 @@ void Definition::_setInbodyDocumentation(const char *doc,const char *inbodyFile,
   {
     m_impl->inbodyDocs = new DocInfo;
   }
-  if (m_impl->inbodyDocs->doc.isEmpty()) // fresh inbody docs
+  if (m_impl->inbodyDocs->doc.stripWhiteSpace().isEmpty()) // fresh inbody docs
   {
     m_impl->inbodyDocs->doc  = doc;
     m_impl->inbodyDocs->file = inbodyFile;
@@ -1460,9 +1460,9 @@ bool Definition::hasDocumentation() const
   static bool extractAll    = Config_getBool(EXTRACT_ALL); 
   //static bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
   bool hasDocs = 
-         (m_impl->details    && !m_impl->details->doc.isEmpty())    || // has detailed docs
-         (m_impl->brief      && !m_impl->brief->doc.isEmpty())      || // has brief description
-         (m_impl->inbodyDocs && !m_impl->inbodyDocs->doc.isEmpty()) || // has inbody docs
+         (m_impl->details    && !m_impl->details->doc.stripWhiteSpace().isEmpty())    || // has detailed docs
+         (m_impl->brief      && !m_impl->brief->doc.stripWhiteSpace().isEmpty())      || // has brief description
+         (m_impl->inbodyDocs && !m_impl->inbodyDocs->doc.stripWhiteSpace().isEmpty()) || // has inbody docs
          extractAll //||                   // extract everything
   //       (sourceBrowser && m_impl->body && 
   //        m_impl->body->startLine!=-1 && m_impl->body->fileDef)
@@ -2015,7 +2015,7 @@ QCString Definition::briefDescriptionAsTooltip() const
 {
   if (m_impl->brief)
   {
-    if (m_impl->brief->tooltip.isEmpty() && !m_impl->brief->doc.isEmpty())
+    if (m_impl->brief->tooltip.isEmpty() && !m_impl->brief->doc.stripWhiteSpace().isEmpty())
     {
       static bool reentering=FALSE; 
       if (!reentering)

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -126,7 +126,7 @@ QCString DirDef::getOutputFileBase() const
 void DirDef::writeDetailedDescription(OutputList &ol,const QCString &title)
 {
   if ((!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF)) || 
-      !documentation().isEmpty())
+      !documentation().stripWhiteSpace().isEmpty())
   {
     ol.pushGeneratorState();
       ol.disable(OutputGenerator::Html);
@@ -147,7 +147,7 @@ void DirDef::writeDetailedDescription(OutputList &ol,const QCString &title)
     }
     // separator between brief and details
     if (!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF) && 
-        !documentation().isEmpty())
+        !documentation().stripWhiteSpace().isEmpty())
     {
       ol.pushGeneratorState();
         ol.disable(OutputGenerator::Man);
@@ -161,7 +161,7 @@ void DirDef::writeDetailedDescription(OutputList &ol,const QCString &title)
     }
 
     // write documentation
-    if (!documentation().isEmpty())
+    if (!documentation().stripWhiteSpace().isEmpty())
     {
       ol.generateDoc(docFile(),docLine(),this,0,documentation()+"\n",TRUE,FALSE);
     }
@@ -188,7 +188,7 @@ void DirDef::writeBriefDescription(OutputList &ol)
       ol.enable(OutputGenerator::RTF);
 
       if (Config_getBool(REPEAT_BRIEF) ||
-          !documentation().isEmpty()
+          !documentation().stripWhiteSpace().isEmpty()
          )
       {
         ol.disableAllBut(OutputGenerator::Html);
@@ -365,7 +365,7 @@ QCString DirDef::shortTitle() const
 bool DirDef::hasDetailedDescription() const
 {
   static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
-  return (!briefDescription().isEmpty() && repeatBrief) || !documentation().isEmpty();
+  return (!briefDescription().isEmpty() && repeatBrief) || !documentation().stripWhiteSpace().isEmpty();
 }
 
 void DirDef::writeTagFile(FTextStream &tagFile)

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1812,7 +1812,7 @@ static int internalValidatingParseDoc(DocNode *parent,QList<DocNode> &children,
 {
   int retval = RetVal_OK;
 
-  if (doc.isEmpty()) return retval;
+  if (doc.stripWhiteSpace().isEmpty()) return retval;
 
   doctokenizerYYinit(doc,g_fileName);
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -666,7 +666,7 @@ static void buildGroupListFiltered(EntryNav *rootNav,bool additional, bool inclu
         }
         gd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
         // allow empty docs for group
-        gd->setDocumentation(!root->doc.isEmpty() ? root->doc : QCString(" "),root->docFile,root->docLine,FALSE);
+        gd->setDocumentation(!root->doc.stripWhiteSpace().isEmpty() ? root->doc : QCString(" "),root->docFile,root->docLine,FALSE);
         gd->setInbodyDocumentation( root->inbodyDocs, root->inbodyFile, root->inbodyLine );
         gd->addSectionsToDefinition(root->anchors);
         Doxygen::groupSDict->append(root->name,gd);
@@ -787,7 +787,7 @@ static void buildFileList(EntryNav *rootNav)
     if (fd && !ambig)
     {
 #if 0
-      if ((!root->doc.isEmpty() && !fd->documentation().isEmpty()) ||
+      if ((!root->doc.stripWhiteSpace().isEmpty() && !fd->documentation().stripWhiteSpace().isEmpty()) ||
           (!root->brief.isEmpty() && !fd->briefDescription().isEmpty()))
       {
         warn(
@@ -2181,7 +2181,7 @@ static void findUsingDeclImports(EntryNav *rootNav)
                   }
                   newMd->setMemberClass(cd);
                   cd->insertMember(newMd);
-                  if (!root->doc.isEmpty() || !root->brief.isEmpty())
+                  if (!root->doc.stripWhiteSpace().isEmpty() || !root->brief.isEmpty())
                   {
                     newMd->setDocumentation(root->doc,root->docFile,root->docLine);
                     newMd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
@@ -3693,9 +3693,9 @@ static void buildFunctionList(EntryNav *rootNav)
               if (found)
               {
                 // merge argument lists
-                mergeArguments(mdAl,root->argList,!root->doc.isEmpty());
+                mergeArguments(mdAl,root->argList,!root->doc.stripWhiteSpace().isEmpty());
                 // merge documentation
-                if (md->documentation().isEmpty() && !root->doc.isEmpty())
+                if (md->documentation().stripWhiteSpace().isEmpty() && !root->doc.stripWhiteSpace().isEmpty())
                 {
                   ArgumentList *argList = new ArgumentList;
                   stringToArgumentList(root->args,argList);
@@ -3962,11 +3962,11 @@ static void findFriends()
                // function is actually a friend.
           {
             mergeArguments(mmdAl,fmdAl);
-            if (!fmd->documentation().isEmpty())
+            if (!fmd->documentation().stripWhiteSpace().isEmpty())
             {
               mmd->setDocumentation(fmd->documentation(),fmd->docFile(),fmd->docLine());
             }
-            else if (!mmd->documentation().isEmpty())
+            else if (!mmd->documentation().stripWhiteSpace().isEmpty())
             {
               fmd->setDocumentation(mmd->documentation(),mmd->docFile(),mmd->docLine());
             }
@@ -5429,8 +5429,8 @@ static void addMemberDocs(EntryNav *rootNav,
   ArgumentList *mdAl = md->argumentList();
   if (al)
   {
-    //printf("merging arguments (1) docs=%d\n",root->doc.isEmpty());
-    mergeArguments(mdAl,al,!root->doc.isEmpty());
+    //printf("merging arguments (1) docs=%d\n",root->doc.stripWhiteSpace().isEmpty());
+    mergeArguments(mdAl,al,!root->doc.stripWhiteSpace().isEmpty());
   }
   else
   {
@@ -5442,13 +5442,13 @@ static void addMemberDocs(EntryNav *rootNav,
        )
     {
       //printf("merging arguments (2)\n");
-      mergeArguments(mdAl,root->argList,!root->doc.isEmpty());
+      mergeArguments(mdAl,root->argList,!root->doc.stripWhiteSpace().isEmpty());
     }
   }
   if (over_load)  // the \overload keyword was used
   {
     QCString doc=getOverloadDocs();
-    if (!root->doc.isEmpty())
+    if (!root->doc.stripWhiteSpace().isEmpty())
     {
       doc+="<p>";
       doc+=root->doc;
@@ -8265,10 +8265,10 @@ static void inheritDocumentation()
     for (;(md=mni.current());++mni)
     {
       //printf("%04d Member `%s'\n",count++,md->name().data());
-      if (md->documentation().isEmpty() && md->briefDescription().isEmpty())
+      if (md->documentation().stripWhiteSpace().isEmpty() && md->briefDescription().isEmpty())
       { // no documentation yet
         MemberDef *bmd = md->reimplements();
-        while (bmd && bmd->documentation().isEmpty() &&
+        while (bmd && bmd->documentation().stripWhiteSpace().isEmpty() &&
                       bmd->briefDescription().isEmpty()
               )
         { // search up the inheritance tree for a documentation member
@@ -8619,7 +8619,7 @@ static void findDefineDocumentation(EntryNav *rootNav)
         }
       }
       else if (count>1 &&
-               (!root->doc.isEmpty() ||
+               (!root->doc.stripWhiteSpace().isEmpty() ||
                 !root->brief.isEmpty() ||
                 root->bodyLine!=-1
                )
@@ -8636,7 +8636,7 @@ static void findDefineDocumentation(EntryNav *rootNav)
               // doc and define in the same file assume they belong together.
             {
 #if 0
-              if (md->documentation().isEmpty())
+              if (md->documentation().stripWhiteSpace().isEmpty())
 #endif
               {
                 md->setDocumentation(root->doc,root->docFile,root->docLine);
@@ -8668,7 +8668,7 @@ static void findDefineDocumentation(EntryNav *rootNav)
         //     root->startLine,root->fileName.data());
       }
     }
-    else if (!root->doc.isEmpty() || !root->brief.isEmpty()) // define not found
+    else if (!root->doc.stripWhiteSpace().isEmpty() || !root->brief.isEmpty()) // define not found
     {
       static bool preEnabled = Config_getBool(ENABLE_PREPROCESSING);
       if (preEnabled)

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -336,7 +336,7 @@ void FileDef::writeDetailedDescription(OutputList &ol,const QCString &title)
       ol.generateDoc(briefFile(),briefLine(),this,0,briefDescription(),FALSE,FALSE);
     }
     if (!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF) && 
-        !documentation().isEmpty())
+        !documentation().stripWhiteSpace().isEmpty())
     {
       ol.pushGeneratorState();
         ol.disable(OutputGenerator::Man);
@@ -348,7 +348,7 @@ void FileDef::writeDetailedDescription(OutputList &ol,const QCString &title)
         ol.writeString("\n\n");
       ol.popGeneratorState();
     }
-    if (!documentation().isEmpty())
+    if (!documentation().stripWhiteSpace().isEmpty())
     {
       ol.generateDoc(docFile(),docLine(),this,0,documentation()+"\n",TRUE,FALSE);
     }
@@ -414,7 +414,7 @@ void FileDef::writeBriefDescription(OutputList &ol)
       ol.enable(OutputGenerator::RTF);
 
       if (Config_getBool(REPEAT_BRIEF) ||
-          !documentation().isEmpty()
+          !documentation().stripWhiteSpace().isEmpty()
          )
       {
         ol.disableAllBut(OutputGenerator::Html);

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2545,6 +2545,7 @@ static void subrHandleCommentBlock(const QCString &doc,bool brief)
   // analogous to the [in] case; here no direction specified
   else
   {
+    loc_doc.stripWhiteSpace();
     if (loc_doc.isEmpty() || (loc_doc.lower() == argName.lower()))
     {
       current=tmp_entry;

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -708,7 +708,7 @@ void GroupDef::writeTagFile(FTextStream &tagFile)
 void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
 {
   if ((!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF)) 
-      || !documentation().isEmpty() || !inbodyDocumentation().isEmpty()
+      || !documentation().stripWhiteSpace().isEmpty() || !inbodyDocumentation().isEmpty()
      )
   {
     ol.pushGeneratorState();
@@ -739,7 +739,7 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
     }
     // write separator between brief and details
     if (!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF) &&
-        !documentation().isEmpty())
+        !documentation().stripWhiteSpace().isEmpty())
     {
       ol.pushGeneratorState();
       ol.disable(OutputGenerator::Man);
@@ -753,7 +753,7 @@ void GroupDef::writeDetailedDescription(OutputList &ol,const QCString &title)
     }
 
     // write detailed documentation
-    if (!documentation().isEmpty())
+    if (!documentation().stripWhiteSpace().isEmpty())
     {
       ol.generateDoc(docFile(),docLine(),this,0,documentation()+"\n",TRUE,FALSE);
     }
@@ -786,7 +786,7 @@ void GroupDef::writeBriefDescription(OutputList &ol)
       ol.enable(OutputGenerator::RTF);
 
       if (Config_getBool(REPEAT_BRIEF) ||
-          !documentation().isEmpty()
+          !documentation().stripWhiteSpace().isEmpty()
          )
       {
         ol.disableAllBut(OutputGenerator::Html);
@@ -1461,11 +1461,11 @@ void addMemberToGroups(Entry *root,MemberDef *md)
       {
         if (md->getGroupPri()==pri)
         {
-          if (!root->doc.isEmpty() && !md->getGroupHasDocs())
+          if (!root->doc.stripWhiteSpace().isEmpty() && !md->getGroupHasDocs())
           {
             moveit = TRUE;
           }
-          else if (!root->doc.isEmpty() && md->getGroupHasDocs())
+          else if (!root->doc.stripWhiteSpace().isEmpty() && md->getGroupHasDocs())
           {
             warn(md->getGroupFileName(),md->getGroupStartLine(),
                 "Member documentation for %s found several times in %s groups!\n"
@@ -1497,7 +1497,7 @@ void addMemberToGroups(Entry *root,MemberDef *md)
       {
         //printf("insertMember successful\n");
         md->setGroupDef(fgd,pri,root->fileName,root->startLine,
-            !root->doc.isEmpty());
+            !root->doc.stripWhiteSpace().isEmpty());
         ClassDef *cd = md->getClassDefOfAnonymousType();
         if (cd) 
         {
@@ -1670,6 +1670,6 @@ bool GroupDef::hasDetailedDescription() const
 {
   static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   return ((!briefDescription().isEmpty() && repeatBrief) ||
-          !documentation().isEmpty());
+          !documentation().stripWhiteSpace().isEmpty());
 }
 

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1331,7 +1331,7 @@ bool MemberDef::isBriefSectionVisible() const
   //QCString *pMemGrp = Doxygen::memberDocDict[grpId];
   bool hasDocs = hasDocumentation() ||
                   // part of a documented member group
-                 (m_impl->grpId!=-1 && info && !(info->doc.isEmpty() && info->header.isEmpty()));
+                 (m_impl->grpId!=-1 && info && !(info->doc.stripWhiteSpace().isEmpty() && info->header.isEmpty()));
 
   // only include static members with file/namespace scope if
   // explicitly enabled in the config file
@@ -1350,7 +1350,7 @@ bool MemberDef::isBriefSectionVisible() const
   // hide members with no detailed description and brief descriptions
   // explicitly disabled.
   bool visibleIfEnabled = !(hideUndocMembers &&
-                            documentation().isEmpty() &&
+                            documentation().stripWhiteSpace().isEmpty() &&
                             !briefMemberDesc &&
                             !repeatBrief
                            );
@@ -1902,7 +1902,7 @@ bool MemberDef::isDetailedSectionLinkable() const
          // treat everything as documented
          extractAll ||
          // has detailed docs
-         !documentation().isEmpty() ||
+         !documentation().stripWhiteSpace().isEmpty() ||
          // has inbody docs
          !inbodyDocumentation().isEmpty() ||
          // is an enum with values that are documented
@@ -2388,7 +2388,7 @@ void MemberDef::_writeEnumValues(OutputList &ol,Definition *container,
           ol.startDescTableData();
 
           bool hasBrief = !fmd->briefDescription().isEmpty();
-          bool hasDetails = !fmd->documentation().isEmpty();
+          bool hasDetails = !fmd->documentation().stripWhiteSpace().isEmpty();
 
           if (hasBrief)
           {
@@ -2398,7 +2398,7 @@ void MemberDef::_writeEnumValues(OutputList &ol,Definition *container,
           }
           // FIXME:PARA
           //if (!fmd->briefDescription().isEmpty() &&
-          //    !fmd->documentation().isEmpty())
+          //    !fmd->documentation().stripWhiteSpace().isEmpty())
           //{
           //  ol.newParagraph();
           //}
@@ -5112,7 +5112,7 @@ void combineDeclarationAndDefinition(MemberDef *mdec,MemberDef *mdef)
       {
         mdec->setBriefDescription(mdef->briefDescription(),mdef->briefFile(),mdef->briefLine());
       }
-      if (!mdef->documentation().isEmpty())
+      if (!mdef->documentation().stripWhiteSpace().isEmpty())
       {
         //printf("transferring docs mdef->mdec (%s->%s)\n",mdef->argsString(),mdec->argsString());
         mdec->setDocumentation(mdef->documentation(),mdef->docFile(),mdef->docLine());
@@ -5125,7 +5125,7 @@ void combineDeclarationAndDefinition(MemberDef *mdec,MemberDef *mdef)
           mdec->setArgumentList(mdefAlComb);
         }
       }
-      else if (!mdec->documentation().isEmpty())
+      else if (!mdec->documentation().stripWhiteSpace().isEmpty())
       {
         //printf("transferring docs mdec->mdef (%s->%s)\n",mdec->argsString(),mdef->argsString());
         mdef->setDocumentation(mdec->documentation(),mdec->docFile(),mdec->docLine());

--- a/src/membergroup.cpp
+++ b/src/membergroup.cpp
@@ -112,7 +112,7 @@ void MemberGroup::writeDeclarations(OutputList &ol,
 {
   //printf("MemberGroup::writeDeclarations() %s\n",grpHeader.data());
   QCString ldoc = doc;
-  if (!ldoc.isEmpty()) ldoc.prepend("<a name=\""+anchor()+"\" id=\""+anchor()+"\"></a>");
+  if (!ldoc.stripWhiteSpace().isEmpty()) ldoc.prepend("<a name=\""+anchor()+"\" id=\""+anchor()+"\"></a>");
   memberList->writeDeclarations(ol,cd,nd,fd,gd,grpHeader,ldoc,FALSE,showInline);
 }
 
@@ -224,7 +224,7 @@ void MemberGroup::distributeMemberGroupDocumentation()
   {
     //printf("checking md=%s\n",md->name().data());
     // find the first member of the group with documentation
-    if (!md->documentation().isEmpty()       ||
+    if (!md->documentation().stripWhiteSpace().isEmpty()       ||
         !md->briefDescription().isEmpty()    ||
         !md->inbodyDocumentation().isEmpty()
        )
@@ -239,7 +239,7 @@ void MemberGroup::distributeMemberGroupDocumentation()
     MemberDef *omd;
     for (li.toFirst();(omd=li.current());++li)
     {
-      if (md!=omd && omd->documentation().isEmpty() &&
+      if (md!=omd && omd->documentation().stripWhiteSpace().isEmpty() &&
                      omd->briefDescription().isEmpty() &&
                      omd->inbodyDocumentation().isEmpty()
          )

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -656,7 +656,7 @@ void MemberList::writeDeclarations(OutputList &ol,
             ol.parseText(mg->header());
           }
           ol.endMemberGroupHeader();
-          if (!mg->documentation().isEmpty())
+          if (!mg->documentation().stripWhiteSpace().isEmpty())
           {
             //printf("Member group has docs!\n");
             ol.startMemberGroupDocs();

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -310,7 +310,7 @@ bool NamespaceDef::hasDetailedDescription() const
 {
   static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   return ((!briefDescription().isEmpty() && repeatBrief) ||
-          !documentation().isEmpty());
+          !documentation().stripWhiteSpace().isEmpty());
 }
 
 void NamespaceDef::writeTagFile(FTextStream &tagFile)
@@ -423,7 +423,7 @@ void NamespaceDef::writeDetailedDescription(OutputList &ol,const QCString &title
       ol.generateDoc(briefFile(),briefLine(),this,0,briefDescription(),FALSE,FALSE);
     }
     if (!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF) &&
-        !documentation().isEmpty())
+        !documentation().stripWhiteSpace().isEmpty())
     {
       ol.pushGeneratorState();
         ol.disable(OutputGenerator::Man);
@@ -435,7 +435,7 @@ void NamespaceDef::writeDetailedDescription(OutputList &ol,const QCString &title
         ol.writeString("\n\n");
       ol.popGeneratorState();
     }
-    if (!documentation().isEmpty())
+    if (!documentation().stripWhiteSpace().isEmpty())
     {
       ol.generateDoc(docFile(),docLine(),this,0,documentation()+"\n",TRUE,FALSE);
     }

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -316,7 +316,7 @@ static void handleCommentBlock(const QCString &doc,bool brief)
   // TODO: Fix me
   docBlockInBody=FALSE;
   
-  if (docBlockInBody && previous && !previous->doc.isEmpty())
+  if (docBlockInBody && previous && !previous->doc.stripWhiteSpace().isEmpty())
   {
     previous->doc=previous->doc.stripWhiteSpace()+"\n\n";
   }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4218,7 +4218,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  {
 					    if (!isTypedef && msName.isEmpty() && memspecEntry && (current->section&Entry::COMPOUND_MASK))
 					    { // case where a class/struct has a doc block after it
-					      if (!current->doc.isEmpty())
+					      if (!current->doc.stripWhiteSpace().isEmpty())
 					      {
 					        memspecEntry->doc += current->doc;
 					      }
@@ -6205,7 +6205,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					  //printf("Start doc block at %d\n",yyLineNr);
 					  removeSlashes=(yytext[1]=='/');
 					  tmpDocType=-1;
-					  if (!current->doc.isEmpty())
+					  if (!current->doc.stripWhiteSpace().isEmpty())
 					  {
 					    current->doc+="\n\n";
 					  }

--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -1428,7 +1428,7 @@ QCString getSQLDocBlock(const Definition *scope,
   int lineNr)
 {
   QGString s;
-  if (doc.isEmpty()) return s.data();
+  if (doc.stripWhiteSpace().isEmpty()) return s.data();
   FTextStream t(&s);
   DocNode *root = validatingParseDoc(
     fileName,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7565,7 +7565,7 @@ QCString parseCommentAsText(const Definition *scope,const MemberDef *md,
     const QCString &doc,const QCString &fileName,int lineNr)
 {
   QGString s;
-  if (doc.isEmpty()) return s.data();
+  if (doc.stripWhiteSpace().isEmpty()) return s.data();
   FTextStream t(&s);
   DocNode *root = validatingParseDoc(fileName,lineNr,
       (Definition*)scope,(MemberDef*)md,doc,FALSE,FALSE);

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2359,7 +2359,7 @@ void VhdlDocGen::writeVHDLDeclarations(MemberList* ml,OutputList &ol,
           ol.parseText(mg->header());
         }
         ol.endMemberGroupHeader();
-        if (!mg->documentation().isEmpty())
+        if (!mg->documentation().stripWhiteSpace().isEmpty())
         {
           //printf("Member group has docs!\n");
           ol.startMemberGroupDocs();

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -248,7 +248,7 @@ void VhdlParser::handleCommentBlock(const char* doc1,bool brief)
   QCString doc;
   doc.append(doc1);
  // fprintf(stderr,"\n %s",doc.data());
-  if (doc.isEmpty()) return;
+  if (doc.stripWhiteSpace().isEmpty()) return;
 
   if (checkMultiComment(doc,yyLineNr))
   {

--- a/testing/080/080__xml__summary_8cs.xml
+++ b/testing/080/080__xml__summary_8cs.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="080__xml__summary_8cs" kind="file" language="C#">
+    <compoundname>080_xml_summary.cs</compoundname>
+    <innerclass refid="class_my_name_space_works_1_1_my_class_which_works" prot="public">MyNameSpaceWorks::MyClassWhichWorks</innerclass>
+    <innerclass refid="class_my_name_space_doesnt_1_1_my_class_which_doesnt" prot="public">MyNameSpaceDoesnt::MyClassWhichDoesnt</innerclass>
+    <innernamespace refid="namespace_my_name_space_works">MyNameSpaceWorks</innernamespace>
+    <innernamespace refid="namespace_my_name_space_doesnt">MyNameSpaceDoesnt</innernamespace>
+    <innernamespace refid="namespace_system">System</innernamespace>
+    <innernamespace refid="namespace_system_1_1_text">System::Text</innernamespace>
+    <innernamespace refid="namespace_system_1_1_runtime_1_1_interop_services">System::Runtime::InteropServices</innernamespace>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs"/>
+  </compounddef>
+</doxygen>

--- a/testing/080/class_my_name_space_doesnt_1_1_my_class_which_doesnt.xml
+++ b/testing/080/class_my_name_space_doesnt_1_1_my_class_which_doesnt.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="class_my_name_space_doesnt_1_1_my_class_which_doesnt" kind="class" language="C#" prot="public">
+    <compoundname>MyNameSpaceDoesnt::MyClassWhichDoesnt</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="class_my_name_space_doesnt_1_1_my_class_which_doesnt_1ad00a5b068767595072087d330f3ed6fb" prot="public" static="no" mutable="no">
+        <type>const int</type>
+        <definition>const int MyNameSpaceDoesnt.MyClassWhichDoesnt.MyOtherConstant</definition>
+        <argsstring/>
+        <name>MyOtherConstant</name>
+        <initializer>= 1</initializer>
+        <briefdescription>
+          <para>The idea is that this is the brief description without a detail section </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_xml_summary.cs" line="36" column="1" bodyfile="080_xml_summary.cs" bodystart="36" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>The class which doesn't</para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs" line="31" column="1" bodyfile="080_xml_summary.cs" bodystart="30" bodyend="37"/>
+    <listofallmembers>
+      <member refid="class_my_name_space_doesnt_1_1_my_class_which_doesnt_1ad00a5b068767595072087d330f3ed6fb" prot="public" virt="non-virtual">
+        <scope>MyNameSpaceDoesnt::MyClassWhichDoesnt</scope>
+        <name>MyOtherConstant</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/080/class_my_name_space_works_1_1_my_class_which_works.xml
+++ b/testing/080/class_my_name_space_works_1_1_my_class_which_works.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="class_my_name_space_works_1_1_my_class_which_works" kind="class" language="C#" prot="public">
+    <compoundname>MyNameSpaceWorks::MyClassWhichWorks</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="class_my_name_space_works_1_1_my_class_which_works_1a61ee346e0b3ae52f720eff4ffa71258b" prot="public" static="no" mutable="no">
+        <type>const int</type>
+        <definition>const int MyNameSpaceWorks.MyClassWhichWorks.MyConstant</definition>
+        <argsstring/>
+        <name>MyConstant</name>
+        <initializer>= 1</initializer>
+        <briefdescription>
+          <para>This is the brief description. Nothing else. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="080_xml_summary.cs" line="22" column="1" bodyfile="080_xml_summary.cs" bodystart="22" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>The class which works. </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs" line="20" column="1" bodyfile="080_xml_summary.cs" bodystart="19" bodyend="23"/>
+    <listofallmembers>
+      <member refid="class_my_name_space_works_1_1_my_class_which_works_1a61ee346e0b3ae52f720eff4ffa71258b" prot="public" virt="non-virtual">
+        <scope>MyNameSpaceWorks::MyClassWhichWorks</scope>
+        <name>MyConstant</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/080/namespace_my_name_space_doesnt.xml
+++ b/testing/080/namespace_my_name_space_doesnt.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespace_my_name_space_doesnt" kind="namespace" language="C#">
+    <compoundname>MyNameSpaceDoesnt</compoundname>
+    <innerclass refid="class_my_name_space_doesnt_1_1_my_class_which_doesnt" prot="public">MyNameSpaceDoesnt::MyClassWhichDoesnt</innerclass>
+    <briefdescription>
+      <para>The namespace which doesn't</para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs" line="28" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/080/namespace_my_name_space_works.xml
+++ b/testing/080/namespace_my_name_space_works.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespace_my_name_space_works" kind="namespace" language="C#">
+    <compoundname>MyNameSpaceWorks</compoundname>
+    <innerclass refid="class_my_name_space_works_1_1_my_class_which_works" prot="public">MyNameSpaceWorks::MyClassWhichWorks</innerclass>
+    <briefdescription>
+      <para>The workspace which works. </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs" line="17" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/080/namespace_system.xml
+++ b/testing/080/namespace_system.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespace_system" kind="namespace" language="Unknown">
+    <compoundname>System</compoundname>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs" line="11" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/080/namespace_system_1_1_runtime_1_1_interop_services.xml
+++ b/testing/080/namespace_system_1_1_runtime_1_1_interop_services.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespace_system_1_1_runtime_1_1_interop_services" kind="namespace" language="Unknown">
+    <compoundname>System::Runtime::InteropServices</compoundname>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs" line="13" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/080/namespace_system_1_1_text.xml
+++ b/testing/080/namespace_system_1_1_text.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="namespace_system_1_1_text" kind="namespace" language="Unknown">
+    <compoundname>System::Text</compoundname>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="080_xml_summary.cs" line="12" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/080_xml_summary.cs
+++ b/testing/080_xml_summary.cs
@@ -1,0 +1,38 @@
+// objective: test <summay> against @brief
+// check: 080__xml__summary_8cs.xml
+// check: class_my_name_space_doesnt_1_1_my_class_which_doesnt.xml
+// check: class_my_name_space_works_1_1_my_class_which_works.xml
+// check: namespace_my_name_space_doesnt.xml
+// check: namespace_my_name_space_works.xml
+// check: namespace_system.xml
+// check: namespace_system_1_1_runtime_1_1_interop_services.xml
+// check: namespace_system_1_1_text.xml
+// config: REPEAT_BRIEF=NO
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+/// \brief The workspace which works
+namespace MyNameSpaceWorks
+{
+    /// \brief The class which works
+    public class MyClassWhichWorks
+    {
+
+        public const int MyConstant = 1; ///< This is the brief description. Nothing else
+    }
+}
+	
+/// <summary>The namespace which doesn't</summary>
+namespace MyNameSpaceDoesnt
+{
+    /// <summary>The class which doesn't</summary>
+    public class MyClassWhichDoesnt
+    {
+
+        /// <summary>
+        /// The idea is that this is the brief description without a detail section
+        /// </summary>
+        public const int MyOtherConstant = 1;
+    }
+}


### PR DESCRIPTION
Main problem is that the `</summary>` tag lands in the detailed description as the brief description could not be appended (commentscan.l).
Furthermore a detailed description with just a space was not seen as empty (correct for isEmpty function), string has been stripped for test.
Added test case.