### PR TITLE
issue #6732 align environment for formula (\f{align}) no longer working

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1121,6 +1121,8 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           // the {B}* in the front was added for bug620924
                                           QCString fullMatch = QCString(yytext);
                                           int idx = fullMatch.find('{');
+                                          /* handle `\f{` and `@f{` as special cases */
+                                          if ((idx > 1) && (yytext[idx-1] == 'f') && (yytext[idx-2] == '\\' || yytext[idx-2] =='@')) REJECT;
                                           int idxEnd = fullMatch.find("}",idx+1);
                                           QCString cmdName;
                                           QCStringList optList;


### PR DESCRIPTION
The `\f{..}` looks like the, new, option handling, but the handling if `\f{` is done at another place and would now be included here due to the first part `<Comment>{B}*{CMD}[a-z_A-Z]+"{"[a-zA-Z_,:0-9\. ]*"}"{B}*` of the rules.