### PR TITLE
issue #6733 invalid cite anchor id when using crossref

### DIFF
--- a/templates/html/doxygen.bst
+++ b/templates/html/doxygen.bst
@@ -549,7 +549,7 @@ FUNCTION {format.tr.number}
 
 FUNCTION {format.article.crossref}
 {
-  "In <a href=" quote$ * "#" * crossref * quote$ * ">" *
+  "In <a href=" quote$ * "#" * "CITEREF_" * crossref * quote$ * ">" *
   key empty$
     { journal empty$
 	{ "need key or journal for " cite$ * " to crossref " * crossref *
@@ -561,7 +561,7 @@ FUNCTION {format.article.crossref}
     }
     { key * }
   if$
-  "</a> \citelabel{" * crossref * "}" *
+  "</a> \citelabel{" * "CITEREF_" * crossref * "}" *
 }
 
 FUNCTION {format.crossref.editor}
@@ -590,7 +590,7 @@ FUNCTION {format.book.crossref}
       " of " *
     }
   if$
-  "<a href=" * quote$ * "#" * crossref * quote$ * ">" *
+  "<a href=" * "CITEREF_" * quote$ * "#" * crossref * quote$ * ">" *
   editor empty$
   editor field.or.null author field.or.null =
   or
@@ -608,12 +608,12 @@ FUNCTION {format.book.crossref}
     }
     { format.crossref.editor * }
   if$
-  "</a> \citelabel{" * crossref * "}" *
+  "</a> \citelabel{" * "CITEREF_" * crossref * "}" *
 }
 
 FUNCTION {format.incoll.inproc.crossref}
 {
-  "In <a href=" quote$ * "#" * crossref * quote$ * ">" *
+  "In <a href=" quote$ * "#" * "CITEREF_" * crossref * quote$ * ">" *
   editor empty$
   editor field.or.null author field.or.null =
   or
@@ -631,7 +631,7 @@ FUNCTION {format.incoll.inproc.crossref}
     }
     { format.crossref.editor * }
   if$
-  "</a> \citelabel{" * crossref * "}" *
+  "</a> \citelabel{" * "CITEREF_" * crossref * "}" *
 }
 
 FUNCTION {article}

--- a/testing/012/citelist.xml
+++ b/testing/012/citelist.xml
@@ -9,10 +9,31 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="citelist_1CITEREF_knuth79"/>[1]</term>
+            <term><anchor id="citelist_1CITEREF_Be09"/>[1]</term>
+          </varlistentry>
+          <listitem>
+            <para>P.<nonbreakablespace/>Belotti. <ulink url="http://doi.org/10.1007/978-1-4614-1927-3_5">Disjunctive cuts for non-convex MINLP</ulink>. In <ulink url="#CITEREF_LeLe12">Lee and Leyffer</ulink> <ulink url="#CITEREF_LeLe12">[4]</ulink>, pages 117<ndash/>144.</para>
+            <para/>
+          </listitem>
+          <varlistentry>
+            <term><anchor id="citelist_1CITEREF_BertholdHeinzVigerske2009"/>[2]</term>
+          </varlistentry>
+          <listitem>
+            <para>T.<nonbreakablespace/>Berthold, S.<nonbreakablespace/>Heinz, and S.<nonbreakablespace/>Vigerske. <ulink url="http://doi.org/10.1007/978-1-4614-1927-3_15">Extending a CIP framework to solve MIQCPs</ulink>. In <ulink url="#CITEREF_LeLe12">Lee and Leyffer</ulink> <ulink url="#CITEREF_LeLe12">[4]</ulink>, pages 427<ndash/>444.</para>
+            <para/>
+          </listitem>
+          <varlistentry>
+            <term><anchor id="citelist_1CITEREF_knuth79"/>[3]</term>
           </varlistentry>
           <listitem>
             <para>Donald<nonbreakablespace/>E. Knuth. <emphasis>Tex and Metafont, New Directions in Typesetting</emphasis>. American Mathematical Society and Digital Press, Stanford, 1979.</para>
+            <para/>
+          </listitem>
+          <varlistentry>
+            <term><anchor id="citelist_1CITEREF_LeLe12"/>[4]</term>
+          </varlistentry>
+          <listitem>
+            <para>Jon Lee and Sven Leyffer, editors. <ulink url="http://doi.org/10.1007/978-1-4614-1927-3"><emphasis>Mixed Integer Nonlinear Programming</emphasis></ulink>, volume 154 of <emphasis>The IMA Volumes in Mathematics and its Applications</emphasis>. Springer, 2012.</para>
             <para/>
           </listitem>
         </variablelist>

--- a/testing/012/indexpage.xml
+++ b/testing/012/indexpage.xml
@@ -6,7 +6,8 @@
     <briefdescription>
     </briefdescription>
     <detaileddescription>
-      <para>See <ref refid="citelist_1CITEREF_knuth79" kindref="member">[1]</ref> for more info. </para>
+      <para>See <ref refid="citelist_1CITEREF_knuth79" kindref="member">[3]</ref> for more info.</para>
+      <para>Oter references with crosreference see <ref refid="citelist_1CITEREF_Be09" kindref="member">[1]</ref> and <ref refid="citelist_1CITEREF_BertholdHeinzVigerske2009" kindref="member">[2]</ref> for more info. </para>
     </detaileddescription>
   </compounddef>
 </doxygen>

--- a/testing/012_cite.dox
+++ b/testing/012_cite.dox
@@ -4,4 +4,6 @@
 // config: CITE_BIB_FILES = $INPUTDIR/sample.bib
 /** \mainpage
  *  See \cite knuth79 for more info.
+ *  
+ *  Oter references with crosreference see \cite Be09 and \cite BertholdHeinzVigerske2009 for more info.
  */

--- a/testing/050/indexpage.xml
+++ b/testing/050/indexpage.xml
@@ -14,6 +14,31 @@
         publisher = "American Mathematical Society and Digital Press",
         address = "Stanford"
 }
+@InCollection{    BertholdHeinzVigerske2009,
+  author        = {T. Berthold and S. Heinz and S. Vigerske},
+  title         = {Extending a {CIP} framework to solve {MIQCP}s},
+  crossref      = {LeLe12},
+  pages         = {427--444},
+  url           = {http://doi.org/10.1007/978-1-4614-1927-3_15}
+}
+@Book{            LeLe12,
+  title         = {Mixed Integer Nonlinear Programming},
+  booktitle     = {Mixed Integer Nonlinear Programming},
+  publisher     = {Springer},
+  year          = {2012},
+  editor        = {Jon Lee and Sven Leyffer},
+  volume        = {154},
+  series        = {The IMA Volumes in Mathematics and its Applications},
+  url           = {http://doi.org/10.1007/978-1-4614-1927-3},
+  issn          = {978-1-4614-1926-6}
+}
+@InCollection{    Be09,
+  author        = {P. Belotti},
+  title         = {Disjunctive cuts for non-convex {MINLP}},
+  crossref      = {LeLe12},
+  pages         = {117--144},
+  url           = {http://doi.org/10.1007/978-1-4614-1927-3_5}
+}
 </verbatim> More text after the verbatim section. </para>
     </detaileddescription>
   </compounddef>

--- a/testing/sample.bib
+++ b/testing/sample.bib
@@ -5,3 +5,28 @@
         publisher = "American Mathematical Society and Digital Press",
         address = "Stanford"
 }
+@InCollection{    BertholdHeinzVigerske2009,
+  author        = {T. Berthold and S. Heinz and S. Vigerske},
+  title         = {Extending a {CIP} framework to solve {MIQCP}s},
+  crossref      = {LeLe12},
+  pages         = {427--444},
+  url           = {http://doi.org/10.1007/978-1-4614-1927-3_15}
+}
+@Book{            LeLe12,
+  title         = {Mixed Integer Nonlinear Programming},
+  booktitle     = {Mixed Integer Nonlinear Programming},
+  publisher     = {Springer},
+  year          = {2012},
+  editor        = {Jon Lee and Sven Leyffer},
+  volume        = {154},
+  series        = {The IMA Volumes in Mathematics and its Applications},
+  url           = {http://doi.org/10.1007/978-1-4614-1927-3},
+  issn          = {978-1-4614-1926-6}
+}
+@InCollection{    Be09,
+  author        = {P. Belotti},
+  title         = {Disjunctive cuts for non-convex {MINLP}},
+  crossref      = {LeLe12},
+  pages         = {117--144},
+  url           = {http://doi.org/10.1007/978-1-4614-1927-3_5}
+}


### PR DESCRIPTION
The cross reference possibility was not properly taken into account in bibtex conversion for other formats than LaTeX.
- doxygen.bst: use correct labels (i.e. add 'CITEREF_' in case of cross references to the giver name)
- cite.cpp: add the cross references to the citation dictionary (to overcome warning message).
- extending test 012