### PR TITLE
Implementing `<hr>` for LaTeX

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -280,7 +280,7 @@ void LatexDocVisitor::visit(DocLineBreak *)
 void LatexDocVisitor::visit(DocHorRuler *)
 {
   if (m_hide) return;
-  m_t << "\n\n";
+  m_t << "\\DoxyHorRuler\n";
 }
 
 void LatexDocVisitor::visit(DocStyleChange *s)

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -35,6 +35,10 @@
   \endgroup%
 }
 
+\newcommand{\DoxyHorRuler}{%
+  \setlength{\parskip}{0ex plus 0ex minus 0ex}%
+  \hrule%
+}
 \newcommand{\DoxyLabelFont}{}
 \newcommand{\entrylabel}[1]{%
   {%


### PR DESCRIPTION
In LaTeX the `<hr>` was implemented as a"new paragraph", now as a horizontal line.