### PR TITLE
issue #6727 SHOW_NAMESPACES = NO breaks latex PDF

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4670,7 +4670,7 @@ static void writeIndex(OutputList &ol)
       ol.parseText(/*projPrefix+*/ theTranslator->trModuleIndex());
       ol.endIndexSection(isModuleIndex);
     }
-    if (documentedNamespaces>0)
+    if (Config_getBool(SHOW_NAMESPACES) && (documentedNamespaces>0))
     {
       ol.startIndexSection(isNamespaceIndex);
       ol.parseText(/*projPrefix+*/(fortranOpt?theTranslator->trModulesIndex():theTranslator->trNamespaceIndex()));


### PR DESCRIPTION
Only write the namespace index file reference (i.e. namespaces.tex , namespaces.rtf) to the overall file (i.e. refman.tex. refman.rtf) in case SHOW_NAMESPACES is set and there are namespaces.