### PR TITLE
Double defined operator in test 74

### DIFF
--- a/testing/074/namespacens.xml
+++ b/testing/074/namespacens.xml
@@ -2,7 +2,7 @@
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
   <compounddef id="namespacens" kind="namespace" language="C++">
     <compoundname>ns</compoundname>
-      <sectiondef kind="func">
+    <sectiondef kind="func">
       <memberdef kind="function" id="namespacens_1afd2e8a8437eff630f52a452ea6dc6e82" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>int</type>
         <definition>int ns::operator""_op</definition>
@@ -18,7 +18,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="66" column="1"/>
+        <location file="074_ref.cpp" line="67" column="1"/>
       </memberdef>
       <memberdef kind="function" id="namespacens_1a47f70e51e66b81b8383a4e2da66f1e09" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>int</type>
@@ -35,7 +35,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="69" column="1"/>
+        <location file="074_ref.cpp" line="70" column="1"/>
       </memberdef>
       <memberdef kind="function" id="namespacens_1aaa9eb8a7b40d4ed0edbe5e163b4e6e8d" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>
@@ -52,11 +52,11 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="72" column="1"/>
+        <location file="074_ref.cpp" line="73" column="1"/>
       </memberdef>
-      </sectiondef>
+    </sectiondef>
     <briefdescription>
-<para>A namespace. </para>
+      <para>A namespace. </para>
     </briefdescription>
     <detaileddescription>
       <para>
@@ -76,6 +76,6 @@
         </itemizedlist>
       </para>
     </detaileddescription>
-    <location file="074_ref.cpp" line="63" column="1"/>
+    <location file="074_ref.cpp" line="64" column="1"/>
   </compounddef>
 </doxygen>

--- a/testing/074/struct_foo.xml
+++ b/testing/074/struct_foo.xml
@@ -15,7 +15,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="20" column="1"/>
+        <location file="074_ref.cpp" line="21" column="1"/>
       </memberdef>
       <memberdef kind="function" id="struct_foo_1a279debd94d894223fa8468933e2d6188" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type><ref refid="struct_foo" kindref="compound">Foo</ref> &amp;</type>
@@ -33,7 +33,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="31" column="1"/>
+        <location file="074_ref.cpp" line="32" column="1"/>
       </memberdef>
       <memberdef kind="function" id="struct_foo_1a48bcc3de9b2f1ad09a3518a0c9f0da61" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
         <type>const <ref refid="struct_foo" kindref="compound">Foo</ref> &amp;</type>
@@ -51,7 +51,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="34" column="1"/>
+        <location file="074_ref.cpp" line="35" column="1"/>
       </memberdef>
       <memberdef kind="function" id="struct_foo_1a3a41dcf8c53f777d50676ea28400a640" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>int</type>
@@ -69,7 +69,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="37" column="1"/>
+        <location file="074_ref.cpp" line="38" column="1"/>
       </memberdef>
       <memberdef kind="function" id="struct_foo_1ae3c9c1f33cdb8b932c6eb104660a262b" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
         <type>int</type>
@@ -87,7 +87,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="40" column="1"/>
+        <location file="074_ref.cpp" line="41" column="1"/>
       </memberdef>
       <memberdef kind="function" id="struct_foo_1aa20bd44b1bb87a652ac65170ddfa1a5a" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type><ref refid="struct_foo" kindref="compound">Foo</ref> &amp;</type>
@@ -105,12 +105,12 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="43" column="1"/>
+        <location file="074_ref.cpp" line="44" column="1"/>
       </memberdef>
-      <memberdef kind="function" id="struct_foo_1aa20bd44b1bb87a652ac65170ddfa1a5a" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
-        <type><ref refid="struct_foo" kindref="compound">Foo</ref> &amp;</type>
-        <definition>Foo&amp; Foo::operator&amp;=</definition>
-        <argsstring>(const Foo &amp;rhs)</argsstring>
+      <memberdef kind="function" id="struct_foo_1ab1a2a53ad5b2a0f97422630330c151fe" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+        <type>const <ref refid="struct_foo" kindref="compound">Foo</ref> &amp;</type>
+        <definition>const Foo&amp; Foo::operator&amp;=</definition>
+        <argsstring>(const Foo &amp;rhs) const</argsstring>
         <name>operator&amp;=</name>
         <param>
           <type>const <ref refid="struct_foo" kindref="compound">Foo</ref> &amp;</type>
@@ -123,7 +123,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="46" column="1"/>
+        <location file="074_ref.cpp" line="47" column="1"/>
       </memberdef>
       <memberdef kind="function" id="struct_foo_1a0514e1f5b30cbf77e1c39d7aba308656" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>int *</type>
@@ -141,7 +141,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="49" column="1"/>
+        <location file="074_ref.cpp" line="50" column="1"/>
       </memberdef>
       <memberdef kind="function" id="struct_foo_1a978acd73e910ce56cc169ebec8736669" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
         <type>
@@ -157,7 +157,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="52" column="1"/>
+        <location file="074_ref.cpp" line="53" column="1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="public-static-func">
@@ -206,7 +206,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="074_ref.cpp" line="28" column="1"/>
+        <location file="074_ref.cpp" line="29" column="1"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
@@ -236,11 +236,14 @@
           <para><ref refid="struct_foo_1aa20bd44b1bb87a652ac65170ddfa1a5a" kindref="member">and equal operator</ref>. </para>
         </simplesect>
         <simplesect kind="see">
+          <para><ref refid="struct_foo_1ab1a2a53ad5b2a0f97422630330c151fe" kindref="member">const and equal operator</ref>. </para>
+        </simplesect>
+        <simplesect kind="see">
           <para><ref refid="struct_foo_1a0514e1f5b30cbf77e1c39d7aba308656" kindref="member">member pointer operator</ref>. </para>
         </simplesect>
       </para>
     </detaileddescription>
-    <location file="074_ref.cpp" line="18" column="1" bodyfile="074_ref.cpp" bodystart="18" bodyend="53"/>
+    <location file="074_ref.cpp" line="19" column="1" bodyfile="074_ref.cpp" bodystart="19" bodyend="54"/>
     <listofallmembers>
       <member refid="struct_foo_1a5c036d1b3561a0e1beffe8c6799a4276" prot="public" virt="non-virtual">
         <scope>Foo</scope>
@@ -258,7 +261,7 @@
         <scope>Foo</scope>
         <name>operator&amp;=</name>
       </member>
-      <member refid="struct_foo_1aa20bd44b1bb87a652ac65170ddfa1a5a" prot="public" virt="non-virtual">
+      <member refid="struct_foo_1ab1a2a53ad5b2a0f97422630330c151fe" prot="public" virt="non-virtual">
         <scope>Foo</scope>
         <name>operator&amp;=</name>
       </member>

--- a/testing/074_ref.cpp
+++ b/testing/074_ref.cpp
@@ -13,6 +13,7 @@
  *  @see @ref operator()(int) "call operator".
  *  @see @ref operator()(int) const "const call operator".
  *  @see @ref operator&=(const Foo&) "and equal operator".
+ *  @see @ref operator&=(const Foo&) const "const and equal operator".
  *  @see @ref operator->*(int *) "member pointer operator".
  */
 struct Foo {
@@ -43,7 +44,7 @@ struct Foo {
   Foo& operator&=(const Foo& rhs);
 
   /** and equal operator */
-  Foo& operator&=(const Foo& rhs);
+  const Foo& operator&=(const Foo& rhs) const;
 
   /** Member pointer operator */
   int* operator->*(int *p);


### PR DESCRIPTION
In test  074 the operator `&=` was identically defined twice, now corrected with const.
In XHTML this resulted in error:
`struct_foo.xhtml:204: element a: validity error : ID aa20bd44b1bb87a652ac65170ddfa1a5a already defined`