### PR TITLE
Tests are unsorted

### DIFF
--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -412,7 +412,7 @@ def main():
 			tests.append(glob.glob('0%s_*'%id))
 			tests.append(glob.glob('00%s_*'%id))
 	if (not args.ids and not args.start_id):  # find all tests
-		tests = glob.glob('[0-9][0-9][0-9]_*')
+		tests = sorted(glob.glob('[0-9][0-9][0-9]_*'))
 	else:
 		tests = list(itertools.chain.from_iterable(tests))
 	os.chdir(starting_directory)


### PR DESCRIPTION
When requesting all tests they are sorted in the way `glob.glob` returns them, i.e. unsorted, better, more intuitive and easier for finding problems, would be sorted.