### PR TITLE
issue #6744 Ampersand in Markdown image URL is not escaped in XML output

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1584,7 +1584,7 @@ void HtmlDocVisitor::visitPre(DocHRef *href)
   else
   {
     QCString url = correctURL(href->url(),href->relPath());
-    m_t << "<a href=\"" << convertToXML(url)  << "\""
+    m_t << "<a href=\"" << convertToHtml(url)  << "\""
         << htmlAttribsToString(href->attribs()) << ">";
   }
 }
@@ -1668,7 +1668,7 @@ void HtmlDocVisitor::visitPre(DocImage *img)
     }
     else
     {
-      m_t << "<img src=\"" << src << "\" alt=\"" << alt << "\"" << sizeAttribs << attrs;
+      m_t << "<img src=\"" << convertToHtml(src) << "\" alt=\"" << alt << "\"" << sizeAttribs << attrs;
       if (inlineImage)
       {
         m_t << " class=\"inline\"";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5914,7 +5914,7 @@ QCString convertToId(const char *s)
 }
 
 /*! Converts a string to an XML-encoded string */
-QCString convertToXML(const char *s)
+QCString convertToXML(const char *s, bool keepEntities)
 {
   static GrowBuf growBuf;
   growBuf.clear();
@@ -5927,7 +5927,30 @@ QCString convertToXML(const char *s)
     {
       case '<':  growBuf.addStr("&lt;");   break;
       case '>':  growBuf.addStr("&gt;");   break;
-      case '&':  growBuf.addStr("&amp;");  break;
+      case '&':  if (keepEntities)
+                 {
+                   const char *e=p;
+                   char ce;
+                   while ((ce=*e++))
+                   {
+                     if (ce==';' || (!(isId(ce) || ce=='#'))) break;
+                   }
+                   if (ce==';') // found end of an entity
+                   {
+                     // copy entry verbatim
+                     growBuf.addChar(c);
+                     while (p<e) growBuf.addChar(*p++);
+                   }
+                   else
+                   {
+                     growBuf.addStr("&amp;");
+                   }
+                 }
+                 else
+                 {
+                   growBuf.addStr("&amp;");
+                 }
+                 break;
       case '\'': growBuf.addStr("&apos;"); break; 
       case '"':  growBuf.addStr("&quot;"); break;
       case  1: case  2: case  3: case  4: case  5: case  6: case  7: case  8:

--- a/src/util.h
+++ b/src/util.h
@@ -284,7 +284,7 @@ QCString convertToHtml(const char *s,bool keepEntities=TRUE);
 
 QCString convertToLaTeX(const QCString &s,bool insideTabbing=FALSE,bool keepSpaces=FALSE);
 
-QCString convertToXML(const char *s);
+QCString convertToXML(const char *s, bool keepEntities=FALSE);
 
 QCString convertToDocBook(const char *s);
 

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -60,7 +60,7 @@ static void visitPreStart(FTextStream &t, const char *cmd, bool doCaption,
   }
   if (!name.isEmpty())
   {
-    t << " name=\"" << name << "\"";
+    t << " name=\"" << convertToXML(name, TRUE) << "\"";
   }
   if (!width.isEmpty())
   {
@@ -770,9 +770,7 @@ void XmlDocVisitor::visitPost(DocInternal *)
 void XmlDocVisitor::visitPre(DocHRef *href)
 {
   if (m_hide) return;
-  m_t << "<ulink url=\"";
-  filter(href->url());
-  m_t << "\">";
+  m_t << "<ulink url=\"" << convertToXML(href->url(), TRUE) << "\">";
 }
 
 void XmlDocVisitor::visitPost(DocHRef *) 

--- a/testing/031/indexpage.xml
+++ b/testing/031/indexpage.xml
@@ -39,9 +39,16 @@ This image is inline <image type="html" name="license-MIT-brightgreen.png" inlin
       <para>HTML style unlinked SVG image:<linebreak/>
 <image type="html" name="license-MIT-brightgreen.svg" inline="yes"/>
 </para>
-      <para>HTML style unlined PNG image:<linebreak/>
+      <para>HTML style unlinked PNG image:<linebreak/>
 <image type="html" name="license-MIT-brightgreen.png" inline="yes"/>
- </para>
+</para>
+      <para>Some markdown image tests<linebreak/>
+<image type="html" name="docs-Doxygen-blue.svg?foo&amp;bar" inline="yes"/>
+ <ulink url="http://www.doxygen.nl?foo&amp;bar">Some normal link</ulink></para>
+      <para>
+        <image type="html" name="docs-Doxygen-blue.svg?foo&amp;bar" inline="yes"/>
+        <ulink url="http://www.doxygen.nl?foo&amp;bar">Some normal link</ulink>
+      </para>
     </detaileddescription>
   </compounddef>
 </doxygen>

--- a/testing/031_image.dox
+++ b/testing/031_image.dox
@@ -47,7 +47,13 @@ HTML style linked PNG image:\n
 HTML style unlinked SVG image:\n
 <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT license"/>
 
-HTML style unlined PNG image:\n
+HTML style unlinked PNG image:\n
 <img src="http://img.shields.io/badge/license-MIT-brightgreen.png" alt="MIT license"/>
 
+Some markdown image tests\n
+![Some SVG image](https://img.shields.io/badge/docs-Doxygen-blue.svg?foo&bar)
+[Some normal link](http://www.doxygen.nl?foo&bar)
+
+![Some SVG image](https://img.shields.io/badge/docs-Doxygen-blue.svg?foo&amp;bar)
+[Some normal link](http://www.doxygen.nl?foo&amp;bar)
 */


### PR DESCRIPTION
Convert name / url based on HTML / XML conventions and don't do double conversions (XML).