### PR TITLE
issue #6749 doxygen 1.8.15 segfault

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5444,6 +5444,7 @@ QCString escapeCharsInString(const char *name,bool allowDots,bool allowUnderscor
   static bool allowUnicodeNames = Config_getBool(ALLOW_UNICODE_NAMES);
   static GrowBuf growBuf;
   growBuf.clear();
+  if (name==0) return "";
   char c;
   const char *p=name;
   while ((c=*p++)!=0)
@@ -6962,6 +6963,7 @@ void filterLatexString(FTextStream &t,const char *str,
 
 QCString latexEscapeLabelName(const char *s)
 {
+  if (s==0) return "";
   QGString result;
   QCString tmp(qstrlen(s)+1);
   FTextStream t(&result);
@@ -6999,6 +7001,7 @@ QCString latexEscapeLabelName(const char *s)
 
 QCString latexEscapeIndexChars(const char *s)
 {
+  if (s==0) return "";
   QGString result;
   QCString tmp(qstrlen(s)+1);
   FTextStream t(&result);
@@ -7037,6 +7040,7 @@ QCString latexEscapeIndexChars(const char *s)
 
 QCString latexEscapePDFString(const char *s)
 {
+  if (s==0) return "";
   QGString result;
   FTextStream t(&result);
   const char *p=s;
@@ -7061,6 +7065,7 @@ QCString latexEscapePDFString(const char *s)
 
 QCString latexFilterURL(const char *s)
 {
+  if (s==0) return "";
   QGString result;
   FTextStream t(&result);
   const char *p=s;


### PR DESCRIPTION
An empty string was defined in a `<a href="">` resulting in a null pointer access.