### PR TITLE
issue #6748 1.8.15 regression with C# internal modifier

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2438,6 +2438,10 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					    {
 					      current->protection = Protected;
 					    }
+					    else if ((insideCS || insideD || insidePHP || insideJS) && qstrcmp(yytext,"internal")==0)
+					    {
+					      current->protection = Package;
+					    }
 					    else if (javaLike && qstrcmp(yytext,"private")==0)
 					    {
 					      current->protection = Private;


### PR DESCRIPTION
In the fix for issue #677 / bug 743539 only the Java part, in scanner.l, should have been removed and not the other languages in respect to the word "internal", compare also code.l