### PR TITLE
Terminating brief command

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -277,6 +277,8 @@ static DocCmdMap docCmdMap[] =
   { "verbinclude",     0,                       FALSE },
   { "version",         0,                       TRUE  },
   { "warning",         0,                       TRUE  },
+  { "snippet",         0,                       TRUE  },
+  { "snippetlineno",   0,                       TRUE  },
   { 0, 0, FALSE }
 };
 
@@ -1191,6 +1193,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 				          }
   					}
 <Comment>{B}*{CMD}"f{"[^}\n]+"}"("{"?)  { // start of a formula with custom environment
+					  setOutput(OutputDoc);
 					  formulaText="\\begin";
 					  formulaEnv=QString(yytext).stripWhiteSpace().data()+2;
 					  if (formulaEnv.at(formulaEnv.length()-1)=='{')
@@ -1208,6 +1211,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					  BEGIN(ReadFormulaShort);
   					}
 <Comment>{B}*{CMD}"f["			{ // start of a block formula
+					  setOutput(OutputDoc);
 					  formulaText="\\[";
 					  formulaNewLines=0;
 					  BEGIN(ReadFormulaLong);


### PR DESCRIPTION
The brief command is intended for a small description of a function / class / namespace etc. and not to have extensive formulas or code snippets. These commands should terminate the brief description and start the detailed section.
The commands `\snippet` and `\snippetlineno` are added to the list of commands to terminate the brief description.
The commands `\f[` and `\f{` are handled separately but now also start a detailed description.

The `\f$` is just for small formulas and thus possible in a brief description.