### PR TITLE
No translation of markdown in <pre>

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2535,7 +2535,9 @@ QCString processMarkdown(const QCString &fileName,const int lineNr,Entry *e,cons
   out.clear();
   int refIndent;
   // for replace tabs by spaces
-  QCString s = detab(input,refIndent);
+  QCString s = input;
+  if (s.find('\n',s.length()-1) == -1) s += "\n";
+  s = detab(s,refIndent);
   //printf("======== DeTab =========\n---- output -----\n%s\n---------\n",s.data());
   // then process quotation blocks (as these may contain other blocks)
   s = processQuotations(s,refIndent);

--- a/testing/081/081__markdown__pre_8f90.xml
+++ b/testing/081/081__markdown__pre_8f90.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="081__markdown__pre_8f90" kind="file" language="Fortran">
+    <compoundname>081_markdown_pre.f90</compoundname>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="081__markdown__pre_8f90_1aae79d7941f2dce9b2d61fc852f3031d1" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>subroutine</type>
+        <definition>subroutine subr1</definition>
+        <argsstring>()</argsstring>
+        <name>subr1</name>
+        <briefdescription>
+          <para>subr1 </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>
+            <preformatted>
+                     ___________________________
+</preformatted>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="081_markdown_pre.f90" line="9" column="1" bodyfile="081_markdown_pre.f90" bodystart="10" bodyend="9"/>
+      </memberdef>
+      <memberdef kind="function" id="081__markdown__pre_8f90_1a799d06e535f6b6e83331907261cef116" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>subroutine</type>
+        <definition>subroutine subr2</definition>
+        <argsstring>()</argsstring>
+        <name>subr2</name>
+        <briefdescription>
+          <para>subr2 </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>
+            <preformatted>
+                     ___________________________
+</preformatted>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="081_markdown_pre.f90" line="17" column="1" bodyfile="081_markdown_pre.f90" bodystart="18" bodyend="17"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="081_markdown_pre.f90"/>
+  </compounddef>
+</doxygen>

--- a/testing/081_markdown_pre.f90
+++ b/testing/081_markdown_pre.f90
@@ -1,0 +1,18 @@
+! // objective: test <pre> in Fortran, no translation of markdown
+! // check: 081__markdown__pre_8f90.xml
+!> \file
+
+!> subr1
+!><pre>
+!>                     ___________________________
+!></pre>
+subroutine subr1()
+end subroutine
+
+!> subr2
+!><pre>
+!>                     ___________________________
+!></pre>
+!>
+subroutine subr2()
+end subroutine


### PR DESCRIPTION
According to the documentation:
> Doxygen does not have this requirement, and will also process Markdown formatting inside such HTML blocks. The only exception is \<pre\> blocks, which are passed untouched (handy for ASCII art).

Though in case the `</pre>` is the last statement in a non block type comment the markdown is processed. C has block type `/* ... */` and `///` is translated to this, Fortran, Python are line type comments.
Adding a `\n` at the end when no `\n` is present at the end  solves the problem.