### PR TITLE
Invalid id possible with tooltips

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -769,7 +769,7 @@ void HtmlGenerator::init()
         t << endl <<
           "$(document).ready(function() {\n"
           "  $('.code,.codeRef').each(function() {\n"
-          "    $(this).data('powertip',$('#'+$(this).attr('href').replace(/.*\\//,'').replace(/[^a-z_A-Z0-9]/g,'_')).html());\n"
+          "    $(this).data('powertip',$('#a'+$(this).attr('href').replace(/.*\\//,'').replace(/[^a-z_A-Z0-9]/g,'_')).html());\n"
           "    $(this).powerTip({ placement: 's', smartPlacement: true, mouseOnToPopup: true });\n"
           "  });\n"
           "});\n";

--- a/src/tooltip.cpp
+++ b/src/tooltip.cpp
@@ -84,6 +84,7 @@ void TooltipManager::addTooltip(Definition *d)
   {
     id+="_"+anc;
   }
+  id = "a" + id;
   if (p->tooltipInfo.find(id)==0)
   {
     p->tooltipInfo.insert(id,d);


### PR DESCRIPTION
In case a filename starts with a number the `id` also starts with a number and this is not allowed in XHTML and results in the message:
`Syntax of value for attribute id of div is not valid`
on other places it has been solved by placing an `a` as first character, this is done here as well but also needs to be don in the transformation from reference to tooltip id (htmlgen.cpp)