### PR TITLE
Terminate brief in case of `-#` list

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1282,6 +1282,11 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           addOutput(insidePre || Doxygen::markdownSupport ? yytext : "&ndash;");
                                         }
 <Comment>"-#"{B}+                       { // numbered item
+                                          if (inContext!=OutputXRef)
+                                          {
+                                            briefEndsAtDot=FALSE;
+                                            setOutput(OutputDoc);
+                                          }
                                           addOutput(yytext);
                                         }
 <Comment>("."+)[a-z_A-Z0-9\)]		{ // . at start or in the middle of a word, or ellipsis

--- a/testing/081/081__brief__lists_8h.xml
+++ b/testing/081/081__brief__lists_8h.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="081__brief__lists_8h" kind="file" language="C++">
+    <compoundname>081_brief_lists.h</compoundname>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="081__brief__lists_8h_1a319a01268f470ad2ab65e6838e13cc05" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void c_subr1</definition>
+        <argsstring>(void)</argsstring>
+        <name>c_subr1</name>
+        <param>
+          <type>void</type>
+        </param>
+        <briefdescription>
+          <para>Just with minus. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>
+            <itemizedlist>
+              <listitem>
+                <para>Item 1</para>
+              </listitem>
+              <listitem>
+                <para>Item 2 </para>
+              </listitem>
+            </itemizedlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="081_brief_lists.h" line="8" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="081__brief__lists_8h_1a6724979ae3655ed6eb8b377337119d94" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void c_subr2</definition>
+        <argsstring>(void)</argsstring>
+        <name>c_subr2</name>
+        <param>
+          <type>void</type>
+        </param>
+        <briefdescription>
+          <para>With minus and hash. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>
+            <orderedlist>
+              <listitem>
+                <para>Item 3</para>
+              </listitem>
+              <listitem>
+                <para>Item 4 </para>
+              </listitem>
+            </orderedlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="081_brief_lists.h" line="13" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="081__brief__lists_8h_1a32cca553d19c1f483a6c308000517353" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void c_subr3</definition>
+        <argsstring>(void)</argsstring>
+        <name>c_subr3</name>
+        <param>
+          <type>void</type>
+        </param>
+        <briefdescription>
+          <para>With numbers. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>
+            <orderedlist>
+              <listitem>
+                <para>Item 5</para>
+              </listitem>
+              <listitem>
+                <para>Item 6 </para>
+              </listitem>
+            </orderedlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="081_brief_lists.h" line="18" column="1"/>
+      </memberdef>
+      <memberdef kind="function" id="081__brief__lists_8h_1a350caf1b2bbbbb18b9b4f08bb799f86b" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void c_subr4</definition>
+        <argsstring>(void)</argsstring>
+        <name>c_subr4</name>
+        <param>
+          <type>void</type>
+        </param>
+        <briefdescription>
+          <para>With asterisk. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>
+            <itemizedlist>
+              <listitem>
+                <para>Item 7</para>
+              </listitem>
+              <listitem>
+                <para>Item 8 </para>
+              </listitem>
+            </itemizedlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="081_brief_lists.h" line="23" column="1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="081_brief_lists.h"/>
+  </compounddef>
+</doxygen>

--- a/testing/081_brief_lists.h
+++ b/testing/081_brief_lists.h
@@ -1,0 +1,23 @@
+// objective: Test termination of brief description with lists
+// check: 081__brief__lists_8h.xml
+/// \file
+
+/// @brief Just with minus
+/// - Item 1
+/// - Item 2
+void c_subr1(void);
+
+/// @brief With minus and hash
+/// -# Item 3
+/// -# Item 4
+void c_subr2(void);
+
+/// @brief With numbers
+/// 1. Item 5
+/// 2. Item 6
+void c_subr3(void);
+
+/// @brief With asterisk
+/// * Item 7
+/// * Item 8
+void c_subr4(void);


### PR DESCRIPTION
With the list types `-`, `*` and `1.` the brief description is terminated, with the `-#` lists this was not the case.