### PR TITLE
Minimum required version for CMake

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -1,5 +1,5 @@
 Doxygen uses cmake (http://www.cmake.org/) to build executables for various platforms.
-It's required at least cmake version 2.8.12
+It's required at least cmake version 3.1.3
 
 The first step is to create a build directory where the output should be stored.
 Doxygen can be fully build outside of the source tree.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Documents produced by Doxygen are derivative works derived from the
 # input used in their production; they are not affected by this license.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.3)
 project(doxygen)
 
 option(build_wizard    "Build the GUI frontend for doxygen." OFF)

--- a/doc/install.doc
+++ b/doc/install.doc
@@ -38,7 +38,7 @@ following to build the executable:
     \addindex python
 <li>You need \c python (version 2.6 or higher, see https://www.python.org).
 <li>In order to generate a \c Makefile for your platform, you need 
-    <a href="https://cmake.org/">cmake</a> version 2.8.12 or later.
+    <a href="https://cmake.org/">cmake</a> version 3.1.3 or later.
     \addindex cmake
 </ul>
 


### PR DESCRIPTION
The `env` command with `-E` is first supported with version 3.1 setting the minimum required version as such
(Based on message: https://stackoverflow.com/questions/54194646/make-docs-fails-while-building-doxygen-v1-8-15-for-rhel-distros-for-s390x and CMake documentation: https://cmake.org/cmake/help/v2.8.12/cmake.html, https://cmake.org/cmake/help/v3.0/manual/cmake.1.html and https://cmake.org/cmake/help/v3.1/manual/cmake.1.html)