### PR TITLE
issue #6764 Incorrect parsing of C enum comments defined using a macro

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -882,6 +882,21 @@ static bool replaceFunctionMacro(const QCString &expr,QCString *rest,int pos,int
 	  arg+=c;
 	}
       }	    
+      else if (c=='/') // possible start of a comment
+      {
+        char prevChar = '\0';
+        arg+=c;
+        if ((cc=getCurrentChar(expr,rest,j)) == '*') // we have a comment
+        {
+          while ((cc=getNextChar(expr,rest,j))!=EOF && cc!=0)
+          {
+            c=(char)cc;
+            arg+=c;
+            if (c == '/' && prevChar == '*') break; // we have an end of comment
+            prevChar = c;
+          }
+        }
+      }
       else // append other characters
       {
 	arg+=c;
@@ -1110,7 +1125,6 @@ static void expandExpression(QCString &expr,QCString *rest,int pos)
 
 	if (replaced) // expand the macro and rescan the expression
 	{
-	    
 	  //printf("replacing `%s'->`%s'\n",expr.mid(p,len).data(),expMacro.data());
 	  QCString resultExpr=expMacro;
 	  QCString restExpr=expr.right(expr.length()-len-p);


### PR DESCRIPTION
When in a `/*` comment skip till end of the comment so a `,` won't be seen as the argument separator.