### PR TITLE
Double id for tooltips in XHTML possible.

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -825,7 +825,6 @@ static void detectFunctionBody(const char *s)
 
 void ClangParser::writeSources(CodeOutputInterface &ol,FileDef *fd)
 {
-  TooltipManager::instance()->clearTooltips();
   // (re)set global parser state
   g_currentDefinition=0;
   g_currentMemberDef=0;
@@ -934,7 +933,6 @@ void ClangParser::writeSources(CodeOutputInterface &ol,FileDef *fd)
     clang_disposeString(tokenString);
   }
   ol.endCodeLine();
-  TooltipManager::instance()->writeTooltips(ol);
 }
 
 ClangParser::ClangParser()

--- a/src/code.l
+++ b/src/code.l
@@ -3745,7 +3745,6 @@ void parseCCode(CodeOutputInterface &od,const char *className,const QCString &s,
 
   printlex(yy_flex_debug, TRUE, __FILE__, fd ? fd->fileName().data(): NULL);
 
-  TooltipManager::instance()->clearTooltips();
   if (g_codeClassSDict==0)
   {
     resetCCodeParserState();
@@ -3827,10 +3826,6 @@ void parseCCode(CodeOutputInterface &od,const char *className,const QCString &s,
     endFontClass();
     DBG_CTX((stderr,"endCodeLine(%d)\n",g_yyLineNr));
     g_code->endCodeLine();
-  }
-  if (fd)
-  {
-    TooltipManager::instance()->writeTooltips(*g_code);
   }
   if (cleanupSourceDef)
   {

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1327,7 +1327,6 @@ void parseFortranCode(CodeOutputInterface &od,const char *className,const QCStri
 
   if (s.isEmpty()) return;
   printlex(yy_flex_debug, TRUE, __FILE__, fd ? fd->fileName().data(): NULL);
-  TooltipManager::instance()->clearTooltips();
   g_code = &od;
   g_inputString   = s;
   g_inputPosition = 0;
@@ -1381,10 +1380,6 @@ void parseFortranCode(CodeOutputInterface &od,const char *className,const QCStri
   {
     endFontClass();
     g_code->endCodeLine();
-  }
-  if (fd)
-  {
-    TooltipManager::instance()->writeTooltips(*g_code);
   }
   if (exBlock && g_sourceFileDef)
   {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -43,7 +43,7 @@
 #include "ftvhelp.h"
 #include "bufstr.h"
 #include "resourcemgr.h"
-
+#include "tooltip.h"
 
 //#define DBG_HTML(x) x;
 #define DBG_HTML(x)
@@ -981,6 +981,9 @@ void HtmlGenerator::writePageFooter(FTextStream &t,const QCString &lastTitle,
 
 void HtmlGenerator::writeFooter(const char *navPath)
 {
+  // Currently only tooltips in HTML
+  TooltipManager::instance()->writeTooltips(m_codeGen);
+
   writePageFooter(t,lastTitle,relPath,navPath);
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -48,6 +48,7 @@
 #include "classlist.h"
 #include "namespacedef.h"
 #include "filename.h"
+#include "tooltip.h"
 
 #define MAX_ITEMS_BEFORE_MULTIPAGE_INDEX 200
 #define MAX_ITEMS_BEFORE_QUICK_INDEX 30
@@ -301,9 +302,11 @@ void endFile(OutputList &ol,bool skipNavIndex,bool skipEndContents,
       ol.writeString("</div><!-- doc-content -->\n");
     }
   }
+
   ol.writeFooter(navPath); // write the footer
   ol.popGeneratorState();
   ol.endFile();
+  TooltipManager::instance()->clearTooltips(); // Only clear after the last is written
 }
 
 void endFileWithNavPath(Definition *d,OutputList &ol)

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1569,7 +1569,6 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
   if (s.isEmpty()) return;
   printlex(yy_flex_debug, TRUE, __FILE__, fd ? fd->fileName().data(): NULL);
   g_codeClassSDict.setAutoDelete(TRUE);
-  TooltipManager::instance()->clearTooltips();
   g_code = &od;
   g_inputString   = s;
   g_inputPosition = 0;
@@ -1619,10 +1618,6 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
   if (g_needsTermination)
   {
     endCodeLine();
-  }
-  if (fd)
-  {
-    TooltipManager::instance()->writeTooltips(*g_code);
   }
   if (cleanupSourceDef)
   {

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -355,8 +355,6 @@ void parseSqlCode(
 {  
   if (s.isEmpty()) return;
   
-  TooltipManager::instance()->clearTooltips();
-  
   g_code = &od;
   g_inputString   = s;
   g_inputPosition = 0;
@@ -403,10 +401,6 @@ void parseSqlCode(
   if (g_needsTermination)
   {
     endCodeLine();
-  }
-  if (fd)
-  {
-    TooltipManager::instance()->writeTooltips(*g_code);
   }
   if (cleanupSourceDef)
   {

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1549,7 +1549,6 @@ void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString 
   //printf("***parseCode() exBlock=%d exName=%s fd=%p\n",exBlock,exName,fd);
   if (s.isEmpty()) return;
   printlex(yy_flex_debug, TRUE, __FILE__, fd ? fd->fileName().data(): NULL);
-  TooltipManager::instance()->clearTooltips();
   if (memberDef)
   {
     ClassDef *dd=memberDef->getClassDef();
@@ -1622,10 +1621,6 @@ void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString 
   if (g_needsTermination)
   {
     endCodeLine();
-  }
-  if (fd)
-  {
-    TooltipManager::instance()->writeTooltips(*g_code);
   }
   if (cleanupSourceDef)
   {

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -339,8 +339,6 @@ void parseXmlCode(
 {  
   if (s.isEmpty()) return;
   
-  TooltipManager::instance()->clearTooltips();
-  
   g_code = &od;
   g_inputString   = s;
   g_inputPosition = 0;
@@ -387,10 +385,6 @@ void parseXmlCode(
   if (g_needsTermination)
   {
     endCodeLine();
-  }
-  if (fd)
-  {
-    TooltipManager::instance()->writeTooltips(*g_code);
   }
   if (cleanupSourceDef)
   {

--- a/testing/085/085__tooltip_8cpp.xml
+++ b/testing/085/085__tooltip_8cpp.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="085__tooltip_8cpp" kind="file" language="C++">
+    <compoundname>085_tooltip.cpp</compoundname>
+    <sectiondef kind="define">
+      <memberdef kind="define" id="085__tooltip_8cpp_1ace0cca79d3f7e7c96b6edcb1b8d31e66" prot="public" static="no">
+        <name>FOPEN_MACRO</name>
+        <param>
+          <defname>fn</defname>
+        </param>
+        <param>
+          <defname>mod</defname>
+        </param>
+        <initializer>if ((<ref refid="085__tooltip_8cpp_1a5cccf7694b5d688466063895f39ee5d1" kindref="member">unit</ref> = fopen(fn, mod)) == NULL) \
+  {                                    \
+    msg(OPEN_ERR,strerror(errno));     \
+  }</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>a general open macro </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="085_tooltip.cpp" line="11" column="9" bodyfile="085_tooltip.cpp" bodystart="11" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="define" id="085__tooltip_8cpp_1a11a2c0486e2bbd915f975a3517817de6" prot="public" static="no">
+        <name>FCLOSE_MACRO</name>
+        <initializer>if (fclose(<ref refid="085__tooltip_8cpp_1a5cccf7694b5d688466063895f39ee5d1" kindref="member">unit</ref>) != 0)               \
+  {                                    \
+    msg(CLOSE_ERR,strerror(errno));    \
+  }</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>a general close macro </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="085_tooltip.cpp" line="18" column="9" bodyfile="085_tooltip.cpp" bodystart="18" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="var">
+      <memberdef kind="variable" id="085__tooltip_8cpp_1a5cccf7694b5d688466063895f39ee5d1" prot="public" static="no" mutable="no">
+        <type>FILE *</type>
+        <definition>FILE* unit</definition>
+        <argsstring/>
+        <name>unit</name>
+        <initializer>= NULL</initializer>
+        <briefdescription>
+          <para>the unit </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="085_tooltip.cpp" line="8" column="1" bodyfile="085_tooltip.cpp" bodystart="8" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="085_tooltip.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/085_tooltip.cpp
+++ b/testing/085_tooltip.cpp
@@ -1,0 +1,22 @@
+// objective: test tooltip in XHTML
+// check: 085__tooltip_8cpp.xml
+// config: SOURCE_BROWSER=YES
+/** \file */
+
+
+/** \brief the unit */
+FILE *unit = NULL;
+
+/** a general open macro */
+#define FOPEN_MACRO(fn ,mod)           \
+  if ((unit = fopen(fn, mod)) == NULL) \
+  {                                    \
+    msg(OPEN_ERR,strerror(errno));     \
+  }
+
+/** a general close macro */
+#define FCLOSE_MACRO                   \
+  if (fclose(unit) != 0)               \
+  {                                    \
+    msg(CLOSE_ERR,strerror(errno));    \
+  }


### PR DESCRIPTION
The tooltips (XHTML) should not be displayed per code fragment but for the entire (output) file as otherwise tooltips might be added multiple times resulting in double IDs.