### PR TITLE
issue #6679 Multiple use of section label warning for Setex-stype headers in markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2282,28 +2282,6 @@ static QCString processBlocks(const QCString &s,int indent)
             out.addStr(" ");
             out.addStr(header);
             out.addStr("\n\n");
-            SectionInfo *si = Doxygen::sectionDict->find(id);
-            if (si)
-            {
-              if (si->lineNr != -1)
-              {
-                warn(g_fileName,g_lineNr,"multiple use of section label '%s', (first occurrence: %s, line %d)",header.data(),si->fileName.data(),si->lineNr);
-              }
-              else
-              {
-                warn(g_fileName,g_lineNr,"multiple use of section label '%s', (first occurrence: %s)",header.data(),si->fileName.data());
-              }
-            }
-            else
-            {
-              si = new SectionInfo(g_fileName,g_lineNr,id,header,
-                      level==1 ? SectionInfo::Section : SectionInfo::Subsection,level);
-              if (g_current)
-              {
-                g_current->anchors->append(si);
-              }
-              Doxygen::sectionDict->append(id,si);
-            }
           }
           else
           {


### PR DESCRIPTION
Due to the move of the markdown code to another place the adding of the section info of section, subsection etc. would be attempted to add twice (first in markdown and later on again when translating the resulting '`section`, `\subsection` commands. The adding should only take place when handling the (replaced) commands.

Removing the test in `addSection` won't work as in that case using twice a sectioning command with the same label would not be signaled anymore.