### PR TITLE
issue #6781 Unable to use math in markdown table headers

### DIFF
--- a/doc/translator.py
+++ b/doc/translator.py
@@ -1821,9 +1821,9 @@ class TrManager:
         tplDic['numLangStr'] = str(self.numLang)
 
         # Define templates for HTML table parts of the documentation.
-        htmlTableTpl = '''\
+        htmlTableTpl = '''
             \\htmlonly
-			</p>
+            </p>
             <table align="center" cellspacing="0" cellpadding="0" border="0">
             <tr bgcolor="#000000">
             <td>
@@ -1842,7 +1842,7 @@ class TrManager:
             </td>
             </tr>
             </table>
-			<p>
+            <p>
             \\endhtmlonly
             '''
         htmlTableTpl = textwrap.dedent(htmlTableTpl)

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -523,7 +523,7 @@ static int processQuoted(GrowBuf &out,const char *data,int,int size)
 /** Process a HTML tag. Note that <pre>..</pre> are treated specially, in
  *  the sense that all code inside is written unprocessed
  */
-static int processHtmlTag(GrowBuf &out,const char *data,int offset,int size)
+static int processHtmlTagWrite(GrowBuf &out,const char *data,int offset,int size,bool doWrite)
 {
   if (offset>0 && data[-1]=='\\') return 0; // escaped <
 
@@ -546,7 +546,7 @@ static int processHtmlTag(GrowBuf &out,const char *data,int offset,int size)
             tolower(data[i+2])=='p' && tolower(data[i+3])=='r' &&
             tolower(data[i+4])=='e' && tolower(data[i+5])=='>')
         { // found </pre> tag, copy from start to end of tag
-          out.addStr(data,i+6);
+          if (doWrite) out.addStr(data,i+6);
           //printf("found <pre>..</pre> [%d..%d]\n",0,i+6);
           return i+6;
         }
@@ -569,13 +569,13 @@ static int processHtmlTag(GrowBuf &out,const char *data,int offset,int size)
       if (data[i]=='/' && i<size-1 && data[i+1]=='>') // <bla/>
       {
         //printf("Found htmlTag={%s}\n",QCString(data).left(i+2).data());
-        out.addStr(data,i+2);
+        if (doWrite) out.addStr(data,i+2);
         return i+2;
       }
       else if (data[i]=='>') // <bla>
       {
         //printf("Found htmlTag={%s}\n",QCString(data).left(i+1).data());
-        out.addStr(data,i+1);
+        if (doWrite) out.addStr(data,i+1);
         return i+1;
       }
       else if (data[i]==' ') // <bla attr=...
@@ -595,7 +595,7 @@ static int processHtmlTag(GrowBuf &out,const char *data,int offset,int size)
           else if (!insideAttr && data[i]=='>') // found end of tag
           {
             //printf("Found htmlTag={%s}\n",QCString(data).left(i+1).data());
-            out.addStr(data,i+1);
+            if (doWrite) out.addStr(data,i+1);
             return i+1;
           }
           i++;
@@ -605,6 +605,10 @@ static int processHtmlTag(GrowBuf &out,const char *data,int offset,int size)
   }
   //printf("Not a valid html tag\n");
   return 0;
+}
+static int processHtmlTag(GrowBuf &out,const char *data,int offset,int size)
+{
+  return processHtmlTagWrite(out,data,offset,size,true);
 }
 
 static int processEmphasis(GrowBuf &out,const char *data,int offset,int size)
@@ -2086,17 +2090,9 @@ static void findEndOfLine(GrowBuf &out,const char *data,int size,
           {
             if (qstrncmp(&data[end+1],endBlockName,l)==0)
             {
-              if (pi!=-1) // output previous line if available
-              {
-                //printf("feol out={%s}\n",QCString(data+pi).left(i-pi).data());
-                out.addStr(data+pi,i-pi);
-              }
               // found end marker, skip over this block
               //printf("feol.block out={%s}\n",QCString(data+i).left(end+l+1-i).data());
-              out.addStr(data+i,end+l+1-i);
-              pi=-1;
-              i=end+l+1; // continue after block
-              end=i+1;
+              end = end + l + 2;
               break;
             }
           }
@@ -2110,16 +2106,8 @@ static void findEndOfLine(GrowBuf &out,const char *data,int size,
       if (tolower(data[end])=='p' && tolower(data[end+1])=='r' &&
           tolower(data[end+2])=='e' && data[end+3]=='>') // <pre> tag
       {
-        if (pi!=-1) // output previous line if available
-        {
-          out.addStr(data+pi,i-pi);
-        }
-        // output part until <pre>
-        out.addStr(data+i,end-1-i); 
-        // output part until </pre>
-        i = end-1 + processHtmlTag(out,data+end-1,end-1,size-end+1);
-        pi=-1;
-        end = i+1;
+        // skip part until including </pre>
+        end  = end + processHtmlTagWrite(out,data+end-1,end-1,size-end+1,false) + 2;
         break;
       }
       else


### PR DESCRIPTION
Due to the change of the place where the markdown processing is done the end of the line must be calculated a little bit differently.

Note: translator.py gave an error due to a strange indentation (did surface now), so had to be corrected as well.