### PR TITLE
Warning for documented return of void type function

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -616,27 +616,16 @@ static void detectNoDocumentedParams()
         g_memberDef->setHasDocumentedParams(TRUE);
       }
     }
-    //printf("Member %s hadDocumentedReturnType()=%d hasReturnCommand=%d\n",
+    //printf("Member %s hasDocumentedReturnType()=%d hasReturnCommand=%d\n",
     //    g_memberDef->name().data(),g_memberDef->hasDocumentedReturnType(),g_hasReturnCommand);
     if (!g_memberDef->hasDocumentedReturnType() && // docs not yet found
         g_hasReturnCommand)
     {
       g_memberDef->setHasDocumentedReturnType(TRUE);
     }
-    else if ( // see if return needs to documented 
-        g_memberDef->hasDocumentedReturnType() ||
-        returnType.isEmpty()         || // empty return type
-        returnType.find("void")!=-1  || // void return type
-        returnType.find("subroutine")!=-1 || // fortran subroutine
-        g_memberDef->isConstructor() || // a constructor
-        g_memberDef->isDestructor()     // or destructor
-       )
-    {
-      g_memberDef->setHasDocumentedReturnType(TRUE);
-    }
     else if ( // see if return type is documented in a function w/o return type
-        g_memberDef->hasDocumentedReturnType() &&
-        (returnType.isEmpty()              || // empty return type
+        g_hasReturnCommand &&
+        (//returnType.isEmpty()              || // empty return type
          returnType.find("void")!=-1       || // void return type
          returnType.find("subroutine")!=-1 || // fortran subroutine
          g_memberDef->isConstructor()      || // a constructor
@@ -644,7 +633,18 @@ static void detectNoDocumentedParams()
         )
        )
     {
-      warn_doc_error(g_fileName,doctokenizerYYlineno,"documented empty return type");
+      warn_doc_error(g_fileName,doctokenizerYYlineno,"documented empty return type of  %s",g_memberDef->qualifiedName().data());
+    }
+    else if ( // see if return needs to documented 
+        g_memberDef->hasDocumentedReturnType() ||
+        //returnType.isEmpty()         || // empty return type
+        returnType.find("void")!=-1  || // void return type
+        returnType.find("subroutine")!=-1 || // fortran subroutine
+        g_memberDef->isConstructor() || // a constructor
+        g_memberDef->isDestructor()     // or destructor
+       )
+    {
+      g_memberDef->setHasDocumentedReturnType(TRUE);
     }
   }
 }


### PR DESCRIPTION
In case a void type function is documented it is not allowed to used a `\return` or `\retval` command. The test was present but not correct
- test on `g_hasReturnCommand ` which signals whether of not `\ret...` is used instead of  `g_memberDef->hasDocumentedReturnType()`
- removed test on emty return type (empty return type is assumed to be non void, see e.g. C, Fortran).
- order of the tests is important