### PR TITLE
issue #6791 TOC not generated when using a particular Markdown headerstyle

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -667,7 +667,7 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
-    <option type='int' id='TOC_INCLUDE_HEADINGS' minval='0' maxval='99' defval='0' depends='MARKDOWN_SUPPORT'>
+    <option type='int' id='TOC_INCLUDE_HEADINGS' minval='0' maxval='99' defval='5' depends='MARKDOWN_SUPPORT'>
       <docs>
 <![CDATA[
  When the \c TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings

--- a/testing/055/md_055_markdown.xml
+++ b/testing/055/md_055_markdown.xml
@@ -6,26 +6,26 @@
     <briefdescription>
     </briefdescription>
     <detaileddescription>
-      <para>
-        <heading level="1">Foo</heading>
-      </para>
-      <para>
-        <heading level="2">Bar</heading>
-      </para>
-      <para>
-        <ulink url="http://example.com/inline">Inline link</ulink>
-      </para>
-      <para>
-        <ulink url="http://example.com/reference">Reference link</ulink>
-      </para>
-      <para>
-        <heading level="2">Baz</heading>
-      </para>
-      <para>More text</para>
-      <para>
-        <ulink url="http://example.com/last-line">Upper-cased reference link on last line</ulink>
-      </para>
-      <para>Dash - NDash <ndash/> MDash <mdash/> EDash - ENDash -- EMDash --- E3Dash --- </para>
+      <sect1 id="md_055_markdown_1autotoc_md0">
+        <title>Foo</title>
+        <sect2 id="md_055_markdown_1autotoc_md1">
+          <title>Bar</title>
+          <para>
+            <ulink url="http://example.com/inline">Inline link</ulink>
+          </para>
+          <para>
+            <ulink url="http://example.com/reference">Reference link</ulink>
+          </para>
+        </sect2>
+        <sect2 id="md_055_markdown_1autotoc_md2">
+          <title>Baz</title>
+          <para>More text</para>
+          <para>
+            <ulink url="http://example.com/last-line">Upper-cased reference link on last line</ulink>
+          </para>
+          <para>Dash - NDash <ndash/> MDash <mdash/> EDash - ENDash -- EMDash --- E3Dash --- </para>
+        </sect2>
+      </sect1>
     </detaileddescription>
   </compounddef>
 </doxygen>


### PR DESCRIPTION
The default for the `TOC_INCLUDE_HEADERINGS` was set to 0, for compatibility this should be 5.
(Problem was observed in the doxygen documentation, chapter markdown, where the TOC was missing; alternatively in the Doxyfile the `TOC_INCLUDE_HEADERINGS` could be set to `5`,. The solution chosen is more consistent with the old situation).