### PR TITLE
issue #6796 Bad link to section, subsection if pointing at item past suspicious text

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1181,7 +1181,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					    addOutput(yytext);
 					  }
   					}
-<Comment>{B}*("\\\\"|"@@")"f"[$\[{]	{ // escaped formula command
+<Comment>{B}*({CMD}{CMD})"f"[$\[{]	{ // escaped formula command
   					  addOutput(yytext);
   					}
 <Comment>{B}*{CMD}"~"[a-z_A-Z-]*		{ // language switch command
@@ -1805,7 +1805,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  g_sectionTitle+=yytext;
 					  addOutput(yytext);
   					}
-<SectionTitle>("\\\\"|"@@"){ID}		{ // unescape escaped command
+<SectionTitle>({CMD}{CMD}){ID}		{ // unescape escaped command
   					  g_sectionTitle+=&yytext[1];
 					  addOutput(yytext);
   					}

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1227,7 +1227,7 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
      /* State for the pass used to find the anchors and sections */ 
 
 <St_Sections>[^\n@\\<]+
-<St_Sections>"@@"|"\\\\"|"@<"|"\\<"
+<St_Sections>{CMD}("<"|{CMD})
 <St_Sections>"<"{CAPTION}({WS}+{ATTRIB})*">" {
                                       QCString tag=yytext;
                                       int s=tag.find("id=");

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6542,7 +6542,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           // middle of a comment block
   					  docBlock+=yytext;
   					}
-<DocBlock>("@@"|"\\\\"){ID}/[^a-z_A-Z0-9] { // escaped command
+<DocBlock>({CMD}{CMD}){ID}/[^a-z_A-Z0-9] { // escaped command
   					  docBlock+=yytext;
   					}
 <DocBlock>{CMD}("f$"|"f["|"f{")	        {


### PR DESCRIPTION
To escape `\` and `@` not only `\\` and `@@` should be possible  but also `\@` and  `@\`