### PR TITLE
issue #6794 C# code does not properly link to docs

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1141,7 +1141,7 @@ static bool generateClassMemberLink(CodeOutputInterface &ol,MemberDef *xmd,const
 
   ClassDef *typeClass = stripClassName(removeAnonymousScopes(xmd->typeString()),xmd->getOuterScope());
   DBG_CTX((stderr,"%s -> typeName=%p\n",xmd->typeString(),typeClass));
-  g_theCallContext.setScope(typeClass);
+  if (typeClass) g_theCallContext.setScope(typeClass);
 
   Definition *xd = xmd->getOuterScope()==Doxygen::globalScope ?
                    xmd->getFileDef() : xmd->getOuterScope();


### PR DESCRIPTION
Only set a new  call scope in case typeClass exists.