### PR TITLE
issue #6800 Markdown line ending problems in 1.8.15 and master

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1886,10 +1886,12 @@ static int writeTableBlock(GrowBuf &out,const char *data,int size)
 static int hasLineBreak(const char *data,int size)
 {
   int i=0;
-  while (i<size && data[i]!='\n') i++;
+  int j=0;
+  /* search for end of line and also check if it is not a completely empty, i.e. only spaces or tabs, line is */
+  while (i<size && data[i]!='\n') {if (data[i] != ' ' && data[i] != '\t') j++;i++;}
   if (i>=size) return 0; // empty line
   if (i<2) return 0; // not long enough
-  return (data[i-1]==' ' && data[i-2]==' ');
+  return (j && data[i-1]==' ' && data[i-2]==' ');
 }
 
 
@@ -1947,7 +1949,7 @@ void writeOneLineHeaderOrRuler(GrowBuf &out,const char *data,int size)
     out.addStr(data,size);
     if (hasLineBreak(data,size))
     {
-      out.addStr("\n");
+      out.addStr("<br>");
     }
   }
 }


### PR DESCRIPTION
In case of a completely empty line with 2 spaces at the end don't consider this as a 2 space terminated line.
Regression of #6448