### PR TITLE
Inline VHDL code

### DIFF
--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1554,7 +1554,6 @@ void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString 
   {
     ClassDef *dd=memberDef->getClassDef();
     if (dd) g_CurrClass=dd->name();
-    startLine--;
   }
   resetVhdlCodeParserState();
   g_code = &od;
@@ -1599,10 +1598,7 @@ void parseVhdlCode(CodeOutputInterface &od,const char *className,const QCString 
     g_exampleFile = convertNameToFile(g_exampleName+"-example");
   }
   g_includeCodeFragment = inlineFragment;
-  if (!memberDef)
-  {
-    startCodeLine();
-  }
+  startCodeLine();
   // g_type.resize(0);
   // g_name.resize(0);
   // g_args.resize(0);


### PR DESCRIPTION
Based on the example of #6805
- First line of inline documentation didn't have a line number
- The line numbers in inline documentation were off by one

Original:
![old](https://user-images.githubusercontent.com/5223533/51981749-4bfad400-2494-11e9-8fdd-a026715c73cc.jpg)

Corrected:
![new](https://user-images.githubusercontent.com/5223533/51981753-4dc49780-2494-11e9-8eb6-0a93de871e75.jpg)
