### PR TITLE
Bug 141919 - Wrong param and exception style in RTF output

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -767,14 +767,12 @@ DB_VIS_C
       }
       break;
     case DocSimpleSect::User:
+    case DocSimpleSect::Rcs:
+    case DocSimpleSect::Unknown:
       if (s->hasTitle())
         m_t << "<formalpara>" << endl;
       else
         m_t << "<para>" << endl;
-      break;
-    case DocSimpleSect::Rcs:
-    case DocSimpleSect::Unknown:
-      m_t << "<para>" << endl;
       break;
   }
 }
@@ -785,11 +783,9 @@ DB_VIS_C
   if (m_hide) return;
   switch(s->type())
   {
+    case DocSimpleSect::User:
     case DocSimpleSect::Rcs:
     case DocSimpleSect::Unknown:
-      m_t << "</para>" << endl;
-      break;
-    case DocSimpleSect::User:
       if (s->hasTitle())
         m_t << "</formalpara>" << endl;
       else

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -771,16 +771,18 @@ void RTFDocVisitor::visitPre(DocSimpleSect *s)
     m_t << "}"; // end bold
     incIndentLevel();
     m_t << rtf_Style_Reset << getStyle("DescContinue");
+    m_t << "{\\s17 \\sa60 \\sb30\n";
   }
   m_lastIsPara=FALSE;
 }
 
-void RTFDocVisitor::visitPost(DocSimpleSect *)
+void RTFDocVisitor::visitPost(DocSimpleSect *s)
 {
   if (m_hide) return;
   DBG_RTF("{\\comment RTFDocVisitor::visitPost(DocSimpleSect)}\n");
   if (!m_lastIsPara) m_t << "\\par" << endl;
   decIndentLevel();
+  if (s->type()!=DocSimpleSect::User && s->type()!=DocSimpleSect::Rcs) m_t << "}";
   m_t << "}"; // end desc
   m_lastIsPara=TRUE;
 }

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -701,7 +701,7 @@ dl.reflist dd {
         padding-left: 0px;
 }       
 
-.params .paramname, .retval .paramname, .tparams .paramname {
+.params .paramname, .retval .paramname, .tparams .paramname, .exception .paramname {
         font-weight: bold;
         vertical-align: top;
 }

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -53,7 +53,7 @@
   \ensurespace{4\baselineskip}%
   \begin{list}{}{%
     \settowidth{\labelwidth}{20pt}%
-    \setlength{\parsep}{0pt}%
+    %\setlength{\parsep}{0pt}%
     \setlength{\itemsep}{0pt}%
     \setlength{\leftmargin}{\labelwidth+\labelsep}%
     \renewcommand{\makelabel}{\entrylabel}%


### PR DESCRIPTION
Some small improvements in the different formats based on the problems signaled with the issue
- doxygen.css make exceptions in line with other tables (i.e. the appearance of the name of the exception)
- doxygen.sty, rtfdocvisitor.cpp between items in e.g. Precondition, Postcondition, Note place a paragraph distance (like in main text)
- docbookvisitor.cpp handle title of Rcs and User sections correctly.

Example (with dummy texts): [aa.zip](https://github.com/doxygen/doxygen/files/2821877/aa.zip)
