### PR TITLE
issue #6812 Empty lines are lost when copy-pasting from code section.

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -667,7 +667,15 @@ void HtmlCodeGenerator::startCodeLine(bool hasLineNumbers)
 
 void HtmlCodeGenerator::endCodeLine()
 {
-  if (m_streamSet) m_t << "</div>";
+  if (m_streamSet)
+  {
+    if (m_col == 0)
+    {
+      m_t << " ";
+      m_col++;
+    }
+    m_t << "</div>";
+  }
 }
 
 void HtmlCodeGenerator::startFontClass(const char *s)


### PR DESCRIPTION
In case of an empty line insert an space so the line will be shown with copy & paste (including the space!).