### PR TITLE
Problem with just an asterisks on a `\code` line

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6651,7 +6651,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                             docBlock+=indent;
                                           }
   					}
-<DocCopyBlock>^{B}*"*"+/{BN}+"*"{BN}*	{ // start of a comment line with two *'s
+<DocCopyBlock>^{B}*"*"+/{B}+"*"{BN}*	{ // start of a comment line with two *'s
   					  if (docBlockName=="code")
                                           {
                                             QCString indent;


### PR DESCRIPTION
Problem occurs when a line with just a `*` is followed by another line with an `# and some comment. The test on newline has been removed.
Problem is most likely a consequence of Bug #5288 - Asterisks in comment wrongly displayed for @code, i.e. 23f337e64b95d3fa08f32980c866669b190c872f

Problem showed in the doxygen documentation with the description of the `\dot` command and a small version is in the attached example  (STRIP_CODE_COMMENTS=NO is essential):  [example.zip](https://github.com/doxygen/doxygen/files/2824418/example.zip)
