### PR TITLE
Bug 136299 - attributes to <p> tag get lost

### DIFF
--- a/src/docparser.h
+++ b/src/docparser.h
@@ -300,37 +300,52 @@ class DocURL : public DocNode
 class DocLineBreak : public DocNode
 {
   public:
-    DocLineBreak(DocNode *parent) { m_parent=parent; }
+    DocLineBreak(DocNode *parent) { m_parent = parent; }
+    DocLineBreak(DocNode *parent,const HtmlAttribList &attribs)
+      : m_attribs(attribs) { m_parent = parent; }
     Kind kind() const          { return Kind_LineBreak; }
     void accept(DocVisitor *v) { v->visit(this); }
 
+    const HtmlAttribList &attribs() const { return m_attribs; }
+
   private:
+    HtmlAttribList m_attribs;
 };
 
 /** Node representing a horizontal ruler */
 class DocHorRuler : public DocNode
 {
   public:
-    DocHorRuler(DocNode *parent) { m_parent = parent; }
+    DocHorRuler(DocNode *parent,const HtmlAttribList &attribs)
+      : m_attribs(attribs) { m_parent = parent; }
     Kind kind() const          { return Kind_HorRuler; }
     void accept(DocVisitor *v) { v->visit(this); }
 
+    const HtmlAttribList &attribs() const { return m_attribs; }
+
   private:
+    HtmlAttribList m_attribs;
 };
 
 /** Node representing an anchor */
 class DocAnchor : public DocNode
 {
   public:
-    DocAnchor(DocNode *parent,const QCString &id,bool newAnchor);
+    DocAnchor(DocNode *parent,const QCString &id,bool newAnchor){docAnchorInit(parent,id,newAnchor);}
+    DocAnchor(DocNode *parent,const QCString &id,bool newAnchor,const HtmlAttribList &attribs) : m_attribs(attribs)
+     {docAnchorInit(parent,id,newAnchor);}
     Kind kind() const          { return Kind_Anchor; }
     QCString anchor() const    { return m_anchor; }
     QCString file() const      { return m_file; }
     void accept(DocVisitor *v) { v->visit(this); }
 
+    const HtmlAttribList &attribs() const { return m_attribs; }
+
   private:
     QCString  m_anchor;
     QCString  m_file;
+    HtmlAttribList m_attribs;
+    void docAnchorInit(DocNode *parent,const QCString &id,bool newAnchor);
 };
 
 /** Node representing a citation of some bibliographic reference */
@@ -1199,11 +1214,13 @@ class DocPara : public CompAccept<DocPara>
     int handleHtmlHeader(const HtmlAttribList &tagHtmlAttribs,int level);
 
     bool injectToken(int tok,const QCString &tokText);
+    const HtmlAttribList &attribs() const { return m_attribs; }
 
   private:
     QCString  m_sectionId;
     bool     m_isFirst;
     bool     m_isLast;
+    HtmlAttribList m_attribs;
 };
 
 /** Node representing a parameter list. */

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -350,17 +350,17 @@ void HtmlDocVisitor::visit(DocURL *u)
   }
 }
 
-void HtmlDocVisitor::visit(DocLineBreak *)
+void HtmlDocVisitor::visit(DocLineBreak *br)
 {
   if (m_hide) return;
-  m_t << "<br />\n";
+  m_t << "<br "<< htmlAttribsToString(br->attribs()) << " />\n";
 }
 
 void HtmlDocVisitor::visit(DocHorRuler *hr)
 {
   if (m_hide) return;
   forceEndParagraph(hr);
-  m_t << "<hr/>\n";
+  m_t << "<hr "<< htmlAttribsToString(hr->attribs()) << " />\n";
   forceStartParagraph(hr);
 }
 
@@ -614,7 +614,7 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
 void HtmlDocVisitor::visit(DocAnchor *anc)
 {
   if (m_hide) return;
-  m_t << "<a class=\"anchor\" id=\"" << anc->anchor() << "\"></a>";
+  m_t << "<a class=\"anchor\" id=\"" << anc->anchor() << "\"" << htmlAttribsToString(anc->attribs()) << "></a>";
 }
 
 void HtmlDocVisitor::visit(DocInclude *inc)
@@ -1206,9 +1206,9 @@ void HtmlDocVisitor::visitPre(DocPara *p)
   //printf("  needsTag=%d\n",needsTag);
   // write the paragraph tag (if needed)
   if (needsTag)
-    m_t << "<p" << getDirHtmlClassOfNode(getTextDirByConfig(p), contexts[t]) << ">";
+    m_t << "<p" << getDirHtmlClassOfNode(getTextDirByConfig(p), contexts[t]) << htmlAttribsToString(p->attribs()) << ">";
   else if(!paragraphAlreadyStarted)
-    m_t << getHtmlDirEmbedingChar(getTextDirByConfig(p));
+    m_t << getHtmlDirEmbedingChar(getTextDirByConfig(p)) << htmlAttribsToString(p->attribs());
 }
 
 void HtmlDocVisitor::visitPost(DocPara *p)
@@ -1492,7 +1492,9 @@ void HtmlDocVisitor::visitPre(DocHtmlTable *t)
 
   if (t->hasCaption())
   {
-    m_t << "<a class=\"anchor\" id=\"" << t->caption()->anchor() << "\"></a>\n";
+    QCString anc =  t->caption()->anchor();
+    if (!anc.isEmpty())
+      m_t << "<a class=\"anchor\" id=\"" << anc << "\"></a>\n";
   }
 
   QString attrs = htmlAttribsToString(t->attribs());

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6732,7 +6732,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					}
 <DocCopyBlock><<EOF>>			{
   					  warn(yyFileName,yyLineNr,
-					      "reached end of file while inside a %s block!\n"
+					      "reached end of file while inside a `%s' block!\n"
 					      "The command that should end the block seems to be missing!\n",
 					      docBlockName.data());
   					  yyterminate();


### PR DESCRIPTION
Besides the `p` tag there were a number of other tags were also the attributes were lost:
- `br`
- `hr`
- `a` in case of used as an anchor i.e. with the `name=` attribute

In case of a `caption` with a `table` and no `id=` attribute with the `caption` there was still an anchor generated

In scanner.l the warnings message was a bit unclear.