### PR TITLE
Issue #6818 Certain regex pattern in class constant causes PHP class to be ignored

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6829,6 +6829,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <SkipComment>[^\*\n]+
 
 <*>"[["                                 { // C++11 attribute
+  					  if (!insideCpp) REJECT;
                                           lastC11AttributeContext = YY_START;
                                           BEGIN( SkipC11Attribute );
                                         }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6829,7 +6829,8 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <SkipComment>[^\*\n]+
 
 <*>"[["                                 { // C++11 attribute
-  					  if (!insideCpp) REJECT;
+                                          if (!insideCpp) REJECT;
+                                          if (YY_START == CopyGString || YY_START == CopyGString) REJECT;
                                           lastC11AttributeContext = YY_START;
                                           BEGIN( SkipC11Attribute );
                                         }


### PR DESCRIPTION
Only apply the rule `<*>"[["` for Cpp
See also fix d8001efd89146e04d92f5ea41ab27a7de09b6c53 i.e. Problem parsing c++ gnu::visibility (Origin: bugzilla #787952) #6259