### PR TITLE
Bug 766508 - missing comments of overridden methods

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7818,6 +7818,7 @@ static void computeMemberRelations()
           //      );
           if (md!=bmd && bmcd && mcd && bmcd!=mcd &&
               (bmd->virtualness()!=Normal || bmd->getLanguage()==SrcLangExt_Python ||
+               bmd->getLanguage()==SrcLangExt_Java || bmd->getLanguage()==SrcLangExt_PHP ||
                bmcd->compoundType()==ClassDef::Interface ||
                bmcd->compoundType()==ClassDef::Protocol
               ) &&


### PR DESCRIPTION
Analogous to python also for PHP and Java all functions are by default virtual (for python fix see problem #6566 and fix #6570)