### PR TITLE
Bug 626582 - Function overloads are not actually sorted in member function list

### DIFF
--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -90,6 +90,7 @@ int MemberList::compareValues(const MemberDef *c1, const MemberDef *c2) const
       return 1;
   }
   int cmp = qstricmp(c1->name(),c2->name());
+  if (cmp==0) cmp = qstricmp(c1->argsString(),c2->argsString());
   return cmp!=0 ? cmp : c1->getDefLine()-c2->getDefLine();
 }
 


### PR DESCRIPTION
List was only sorted on member names, now also subsequently sorted on arguments.