### PR TITLE
issue #6828 Physical newlines (^^) in ALIASES configuration tags not working with sections, subsections, subsubsections and paragraphs

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10021,7 +10021,7 @@ static void escapeAliases()
     while ((in=value.find("^^",p))!=-1)
     {
       newValue+=value.mid(p,in-p);
-      newValue+="@_linebr";
+      newValue+="\\\\_linebr";
       p=in+2;
     }
     newValue+=value.mid(p,value.length()-p);


### PR DESCRIPTION
Previous changes corrected use of _linebr, missed one so this was not handled properly.