### PR TITLE
Section title runs into margin

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -38,7 +38,7 @@
 
 const int maxLevels=5;
 static const char *secLabels[maxLevels] = 
-   { "section","subsection","subsubsection","paragraph","subparagraph" };
+   { "doxysection","doxysubsection","doxysubsubsection","doxyparagraph","doxysubparagraph" };
 
 static const char *getSectionName(int level)
 {

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -913,39 +913,39 @@ void LatexGenerator::startIndexSection(IndexSections is)
       }
       break;
     case isMainPage:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Introduction}\n"
       break;
     //case isPackageIndex:
-    //  if (compactLatex) t << "\\section"; else t << "\\chapter";
+    //  if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
     //  t << "{"; //Package Index}\n"
     //  break;
     case isModuleIndex:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Module Index}\n"
       break;
     case isDirIndex:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Directory Index}\n"
       break;
     case isNamespaceIndex:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Namespace Index}\"
       break;
     case isClassHierarchyIndex:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Hierarchical Index}\n"
       break;
     case isCompoundIndex:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Annotated Compound Index}\n"
       break;
     case isFileIndex:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Annotated File Index}\n"
       break;
     case isPageIndex:
-      if (compactLatex) t << "\\section"; else t << "\\chapter";
+      if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
       t << "{"; //Annotated Page Index}\n"
       break;
     case isModuleDocumentation:
@@ -957,7 +957,7 @@ void LatexGenerator::startIndexSection(IndexSections is)
         {
           if (!gd->isReference())
           {
-            if (compactLatex) t << "\\section"; else t << "\\chapter";
+            if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
             t << "{"; //Module Documentation}\n";
             found=TRUE;
           }
@@ -973,7 +973,7 @@ void LatexGenerator::startIndexSection(IndexSections is)
         {
           if (dd->isLinkableInProject())
           {
-            if (compactLatex) t << "\\section"; else t << "\\chapter";
+            if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
             t << "{"; //Module Documentation}\n";
             found=TRUE;
           }
@@ -989,7 +989,7 @@ void LatexGenerator::startIndexSection(IndexSections is)
         {
           if (nd->isLinkableInProject())
           {
-            if (compactLatex) t << "\\section"; else t << "\\chapter";
+            if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
             t << "{"; // Namespace Documentation}\n":
             found=TRUE;
           }
@@ -1008,7 +1008,7 @@ void LatexGenerator::startIndexSection(IndexSections is)
               !cd->isEmbeddedInOuterScope()
              )
           {
-            if (compactLatex) t << "\\section"; else t << "\\chapter";
+            if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
             t << "{"; //Compound Documentation}\n";
             found=TRUE;
           }
@@ -1030,7 +1030,7 @@ void LatexGenerator::startIndexSection(IndexSections is)
             {
               if (isFirst)
               {
-                if (compactLatex) t << "\\section"; else t << "\\chapter";
+                if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
                 t << "{"; //File Documentation}\n";
                 isFirst=FALSE;
                 break;
@@ -1042,13 +1042,13 @@ void LatexGenerator::startIndexSection(IndexSections is)
       break;
     case isExampleDocumentation:
       {
-        if (compactLatex) t << "\\section"; else t << "\\chapter";
+        if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
         t << "{"; //Example Documentation}\n";
       }
       break;
     case isPageDocumentation:
       {
-        if (compactLatex) t << "\\section"; else t << "\\chapter";
+        if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
         t << "{"; //Page Documentation}\n";
       }
       break;
@@ -1275,7 +1275,7 @@ void LatexGenerator::endIndexSection(IndexSections is)
         {
           if (!pd->getGroupDef() && !pd->isReference())
           {
-             if (compactLatex) t << "\\section"; else t << "\\chapter";
+             if (compactLatex) t << "\\doxysection"; else t << "\\chapter";
              t << "{" << pd->title();
              t << "}\n";
             
@@ -1515,11 +1515,11 @@ void LatexGenerator::startTitleHead(const char *fileName)
   }
   if (Config_getBool(COMPACT_LATEX)) 
   {
-    t << "\\subsection{"; 
+    t << "\\doxysubsection{"; 
   }
   else 
   {
-    t << "\\section{"; 
+    t << "\\doxysection{"; 
   }
 }
 
@@ -1540,11 +1540,11 @@ void LatexGenerator::startTitle()
 {
   if (Config_getBool(COMPACT_LATEX)) 
   {
-    t << "\\subsection{"; 
+    t << "\\doxysubsection{"; 
   }
   else 
   {
-    t << "\\section{"; 
+    t << "\\doxysection{"; 
   }
 }
 
@@ -1557,19 +1557,19 @@ void LatexGenerator::startGroupHeader(int extraIndentLevel)
 
   if (extraIndentLevel==3)
   {
-    t << "\\subparagraph*{"; 
+    t << "\\doxysubparagraph*{"; 
   }
   else if (extraIndentLevel==2)
   {
-    t << "\\paragraph{";
+    t << "\\doxyparagraph{";
   }
   else if (extraIndentLevel==1)
   {
-    t << "\\subsubsection{";
+    t << "\\doxysubsubsection{";
   }
   else // extraIndentLevel==0
   {
-    t << "\\subsection{";
+    t << "\\doxysubsection{";
   }
   disableLinks=TRUE;
 }
@@ -1584,11 +1584,11 @@ void LatexGenerator::startMemberHeader(const char *,int)
 {
   if (Config_getBool(COMPACT_LATEX)) 
   {
-    t << "\\subsubsection*{"; 
+    t << "\\doxysubsubsection*{"; 
   }
   else 
   {
-    t << "\\subsection*{";
+    t << "\\doxysubsection*{";
   }
   disableLinks=TRUE;
 }
@@ -1637,7 +1637,7 @@ void LatexGenerator::startMemberDoc(const char *clname,
     }
     t << "}" << endl;
   }
-  static const char *levelLab[] = { "subsubsection","paragraph","subparagraph", "subparagraph" };
+  static const char *levelLab[] = { "doxysubsubsection","doxyparagraph","doxysubparagraph", "doxysubparagraph" };
   static bool compactLatex = Config_getBool(COMPACT_LATEX);
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   int level=0;
@@ -1755,11 +1755,11 @@ void LatexGenerator::startSection(const char *lab,const char *,SectionInfo::Sect
   {
     switch(type)
     {
-      case SectionInfo::Page:          t << "subsection"; break;
-      case SectionInfo::Section:       t << "subsubsection"; break;
-      case SectionInfo::Subsection:    t << "paragraph"; break;
-      case SectionInfo::Subsubsection: t << "subparagraph"; break;
-      case SectionInfo::Paragraph:     t << "subparagraph"; break;
+      case SectionInfo::Page:          t << "doxysubsection"; break;
+      case SectionInfo::Section:       t << "doxysubsubsection"; break;
+      case SectionInfo::Subsection:    t << "doxyparagraph"; break;
+      case SectionInfo::Subsubsection: t << "doxysubparagraph"; break;
+      case SectionInfo::Paragraph:     t << "doxysubparagraph"; break;
       default: ASSERT(0); break;
     }
     t << "{";
@@ -1768,11 +1768,11 @@ void LatexGenerator::startSection(const char *lab,const char *,SectionInfo::Sect
   {
     switch(type)
     {
-      case SectionInfo::Page:          t << "section"; break;
-      case SectionInfo::Section:       t << "subsection"; break;
-      case SectionInfo::Subsection:    t << "subsubsection"; break;
-      case SectionInfo::Subsubsection: t << "paragraph"; break;
-      case SectionInfo::Paragraph:     t << "subparagraph"; break;
+      case SectionInfo::Page:          t << "doxysection"; break;
+      case SectionInfo::Section:       t << "doxysubsection"; break;
+      case SectionInfo::Subsection:    t << "doxysubsubsection"; break;
+      case SectionInfo::Subsubsection: t << "doxyparagraph"; break;
+      case SectionInfo::Paragraph:     t << "doxysubparagraph"; break;
       default: ASSERT(0); break;
     }
     t << "{";
@@ -1800,7 +1800,7 @@ void LatexGenerator::writeChar(char c)
 
 void LatexGenerator::startClassDiagram()
 {
-  //if (Config_getBool(COMPACT_LATEX)) t << "\\subsubsection"; else t << "\\subsection";
+  //if (Config_getBool(COMPACT_LATEX)) t << "\\doxysubsubsection"; else t << "\\doxysubsection";
   //t << "{";
 }
 
@@ -1994,11 +1994,11 @@ void LatexGenerator::startMemberGroupHeader(bool hasHeader)
   // changed back to rev 756 due to bug 660501
   //if (Config_getBool(COMPACT_LATEX)) 
   //{
-  //  t << "\\subparagraph*{";
+  //  t << "\\doxysubparagraph*{";
   //}
   //else
   //{
-  //  t << "\\paragraph*{";
+  //  t << "\\doxyparagraph*{";
   //}
 }
 
@@ -2243,11 +2243,11 @@ void LatexGenerator::startInlineHeader()
 {
   if (Config_getBool(COMPACT_LATEX)) 
   {
-    t << "\\paragraph*{"; 
+    t << "\\doxyparagraph*{"; 
   }
   else 
   {
-    t << "\\subsubsection*{";
+    t << "\\doxysubsubsection*{";
   }
 }
 

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -545,6 +545,15 @@
 % Version of hypertarget with correct landing location
 \newcommand{\Hypertarget}[1]{\Hy@raisedlink{\hypertarget{#1}{}}}
 
+% possibility to have sections etc. be within the margins
+\makeatletter
+\newcommand{\doxysection}[1]{\@ifstar{\begingroup\sloppy\raggedright\section*{#1}\endgroup}{\begingroup\sloppy\raggedright\section{#1}\endgroup}}
+\newcommand{\doxysubsection}[1]{\@ifstar{\begingroup\sloppy\raggedright\subsection*{#1}\endgroup}{\begingroup\sloppy\raggedright\subsection{#1}\endgroup}}
+\newcommand{\doxysubsubsection}[1]{\@ifstar{\begingroup\sloppy\raggedright\subsubsection*{#1}\endgroup}{\begingroup\sloppy\raggedright\subsubsection{#1}\endgroup}}
+\newcommand{\doxyparagraph}[1]{@ifstar{\begingroup\sloppy\raggedright\paragraph*{#1}\endgroup}{\begingroup\sloppy\raggedright\paragraph{#1}\endgroup}}
+\newcommand{\doxysubparagraph}[1]{@ifstar{\begingroup\sloppy\raggedright\subparagraph*{#1}\endgroup}{\begingroup\sloppy\raggedright\subparagraph{#1}\endgroup}}
+\makeatother
+
 % Define caption that is also suitable in a table
 \makeatletter
 \def\doxyfigcaption{%


### PR DESCRIPTION
In the PDF version of the doxygen manual we see that for the `\image` command the chapter title the text runs into the margin (due to an unbreakable part).
With this fix the problem is solved.
(see also: https://tex.stackexchange.com/questions/474055/section-title-running-into-margin and , for the ifstar part, https://tex.stackexchange.com/questions/376375/using-ifstar-to-define-a-star-variant)