### PR TITLE
issue #6830 Message: graph_legend:39: error: Prevented to copy file <path_to_html_output>/graph_legend.png onto itself!

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -335,11 +335,11 @@ static QCString findAndCopyImage(const char *fileName,DocImage::Type type, bool 
               "could not write output image %s",qPrint(outputFile));
         }
       }
-      else
-      {
-        warn(g_fileName,doctokenizerYYlineno,
-             "Prevented to copy file %s onto itself!\n",qPrint(inputFile));
-      }
+      //else
+      //{
+      //  warn(g_fileName,doctokenizerYYlineno,
+      //       "Prevented to copy file %s onto itself!\n",qPrint(inputFile));
+      //}
     }
     else
     {


### PR DESCRIPTION
In version 1.8.14 the message "Source and Destination are the same!" was given, this message could not be suppressed as can be done with normal warnings, this was corrected in 1.8.15 but backfires in case `WARN_AS_ERROR` is set. The problem only occurs when the output directory is searched for images.
Removed the message as it does not contain real information.