### PR TITLE
Bug 399222 - SORT_BRIEF_DOCS produces wrong results

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1966,6 +1966,18 @@ void FileDef::sortMemberLists()
   {
     if (ml->needsSorting()) { ml->sort(); ml->setNeedsSorting(FALSE); }
   }
+
+  if (m_memberGroupSDict)
+  {
+    MemberGroupSDict::Iterator mgli(*m_memberGroupSDict);
+    MemberGroup *mg;
+    for (;(mg=mgli.current());++mgli)
+    {
+      MemberList *mlg = mg->members();
+      if (mlg->needsSorting()) { mlg->sort(); mlg->setNeedsSorting(FALSE); }
+    }
+  }
+
 }
 
 MemberList *FileDef::getMemberList(MemberListType lt) const

--- a/src/membergroup.cpp
+++ b/src/membergroup.cpp
@@ -44,8 +44,11 @@ MemberGroup::MemberGroup()
 MemberGroup::MemberGroup(Definition *parent,
       int id,const char *hdr,const char *d,const char *docFile,int docLine)
 {
+  static bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
+
   //printf("New member group id=%d header=%s desc=%s\n",id,hdr,d);
   memberList      = new MemberList(MemberListType_memberGroup);
+  memberList->setNeedsSorting(sortBriefDocs); // detailed sections are already sorted elsewhere.
   grpId           = id;
   grpHeader       = hdr;
   doc             = d;


### PR DESCRIPTION
Grouped brief (with `\{ ..\}` descriptions were not sorted when `SORT_BRIEF_DOCS` was set, the detailed documentation was sorted already.