### PR TITLE
Adjustment of xhtml1-transitional.dtd

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -3854,7 +3854,7 @@ class TextGeneratorHtml : public TextGeneratorIntf
       if (ref)
       {
         m_ts << "<a class=\"elRef\" ";
-        m_ts << externalLinkTarget() << externalRef(m_relPath,ref,FALSE);
+        m_ts << externalLinkTarget();
       }
       else
       {

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -261,7 +261,7 @@ static void writeMapArea(FTextStream &t,ClassDef *cd,QCString relPath,
     t << "<area ";
     if (!ref.isEmpty()) 
     {
-      t << externalLinkTarget() << externalRef(relPath,ref,FALSE);
+      t << externalLinkTarget();
     }
     t << "href=\"";
     t << externalRef(relPath,ref,TRUE);

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -336,7 +336,6 @@ static QCString replaceRef(const QCString &buf,const QCString relPath,
         {
           result = externalLinkTarget();
 	  if (result != "") setTarget = TRUE;
-	  result += externalRef(relPath,ref,FALSE);
         }
         result+= href+"=\"";
         result+=externalRef(relPath,ref,TRUE);

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -721,7 +721,7 @@ static bool insertMapFile(FTextStream &out,const QCString &mapFile,
   {
     QGString tmpstr;
     FTextStream tmpout(&tmpstr);
-    convertMapFile(tmpout,mapFile,relPath);
+    convertMapFile(tmpout,mapFile,relPath,TRUE);
     if (!tmpstr.isEmpty())
     {
       out << "<map name=\"" << mapLabel << "\" id=\"" << mapLabel << "\">" << endl;

--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -286,7 +286,7 @@ void FTVHelp::generateLink(FTextStream &t,FTVNode *n)
       t << "<a class=\"elRef\" ";
       QCString result = externalLinkTarget();
       if (result != "") setTarget = TRUE;
-      t << result << externalRef("",n->ref,FALSE);
+      t << result;
     }
     else // local link
     {

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2195,7 +2195,7 @@ void HtmlDocVisitor::startLink(const QCString &ref,const QCString &file,
   if (!ref.isEmpty()) // link to entity imported via tag file
   {
     m_t << "<a class=\"elRef\" ";
-    m_t << externalLinkTarget() << externalRef(relPath,ref,FALSE);
+    m_t << externalLinkTarget();
   }
   else // local link
   {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1122,7 +1122,7 @@ void HtmlGenerator::startIndexItem(const char *ref,const char *f)
     if (ref)
     {
       t << "<a class=\"elRef\" ";
-      t << externalLinkTarget() << externalRef(relPath,ref,FALSE);
+      t << externalLinkTarget();
     }
     else
     {
@@ -1168,7 +1168,7 @@ void HtmlGenerator::writeObjectLink(const char *ref,const char *f,
   if (ref)
   {
     t << "<a class=\"elRef\" ";
-    t << externalLinkTarget() << externalRef(relPath,ref,FALSE);
+    t << externalLinkTarget();
   }
   else
   {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -556,7 +556,7 @@ void HtmlCodeGenerator::_writeCodeLink(const char *className,
   if (ref)
   {
     m_t << "<a class=\"" << className << "Ref\" ";
-    m_t << externalLinkTarget() << externalRef(m_relPath,ref,FALSE);
+    m_t << externalLinkTarget();
   }
   else
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8220,10 +8220,6 @@ QCString externalRef(const QCString &relPath,const QCString &ref,bool href)
         result.prepend(relPath);
         l+=relPath.length();
       }
-      if (!href){
-        result.prepend("doxygen=\""+ref+":");
-        l+=10+ref.length();
-      }
       if (l>0 && result.at(l-1)!='/') result+='/';
       if (!href) result.append("\" ");
     }

--- a/testing/dtd/xhtml1-transitional.dtd
+++ b/testing/dtd/xhtml1-transitional.dtd
@@ -30,14 +30,6 @@
          <!ATTLIST script
        added 
          async       (async)        #IMPLIED
-     - in
-         <!ATTLIST a
-       added 
-         doxygen     %URI;          #IMPLIED
-     - in
-         <!ATTLIST area
-       added
-         doxygen     %URI;          #IMPLIED
 -->
 
 <!--================ Character mnemonic entities =========================-->
@@ -654,7 +646,6 @@
 <!--================== The Anchor Element ================================-->
 
 <!-- content is %Inline; except that anchors shouldn't be nested -->
-<!-- added for doxygen: doxygen     %URI;          #IMPLIED -->
 
 <!ELEMENT a %a.content;>
 <!ATTLIST a
@@ -663,7 +654,6 @@
   charset     %Charset;      #IMPLIED
   type        %ContentType;  #IMPLIED
   name        NMTOKEN        #IMPLIED
-  doxygen     %URI;          #IMPLIED
   href        %URI;          #IMPLIED
   hreflang    %LanguageCode; #IMPLIED
   rel         %LinkTypes;    #IMPLIED
@@ -889,14 +879,12 @@
   name        CDATA          #IMPLIED
   >
 
-<!-- added for doxygen: doxygen     %URI;          #IMPLIED -->
 <!ELEMENT area EMPTY>
 <!ATTLIST area
   %attrs;
   %focus;
   shape       %Shape;        "rect"
   coords      %Coords;       #IMPLIED
-  doxygen     %URI;          #IMPLIED
   href        %URI;          #IMPLIED
   nohref      (nohref)       #IMPLIED
   alt         %Text;         #REQUIRED

--- a/testing/dtd/xhtml1-transitional.dtd
+++ b/testing/dtd/xhtml1-transitional.dtd
@@ -34,6 +34,10 @@
          <!ATTLIST a
        added 
          doxygen     %URI;          #IMPLIED
+     - in
+         <!ATTLIST area
+       added
+         doxygen     %URI;          #IMPLIED
 -->
 
 <!--================ Character mnemonic entities =========================-->
@@ -885,12 +889,14 @@
   name        CDATA          #IMPLIED
   >
 
+<!-- added for doxygen: doxygen     %URI;          #IMPLIED -->
 <!ELEMENT area EMPTY>
 <!ATTLIST area
   %attrs;
   %focus;
   shape       %Shape;        "rect"
   coords      %Coords;       #IMPLIED
+  doxygen     %URI;          #IMPLIED
   href        %URI;          #IMPLIED
   nohref      (nohref)       #IMPLIED
   alt         %Text;         #REQUIRED


### PR DESCRIPTION
Adding attributes:
- doxygen
to be able to validate doxygen generated xhtml documents.

Analogous to #6681 but now for the area tag (found in the doxygen tag example).