### PR TITLE
issue #6840 Hash character in Markdown code span not rendered correctly

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -138,6 +138,7 @@ static QCString escapeSpecialChars(const QCString &s)
       case '>':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('>'); break;
       case '\\': if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('\\'); break;
       case '@':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('@'); break;
+      case '#':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('#'); break;
       default:   growBuf.addChar(c); break;
     }
     pc=c;


### PR DESCRIPTION
A hash sign has a special meaning, so it should be escaped in a code span.