### PR TITLE
Bug 322353 - C variable argument list doesn't work in @param

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6987,6 +6987,7 @@ static void handleParametersCommentBlocks(ArgumentList *al)
     //printf("    Param %s docs=%s\n",a->name.data(),a->docs.data());
     if (!a->docs.isEmpty())
     {
+      if  (!a->name && a->type == "...") a->name= "...";
       int position=0;
       bool needsEntry;
 


### PR DESCRIPTION
The `...` argument was not documented in case of inline parameter documentation, with `\param` it was possible to document the `...` argument.