### PR TITLE
Latex code double minus goes to endash

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6856,6 +6856,7 @@ void filterLatexString(FTextStream &t,const char *str,
         case '%':  t << "\\%"; break;
         case '#':  t << "\\#"; break;
         case '$':  t << "\\$"; break;
+        case '-':  t << "-\\/"; break;
         case '^':  (usedTableLevels()>0) ? t << "\\string^" : t << (char)c;    break;
         case '~':  (usedTableLevels()>0) ? t << "\\string~" : t << (char)c;    break;
         case ' ':  if (keepSpaces) t << "~"; else t << ' ';


### PR DESCRIPTION
In case in code 2 consecutive minus signs are present they are shown as endash.
using the same code as in the non code part solves the issue.
Issue can e.g. be seen in cpp source code (with e.g. i--) and in the doxygen documentation in the paragraph "Comment blocks in VHDL"
This is a regression in 1.8.15