### PR TITLE
Removed page restriction with `\anchor` command in documentation

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -1969,10 +1969,6 @@ Commands to create links
   This command places an invisible, named anchor into the documentation
   to which you can refer with the \ref cmdref "\\ref" command.
 
-  \note Anchors can currently only be put into a comment block
-  that is marked as a page (using \ref cmdpage "\\page") or mainpage
-  (\ref cmdmainpage "\\mainpage").
-
   \sa section \ref cmdref "\\ref".
 
 <hr>


### PR DESCRIPTION
The `\anchor` command can used on other places as well.