### PR TITLE
Indentation of paragraphs in LaTeX

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -308,7 +308,7 @@
 \newenvironment{DoxyParagraph}[1]{%
   \begin{list}{}{%
     \settowidth{\labelwidth}{40pt}%
-    \setlength{\leftmargin}{\labelwidth}%
+    \setlength{\leftmargin}{\labelwidth+\labelsep}%
     \setlength{\parsep}{0pt}%
     \setlength{\itemsep}{-4pt}%
     \renewcommand{\makelabel}{\entrylabel}%


### PR DESCRIPTION
Looking in the documentation at e.g. the commands `\class` or `\image` (in the doxygen documentation) we see that the start of some paragraph titles in LaTeX is a bit to the left of the normal indentation.
Corrected the leftmargin setting (consistent with other settings).