### PR TITLE
Bug 645910 - Segfault on recursion while parsing "\subpage A" in "\page A"

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8727,7 +8727,14 @@ static void computePageRelations(Entry *root)
       for (bii.toFirst();(bi=bii.current());++bii)
       {
         PageDef *subPd = Doxygen::pageSDict->find(bi->name);
-        if (subPd)
+        if (pd==subPd)
+        {
+         err("page defined at line %d of file %s with label %s is a direct "
+             "subpage of itself! Please remove this cyclic dependency.\n",
+              pd->docLine(),pd->docFile().data(),pd->name().data());
+          exit(1);
+        }
+        else if (subPd)
         {
           pd->addInnerCompound(subPd);
           //printf("*** Added subpage relation: %s->%s\n",


### PR DESCRIPTION
In version 1.7.3 (till 1.8.7) the problem of direct recursion (i.e. in a page is a subpage to itself) we got a segmentation fault, as of 1.8.8 the problem went into an endless loop.
The direct recursion is now detected.