### PR TITLE
issue #6847 Physical newlines (^^) in ALIASES produce a mismatch between documentation and source code

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9824,7 +9824,7 @@ static void escapeAliases()
     while ((in=value.find("^^",p))!=-1)
     {
       newValue+=value.mid(p,in-p);
-      newValue+="\\\\_linebr";
+      newValue+="\\\\_linebr ";
       p=in+2;
     }
     newValue+=value.mid(p,value.length()-p);


### PR DESCRIPTION
In 1.8.15 the `^^` was already translated to `\_linebr` but here there was a ` ` (space) after the `^^`, here this is not the case resulting in "warning: Found unknown command `\_linebrline` "
placing a ` `  after the translated value solves this problem.