### PR TITLE
issue #6856 Doxygen only expands macro defined in header file once when referred multiple times

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -464,13 +464,10 @@ static FileState *checkAndOpenFile(const QCString &fileName,bool &alreadyInclude
     // global guard
     if (g_curlyCount==0) // not #include inside { ... }
     {
-      if (g_allIncludes.find(absName)!=0)
+      if (g_allIncludes.find(absName)==0)
       {
-        alreadyIncluded = TRUE;
-        //printf("  already included 1\n");
-        return 0; // already done
+        g_allIncludes.insert(absName,(void *)0x8);
       }
-      g_allIncludes.insert(absName,(void *)0x8);
     }
     // check include stack for absName
 


### PR DESCRIPTION
In case the include file is already is already in the global stack it should not be added to the global stack, but still be handled for the current file