### PR TITLE
Warning if no file specified for special reading commands

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2048,6 +2048,29 @@ void DocInclude::parse()
 
 void DocIncOperator::parse()
 {
+  if (g_includeFileName.isEmpty())
+  {
+    QCString cmd;
+    switch(type())
+    {
+      case Line:
+        cmd = "\\line";
+        break;
+      case SkipLine:
+        cmd = "\\skipLine";
+        break;
+      case Skip:
+        cmd = "\\skip";
+        break;
+      case Until:
+        cmd = "\\until";
+        break;
+    }
+    warn_doc_error(g_fileName,doctokenizerYYlineno,
+                   "No previous '\\include' or \\dontinclude' command for '%s' present",
+                   cmd.data());
+  }
+
   m_includeFileName = g_includeFileName;
   const char *p = g_includeFileText;
   uint l = g_includeFileLength;


### PR DESCRIPTION
Create a warning in case no `\include` or `\dontinclude` command has been given before using `\skip`, `\line`, `\skipline` or `\until`