### PR TITLE
Show line numbers in "split" examples

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2186,7 +2186,7 @@ Commands for displaying examples
 \htmlonly</p></center><p>\endhtmlonly
 
 <hr>
-\section cmddontinclude \\dontinclude <file-name>
+\section cmddontinclude \\dontinclude[{lineno}] <file-name>
 
   \addindex \\dontinclude
   This command can be used to parse a source file without actually
@@ -2196,6 +2196,8 @@ Commands for displaying examples
   Source files or directories can be specified using the
   \ref cfg_example_path "EXAMPLE_PATH"
   tag of doxygen's configuration file.
+
+  You can add option `{lineno}` to enable line numbers for the included code if desired.
 
   The class and member declarations and definitions inside the code fragment
   are 'remembered' during the parsing of the comment block that contained

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -479,10 +479,25 @@ DB_VIS_C
     popEnabled();
     if (!m_hide)
     {
+      FileDef *fd;
+      if (!op->includeFileName().isEmpty())
+      {
+        QFileInfo cfi( op->includeFileName() );
+        fd = createFileDef( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+      }
+
       Doxygen::parserManager->getParser(m_langExt)
         ->parseCode(m_ci,op->context(),
             op->text(),langExt,op->isExample(),
-            op->exampleFile());
+            op->exampleFile(),
+            fd,     // fileDef
+            op->line(),    // startLine
+            -1,    // endLine
+            FALSE, // inline fragment
+            0,     // memberDef
+            op->lineno()  // show line numbers
+         );
+      if (fd) delete fd;
     }
     pushEnabled();
     m_hide=TRUE;

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -563,7 +563,8 @@ class DocInclude : public DocNode
 {
   public:
   enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude,
-	      IncWithLines, Snippet , IncludeDoc, SnippetDoc, SnipWithLines};
+	      IncWithLines, Snippet , IncludeDoc, SnippetDoc, SnipWithLines,
+	      DontIncWithLines};
     DocInclude(DocNode *parent,const QCString &file,
                const QCString context, Type t,
                bool isExample,const QCString exampleFile,
@@ -612,6 +613,8 @@ class DocIncOperator : public DocNode
       m_isExample(isExample), m_exampleFile(exampleFile) { m_parent = parent; }
     Kind kind() const           { return Kind_IncOperator; }
     Type type() const           { return m_type; }
+    int line() const             { return m_line; }
+    bool lineno() const          { return m_lineno; }
     QCString text() const        { return m_text; }
     QCString pattern() const     { return m_pattern; }
     QCString context() const     { return m_context; }
@@ -627,6 +630,8 @@ class DocIncOperator : public DocNode
 
   private:
     Type     m_type;
+    int      m_line;
+    bool     m_lineno;
     QCString  m_text;
     QCString  m_pattern;
     QCString  m_context;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -762,6 +762,12 @@ void HtmlDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
+      FileDef *fd;
+      if (!op->includeFileName().isEmpty())
+      {
+        QFileInfo cfi( op->includeFileName() );
+        fd = createFileDef( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+      }
       Doxygen::parserManager->getParser(m_langExt)
                             ->parseCode(
                                 m_ci,
@@ -770,14 +776,15 @@ void HtmlDocVisitor::visit(DocIncOperator *op)
                                 langExt,
                                 op->isExample(),
                                 op->exampleFile(),
-                                0,     // fileDef
-                                -1,    // startLine
+                                fd,     // fileDef
+                                op->line(),    // startLine
                                 -1,    // endLine
                                 FALSE, // inline fragment
                                 0,     // memberDef
-                                TRUE,  // show line numbers
+                                op->lineno(),  // show line numbers
                                 m_ctx  // search context
                                );
+      if (fd) delete fd;
     }
     pushEnabled();
     m_hide=TRUE;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -572,9 +572,24 @@ void LatexDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
+      FileDef *fd;
+      if (!op->includeFileName().isEmpty())
+      {
+        QFileInfo cfi( op->includeFileName() );
+        fd = createFileDef( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+      }
+
       Doxygen::parserManager->getParser(m_langExt)
                             ->parseCode(m_ci,op->context(),op->text(),langExt,
-                                        op->isExample(),op->exampleFile());
+                                        op->isExample(),op->exampleFile(),
+                                        fd,     // fileDef
+                                        op->line(),    // startLine
+                                        -1,    // endLine
+                                        FALSE, // inline fragment
+                                        0,     // memberDef
+                                        op->lineno()  // show line numbers
+                                       );
+      if (fd) delete fd;
     }
     pushEnabled();
     m_hide=TRUE;

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -387,9 +387,24 @@ void ManDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
+      FileDef *fd;
+      if (!op->includeFileName().isEmpty())
+      {
+        QFileInfo cfi( op->includeFileName() );
+        fd = createFileDef( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+      }
+
       Doxygen::parserManager->getParser(m_langExt)
                             ->parseCode(m_ci,op->context(),op->text(),langExt,
-                                        op->isExample(),op->exampleFile());
+                                        op->isExample(),op->exampleFile(),
+                                        fd,     // fileDef
+                                        op->line(),    // startLine
+                                        -1,    // endLine
+                                        FALSE, // inline fragment
+                                        0,     // memberDef
+                                        op->lineno()  // show line numbers
+                                       );
+      if (fd) delete fd;
     }
     pushEnabled();
     m_hide=TRUE;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -550,9 +550,24 @@ void RTFDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
+      FileDef *fd;
+      if (!op->includeFileName().isEmpty())
+      {
+        QFileInfo cfi( op->includeFileName() );
+        fd = createFileDef( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+      }
+
       Doxygen::parserManager->getParser(m_langExt)
                             ->parseCode(m_ci,op->context(),op->text(),langExt,
-                                        op->isExample(),op->exampleFile());
+                                        op->isExample(),op->exampleFile(),
+                                        fd,     // fileDef
+                                        op->line(),    // startLine
+                                        -1,    // endLine
+                                        FALSE, // inline fragment
+                                        0,     // memberDef
+                                        op->lineno()  // show line numbers
+                                       );
+      if (fd) delete fd;
     }
     pushEnabled();
     m_hide=TRUE;

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -420,10 +420,25 @@ void XmlDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
+      FileDef *fd;
+      if (!op->includeFileName().isEmpty())
+      {
+        QFileInfo cfi( op->includeFileName() );
+        fd = createFileDef( cfi.dirPath().utf8(), cfi.fileName().utf8() );
+      }
+
       Doxygen::parserManager->getParser(m_langExt)
                             ->parseCode(m_ci,op->context(),
                                         op->text(),langExt,op->isExample(),
-                                        op->exampleFile());
+                                        op->exampleFile(),
+                                        fd,     // fileDef
+                                        op->line(),    // startLine
+                                        -1,    // endLine
+                                        FALSE, // inline fragment
+                                        0,     // memberDef
+                                        op->lineno()  // show line numbers
+                                       );
+      if (fd) delete fd;
     }
     pushEnabled();
     m_hide=TRUE;


### PR DESCRIPTION
With the commands like `\skip`, `\skipline` it is possible to show parts of a file for further explanation / tutorials. They can be started with `\include` or `\dontinclude` but in case `\include` specifies that the line numbers have to be shown they are only shown in the full example and not in the split up example
- show line numbers in split up example in case `lineno` is required
- add `lineno` option to `\dontinclude` so here also line numbers can be shown.