### PR TITLE
secreflist command output shows in 1 column (HTML)

### DIFF
--- a/doc/doxygen_manual.css
+++ b/doc/doxygen_manual.css
@@ -49,11 +49,13 @@ dt {
 	font-weight: bold;
 }
 
-div.multicol {
+ul.multicol {
 	-moz-column-gap: 1em;
 	-webkit-column-gap: 1em;
+	column-gap: 1em;
 	-moz-column-count: 3;
 	-webkit-column-count: 3;
+	column-count: 3;
 }
 
 p.startli, p.startdd {

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1873,8 +1873,8 @@ void HtmlDocVisitor::visitPre(DocSecRefList *s)
 {
   if (m_hide) return;
   forceEndParagraph(s);
-  m_t << "<div class=\"multicol\">" << endl;
-  m_t << "<ul>" << endl;
+  m_t << "<div>" << endl;
+  m_t << "<ul class=\"multicol\">" << endl;
 }
 
 void HtmlDocVisitor::visitPost(DocSecRefList *s) 

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -53,11 +53,13 @@ dt {
 	font-weight: bold;
 }
 
-div.multicol {
+ul.multicol {
 	-moz-column-gap: 1em;
 	-webkit-column-gap: 1em;
+	column-gap: 1em;
 	-moz-column-count: 3;
 	-webkit-column-count: 3;
+	column-count: 3;
 }
 
 p.startli, p.startdd {


### PR DESCRIPTION
The output from the `\secreflist` command shows in 1 column instead of 3.
The `column-count` (also possible without `-moz` or `-webkit`) should be with the `<ul>` tag instead of the `<div>` tag.

Problem shows already with a small problem:
```
/** \file
  * test for secreflist
  * \anchor something
  * \secreflist
  * \refitem something something
  * \refitem something something
  * \refitem something something
  * \endsecreflist
  */
```