### PR TITLE
issue #6869 SVG image generated by \dot or \dotfile does not render properly in HTML

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -4331,7 +4331,7 @@ void writeDotImageMapFromFile(FTextStream &t,
     QCString svgName=outDir+"/"+baseName+".svg";
     writeSVGFigureLink(t,relPath,baseName,svgName);
     DotFilePatcher patcher(svgName);
-    patcher.addSVGConversion(relPath,TRUE,context,TRUE,graphId);
+    patcher.addSVGConversion("",TRUE,context,TRUE,graphId);
     patcher.run();
   }
   else // bitmap graphics


### PR DESCRIPTION
The path to the svgpan.js should be relative to the svg file. For files generated with `dot` or `\dotfile` this is the root of the HTML tree, so relpath is here an empty reference (the svg file still needs the relpath as this file is referenced from a html file that is possibly in a sub directory).