### PR TITLE
qglobal.h: Fix build on AIX

### DIFF
--- a/qtools/qglobal.h
+++ b/qtools/qglobal.h
@@ -357,7 +357,9 @@ typedef const char     *pcchar;
 typedef __int64            int64;
 typedef unsigned __int64   uint64;
 #else
+#if !defined(_OS_AIX_) || !defined(_H_INTTYPES)
 typedef long long          int64;
+#endif
 typedef unsigned long long uint64;
 #endif
 


### PR DESCRIPTION
AIX's inttypes.h already defines the type int64, check if it is
already included before attempting to redefine it.

Tested on AIX 7.2