### PR TITLE
issue #6882 1.8.15 regression: caller graph created even though CALLER_GRAPH = NO

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -5572,9 +5572,9 @@ void combineDeclarationAndDefinition(MemberDef *mdec,MemberDef *mdef)
       mdec->enableCallerGraph(mdec->hasCallerGraph() || mdef->hasCallerGraph());
 
       mdef->enableReferencedByRelation(mdec->hasReferencedByRelation() || mdef->hasReferencedByRelation());
-      mdef->enableCallerGraph(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
+      mdef->enableReferencesRelation(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
       mdec->enableReferencedByRelation(mdec->hasReferencedByRelation() || mdef->hasReferencedByRelation());
-      mdec->enableCallerGraph(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
+      mdec->enableReferencesRelation(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
     }
   }
 }


### PR DESCRIPTION
The enabling of the caller graph was set by the references relation (regression on issue #6562)