### PR TITLE
at sign (`@`) not handled correctly in preprocessor

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1178,15 +1178,21 @@ QCString removeIdsAndMarkers(const char *s)
     {
       if (c=='@') // replace @@ with @ and remove @E
       {
-	if (*(p+1)=='@')
-	{
-	  result+=c; 
-	}
-	else if (*(p+1)=='E')
-	{
-	  // skip
-	}
-	p+=2;
+        if (*(p+1)=='@')
+        {
+          result+=c;
+          p+=2;
+        }
+        else if (*(p+1)=='E')
+        {
+          // skip
+          p+=2;
+        }
+        else
+        {
+          result+=c;
+          p++;
+        }
       }
       else if (isdigit(c)) // number
       {


### PR DESCRIPTION
When having the problem (reduced to show problem):
```
#if ('@' == 0x40)
#endif
```
we get the warning:
```
warning: preprocessing issue while doing constant expression evaluation: syntax error
```

The `@` was eaten although only `@@` and `@E` should be handled.