### PR TITLE
issue #6892 xml not well-formed (invalid token) for c++

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -360,8 +360,8 @@ static void writeTemplateArgumentList(ArgumentList *al,
       }
       if (!a->name.isEmpty())
       {
-        t << indentStr <<  "    <declname>" << a->name << "</declname>" << endl;
-        t << indentStr <<  "    <defname>" << a->name << "</defname>" << endl;
+        t << indentStr <<  "    <declname>" << convertToXML(a->name) << "</declname>" << endl;
+        t << indentStr <<  "    <defname>" << convertToXML(a->name) << "</defname>" << endl;
       }
       if (!a->defval.isEmpty())
       {


### PR DESCRIPTION
the `declname` and `defname` should  also be converted (compare as well the routine `generateXMLForMember`)