### PR TITLE
Problem with referenced / references relations

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3650,10 +3650,10 @@ static void buildFunctionList(Entry *root)
 
                 md->addSectionsToDefinition(root->anchors);
 
-                md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-                md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
-                md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
-                md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+                md->enableCallGraph(md->hasCallGraph(), root->callGraph);
+                md->enableCallerGraph(md->hasCallerGraph(), root->callerGraph);
+                md->enableReferencedByRelation(md->hasReferencedByRelation(), root->referencedByRelation);
+                md->enableReferencesRelation(md->hasReferencesRelation(), root->referencesRelation);
 
                 // merge ingroup specifiers
                 if (md->getGroupDef()==0 && root->groups->getFirst()!=0)
@@ -5277,10 +5277,10 @@ static void addMemberDocs(Entry *root,
   // strip extern specifier
   fDecl.stripPrefix("extern ");
   md->setDefinition(fDecl);
-  md->enableCallGraph(root->callGraph);
-  md->enableCallerGraph(root->callerGraph);
-  md->enableReferencedByRelation(root->referencedByRelation);
-  md->enableReferencesRelation(root->referencesRelation);
+  md->enableCallGraph(md->hasCallGraph(),root->callGraph);
+  md->enableCallerGraph(md->hasCallerGraph(),root->callerGraph);
+  md->enableReferencedByRelation(md->hasReferencedByRelation(), root->referencedByRelation);
+  md->enableReferencesRelation(md->hasReferencesRelation(),root->referencesRelation);
   ClassDef     *cd=md->getClassDef();
   NamespaceDef *nd=md->getNamespaceDef();
   QCString fullName;
@@ -5371,10 +5371,10 @@ static void addMemberDocs(Entry *root,
     md->setRefItems(root->sli);
   }
 
-  md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-  md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
-  md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
-  md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+  md->enableCallGraph(md->hasCallGraph(), root->callGraph);
+  md->enableCallerGraph(md->hasCallerGraph(), root->callerGraph);
+  md->enableReferencedByRelation(md->hasReferencedByRelation(), root->referencedByRelation);
+  md->enableReferencesRelation(md->hasReferencesRelation(), root->referencesRelation);
 
   md->mergeMemberSpecifiers(root->spec);
   md->addSectionsToDefinition(root->anchors);

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -284,9 +284,13 @@ class MemberDefImpl : public DefinitionImpl, public MemberDef
     virtual void setFromAnonymousScope(bool b);
     virtual void setFromAnonymousMember(MemberDef *m);
     virtual void enableCallGraph(bool e);
+    virtual void enableCallGraph(bool e, bool e2);
     virtual void enableCallerGraph(bool e);
+    virtual void enableCallerGraph(bool e, bool e2);
     virtual void enableReferencedByRelation(bool e);
+    virtual void enableReferencedByRelation(bool e, bool e2);
     virtual void enableReferencesRelation(bool e);
+    virtual void enableReferencesRelation(bool e, bool e2);
     virtual void setTemplateMaster(MemberDef *mt);
     virtual void addListReference(Definition *d);
     virtual void setDocsForDefinition(bool b);
@@ -4346,9 +4350,37 @@ void MemberDefImpl::enableCallGraph(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
+void MemberDefImpl::enableCallGraph(bool e, bool e2)
+{
+  static bool callGraph = Config_getBool(CALL_GRAPH);
+  if (e != e2)
+  {
+    m_impl->hasCallGraph= !callGraph;
+  }
+  else
+  {
+    m_impl->hasCallGraph=e;
+  }
+  if (m_impl->hasCallGraph) Doxygen::parseSourcesNeeded = TRUE;
+}
+
 void MemberDefImpl::enableCallerGraph(bool e)
 {
   m_impl->hasCallerGraph=e;
+  if (m_impl->hasCallerGraph) Doxygen::parseSourcesNeeded = TRUE;
+}
+
+void MemberDefImpl::enableCallerGraph(bool e, bool e2)
+{
+  static bool callerGraph = Config_getBool(CALLER_GRAPH);
+  if (e != e2)
+  {
+    m_impl->hasCallerGraph= !callerGraph;
+  }
+  else
+  {
+    m_impl->hasCallerGraph=e;
+  }
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
@@ -4358,9 +4390,37 @@ void MemberDefImpl::enableReferencedByRelation(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
+void MemberDefImpl::enableReferencedByRelation(bool e, bool e2)
+{
+  static bool refByRel = Config_getBool(REFERENCED_BY_RELATION);
+  if (e != e2)
+  {
+    m_impl->hasReferencedByRelation= !refByRel;
+  }
+  else
+  {
+    m_impl->hasReferencedByRelation=e;
+  }
+  if (m_impl->hasReferencedByRelation) Doxygen::parseSourcesNeeded = TRUE;
+}
+
 void MemberDefImpl::enableReferencesRelation(bool e)
 {
   m_impl->hasReferencesRelation=e;
+  if (m_impl->hasReferencesRelation) Doxygen::parseSourcesNeeded = TRUE;
+}
+
+void MemberDefImpl::enableReferencesRelation(bool e, bool e2)
+{
+  static bool refsRel = Config_getBool(REFERENCES_RELATION);
+  if (e != e2)
+  {
+    m_impl->hasReferencesRelation= !refsRel;
+  }
+  else
+  {
+    m_impl->hasReferencesRelation=e;
+  }
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -340,10 +340,14 @@ class MemberDef : virtual public Definition
     virtual void setFromAnonymousMember(MemberDef *m) = 0;
 
     virtual void enableCallGraph(bool e) = 0;
+    virtual void enableCallGraph(bool e, bool e2) = 0;
     virtual void enableCallerGraph(bool e) = 0;
+    virtual void enableCallerGraph(bool e, bool e2) = 0;
 
     virtual void enableReferencedByRelation(bool e) = 0;
+    virtual void enableReferencedByRelation(bool e, bool e2) = 0;
     virtual void enableReferencesRelation(bool e) = 0;
+    virtual void enableReferencesRelation(bool e, bool e2) = 0;
 
     virtual void setTemplateMaster(MemberDef *mt) = 0;
     virtual void addListReference(Definition *d) = 0;


### PR DESCRIPTION
Main problem is that when the documentation is in the `.h` file, including e.g. `\showrefby` this is overwritten by the global setting from the `.cpp` file.
Strategy is that in case something is explicitly set this should be used (resulting in a function with both fields, i.e. from `.h` and `.cpp`) when merging the documentation  (i.e. `addMemberDocs` in doxygen.cpp).
On other places where a `root` and member are merged the `||` operation has also been changed to  the 2 agruent version.