### PR TITLE
Bug 685714 - false positives reporting parameters or return value not being documented

### DIFF
--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -150,7 +150,7 @@ class BaseOutputDocInterface : public CodeOutputInterface
                         Examples 
                       };
 
-    virtual bool parseText(const QCString &s)  { return s.isEmpty(); }
+    virtual void parseText(const QCString &s) {}
     
     /*! Start of a bullet list: e.g. \c \<ul\> in html. startItemListItem() is
      *  Used for the bullet items.

--- a/src/outputlist.cpp
+++ b/src/outputlist.cpp
@@ -143,12 +143,16 @@ bool OutputList::generateDoc(const char *fileName,int startLine,
   {
     if (og->isEnabled()) count++;
   }
-  if (count==0) return TRUE; // no output formats enabled.
 
+  // we want to validate irrespective of the number of output formats
+  // specified as:
+  // - when only XML format there should be warnings as well (XML has its own write routines)
+  // - no formats there should be warnings as well
   DocRoot *root=0;
   root = validatingParseDoc(fileName,startLine,
                             ctx,md,docStr,indexWords,isExample,exampleName,
                             singleLine,linkFromIndex);
+  if (count==0) return TRUE; // no output formats enabled.
 
   writeDoc(root,ctx,md);
 
@@ -181,9 +185,14 @@ bool OutputList::parseText(const QCString &textStr)
   {
     if (og->isEnabled()) count++;
   }
-  if (count==0) return TRUE; // no output formats enabled.
 
+  // we want to validate irrespective of the number of output formats
+  // specified as:
+  // - when only XML format there should be warnings as well (XML has its own write routines)
+  // - no formats there should be warnings as well
   DocText *root = validatingParseText(textStr);
+
+  if (count==0) return TRUE; // no output formats enabled.
 
   for (it.toFirst();(og=it.current());++it)
   {

--- a/src/outputlist.cpp
+++ b/src/outputlist.cpp
@@ -128,14 +128,14 @@ void OutputList::popGeneratorState()
   }
 }
 
-bool OutputList::generateDoc(const char *fileName,int startLine,
+void OutputList::generateDoc(const char *fileName,int startLine,
                   Definition *ctx,MemberDef * md,
                   const QCString &docStr,bool indexWords,
                   bool isExample,const char *exampleName,
                   bool singleLine,bool linkFromIndex)
 {
   int count=0;
-  if (docStr.isEmpty()) return TRUE;
+  if (docStr.isEmpty()) return;
 
   QListIterator<OutputGenerator> it(m_outputs);
   OutputGenerator *og;
@@ -152,15 +152,8 @@ bool OutputList::generateDoc(const char *fileName,int startLine,
   root = validatingParseDoc(fileName,startLine,
                             ctx,md,docStr,indexWords,isExample,exampleName,
                             singleLine,linkFromIndex);
-  if (count==0) return TRUE; // no output formats enabled.
-
-  writeDoc(root,ctx,md);
-
-  bool isEmpty = root->isEmpty();
-
+  if (count>0) writeDoc(root,ctx,md);
   delete root;
-
-  return isEmpty;
 }
 
 void OutputList::writeDoc(DocRoot *root,Definition *ctx,MemberDef *md)
@@ -176,7 +169,7 @@ void OutputList::writeDoc(DocRoot *root,Definition *ctx,MemberDef *md)
   VhdlDocGen::setFlowMember(0);
 }
 
-bool OutputList::parseText(const QCString &textStr)
+void OutputList::parseText(const QCString &textStr)
 {
   int count=0;
   QListIterator<OutputGenerator> it(m_outputs);
@@ -192,18 +185,15 @@ bool OutputList::parseText(const QCString &textStr)
   // - no formats there should be warnings as well
   DocText *root = validatingParseText(textStr);
 
-  if (count==0) return TRUE; // no output formats enabled.
-
-  for (it.toFirst();(og=it.current());++it)
+  if (count>0)
   {
-    if (og->isEnabled()) og->writeDoc(root,0,0);
+    for (it.toFirst();(og=it.current());++it)
+    {
+      if (og->isEnabled()) og->writeDoc(root,0,0);
+    }
   }
 
-  bool isEmpty = root->isEmpty();
-
   delete root;
-
-  return isEmpty;
 }
 
 

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -74,12 +74,12 @@ class OutputList : public OutputDocInterface
     // OutputDocInterface implementation
     //////////////////////////////////////////////////
 
-    bool generateDoc(const char *fileName,int startLine,
+    void generateDoc(const char *fileName,int startLine,
                      Definition *ctx,MemberDef *md,const QCString &docStr,
                      bool indexWords,bool isExample,const char *exampleName=0,
                      bool singleLine=FALSE,bool linkFromIndex=FALSE);
     void writeDoc(DocRoot *root,Definition *ctx,MemberDef *md);
-    bool parseText(const QCString &textStr);
+    void parseText(const QCString &textStr);
     
 
     void startIndexSection(IndexSections is)


### PR DESCRIPTION
The "validating" routines should always be called.
They were missed out in case of:
- only XML format there should be warnings as well (XML has its own write routines)
- no formats there should be warnings as well