### PR TITLE
issue #6908 Page title not using heading when comment starts page in markdown

### DIFF
--- a/testing/055_markdown.md
+++ b/testing/055_markdown.md
@@ -2,6 +2,7 @@
 // objective: test markdown parsing
 // check: md_055_markdown.xml
 -->
+@page md_055_markdown 055_markdown
 
 # Foo
 


### PR DESCRIPTION
Support the following comments types also on the beginning of a markdown file (i.e. as white space):
HTML comment:
- `<!-- ... -->`
Markdown comment (see also https://stackoverflow.com/questions/4823468/comments-in-markdown/20885980#20885980):
- `[comment]: <> (This is a comment)`
- `[comment]: # (This is a comment)`
- `[//]: <> (This is a comment)`
- `[//]: # (This is a comment)`

File 055_markdown.md has to be updated as now the initial `@page` was mot present and thus the `# Foo`, `## Bar` etc. were out of place