### PR TITLE
Adding HTML tags ins and del

### DIFF
--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -45,6 +45,8 @@ of a HTML tag are passed on to the HTML output only
                        \ref cmdendcode "\\endcode".
 <li><tt>\<DD\></tt>    Starts an item description.
 <li><tt>\</DD\></tt>   Ends an item description.
+<li><tt>\<DEL\></tt>   Starts a section of deleted text, typically shown strike through text.
+<li><tt>\</DEL\></tt>  Ends a section of deleted text.
 <li><tt>\<DFN\></tt>   Starts a piece of text displayed in a typewriter font.
 <li><tt>\</DFN\></tt>  Ends a <tt>\<DFN\></tt> section.
 <li><tt>\<DIV></tt>    Starts a section with a specific style (HTML only)
@@ -71,6 +73,8 @@ of a HTML tag are passed on to the HTML output only
 <li><tt>\<I\></tt>     Starts a piece of text displayed in an italic font.
 <li><tt>\</I\></tt>    Ends a <tt>\<I\></tt> section.
 <li><tt>\<IMG SRC="..." ...\></tt>   This command is written with its attributes to the HTML output only. The SRC attribute is mandatory.
+<li><tt>\<INS\></tt>   Starts a section of inserted text, typically shown as underlined text.
+<li><tt>\</INS\></tt>  Ends a section of inserted text.
 <li><tt>\<LI\></tt>    Starts a new list item.
 <li><tt>\</LI\></tt>   Ends a list item.
 <li><tt>\<OL\></tt>    Starts a numbered item list.

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -197,6 +197,8 @@ CommandMap htmlTagMap[] =
   { "blockquote", HTML_BLOCKQUOTE },
   { "strike",     HTML_STRIKE },
   { "u",          HTML_UNDERLINE },
+  { "ins",        HTML_INS },
+  { "del",        HTML_DEL },
 
   { "c",            XML_C },
   // { "code",       XML_CODE },  <= ambiguous <code> is also a HTML tag

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -179,6 +179,8 @@ enum HtmlTagType
   HTML_BLOCKQUOTE= 33,
   HTML_STRIKE    = 34,
   HTML_UNDERLINE = 35,
+  HTML_INS       = 36,
+  HTML_DEL       = 37,
 
   XML_CmdMask    = 0x100,
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -263,7 +263,9 @@ DB_VIS_C
     case DocStyleChange::Small: /* XSLT Stylesheets can be used */ break;
                                                                    /* HTML only */
     case DocStyleChange::Strike:  break;
+    case DocStyleChange::Del:        break;
     case DocStyleChange::Underline:  break;
+    case DocStyleChange::Ins:        break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
   }

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1095,7 +1095,9 @@ const char *DocStyleChange::styleString() const
     case DocStyleChange::Div:          return "div";
     case DocStyleChange::Span:         return "span";
     case DocStyleChange::Strike:       return "strike";
+    case DocStyleChange::Del:          return "del";
     case DocStyleChange::Underline:    return "u";
+    case DocStyleChange::Ins:          return "ins";
   }
   return "<invalid>";
 }
@@ -1625,6 +1627,16 @@ reparsetoken:
               handleStyleLeave(parent,children,DocStyleChange::Strike,tokenName);
             }
             break;
+          case HTML_DEL:
+            if (!g_token->endTag)
+            {
+              handleStyleEnter(parent,children,DocStyleChange::Del,&g_token->attribs);
+            }
+            else
+            {
+              handleStyleLeave(parent,children,DocStyleChange::Del,tokenName);
+            }
+            break;
           case HTML_UNDERLINE:
             if (!g_token->endTag)
             {
@@ -1633,6 +1645,16 @@ reparsetoken:
             else
             {
               handleStyleLeave(parent,children,DocStyleChange::Underline,tokenName);
+            }
+            break;
+          case HTML_INS:
+            if (!g_token->endTag)
+            {
+              handleStyleEnter(parent,children,DocStyleChange::Ins,&g_token->attribs);
+            }
+            else
+            {
+              handleStyleLeave(parent,children,DocStyleChange::Ins,tokenName);
             }
             break;
           case HTML_CODE:
@@ -6041,8 +6063,14 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
     case HTML_STRIKE:
       handleStyleEnter(this,m_children,DocStyleChange::Strike,&g_token->attribs);
       break;
+    case HTML_DEL:
+      handleStyleEnter(this,m_children,DocStyleChange::Del,&g_token->attribs);
+      break;
     case HTML_UNDERLINE:
       handleStyleEnter(this,m_children,DocStyleChange::Underline,&g_token->attribs);
+      break;
+    case HTML_INS:
+      handleStyleEnter(this,m_children,DocStyleChange::Ins,&g_token->attribs);
       break;
     case HTML_CODE:
       if (/*getLanguageFromFileName(g_fileName)==SrcLangExt_CSharp ||*/ g_xmlComment) 
@@ -6456,8 +6484,14 @@ int DocPara::handleHtmlEndTag(const QCString &tagName)
     case HTML_STRIKE:
       handleStyleLeave(this,m_children,DocStyleChange::Strike,"strike");
       break;
+    case HTML_DEL:
+      handleStyleLeave(this,m_children,DocStyleChange::Del,"del");
+      break;
     case HTML_UNDERLINE:
       handleStyleLeave(this,m_children,DocStyleChange::Underline,"u");
+      break;
+    case HTML_INS:
+      handleStyleLeave(this,m_children,DocStyleChange::Ins,"ins");
       break;
     case HTML_CODE:
       handleStyleLeave(this,m_children,DocStyleChange::Code,"code");

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -382,7 +382,9 @@ class DocStyleChange : public DocNode
                  Span          = (1<<8),
                  Div           = (1<<9),
                  Strike        = (1<<10),
-                 Underline     = (1<<11)
+                 Underline     = (1<<11),
+                 Del           = (1<<12),
+                 Ins           = (1<<13)
                };
 
     DocStyleChange(DocNode *parent,uint position,Style s,bool enable,

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -405,8 +405,8 @@ WORD1NQ   {ESCWORD}|{CHARWORDQ}+|"{"|"}"
 WORD2NQ   "."|","|"("|")"|"["|"]"|"::"|":"|";"|"\?"|"="|"'"
 CAPTION   [cC][aA][pP][tT][iI][oO][nN]
 HTMLTAG   "<"(("/")?){ID}({WS}+{ATTRIB})*{WS}*(("/")?)">" 
-HTMLKEYL  "strong"|"center"|"table"|"caption"|"small"|"code"|"dfn"|"var"|"img"|"pre"|"sub"|"sup"|"tr"|"td"|"th"|"ol"|"ul"|"li"|"tt"|"kbd"|"em"|"hr"|"dl"|"dt"|"dd"|"br"|"i"|"a"|"b"|"p"|"strike"|"u"
-HTMLKEYU  "STRONG"|"CENTER"|"TABLE"|"CAPTION"|"SMALL"|"CODE"|"DFN"|"VAR"|"IMG"|"PRE"|"SUB"|"SUP"|"TR"|"TD"|"TH"|"OL"|"UL"|"LI"|"TT"|"KBD"|"EM"|"HR"|"DL"|"DT"|"DD"|"BR"|"I"|"A"|"B"|"P"|"STRIKE"|"U"
+HTMLKEYL  "strong"|"center"|"table"|"caption"|"small"|"code"|"dfn"|"var"|"img"|"pre"|"sub"|"sup"|"tr"|"td"|"th"|"ol"|"ul"|"li"|"tt"|"kbd"|"em"|"hr"|"dl"|"dt"|"dd"|"br"|"i"|"a"|"b"|"p"|"strike"|"u"|"del"|"ins"
+HTMLKEYU  "STRONG"|"CENTER"|"TABLE"|"CAPTION"|"SMALL"|"CODE"|"DFN"|"VAR"|"IMG"|"PRE"|"SUB"|"SUP"|"TR"|"TD"|"TH"|"OL"|"UL"|"LI"|"TT"|"KBD"|"EM"|"HR"|"DL"|"DT"|"DD"|"BR"|"I"|"A"|"B"|"P"|"STRIKE"|"U"|"DEL"|"INS"
 HTMLKEYW  {HTMLKEYL}|{HTMLKEYU}
 REFWORD2_PRE   ("#"|"::")?((({ID}{TEMPLPART}?)|{ANONNS})("."|"#"|"::"|"-"|"/"))*({ID}{TEMPLPART}?(":")?)
 REFWORD2       {REFWORD2_PRE}{FUNCARG2}?

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -403,8 +403,14 @@ void HtmlDocVisitor::visit(DocStyleChange *s)
     case DocStyleChange::Strike:
       if (s->enable()) m_t << "<strike" << htmlAttribsToString(s->attribs()) << ">";      else m_t << "</strike>";
       break;
+    case DocStyleChange::Del:
+      if (s->enable()) m_t << "<del" << htmlAttribsToString(s->attribs()) << ">";      else m_t << "</del>";
+      break;
     case DocStyleChange::Underline:
       if (s->enable()) m_t << "<u" << htmlAttribsToString(s->attribs()) << ">";      else m_t << "</u>";
+      break;
+    case DocStyleChange::Ins:
+      if (s->enable()) m_t << "<ins" << htmlAttribsToString(s->attribs()) << ">";      else m_t << "</ins>";
       break;
     case DocStyleChange::Italic:
       if (s->enable()) m_t << "<em" << htmlAttribsToString(s->attribs()) << ">";     else m_t << "</em>";

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -292,9 +292,11 @@ void LatexDocVisitor::visit(DocStyleChange *s)
       if (s->enable()) m_t << "{\\bfseries{";      else m_t << "}}";
       break;
     case DocStyleChange::Strike:
+    case DocStyleChange::Del:
       if (s->enable()) m_t << "\\sout{";     else m_t << "}";
       break;
     case DocStyleChange::Underline:
+    case DocStyleChange::Ins:
       if (s->enable()) m_t << "\\uline{";     else m_t << "}";
       break;
     case DocStyleChange::Italic:

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -137,9 +137,11 @@ void ManDocVisitor::visit(DocStyleChange *s)
       m_firstCol=FALSE;
       break;
     case DocStyleChange::Strike:
+    case DocStyleChange::Del:
       /* not supported */
       break;
     case DocStyleChange::Underline: //underline is shown as emphasis
+    case DocStyleChange::Ins:
       if (s->enable()) m_t << "\\fI";     else m_t << "\\fP";
       m_firstCol=FALSE;
       break;

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -642,7 +642,9 @@ void PerlModDocVisitor::visit(DocStyleChange *s)
   {
     case DocStyleChange::Bold:          style = "bold"; break;
     case DocStyleChange::Strike:        style = "strike"; break;
+    case DocStyleChange::Del:           style = "del"; break;
     case DocStyleChange::Underline:     style = "underline"; break;
+    case DocStyleChange::Ins:           style = "ins"; break;
     case DocStyleChange::Italic:        style = "italic"; break;
     case DocStyleChange::Code:          style = "code"; break;
     case DocStyleChange::Subscript:     style = "subscript"; break;

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -108,8 +108,14 @@ class PrintDocVisitor : public DocVisitor
         case DocStyleChange::Strike:
           if (s->enable()) printf("<strike>"); else printf("</strike>");
           break;
+        case DocStyleChange::Del:
+          if (s->enable()) printf("<del>"); else printf("</del>");
+          break;
         case DocStyleChange::Underline:
           if (s->enable()) printf("<underline>"); else printf("</underline>");
+          break;
+        case DocStyleChange::Ins:
+          if (s->enable()) printf("<ins>"); else printf("</ins>");
           break;
         case DocStyleChange::Italic:
           if (s->enable()) printf("<italic>"); else printf("</italic>");

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -236,9 +236,11 @@ void RTFDocVisitor::visit(DocStyleChange *s)
       if (s->enable()) m_t << "{\\b ";      else m_t << "} ";
       break;
     case DocStyleChange::Strike:
+    case DocStyleChange::Del:
       if (s->enable()) m_t << "{\\strike ";      else m_t << "} ";
       break;
     case DocStyleChange::Underline:
+    case DocStyleChange::Ins:
       if (s->enable()) m_t << "{\\ul ";      else m_t << "} ";
       break;
     case DocStyleChange::Italic:

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -190,8 +190,14 @@ void XmlDocVisitor::visit(DocStyleChange *s)
     case DocStyleChange::Strike:
       if (s->enable()) m_t << "<strike>";      else m_t << "</strike>";
       break;
+    case DocStyleChange::Del:
+      if (s->enable()) m_t << "<del>";      else m_t << "</del>";
+      break;
     case DocStyleChange::Underline:
       if (s->enable()) m_t << "<underline>";      else m_t << "</underline>";
+      break;
+    case DocStyleChange::Ins:
+      if (s->enable()) m_t << "<ins>";      else m_t << "</ins>";
       break;
     case DocStyleChange::Italic:
       if (s->enable()) m_t << "<emphasis>";     else m_t << "</emphasis>";

--- a/testing/086/086__style__tags_8h.xml
+++ b/testing/086/086__style__tags_8h.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="086__style__tags_8h" kind="file" language="C++">
+    <compoundname>086_style_tags.h</compoundname>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+      <para>In the following the word tag has the style as indicated before it.<itemizedlist><listitem><para>This is a bold <bold>tag</bold>.</para></listitem><listitem><para>This is a <computeroutput>strong</computeroutput> bold <bold>tag</bold>.</para></listitem><listitem><para>This is an italic <emphasis>tag</emphasis>.</para></listitem><listitem><para>This is an <computeroutput>em</computeroutput> italic <emphasis>tag</emphasis>.</para></listitem><listitem><para>This is a strike through <strike>tag</strike>.</para></listitem><listitem><para>This is an underline <underline>tag</underline>.</para></listitem><listitem><para>This is an insterted <ins>tag</ins>.</para></listitem><listitem><para>This is a deleted <del>tag</del>.</para></listitem><listitem><para>This is a typewriter <computeroutput>tag</computeroutput>. </para></listitem></itemizedlist>
+</para>
+    </detaileddescription>
+    <location file="086_style_tags.h"/>
+  </compounddef>
+</doxygen>

--- a/testing/086_style_tags.h
+++ b/testing/086_style_tags.h
@@ -1,0 +1,17 @@
+// objective: test different HTML style tags
+// check: 086__style__tags_8h.xml
+/**
+\file
+
+In the following the word tag has the style as indicated before it.
+- This is a bold <b>tag</b>.
+- This is a `strong` bold <strong>tag</strong>.
+- This is an italic <i>tag</i>.
+- This is an `em` italic <em>tag</em>.
+- This is a strike through <strike>tag</strike>.
+- This is an underline <u>tag</u>.
+- This is an insterted <ins>tag</ins>.
+- This is a deleted <del>tag</del>.
+- This is a typewriter <tt>tag</tt>.
+*/
+


### PR DESCRIPTION
Github does not support the `<u>` tag for underlined text, in HTML there exists the tag `<ins>`. On https://www.w3schools.com/tags/tag_ins.asp is written:
The `<ins>` tag defines a text that has been inserted into a document.
Browsers will normally strike a line through deleted text and underline inserted text.

Most browsers will display the `<ins>` element with the following default values:
```
ins {
  text-decoration: underline;
}
```

analogous there exists the tag `<del>` (https://www.w3schools.com/tags/tag_del.asp):
The `<del>` tag defines text that has been deleted from a document.
Browsers will normally strike a line through deleted text and underline inserted text.

Most browsers will display the `<del>` element with the following default values:
```
del {
  text-decoration: line-through;
}
```

Definitions analogue to the underline and strike through tag the implementation for the other formats has been chosen.