### PR TITLE
Markdown file as internet link

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -915,8 +915,6 @@ static int processLink(GrowBuf &out,const char *data,int,int size)
   {
     SrcLangExt lang = getLanguageFromFileName(link);
     int lp=-1;
-    printf("==> %d #%s#\n",isURL(link),link.data());
-    printf("==> %d \n", ((lp=link.find("@ref "))!=-1 || (lp=link.find("\\ref "))!=-1 || (lang==SrcLangExt_Markdown && !isURL(link))) );
     if ((lp=link.find("@ref "))!=-1 || (lp=link.find("\\ref "))!=-1 || (lang==SrcLangExt_Markdown && !isURL(link))) 
         // assume doxygen symbol link
     {

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -915,7 +915,9 @@ static int processLink(GrowBuf &out,const char *data,int,int size)
   {
     SrcLangExt lang = getLanguageFromFileName(link);
     int lp=-1;
-    if ((lp=link.find("@ref "))!=-1 || (lp=link.find("\\ref "))!=-1 || lang==SrcLangExt_Markdown) 
+    printf("==> %d #%s#\n",isURL(link),link.data());
+    printf("==> %d \n", ((lp=link.find("@ref "))!=-1 || (lp=link.find("\\ref "))!=-1 || (lang==SrcLangExt_Markdown && !isURL(link))) );
+    if ((lp=link.find("@ref "))!=-1 || (lp=link.find("\\ref "))!=-1 || (lang==SrcLangExt_Markdown && !isURL(link))) 
         // assume doxygen symbol link
     {
       if (lp==-1) // link to markdown page

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8452,16 +8452,20 @@ QCString getLanguageSpecificSeparator(SrcLangExt lang,bool classScope)
     return "::";
   }
 }
-
+/** Checks whether the given url starts with a supported protocol */
+bool isURL(const QCString &url)
+{
+  QCString loc_url = url.stripWhiteSpace();
+  return loc_url.left(5)=="http:" || loc_url.left(6)=="https:" || 
+         loc_url.left(4)=="ftp:"  || loc_url.left(5)=="file:";
+}
 /** Corrects URL \a url according to the relative path \a relPath.
  *  Returns the corrected URL. For absolute URLs no correction will be done.
  */
 QCString correctURL(const QCString &url,const QCString &relPath)
 {
   QCString result = url;
-  if (!relPath.isEmpty() && 
-      url.left(5)!="http:" && url.left(6)!="https:" && 
-      url.left(4)!="ftp:"  && url.left(5)!="file:")
+  if (!relPath.isEmpty() && !isURL(url))
   {
     result.prepend(relPath);
   }

--- a/src/util.h
+++ b/src/util.h
@@ -453,6 +453,8 @@ bool copyFile(const QCString &src,const QCString &dest);
 QCString extractBlock(const QCString text,const QCString marker);
 int lineBlock(const QCString text,const QCString marker);
 
+bool isURL(const QCString &url);
+
 QCString correctURL(const QCString &url,const QCString &relPath);
 
 QCString processMarkup(const QCString &s);


### PR DESCRIPTION
See a link in case of a md file only as local link if it doesn't start with a supported protocol.
Example found was:
```
[Ansibullbot](https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md)
```