### PR TITLE
Image not seen as svg image

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -3019,7 +3019,21 @@ DocImage::DocImage(DocNode *parent,const HtmlAttribList &attribs,const QCString 
 
 bool DocImage::isSVG() const
 {
-  return m_url.isEmpty() ? m_name.right(4)==".svg" : m_url.right(4)==".svg";
+  QCString  loc_name;
+  if (m_url.isEmpty())
+  {
+    loc_name =  m_name;
+  }
+  else
+  {
+    loc_name =  m_url;
+  }
+  int fnd = loc_name.find('?');
+  if (fnd != -1)
+  {
+    loc_name = loc_name.left(fnd);
+  }
+  return loc_name.right(4)==".svg";
 }
 
 void DocImage::parse()


### PR DESCRIPTION
In case a svg image url has some decoration behind it, the image is not seen as a svg image. The decoration is taken away from the determination.
Found by means of:
```
[![Build Status](https://api.travis-ci.com/ILIAS-eLearning/ILIAS.svg?branch=release_5-3)](https://travis-ci.com/ILIAS-eLearning/ILIAS)
[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg)](https://php.net/)
```
where the output was not aligned.