### PR TITLE
Class definition with collections

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -537,6 +537,8 @@ STARTDOCSYMS      "##"
 %x SingleQuoteString
 %x DoubleQuoteString
 %x TripleString
+%x SingleQuoteStringIgnore
+%x DoubleQuoteStringIgnore
 
   /* import */
 %x FromMod
@@ -1282,8 +1284,28 @@ STARTDOCSYMS      "##"
 					    );
                          //Has base class-do stuff
                        }
+    "'"	               { // start of a single quoted string
+       			 g_stringContext=YY_START;
+                         BEGIN( SingleQuoteStringIgnore );
+                       }
+    "\""               { // start of a double quoted string
+       			 g_stringContext=YY_START;
+                         BEGIN( DoubleQuoteStringIgnore );
+                       }
 }
 
+<SingleQuoteStringIgnore>{
+    "'"	               { // end of a single quoted string
+			 BEGIN(g_stringContext);
+                       }
+    .	               { }
+}
+<DoubleQuoteStringIgnore>{
+    "\""	       { // end of a double quoted string
+			 BEGIN(g_stringContext);
+                       }
+    .	               { }
+}
 
 <ClassCaptureIndent>{
     "\n"|({BB}"\n")            {
@@ -1700,6 +1722,10 @@ STARTDOCSYMS      "##"
 				 //       YY_START, yyLineNr);
 
                                  lineCount();
+                               }
+
+<*>"'"                         {
+       fprintf(stderr,"Quote: %d\n",YY_START);
                                }
 
 <*>.                           {


### PR DESCRIPTION
Class definitions can have collections and these can have strings e.g.:
```
  class Url(namedtuple('Url', url_attrs)):
```
and this results in:
>  warning: Detected potential recursive class relation between class conda::_vendor::urllib3::util::url::Url and base class Url!

Strings are now possible and seen as strings.

See also (including example with namedtuble): https://docs.python.org/3/library/collections.html