### PR TITLE
issue #6607 Don't warn about missing parameter documentation for deleted functions

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3647,6 +3647,7 @@ void MemberDefImpl::warnIfUndocumentedParams()
   if (!Config_getBool(EXTRACT_ALL) &&
       Config_getBool(WARN_IF_UNDOCUMENTED) &&
       Config_getBool(WARN_NO_PARAMDOC) &&
+      !isDeleted() &&
       !isReference() &&
       !Doxygen::suppressDocWarnings)
   {


### PR DESCRIPTION
Don't emit warnings in case member is deleted.