### PR TITLE
Regression #6836 URL contains $ sign on second run in map of images

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -322,6 +322,11 @@ static QCString replaceRef(const QCString &buf,const QCString relPath,
       }
       else
       {
+        int marker = link.find('$');
+        if (marker == 0 ) // we have just $url, e.g. include graphs
+        {
+          link = link.mid(1);
+        }
         result = href+"=\"" + link + "\"";
       }
     }


### PR DESCRIPTION
When running doxygen twice on a repository the generation of e.g. 'included directory' images  (also seen for a.o. 'class' image) is not done again and the available map file is used, but the replacement of some terms is not done properly (the $ at the beginning is not removed).

This is a regression on #6836.

Attached is minimal example ( [regression_6836.zip](https://github.com/doxygen/doxygen/files/3068013/regression_6836.zip) ) to show the problem when running doxygen twice.
