### PR TITLE
Remove superfluous '\n' in warnings

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -228,8 +228,20 @@ void err(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  vfprintf(warnFile, (QCString(error_str) + fmt).data(), args);
+  const int bufSize = 40960;
+  char text[bufSize];
+  // we use -2 so we have place for \n and \0
+  vsnprintf(text, bufSize-2, fmt, args);
+  text[bufSize-2]='\0';
   va_end(args);
+  int l = strlen(text);
+  if (text[l-1] != '\n')
+  {
+    text[l]='\n'; // over the \0
+    text[l+1]='\0'; // new \0
+    l++;
+  }
+  fwrite(text,1,l,warnFile);
 }
 
 extern void err_full(const char *file,int line,const char *fmt, ...)

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -154,7 +154,8 @@ static void format_warn(const char *file,int line,const char *text)
   {
     msgText += " (warning treated as error, aborting now)";
   }
-  msgText += '\n';
+  // only add '\n' when last character is not a '\n'
+  if (msgText[msgText.length() - 1] != '\n') msgText += '\n';
 
   // print resulting message
   fwrite(msgText.data(),1,msgText.length(),warnFile);


### PR DESCRIPTION
A number of warning messages have a double '\n' due to the fact that the message itself contains a '\n' and the warning routine automatically adds a '\n'.
Only add the 'n' in the warnings routine in case it is not present.