### PR TITLE
Count user comment lines

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -699,12 +699,12 @@ static void readIncludeFile(const char *incName)
 %%
 
 <*>\0x0d
-<PreStart>"##".*"\n" { config->appendStartComment(yytext);}
+<PreStart>"##".*"\n" { config->appendStartComment(yytext);yyLineNr++;}
 <PreStart>. {
               BEGIN(Start);
               unput(*yytext);
             }
-<Start,GetString,GetStrList,GetBool,SkipInvalid>"##".*"\n" { config->appendUserComment(yytext);}
+<Start,GetString,GetStrList,GetBool,SkipInvalid>"##".*"\n" { config->appendUserComment(yytext);yyLineNr++;}
 <Start,GetString,GetStrList,GetBool,SkipInvalid>"#"	   { BEGIN(SkipComment); }
 <Start>[a-z_A-Z][a-z_A-Z0-9]*[ \t]*"="	 { QCString cmd=yytext;
                                            cmd=cmd.left(cmd.length()-1).stripWhiteSpace(); 


### PR DESCRIPTION
The user comment lines were not counted resulting in a wrong line number in case of an error message.