### PR TITLE
Windows crash in case of incorrect end statement

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -698,6 +698,14 @@ private                                 {
                                           typeMode = false;
                                           yy_pop_state();
                                         }
+^{BS}"end"{BS}/(\n|!|;) { /* incorrect end type definition */
+                                          warn(yyFileName,yyLineNr, "Found 'END' instead of 'END TYPE'");
+                                          last_entry->parent()->endBodyLine = yyLineNr;
+                                          if (!endScope(current_root))
+                                            yyterminate();
+                                          typeMode = false;
+                                          yy_pop_state();
+                                        }
 }
 
  /*------- module/global/typedef variable ---------------------------------------------------*/
@@ -2819,7 +2827,7 @@ static void scanner_abort()
 
   // dummy call to avoid compiler warning
   (void)yy_top_state();
-  
+
   return;
   //exit(-1);
 }


### PR DESCRIPTION
Some Fortran compilers accept the END statement instead of the mandatory END TYPE. The code crashes on Windows as no correct END statement is found.