### PR TITLE
Crash in case of usage of \line without \include

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2063,7 +2063,7 @@ void DocIncOperator::parse()
   if (g_includeFileName.isEmpty())
   {
     warn_doc_error(g_fileName,doctokenizerYYlineno,
-                   "No previous '\\include' or \\dontinclude' command for '\\%s' present",
+                   "No previous '\\include' or '\\dontinclude' command for '\\%s' present",
                    typeAsString());
   }
 

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -790,7 +790,7 @@ void HtmlDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
-      FileDef *fd;
+      FileDef *fd = NULL;
       if (!op->includeFileName().isEmpty())
       {
         QFileInfo cfi( op->includeFileName() );


### PR DESCRIPTION
In case the `\line` command is used without previous `\include` or `\dontinclude` command doxygen will crash due to a non initialized `fd`.
We get the message:
`warning: No previous '\include' or \dontinclude' command for '\line' present`

also a small correcting regarding the warning message is done.