### PR TITLE
Warning when preprocessing conditionals

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1255,6 +1255,7 @@ QCString removeIdsAndMarkers(const char *s)
 	result+="0L";
 	p++;
 	while ((c=*p) && isId(c)) p++;
+	while ((c=*p) && isspace((uchar)c)) p++;
 	if (*p=='(') // undefined function macro
 	{
 	  p++;


### PR DESCRIPTION
In case in a `#if` statement a space in the use of a macro is present a warning of the type:

> warning: preprocessing issue while doing constant expression evaluation: syntax error

is given. Removing the white space after an ID solves the issue

In the following the first expressing gives a warning whilst the second expression doesn't:
```
#if (!__GNUC_PREREQ (4, 6))
  int i0;
#endif
#if (!__GNUC_PREREQ(4, 6))
  int k0;
#endif
```