### PR TITLE
Handling digraph versus label

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -231,6 +231,8 @@ static EdgeProperties umlEdgeProps =
 };
 
 
+static QCString convertLabel(const QCString &l);
+
 static QCString getDotFontName()
 {
   static QCString dotFontName = Config_getString(DOT_FONTNAME);
@@ -259,7 +261,7 @@ static void writeGraphHeader(FTextStream &t,const QCString &title=QCString())
   }
   else
   {
-    t << "\"" << convertToXML(title) << "\"";
+    t << "\"" << convertLabel(title) << "\"";
   }
   t << endl << "{" << endl;
   if (interactiveSVG) // insert a comment to force regeneration when this
@@ -4807,7 +4809,7 @@ void DotGroupCollaboration::writeGraphHeader(FTextStream &t,
   }
   else
   {
-    t << "\"" << convertToXML(title) << "\"";
+    t << "\"" << convertLabel(title) << "\"";
   }
   t << endl;
   t << "{" << endl;


### PR DESCRIPTION
In case a label contains a backslash (at the end), the digraph statement remains unchanged, though with the label= this backslash is converted to a double backslash.
Especially at the end (just before the " this can lead to problems, making the handling uniform.