### PR TITLE
issue #6946 Compilation error (clangparser.cpp)

### DIFF
--- a/addon/doxyapp/CMakeLists.txt
+++ b/addon/doxyapp/CMakeLists.txt
@@ -19,6 +19,11 @@ include_directories(
 add_executable(doxyapp
 doxyapp.cpp
 )
+
+if (use_libclang)
+    set(CLANG_LIBS libclang clangTooling ${llvm_libs})
+endif()
+
 target_link_libraries(doxyapp
 _doxygen
 qtools

--- a/addon/doxyparse/CMakeLists.txt
+++ b/addon/doxyparse/CMakeLists.txt
@@ -19,6 +19,11 @@ include_directories(
 add_executable(doxyparse
 doxyparse.cpp
 )
+
+if (use_libclang)
+    set(CLANG_LIBS libclang clangTooling ${llvm_libs})
+endif()
+
 target_link_libraries(doxyparse
 _doxygen
 qtools

--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -782,7 +782,7 @@ void ClangParser::linkIdentifier(CodeOutputInterface &ol,FileDef *fd,
         g_currentMemberDef && d->definitionType()==Definition::TypeMember && 
         (g_currentMemberDef!=d || g_currentLine<line)) // avoid self-reference
     {
-      addDocCrossReference(g_currentMemberDef,(MemberDef*)d);
+      addDocCrossReference(g_currentMemberDef,dynamic_cast<MemberDef *>(d));
     }
     writeMultiLineCodeLink(ol,fd,line,column,d,text);
   }


### PR DESCRIPTION
corrected clangparser conform other source code in respect to casting.
Corrected doxyapp and doxyparse make scripts for usage with clang parser.