### PR TITLE
issue #6950 XML - <initializer> for array of structure only contains references in first array element

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2031,10 +2031,16 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
   int floatingIndex=0;
   if (strLen==0) return;
   // read a word from the text string
-  while ((newIndex=regExp.match(txtStr,index,&matchLen))!=-1 && 
-      (newIndex==0 || !(txtStr.at(newIndex-1)>='0' && txtStr.at(newIndex-1)<='9')) // avoid matching part of hex numbers
-      )
+  newIndex=regExp.match(txtStr,index,&matchLen);
+  while ((newIndex=regExp.match(txtStr,index,&matchLen))!=-1)
   {
+    if (!(newIndex == 0 || !(txtStr.at(newIndex-1)>='0' && txtStr.at(newIndex-1)<='9'))) // avoid matching part of hex numbers
+    {
+      out.writeString(txtStr.mid(skipIndex,newIndex+matchLen-skipIndex),keepSpaces);
+      floatingIndex+=newIndex-skipIndex+matchLen;
+      skipIndex=index=newIndex+matchLen;
+      continue;
+    }
     // add non-word part to the result
     floatingIndex+=newIndex-skipIndex+matchLen;
     bool insideString=FALSE; 


### PR DESCRIPTION
Don't stop at a hexadecimal number, but output the hexadecimal number (plus the part that has not been printed yet) and continue with the next input part.