### PR TITLE
Handles fencedCodeBlock with lang=plantuml as umldiagram

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2172,7 +2172,15 @@ static QCString processQuotations(const QCString &s,int refIndent)
     {
       if (isFencedCodeBlock(data+pi,size-pi,refIndent,lang,blockStart,blockEnd,blockOffset))
       {
-        writeFencedCodeBlock(out,data+pi,lang,blockStart,blockEnd);
+        if ( lang == "plantuml" )
+        {
+          int cmdStart = pi+blockStart+1;
+          processSpecialCommand(out, data+cmdStart, cmdStart, size-cmdStart );
+        }
+        else
+        {
+          writeFencedCodeBlock(out,data+pi,lang,blockStart,blockEnd);
+        }
         i=pi+blockOffset;
         pi=-1;
         end=i+1;


### PR DESCRIPTION
Markdown editor VSCODE allows inline definitions of PLANTUML diagrams using the plantuml extension:
````
# Markdown doc with plantuml diagram

Text with uml diagram 

```plantuml
@startuml
Bob->Alice : Hello
Bob<--Alice : Hi
@enduml
```

## topic

text

````

This patch makes doxygen behave the same: render the diagram, not the code.