### PR TITLE
Ambiguous file name in file command

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -766,6 +766,16 @@ static void buildFileList(Entry *root)
   {
     bool ambig;
     FileDef *fd=findFileDef(Doxygen::inputNameDict,root->name,ambig);
+    if (!fd || ambig)
+    {
+      int save_ambig = ambig;
+      // use the directory of the file to see if the described file is in the same
+      // directory as the describing file.
+      QCString fn = root->fileName;
+      int newIndex=fn.findRev('/');
+      fd=findFileDef(Doxygen::inputNameDict,fn.left(newIndex) + "/" + root->name,ambig);
+      if (!fd) ambig = save_ambig;
+    }
     //printf("**************** root->name=%s fd=%p\n",root->name.data(),fd);
     if (fd && !ambig)
     {

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -805,7 +805,7 @@ static void buildFileList(Entry *root)
       const char *fn = root->fileName.data();
       QCString text(4096);
       text.sprintf("the name `%s' supplied as "
-          "the second argument in the \\file statement ",
+          "the argument in the \\file statement ",
           qPrint(root->name));
       if (ambig) // name is ambiguous
       {


### PR DESCRIPTION
I some cases a file name is used with the `\file` command and this filename exists multiple times although the `\file` command is in the file itself (actually file name can be omitted).
Another possibility is that the file description is in another file in the same directory.
When file is not found or ambiguous, try to prepend the path of the current file to it and see if the file can be found.

Example is shown in the warnings file like:
```
gmic-2.6.1/gmic-qt/src/Common.h:3: warning: the name `Common.h' supplied as the second argument in the \file statement matches the following input files:
   gmic-2.6.1/gmic-qt/src/Common.h
   gmic-2.6.1/zart/include/Common.h
Please use a more specific name by including a (larger) part of the path!
```
and here it is quite clear and unambiguous which file is meant.