### PR TITLE
issue #6955 Allow Javadoc-style comment blocks with a Doxyfile variable

### DIFF
--- a/doc/docblocks.doc
+++ b/doc/docblocks.doc
@@ -109,6 +109,14 @@ Some people like to make their comment blocks more visible in the
 documentation. For this purpose you can use the following:
 
 \verbatim
+/************************************************
+ *  ... text
+ ***********************************************/
+\endverbatim
+
+or
+
+\verbatim
 /********************************************//**
  *  ... text
  ***********************************************/

--- a/src/code.l
+++ b/src/code.l
@@ -3553,7 +3553,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					    BEGIN(SkipComment);
   					  }
 					}
-<*>^{B}*"/*"[!*]/[^/*]			{ // special C comment block at a new line
+<*>^{B}*"/*"[!*][*]*/[^/]		{ // special C comment block at a new line
 					  if (Config_getBool(STRIP_CODE_COMMENTS))
 					  {
 					    g_lastSpecialCContext = YY_START;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6252,7 +6252,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  startCommentBlock(FALSE);
 					  BEGIN( DocBlock );
 					}
-<FindMembers,FindFields,MemberSpec,FuncQual,SkipCurly,Operator,ClassVar,SkipInits,Bases,OldStyleArgs>("//"{B}*)?"/**"/[^/*] {
+<FindMembers,FindFields,MemberSpec,FuncQual,SkipCurly,Operator,ClassVar,SkipInits,Bases,OldStyleArgs>("//"{B}*)?"/*"[\*]+/[^/] {
   					  removeSlashes=(yytext[1]=='/');
 					  lastDocContext = YY_START;
 


### PR DESCRIPTION
See to it that comments in the form of  `/*****************` are also accepted and not only `/*************//**`