### PR TITLE
Incorrect Reached end of file while still inside a (nested) comment for TCL / Python

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -399,6 +399,10 @@ void replaceComment(int offset);
                                      copyToOutput(yytext,(int)yyleng);
                                    }
 <Scan>"/*"[*!]?			   { /* start of a C comment */
+                                     if ((g_lang==SrcLangExt_Python) || (g_lang==SrcLangExt_Tcl))
+				     {
+				       REJECT;
+                                     }
   			             g_specialComment=(int)yyleng==3;
                                      g_nestingCount=0;
                                      g_commentStack.clear(); /*  to be on the save side */
@@ -660,12 +664,16 @@ void replaceComment(int offset);
 				     }
                                    }
 <CComment>"/"+"*"                  { /* nested C comment */
+                                     if ((g_lang==SrcLangExt_Python) || (g_lang==SrcLangExt_Tcl))
+				     {
+				       REJECT;
+                                     }
                                      g_nestingCount++;
                                      g_commentStack.push(new CommentCtx(g_lineNr));
                                      copyToOutput(yytext,(int)yyleng); 
                                    }
 <CComment>"*"+"/"                  { /* end of C comment */
-                                     if (g_lang==SrcLangExt_Python)
+                                     if ((g_lang==SrcLangExt_Python) || (g_lang==SrcLangExt_Tcl))
 				     {
 				       REJECT;
 				     }


### PR DESCRIPTION
In case we have in the comment (or in the code) of a TCL file of Python file a construct like:
```
proc get_suite {dir {sort 1}} {
 set files [glob -nocomplain $dir/*.bin]
 set files [glob -nocomplain $dir/*.ps]
}
```
we get the warning:
```
warning: Reached end of file while still inside a (nested) comment. Nesting level 2 (probable line reference: 3, 2)
```
although the `/*` construct has no special comment meaning in TCL / Python (comment signs `#` / `#` or `"""`). So if a c-comment construct is found it is ignored for TCL and Python.