### PR TITLE
Incorrect output tag order

### DIFF
--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -268,16 +268,16 @@ void PageDefImpl::writeDocumentation(OutputList &ol)
   }
 
   writePageDocumentation(ol);
+  ol.endContents();
   ol.endPageDoc();
 
   if (generateTreeView && getOuterScope()!=Doxygen::globalScope && !Config_getBool(DISABLE_INDEX))
   {
-    ol.endContents();
     endFileWithNavPath(getOuterScope(),ol);
   }
   else
   {
-    endFile(ol);
+    endFile(ol,FALSE,TRUE);
   }
 
   ol.popGeneratorState();


### PR DESCRIPTION
When we have the Mardown file:
```
# First heading level 1
  Some text ...
```
we get in the HTML file:
```
...
<div class="PageDoc"><div class="header">
  <div class="headertitle">
<div class="title">First heading level 1 </div>  </div>
</div><!--header-->javascript">
<div class="contents">
<div class="textblock"><p>Some text ... </p>
</div></div><!-- PageDoc -->
</div><!-- contents -->
...
```
Here we see that the `PageDoc` is closed before the `Contents` although the `PageDoc` was opened before the `Contents`.
In this constellation it doesn't give problems as both translate to `</div>` tag and in other output formats nothing is outputted, but in case in another format something is outputted this might lead to problems also the comment is now so that is indicates the error.