### PR TITLE
Truncated warning message

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -167,17 +167,25 @@ static void format_warn(const char *file,int line,const char *text)
 static void do_warn(bool enabled, const char *file, int line, const char *prefix, const char *fmt, va_list args)
 {
   if (!enabled) return; // warning type disabled
-  const int bufSize = 40960;
-  char text[bufSize];
   int l=0;
   if (prefix)
   {
-    qstrncpy(text,prefix,bufSize);
     l=strlen(prefix);
+  }
+  // determine needed buffersize based on:
+  // format + arguments
+  // prefix
+  // 1 position for `\0`
+  int bufSize = vsnprintf(NULL, 0, fmt, args) + l + 1;
+  char *text = (char *)malloc(sizeof(char) * bufSize);
+  if (prefix)
+  {
+    qstrncpy(text,prefix,bufSize);
   }
   vsnprintf(text+l, bufSize-l, fmt, args);
   text[bufSize-1]='\0';
   format_warn(file,line,text);
+  free(text);
 }
 
 void warn(const char *file,int line,const char *fmt, ...)


### PR DESCRIPTION
In case of extremely long warning messages (e.g. in case of overloaded methods with a lot of alternatives) the warning message is truncated due to the "limited" buffer size.
By using `vsnprintf(NULL, 0, fmt, args)` it is possible to determine the length of the message based on format and actual arguments.

`char text[bufSize]` cannot be used as some older compilers don't accept it.

(reference: https://stackoverflow.com/questions/3919995/determining-sprintf-buffer-size-whats-the-standard/30909417#30909417)