### PR TITLE
Fix #6906

### DIFF
--- a/addon/doxyapp/CMakeLists.txt
+++ b/addon/doxyapp/CMakeLists.txt
@@ -1,11 +1,3 @@
-# configvalues.h
-add_custom_command(
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/configgen.py -maph ${CMAKE_SOURCE_DIR}/src/config.xml > ${GENERATED_SRC}/configvalues.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/src/config.xml ${CMAKE_SOURCE_DIR}/src/configgen.py
-    OUTPUT ${GENERATED_SRC}/configvalues.h
-)
-set_source_files_properties(${GENERATED_SRC}/configvalues.h PROPERTIES GENERATED 1)
-
 find_package(Iconv)
 
 include_directories(

--- a/addon/doxyparse/CMakeLists.txt
+++ b/addon/doxyparse/CMakeLists.txt
@@ -1,11 +1,3 @@
-# configvalues.h
-add_custom_command(
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/configgen.py -maph ${CMAKE_SOURCE_DIR}/src/config.xml > ${GENERATED_SRC}/configvalues.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/src/config.xml ${CMAKE_SOURCE_DIR}/src/configgen.py
-    OUTPUT ${GENERATED_SRC}/configvalues.h
-)
-set_source_files_properties(${GENERATED_SRC}/configvalues.h PROPERTIES GENERATED 1)
-
 find_package(Iconv)
 
 include_directories(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,10 @@ add_custom_command(
     OUTPUT ${GENERATED_SRC}/configvalues.h
 )
 set_source_files_properties(${GENERATED_SRC}/configvalues.h PROPERTIES GENERATED 1)
+add_custom_target(
+    generate_configvalues_header
+    DEPENDS ${GENERATED_SRC}/configvalues.h
+)
 
 # configvalues.cpp
 add_custom_command(

--- a/vhdlparser/CMakeLists.txt
+++ b/vhdlparser/CMakeLists.txt
@@ -1,14 +1,5 @@
-# configvalues.h
-add_custom_command(
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/configgen.py -maph ${CMAKE_SOURCE_DIR}/src/config.xml > ${GENERATED_SRC}/configvalues.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/src/config.xml ${CMAKE_SOURCE_DIR}/src/configgen.py
-    OUTPUT ${GENERATED_SRC}/configvalues.h
-)
-set_source_files_properties(${GENERATED_SRC}/configvalues.h PROPERTIES GENERATED 1)
-
 include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/qtools ${GENERATED_SRC})
 add_library(vhdlparser STATIC
-${GENERATED_SRC}/configvalues.h
 CharStream.cc
 ParseException.cc
 Token.cc
@@ -16,4 +7,7 @@ TokenMgrError.cc
 VhdlParser.cc
 VhdlParserTokenManager.cc
 VhdlParserIF.cpp
+)
+add_dependencies(vhdlparser
+    generate_configvalues_header
 )


### PR DESCRIPTION
Generate configvalues.h only as a dependency for the VHDL parser. Fixes a problem in combination with Ninja v1.9.0 because of duplicate rules for generating configvalues.h.