### PR TITLE
Bug 783759 - PERL_PATH config option: when is this needed? Still used?

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -276,7 +276,6 @@ GENERATE_TAGFILE       = doxygen.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
-PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------

--- a/addon/doxmlparser/Doxyfile
+++ b/addon/doxmlparser/Doxyfile
@@ -146,7 +146,6 @@ SKIP_FUNCTION_MACROS   = YES
 TAGFILES               = ../../qtools_docs/qtools.tag=../../../../qtools_docs/html
 GENERATE_TAGFILE       = 
 ALLEXTERNALS           = NO
-PERL_PATH              = 
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool   
 #---------------------------------------------------------------------------

--- a/addon/doxmlparser/Doxyfile.impl
+++ b/addon/doxmlparser/Doxyfile.impl
@@ -148,7 +148,6 @@ TAGFILES               = ../../qtools_docs/qtools.tag=../../../../qtools_docs/ht
 GENERATE_TAGFILE       = 
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = 
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool   
 #---------------------------------------------------------------------------

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -45,7 +45,6 @@ EXAMPLE_PATH      = ../examples
 RECURSIVE         = NO
 TAGFILES          =
 ALLEXTERNALS      = NO
-PERL_PATH         = /usr/bin/perl
 SEARCHENGINE      = NO
 PDF_HYPERLINKS    = YES
 USE_PDFLATEX      = YES

--- a/examples/tag.cfg
+++ b/examples/tag.cfg
@@ -6,7 +6,6 @@ GENERATE_RTF     = NO
 CASE_SENSE_NAMES = NO
 INPUT            = tag.cpp
 TAGFILES         = example.tag=../../example/html
-PERL_PATH        = perl
 QUIET            = YES
 JAVADOC_AUTOBRIEF = YES
 SEARCHENGINE     = NO

--- a/qtools/Doxyfile
+++ b/qtools/Doxyfile
@@ -280,7 +280,6 @@ GENERATE_TAGFILE       = ../qtools_docs/qtools.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
-PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------

--- a/src/config.xml
+++ b/src/config.xml
@@ -105,7 +105,6 @@ PROJECT_NAME     = Example
 INPUT            = example.cc example.h
 WARNINGS         = YES
 TAGFILES         = qt.tag
-PERL_PATH        = /usr/local/bin/perl
 SEARCHENGINE     = NO
 \endverbatim
 
@@ -120,7 +119,6 @@ INPUT            = examples/examples.doc src
 FILE_PATTERNS    = *.cc *.h
 INCLUDE_PATH     = examples
 TAGFILES         = qt.tag
-PERL_PATH        = /usr/bin/perl
 SEARCHENGINE     = YES
 \endverbatim
 
@@ -3229,14 +3227,6 @@ where `loc1` and `loc2` can be relative or absolute paths or URLs.
 ]]>
       </docs>
     </option>
-    <option type='string' id='PERL_PATH' format='file' defval='/usr/bin/perl' abspath='1'>
-      <docs>
-<![CDATA[
- The \c PERL_PATH should be the absolute path and name of the perl script
- interpreter (i.e. the result of `'which perl'`).
-]]>
-      </docs>
-    </option>
   </group>
   <group name='Dot' docs='Configuration options related to the dot tool'>
     <option type='bool' id='CLASS_DIAGRAMS' defval='1'>
@@ -3639,5 +3629,6 @@ remove the intermediate dot files that are used to generate the various graphs.
     <option type='obsolete' id='SYMBOL_CACHE_SIZE'/>
     <option type='obsolete' id='XML_SCHEMA'/>
     <option type='obsolete' id='XML_DTD'/>
+    <option type='obsolete' id='PERL_PATH'/>
   </group>
 </doxygenconfig>


### PR DESCRIPTION
As, more or less, mentioned in the bug report: in version 1.7.6.1 the PERL_PATH is still in use (instdox.cpp) but in version 1.8.0 it is not used anymore, so the parameter has been set to obsolete now.