### PR TITLE
issue #6968 INLINE_INHERITED_MEMB doesn't respect EXTRACT_PRIVATE=NO

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -3646,7 +3646,8 @@ void ClassDefImpl::mergeMembers()
 
   m_impl->membersMerged=TRUE;
   //printf("  mergeMembers for %s\n",name().data());
-  bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
+  static bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
+  static bool extractPrivate         = Config_getBool(EXTRACT_PRIVATE);
   if (baseClasses())
   {
     //printf("  => has base classes!\n");
@@ -3842,7 +3843,7 @@ void ClassDefImpl::mergeMembers()
                 //    name().data(),mi->memberDef->name().data(),mi->prot,
                 //    bcd->prot,prot);
 
-                if (mi->prot!=Private)
+                if (prot!=Private || extractPrivate)
                 {
                   Specifier virt=mi->virt;
                   if (mi->virt==Normal && bcd->virt!=Normal) virt=bcd->virt;


### PR DESCRIPTION
Check besides the protection of the method also the protection of the class (but don't forget to ignore it when EXTRACT_PRIVATE is set).