### PR TITLE
issue #6979 Method parameters documented inline are not present in documentation of overriding/implementing methods

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -5929,6 +5929,7 @@ void MemberDefImpl::copyArgumentNames(MemberDef *bmd)
       for (;(argDst=aliDst.current()) && (argSrc=aliSrc.current());++aliDst,++aliSrc)
       {
         argDst->name = argSrc->name;
+        argDst->docs = argSrc->docs;
       }
     }
   }
@@ -5943,6 +5944,7 @@ void MemberDefImpl::copyArgumentNames(MemberDef *bmd)
       for (;(argDst=aliDst.current()) && (argSrc=aliSrc.current());++aliDst,++aliSrc)
       {
         argDst->name = argSrc->name;
+        argDst->docs = argSrc->docs;
       }
     }
   }


### PR DESCRIPTION
Not only the name of the argument should be copied but also the documentation (this routine is only used for reimplemented members).