### PR TITLE
Bug 781306 - *** Error in `doxygen': realloc(): invalid pointer: 0x0000000001d45ba0 @ exit

### DIFF
--- a/src/htags.cpp
+++ b/src/htags.cpp
@@ -128,7 +128,7 @@ bool Htags::loadFilemap(const QCString &htmlDir)
       int len;
       while ((len=f.readLine(line.rawData(),maxlen))>0)
       {
-        line.resize(len+1);
+        line.at(len)='\0';
         //printf("Read line: %s",line.data());
         int sep = line.find('\t');
         if (sep!=-1)


### PR DESCRIPTION
Crash occurs, as indicated in error report, on line 131 of htags.cpp (line.resize(len+1);)
Looks like there is a buffer problem (enlarge after making the buffer smaller beforehand).
The readLine should place a `\0` at the end but to be on the save side.