### PR TITLE
alternate fix for .dot file handling

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -743,6 +743,25 @@ static void removeDotGraph(const QCString &dotName)
 }
 
 
+/*! Calculates the md5 signature for a given graph.
+ *  Node numbers are removed to not have md5 mismatches in case just the node
+ *  numbers are different.
+ */
+static void calculateMd5Signature(QGString const & theGraph, QCString & sigStr)
+{
+  ASSERT(sigStr.length() >= 32);
+
+  uchar md5_sig[16];
+
+  // convert to a string with regexp
+  QCString theGraphTemp(theGraph.data());
+  // remove node numbers
+  theGraphTemp.replace(QRegExp("Node[0-9]*"), "Node");
+  // calculate md5
+  MD5Buffer((const unsigned char*)theGraphTemp.data(), theGraphTemp.length(), md5_sig);
+  // convert result to a string
+  MD5SigToString(md5_sig, sigStr.rawData(), 33);
+}
 
 /*! Checks if a file "baseName".md5 exists. If so the contents
  *  are compared with \a md5. If equal FALSE is returned. If the .md5
@@ -2381,10 +2400,9 @@ void DotGfxHierarchyTable::createGraph(DotNode *n,FTextStream &out,
     }
   }
   writeGraphFooter(md5stream);
-  uchar md5_sig[16];
   QCString sigStr(33);
-  MD5Buffer((const unsigned char *)theGraph.data(),theGraph.length(),md5_sig);
-  MD5SigToString(md5_sig,sigStr.rawData(),33);
+  calculateMd5Signature(theGraph, sigStr);
+
   bool regenerate=FALSE;
   if (checkAndUpdateMd5Signature(absBaseName,sigStr) || 
       !checkDeliverables(absImgName,absMapName))
@@ -3157,10 +3175,9 @@ QCString computeMd5Signature(DotNode *root,
     }
   }
   writeGraphFooter(md5stream);
-  uchar md5_sig[16];
   QCString sigStr(33);
-  MD5Buffer((const unsigned char *)buf.data(),buf.length(),md5_sig);
-  MD5SigToString(md5_sig,sigStr.rawData(),33);
+  calculateMd5Signature(buf, sigStr);
+
   graphStr=buf.data();
   //printf("md5: %s | file: %s\n",sigStr,baseName.data());
   return sigStr;
@@ -4057,10 +4074,8 @@ QCString DotDirDeps::writeGraph(FTextStream &out,
   FTextStream md5stream(&theGraph);
   //m_dir->writeDepGraph(md5stream);
   writeDotDirDepGraph(md5stream,m_dir,linkRelations);
-  uchar md5_sig[16];
   QCString sigStr(33);
-  MD5Buffer((const unsigned char *)theGraph.data(),theGraph.length(),md5_sig);
-  MD5SigToString(md5_sig,sigStr.rawData(),33);
+  calculateMd5Signature(theGraph, sigStr);
   bool regenerate=FALSE;
   if (checkAndUpdateMd5Signature(absBaseName,sigStr) ||
       !checkDeliverables(graphFormat==GOF_BITMAP ? absImgName :
@@ -4200,10 +4215,8 @@ void generateGraphLegend(const char *path)
   md5stream << "  Node18 -> Node9 [dir=\"back\",color=\"darkorchid3\",fontsize=\"" << FONTSIZE << "\",style=\"dashed\",label=\"m_usedClass\",fontname=\"" << FONTNAME << "\"];\n";
   md5stream << "  Node18 [shape=\"box\",label=\"Used\",fontsize=\"" << FONTSIZE << "\",height=0.2,width=0.4,fontname=\"" << FONTNAME << "\",color=\"black\",URL=\"$classUsed" << Doxygen::htmlFileExtension << "\"];\n";
   writeGraphFooter(md5stream);
-  uchar md5_sig[16];
   QCString sigStr(33);
-  MD5Buffer((const unsigned char *)theGraph.data(),theGraph.length(),md5_sig);
-  MD5SigToString(md5_sig,sigStr.rawData(),33);
+  calculateMd5Signature(theGraph, sigStr);
   QCString absBaseName = (QCString)path+"/graph_legend";
   QCString absDotName  = absBaseName+".dot";
   QCString imgExt = getDotImageExtension();
@@ -4614,10 +4627,8 @@ QCString DotGroupCollaboration::writeGraph( FTextStream &t,
   }
 
   writeGraphFooter(md5stream);
-  uchar md5_sig[16];
   QCString sigStr(33);
-  MD5Buffer((const unsigned char *)theGraph.data(),theGraph.length(),md5_sig);
-  MD5SigToString(md5_sig,sigStr.rawData(),33);
+  calculateMd5Signature(theGraph, sigStr);
   QCString imgExt = getDotImageExtension();
   QCString imgFmt = Config_getEnum(DOT_IMAGE_FORMAT);
   QCString baseName    = m_diskName;

--- a/src/dot.h
+++ b/src/dot.h
@@ -393,8 +393,8 @@ class DotRunner
     };
 
     /** Creates a runner for a dot \a file. */
-    DotRunner(const QCString &file,const QCString &fontPath,bool checkResult,
-        const QCString &imageName = QCString());
+    DotRunner(const QCString& baseName, const QCString& path, const QCString& md5Hash,
+        bool checkResult, const QCString &imageName = QCString());
 
     /** Adds an additional job to the run.
      *  Performing multiple jobs one file can be faster.
@@ -415,13 +415,14 @@ class DotRunner
     QList<DotConstString> m_jobs;
     DotConstString m_postArgs;
     DotConstString m_postCmd;
-    DotConstString m_file;
+    DotConstString m_baseName;
     DotConstString m_path;
     bool m_checkResult;
     DotConstString m_imageName;
     DotConstString m_imgExt;
     bool m_cleanUp;
     CleanupItem m_cleanupItem;
+    DotConstString m_md5Hash;
 };
 
 /** Helper class to insert a set of map file into an output file */

--- a/src/dot.h
+++ b/src/dot.h
@@ -409,6 +409,10 @@ class DotRunner
     bool run();
     const CleanupItem &cleanup() const { return m_cleanupItem; }
 
+    DotConstString const& getBaseName() { return m_baseName; }
+    DotConstString const& getPath() { return m_path; }
+    DotConstString const& getMd5Hash() { return m_md5Hash; }
+
   private:
     DotConstString m_dotExe;
     bool m_multiTargets;
@@ -497,6 +501,8 @@ class DotManager
     int addSVGObject(const QCString &file,const QCString &baseName,
                      const QCString &figureNAme,const QCString &relPath);
     bool run();
+
+    bool containsRun(const QCString& baseName, const QCString& path, const QCString& md5Hash);
 
   private:
     DotManager();


### PR DESCRIPTION
issue #6960
alternate solution to #6980

this fix fixes the problem in a different approach
1. node numbers are removed before md5 is calculated to prevent different md5 values for the same .dot file
2. .md5 files are stored after successful creation of dot output files. This prevents that a valid .md5 file exists but no output file
3. added checks if a DotRunner job already exists before a new one is created of a .dot file