### PR TITLE
USE_HTAGS = YES, there are _no_ call / caller graphs in the documentation

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7958,7 +7958,7 @@ static void generateFileSources()
           {
             QStrList filesInSameTu;
             fd->startParsing();
-            if (fd->generateSourceFile() && !g_useOutputTemplate) // sources need to be shown in the output
+            if (fd->generateSourceFile() && !Htags::useHtags && !g_useOutputTemplate) // sources need to be shown in the output
             {
               msg("Generating code for file %s...\n",fd->docName().data());
               fd->writeSource(*g_outputList,FALSE,filesInSameTu);
@@ -7988,7 +7988,7 @@ static void generateFileSources()
         {
           QStrList filesInSameTu;
           fd->startParsing();
-          if (fd->generateSourceFile() && !g_useOutputTemplate) // sources need to be shown in the output
+          if (fd->generateSourceFile() && !Htags::useHtags && !g_useOutputTemplate) // sources need to be shown in the output
           {
             msg("Generating code for file %s...\n",fd->docName().data());
             fd->writeSource(*g_outputList,FALSE,filesInSameTu);
@@ -11737,12 +11737,9 @@ void generateOutput()
   generateExampleDocs();
   g_s.end();
 
-  if (!Htags::useHtags)
-  {
-    g_s.begin("Generating file sources...\n");
-    generateFileSources();
-    g_s.end();
-  }
+  g_s.begin("Generating file sources...\n");
+  generateFileSources();
+  g_s.end();
 
   g_s.begin("Generating file documentation...\n");
   generateFileDocs();


### PR DESCRIPTION
Even when htags are enabled the source code has to be parsed, but should not be written by doxygen writers. During the "generateFileSources" some other settings are done as well like for "REFERENCED_BY_RELATION".

(based on question of Maciej W via lists.sourceforge.net   on March 24 2014)

Example: [example.zip](https://github.com/doxygen/doxygen/files/3178809/example.zip)
