### PR TITLE
Don't try to load htags filemap  in case htags fails

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11690,7 +11690,7 @@ void generateOutput()
     QCString htmldir = Config_getString(HTML_OUTPUT);
     if (!Htags::execute(htmldir))
        err("USE_HTAGS is YES but htags(1) failed. \n");
-    if (!Htags::loadFilemap(htmldir))
+    else if (!Htags::loadFilemap(htmldir))
        err("htags(1) ended normally but failed to load the filemap. \n");
   }
 


### PR DESCRIPTION
Don't try to load htags filemap  in case htags fails as when a wrong / old filemap is lying around this leads / can lead to incorrect results