### PR TITLE
issue #6990 Dot produces no Graphs

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -1699,6 +1699,7 @@ static QCString escapeTooltip(const QCString &tooltip)
     switch(c)
     {
       case '"': result+="\\\""; break;
+      case '\\': result+="\\\\"; break;
       default: result+=c; break;
     }
   }


### PR DESCRIPTION
Backslashes also have to be escaped otherwise a tooltip / brief description like `//!replace "\" with "\\"` won't be produced properly.