### PR TITLE
enable debug for re-entrant lexers

### DIFF
--- a/src/constexp.l
+++ b/src/constexp.l
@@ -113,6 +113,10 @@ bool parseconstexp(const char *fileName,int lineNr,const QCString &s)
   constexpYYlex_init_extra(&constexpYY_extra, &yyscanner);
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
 
+#ifdef FLEX_DEBUG
+  yyset_debug(1,yyscanner);
+#endif
+
   yyextra->g_constExpFileName = fileName;
   yyextra->g_constExpLineNr = lineNr;
   yyextra->g_inputString = s;

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -250,6 +250,10 @@ void parseFuncDecl(const QCString &decl,bool objC,QCString &cl,QCString &t,
   declinfoYYlex_init_extra(&g_declinfo_extra, &g_yyscanner);
   struct yyguts_t *yyg = (struct yyguts_t*)g_yyscanner;
 
+#ifdef FLEX_DEBUG
+  yyset_debug(1,g_yyscanner);
+#endif
+
   printlex(yy_flex_debug, TRUE, __FILE__, NULL);
   yyextra->inputString   = decl;
   //printf("Input=`%s'\n",yyextra->inputString);

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -380,6 +380,11 @@ void parseSqlCode(
 
   sqlcodeYYlex_init_extra(&sqlcode_extra, &yyscanner);
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+
+#ifdef FLEX_DEBUG
+  yyset_debug(1,yyscanner);
+#endif
+
   printlex(yy_flex_debug, TRUE, __FILE__, fd ? fd->fileName().data(): NULL);
   
   yyextra->code = &od;


### PR DESCRIPTION
Albert points out that re-entrant lexers has an inverted debug flag from the non-re-entrant ones.
This should fix #7003