### PR TITLE
issue 7015 Parsing issue with @includedoc and @startuml

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -902,6 +902,7 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                          g_token->sectionId = QCString(yytext).stripWhiteSpace();
                          return RetVal_OK;
                        }
+<St_PlantUMLOpt>"\n"   |
 <St_PlantUMLOpt>.      {
                          g_token->sectionId = "";
                          unput(*yytext);


### PR DESCRIPTION
In case of `\includedoc` the `\n` was not handled on the first line (`@startuml`)

Extended example: [example.zip](https://github.com/doxygen/doxygen/files/3233413/example.zip)
