### PR TITLE
Conflict between RCS tag and (e.g.) php description

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -658,7 +658,7 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 			 g_token->isEMailAddr=TRUE;
 			 return TK_URL;
                        }
-<St_Para>"$"{ID}":"[^\n$]+"$" { /* RCS tag */
+<St_Para>"$"{ID}":"[^:\n$][^\n$]*"$" { /* RCS tag */
                          QCString tagName(yytext+1);
 			 int index=tagName.find(':');
   			 g_token->name = tagName.left(index);


### PR DESCRIPTION
In some  languages the `$` is used to start a variable name (php, perl).
When having a description like:
```
 <b>$RRDp::error_mode</b>, <b>$RRDp::error</b>
```
this will lead to a message like:
```
warning: found </b> at different nesting level (4) than expected (2)
```
because the part `$RRDp:` is seen as start of a RCS tag and runs till the next `$`.

Though the `::` indicates here a class / namespace separator and in case of `$...:`  directly followed by a `:` this should not be seen as RCS tag.