### PR TITLE
Doxygen crash on ceph project

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -516,7 +516,7 @@ class ClassDefAliasImpl : public DefinitionAliasImpl, public ClassDef
     { return getCdAlias()->countInheritanceNodes(); }
     virtual int countMemberDeclarations(MemberListType lt,const ClassDef *inheritedFrom,
                 int lt2,bool invert,bool showAlways,QPtrDict<void> *visitedClasses) const
-    { return countMemberDeclarations(lt,inheritedFrom,lt2,invert,showAlways,visitedClasses); }
+    { return getCdAlias()->countMemberDeclarations(lt,inheritedFrom,lt2,invert,showAlways,visitedClasses); }
     virtual void writeMemberDeclarations(OutputList &ol,MemberListType lt,const QCString &title,
                  const char *subTitle=0,bool showInline=FALSE,const ClassDef *inheritedFrom=0,
                  int lt2=-1,bool invert=FALSE,bool showAlways=FALSE,


### PR DESCRIPTION
When running doxygen (master) on the ceph project (https://github.com/ceph/ceph/archive/v15.0.0.tar.gz) doxygen crashes with what looks like an endless loop.
Seen the code:
```
    virtual int countMemberDeclarations(MemberListType lt,const ClassDef *inheritedFrom,
                int lt2,bool invert,bool showAlways,QPtrDict<void> *visitedClasses) const
    { return countMemberDeclarations(lt,inheritedFrom,lt2,invert,showAlways,visitedClasses); }
```
and the above code, it looks like the fix might be:
```
    virtual int countMemberDeclarations(MemberListType lt,const ClassDef *inheritedFrom,
                int lt2,bool invert,bool showAlways,QPtrDict<void> *visitedClasses) const
    { return getCdAlias()->countMemberDeclarations(lt,inheritedFrom,lt2,invert,showAlways,visitedClasses); }
```

Note: problem was not in the executable from April 14 2019 but appeared in the executable from April 28 2019)