### PR TITLE
End comment marker in \code section.

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1895,17 +1895,20 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					  addOutput('\n');
   					}
 <FormatBlock>"/*"			{ // start of a C-comment
-  					  g_commentCount++;
+					  if (!(blockName=="code" || blockName=="verbatim")) g_commentCount++;
   					  addOutput(yytext);
   					}
 <FormatBlock>"*/"			{ // end of a C-comment
   					  addOutput(yytext);
-  					  g_commentCount--;
-					  if (g_commentCount<0 && blockName!="verbatim")
-					  {
-					    warn(yyFileName,yyLineNr,
+					  if (!(blockName=="code" || blockName=="verbatim"))
+                                          {
+                                            g_commentCount--;
+					    if (g_commentCount<0)
+					    {
+					      warn(yyFileName,yyLineNr,
 					         "found */ without matching /* while inside a \\%s block! Perhaps a missing \\end%s?\n",blockName.data(),blockName.data());
-					  }
+					    }
+  					  }
   					}
 <FormatBlock>.				{
   					  addOutput(*yytext);


### PR DESCRIPTION
When we have an end comment in a `\code` segment in a section we can get a message like:
```
warning: found */ without matching /* while inside a \code block! Perhaps a missing \endcode?
```
in the similar situation in a `\verbatim` section this message is not given. Switching from `\code` to `\verbatim` is not an option here as in that case other "commands" can lead to problems like in a code  like `$string =~ s/^\s*//;`

In this patch the start `/*` and end `*/` comment markers for `\code` and `\verbatim` are completely ignored.