### PR TITLE
Problems with escaped tilde

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1184,13 +1184,24 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 <Comment>{B}*({CMD}{CMD})"f"[$\[{]	{ // escaped formula command
   					  addOutput(yytext);
   					}
-<Comment>{B}*{CMD}"~"[a-z_A-Z-]*		{ // language switch command
+<Comment>{B}*{CMD}"~"[0-9]+             { /* the ~ is escaped followed by a number, so no language */
+				          addOutput(yytext + 1);
+                                        }
+<Comment>{B}*{CMD}"~"[a-z_A-Z-]*	{ // language switch command
                                           QCString langId = QString(yytext).stripWhiteSpace().data()+2;
-			       	          if (!langId.isEmpty() &&
-					      qstricmp(Config_getEnum(OUTPUT_LANGUAGE),langId)!=0)
-				          { // enable language specific section
-				            BEGIN(SkipLang);
-				          }
+                                          if (langId.isEmpty())
+                                          { /* just ignore \~ */ }
+                                          else if (possibleLanguage(langId.data()))
+                                          {
+				            if (qstricmp(Config_getEnum(OUTPUT_LANGUAGE),langId)!=0)
+				            { // enable language specific section
+				              BEGIN(SkipLang);
+				            }
+                                          }
+                                          else
+                                          {
+				            addOutput(yytext + 1);
+                                          }
   					}
 <Comment>{B}*{CMD}"f{"[^}\n]+"}"("{"?)  { // start of a formula with custom environment
 					  setOutput(OutputDoc);
@@ -2253,13 +2264,24 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 
   /* ----- handle language specific sections ------- */
 
+<SkipLang>[\\@]"~"[0-9]+            { /* the ~ is escaped followed by a number, so no end of language section */
+                                    }
 <SkipLang>[\\@]"~"[a-zA-Z-]*        { /* language switch */
                                      QCString langId = &yytext[2];
-				     if (langId.isEmpty() ||
-					 qstricmp(Config_getEnum(OUTPUT_LANGUAGE),langId)==0)
-				     { // enable language specific section
+                                     if (langId.isEmpty())
+                                     {
 				       BEGIN(Comment);
-				     }
+                                     }
+                                     else if (possibleLanguage(&yytext[2]))
+                                     {
+				       if (qstricmp(Config_getEnum(OUTPUT_LANGUAGE),langId)==0)
+				       { // enable language specific section
+				         BEGIN(Comment);
+				       }
+                                     }
+                                     else
+                                     { /* the ~ is escaped followed by non language id, so no end of language */
+                                     }
                                    }
 <SkipLang>[^*@\\\n]*		   { /* any character not a *, @, backslash or new line */
                                    }

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -420,3 +420,64 @@ bool setTranslator(const char *langName)
   if (!msg.isEmpty()) warn_uncond(msg);
   return TRUE;
 }
+
+/**
+ * List of all languages that are in principle available in doxygen
+ * the languages are not necessarily enabled.
+ */
+static const char *possibleLanguagesList[] =
+{
+  "english",
+  "dutch",
+  "armenian",
+  "swedish",
+  "czech",
+  "french",
+  "indonesian",
+  "italian",
+  "german",
+  "japanese",
+  "japanese-en",
+  "spanish",
+  "finnish",
+  "russian",
+  "croatian",
+  "polish",
+  "portuguese",
+  "hungarian",
+  "korean",
+  "korean-en",
+  "romanian",
+  "slovene",
+  "chinese",
+  "chinese-traditional",
+  "norwegian",
+  "brazilian",
+  "danish",
+  "slovak",
+  "ukrainian",
+  "greek",
+  "serbian",
+  "serbian-cyrillic",
+  "serbiancyr",
+  "catalan",
+  "lithuanian",
+  "latvian",
+  "afrikaans",
+  "arabic",
+  "persian",
+  "farsi",
+  "macedonian",
+  "vietnamese",
+  "turkish",
+  "esperanto"
+};
+
+bool possibleLanguage(const char *langName)
+{
+  for (int i = 0; i < sizeof(possibleLanguagesList) / sizeof(*possibleLanguagesList); i++)
+  {
+    if (L_EQUAL(possibleLanguagesList[i])) return TRUE;
+  }
+  return FALSE;
+}

--- a/src/language.h
+++ b/src/language.h
@@ -22,5 +22,6 @@
 
 extern Translator *theTranslator;
 extern bool setTranslator(const char *languageName);
+extern bool possibleLanguage(const char *langName);
 
 #endif


### PR DESCRIPTION
In some input formats it is necessary to escape a tilde (~) and this leads to a conflict with the selection of the language specific filter in doxygen.
things that lead to problems are e.g. `~user` or `~1MBit`.

This patch checks whether the used 'LanguageId' really is a doxygen supported language (note it is possible that the language is not enabled in the used doxygen executable).

Example: [example_2.zip](https://github.com/doxygen/doxygen/files/3253425/example_2.zip)
