### PR TITLE
Don't remove `*` in case of `*/` inside code block (at start of line)

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6714,7 +6714,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                             REJECT;
                                           }
                                         }
-<DocCopyBlock>^{B}*"*"+/{BN}*		{ // start of a comment line with one *
+<DocCopyBlock>^{B}*"*"+/[^/] 		{ // start of a comment line with one *
   					  if (docBlockName=="code")
                                           {
                                             QCString indent;


### PR DESCRIPTION
When having in a `\code` block  a comment line like ` * statement` the `*` is removed as it is (probably) just required from the coding style / readability in the code.
When having though a line `*/` in a `\code` block the `*` is also removed and in this case it should not be done.

Example: [example.zip](https://github.com/doxygen/doxygen/files/3256413/example.zip)
