### PR TITLE
Relative markdown file reference

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -51,6 +51,7 @@
 #include "config.h"
 #include "section.h"
 #include "message.h"
+#include "portable.h"
 
 //-----------
 
@@ -915,6 +916,20 @@ static int processLink(GrowBuf &out,const char *data,int,int size)
       if (lp==-1) // link to markdown page
       {
         out.addStr("@ref ");
+        if (!(portable_isAbsolutePath(link) || isURL(link)))
+        {
+          QFileInfo forg(link);
+          if (!(forg.exists() && forg.isReadable()))
+          {
+            QFileInfo fi(g_fileName);
+            QCString mdFile = g_fileName.left(g_fileName.length()-fi.fileName().length()) + link;
+            QFileInfo fmd(mdFile);
+            if (fmd.exists() && fmd.isReadable())
+            {
+              link = fmd.absFilePath().data();
+            }
+          }
+        }
       }
       out.addStr(link);
       out.addStr(" \"");


### PR DESCRIPTION
In case we have a relative reference to a local markdown file this file is not found when the relative path starts e.g. with `..`
So when we have a file:
```
docs\tutorial\security.md
```
and this references the file:
```
../api/browser-window.md
```
through the markdown syntax:
```
[`BrowserWindow`](../api/browser-window.md)
```
then the link was not found and a warning was given.

Example: [example.zip](https://github.com/doxygen/doxygen/files/3257344/example.zip)
