### PR TITLE
Bug 304793 - paramType does not contain attribute element in compound.xsd schema

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -232,6 +232,7 @@
 
   <xsd:complexType name="paramType">
     <xsd:sequence>
+      <xsd:element name="attributes" minOccurs="0" />
       <xsd:element name="type" type="linkedTextType" minOccurs="0" />
       <xsd:element name="declname" minOccurs="0" />
       <xsd:element name="defname" minOccurs="0" />


### PR DESCRIPTION
Added "attributes" to "paramType"