### PR TITLE
Bug 504025 - preprocessor-directive doxygen is not able to recognize

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2061,7 +2061,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  endFontClass();
 					  BEGIN( Body );
   					}
-<Body,Bases>^[ \t]*"#"			{ 
+<*>^[ \t]*"#"			{ 
   					  startFontClass("preprocessor");
 					  g_lastSkipCppContext = YY_START;
   					  g_code->codify(yytext);


### PR DESCRIPTION
No reason to limit preprocessor detection to states 'Body' and 'Bases'.