### PR TITLE
Bug 664652 - Incorrect processing of the \date command in C++

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2320,6 +2320,10 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 static bool handleBrief(const QCString &, const QCStringList &)
 {
   //printf("handleBrief\n");
+  if (inContext!=OutputBrief)
+  {
+    addOutput("\n\n");
+  }
   setOutput(OutputBrief);
   return FALSE;
 }


### PR DESCRIPTION
In case of a `\brief` command terminate the current paragraph / section.