### PR TITLE
issue #7038 Broken refman.tex with SHOW_FILES=NO and doxygen groups

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4730,7 +4730,7 @@ static void writeIndex(OutputList &ol)
       ol.parseText(/*projPrefix+*/theTranslator->trExceptionIndex());
       ol.endIndexSection(isCompoundIndex);
     }
-    if (documentedFiles>0)
+    if (Config_getBool(SHOW_FILES) && (documentedFiles>0))
     {
       ol.startIndexSection(isFileIndex);
       ol.parseText(/*projPrefix+*/theTranslator->trFileIndex());


### PR DESCRIPTION
Only have index section when SHOW_FILES is set (analogous to index for namespaces)