### PR TITLE
Bug 632754 - The \copydoc Command Requires The Use of C++ Syntax in C# Code

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -662,6 +662,8 @@ static bool findDocsForMemberOrCompound(const char *commandName,
   *pBrief="";
   *pDef=0;
   QCString cmdArg=substitute(commandName,"#","::");
+  cmdArg = replaceScopeSeparator(cmdArg);
+
   int l=cmdArg.length();
   if (l==0) return FALSE;
 
@@ -687,7 +689,6 @@ static bool findDocsForMemberOrCompound(const char *commandName,
 
   QCString name=removeRedundantWhiteSpace(cmdArg.left(funcStart));
   QCString args=cmdArg.right(l-funcStart);
-
   // try if the link is to a member
   const MemberDef    *md=0;
   const ClassDef     *cd=0;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8454,6 +8454,11 @@ QCString getLanguageSpecificSeparator(SrcLangExt lang,bool classScope)
     return "::";
   }
 }
+QCString replaceScopeSeparator(QCString str)
+{
+  // we don't know about the language so we have to go for the worse
+  return substitute(substitute(str,"\\","::"),".","::");  // PHP and Java, CSharp, VHDL, Python
+}
 /** Checks whether the given url starts with a supported protocol */
 bool isURL(const QCString &url)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -119,6 +119,7 @@ class LetterToIndexMap : public SIntDict<T>
 
 QCString langToString(SrcLangExt lang);
 QCString getLanguageSpecificSeparator(SrcLangExt lang,bool classScope=FALSE);
+QCString replaceScopeSeparator(QCString str);
 
 //--------------------------------------------------------------------
 


### PR DESCRIPTION
Replace the scope separators to the default scope separators (::) of doxygen.