### PR TITLE
No space when replacing `\copydoc` by `\copydetails`

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2298,7 +2298,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  if (*yytext=='\n') yyLineNr++;
 					  addOutput('\n');
 					  setOutput(OutputDoc);
-                                          addOutput("\\copydetails ");
+                                          addOutput(" \\copydetails ");
 					  addOutput(g_copyDocArg);
 					  addOutput("\n");
 					  BEGIN(Comment);


### PR DESCRIPTION
In case we have something like (taken loosely from issue #4554):
```
- \subpage id_201201031218 \copydoc id_201201031218
```
this would be translated into:
```
- @subpage id_201201031218\copydetails id_201201031218]
```
and subsequently the first word of the `\copydetails` part is placed directly to the `id_201201031218` resulting in an unknown id like `id_201201031218this`

(This actual case it doesn't make much sense to use a `\copydoc` but this can happen in other cases as well).