### PR TITLE
issue #7043 html output for markdown: different output when using '# Header {#mainpage}' and 'Header {#mainpage}\n===='

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2439,7 +2439,10 @@ static QCString extractPageTitle(QCString &docs,QCString &id)
   {
     docs=docs.mid(end1);
   }
-  id = extractTitleId(title, 0);
+  else
+  {
+    id = extractTitleId(title, 0);
+  }
   //printf("extractPageTitle(title='%s' docs='%s' id='%s')\n",title.data(),docs.data(),id.data());
   return title;
 }


### PR DESCRIPTION
In case of an ATX header the id was overwritten again by the subsequent call to extractTitleId, this should only happen in case of a non ATX header ('===' headers returned already beforehand).