### PR TITLE
Bug 566109 - unable to resolve links to java functions with array arguments

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1847,6 +1847,7 @@ QCString removeRedundantWhiteSpace(const QCString &s)
           *dst++=' '; // add extra space after
         }
         break;
+      case '[':
       case '*':
         if (i>0 && pc!=' ' && pc!='\t' && pc!=':' &&
                    pc!='*' && pc!='&'  && pc!='(' && pc!='/' &&


### PR DESCRIPTION
Also handle '[' in the removeRedundantWhiteSpace, analogous to a '*'