### PR TITLE
Bug 535853 - C# consts incorrectly placed under instance variables

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1390,6 +1390,10 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  current->explicitExternal = TRUE;
 					  lineCount();
   					}
+<FindMembers>{B}*"const"{BN}+    	{ current->type += " const ";
+					  if (insideCS) current->stat = TRUE;
+					  lineCount();
+					}
 <FindMembers>{B}*"virtual"{BN}+    	{ current->type += " virtual ";
 					  current->virt = Virtual;
 					  lineCount();


### PR DESCRIPTION
Handle consts separately and in case of CSharp set the static flag.