### PR TITLE
Missing brief descriptions with `\defgroup`

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2359,6 +2359,7 @@ static bool handleDefGroup(const QCString &, const QCStringList &)
 {
   bool stop=makeStructuralIndicator(Entry::GROUPDOC_SEC);
   current->groupDocType = Entry::GROUPDOC_NORMAL;
+  setOutput(OutputBrief);
   BEGIN( GroupDocArg1 );
   return stop;
 }

--- a/testing/019/group__g1.xml
+++ b/testing/019/group__g1.xml
@@ -20,9 +20,9 @@
       </memberdef>
     </sectiondef>
     <briefdescription>
+      <para>Text for first group. </para>
     </briefdescription>
     <detaileddescription>
-      <para>Text for first group. </para>
     </detaileddescription>
   </compounddef>
 </doxygen>

--- a/testing/019/group__g2.xml
+++ b/testing/019/group__g2.xml
@@ -21,9 +21,9 @@
       </memberdef>
     </sectiondef>
     <briefdescription>
+      <para>Text for second group. </para>
     </briefdescription>
     <detaileddescription>
-      <para>Text for second group. </para>
     </detaileddescription>
   </compounddef>
 </doxygen>

--- a/testing/019/group__g3.xml
+++ b/testing/019/group__g3.xml
@@ -34,9 +34,9 @@
       </memberdef>
     </sectiondef>
     <briefdescription>
+      <para>Text for third group. </para>
     </briefdescription>
     <detaileddescription>
-      <para>Text for third group. </para>
     </detaileddescription>
   </compounddef>
 </doxygen>


### PR DESCRIPTION
Due to the fact that issue #6945 ended a brief description, all following was put into the detailed description (unless explicit \brief was used). The `\defgroup` should end the current brief description, but first line of the `\defgroup` should be seen as a new brief description.
Problem can be seen with in the doxygen documentation in the example in the Grouping part and also with #7053 a small example is given in the comment.

Test 19 was incorrect, didn't show group description either (see make tests `TEST_FLAGS="--keep --xhtml --id=19"`