### PR TITLE
Bug 489766 - Wrong MSC syntax rejected *silently*

### DIFF
--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -65,6 +65,8 @@ void writeDiaGraphFromFile(const char *inFile,const char *outDir,
   portable_sysTimerStart();
   if ((exitCode=portable_system(diaExe,diaArgs,FALSE))!=0)
   {
+    err("Problems running %s. Check your installation or look typos in you dia file %s\n",
+        diaExe.data(),inFile);
     portable_sysTimerStop();
     goto error;
   }

--- a/src/htags.cpp
+++ b/src/htags.cpp
@@ -91,6 +91,10 @@ bool Htags::execute(const QCString &htmldir)
   //printf("CommandLine=[%s]\n",commandLine.data());
   portable_sysTimerStart();
   bool result=portable_system("htags",commandLine,FALSE)==0;
+  if (!result)
+  {
+    err("Problems running %s. Check your installation\n", "htags");
+  }
   portable_sysTimerStop();
   QDir::setCurrent(oldDir);
   return result;

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -132,6 +132,8 @@ void writeMscGraphFromFile(const char *inFile,const char *outDir,
   portable_sysTimerStart();
   if ((exitCode=portable_system(mscExe,mscArgs,FALSE))!=0)
   {
+    err("Problems running %s. Check your installation or look typos in you msc file %s\n",
+        mscExe.data(),inFile);
     portable_sysTimerStop();
     goto error;
   }
@@ -178,6 +180,8 @@ QCString getMscImageMapFromFile(const QCString& inFile, const QCString& outDir,
   portable_sysTimerStart();
   if ((exitCode=portable_system(mscExe,mscArgs,FALSE))!=0)
   {
+    err("Problems running %s (mapping phase). Check your installation or look typos in you msc file %s\n",
+        mscExe.data(),inFile);
     portable_sysTimerStop();
     QDir::setCurrent(oldDir);
     return "";

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -181,7 +181,7 @@ QCString getMscImageMapFromFile(const QCString& inFile, const QCString& outDir,
   if ((exitCode=portable_system(mscExe,mscArgs,FALSE))!=0)
   {
     err("Problems running %s (mapping phase). Check your installation or look typos in you msc file %s\n",
-        mscExe.data(),inFile);
+        mscExe.data(),inFile.data());
     portable_sysTimerStop();
     QDir::setCurrent(oldDir);
     return "";


### PR DESCRIPTION
In case of an error at least a message (consistency) should be given (besides msc also for dia and htags).