### PR TITLE
Cygwin should by default also have `CASE_SENSE_NAMES=NO`

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -960,8 +960,8 @@ Go to the <a href="commands.html">next</a> section or return to the
  will only generate file names in lower-case letters. If set to
  \c YES, upper-case letters are also allowed. This is useful if you have
  classes or files whose names only differ in case and if your file system
- supports case sensitive file names. Windows and Mac users are advised to set this
- option to \c NO.
+ supports case sensitive file names. Windows (including Cygwin) ands
+ Mac users are advised to set this option to \c NO.
 ]]>
       </docs>
     </option>

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -396,7 +396,7 @@ const char *portable_commandExtension()
 
 bool portable_fileSystemIsCaseSensitive()
 {
-#if defined(_WIN32) || defined(macintosh) || defined(__MACOSX__) || defined(__APPLE__)
+#if defined(_WIN32) || defined(macintosh) || defined(__MACOSX__) || defined(__APPLE__) || defined(__CYGWIN__)
   return FALSE;
 #else
   return TRUE;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5129,7 +5129,7 @@ FileDef *findFileDef(const FileNameDict *fnDict,const char *n,bool &ambig)
     if (fn->count()==1)
     {
       FileDef *fd = fn->getFirst();
-#if defined(_WIN32) || defined(__MACOSX__) // Windows or MacOSX
+#if defined(_WIN32) || defined(__MACOSX__) || defined(__CYGWIN__) // Windows or MacOSX
       bool isSamePath = fd->getPath().right(path.length()).lower()==path.lower();
 #else // Unix
       bool isSamePath = fd->getPath().right(path.length())==path;
@@ -8138,7 +8138,7 @@ bool patternMatch(const QFileInfo &fi,const QStrList *patList)
   bool found = FALSE;
 
   // For Windows/Mac, always do the case insensitive match
-#if defined(_WIN32) || defined(__MACOSX__)
+#if defined(_WIN32) || defined(__MACOSX__) || defined(__CYGWIN__)
   caseSenseNames = FALSE;
 #endif
 


### PR DESCRIPTION
Cygwin should by default also have `CASE_SENSE_NAMES=NO` like is the case for the underlying Windows.
In case of Cygwin  the define `_WIN32` is not set so we also have to test for `__CYGWIN__`