### PR TITLE
Remove compilation warnings from doxmlparser

### DIFF
--- a/addon/doxmlparser/src/compoundhandler.cpp
+++ b/addon/doxmlparser/src/compoundhandler.cpp
@@ -22,6 +22,7 @@
 #include "paramhandler.h"
 #include "loamhandler.h"
 #include "memberhandler.h"
+#include "linkedtexthandler.h"
 
 //----------------------------------------------------------------------------
 

--- a/addon/doxmlparser/src/loamhandler.cpp
+++ b/addon/doxmlparser/src/loamhandler.cpp
@@ -1,5 +1,7 @@
 #include "loamhandler.h"
 #include "memberhandler.h"
+#include "linkedtexthandler.h"
+#include "paramhandler.h"
 
 
 ListOfAllMembersHandler::ListOfAllMembersHandler(IBaseHandler *parent) : m_parent(parent)

--- a/addon/doxmlparser/src/mainhandler.cpp
+++ b/addon/doxmlparser/src/mainhandler.cpp
@@ -20,6 +20,8 @@
 #include "graphhandler.h"
 #include "dochandler.h"
 #include "memberhandler.h"
+#include "linkedtexthandler.h"
+#include "paramhandler.h"
 #include "debug.h"
 
 

--- a/addon/doxmlparser/src/sectionhandler.cpp
+++ b/addon/doxmlparser/src/sectionhandler.cpp
@@ -17,6 +17,8 @@
 #include "compoundhandler.h"
 #include "sectionhandler.h"
 #include "memberhandler.h"
+#include "linkedtexthandler.h"
+#include "paramhandler.h"
 #include "dochandler.h"
 #include "debug.h"
 


### PR DESCRIPTION
Remove some warnings about incomplete types like:
```
D:\Programs\Doxygen\fork\doxygen\qtools\qlist.h(109) : warning C4150: deletion of pointer to incomplete type 'ParamHandler'; no destructor called
        d:\programs\doxygen\fork\doxygen\addon\doxmlparser\src\memberhandler.h(31) : see declaration of 'ParamHandler'
        D:\Programs\Doxygen\fork\doxygen\qtools\qlist.h(109) : while compiling class template member function 'void QList<ParamHandler>::deleteValue(type *) const'
        with
        [
            type=ParamHandler
        ]
        d:\programs\doxygen\fork\doxygen\addon\doxmlparser\src\memberhandler.h(189) : see reference to class template instantiation 'QList<ParamHandler>' being compiled
```
from doxmlparser