### PR TITLE
(X)HTML warning when `[` or `]` in constructed ids

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5479,6 +5479,8 @@ QCString escapeCharsInString(const char *name,bool allowDots,bool allowUnderscor
       case '$': growBuf.addStr("_0B"); break;
       case '\\': growBuf.addStr("_0C"); break;
       case '@': growBuf.addStr("_0D"); break;
+      case ']': growBuf.addStr("_0E"); break;
+      case '[': growBuf.addStr("_0F"); break;
       default: 
                 if (c<0)
                 {


### PR DESCRIPTION
When we have a construct like:
```
template <typename Element, size_t N>
class StlContainerView<Element[N]> {
 public:
  typedef internal::NativeArray<RawElement> type;
};
```
this will lead to files with `[` and `]` in it, as such not nice, but it is used in ids inside the code as well like:
```
id="aclass_stl_container_view_3_01_element[_n]_4_html_a1bf60158ff15896f2b53af11c09524fb"
```
running
```
xmllint --path ..../testing/dtd --noout  --nonet --postvalid html_org/*html
```
this leads to the message:
```
Syntax of value for attribute id of div is not valid
Document html_org/test_8h_source.html does not validate
```

escaping the `[` and `]` as done with other special characters solves this problem.

Example case with original and new results: [example.zip](https://github.com/doxygen/doxygen/files/3294367/example.zip)
