### PR TITLE
Upper case characters in filename despite CASE_SENSE_NAME=NO

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5475,10 +5475,10 @@ QCString escapeCharsInString(const char *name,bool allowDots,bool allowUnderscor
       case '(': growBuf.addStr("_07"); break;
       case ')': growBuf.addStr("_08"); break;
       case '+': growBuf.addStr("_09"); break;
-      case '=': growBuf.addStr("_0A"); break;
-      case '$': growBuf.addStr("_0B"); break;
-      case '\\': growBuf.addStr("_0C"); break;
-      case '@': growBuf.addStr("_0D"); break;
+      case '=': growBuf.addStr("_0a"); break;
+      case '$': growBuf.addStr("_0b"); break;
+      case '\\': growBuf.addStr("_0c"); break;
+      case '@': growBuf.addStr("_0d"); break;
       default: 
                 if (c<0)
                 {

--- a/testing/071/namespace_a_namespace_1_1_0D0.xml
+++ b/testing/071/namespace_a_namespace_1_1_0D0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
-  <compounddef id="namespace_a_namespace_1_1_0D0" kind="namespace" language="C++">
+  <compounddef id="namespace_a_namespace_1_1_0d0" kind="namespace" language="C++">
     <compoundname>ANamespace::@0</compoundname>
     <sectiondef kind="enum">
       <memberdef kind="enum" id="071__enum__in__anon__ns_8cpp_1a96ab6574751fdf6a53ceec8a3896c45d" prot="public" static="no" strong="yes">


### PR DESCRIPTION
In case special characters in a filename need escaping into something like: `_0` the `0` should not be followed by an uppercase character as this would be in contradiction wit the setting `CASE_SENSE_NAMES=NO`.

Test case used the case of #7059.

NOTE: pull request #7059 contains also 2 "conversions" `_0E` and `_0F`, these have to be converted to lowercase as well when this issue is integrated before #7059.