### PR TITLE
Incorrect (X)HTML code when generating source code.

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -185,7 +185,7 @@ void DocbookCodeGenerator::startCodeLine(bool)
 }
 void DocbookCodeGenerator::endCodeLine()
 {
-  m_t << endl;
+  if (m_insideCodeLine) m_t << endl;
   Docbook_DB(("(endCodeLine)\n"));
   m_lineNumber = -1;
   m_refId.resize(0);
@@ -243,7 +243,7 @@ void DocbookCodeGenerator::addWord(const char *,bool)
 }
 void DocbookCodeGenerator::finish()
 {
-  if (m_insideCodeLine) endCodeLine();
+  endCodeLine();
 }
 void DocbookCodeGenerator::startCodeFragment()
 {
@@ -251,6 +251,9 @@ void DocbookCodeGenerator::startCodeFragment()
 }
 void DocbookCodeGenerator::endCodeFragment()
 {
+  //endCodeLine checks is there is still an open code line, if so closes it.
+  endCodeLine();
+
   m_t << "</computeroutput></literallayout>" << endl;
 }
 
@@ -1007,6 +1010,9 @@ DB_GEN_C
 void DocbookGenerator::endCodeFragment()
 {
 DB_GEN_C
+  //endCodeLine checks is there is still an open code line, if so closes it.
+  endCodeLine();
+
     t << "</programlisting>";
 }
 void DocbookGenerator::startMemberTemplateParams()

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -212,8 +212,8 @@ class HtmlGenerator : public OutputGenerator
     void writeRuler()    { t << "<hr/>"; }
     void writeAnchor(const char *,const char *name) 
                          { t << "<a name=\"" << name <<"\" id=\"" << name << "\"></a>"; }
-    void startCodeFragment() { t << PREFRAG_START; }
-    void endCodeFragment()   { t << PREFRAG_END; } 
+    void startCodeFragment();
+    void endCodeFragment();
     void startEmphasis() { t << "<em>";  }
     void endEmphasis()   { t << "</em>"; }
     void startBold()     { t << "<b>"; }

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -48,6 +48,8 @@
 #include "filename.h"
 #include "namespacedef.h"
 
+static bool DoxyCodeLineOpen = FALSE;
+
 //#define DBG_RTF(x) x;
 #define DBG_RTF(x)
 
@@ -1952,6 +1954,9 @@ void RTFGenerator::endCodeFragment()
   //styleStack.pop();
   //printf("RTFGenerator::endCodeFrament() top=%s\n",styleStack.top());
   //t << rtf_Style_Reset << styleStack.top() << endl;
+  //endCodeLine checks is there is still an open code line, if so closes it.
+  endCodeLine();
+
   DBG_RTF(t << "{\\comment (endCodeFragment) }"    << endl)
   t << "}" << endl;
   m_omitParagraph = TRUE;
@@ -3039,6 +3044,22 @@ void RTFGenerator::endInlineMemberDoc()
 {
   DBG_RTF(t << "{\\comment (endInlineMemberDoc)}" << endl)
   t << "\\cell }{\\row }" << endl;
+}
+
+void RTFGenerator::writeLineNumber(const char *,const char *,const char *,int l)
+{
+  DoxyCodeLineOpen = TRUE;
+  t << QString("%1").arg(l,5) << " ";
+}
+void RTFGenerator::startCodeLine(bool)
+{
+  DoxyCodeLineOpen = TRUE;
+  col=0;
+}
+void RTFGenerator::endCodeLine()
+{
+  if (DoxyCodeLineOpen) lineBreak();
+  DoxyCodeLineOpen = FALSE;
 }
 
 void RTFGenerator::startLabels()

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -127,9 +127,9 @@ class RTFGenerator : public OutputGenerator
     void writeAnchor(const char *fileName,const char *name);
     void startCodeFragment();
     void endCodeFragment();
-    void writeLineNumber(const char *,const char *,const char *,int l) { t << QString("%1").arg(l,5) << " "; }
-    void startCodeLine(bool) { col=0; }
-    void endCodeLine() { lineBreak(); }
+    void writeLineNumber(const char *,const char *,const char *,int l);
+    void startCodeLine(bool);
+    void endCodeLine();
     void startEmphasis() { t << "{\\i ";  }
     void endEmphasis()   { t << "}"; }
     void startBold()     { t << "{\\b "; }


### PR DESCRIPTION
When having the example:
```
/*! \file
 * \brief
 * Prerequisite header file
 */
//! \cond
#ifdef HAVE_CONFIG_H
#include "gmxpre-config.h"
#endif
//! \endcond
```
and we run xmllint on it:
```
xmllint --path .../testing/dtd --noout  --nonet --postvalid html/*.html
```
we get the messages:
```
html/aa_8h_source.html:75: parser error : Opening and ending tag mismatch: div line 67 and body
</body>
       ^
html/aa_8h_source.html:76: parser error : Opening and ending tag mismatch: body line 17 and html
</html>
       ^
html/aa_8h_source.html:77: parser error : Premature end of data in tag html line 2

^
```

It looks like the problematic part in this case is the doxygen type comment at the end of the file.

In the past similar situations were present in LaTeX (related to maximum line length correction), but it was only fixed for LaTeX.

Besides the change for HTML also small changes were necessary for RTF and docbook.

Example case: [example.zip](https://github.com/doxygen/doxygen/files/3296891/example.zip)
