### PR TITLE
Non existing MSC file crashes doxygen

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1241,41 +1241,41 @@ void DocbookDocVisitor::visitPre(DocDotFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  startDotFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
+  if (!df->file().isEmpty()) startDotFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
 }
 
 void DocbookDocVisitor::visitPost(DocDotFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  endDotFile(df->hasCaption());
+  if (!df->file().isEmpty()) endDotFile(df->hasCaption());
 }
 
 void DocbookDocVisitor::visitPre(DocMscFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  startMscFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
+  if (!df->file().isEmpty()) startMscFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
 }
 
 void DocbookDocVisitor::visitPost(DocMscFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  endMscFile(df->hasCaption());
+  if (!df->file().isEmpty()) endMscFile(df->hasCaption());
 }
 void DocbookDocVisitor::visitPre(DocDiaFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  startDiaFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
+  if (!df->file().isEmpty()) startDiaFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
 }
 
 void DocbookDocVisitor::visitPost(DocDiaFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  endDiaFile(df->hasCaption());
+  if (!df->file().isEmpty()) endDiaFile(df->hasCaption());
 }
 
 void DocbookDocVisitor::visitPre(DocLink *lnk)

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1809,7 +1809,7 @@ void HtmlDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
   m_t << "<div class=\"dotgraph\">" << endl;
-  writeDotFile(df->file(),df->relPath(),df->context());
+  if (!df->file().isEmpty()) writeDotFile(df->file(),df->relPath(),df->context());
   if (df->hasCaption())
   { 
     m_t << "<div class=\"caption\">" << endl;
@@ -1830,7 +1830,7 @@ void HtmlDocVisitor::visitPre(DocMscFile *df)
 {
   if (m_hide) return;
   m_t << "<div class=\"mscgraph\">" << endl;
-  writeMscFile(df->file(),df->relPath(),df->context());
+  if (!df->file().isEmpty()) writeMscFile(df->file(),df->relPath(),df->context());
   if (df->hasCaption())
   { 
     m_t << "<div class=\"caption\">" << endl;
@@ -1850,7 +1850,7 @@ void HtmlDocVisitor::visitPre(DocDiaFile *df)
 {
   if (m_hide) return;
   m_t << "<div class=\"diagraph\">" << endl;
-  writeDiaFile(df->file(),df->relPath(),df->context());
+  if (!df->file().isEmpty()) writeDiaFile(df->file(),df->relPath(),df->context());
   if (df->hasCaption())
   {
     m_t << "<div class=\"caption\">" << endl;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1377,36 +1377,36 @@ void LatexDocVisitor::visitPost(DocImage *img)
 void LatexDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
-  startDotFile(df->file(),df->width(),df->height(),df->hasCaption());
+  if (!df->file().isEmpty()) startDotFile(df->file(),df->width(),df->height(),df->hasCaption());
 }
 
 void LatexDocVisitor::visitPost(DocDotFile *df) 
 {
   if (m_hide) return;
-  endDotFile(df->hasCaption());
+  if (!df->file().isEmpty()) endDotFile(df->hasCaption());
 }
 void LatexDocVisitor::visitPre(DocMscFile *df)
 {
   if (m_hide) return;
-  startMscFile(df->file(),df->width(),df->height(),df->hasCaption());
+  if (!df->file().isEmpty()) startMscFile(df->file(),df->width(),df->height(),df->hasCaption());
 }
 
 void LatexDocVisitor::visitPost(DocMscFile *df) 
 {
   if (m_hide) return;
-  endMscFile(df->hasCaption());
+  if (!df->file().isEmpty()) endMscFile(df->hasCaption());
 }
 
 void LatexDocVisitor::visitPre(DocDiaFile *df)
 {
   if (m_hide) return;
-  startDiaFile(df->file(),df->width(),df->height(),df->hasCaption());
+  if (!df->file().isEmpty()) startDiaFile(df->file(),df->width(),df->height(),df->hasCaption());
 }
 
 void LatexDocVisitor::visitPost(DocDiaFile *df)
 {
   if (m_hide) return;
-  endDiaFile(df->hasCaption());
+  if (!df->file().isEmpty()) endDiaFile(df->hasCaption());
 }
 void LatexDocVisitor::visitPre(DocLink *lnk)
 {

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1234,36 +1234,36 @@ void RTFDocVisitor::includePicturePostRTF(bool isTypeRTF, bool hasCaption, bool 
 void RTFDocVisitor::visitPre(DocDotFile *df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocDotFile)}\n");
-  writeDotFile(df);
+  if (!df->file().isEmpty()) writeDotFile(df);
 }
 
 void RTFDocVisitor::visitPost(DocDotFile *df) 
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPost(DocDotFile)}\n");
-  includePicturePostRTF(true, df->hasCaption());
+  if (!df->file().isEmpty()) includePicturePostRTF(true, df->hasCaption());
 }
 void RTFDocVisitor::visitPre(DocMscFile *df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocMscFile)}\n");
-  writeMscFile(df);
+  if (!df->file().isEmpty()) writeMscFile(df);
 }
 
 void RTFDocVisitor::visitPost(DocMscFile *df) 
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPost(DocMscFile)}\n");
-  includePicturePostRTF(true, df->hasCaption());
+  if (!df->file().isEmpty()) includePicturePostRTF(true, df->hasCaption());
 }
 
 void RTFDocVisitor::visitPre(DocDiaFile *df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocDiaFile)}\n");
-  writeDiaFile(df);
+  if (!df->file().isEmpty()) writeDiaFile(df);
 }
 
 void RTFDocVisitor::visitPost(DocDiaFile *df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPost(DocDiaFile)}\n");
-  includePicturePostRTF(true, df->hasCaption());
+  if (!df->file().isEmpty()) includePicturePostRTF(true, df->hasCaption());
 }
 
 void RTFDocVisitor::visitPre(DocLink *lnk)

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -853,37 +853,37 @@ void XmlDocVisitor::visitPost(DocImage *)
 void XmlDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
-  visitPreStart(m_t, "dotfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
+  if (!df->file().isEmpty()) visitPreStart(m_t, "dotfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
 }
 
-void XmlDocVisitor::visitPost(DocDotFile *) 
+void XmlDocVisitor::visitPost(DocDotFile *df) 
 {
   if (m_hide) return;
-  visitPostEnd(m_t, "dotfile");
+  if (!df->file().isEmpty()) visitPostEnd(m_t, "dotfile");
 }
 
 void XmlDocVisitor::visitPre(DocMscFile *df)
 {
   if (m_hide) return;
-  visitPreStart(m_t, "mscfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
+  if (!df->file().isEmpty()) visitPreStart(m_t, "mscfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
 }
 
-void XmlDocVisitor::visitPost(DocMscFile *) 
+void XmlDocVisitor::visitPost(DocMscFile *df) 
 {
   if (m_hide) return;
-  visitPostEnd(m_t, "mscfile");
+  if (!df->file().isEmpty()) visitPostEnd(m_t, "mscfile");
 }
 
 void XmlDocVisitor::visitPre(DocDiaFile *df)
 {
   if (m_hide) return;
-  visitPreStart(m_t, "diafile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
+  if (!df->file().isEmpty()) visitPreStart(m_t, "diafile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
 }
 
-void XmlDocVisitor::visitPost(DocDiaFile *)
+void XmlDocVisitor::visitPost(DocDiaFile *df)
 {
   if (m_hide) return;
-  visitPostEnd(m_t, "diafile");
+  if (!df->file().isEmpty()) visitPostEnd(m_t, "diafile");
 }
 
 void XmlDocVisitor::visitPre(DocLink *lnk)


### PR DESCRIPTION
- In case a msc file does not exist doxygen crashes (on Windows) as the msc conversion tries to access a NULL Pointer.
- Analogous for dot and dia to prevent messages about conversion errors fro a `.dot` / `.dia` file to the required output format.

example: [msc_2.zip](https://github.com/doxygen/doxygen/files/3335868/msc_2.zip)
