### PR TITLE
XML validation \msc... \dot... \dia...

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -423,8 +423,8 @@
       <xsd:element name="rtfonly" type="xsd:string" />
       <xsd:element name="latexonly" type="xsd:string" />
       <xsd:element name="image" type="docImageType" />
-      <xsd:element name="dot" type="xsd:string" />
-      <xsd:element name="msc" type="xsd:string" />
+      <xsd:element name="dot" type="docImgFileType" />
+      <xsd:element name="msc" type="docImgFileType" />
       <xsd:element name="plantuml" type="xsd:string" />
       <xsd:element name="anchor" type="docAnchorType" />
       <xsd:element name="formula" type="docFormulaType" />
@@ -588,6 +588,15 @@
   <xsd:complexType name="docFileType" mixed="true">
     <xsd:group ref="docTitleCmdGroup" minOccurs="0" maxOccurs="unbounded" />
     <xsd:attribute name="name" type="xsd:string" /> 
+    <xsd:attribute name="width" type="xsd:string" /> 
+    <xsd:attribute name="height" type="xsd:string" /> 
+  </xsd:complexType>
+
+  <xsd:complexType name="docImgFileType" mixed="true">
+    <xsd:group ref="docTitleCmdGroup" minOccurs="0" maxOccurs="unbounded" />
+    <xsd:attribute name="caption" type="xsd:string" /> 
+    <xsd:attribute name="width" type="xsd:string" /> 
+    <xsd:attribute name="height" type="xsd:string" /> 
   </xsd:complexType>
 
   <xsd:complexType name="docTocItemType" mixed="true">


### PR DESCRIPTION
The items for caption, and size were not added to the xml schema for `\msc` `\mscfile` `\dot` `\dotfile` `\diafile`

example (including validation script): [msc_4.zip](https://github.com/doxygen/doxygen/files/3336023/msc_4.zip)
