### PR TITLE
Bug 437181 - The -d Preprocessor option doesn't work for php, should be in the doc.

### DIFF
--- a/doc/preprocessing.doc
+++ b/doc/preprocessing.doc
@@ -264,6 +264,10 @@ preprocessing has been done (Hint: set <code>QUIET = YES</code> and
 <code>WARNINGS = NO</code> in the configuration file to disable any other 
 output).
 
+Note preprocessing is not done for all languages. Preprocesing is enabled for files
+that use the "C" scanner (with the exception of 'java', 'd' and 'php'), Fortran files
+(only in case the extension contains at least one upper case character) and vhdl files.
+
 \htmlonly
 Go to the <a href="autolink.html">next</a> section or return to the
  <a href="index.html">index</a>.

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7457,7 +7457,7 @@ bool CLanguageScanner::needsPreprocessing(const QCString &extension)
   SrcLangExt lang = getLanguageFromFileName(extension);
   return (SrcLangExt_Cpp == lang) ||
    !( fe==".java" || fe==".as"  || fe==".d"    || fe==".php" || 
-      fe==".php4" || fe==".inc" || fe==".phtml" 
+      fe==".php4" || fe==".inc" || fe==".phtml"|| fe==".php5"
     );
 }
 


### PR DESCRIPTION
 - excluded `.php5` files from preprocessing (like other php files)
 - made remark about some limits in files that are preprocessed in documentation