### PR TITLE
High consequence coverity mesages

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -480,7 +480,7 @@ DB_VIS_C
     popEnabled();
     if (!m_hide)
     {
-      FileDef *fd;
+      FileDef *fd = 0;
       if (!op->includeFileName().isEmpty())
       {
         QFileInfo cfi( op->includeFileName() );

--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -128,6 +128,7 @@ bool DotRunner::readBoundingBox(const char *fileName,int *width,int *height,bool
      if (p) // found PageBoundingBox or /MediaBox string
      {
        int x,y;
+       fclose(f);
        if (sscanf(p+bblen,"%d %d %d %d",&x,&y,width,height)!=4)
        {
          //printf("readBoundingBox sscanf fail\n");
@@ -137,6 +138,7 @@ bool DotRunner::readBoundingBox(const char *fileName,int *width,int *height,bool
      }
   }
   err("Failed to extract bounding box from generated diagram file %s\n",fileName);
+  fclose(f);
   return FALSE;
 }
 

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -574,7 +574,7 @@ void LatexDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
-      FileDef *fd;
+      FileDef *fd = 0;
       if (!op->includeFileName().isEmpty())
       {
         QFileInfo cfi( op->includeFileName() );

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -388,7 +388,7 @@ void ManDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
-      FileDef *fd;
+      FileDef *fd = 0;
       if (!op->includeFileName().isEmpty())
       {
         QFileInfo cfi( op->includeFileName() );

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -551,7 +551,7 @@ void RTFDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
-      FileDef *fd;
+      FileDef *fd = 0;
       if (!op->includeFileName().isEmpty())
       {
         QFileInfo cfi( op->includeFileName() );

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -423,7 +423,7 @@ void XmlDocVisitor::visit(DocIncOperator *op)
     popEnabled();
     if (!m_hide) 
     {
-      FileDef *fd;
+      FileDef *fd = 0;
       if (!op->includeFileName().isEmpty())
       {
         QFileInfo cfi( op->includeFileName() );


### PR DESCRIPTION
- initializing fd (analogous to htmldocvisitor)
- always good to close file pointers