### PR TITLE
Incorrect joining documentation sections.

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -827,6 +827,7 @@ static inline void setOutput(OutputContext ctx)
       }
       else
       {
+        if (!current->doc.isEmpty()) current->doc += "\n";
         pOutputString = &current->doc;
 	inContext = OutputDoc; // need to switch to detailed docs, see bug 631380
       }
@@ -3158,6 +3159,8 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
   parseMore      = FALSE;
   inBody         = isInbody;
   outputXRef.resize(0);
+  if (!(isBrief || isAutoBriefOn))
+    if (!current->doc.isEmpty()) current->doc += "\n";
   setOutput( isBrief || isAutoBriefOn ? OutputBrief : OutputDoc );
   briefEndsAtDot = isAutoBriefOn;
   g_condCount    = 0;


### PR DESCRIPTION
In case we have a documentation block that is interrupted the following part is directly appended to it without an appropriate newline and results, in this case, in messages like:
```
aa.c:13: warning: Illegal command @verbatim  as part of a title section
aa.c:15: warning: unexpected command endverbatim
bb.f:13: warning: Illegal command @verbatim  as part of a title section
bb.f:15: warning: unexpected command endverbatim
```
We need a solution at 2 places due to the reset of of `OutputBrief` to `OutputDoc` in `setOutput`

The original problem results from the "The R Project for Statistical Computing" version 3.6.1 in the Fortran part.

Example: [example.zip](https://github.com/doxygen/doxygen/files/3365699/example.zip)
