### PR TITLE
issue #7110 URL Encoding for Hyperlinks in PDF

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1381,7 +1381,7 @@ void LatexGenerator::startHtmlLink(const char *url)
   if (Config_getBool(PDF_HYPERLINKS))
   {
     t << "\\href{";
-    t << url;
+    t << latexFilterURL(url);
     t << "}";
   }
   t << "{\\texttt{ ";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7082,6 +7082,7 @@ QCString latexFilterURL(const char *s)
     switch (c)
     {
       case '#':  t << "\\#"; break;
+      case '%':  t << "\\%"; break;
       default:
         t << c;
         break;


### PR DESCRIPTION
For an URL also the percentage (`%`) sign has to be escaped