### PR TITLE
issue #7113 Doxygen doesn't process markdown tables correctly

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1900,7 +1900,7 @@ static int writeTableBlock(GrowBuf &out,const char *data,int size)
       }
       // need at least one space on either side of the cell text in
       // order for doxygen to do other formatting
-      out.addStr("> " + cellText + " </" + cellTag + ">\n");
+      out.addStr("> " + cellText + "\n</" + cellTag + ">\n");
     }
     cellTag = "td";
     cellClass = "class=\"markdownTableBody";


### PR DESCRIPTION
Better to have the end tag start at a new line so it cannot be added to a command that runs till the end of the line