### PR TITLE
regression #7105 correct counting for group close counting

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3361,6 +3361,7 @@ void closeGroup(Entry *e,const char *fileName,int line,bool foundInline)
   g_openCount--;
   if (g_openCount < 0)
   {
+    g_openCount++; // undo an extra non existing specified level
     warn(fileName,line,"unbalanced grouping commands");
   }
   //printf("==> closeGroup(name=%s,sec=%x,file=%s,line=%d) g_autoGroupStack=%d\n",


### PR DESCRIPTION
In case of an extra closing we should not count this closing as otherwise sequences like:
```
  @}
  ...
  @{
  ...
  @}
```
will give a warning at both `@}` statements and not just at the first (second one has an opening statement).

Small regression on #7105