### PR TITLE
Problem with with comment recognition for group open and closing commands

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2849,7 +2849,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  }
   					}
    
-<FindMembers,FindFields>("//"([!/]?){B}*{CMD}"{")|("/*"([!*]?){B}*{CMD}"{")	{
+<FindMembers,FindFields>("//"([!/]){B}*{CMD}"{")|("/*"([!*]){B}*{CMD}"{")	{
   					  //handleGroupStartCommand(current->name);
                                           if (previous && previous->section==Entry::GROUPDOC_SEC)
 					  {
@@ -2901,7 +2901,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					    }
 					  }
   					}
-<FindMembers,FindFields,ReadInitializer>"//"([!/]?){B}*{CMD}"}".*|"/*"([!*]?){B}*{CMD}"}"[^*]*"*/"	{
+<FindMembers,FindFields,ReadInitializer>"//"([!/]){B}*{CMD}"}".*|"/*"([!*]){B}*{CMD}"}"[^*]*"*/"	{
                                           bool insideEnum = YY_START==FindFields || (YY_START==ReadInitializer && lastInitializerContext==FindFields); // see bug746226
   					  closeGroup(current,yyFileName,yyLineNr,insideEnum);
   					}


### PR DESCRIPTION
Besides the wanted start of comments `//!`, `///`, `/*!` and `/**` also the "normal" comments `//` and `/*` were recognized as starting a comment for the group open (`\{`, `@{`) and group closing (`\}`, `@}`) commands.
This was due to the usage of `?` in the regular expression meaning 0 or 1 times.