### PR TITLE
regression #7105 Correct counting in case of `\name`

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3208,6 +3208,7 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
       g_memberGroupId==DOX_NOGROUP) // @name section but no group started yet
   {
     openGroup(current,yyFileName,yyLineNr);
+    g_openCount--;
   }
 
   Debug::print(Debug::CommentScan,0,"-----------\nCommentScanner: %s:%d\noutput=[\n"


### PR DESCRIPTION
In case of the `\name` command it is possible that a group is opened, but this group is not closed (for the `\name`), so the counting should not increase.