### PR TITLE
issue #7123: some code line are missed in the xml file for java

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -3454,14 +3454,14 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <*>\n{B}*"/*@"[{}]			{ // remove one-line group marker
 					  if (Config_getBool(STRIP_CODE_COMMENTS))
   					  {
-					    g_lastSpecialCContext = YY_START;
+					    if (YY_START != RemoveSpecialCComment) g_lastSpecialCContext = YY_START;
 					    g_yyLineNr++;
 					    BEGIN(RemoveSpecialCComment);
 					  }
 					  else
 					  {
 					    // check is to prevent getting stuck in skipping C++ comments
-					    if (YY_START != SkipCxxComment)
+					    if (YY_START != SkipComment && YY_START != SkipCxxComment)
 					    {
   					      g_lastCContext = YY_START ;
 					    }
@@ -3486,13 +3486,13 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <*>^{B}*"/*@"[{}]			{ // remove multi-line group marker
 					  if (Config_getBool(STRIP_CODE_COMMENTS))
 					  {
-					    g_lastSpecialCContext = YY_START;
+					    if (YY_START != RemoveSpecialCComment) g_lastSpecialCContext = YY_START;
 					    BEGIN(RemoveSpecialCComment);
 					  }
 					  else
 					  {
 					    // check is to prevent getting stuck in skipping C++ comments
-					    if (YY_START != SkipCxxComment)
+					    if (YY_START != SkipComment && YY_START != SkipCxxComment)
 					    {
   					      g_lastCContext = YY_START ;
 					    }
@@ -3537,14 +3537,14 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <*>\n{B}*"/*"[!*]/[^/*] 		{
 					  if (Config_getBool(STRIP_CODE_COMMENTS))
   					  {
-					    g_lastSpecialCContext = YY_START;
+					    if (YY_START != RemoveSpecialCComment) g_lastSpecialCContext = YY_START;
 					    g_yyLineNr++;
 					    BEGIN(RemoveSpecialCComment);
 					  }
 					  else
 					  {
 					    // check is to prevent getting stuck in skipping C++ comments
-					    if (YY_START != SkipCxxComment)
+					    if (YY_START != SkipComment && YY_START != SkipCxxComment)
 					    {
   					      g_lastCContext = YY_START ;
 					    }
@@ -3556,13 +3556,13 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <*>^{B}*"/**"[*]+/[^/]			{ // special C "banner" comment block at a new line
 					  if (Config_getBool(JAVADOC_BANNER) && Config_getBool(STRIP_CODE_COMMENTS))
 					  {
-					    g_lastSpecialCContext = YY_START;
+					    if (YY_START != RemoveSpecialCComment) g_lastSpecialCContext = YY_START;
 					    BEGIN(RemoveSpecialCComment);
 					  }
 					  else
 					  {
 					    // check is to prevent getting stuck in skipping C++ comments
-					    if (YY_START != SkipCxxComment)
+					    if (YY_START != SkipComment && YY_START != SkipCxxComment)
 					    {
   					      g_lastCContext = YY_START ;
 					    }
@@ -3574,13 +3574,13 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <*>^{B}*"/*"[!*]/[^/*]			{ // special C comment block at a new line
 					  if (Config_getBool(STRIP_CODE_COMMENTS))
 					  {
-					    g_lastSpecialCContext = YY_START;
+					    if (YY_START != RemoveSpecialCComment) g_lastSpecialCContext = YY_START;
 					    BEGIN(RemoveSpecialCComment);
 					  }
 					  else
 					  {
 					    // check is to prevent getting stuck in skipping C++ comments
-					    if (YY_START != SkipCxxComment)
+					    if (YY_START != SkipComment && YY_START != SkipCxxComment)
 					    {
   					      g_lastCContext = YY_START ;
 					    }
@@ -3593,13 +3593,13 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
                                           if (YY_START==SkipString) REJECT;
 					  if (Config_getBool(STRIP_CODE_COMMENTS))
 					  {
-					    g_lastSpecialCContext = YY_START;
+					    if (YY_START != RemoveSpecialCComment) g_lastSpecialCContext = YY_START;
 					    BEGIN(RemoveSpecialCComment);
 					  }
 					  else
 					  {
 					    // check is to prevent getting stuck in skipping C++ comments
-					    if (YY_START != SkipCxxComment)
+					    if (YY_START != SkipComment && YY_START != SkipCxxComment)
 					    {
   					      g_lastCContext = YY_START ;
 					    }
@@ -3624,7 +3624,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  startFontClass("comment");
   					  g_code->codify(yytext);
 					  // check is to prevent getting stuck in skipping C++ comments
-					  if (YY_START != SkipCxxComment)
+					  if (YY_START != SkipComment && YY_START != SkipCxxComment)
 					  {
   					    g_lastCContext = YY_START ;
 					  }


### PR DESCRIPTION
When already in a comment block don't reset the last comment type.
Problem also occurs with e.g. C