### PR TITLE
Latex output format fixes

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -797,7 +797,7 @@ void LatexDocVisitor::visitPre(DocSimpleSect *s)
   // special case 1: user defined title
   if (s->type()!=DocSimpleSect::User && s->type()!=DocSimpleSect::Rcs)
   {
-    m_t << "}\n";
+    m_t << ":}\n";
   }
   else
   {
@@ -1517,7 +1517,7 @@ void LatexDocVisitor::visitPre(DocParamSect *s)
     default:
       ASSERT(0);
   }
-  m_t << "}\n";
+  m_t << ":}\n";
 }
 
 void LatexDocVisitor::visitPost(DocParamSect *s)

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -306,16 +306,9 @@
 
 % Used by @par and @paragraph
 \newenvironment{DoxyParagraph}[1]{%
-  \begin{list}{}{%
-    \settowidth{\labelwidth}{40pt}%
-    \setlength{\leftmargin}{\labelwidth+\labelsep}%
-    \setlength{\parsep}{0pt}%
-    \setlength{\itemsep}{-4pt}%
-    \renewcommand{\makelabel}{\entrylabel}%
-  }%
-  \item[#1]%
+  \begin{DoxyDesc}{#1}%
 }{%
-  \end{list}%
+  \end{DoxyDesc}%
 }
 
 % Used by parameter lists


### PR DESCRIPTION
In this pull requests two issues related to LaTeX output are addressed
1. Align latex output to man format where each section name is terminated with colon.
2. Paragraph header in pdf has same indent as other sections like param or retval 