### PR TITLE
Option for 'input buffer overflow'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ option(win_static      "Link with /MT in stead of /MD on windows" OFF)
 option(english_only    "Only compile in support for the English language" OFF)
 option(force_qt4       "Forces doxywizard to build using Qt4 even if Qt5 is installed" OFF)
 
+SET(enlarge_lex_buffers "262144" CACHE INTERNAL "Sets the lex input and read buffere to the specified size")
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(TOP "${CMAKE_SOURCE_DIR}")
 include(version)

--- a/doc/faq.doc
+++ b/doc/faq.doc
@@ -235,6 +235,13 @@ should send me a code fragment that triggers the message. To work around
 the problem, put some line-breaks into your file, split it up into smaller 
 parts, or exclude it from the input using EXCLUDE.
 
+Another way to work around this problem is to use the cmake command with the option:
+```
+-Denlarge_lex_buffers=<size>
+```
+where `<size>` is the new size of the input (`YY_BUF_SIZE`) and read (`YY_READ_BUF_SIZE`) buffer.
+In case this option is not given the default value of 262144 (i.e. 256K) will be used.
+
 \section faq_latex When running make in the latex directory I get "TeX capacity exceeded". Now what?
 
 You can edit the texmf.cfg file to increase the default values of the 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ file(MAKE_DIRECTORY ${GENERATED_SRC})
 file(GLOB LANGUAGE_FILES "${CMAKE_SOURCE_DIR}/src/translator_??.h")
 
 # instead of increasebuffer.py
-add_definitions(-DYY_BUF_SIZE=262144 -DYY_READ_BUF_SIZE=262144)
+add_definitions(-DYY_BUF_SIZE=${enlarge_lex_buffers} -DYY_READ_BUF_SIZE=${enlarge_lex_buffers})
 
 # generate settings.h
 file(GENERATE OUTPUT ${GENERATED_SRC}/settings.h


### PR DESCRIPTION
Cmake option `-Denlarge_lex_buffers=<size>` to enlarge input and read buffers for source code lexers.