### PR TITLE
take doc group out of commentscan.l

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -254,6 +254,7 @@ add_library(_doxygen STATIC
     xmlgen.cpp
     docbookvisitor.cpp
     docbookgen.cpp
+    docgroup.cpp
 )
 
 add_executable(doxygen main.cpp)

--- a/src/commentscan.h
+++ b/src/commentscan.h
@@ -85,13 +85,5 @@ bool parseCommentBlock(ParserInterface *parser,
                        bool &newEntryNeeded
 		     );
 
-void groupEnterFile(const char *file,int line);
-void groupLeaveFile(const char *file,int line);
-void groupLeaveCompound(const char *file,int line,const char *name);
-void groupEnterCompound(const char *file,int line,const char *name);
-void openGroup(Entry *e,const char *file,int line);
-void closeGroup(Entry *,const char *file,int line,bool foundInline=FALSE);
-void initGroupInfo(Entry *e);
-
 
 #endif

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -386,11 +386,6 @@ class GuardedSection
     bool m_parentVisible;
 };
 
-void openGroup(Entry *e,const char *file,int line);
-void closeGroup(Entry *e,const char *file,int line,bool foundInline=FALSE);
-void initGroupInfo(Entry *e);
-static void groupAddDocs(Entry *e);
-
 /* -----------------------------------------------------------------
  *
  *	statics
@@ -451,21 +446,11 @@ static bool             g_insideParBlock;
 
 //-----------------------------------------------------------------------------
 
-static QStack<Grouping> g_autoGroupStack;
-static int              g_memberGroupId = DOX_NOGROUP;
-static QCString         g_memberGroupHeader;
-static QCString         g_memberGroupDocs;
-static QCString         g_memberGroupRelates;
-static QCString         g_compoundName;
-
-static int g_openCount = 0;
-//-----------------------------------------------------------------------------
-
 static void initParser()
 {
   g_sectionLabel.resize(0);
   g_sectionTitle.resize(0);
-  g_memberGroupHeader.resize(0);
+  Doxygen::docGroup.clearHeader();
   g_insideParBlock = FALSE;
 }
 
@@ -1219,12 +1204,12 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					}
 <Comment>{B}*{CMD}"{"                   { // begin of a group
                                           //langParser->handleGroupStartCommand(g_memberGroupHeader);
-                                          openGroup(current,yyFileName,yyLineNr);
+                                          Doxygen::docGroup.open(current,yyFileName,yyLineNr);
                                         }
 <Comment>{B}*{CMD}"}"                   { // end of a group
                                           //langParser->handleGroupEndCommand();
-                                          closeGroup(current,yyFileName,yyLineNr,TRUE);
-                                          g_memberGroupHeader.resize(0);
+                                          Doxygen::docGroup.close(current,yyFileName,yyLineNr,TRUE);
+					  Doxygen::docGroup.clearHeader();
 					  parseMore=TRUE;
                                           needNewEntry = TRUE;
 #if YY_FLEX_MAJOR_VERSION>=2 && (YY_FLEX_MINOR_VERSION>5 || (YY_FLEX_MINOR_VERSION==5 && YY_FLEX_SUBMINOR_VERSION>=33))
@@ -2130,10 +2115,10 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 <NameParam>{LC}				{ // line continuation
                                           yyLineNr++; 
 					  addOutput('\n');
-					  g_memberGroupHeader+=' ';
+					  Doxygen::docGroup.appendHeader(' ');
   					}
 <NameParam>.				{ // ignore other stuff
-					  g_memberGroupHeader+=*yytext;
+					  Doxygen::docGroup.appendHeader(*yytext);
 					  current->name+=*yytext;
   					}
 
@@ -2553,11 +2538,11 @@ static bool handleName(const QCString &, const QCStringList &)
   bool stop=makeStructuralIndicator(Entry::MEMBERGRP_SEC);
   if (!stop)
   {
-    g_memberGroupHeader.resize(0);
+    Doxygen::docGroup.clearHeader();
     BEGIN( NameParam );
-    if (g_memberGroupId!=DOX_NOGROUP) // end of previous member group
+    if (!Doxygen::docGroup.isEmpty()) // end of previous member group
     {
-      closeGroup(current,yyFileName,yyLineNr,TRUE);
+      Doxygen::docGroup.close(current,yyFileName,yyLineNr,TRUE);
     }
   }
   return stop;
@@ -3205,9 +3190,9 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
   }
 
   if (current->section==Entry::MEMBERGRP_SEC &&
-      g_memberGroupId==DOX_NOGROUP) // @name section but no group started yet
+      Doxygen::docGroup.isEmpty()) // @name section but no group started yet
   {
-    openGroup(current,yyFileName,yyLineNr);
+    Doxygen::docGroup.open(current,yyFileName,yyLineNr);
   }
 
   Debug::print(Debug::CommentScan,0,"-----------\nCommentScanner: %s:%d\noutput=[\n"
@@ -3221,7 +3206,7 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
   checkFormula();
   prot = protection;
   
-  groupAddDocs(curEntry);
+  Doxygen::docGroup.addDocs(curEntry);
 
   newEntryNeeded = needNewEntry;
 
@@ -3240,195 +3225,6 @@ bool parseCommentBlock(/* in */     ParserInterface *parser,
   return parseMore;
 }
 
-//---------------------------------------------------------------------------
-
-void groupEnterFile(const char *fileName,int)
-{
-  g_openCount = 0;
-  g_autoGroupStack.setAutoDelete(TRUE);
-  g_autoGroupStack.clear();
-  g_memberGroupId = DOX_NOGROUP;
-  g_memberGroupDocs.resize(0);
-  g_memberGroupRelates.resize(0);
-  g_compoundName=fileName;
-}
-
-void groupLeaveFile(const char *fileName,int line)
-{
-  //if (g_memberGroupId!=DOX_NOGROUP)
-  //{
-  //  warn(fileName,line,"end of file while inside a member group\n");
-  //}
-  g_memberGroupId=DOX_NOGROUP;
-  g_memberGroupRelates.resize(0);
-  g_memberGroupDocs.resize(0);
-  if (!g_autoGroupStack.isEmpty())
-  {
-    warn(fileName,line,"end of file while inside a group");
-  }
-  else if (g_openCount > 0) // < 0 is already handled on close call
-  {
-    warn(fileName,line,"end of file with unbalanced grouping commands");
-  }
-}
-
-void groupEnterCompound(const char *fileName,int line,const char *name)
-{
-  if (g_memberGroupId!=DOX_NOGROUP)
-  {
-    warn(fileName,line,"try to put compound %s inside a member group\n",name);
-  }
-  g_memberGroupId=DOX_NOGROUP;
-  g_memberGroupRelates.resize(0);
-  g_memberGroupDocs.resize(0);
-  g_compoundName = name;
-  int i = g_compoundName.find('(');
-  if (i!=-1) 
-  {
-    g_compoundName=g_compoundName.left(i); // strip category (Obj-C)
-  }
-  if (g_compoundName.isEmpty())
-  {
-    g_compoundName=fileName;
-  }
-  //printf("groupEnterCompound(%s)\n",name);
-}
-
-void groupLeaveCompound(const char *,int,const char * /*name*/)
-{
-  //printf("groupLeaveCompound(%s)\n",name);
-  //if (g_memberGroupId!=DOX_NOGROUP)
-  //{
-  //  warn(fileName,line,"end of compound %s while inside a member group\n",name);
-  //}
-  g_memberGroupId=DOX_NOGROUP;
-  g_memberGroupRelates.resize(0);
-  g_memberGroupDocs.resize(0);
-  g_compoundName.resize(0);
-}
-
-static int findExistingGroup(int &groupId,const MemberGroupInfo *info)
-{
-  //printf("findExistingGroup %s:%s\n",info->header.data(),info->compoundName.data());
-  QIntDictIterator<MemberGroupInfo> di(Doxygen::memGrpInfoDict);
-  MemberGroupInfo *mi;
-  for (di.toFirst();(mi=di.current());++di)
-  {
-    if (g_compoundName==mi->compoundName &&  // same file or scope
-	!mi->header.isEmpty() &&             // not a nameless group
-	qstricmp(mi->header,info->header)==0  // same header name
-       )
-    {
-      //printf("Found it!\n");
-      return (int)di.currentKey(); // put the item in this group
-    }
-  }
-  groupId++; // start new group
-  return groupId;
-}
-
-void openGroup(Entry *e,const char *,int)
-{
-  g_openCount++;
-  //printf("==> openGroup(name=%s,sec=%x) g_autoGroupStack=%d\n",
-  //  	e->name.data(),e->section,g_autoGroupStack.count());
-  if (e->section==Entry::GROUPDOC_SEC) // auto group
-  {
-    g_autoGroupStack.push(new Grouping(e->name,e->groupingPri()));
-  }
-  else // start of a member group
-  {
-    //printf("    membergroup id=%d %s\n",g_memberGroupId,g_memberGroupHeader.data());
-    if (g_memberGroupId==DOX_NOGROUP) // no group started yet
-    {
-      static int curGroupId=0;
-
-      MemberGroupInfo *info = new MemberGroupInfo;
-      info->header = g_memberGroupHeader.stripWhiteSpace();
-      info->compoundName = g_compoundName;
-      g_memberGroupId = findExistingGroup(curGroupId,info);
-      //printf("    use membergroup %d\n",g_memberGroupId);
-      Doxygen::memGrpInfoDict.insert(g_memberGroupId,info);
-
-      g_memberGroupRelates = e->relates;
-      e->mGrpId = g_memberGroupId;
-    }
-  }
-}
-
-void closeGroup(Entry *e,const char *fileName,int line,bool foundInline)
-{
-  g_openCount--;
-  if (g_openCount < 0)
-  {
-    warn(fileName,line,"unbalanced grouping commands");
-  }
-  //printf("==> closeGroup(name=%s,sec=%x,file=%s,line=%d) g_autoGroupStack=%d\n",
-  //    e->name.data(),e->section,fileName,line,g_autoGroupStack.count());
-  if (g_memberGroupId!=DOX_NOGROUP) // end of member group
-  {
-    MemberGroupInfo *info=Doxygen::memGrpInfoDict.find(g_memberGroupId);
-    if (info) // known group
-    {
-      info->doc = g_memberGroupDocs;
-      info->docFile = fileName;
-      info->docLine = line;
-    }
-    g_memberGroupId=DOX_NOGROUP;
-    g_memberGroupRelates.resize(0);
-    g_memberGroupDocs.resize(0);
-    if (!foundInline) e->mGrpId=DOX_NOGROUP;
-    //printf("new group id=%d\n",g_memberGroupId);
-  }
-  else if (!g_autoGroupStack.isEmpty()) // end of auto group
-  {
-    Grouping *grp = g_autoGroupStack.pop();
-    // see bug577005: we should not remove the last group for e
-    if (!foundInline) e->groups->removeLast();
-    //printf("Removing %s e=%p\n",grp->groupname.data(),e);
-    delete grp;
-    if (!foundInline) initGroupInfo(e);
-  }
-}
-
-void initGroupInfo(Entry *e)
-{
-  //printf("==> initGroup(id=%d,related=%s,e=%p)\n",g_memberGroupId,
-  //       g_memberGroupRelates.data(),e);
-  e->mGrpId     = g_memberGroupId;
-  e->relates    = g_memberGroupRelates;
-  if (!g_autoGroupStack.isEmpty())
-  {
-    //printf("Appending group %s to %s: count=%d entry=%p\n",
-    //	g_autoGroupStack.top()->groupname.data(),
-    //	e->name.data(),e->groups->count(),e);
-    e->groups->append(new Grouping(*g_autoGroupStack.top()));
-  }
-}
-
-static void groupAddDocs(Entry *e)
-{
-  if (e->section==Entry::MEMBERGRP_SEC)
-  {
-    g_memberGroupDocs=e->brief.stripWhiteSpace();
-    e->doc = stripLeadingAndTrailingEmptyLines(e->doc,e->docLine);
-    if (!g_memberGroupDocs.isEmpty() && !e->doc.isEmpty())
-    {
-      g_memberGroupDocs+="\n\n";
-    }
-    g_memberGroupDocs+=e->doc;
-    MemberGroupInfo *info=Doxygen::memGrpInfoDict.find(g_memberGroupId);
-    if (info) 
-    {
-      info->doc = g_memberGroupDocs;
-      info->docFile = e->docFile;
-      info->docLine = e->docLine;
-      info->setRefItems(e->sli);
-    }
-    e->doc.resize(0);
-    e->brief.resize(0);
-  }
-}
 
 static void handleGuard(const QCString &expr)
 {

--- a/src/docgroup.cpp
+++ b/src/docgroup.cpp
@@ -1,0 +1,209 @@
+#include "doxygen.h"
+#include "util.h"
+#include "entry.h"
+#include "message.h"
+#include "docgroup.h"
+
+
+void DocGroup::enterFile(const char *fileName,int)
+{
+  g_openCount = 0;
+  g_autoGroupStack.setAutoDelete(TRUE);
+  g_autoGroupStack.clear();
+  g_memberGroupId = DOX_NOGROUP;
+  g_memberGroupDocs.resize(0);
+  g_memberGroupRelates.resize(0);
+  g_compoundName=fileName;
+}
+
+void DocGroup::leaveFile(const char *fileName,int line)
+{
+  //if (g_memberGroupId!=DOX_NOGROUP)
+  //{
+  //  warn(fileName,line,"end of file while inside a member group\n");
+  //}
+  g_memberGroupId=DOX_NOGROUP;
+  g_memberGroupRelates.resize(0);
+  g_memberGroupDocs.resize(0);
+  if (!g_autoGroupStack.isEmpty())
+  {
+    warn(fileName,line,"end of file while inside a group");
+  }
+  else if (g_openCount > 0) // < 0 is already handled on close call
+  {
+    warn(fileName,line,"end of file with unbalanced grouping commands");
+  }
+}
+
+void DocGroup::enterCompound(const char *fileName,int line,const char *name)
+{
+  if (g_memberGroupId!=DOX_NOGROUP)
+  {
+    warn(fileName,line,"try to put compound %s inside a member group\n",name);
+  }
+  g_memberGroupId=DOX_NOGROUP;
+  g_memberGroupRelates.resize(0);
+  g_memberGroupDocs.resize(0);
+  g_compoundName = name;
+  int i = g_compoundName.find('(');
+  if (i!=-1) 
+  {
+    g_compoundName=g_compoundName.left(i); // strip category (Obj-C)
+  }
+  if (g_compoundName.isEmpty())
+  {
+    g_compoundName=fileName;
+  }
+  //printf("groupEnterCompound(%s)\n",name);
+}
+
+void DocGroup::leaveCompound(const char *,int,const char * /*name*/)
+{
+  //printf("groupLeaveCompound(%s)\n",name);
+  //if (g_memberGroupId!=DOX_NOGROUP)
+  //{
+  //  warn(fileName,line,"end of compound %s while inside a member group\n",name);
+  //}
+  g_memberGroupId=DOX_NOGROUP;
+  g_memberGroupRelates.resize(0);
+  g_memberGroupDocs.resize(0);
+  g_compoundName.resize(0);
+}
+
+int DocGroup::findExistingGroup(int &groupId,const MemberGroupInfo *info)
+{
+  //printf("findExistingGroup %s:%s\n",info->header.data(),info->compoundName.data());
+  QIntDictIterator<MemberGroupInfo> di(Doxygen::memGrpInfoDict);
+  MemberGroupInfo *mi;
+  for (di.toFirst();(mi=di.current());++di)
+  {
+    if (g_compoundName==mi->compoundName &&  // same file or scope
+	!mi->header.isEmpty() &&             // not a nameless group
+	qstricmp(mi->header,info->header)==0  // same header name
+       )
+    {
+      //printf("Found it!\n");
+      return (int)di.currentKey(); // put the item in this group
+    }
+  }
+  groupId++; // start new group
+  return groupId;
+}
+
+void DocGroup::open(Entry *e,const char *,int)
+{
+  g_openCount++;
+  //printf("==> openGroup(name=%s,sec=%x) g_autoGroupStack=%d\n",
+  //  	e->name.data(),e->section,g_autoGroupStack.count());
+  if (e->section==Entry::GROUPDOC_SEC) // auto group
+  {
+    g_autoGroupStack.push(new Grouping(e->name,e->groupingPri()));
+  }
+  else // start of a member group
+  {
+    //printf("    membergroup id=%d %s\n",g_memberGroupId,g_memberGroupHeader.data());
+    if (g_memberGroupId==DOX_NOGROUP) // no group started yet
+    {
+      static int curGroupId=0;
+
+      MemberGroupInfo *info = new MemberGroupInfo;
+      info->header = g_memberGroupHeader.stripWhiteSpace();
+      info->compoundName = g_compoundName;
+      g_memberGroupId = findExistingGroup(curGroupId,info);
+      //printf("    use membergroup %d\n",g_memberGroupId);
+      Doxygen::memGrpInfoDict.insert(g_memberGroupId,info);
+
+      g_memberGroupRelates = e->relates;
+      e->mGrpId = g_memberGroupId;
+    }
+  }
+}
+
+void DocGroup::close(Entry *e,const char *fileName,int line,bool foundInline)
+{
+  g_openCount--;
+  if (g_openCount < 0)
+  {
+    warn(fileName,line,"unbalanced grouping commands");
+  }
+  //printf("==> closeGroup(name=%s,sec=%x,file=%s,line=%d) g_autoGroupStack=%d\n",
+  //    e->name.data(),e->section,fileName,line,g_autoGroupStack.count());
+  if (g_memberGroupId!=DOX_NOGROUP) // end of member group
+  {
+    MemberGroupInfo *info=Doxygen::memGrpInfoDict.find(g_memberGroupId);
+    if (info) // known group
+    {
+      info->doc = g_memberGroupDocs;
+      info->docFile = fileName;
+      info->docLine = line;
+    }
+    g_memberGroupId=DOX_NOGROUP;
+    g_memberGroupRelates.resize(0);
+    g_memberGroupDocs.resize(0);
+    if (!foundInline) e->mGrpId=DOX_NOGROUP;
+    //printf("new group id=%d\n",g_memberGroupId);
+  }
+  else if (!g_autoGroupStack.isEmpty()) // end of auto group
+  {
+    Grouping *grp = g_autoGroupStack.pop();
+    // see bug577005: we should not remove the last group for e
+    if (!foundInline) e->groups->removeLast();
+    //printf("Removing %s e=%p\n",grp->groupname.data(),e);
+    delete grp;
+    if (!foundInline) initGroupInfo(e);
+  }
+}
+
+void DocGroup::initGroupInfo(Entry *e)
+{
+  //printf("==> initGroup(id=%d,related=%s,e=%p)\n",g_memberGroupId,
+  //       g_memberGroupRelates.data(),e);
+  e->mGrpId     = g_memberGroupId;
+  e->relates    = g_memberGroupRelates;
+  if (!g_autoGroupStack.isEmpty())
+  {
+    //printf("Appending group %s to %s: count=%d entry=%p\n",
+    //	g_autoGroupStack.top()->groupname.data(),
+    //	e->name.data(),e->groups->count(),e);
+    e->groups->append(new Grouping(*g_autoGroupStack.top()));
+  }
+}
+
+void DocGroup::addDocs(Entry *e)
+{
+  if (e->section==Entry::MEMBERGRP_SEC)
+  {
+    g_memberGroupDocs=e->brief.stripWhiteSpace();
+    e->doc = stripLeadingAndTrailingEmptyLines(e->doc,e->docLine);
+    if (!g_memberGroupDocs.isEmpty() && !e->doc.isEmpty())
+    {
+      g_memberGroupDocs+="\n\n";
+    }
+    g_memberGroupDocs+=e->doc;
+    MemberGroupInfo *info=Doxygen::memGrpInfoDict.find(g_memberGroupId);
+    if (info) 
+    {
+      info->doc = g_memberGroupDocs;
+      info->docFile = e->docFile;
+      info->docLine = e->docLine;
+      info->setRefItems(e->sli);
+    }
+    e->doc.resize(0);
+    e->brief.resize(0);
+  }
+}
+
+bool DocGroup::isEmpty() const
+{
+  return (g_memberGroupId==DOX_NOGROUP);
+}
+
+void DocGroup::clearHeader()
+{
+  g_memberGroupHeader.resize(0);
+}
+
+void DocGroup::appendHeader(const char text)
+{
+  g_memberGroupHeader += text;
+}

--- a/src/docgroup.h
+++ b/src/docgroup.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *
+ * Copyright (C) 1997-2019 by Dimitri van Heesch.
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation under the terms of the GNU General Public License is hereby 
+ * granted. No representations are made about the suitability of this software 
+ * for any purpose. It is provided "as is" without express or implied warranty.
+ * See the GNU General Public License for more details.
+ *
+ * Documents produced by Doxygen are derivative works derived from the
+ * input used in their production; they are not affected by this license.
+ *
+ */
+
+#ifndef DOCGROUP_H
+#define DOCGROUP_H
+
+#include <qstack.h>
+#include <qstring.h>
+#include "membergroup.h"
+
+class Entry;
+
+class DocGroup
+{
+public:
+  DocGroup() {};
+
+public:
+  void enterFile(const char *fileName,int);
+  void leaveFile(const char *fileName,int line);
+  void enterCompound(const char *fileName,int line,const char *name);
+  void leaveCompound(const char *,int,const char * /*name*/);
+  void open(Entry *e,const char *,int);
+  void close(Entry *e,const char *fileName,int line,bool foundInline);
+  void initGroupInfo(Entry *e);
+  bool isEmpty() const;
+  void clearHeader();
+  void appendHeader(const char);
+  void addDocs(Entry *e);
+
+private:
+  int g_openCount = 0;
+  QCString         g_memberGroupHeader;
+  int              g_memberGroupId = DOX_NOGROUP;
+  int findExistingGroup(int &groupId,const MemberGroupInfo *info);
+  QCString         g_memberGroupRelates;
+  QCString         g_memberGroupDocs;
+  QStack<Grouping> g_autoGroupStack;
+  QCString         g_compoundName;
+};
+
+#endif

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -174,6 +174,7 @@ QCString         Doxygen::spaces;
 bool             Doxygen::generatingXmlOutput = FALSE;
 bool             Doxygen::markdownSupport = TRUE;
 GenericsSDict   *Doxygen::genericsDict;
+DocGroup         Doxygen::docGroup;
 
 // locally accessible globals
 static QDict<Entry>     g_classEntries(1009);

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -27,6 +27,7 @@
 #include "membergroup.h"
 #include "dirdef.h"
 #include "memberlist.h"
+#include "docgroup.h"
 
 class RefList;
 class PageSList;
@@ -150,6 +151,7 @@ class Doxygen
     static bool                      generatingXmlOutput;
     static bool                      markdownSupport;
     static GenericsSDict            *genericsDict;
+    static DocGroup                  docGroup;
 };
 
 void initDoxygen();

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2304,7 +2304,7 @@ static void initEntry()
   current->virt       = virt;
   current->stat       = gstat;
   current->lang       = SrcLangExt_Fortran; 
-  initGroupInfo(current);
+  Doxygen::docGroup.initGroupInfo(current);
 }
 
 /**
@@ -2712,7 +2712,7 @@ static void parseMain(const char *fileName,const char *fileBuf,Entry *rt, Fortra
     global_scope = rt;
     startScope(rt); // implies current_root = rt
     initParser();
-    groupEnterFile(yyFileName,yyLineNr);
+    Doxygen::docGroup.enterFile(yyFileName,yyLineNr);
 
     current          = new Entry;
     current->lang    = SrcLangExt_Fortran; 
@@ -2729,7 +2729,7 @@ static void parseMain(const char *fileName,const char *fileBuf,Entry *rt, Fortra
     }
 
     fortranscannerYYlex();
-    groupLeaveFile(yyFileName,yyLineNr);
+    Doxygen::docGroup.leaveFile(yyFileName,yyLineNr);
 
     if (global_scope && global_scope != (Entry *) -1) endScope(current_root, TRUE); // TRUE - global root
 

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -143,7 +143,7 @@ static void initEntry()
   current->stat       = gstat;
   current->lang       = SrcLangExt_Python; 
   current->setParent(current_root);
-  initGroupInfo(current);
+  Doxygen::docGroup.initGroupInfo(current);
   gstat = FALSE;
 }
 
@@ -1772,14 +1772,14 @@ static void parseCompounds(Entry *rt)
       current = new Entry;
       initEntry();
 
-      groupEnterCompound(yyFileName,yyLineNr,ce->name);
+      Doxygen::docGroup.enterCompound(yyFileName,yyLineNr,ce->name);
       
       pyscannerYYlex() ;
       g_lexInit=TRUE;
       delete current; current=0;
       ce->program.resize(0);
 
-      groupLeaveCompound(yyFileName,yyLineNr,ce->name);
+      Doxygen::docGroup.leaveCompound(yyFileName,yyLineNr,ce->name);
 
     }
     parseCompounds(ce);
@@ -1839,7 +1839,7 @@ static void parseMain(const char *fileName,const char *fileBuf,Entry *rt)
     initParser();
     current       = new Entry;
 
-    groupEnterFile(yyFileName,yyLineNr);
+    Doxygen::docGroup.enterFile(yyFileName,yyLineNr);
     
     current->reset();
     initEntry();
@@ -1848,7 +1848,7 @@ static void parseMain(const char *fileName,const char *fileBuf,Entry *rt)
     pyscannerYYlex();
     g_lexInit=TRUE;
 
-    groupLeaveFile(yyFileName,yyLineNr);
+    Doxygen::docGroup.leaveFile(yyFileName,yyLineNr);
 
     current_root->program.resize(0);
     delete current; current=0;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -247,7 +247,7 @@ static void initEntry()
   //  //printf("Appending group %s\n",autoGroupStack.top()->groupname.data());
   //  current->groups->append(new Grouping(*autoGroupStack.top()));
   //}
-  initGroupInfo(current);
+  Doxygen::docGroup.initGroupInfo(current);
   isTypedef=FALSE;
 }
 
@@ -2854,12 +2854,12 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           if (previous && previous->section==Entry::GROUPDOC_SEC)
 					  {
 					    // link open command to the group defined in the previous entry
-					    openGroup(previous,yyFileName,yyLineNr);
+					    Doxygen::docGroup.open(previous,yyFileName,yyLineNr);
 					  }
 					  else
 					  {
 					    // link open command to the current entry
-					    openGroup(current,yyFileName,yyLineNr);
+					    Doxygen::docGroup.open(current,yyFileName,yyLineNr);
 					  }
 					  //current = tmp;
 					  initEntry();
@@ -2903,7 +2903,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					}
 <FindMembers,FindFields,ReadInitializer>"//"([!/]?){B}*{CMD}"}".*|"/*"([!*]?){B}*{CMD}"}"[^*]*"*/"	{
                                           bool insideEnum = YY_START==FindFields || (YY_START==ReadInitializer && lastInitializerContext==FindFields); // see bug746226
-  					  closeGroup(current,yyFileName,yyLineNr,insideEnum);
+  					  Doxygen::docGroup.close(current,yyFileName,yyLineNr,insideEnum);
   					}
 <FindMembers>"="			{ // in PHP code this could also be due to "<?="
   					  current->bodyLine = yyLineNr;
@@ -7207,13 +7207,13 @@ static void parseCompounds(Entry *rt)
       //memberGroupId = DOX_NOGROUP;
       //memberGroupRelates.resize(0);
       //memberGroupInside.resize(0);
-      groupEnterCompound(yyFileName,yyLineNr,ce->name);
+      Doxygen::docGroup.enterCompound(yyFileName,yyLineNr,ce->name);
       
       scannerYYlex() ;
       g_lexInit=TRUE;
       //forceEndGroup();
 
-      groupLeaveCompound(yyFileName,yyLineNr,ce->name);
+      Doxygen::docGroup.leaveCompound(yyFileName,yyLineNr,ce->name);
       
       delete current; current=0;
       ce->program.resize(0);
@@ -7273,7 +7273,7 @@ static void parseMain(const char *fileName,
 
     current_root  = rt ;
     initParser();
-    groupEnterFile(yyFileName,yyLineNr);
+    Doxygen::docGroup.enterFile(yyFileName,yyLineNr);
     current       = new Entry;
     //printf("current=%p current_root=%p\n",current,current_root);
     int sec=guessSection(yyFileName);
@@ -7305,7 +7305,7 @@ static void parseMain(const char *fileName,
     }
 
     //forceEndGroup();
-    groupLeaveFile(yyFileName,yyLineNr);
+    Doxygen::docGroup.leaveFile(yyFileName,yyLineNr);
 
     //if (depthIf>0)
     //{

--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -486,7 +486,7 @@ Entry* tcl_entry_new()
 //  myEntry->stat       = FALSE;
   myEntry->fileName   = tcl.file_name;
   myEntry->lang       = SrcLangExt_Tcl;
-  initGroupInfo(myEntry);
+  Doxygen::docGroup.initGroupInfo(myEntry);
   // collect entries
   if (!tcl.code)
   {
@@ -2950,7 +2950,7 @@ tcl_inf("%s\n",fileName);
   printlex(yy_flex_debug, TRUE, __FILE__, fileName);
 
   msg("Parsing %s...\n",fileName);
-  groupEnterFile(fileName,yylineno);
+  Doxygen::docGroup.enterFile(fileName,yylineno);
 
   tcl_init();
   tcl.code = NULL;
@@ -2958,7 +2958,7 @@ tcl_inf("%s\n",fileName);
   tcl.this_parser = this;
   tcl.entry_main          = root; /* toplevel entry */
   tcl_parse("","");
-  groupLeaveFile(tcl.file_name,yylineno);
+  Doxygen::docGroup.leaveFile(tcl.file_name,yylineno);
   root->program.resize(0);
   myFile.close();
   printlex(yy_flex_debug, FALSE, __FILE__, fileName);

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -146,7 +146,7 @@ void VHDLLanguageScanner::parseInput(const char *fileName,const char *fileBuf,En
   oldEntry = 0;
   VhdlParser::current=new Entry();
   VhdlParser::initEntry(VhdlParser::current);
-  groupEnterFile(fileName,yyLineNr);
+  Doxygen::docGroup.enterFile(fileName,yyLineNr);
   vhdlFileName = fileName;
   lineParse=new int[200]; // Dimitri: dangerous constant: should be bigger than largest token id in VhdlParserConstants.h
   VhdlParserIF::parseVhdlfile(fileBuf,inLine);
@@ -193,7 +193,7 @@ void VhdlParser::initEntry(Entry *e)
   e->fileName = yyFileName;
   e->lang     = SrcLangExt_VHDL;
   isVhdlDocPending();
-  initGroupInfo(e);
+  Doxygen::docGroup.initGroupInfo(e);
 }
 
 void VhdlParser::newEntry()


### PR DESCRIPTION
most of the flex files have a simple API, usually consisting of a few functions,
making it easy to have a per-call context.
This is not the case with commentscan.l.
The parts that deal with doc group has no logical dependency to the things going on in commentscan.l.

This also helps to refactor commentscan.l into a re-entrant scanner, as the scanner state
will only be about the commentscanner, not commentscanner _and_ doc groups,
making it easier to know when to destroy the scanner state struct.
