### PR TITLE
issue @7140 DoxygenLayout does not support UTF8 BOM format

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11270,9 +11270,7 @@ void parseInput()
   if (layoutFile.open(IO_ReadOnly))
   {
     msg("Parsing layout file %s...\n",layoutFileName.data());
-    QTextStream t(&layoutFile);
-    t.setEncoding(QTextStream::Latin1);
-    LayoutDocManager::instance().parse(t,layoutFileName);
+    LayoutDocManager::instance().parse(layoutFileName);
   }
   else if (!defaultLayoutUsed)
   {

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1538,10 +1538,11 @@ void LayoutDocManager::clear(LayoutDocManager::LayoutPart p)
   d->docEntries[(int)p].clear();
 }
 
-void LayoutDocManager::parse(QTextStream &t,const char *fileName)
+void LayoutDocManager::parse(const char *fileName)
 {
   LayoutErrorHandler errorHandler(fileName);
-  QXmlInputSource source( t );
+  QXmlInputSource source;
+  source.setData(fileToString(fileName));
   QXmlSimpleReader reader;
   reader.setContentHandler( &LayoutParser::instance() );
   reader.setErrorHandler( &errorHandler );

--- a/src/layout.h
+++ b/src/layout.h
@@ -201,7 +201,7 @@ class LayoutDocManager
     LayoutNavEntry *rootNavEntry() const;
 
     /** Parses a user provided layout */
-    void parse(QTextStream &t,const char *fileName);
+    void parse(const char *fileName);
     void init();
   private:
     void addEntry(LayoutPart p,LayoutDocEntry*e);


### PR DESCRIPTION
Read the DoxygenLayout file in a similar way as the header / footer etc. for HTML and feed the (converted) result into the XML reader.