### PR TITLE
issue #7151 Doxygen 1.8.15 TOC_INCLUDE_HEADINGS >0 stops html links being generated in markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2590,6 +2590,7 @@ void MarkdownFileParser::parseInput(const char *fileName,
   QCString docs = fileBuf;
   QCString id;
   QCString title=extractPageTitle(docs,id).stripWhiteSpace();
+  if (QString(id).startsWith("autotoc_md")) id = "";
   g_indentLevel=title.isEmpty() ? 0 : -1;
   QCString titleFn = QFileInfo(fileName).baseName().utf8();
   QCString fn      = QFileInfo(fileName).fileName().utf8();


### PR DESCRIPTION
Don't create autotoc generated ids for pages.
(the `\ref` problem also occurred with `\subage`).