### PR TITLE
Regression: unbalanced grouping commands

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2545,7 +2545,7 @@ static bool handleName(const QCString &, const QCStringList &)
     BEGIN( NameParam );
     if (!Doxygen::docGroup.isEmpty()) // end of previous member group
     {
-      Doxygen::docGroup.close(current,yyFileName,yyLineNr,TRUE);
+      Doxygen::docGroup.close(current,yyFileName,yyLineNr,TRUE,true);
     }
   }
   return stop;

--- a/src/docgroup.cpp
+++ b/src/docgroup.cpp
@@ -119,15 +119,18 @@ void DocGroup::open(Entry *e,const char *,int, bool implicit)
   }
 }
 
-void DocGroup::close(Entry *e,const char *fileName,int line,bool foundInline)
+void DocGroup::close(Entry *e,const char *fileName,int line,bool foundInline,bool implicit)
 {
-  if (m_openCount < 1)
+  if (!implicit)
   {
-    warn(fileName,line,"unbalanced grouping commands");
-  }
-  else
-  {
-    m_openCount--;
+    if (m_openCount < 1)
+    {
+      warn(fileName,line,"unbalanced grouping commands");
+    }
+    else
+    {
+      m_openCount--;
+    }
   }
   //printf("==> closeGroup(name=%s,sec=%x,file=%s,line=%d) m_autoGroupStack=%d\n",
   //    e->name.data(),e->section,fileName,line,m_autoGroupStack.count());

--- a/src/docgroup.h
+++ b/src/docgroup.h
@@ -33,7 +33,7 @@ class DocGroup
     void enterCompound(const char *fileName,int line,const char *name);
     void leaveCompound(const char *,int,const char * /*name*/);
     void open(Entry *e,const char *,int,bool implicit=false);
-    void close(Entry *e,const char *fileName,int line,bool foundInline);
+    void close(Entry *e,const char *fileName,int line,bool foundInline,bool imlicit=false);
     void initGroupInfo(Entry *e);
     bool isEmpty() const;
     void clearHeader();


### PR DESCRIPTION
Regression on #7122 (and #7115 / #7116).
When having multiple consecutive `\name` sections the warning "unbalanced grouping commands" appears
Analogous to the open command also the close command needs an implicit argument.

Example case:  [example.zip](https://github.com/doxygen/doxygen/files/3460617/example.zip)
