### PR TITLE
warning: More #endif's than #if's found.

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2094,6 +2094,8 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 <ReadString>"//"|"/*"			{
   					  g_defArgsStr+=yytext;
   					}
+<ReadString>\\/\n			{ // line continuation
+					}
 <ReadString>\\.				{
   					  g_defArgsStr+=yytext;
   					}


### PR DESCRIPTION
In case in a macro substitution string the last character was a backslash this was, incorrect, not seen as a sign for a line continuation.

Example: [example.zip](https://github.com/doxygen/doxygen/files/3462223/example.zip)
(updated, removed `.o` file and inserted `.c` file)
