### PR TITLE
warning: Member func2InGroup1() (function) of class Memgrp_Test is not documented.

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -849,7 +849,7 @@ Structural indicators
   This command turns a comment block into a header
   definition of a member group. The
   comment block should be followed by a
-  <code>//\@{ ... //\@}</code> block containing the
+  <code>///\@{ ... ///\@}</code> block containing the
   members of the group.
 
   See section \ref memgroup for an example.

--- a/examples/memgrp.cpp
+++ b/examples/memgrp.cpp
@@ -2,11 +2,11 @@
 class Memgrp_Test
 {
   public:
-    //@{
+    ///@{
     /** Same documentation for both members. Details */
     void func1InGroup1();
     void func2InGroup1();
-    //@}
+    ///@}
 
     /** Function without group. Details. */
     void ungroupedFunction();


### PR DESCRIPTION
Correcting code due to the fact that `//@{` isn't seen by doxygen as block start (#7116).
This problem is shown when generating the doxygen documentation.