### PR TITLE
Incorrect paragraph numbers in secref list.

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -66,12 +66,31 @@
 \usepackage{doxygen}
 \usepackage{manual}
 %%
+% unfortunately constructs like: 
+%   \renewcommand{\doxysection}[1]{\doxysubsection{##1}}
+% using values from book.cls (see also doxygen.sty) and redefining sections to correct level.
 \makeatletter
 \newenvironment{DoxygenSubAppendix}{%
-    \renewcommand{\doxysection}{\@ifstar{\doxysubsection@star}{\doxysubsection@nostar}}%
-    \renewcommand{\doxysubsection}{\@ifstar{\doxysubsubsection@star}{\doxysubsubsection@nostar}}
-    \renewcommand{\doxysubsubsection}{\@ifstar{\doxyparagraph@star}{\doxyparagraph@nostar}}
-    \renewcommand{\doxyparagraph}{\@ifstar{\doxysubparagraph@star}{\doxysubparagraph@nostar}}
+\renewcommand\doxysection{\@startsection{subsection}{2}{\z@}%
+                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+                                     {1.5ex \@plus .2ex}%
+                                     {\raggedright\normalfont\large\bfseries}}
+\renewcommand\doxysubsection{\@startsection{subsubsection}{3}{\z@}%
+                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+                                     {1.5ex \@plus .2ex}%
+                                     {\raggedright\normalfont\normalsize\bfseries}}
+\renewcommand\doxysubsubsection{\@startsection{paragraph}{4}{\z@}%
+                                    {3.25ex \@plus1ex \@minus.2ex}%
+                                    {-1em}%
+                                    {\raggedright\normalfont\normalsize\bfseries}}
+\renewcommand\doxyparagraph{\@startsection{subparagraph}{5}{\parindent}%
+                                       {3.25ex \@plus1ex \@minus .2ex}%
+                                       {-1em}%
+                                      {\raggedright\normalfont\normalsize\bfseries}}
+%%\renewcommand{\doxysection}[1]{\doxysubsection{##1}}
+%%\renewcommand{\doxysubsection}[1]{\doxysubsubsection{##1}}
+%%\renewcommand{\doxysubsubsection}[1]{\doxyparagraph{##1}}
+%%\renewcommand{\doxyparagraph}[1]{\doxysubparagraph{##1}}
 }{}
 \makeatother
 %%

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -539,22 +539,28 @@
 \newcommand{\Hypertarget}[1]{\Hy@raisedlink{\hypertarget{#1}{}}}
 
 % possibility to have sections etc. be within the margins
+% unfortunately had to copy part of book.cls and add \raggedright
 \makeatletter
-\newcommand{\doxysection}{\@ifstar{\doxysection@star}{\doxysection@nostar}}
-\newcommand{\doxysection@star}[1]{\begingroup\sloppy\raggedright\section*{#1}\endgroup}
-\newcommand{\doxysection@nostar}[1]{\begingroup\sloppy\raggedright\section{#1}\endgroup}
-\newcommand{\doxysubsection}{\@ifstar{\doxysubsection@star}{\doxysubsection@nostar}}
-\newcommand{\doxysubsection@star}[1]{\begingroup\sloppy\raggedright\subsection*{#1}\endgroup}
-\newcommand{\doxysubsection@nostar}[1]{\begingroup\sloppy\raggedright\subsection{#1}\endgroup}
-\newcommand{\doxysubsubsection}{\@ifstar{\doxysubsubsection@star}{\doxysubsubsection@nostar}}
-\newcommand{\doxysubsubsection@star}[1]{\begingroup\sloppy\raggedright\subsubsection*{#1}\endgroup}
-\newcommand{\doxysubsubsection@nostar}[1]{\begingroup\sloppy\raggedright\subsubsection{#1}\endgroup}
-\newcommand{\doxyparagraph}{\@ifstar{\doxyparagraph@star}{\doxyparagraph@nostar}}
-\newcommand{\doxyparagraph@star}[1]{\begingroup\sloppy\raggedright\paragraph*{#1}\endgroup}
-\newcommand{\doxyparagraph@nostar}[1]{\begingroup\sloppy\raggedright\paragraph{#1}\endgroup}
-\newcommand{\doxysubparagraph}{\@ifstar{\doxysubparagraph@star}{\doxysubparagraph@nostar}}
-\newcommand{\doxysubparagraph@star}[1]{\begingroup\sloppy\raggedright\subparagraph*{#1}\endgroup}
-\newcommand{\doxysubparagraph@nostar}[1]{\begingroup\sloppy\raggedright\subparagraph{#1}\endgroup}
+\newcommand\doxysection{\@startsection {section}{1}{\z@}%
+                                   {-3.5ex \@plus -1ex \@minus -.2ex}%
+                                   {2.3ex \@plus.2ex}%
+                                   {\raggedright\normalfont\Large\bfseries}}
+\newcommand\doxysubsection{\@startsection{subsection}{2}{\z@}%
+                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+                                     {1.5ex \@plus .2ex}%
+                                     {\raggedright\normalfont\large\bfseries}}
+\newcommand\doxysubsubsection{\@startsection{subsubsection}{3}{\z@}%
+                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+                                     {1.5ex \@plus .2ex}%
+                                     {\raggedright\normalfont\normalsize\bfseries}}
+\newcommand\doxyparagraph{\@startsection{paragraph}{4}{\z@}%
+                                    {3.25ex \@plus1ex \@minus.2ex}%
+                                    {-1em}%
+                                    {\raggedright\normalfont\normalsize\bfseries}}
+\newcommand\doxysubparagraph{\@startsection{subparagraph}{5}{\parindent}%
+                                       {3.25ex \@plus1ex \@minus .2ex}%
+                                       {-1em}%
+                                      {\raggedright\normalfont\normalsize\bfseries}}
 \makeatother
 % Define caption that is also suitable in a table
 \makeatletter


### PR DESCRIPTION
The definition of `\doxysection` etc. are using grouping around the section title, and this destroys the \label system as label names are stored locally.
(see also: https://tex.stackexchange.com/questions/502650/section-numbering-in-redefined-sections)

the `\doxysection` commands have been redefined (unfortunately partly copying values from book.cls)

The problem  is shown in the doxygen manual in e.g. the Configuration chapter where we get:
![secref_err](https://user-images.githubusercontent.com/5223533/62422319-e42a7d80-b6b0-11e9-95dd-35f6235b6a52.jpg)

instead of the expected:
![secref_org](https://user-images.githubusercontent.com/5223533/62422322-e7256e00-b6b0-11e9-8d25-ab3fbbe357d1.jpg)

so just chapter number instead of paragraph numbers.

Consequently also the definitions for the (sub-)appendix (e.g. Style Examples) had to be adjusted.