### PR TITLE
issue #7143 note block not generated properly if there are blanks after it

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1982,7 +1982,7 @@ void writeOneLineHeaderOrRuler(GrowBuf &out,const char *data,int size)
     out.addStr(data,size);
     if (hasLineBreak(data,size))
     {
-      out.addStr("<br>");
+      out.addStr("<br>\n");
     }
   }
 }


### PR DESCRIPTION
In case minimal 2 spaces at the end of a line a line break is inserted, but the line was not terminated so it was concatenated with the next line.