### PR TITLE
Problem with '<td nowrap>'

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1105,6 +1105,10 @@ DB_VIS_C
     {
       // just skip it
     }
+    else if (opt->name=="nowrap" && opt->value.isEmpty())
+    {
+      m_t << " " << opt->name << "='nowrap'";
+    }
     else
     {
       m_t << " " << opt->name << "='" << opt->value << "'";

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -222,7 +222,7 @@ static void handleHtmlTag()
     }
     startName=i;
     // search for end of name
-    while (i<(int)yyleng && !isspace((uchar)c) && c!='=') { c=tagText.at(++i); }
+    while (i<(int)yyleng && !isspace((uchar)c) && c!='=' && c!= '>') { c=tagText.at(++i); }
     endName=i;
     HtmlAttrib opt;
     opt.name  = tagText.mid(startName,endName-startName).lower(); 

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -263,6 +263,12 @@ static QCString htmlAttribsToString(const HtmlAttribList &attribs, QCString *pAl
         result+="=\""+convertToXML(att->value)+"\"";
       }
     }
+    else if (att->name=="nowrap") // In XHTML, attribute minimization is forbidden, and the nowrap attribute must be defined as <td nowrap="nowrap">.
+    {
+        result+=" ";
+        result+=att->name;
+        result+="=\"nowrap\"";
+    }
   }
   return result;
 }


### PR DESCRIPTION
In the docbook ouput this was shown with the attribute `nowrap>=''`, in HTML this empty tag was skipped.
Normally a HTML attribute will have a value but in some cases it is possible without attribute and when this is the last attribute the `>` was accidently added to the attribute (in case of the value the `>` was already considered).
Furthermore `In XHTML, attribute minimization is forbidden, and the nowrap attribute must be defined as <td nowrap="nowrap">.`, this is now handled for HTML and docbook as well.