### PR TITLE
Table caption flows in first table field for RTF output

### DIFF
--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1005,11 +1005,14 @@ void RTFDocVisitor::visitPost(DocHtmlTable *)
 void RTFDocVisitor::visitPre(DocHtmlCaption *)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocHtmlCaption)}\n");
+  m_t << "\\pard \\qc \\b";
+  m_t << "{Table \\field\\flddirty{\\*\\fldinst { SEQ Image \\\\*Arabic }}{\\fldrslt {\\noproof 1}} ";
 }
 
 void RTFDocVisitor::visitPost(DocHtmlCaption *) 
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPost(DocHtmlCaption)}\n");
+  m_t << "}\n\\par" << endl;
 }
 
 void RTFDocVisitor::visitPre(DocHtmlRow *r)

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1006,7 +1006,7 @@ void RTFDocVisitor::visitPre(DocHtmlCaption *)
 {
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocHtmlCaption)}\n");
   m_t << "\\pard \\qc \\b";
-  m_t << "{Table \\field\\flddirty{\\*\\fldinst { SEQ Image \\\\*Arabic }}{\\fldrslt {\\noproof 1}} ";
+  m_t << "{Table \\field\\flddirty{\\*\\fldinst { SEQ Table \\\\*Arabic }}{\\fldrslt {\\noproof 1}} ";
 }
 
 void RTFDocVisitor::visitPost(DocHtmlCaption *) 


### PR DESCRIPTION
See to it that the table caption is placed on top of the table and not in the first field.
(See the doxygen documentation in respect to the tables; problem with tables in tables is a a different problem.)