### PR TITLE
Fix for Fortran scanner; missing '.' in regex

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -334,7 +334,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
  /*-----------------------------------------------------------------------------------*/
 
-<Prepass>^{BS}[&]*{BS}!.*\n             { /* skip lines with just comment. Note code was in free format or has been converted to it */
+<Prepass>^{BS}[&].*{BS}!.*\n             { /* skip lines with just comment. Note code was in free format or has been converted to it */
                                           lineCountPrepass ++;
                                         }
 <Prepass>^{BS}\n                        { /* skip empty lines */


### PR DESCRIPTION
Bug introduced in e9ebf43585bffee80c31dd69538feae2a4525178