### PR TITLE
issue #7190 1.8.16: Blank FILE_PATTERNS => no files processed

### DIFF
--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -126,6 +126,7 @@ class ConfigList : public ConfigOption
     void setWidgetType(WidgetType w) { m_widgetType = w; }
     WidgetType widgetType() const { return m_widgetType; }
     QStrList *valueRef() { return &m_value; }
+    QStrList getDefault() { return m_defaultValue; }
     void writeTemplate(FTextStream &t,bool sl,bool);
     void compareDoxyfile(FTextStream &t);
     void substEnvVars();

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1652,11 +1652,17 @@ void Config::checkAndCorrect()
   QStrList &filePatternList = Config_getList(FILE_PATTERNS);
   if (filePatternList.isEmpty())
   {
-      ConfigOption * opt = ConfigImpl::instance()->get("FILE_PATTERNS");
-      if (opt->kind()==ConfigOption::O_List)
+    ConfigOption * opt = ConfigImpl::instance()->get("FILE_PATTERNS");
+    if (opt->kind()==ConfigOption::O_List)
+    {
+      QStrList l = ((ConfigList*)opt)->getDefault();
+      const char *p = l.first();
+      while (p)
       {
-        ((ConfigList*)opt)->init();
+        filePatternList.append(p);
+        p = l.next();
       }
+    }
   }
 
   // add default pattern if needed


### PR DESCRIPTION
This is actually a regression on #7095. Due to the fact that the init() routine has moved up, the settings for `FILE_PATTERNS` have already been done and a call to init does not operate on the `FILE_PATTERNS` variable but on the structure from which the `FILE_PATTERNS` was derived. We have should here operate on the `FILE_PATTERNS` directly as well., bu getting the default values out of the underlying structure.