### PR TITLE
Protection of interfaces and types in Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2245,12 +2245,25 @@ static bool endScope(Entry *scope, bool isGlobalRoot)
     Entry *ce;
     for (;(ce=eli.current());++eli) 
     {
-      if (ce->section != Entry::VARIABLE_SEC && ce->section != Entry::FUNCTION_SEC)
+      if (ce->section != Entry::VARIABLE_SEC && ce->section != Entry::FUNCTION_SEC &&
+          ce->section != Entry::CLASS_SEC)
         continue;
 
       //cout<<ce->name<<", "<<mdfsMap.contains(ce->name.lower())<<mdfsMap.count()<<endl;
       if (mdfsMap.contains(ce->name.lower()))
+      {
         applyModifiers(ce, mdfsMap[ce->name.lower()]);
+      }
+      else
+      {
+        QString nm = ce->name.lower();
+        if (nm.startsWith(scope->name.lower() + "::"))
+        {
+          nm = nm.mid(scope->name.length()+2);
+          if (mdfsMap.contains(nm.data()))
+            applyModifiers(ce, mdfsMap[nm.data()]);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
In the proposed pull request #7192 an attempt was made to get the protection of the types and interfaces correct. This looks like to work in case the types end interfaces are on continuation lines, but as soon as all types and interfaces are in one line this failed (see discussion with #7192).

in this patch it is solved by updating the so called modifiers also for CLASS_SEC (types and interfaces are seen as "classes"), furthermore in case the modifiers are not found a test is done whether or not the module (scope) name is prepended to the entry name as with the modifiers this module name is not present.