### PR TITLE
Protection of interfaces and types in Fortran.

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -587,7 +587,13 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 <ModuleBody>private/{BS}(\n|"!")         { defaultProtection = Private;
                                            current->protection = defaultProtection ;
                                          }
+<ModuleBody>private/{BS}.*(\n|"!")       { defaultProtection = Private;
+                                           current->protection = defaultProtection ;
+                                         }
 <ModuleBody>public/{BS}(\n|"!")          { defaultProtection = Public;
+                                           current->protection = defaultProtection ;
+                                         }
+<ModuleBody>public/{BS}.*(\n|"!")        { defaultProtection = Public;
                                            current->protection = defaultProtection ;
                                          }
 
@@ -2237,20 +2243,33 @@ static bool endScope(Entry *scope, bool isGlobalRoot)
         return TRUE;
       }
     }
-  } 
-  if (scope->section!=Entry::FUNCTION_SEC) 
-  { // not function section 
+  }
+  if (scope->section!=Entry::FUNCTION_SEC)
+  { // not function section
     // iterate variables: get and apply modifiers
     EntryListIterator eli(*scope->children());
     Entry *ce;
-    for (;(ce=eli.current());++eli) 
+    for (;(ce=eli.current());++eli)
     {
-      if (ce->section != Entry::VARIABLE_SEC && ce->section != Entry::FUNCTION_SEC)
+      if (ce->section != Entry::VARIABLE_SEC && ce->section != Entry::FUNCTION_SEC &&
+          ce->section != Entry::CLASS_SEC)
         continue;
-
+ 
       //cout<<ce->name<<", "<<mdfsMap.contains(ce->name.lower())<<mdfsMap.count()<<endl;
       if (mdfsMap.contains(ce->name.lower()))
+      {
         applyModifiers(ce, mdfsMap[ce->name.lower()]);
+      }
+      else
+      {
+        QString nm = ce->name.lower();
+        if (nm.startsWith(scope->name.lower() + "::"))
+        {
+          nm = nm.mid(scope->name.length()+2);
+          if (mdfsMap.contains(nm.data()))
+            applyModifiers(ce, mdfsMap[nm.data()]);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Minor modification to correct the behavior of the public/private
statement in Fortran (based on the #7199 patch).

Using the provided example by @ellio167, the fix in patch #7199 by @albert-github is missing the operator (.eq.) interface. (see discussion at #7192)

<img width="1041" alt="Screen Shot 2019-08-14 at 9 15 39 PM" src="https://user-images.githubusercontent.com/3648098/63071666-74e93080-bedd-11e9-9315-7e129003b894.png">

But the provided minor modification correct this behavior as below:

<img width="1618" alt="Screen Shot 2019-08-14 at 9 17 10 PM" src="https://user-images.githubusercontent.com/3648098/63071680-84687980-bedd-11e9-9452-29281e539156.png">
