### PR TITLE
Problem with fenced code block followed by horizontal ruler

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2177,6 +2177,7 @@ static void writeFencedCodeBlock(GrowBuf &out,const char *data,const char *lng,
   out.addStr(data+blockStart,blockEnd-blockStart);
   out.addStr("\n");
   out.addStr("@endcode");
+  out.addStr("\n");
 }
 
 static QCString processQuotations(const QCString &s,int refIndent)


### PR DESCRIPTION
When we have a program containing:
````
# First

# Second
Third
```
Fourth

```
---
````
then the end of the fenced code block combined with the horizonal ruler is not handled properly.
Adding an extra newline solves the problem (workaround for a user is also to add an extra newline after the close of the fenced code block.