### PR TITLE
Strange '*/' in Fortran nad Markdown with conditional sections

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -914,7 +914,9 @@ void replaceComment(int offset);
     			             {
 				       //printf("** Adding terminator for comment!\n");
 				       if (g_lang!=SrcLangExt_Python &&
-					   g_lang!=SrcLangExt_VHDL)
+					   g_lang!=SrcLangExt_VHDL &&
+					   g_lang!=SrcLangExt_Markdown &&
+					   g_lang!=SrcLangExt_Fortran)
 				       {
  				         ADDCHAR('*');
      				         ADDCHAR('/');


### PR DESCRIPTION
In case of a construct like (Markdown, analogous for Fortran):
```
 test text
 @cond: after cond

 whatever
   @endcond
 some more text
```

we get a `*/` after `test text` that should not be present.

Old situation:

![old](https://user-images.githubusercontent.com/5223533/63214710-14940200-c11c-11e9-959d-bd3805588710.jpg)
required and new situation:

![new](https://user-images.githubusercontent.com/5223533/63214711-14940200-c11c-11e9-8895-d265dde406b1.jpg)


Other places exclude besides Pyton and VHDL also Fortran and Markdown and that should happen here as well.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3512193/example.tar.gz)

Note the construct `@cond:` is a bit strange, but the general idea is that in Markdown and Forran no `*/` should be added.
