### PR TITLE
Problems with Fortran and `@cond`

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -152,23 +152,28 @@ static inline int computeIndent(const char *s)
 
 static inline void copyToOutput(const char *s,int len)
 {
+  static int tabSize=Config_getInt(TAB_SIZE);
   int i;
   if (g_skip) // only add newlines.
   {
     for (i=0;i<len;i++) 
     {
-      if (s[i]=='\n') 
+      switch (s[i])
       {
-	ADDCHAR('\n');
-	//fprintf(stderr,"---> skip %d\n",g_lineNr);
-	g_lineNr++;
+        case '\n':
+	  ADDCHAR('\n');
+	  //fprintf(stderr,"---> skip %d\n",g_lineNr);
+	  g_lineNr++;
+          g_col=0;
+          break;
+	case '\t': g_col+=tabSize-(g_col%tabSize); break;
+	default:   g_col++; break;
       }
     }
   }
   else if (len>0)
   {
     ADDARRAY(s,len);
-    static int tabSize=Config_getInt(TAB_SIZE);
     for (i=0;i<len;i++) 
     {
       switch (s[i])
@@ -903,7 +908,7 @@ void replaceComment(int offset);
   				       BEGIN(g_condCtx);
                                      }
   				   }
-<CondLine>[ \t]*
+<CondLine>[ \t]*/\n |
 <CComment,ReadLine>[\\@]"cond"[ \t\r]*/\n |
 <CondLine>.			   { // forgot section id?
   				     if (YY_START!=CondLine) g_condCtx=YY_START;


### PR DESCRIPTION
In case we have in Fortran (free format) a `@cond` statement without arguments and the next line starts with an exclamation mark we get the warning:
`problem evaluating expression '!': Unexpected end of expression`
a similar construct can be created with fixed form and `ENABLED_SECTIONS` depending on if it is set to 'c' or not, warning:
`Conditional section with label 'c' does not have a corresponding \endcond command within this file.`

- we have to keep track of the column we are in, even in case we we are i 'skip' mode
- line `<CondLine>[ \t]*` is strange, has to be `<CondLine>[ \t]*/\n |` so the entire line is considered Looks also that the line was just a dummy line before.

Example with results: [example.tar.gz](https://github.com/doxygen/doxygen/files/3512897/example.tar.gz)
