### PR TITLE
Problems in markdown with code spans and lists.

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1020,6 +1020,7 @@ static int processCodeSpan(GrowBuf &out, const char *data, int /*offset*/, int s
   {
     QCString codeFragment;
     convertStringFragment(codeFragment,data+f_begin,f_end-f_begin);
+    codeFragment = substitute(codeFragment,'\n',' ');
     out.addStr("<tt>");
     //out.addStr(convertToHtml(codeFragment,TRUE));
     out.addStr(escapeSpecialChars(codeFragment));


### PR DESCRIPTION
In case we have a code span this is intended as "an inline code / typewriter code part" and should not contain newline characters, contrary to fenced code blocks.

In case we have a code span of the form:
```
...
 *    inline `single
 *    - 1` text
...
```
we will get  warnings like:
```
warning: found </c> at different nesting level (5) than expected (2)
warning: end of comment block while expecting command </code>
```

By eliminating the newlines already in the markdown processing we can overcome this problem.
In case the code span doesn't contain something that looks like a list start (i.e. e.g. a '-' at the beginning of a line) the "concatenation" was already done at another level.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3513237/example.tar.gz)

