### PR TITLE
issue #7212 1.8.16: Function returning void pointer generates warning

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4201,19 +4201,19 @@ void MemberDefImpl::detectUndocumentedParams(bool hasParamCommand,bool hasReturn
   else if ( // see if return type is documented in a function w/o return type
       hasReturnCommand &&
       (
-       returnType.find("void")!=-1       || // void return type
+       (returnType.find("void")!=-1 && returnType.find('*')==-1)      || // void return type
        returnType.find("subroutine")!=-1 || // fortran subroutine
        isConstructor()      || // a constructor
        isDestructor()          // or destructor
       )
       )
   {
-    warn_doc_error(getDefFileName(),getDefLine(),"documented empty return type of  %s",
+    warn_doc_error(getDefFileName(),getDefLine(),"documented empty return type of %s",
                           qualifiedName().data());
   }
   else if ( // see if return needs to documented 
       m_impl->hasDocumentedReturnType ||
-      returnType.find("void")!=-1  || // void return type
+      (returnType.find("void")!=-1 && returnType.find('*')==-1)      || // void return type
       returnType.find("subroutine")!=-1 || // fortran subroutine
       isConstructor() || // a constructor
       isDestructor()     // or destructor


### PR DESCRIPTION
Have to see that the argument is not a void pointer but just a void