### PR TITLE
Error in LaTeX with single quote in formula / math mode.

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -621,7 +621,7 @@ void LatexDocVisitor::visit(DocFormula *f)
     {
       switch (c)
       {
-        case '\'': m_t << "\\text{'}"; break;
+        case '\'': m_t << "\\textnormal{\\textquotesingle}"; break;
         default:  m_t << c; break;
       }
     }


### PR DESCRIPTION
When having a text like:
```
\f$ text t' text \f$
```
and conversion this to a pdf (latex directory) we get the error:
```
! Undefined control sequence.
l.3 $ text t\text
                 {'} text $
?
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3537375/example.tar.gz)
