### PR TITLE
Doxygen comment fixes

### DIFF
--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -37,14 +37,14 @@ class ConfigOption
     /*! The type of option */
     enum OptionType 
     { 
-      O_Info,      //<! A section header
-      O_List,      //<! A list of items
-      O_Enum,      //<! A fixed set of items
-      O_String,    //<! A single item
-      O_Int,       //<! An integer value
-      O_Bool,      //<! A boolean value
-      O_Obsolete,  //<! An obsolete option
-      O_Disabled   //<! Disabled compile time option
+      O_Info,      //!< A section header
+      O_List,      //!< A list of items
+      O_Enum,      //!< A fixed set of items
+      O_String,    //!< A single item
+      O_Int,       //!< An integer value
+      O_Bool,      //!< A boolean value
+      O_Obsolete,  //!< An obsolete option
+      O_Disabled   //!< Disabled compile time option
     };
     enum 
     { 

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -381,7 +381,7 @@ static bool getFortranNamespaceDefs(const QCString &mname,
   @param tname the name of the type
   @param moduleName name of enclosing module or null, if global entry
   @param cd the entry, if found or null
-  @param useDict dictionary of data of USE-statement
+  @param usedict dictionary of data of USE-statement
   @returns true, if type is found 
 */
 static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName, 


### PR DESCRIPTION
Fixes some issues found with Clang's `-Wdocumentation -Wdocumentation-pedantic` options. I'm aware these options have several false positives. I'm busy fixing these issues in Clang.