### PR TITLE
Create possibility to define LaTeX commands for formulas

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -398,6 +398,7 @@ static QString getDocsForNode(const QDomElement &child)
 
   // Remove / replace doxygen markup strings
   // the regular expressions are hard to read so the intention will be given
+  // Note: see also configgen.py in the src directory for other doxygen parts
   QRegExp regexp;
   // remove \n at end and replace by a space
   regexp.setPattern(SA("\\n$"));
@@ -432,6 +433,8 @@ static QString getDocsForNode(const QDomElement &child)
   docs.replace(regexp,SA("\"External Indexing and Searching\""));
   regexp.setPattern(SA("\\\\ref[ ]+external"));
   docs.replace(regexp,SA("\"Linking to external documentation\""));
+  regexp.setPattern(SA("\\\\ref[ ]+formulas"));
+  docs.replace(regexp,SA("\"Including formulas\""));
   // fallback for not handled
   docs.replace(SA("\\\\ref"),SA(""));
   // \b word -> <b>word<\b>

--- a/doc/formulas.doc
+++ b/doc/formulas.doc
@@ -100,8 +100,26 @@ the section should contain valid command for the specific environment.
 
 \warning Currently, doxygen is not very fault tolerant in recovering 
 from typos in formulas. It may be necessary to remove the
-files <code>formula.repository</code> that are written to the html and rtf directories to 
+files <code>formula.repository</code> that are written to the html, rtf etc. directories to 
 get rid of an incorrect formula as well as the <code>form_*</code> files.
+
+To have the possibility to define your own \LaTeX commands, for e.g. formula building blocks
+or consistent writing of certain words, the configuration option \ref cfg_formula_macrofile "FORMULA_MACROFILE"
+can be used. to supply a file with \LaTeX commands.
+This file can contain \LaTeX `\newcommand` and \`renewcommand` commands and they are included
+formulas (image version and MathJax version) as well as in the generated \LaTeX output (for PDF generation).<br>
+The `\newcommand` (and `\renewcommand`) are restricted to a version without optional
+parameters so only the following types are supported:
+```
+\newcommand{\cmd}{replacement}
+    and
+\newcommand{\cmd}[nr]{replacement}
+```
+e.g.
+```
+\newcommand{\E}{\mathrm{E}}
+\newcommand{\ccSum}[3]{\sum_{#1}^{#2}{#3}}
+```
 
 \htmlonly
 Go to the <a href="tables.html">next</a> section or return to the

--- a/src/config.xml
+++ b/src/config.xml
@@ -2377,6 +2377,16 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
 ]]>
       </docs>
     </option>
+    <option type='string' id='FORMULA_MACROFILE' format='file' defval=''>
+      <docs>
+<![CDATA[
+ The \c FORMULA_MACROFILE can contain \f$\mbox{\LaTeX}\f$ `\newcommand` and 
+ `\renewcommand` commands to create new \f$\mbox{\LaTeX}\f$ commands to be used
+ in formulas as building blocks.
+ See the section \ref formulas for details.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='USE_MATHJAX' defval='0' depends='GENERATE_HTML'>
       <docs>
 <![CDATA[

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -21,6 +21,7 @@ from xml.dom import minidom, Node
 def transformDocs(doc):
 	# join lines, unless it is an empty line
 	# remove doxygen layout constructs
+        # Note: also look at expert.cpp of doxywizard for doxywizard parts
 	doc = doc.strip()
 	doc = doc.replace("\n", " ")
 	doc = doc.replace("\r", " ")
@@ -57,6 +58,7 @@ def transformDocs(doc):
 				 doc)
 	doc = re.sub('\\\\ref +external', '"Linking to external documentation"',
 				 doc)
+	doc = re.sub('\\\\ref +formulas', '"Including formulas"', doc)
 	# fallback for not handled
 	doc = re.sub('\\\\ref', '', doc)
 	#<a href="address">description</a> -> description (see: address)

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -53,6 +53,15 @@ void FormulaList::generateBitmaps(const char *path)
   // store the original directory
   if (!d.exists()) { err("Output dir %s does not exist!\n",path); exit(1); }
   QCString oldDir = QDir::currentDirPath().utf8();
+  QCString macroFile = Config_getString(FORMULA_MACROFILE);
+  QCString stripMacroFile;
+  if (!macroFile.isEmpty())
+  {
+    QFileInfo fi(macroFile);
+    macroFile=fi.absFilePath().utf8();
+    stripMacroFile = fi.fileName().data();
+  }
+
   // go to the html output directory (i.e. path)
   QDir::setCurrent(d.absPath());
   QDir thisDir;
@@ -74,6 +83,11 @@ void FormulaList::generateBitmaps(const char *path)
     t << "\\usepackage[utf8]{inputenc}" << endl; // looks like some older distributions with newunicode package 1.1 need this option.
     writeExtraLatexPackages(t);
     writeLatexSpecialFormulaChars(t);
+    if (!macroFile.isEmpty())
+    {
+      copyFile(macroFile,stripMacroFile);
+      t << "\\input{" << stripMacroFile << "}" << endl;
+    }
     t << "\\pagestyle{empty}" << endl; 
     t << "\\begin{document}" << endl;
     int page=0;

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -688,6 +688,16 @@ static void writeDefaultHeaderPart1(FTextStream &t)
 
   writeExtraLatexPackages(t);
   writeLatexSpecialFormulaChars(t);
+  QCString macroFile = Config_getString(FORMULA_MACROFILE);
+  if (!macroFile.isEmpty())
+  {
+    QCString dir=Config_getString(LATEX_OUTPUT);
+    QFileInfo fi(macroFile);
+    macroFile=fi.absFilePath().utf8();
+    QCString stripMacroFile = fi.fileName().data();
+    copyFile(macroFile,dir + "/" + stripMacroFile);
+    t << "\\input{" << stripMacroFile << "}" << endl;
+  }
 
   // Hyperlinks
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);


### PR DESCRIPTION
To be able to have building bocks for formulas one can create a `\newcommand` (or when one wants to change a command `\renewcommand`).
Due to the different handling of LaTeX commands in pure LaTeX code (latex output and formulas converted to images) and MathJax it is necessary to transform LaTeX commands to the MathJax equivalent.
This is done in a transparent way by providing the new commands in a file and add this verbatim to the pure LaTeX code and to translate the `\newcommand` and `\renewcomamnd` to MathJax macros.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3546817/example.tar.gz)
