### PR TITLE
Feature/issue 7217

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -807,14 +807,19 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           generateLink(*g_code, yytext);
 					  g_insideBody=FALSE;
 
-					  /* append module name to use dict */
-                                          useEntry = new UseEntry();
-					  //useEntry->module = yytext;
-                                          //useMembers->append(yytext, useEntry);
-					  //addUse(yytext);
-					  useEntry->module = tmp;
-                                          useMembers->append(tmp, useEntry);
-					  addUse(tmp);
+					  /* get module entry from use dict */
+					  /* else append module name to use dict */
+					  useEntry = useMembers->find(tmp);
+					  if (! useEntry) 
+					  {
+                                            useEntry = new UseEntry();
+					    //useEntry->module = yytext;
+                                            //useMembers->append(yytext, useEntry);
+					    //addUse(yytext);
+					    useEntry->module = tmp;
+                                            useMembers->append(tmp, useEntry);
+					    addUse(tmp);
+					  }
                                         }           
 <Use,UseOnly,Import>{BS},{BS}           { codifyLines(yytext); }
 <UseOnly,Import>{BS}&{BS}"\n"           { codifyLines(yytext);


### PR DESCRIPTION
Fix for issue #7217 [Patch] Fortran parser shortcomings for "end" keyword combinations. 

Fixes issues with variable names in assignment statements being detected as Fortran keywords.
Modifies the Fortran lexer to:
- be more restrictive in detecting end subprog keywords,
- be more restrictive in detecting end flow keywords,
- capture variable names on left-hand-side of assignment statements, and
- preserve whitespace between function call and opening parenthesis.