### PR TITLE
Problem with  `<hr>` in LaTeX multicolumn cell

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -66,6 +66,11 @@
 \usepackage{doxygen}
 \usepackage{manual}
 %%
+%gave problems when in doxygen.sty
+\makeatletter
+\newcommand\hrulefilll{\leavevmode\leaders\hrule\hskip 0pt plus 1filll\kern\z@}
+\makeatother
+%%
 % unfortunately constructs like: 
 %   \renewcommand{\doxysection}[1]{\doxysubsection{##1}}
 % using values from book.cls (see also doxygen.sty) and redefining sections to correct level.

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -280,7 +280,10 @@ void LatexDocVisitor::visit(DocLineBreak *)
 void LatexDocVisitor::visit(DocHorRuler *)
 {
   if (m_hide) return;
-  m_t << "\\DoxyHorRuler\n";
+  if (insideTable())
+    m_t << "\\DoxyHorRuler{1}\n";
+  else
+    m_t << "\\DoxyHorRuler{0}\n";
 }
 
 void LatexDocVisitor::visit(DocStyleChange *s)

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -623,6 +623,11 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "}\n"
        "\\makeatother\n"
        "\n";
+  // 
+  t << "\\makeatletter\n"
+       "\\newcommand\\hrulefilll{\\leavevmode\\leaders\\hrule\\hskip 0pt plus 1filll\\kern\\z@}\n"
+       "\\makeatother\n"
+       "\n";
 
   // Headers & footers
   QGString genString;

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -35,10 +35,6 @@
   \endgroup%
 }
 
-\makeatletter
-\newcommand\hrulefilll{\leavevmode\leaders\hrule\hskip 0pt plus 1filll\kern\z@}
-\makeatother
-
 \newcommand{\DoxyHorRuler}[1]{%
   \setlength{\parskip}{0ex plus 0ex minus 0ex}%
   \ifthenelse{#1=0}%

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -35,9 +35,19 @@
   \endgroup%
 }
 
-\newcommand{\DoxyHorRuler}{%
+\makeatletter
+\newcommand\hrulefilll{\leavevmode\leaders\hrule\hskip 0pt plus 1filll\kern\z@}
+\makeatother
+
+\newcommand{\DoxyHorRuler}[1]{%
   \setlength{\parskip}{0ex plus 0ex minus 0ex}%
-  \hrule%
+  \ifthenelse{#1=0}%
+  {%
+    \hrule%
+  }%
+  {%
+    \hrulefilll%
+  }%
 }
 \newcommand{\DoxyLabelFont}{}
 \newcommand{\entrylabel}[1]{%


### PR DESCRIPTION
In case we have a `<hr>` in a table cell then it is displayed as a horizontal line (in LaTeX) unless it is in a multicolumn cell. In the later case it throws an error:
```
! You can't use `\hrule' here except with leaders.
\DoxyHorRuler ... }{0ex plus 0ex minus 0ex}\hrule
```

We have to use use `\hrulefill` in a table but in combination with the table option of xcolor this gives some problems so a new command has to be defined for this.

See also:
- horizontal rule / line inside a multicolumn field (https://tex.stackexchange.com/questions/506211/horizontal-rule-line-inside-a-multicolumn-field)
- interaction between \usepackage[table]{xcolor} and \hrulefill (https://tex.stackexchange.com/questions/506221/interaction-between-usepackagetablexcolor-and-hrulefill)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3556098/example.tar.gz)
