### PR TITLE
Parsing `#` sign inserted by preprocessor in fixed Form Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1654,6 +1654,7 @@ const char* prepassFixedForm(const char* contents, int *hasContLine)
         }
         inBackslash = FALSE;
         // fallthrough
+      case '#':
       case 'C':
       case 'c':
       case '*':


### PR DESCRIPTION
In Fortran a file that is included is replaced by the doxygen preprocessor by something like:
`#    11 "<path>/<filename>" 2`
when this is in fixed form Fortran and the `<path>/<filename>` is long it is possible that the closing double quote is beyond position 72 and thus not seen resulting in:
```
Error in file <path>/<filename> line: 73, state: 22(String)
```
this is caused as the `#` is not handled properly in prepassFixedForm. The `#` should be handled analogous to e.g. `C`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3560954/example.tar.gz)
