### PR TITLE
Backslash in href.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7164,6 +7164,7 @@ QCString latexFilterURL(const char *s)
     {
       case '#':  t << "\\#"; break;
       case '%':  t << "\\%"; break;
+      case '\\':  t << "\\\\"; break;
       default:
         t << c;
         break;


### PR DESCRIPTION
When having a backslash in a href like:
```
<a href="C:\boost">`C:\boost`</a>
```
we get in LaTeX the error:
```
(aa_8h.tex
! Undefined control sequence.
<argument> C:\boost

l.6 \href{C:\boost}
                   {\texttt{ {\ttfamily C\+:\textbackslash{}boost}}}
```
this can be overcome by escaping the backslash.

Note this is just an example, for an URI actually forward slashes should be used. It is just about the backslash not generating an error.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3565694/example.tar.gz)
