### PR TITLE
HTML start comment with 3 dashes

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -480,7 +480,8 @@ static int processNmdash(GrowBuf &out,const char *data,int off,int size)
   {
     count++;
   }
-  if (count==2 && off>=2 && qstrncmp(data-2,"<!",2)==0) return 0; // start HTML comment
+  if ((count==2 || count==3)&& off>=2 && qstrncmp(data-2,"<!",2)==0) return 2-count; // start HTML comment
+  if (count>=4 && off>=2 && qstrncmp(data-2,"<!",2)==0) return -1; // start HTML comment
   if (count==2 && (data[2]=='>')) return 0; // end HTML comment
   if (count==2 && (off<8 || qstrncmp(data-8,"operator",8)!=0)) // -- => ndash
   {
@@ -1087,6 +1088,10 @@ static void processInline(GrowBuf &out,const char *data,int size)
     if (!end)
     {
       end=i+1;
+    }
+    else if (end < 0)
+    {
+      end=i-end+1;
     }
     else
     {


### PR DESCRIPTION
A normal HTML comment `<!--` has 2 `-` signs but it is not prohibited to have 3, but doxygen translates `<!---` into `<!-&ndash;` and thus the comment is not recognized.
By checking and consequently handling, doing the right skipping, also the 3 `-` sign version the problem can be solved.
An end comment cannot contain 3 `-` signs, so here no changes have to take place.
The version with 3 or more `-` are in a start HTML comment does not give a problem with xmllint either.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3578532/example.tar.gz)
