### PR TITLE
Bogus explicit link warning message from irc protocol name

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -353,6 +353,7 @@ ATTRNAME  [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
 ATTRIB    {ATTRNAME}{WS}*("="{WS}*(("\""[^\"]*"\"")|("'"[^\']*"'")|[^ \t\r\n'"><]+))?
 URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=]
 URLMASK   ({URLCHAR}+([({]{URLCHAR}*[)}])?)+
+URLPROTOCOL ("http:"|"https:"|"ftp:"|"file:"|"news:"|"irc")
 FILESCHAR [a-z_A-Z0-9\\:\\\/\-\+&#]
 FILEECHAR [a-z_A-Z0-9\-\+&#]
 HFILEMASK ("."{FILESCHAR}*{FILEECHAR}+)+
@@ -624,17 +625,17 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 			 }
 			 return TK_COMMAND_SEL();
   		       }
-<St_Para>("http:"|"https:"|"ftp:"|"file:"|"news:"){URLMASK}/\. { // URL.
+<St_Para>{URLPROTOCOL}{URLMASK}/\. { // URL.
                          g_token->name=yytext;
 			 g_token->isEMailAddr=FALSE;
 			 return TK_URL;
                        }
-<St_Para>("http:"|"https:"|"ftp:"|"file:"|"news:"){URLMASK} { // URL
+<St_Para>{URLPROTOCOL}{URLMASK} { // URL
                          g_token->name=yytext;
 			 g_token->isEMailAddr=FALSE;
 			 return TK_URL;
                        }
-<St_Para>"<"("http:"|"https:"|"ftp:"|"file:"|"news:"){URLMASK}">" { // URL
+<St_Para>"<"{URLPROTOCOL}{URLMASK}">" { // URL
                          g_token->name=yytext;
                          g_token->name = g_token->name.mid(1,g_token->name.length()-2);
 			 g_token->isEMailAddr=FALSE;


### PR DESCRIPTION
When having:
```
* IRC: irc://irc.gimp.org/#gsconnect
```
we get:
```
warning: explicit link request to 'gsconnect' could not be resolved
```
When using the 'news:" protocol we don't get this message, adding 'irc' to the list of possibilities.

(Found in  https://github.com/andyholmes/gnome-shell-extension-gsconnect )

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3599974/example.tar.gz)
