### PR TITLE
Warning with xrefitem from documentation

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -599,10 +599,12 @@ static void addRelatedPage(Entry *root)
   {
     doc=root->brief+"\n\n"+root->doc+root->inbodyDocs;
   }
+
   PageDef *pd = addRelatedPage(root->name,root->args,doc,root->anchors,
       root->docFile,root->docLine,
       root->sli,
       gd,root->tagInfo,
+      FALSE,
       root->lang
      );
   if (pd)

--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -206,6 +206,6 @@ void RefList::generatePage()
   }
   doc += "</dl>\n";
   //printf("generatePage('%s')\n",doc.data());
-  addRelatedPage(m_listName,m_pageTitle,doc,0,m_fileName,1,0,0,0);
+  addRelatedPage(m_listName,m_pageTitle,doc,0,m_fileName,1,0,0,0,TRUE);
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6745,6 +6745,7 @@ PageDef *addRelatedPage(const char *name,const QCString &ptitle,
     const QList<ListItemInfo> *sli,
     GroupDef *gd,
     TagInfo *tagInfo,
+    bool xref,
     SrcLangExt lang
     )
 {
@@ -6752,7 +6753,7 @@ PageDef *addRelatedPage(const char *name,const QCString &ptitle,
   //printf("addRelatedPage(name=%s gd=%p)\n",name,gd);
   if ((pd=Doxygen::pageSDict->find(name)) && !tagInfo)
   {
-    warn(fileName,startLine,"multiple use of page label '%s', (other occurrence: %s, line: %d)",
+    if (!xref) warn(fileName,startLine,"multiple use of page label '%s', (other occurrence: %s, line: %d)",
          name,pd->docFile().data(),pd->docLine());
     // append documentation block to the page.
     pd->setDocumentation(doc,fileName,startLine);

--- a/src/util.h
+++ b/src/util.h
@@ -337,6 +337,7 @@ PageDef *addRelatedPage(const char *name,
                         const QList<ListItemInfo> *sli,
                         GroupDef *gd=0,
                         TagInfo *tagInfo=0,
+                        bool xref=FALSE,
                         SrcLangExt lang=SrcLangExt_Unknown
                        );
 


### PR DESCRIPTION
The example code with the `xrefitem` in the documentation gives a warning:
```
my_errors:1: warning: multiple use of page label 'my_errors', (other occurrence: .../aa.h, line: 4)
```
it is possible (and explicitly stated) to have an `\page` with the same name giving some extra information.

The warning regarding the multiple page is removed in case of a xrefitem page.

The example case: [example.tar.gz](https://github.com/doxygen/doxygen/files/3610480/example.tar.gz)
