### PR TITLE
issue #7262 ALIASES not found when filename has more than one dot

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7501,7 +7501,8 @@ void addCodeOnlyMappings()
 SrcLangExt getLanguageFromFileName(const QCString& fileName)
 {
   QFileInfo fi(fileName);
-  QCString extName = fi.extension().lower().data();
+  // we need only the part after the last ".", newer implementations of QFileInfo have 'suffix()' for this.
+  QCString extName = fi.extension(FALSE).lower().data();
   if (extName.isEmpty()) extName=".no_extension";
   if (extName.at(0)!='.') extName.prepend(".");
     int *pVal=g_extLookup.find(extName.data());


### PR DESCRIPTION
Take the part after the last '.', method 'extension` gives the extension after the first '.' of a filename.

This is a regression on pull request #7121 (issue #7120)