### PR TITLE
Bug 164073 - There should be a dummy tag that Doxygen ignores

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -1411,6 +1411,13 @@ contains \c TEST, or \c DEV
   then the \c \\details command is not needed.
 
 <hr>
+\section cmdnoop \\noop ( text to be ignored )
+
+  \addindex \\noop
+  All the text, including the command, till the end of the line is ignored.
+  The command will most commonly be used in combination with \ref cfg_aliases "ALIASES"
+  to ignore not supported commands that are present for e.g. other processing tools.
+<hr>
 \section cmdelse \\else
 
   \addindex \\else

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -78,6 +78,7 @@ static bool handleFile(const QCString &, const QCStringList &);
 static bool handleDir(const QCString &, const QCStringList &);
 static bool handleExample(const QCString &, const QCStringList &);
 static bool handleDetails(const QCString &, const QCStringList &);
+static bool handleNoop(const QCString &, const QCStringList &);
 static bool handleName(const QCString &, const QCStringList &);
 static bool handleTodo(const QCString &, const QCStringList &);
 static bool handleTest(const QCString &, const QCStringList &);
@@ -279,6 +280,7 @@ static DocCmdMap docCmdMap[] =
   { "warning",         0,                       TRUE  },
   { "snippet",         0,                       TRUE  },
   { "snippetlineno",   0,                       TRUE  },
+  { "noop",            &handleNoop,             TRUE },
   { 0, 0, FALSE }
 };
 
@@ -998,6 +1000,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 %x	CopyDoc
 %x      GuardExpr
 %x      CdataSection
+%x      Noop
 
 %%
 
@@ -2129,6 +2132,14 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					  current->name+=*yytext;
   					}
 
+  /* ----- handle argument of noop command ------- */
+<Noop>{DOCNL}				{ // end of argument
+					  if (*yytext=='\n') yyLineNr++;
+					  addOutput('\n');
+					  BEGIN( Comment );
+					}
+<Noop>.					{ // ignore other stuff
+					}
   /* ----- handle argument of ingroup command ------- */
 
 <InGroupParam>{LABELID}			{ // group id
@@ -2537,6 +2548,12 @@ static bool handleDetails(const QCString &, const QCStringList &)
                        // as a new paragraph
   }
   setOutput(OutputDoc);
+  return FALSE;
+}
+
+static bool handleNoop(const QCString &, const QCStringList &)
+{
+  BEGIN( Noop );
   return FALSE;
 }
 


### PR DESCRIPTION
Introduced the `\noop` command to ignore text till end of the line.