### PR TITLE
issue #7271 Tilde in preprocessor macro disappears in latex

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6945,7 +6945,7 @@ void filterLatexString(FTextStream &t,const char *str,
         case '$':  t << "\\$"; break;
         case '-':  t << "-\\/"; break;
         case '^':  (usedTableLevels()>0) ? t << "\\string^" : t << (char)c;    break;
-        case '~':  (usedTableLevels()>0) ? t << "\\string~" : t << (char)c;    break;
+        case '~':  t << "\\string~";    break;
         case ' ':  if (keepSpaces) t << "~"; else t << ' ';
                    break;
         default:


### PR DESCRIPTION
In pre part always use `\string~` for `~` otherwise it will be translated to a space.