### PR TITLE
Bug 340202 - @code: static_cast, const_cast, etc C++ keywords

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2606,7 +2606,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 <TemplCast>[*^]*			{
   					  codifyLines(yytext);
 					}
-<Body,FuncCall>{CASTKW}"<"                { // static_cast<T>(
+<Body,MemberCall2,FuncCall>{CASTKW}{B}*"<"  { // static_cast<T>(
   					  startFontClass("keyword");
   					  codifyLines(yytext);
 					  endFontClass();
@@ -2651,6 +2651,12 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					}
 <Body>{SCOPETNAME}{B}*"<"[^\n\/\-\.\{\"\>]*">"/{BN}*"(" |
 <Body>{SCOPETNAME}/{BN}*"("		{ // a() or c::a() or t<A,B>::a() or A\B\foo()
+					  int i=QCString(yytext).find('<');
+					  QCString kw = QCString(yytext).left(i).stripWhiteSpace();
+					  if (kw.right(5)=="_cast" && YY_START==Body)
+					  {
+					    REJECT;
+					  }
   					  addType();
 					  generateFunctionLink(*g_code,yytext);
   					  g_bracketCount=0;
@@ -3062,6 +3068,12 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
                                           endFontClass();
                                         }
 <MemberCall2,FuncCall>{ID}(({B}*"<"[^\n\[\](){}<>]*">")?({B}*"::"{B}*{ID})?)* {
+					  int i=QCString(yytext).find('<');
+					  QCString kw = QCString(yytext).left(i).stripWhiteSpace();
+					  if (kw.right(5)=="_cast")
+					  {
+					    REJECT;
+					  }
 					  addParmType();
 					  g_parmName=yytext; 
 					  generateClassOrGlobalLink(*g_code,yytext,!g_insideBody);


### PR DESCRIPTION
The `*_cast` had already been introduced, but there were some other places that needed the "REJECT" as well.
Also the cast was missing a whitesace between the cast name and the `<`.

Tested also against he doxygen internal documentation.