### PR TITLE
HTML attribute name

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -350,7 +350,7 @@ LISTITEM  {BLANK}*[-]("#")?{WS}
 MLISTITEM {BLANK}*[+*]{WS}
 OLISTITEM {BLANK}*[1-9][0-9]*"."{BLANK}
 ENDLIST   {BLANK}*"."{BLANK}*\n
-ATTRNAME  [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
+ATTRNAME  [a-z_A-Z\x80-\xFF][:a-z_A-Z0-9\x80-\xFF\-]*
 ATTRIB    {ATTRNAME}{WS}*("="{WS}*(("\""[^\"]*"\"")|("'"[^\']*"'")|[^ \t\r\n'"><]+))?
 URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=]
 URLMASK   ({URLCHAR}+([({]{URLCHAR}*[)}])?)+


### PR DESCRIPTION
A HTML attribute name can have e.g. a XML namespace in it and thus containing a colon (`:`) like:
```
<span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Social Icons</span>
```
but this results in
```
warning: found </span> tag without matching <span>
```
and grabled outpuzt.

allowing a colon in the attribute name solves this problem