### PR TITLE
Formulas extension to "as is" images.

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -107,6 +107,11 @@ documentation:
 \refitem cmdfbrclose \\f]
 \refitem cmdfcurlyopen \\f{
 \refitem cmdfcurlyclose \\f}
+\refitem cmdfigdollar \\fig\$
+\refitem cmdfigbropen \\fig[
+\refitem cmdfigbrclose \\fig]
+\refitem cmdfigcurlyopen \\fig{
+\refitem cmdfigcurlyclose \\fig}
 \refitem cmdfile \\file
 \refitem cmdfn \\fn
 \refitem cmdheaderfile \\headerfile
@@ -3098,45 +3103,90 @@ class Receiver
 
   \addindex \\f\$
 
-  Marks the start and end of an in-text formula.
-  \sa section \ref formulas "formulas" for an example.
+  Marks the start and end of an in-text (b/w) formula.
+  \sa section \ref cmdfigdollar "\\fig\$" and section \ref formulas "formulas" for an example.
 
 <hr>
 \section cmdfbropen \\f[
 
   \addindex \\f[
 
-  Marks the start of a long formula that is displayed
+  Marks the start of a (b/w) long formula that is displayed
   centered on a separate line.
-  \sa section \ref cmdfbrclose "\\f]" and section \ref formulas "formulas".
+  \sa section \ref cmdfbrclose "\\f]", section \ref cmdfigbropen "\\fig[" and section \ref formulas "formulas".
 
 <hr>
 \section cmdfbrclose \\f]
 
   \addindex \\f]
 
-  Marks the end of a long formula that is displayed
+  Marks the end of a (b/w) long formula that is displayed
   centered on a separate line.
-  \sa section \ref cmdfbropen "\\f[" and section \ref formulas "formulas".
+  \sa section \ref cmdfbropen "\\f[", section \ref cmdfigbropen "\\fig[" and section \ref formulas "formulas".
 
 <hr>
 \section cmdfcurlyopen \\f{environment}{
 
   \addindex \\f{
 
-  Marks the start of a formula that is in a specific environment.
+  Marks the start of a (b/w) formula that is in a specific environment.
   \note The second \c { is optional and is only to help editors (such as \c Vim) to
   do proper syntax highlighting by making the number of opening and closing braces
   the same.
-  \sa section \ref cmdfcurlyclose "\\f}" and section \ref formulas "formulas".
+  \sa section \ref cmdfcurlyclose "\\f}", section \ref cmdfigcurlyopen "\\fig{" and section \ref formulas "formulas".
 
 <hr>
 \section cmdfcurlyclose \\f}
 
   \addindex \\f}
 
+  Marks the end of a (b/w) formula that is in a specific environment.
+  \sa section \ref cmdfcurlyopen "\\f{", section \ref cmdfigcurlyopen "\\fig{" and section \ref formulas "formulas".
+
+<hr>
+\section cmdfigdollar \\fig$
+
+  \addindex \\fig\$
+
+  Marks the start and end of an in-text formula.
+  \sa section \ref cmdfdollar "\\f\$" and section \ref formulas "formulas" for an example.
+
+<hr>
+\section cmdfigbropen \\fig[
+
+  \addindex \\fig[
+
+  Marks the start of a long formula that is displayed
+  centered on a separate line.
+  \sa section \ref cmdfigbrclose "\\fig]", section \ref cmdfbropen "\\f[" and section \ref formulas "formulas".
+
+<hr>
+\section cmdfigbrclose \\fig]
+
+  \addindex \\fig]
+
+  Marks the end of a long formula that is displayed
+  centered on a separate line.
+  \sa section \ref cmdfigbropen "\\fig[", section \ref cmdfbropen "\\f[" and section \ref formulas "formulas".
+
+<hr>
+\section cmdfigcurlyopen \\fig{environment}{
+
+  \addindex \\fig{
+
+  Marks the start of a formula that is in a specific environment.
+  \note The second \c { is optional and is only to help editors (such as \c Vim) to
+  do proper syntax highlighting by making the number of opening and closing braces
+  the same.
+  \sa section \ref cmdfigcurlyclose "\\fig}", section \ref cmdfcurlyopen "\\f{" and section \ref formulas "formulas".
+
+<hr>
+\section cmdfigcurlyclose \\fig}
+
+  \addindex \\fig}
+
   Marks the end of a formula that is in a specific environment.
-  \sa section \ref cmdfcurlyopen "\\f{" and section \ref formulas "formulas".
+  \sa section \ref cmdfigcurlyopen "\\fig{", section \ref cmdfcurlyopen "\\f{" and section \ref formulas "formulas".
 
 <hr>
 \section cmdhtmlonly \\htmlonly ["[block]"]

--- a/doc/formulas.doc
+++ b/doc/formulas.doc
@@ -17,24 +17,25 @@
 /*! \page formulas Including formulas 
 
 Doxygen allows you to put \LaTeX formulas in the
-output (this works only for the HTML, \LaTeX and RTF output. To be able to include 
-formulas (as images) in the HTML and RTF documentation, you will also need to 
+output (this works only for the HTML, \LaTeX, Docbook and RTF output. To be able to include 
+formulas (as b/w images) in the HTML, Docbook and RTF documentation, you will also need to 
 have the following tools installed
 <ul>
 <li>\c latex: the \LaTeX compiler, needed to parse the formulas. 
-    To test I have used the teTeX 1.0 distribution.
 <li>\c dvips: a tool to convert DVI files to PostScript files 
-    I have used version 5.92b from Radical Eye software for testing.
-<li>\c gs: the GhostScript interpreter for converting PostScript files 
-    to bitmaps. I have used Aladdin GhostScript 8.0 for testing.
+<li>\c ps2epsi: to get the bounding box from PostScript files
+<li>\c gs: the GhostScript interpreter for converting PostScript files to bitmaps.
 </ul>
 For the HTML output there is also an alternative solution using
 <a href="https://www.mathjax.org">MathJax</a> which does not
 require the above tools. If you enable \ref cfg_use_mathjax "USE_MATHJAX" in
 the configuration then the latex formulas will be copied to the HTML "as is" and a
-client side javascript will parse them and turn them into (interactive) images.
+client side javascript will parse them and turn them into (interactive) images.<br>
+Note that MathJax only supports a part of the possibilities from \LaTeX.<br>
+For \LaTeX the formulas are also "as is" into the \LaTeX output, so in principle the
+full palette of \LaTeX.s available<br>
 
-There are three ways to include formulas in the documentation.
+There are basically three ways to include formulas in the documentation.
 <ol>
 <li>Using in-text formulas that appear in the running text. 
     These formulas should be put between a pair of \\f\$ 
@@ -98,10 +99,21 @@ For the first two commands one should make sure formulas contain
 valid commands in \LaTeX's math-mode. For the third command
 the section should contain valid command for the specific environment.
 
+As written before the above mentioned commands, when generating images, are generating b/w images to be included
+in the documentation.
+(in case of \LaTeX the formula is used "as is", and in MathJax the formulas are limited to the \LaTeX that is
+supported by MathJax).<br>
+To overcome the b/w limitations the analogous command pairs `\fig$...\fig$`, `\fig[...\fig]` and `\fig{...\fig}`
+exists. For \LaTeX there is no difference as the formula code is still placed "as is" in the latex output, for the
+other formats always images are included in a similar way as for the `\f...` commands, but without the conversion to
+b/w, so having the possibility to use the full palette of \LaTeX commands. (Note for obvious reasons the MahtJax
+possibility does not existt for the `\fig...` commands).
+
 \warning Currently, doxygen is not very fault tolerant in recovering 
 from typos in formulas. It may be necessary to remove the
-files <code>formula.repository</code> that are written to the html and rtf directories to 
-get rid of an incorrect formula as well as the <code>form_*</code> files.
+files <code>formula.repository</code> that are written to the html, docbook and rtf output directories to 
+get rid of an incorrect formula as well as the <code>form_*</code> files (in case of `\f...` type commands,
+in case if `\fig...` type commands the names are <code>figure.repository</code> and <code>figform_*</code>).
 
 \htmlonly
 Go to the <a href="tables.html">next</a> section or return to the

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -149,6 +149,7 @@ CommandMap cmdMap[] =
   { "---",           CMD_MDASH },
   { "_setscope",     CMD_SETSCOPE },
   { "emoji",         CMD_EMOJI },
+  { "figform",       CMD_FIGURE },
   { 0,               0 },
 };
 

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -138,7 +138,8 @@ enum CommandType
   CMD_SNIPPETDOC   = 108,
   CMD_SNIPWITHLINES= 109,
   CMD_EMOJI        = 110,
-  CMD_EQUAL        = 111
+  CMD_EQUAL        = 111,
+  CMD_FIGURE       = 112
 };
 
 enum HtmlTagType

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -476,7 +476,7 @@ void replaceComment(int offset);
                                      }
                                      BEGIN(VerbatimCode);
   				   }
-<CComment,ReadLine>[\\@]("f$"|"f["|"f{") {
+<CComment,ReadLine>[\\@]("f$"|"f["|"f{"|"fig$"|"fig["|"fig{") {
                                      copyToOutput(yytext,(int)yyleng); 
 				     g_blockName=&yytext[1];
 				     if (g_blockName.at(1)=='[')
@@ -486,6 +486,14 @@ void replaceComment(int offset);
 				     else if (g_blockName.at(1)=='{')
 				     {
 				       g_blockName.at(1)='}';
+				     }
+				     else if (g_blockName.at(3)=='[')
+				     {
+				       g_blockName.at(3)=']';
+				     }
+				     else if (g_blockName.at(3)=='{')
+				     {
+				       g_blockName.at(3)='}';
 				     }
 				     g_lastCommentContext = YY_START;
 				     BEGIN(Verbatim);
@@ -499,7 +507,7 @@ void replaceComment(int offset);
 <Scan>.                            { /* any ather character */
                                      copyToOutput(yytext,(int)yyleng); 
                                    }
-<Verbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"f$"|"f]"|"f}") { /* end of verbatim block */
+<Verbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"f$"|"f]"|"f}"|"fig$"|"fig]"|"fig}") { /* end of verbatim block */
                                      copyToOutput(yytext,(int)yyleng);
 				     if (&yytext[1]==g_blockName) // end of formula
 				     {

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -643,6 +643,30 @@ static QCString addFormula()
   return formLabel;
 }
 
+static QCString addFigure()
+{
+  QCString formLabel;
+  QCString fText=formulaText.simplifyWhiteSpace();
+  Formula *f=0;
+  if ((f=Doxygen::figureDict->find(fText))==0)
+  {
+    f = new Formula(fText, TRUE);
+    Doxygen::figureList->append(f);
+    Doxygen::figureDict->insert(fText,f);
+    formLabel.sprintf("\\figform#%d",f->getId());
+    Doxygen::figureNameDict->insert(formLabel,f);
+  }
+  else
+  {
+    formLabel.sprintf("\\figform#%d",f->getId());
+  }
+  int i;
+  for (i=0;i<formulaNewLines;i++) formLabel+="@_fakenl"; // add fake newlines to
+                                                         // keep the warnings
+                                                         // correctly aligned.
+  return formLabel;
+}
+
 //-----------------------------------------------------------------------------
 
 static void checkFormula();
@@ -1010,6 +1034,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
    *   commands (e.g. @page, or \page)
    *   escaped commands (e.g. @@page or \\page).
    *   formulas (e.g. \f$ \f[ \f{..)
+   *   figures (e.g. \fig$ \fig[ \fig{..)
    *   directories (e.g. \doxygen\src\)
    *   autolist end. (e.g. a dot on an otherwise empty line)
    *   newlines.
@@ -1200,12 +1225,25 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					  formulaNewLines=0;
 					  BEGIN(ReadFormulaLong);
   					}
-<Comment>{B}*{CMD}"f$"			{ // start of a inline formula
+<Comment>{B}*{CMD}"fig{"[^}\n]+"}"("{"?)  { // start of a formula with custom environment
+                                          setOutput(OutputDoc);
+                                          formulaText="\\begin";
+                                          formulaEnv=QString(yytext).stripWhiteSpace().data()+4;
+                                          if (formulaEnv.at(formulaEnv.length()-1)=='{')
+                                          {
+                                            // remove trailing open brace
+                                            formulaEnv=formulaEnv.left(formulaEnv.length()-1);
+                                          }
+                                          formulaText+=formulaEnv;
+                                          formulaNewLines=0;
+                                          BEGIN(ReadFormulaLong);
+                                        }
+<Comment>{B}*{CMD}("f$"|"fig$")         { // start of a inline formula
 					  formulaText="$";
 					  formulaNewLines=0;
 					  BEGIN(ReadFormulaShort);
   					}
-<Comment>{B}*{CMD}"f["			{ // start of a block formula
+<Comment>{B}*{CMD}("f["|"fig[")         { // start of a block formula
 					  setOutput(OutputDoc);
 					  formulaText="\\[";
 					  formulaNewLines=0;
@@ -1395,6 +1433,23 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					  addOutput(" "+addFormula());
 					  BEGIN(Comment);
   					}
+<ReadFormulaShort>{CMD}"fig$"           { // end of inline formula
+                                          formulaText+="$";
+                                          addOutput(" "+addFigure());
+                                          BEGIN(Comment);
+                                        }
+<ReadFormulaLong>{CMD}"fig]"            { // end of block formula
+                                          formulaText+="\\]";
+                                          addOutput(" "+addFigure());
+                                          BEGIN(Comment);
+                                        }
+<ReadFormulaLong>{CMD}"fig}"            { // end of custom env formula
+                                          formulaText+="\\end";
+                                          formulaText+=formulaEnv;
+                                          addOutput(" "+addFigure());
+                                          BEGIN(Comment);
+                                        }
+
 <ReadFormulaLong,ReadFormulaShort>[^\\@\n]+ { // any non-special character
                                           formulaText+=yytext; 
  					} 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1492,6 +1492,12 @@ reparsetoken:
             children.append(form);
           }
           break;
+        case CMD_FIGURE:
+          {
+            DocFormula *form=new DocFormula(parent,g_token->id, TRUE);
+            children.append(form);
+          }
+          break;
         case CMD_ANCHOR:
           {
             DocAnchor *anchor = handleAnchor(parent);
@@ -2205,17 +2211,34 @@ bool DocXRefItem::parse()
 
 //---------------------------------------------------------------------------
 
-DocFormula::DocFormula(DocNode *parent,int id) :
+DocFormula::DocFormula(DocNode *parent,int id,bool fig) :
       m_relPath(g_relPath)
 {
   m_parent = parent; 
   QCString formCmd;
-  formCmd.sprintf("\\form#%d",id);
-  Formula *formula=Doxygen::formulaNameDict->find(formCmd);
+  Formula *formula;
+  if (fig)
+  {
+    formCmd.sprintf("\\figform#%d",id);
+    formula=Doxygen::figureNameDict->find(formCmd);
+  }
+  else
+  {
+    formCmd.sprintf("\\form#%d",id);
+    formula=Doxygen::formulaNameDict->find(formCmd);
+  }
   if (formula)
   {
     m_id = formula->getId();
-    m_name.sprintf("form_%d",m_id);
+    m_fig = fig;
+    if (fig)
+    {
+      m_name.sprintf("figform_%d",m_id);
+    }
+    else
+    {
+      m_name.sprintf("form_%d",m_id);
+    }
     m_text = formula->getFormulaText();
   }
   else // wrong \form#<n> command
@@ -5832,6 +5855,12 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
     case CMD_FORMULA:
       {
         DocFormula *form=new DocFormula(this,g_token->id);
+        m_children.append(form);
+      }
+      break;
+    case CMD_FIGURE:
+      {
+        DocFormula *form=new DocFormula(this,g_token->id, TRUE);
         m_children.append(form);
       }
       break;

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -673,7 +673,7 @@ class DocIncOperator : public DocNode
 class DocFormula : public DocNode
 {
   public:
-    DocFormula(DocNode *parent,int id);
+    DocFormula(DocNode *parent,int id,bool fig = FALSE);
     Kind kind() const          { return Kind_Formula; }
     QCString name() const       { return m_name; }
     QCString text() const       { return m_text; }
@@ -681,12 +681,14 @@ class DocFormula : public DocNode
     int id() const             { return m_id; }
     void accept(DocVisitor *v) { v->visit(this); }
     bool isInline()            { return m_text.length()>0 ? m_text.at(0)!='\\' : TRUE; }
+    bool isFig()               { return m_fig;}
 
   private:
     QCString  m_name;
     QCString  m_text;
     QCString  m_relPath;
-    int      m_id;
+    int       m_id;
+    bool      m_fig;
 };
 
 /** Node representing an entry in the index. */

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -364,6 +364,7 @@ VERBATIM  "verbatim"{BLANK}*
 SPCMD1    {CMD}([a-z_A-Z][a-z_A-Z0-9]*|{VERBATIM}|"--"|"---")
 SPCMD2    {CMD}[\\@<>&$#%~".+=|-]
 SPCMD3    {CMD}form#[0-9]+
+SPCMD3f   {CMD}figform#[0-9]+
 SPCMD4    {CMD}"::"
 SPCMD5    {CMD}":"
 INOUT	  "inout"|"in"|"out"|("in"{BLANK}*","{BLANK}*"out")|("out"{BLANK}*","{BLANK}*"in")
@@ -584,6 +585,13 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 			 ASSERT(ok);
 			 return TK_COMMAND_SEL();
   		       }
+<St_Para>{SPCMD3f}     {
+                         g_token->name = "figform";
+                         bool ok;
+                         g_token->id = QCString(yytext).right((int)yyleng-9).toInt(&ok);
+                         ASSERT(ok);
+                         return TK_COMMAND_SEL();
+                       }
 <St_Para>{CMD}"n"\n    { /* \n followed by real newline */
                          yylineno++;
                          g_token->name = yytext+1;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -129,6 +129,9 @@ GroupSDict      *Doxygen::groupSDict = 0;
 FormulaList     *Doxygen::formulaList = 0;       // all formulas
 FormulaDict     *Doxygen::formulaDict = 0;       // all formulas
 FormulaDict     *Doxygen::formulaNameDict = 0;   // the label name of all formulas
+FormulaList     *Doxygen::figureList = 0;       // all formulas
+FormulaDict     *Doxygen::figureDict = 0;       // all formulas
+FormulaDict     *Doxygen::figureNameDict = 0;   // the label name of all formulas
 PageSDict       *Doxygen::pageSDict = 0;
 PageSDict       *Doxygen::exampleSDict = 0;
 SectionDict     *Doxygen::sectionDict = 0;        // all page sections
@@ -198,6 +201,7 @@ void clearAll()
   Doxygen::exampleSDict->clear();
   Doxygen::inputNameList->clear();
   Doxygen::formulaList->clear();
+  Doxygen::figureList->clear();
   Doxygen::sectionDict->clear();
   Doxygen::inputNameDict->clear();
   Doxygen::includeNameDict->clear();
@@ -208,6 +212,8 @@ void clearAll()
   Doxygen::diaFileNameDict->clear();
   Doxygen::formulaDict->clear();
   Doxygen::formulaNameDict->clear();
+  Doxygen::figureDict->clear();
+  Doxygen::figureNameDict->clear();
   Doxygen::tagDestinationDict.clear();
   delete Doxygen::citeDict;
   delete Doxygen::mainPage; Doxygen::mainPage=0;
@@ -285,6 +291,10 @@ void statistics()
   Doxygen::formulaDict->statistics();
   fprintf(stderr,"--- formulaNameDict stats ----\n");
   Doxygen::formulaNameDict->statistics();
+  fprintf(stderr,"--- figureDict stats ----\n");
+  Doxygen::figureDict->statistics();
+  fprintf(stderr,"--- figureNameDict stats ----\n");
+  Doxygen::figureNameDict->statistics();
   fprintf(stderr,"--- tagDestinationDict stats ----\n");
   Doxygen::tagDestinationDict.statistics();
   fprintf(stderr,"--- g_compoundKeywordDict stats ----\n");
@@ -2125,7 +2135,7 @@ static void findUsingDeclImports(Entry *root)
      )
   {
     //printf("Found using declaration %s inside section %x\n",
-    //    root->name.data(), root->parent()->section);
+    //    root->name().data(), root->parent()->section());
     QCString fullName=removeRedundantWhiteSpace(root->parent()->name);
     fullName=stripAnonymousNamespaceScope(fullName);
     fullName=stripTemplateSpecifiersFromScope(fullName);
@@ -9904,11 +9914,25 @@ int readFileOrDirectory(const char *s,
 
 //----------------------------------------------------------------------------
 
-void readFormulaRepository(QCString dir, bool cmp)
+void readFormulaRepository(QCString dir, bool cmp, bool fig)
 {
-  static int current_repository = 0; 
+  static int current_formula = 0; 
+  static int current_figure = 0; 
   int new_repository = 0; 
-  QFile f(dir+"/formula.repository");
+  const char *repository;
+  int *current_repository = 0; 
+  if (fig)
+  {
+    repository = "figure.repository";
+    current_repository = &current_figure;
+  }
+  else
+  {
+    repository = "formula.repository";
+    current_repository = &current_formula;
+  }
+
+  QFile f(dir+"/"+repository);
   if (f.open(IO_ReadOnly)) // open repository
   {
     msg("Reading formula repository...\n");
@@ -9921,7 +9945,7 @@ void readFormulaRepository(QCString dir, bool cmp)
       int se=line.find(':'); // find name and text separator.
       if (se==-1)
       {
-        warn_uncond("formula.repository is corrupted!\n");
+        warn_uncond("%s is corrupted!\n",repository);
         break;
       }
       else
@@ -9930,37 +9954,59 @@ void readFormulaRepository(QCString dir, bool cmp)
         QCString formText = line.right(line.length()-se-1);
         if (cmp)
         {
-          if ((f=Doxygen::formulaDict->find(formText))==0)
+          if (!fig && (f=Doxygen::formulaDict->find(formText))==0)
           {
             err("discrepancy between formula repositories! Remove "
-                "formula.repository and from_* files from output directories.");
+                "%s and from_* files from output directories.", repository);
+            exit(1);
+          }
+	  else if (fig && (f=Doxygen::figureDict->find(formText))==0)
+          {
+            err("discrepancy between formula repositories! Remove "
+                "%s and from_* files from output directories.", repository);
             exit(1);
           }
           QCString formLabel;
-          formLabel.sprintf("\\form#%d",f->getId());
+	  if (fig)
+	  {
+            formLabel.sprintf("\\figform#%d",f->getId());
+	  }
+	  else
+	  {
+            formLabel.sprintf("\\form#%d",f->getId());
+	  }
           if (formLabel != formName)
           {
             err("discrepancy between formula repositories! Remove "
-                "formula.repository and from_* files from output directories.");
+                "%s and from_* files from output directories.", repository);
             exit(1);
           }
           new_repository++;
         }
         else
         {
-          f=new Formula(formText);
-          Doxygen::formulaList->append(f);
-          Doxygen::formulaDict->insert(formText,f);
-          Doxygen::formulaNameDict->insert(formName,f);
-          current_repository++;
+          f=new Formula(formText,fig);
+	  if (fig)
+	  {
+            Doxygen::figureList->append(f);
+            Doxygen::figureDict->insert(formText,f);
+            Doxygen::figureNameDict->insert(formName,f);
+	  }
+	  else
+	  {
+            Doxygen::formulaList->append(f);
+            Doxygen::formulaDict->insert(formText,f);
+            Doxygen::formulaNameDict->insert(formName,f);
+	  }
+          (*current_repository)++;
         }
       }
     }
   }
-  if (cmp && (current_repository != new_repository))
+  if (cmp && (*current_repository != new_repository))
   {
     err("size discrepancy between formula repositories! Remove "
-        "formula.repository and from_* files from output directories.");
+        "%s and from_* files from output directories.", repository);
     exit(1);
   }
 }
@@ -10245,6 +10291,10 @@ void initDoxygen()
   Doxygen::formulaList->setAutoDelete(TRUE);
   Doxygen::formulaDict = new FormulaDict(1009);
   Doxygen::formulaNameDict = new FormulaDict(1009);
+  Doxygen::figureList = new FormulaList;
+  Doxygen::figureList->setAutoDelete(TRUE);
+  Doxygen::figureDict = new FormulaDict(1009);
+  Doxygen::figureNameDict = new FormulaDict(1009);
   Doxygen::sectionDict = new SectionDict(257);
   Doxygen::sectionDict->setAutoDelete(TRUE);
 
@@ -10278,6 +10328,9 @@ void cleanUpDoxygen()
   delete Doxygen::formulaNameDict;
   delete Doxygen::formulaDict;
   delete Doxygen::formulaList;
+  delete Doxygen::figureNameDict;
+  delete Doxygen::figureDict;
+  delete Doxygen::figureList;
   delete Doxygen::indexList;
   delete Doxygen::genericsDict;
   delete Doxygen::inputNameDict;
@@ -11326,20 +11379,24 @@ void parseInput()
 
   // Notice: the order of the function calls below is very important!
 
-  if (Config_getBool(GENERATE_HTML) && !Config_getBool(USE_MATHJAX))
+  if (Config_getBool(GENERATE_HTML))
   {
-    readFormulaRepository(Config_getString(HTML_OUTPUT));
+    if (!Config_getBool(USE_MATHJAX)) readFormulaRepository(Config_getString(HTML_OUTPUT), FALSE);
+    readFormulaRepository(Config_getString(HTML_OUTPUT), FALSE, TRUE);
   }
   if (Config_getBool(GENERATE_RTF))
   {
     // in case GENERRATE_HTML is set we just have to compare, both repositories should be identical
     readFormulaRepository(Config_getString(RTF_OUTPUT),Config_getBool(GENERATE_HTML) && !Config_getBool(USE_MATHJAX));
+    readFormulaRepository(Config_getString(RTF_OUTPUT),Config_getBool(GENERATE_HTML), TRUE);
   }
   if (Config_getBool(GENERATE_DOCBOOK))
   {
     // in case GENERRATE_HTML is set we just have to compare, both repositories should be identical
     readFormulaRepository(Config_getString(DOCBOOK_OUTPUT),
                          (Config_getBool(GENERATE_HTML) && !Config_getBool(USE_MATHJAX)) || Config_getBool(GENERATE_RTF));
+    readFormulaRepository(Config_getString(DOCBOOK_OUTPUT),
+                         (Config_getBool(GENERATE_HTML)) || Config_getBool(GENERATE_RTF), TRUE);
   }
 
   /**************************************************************************
@@ -11828,7 +11885,7 @@ void generateOutput()
   if (Doxygen::formulaList->count()>0 && generateRtf)
   {
     g_s.begin("Generating bitmaps for formulas in RTF...\n");
-    Doxygen::formulaList->generateBitmaps(Config_getString(RTF_OUTPUT));
+    Doxygen::formulaList->generateBitmaps(Config_getString(RTF_OUTPUT), FALSE, TRUE);
     g_s.end();
   }
 
@@ -11836,6 +11893,26 @@ void generateOutput()
   {
     g_s.begin("Generating bitmaps for formulas in Docbook...\n");
     Doxygen::formulaList->generateBitmaps(Config_getString(DOCBOOK_OUTPUT));
+    g_s.end();
+  }
+
+  if (Doxygen::figureList->count()>0 && generateHtml)
+  {
+    g_s.begin("Generating bitmaps for figures in HTML...\n");
+    Doxygen::figureList->generateBitmaps(Config_getString(HTML_OUTPUT),TRUE);
+    g_s.end();
+  }
+  if (Doxygen::figureList->count()>0 && generateRtf)
+  {
+    g_s.begin("Generating bitmaps for figures in RTF...\n");
+    Doxygen::figureList->generateBitmaps(Config_getString(RTF_OUTPUT),TRUE, TRUE);
+    g_s.end();
+  }
+
+  if (Doxygen::figureList->count()>0 && generateDocbook)
+  {
+    g_s.begin("Generating bitmaps for figures in Docbook...\n");
+    Doxygen::figureList->generateBitmaps(Config_getString(DOCBOOK_OUTPUT),TRUE);
     g_s.end();
   }
 

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -119,6 +119,9 @@ class Doxygen
     static FormulaList              *formulaList;
     static FormulaDict              *formulaDict;
     static FormulaDict              *formulaNameDict;
+    static FormulaList              *figureList;
+    static FormulaDict              *figureDict;
+    static FormulaDict              *figureNameDict;
     static StringDict                tagDestinationDict;
     static StringDict                aliasDict;
     static QIntDict<MemberGroupInfo> memGrpInfoDict;
@@ -162,7 +165,7 @@ void searchInputFiles(StringList &inputFiles);
 void parseInput();
 void generateOutput();
 void readAliases();
-void readFormulaRepository(QCString dir, bool cmp = FALSE);
+void readFormulaRepository(QCString dir, bool cmp, bool fig = FALSE);
 void cleanUpDoxygen();
 int readFileOrDirectory(const char *s,
                         FileNameList *fnList,

--- a/src/formula.h
+++ b/src/formula.h
@@ -25,7 +25,7 @@
 class Formula
 {
   public:
-    Formula(const char *text);
+    Formula(const char *text, bool inpfig=FALSE);
    ~Formula();
     int getId();
     QCString getFormulaText() const { return form; }
@@ -39,7 +39,7 @@ class Formula
 class FormulaList : public QList<Formula>
 {
   public:
-    void generateBitmaps(const char *path);
+    void generateBitmaps(const char *path, bool fig = FALSE, bool rtf = FALSE);
 };
 
 /** Iterator for Formula objects in a FormulaList. */

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -186,6 +186,9 @@ static Alignment markersToAlignment(bool leftMarker,bool rightMarker)
 // \f$..\f$
 // \f[..\f]
 // \f{..\f}
+// \fig$..\fig$
+// \fig[..\fig]
+// \fig{..\fig}
 // \verbatim..\endverbatim
 // \latexonly..\endlatexonly
 // \htmlonly..\endhtmlonly
@@ -238,6 +241,21 @@ static QCString isBlockCommand(const char *data,int offset,int size)
     else if (data[end]=='{')
     {
       return "f}";
+    }
+  }
+  else if (blockName=="fig" && end<size)
+  {
+    if (data[end]=='$')
+    {
+      return "fig$";
+    }
+    else if (data[end]=='[')
+    {
+      return "fig]";
+    }
+    else if (data[end]=='{')
+    {
+      return "fig}";
     }
   }
   return QCString();

--- a/src/pre.l
+++ b/src/pre.l
@@ -2575,7 +2575,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
   					  outputChar('/');outputChar('*');
 					  //g_commentCount++;
   					}
-<SkipCComment>[\\@][\\@]("f{"|"f$"|"f[") {
+<SkipCComment>[\\@][\\@]("f{"|"f$"|"f["|"fig$"|"fig["|"fig{") {
   					  outputArray(yytext,(int)yyleng);
   					}
 <SkipCComment>^({B}*"*"+)?{B}{0,3}"~~~"[~]*   {
@@ -2727,9 +2727,13 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
                                             BEGIN(g_condCtx);
                                           }
   					}
-<SkipVerbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"enddot"|"endcode"|"f$"|"f]"|"f}") { /* end of verbatim block */
+<SkipVerbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"enddot"|"endcode"|"f$"|"f]"|"f}"|"fig$"|"fig]"|"fig}") { /* end of verbatim block */
   					  outputArray(yytext,(int)yyleng);
 					  if (yytext[1]=='f' && g_blockName=="f")
+					  {
+					    BEGIN(SkipCComment);
+					  }
+					  else if (&yytext[1]==g_blockName && g_blockName=="fig")
 					  {
 					    BEGIN(SkipCComment);
 					  }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4689,6 +4689,20 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					  fullArgString+=yytext;
   					  BEGIN(CopyArgVerbatim);
                                         }
+<CopyArgCommentLine>{CMD}("fig$"|"fig["|"fig{")                {
+                                          docBlockName=&yytext[1];
+                                          if (docBlockName.at(3)=='[')
+                                          {
+                                            docBlockName.at(3)='}';
+                                          }
+                                          if (docBlockName.at(3)=='{')
+                                          {
+                                            docBlockName.at(3)='}';
+                                          }
+                                          fullArgString+=yytext;
+                                          BEGIN(CopyArgVerbatim);
+                                        }
+
 <CopyArgVerbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"enddot"|"endcode"|"f$"|"f]"|"f}")/[^a-z_A-Z0-9\-] { // end of verbatim block
   					  fullArgString+=yytext;
 				          if (yytext[1]=='f') // end of formula
@@ -6649,6 +6663,18 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           g_nestedComment=FALSE;
   					  BEGIN(DocCopyBlock);
                                         }
+<DocBlock>{CMD}("fig$"|"fig["|"fig{")   {
+                                           docBlock+=yytext;
+                                           docBlockName=&yytext[1];
+                                           if (docBlockName.at(3)=='{')
+                                           {
+                                             docBlockName.at(3)='}';
+                                           }
+                                           g_fencedSize=0;
+                                           g_nestedComment=FALSE;
+                                           BEGIN(DocCopyBlock);
+                                         }
+
 <DocBlock>{B}*"<"{PRE}">"		{
                                           docBlock+=yytext;
 				          docBlockName="<pre>";
@@ -6717,7 +6743,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					    BEGIN(DocBlock);
 					  }
   					}
-<DocCopyBlock>[\\@]("f$"|"f]"|"f}")     {
+<DocCopyBlock>[\\@]("f$"|"f]"|"f}"|"fig$"|"fig]"|"fig}") {
   					  docBlock+=yytext;
 					  BEGIN(DocBlock);
   					}

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -466,7 +466,9 @@ void XmlDocVisitor::visit(DocIncOperator *op)
 void XmlDocVisitor::visit(DocFormula *f)
 {
   if (m_hide) return;
-  m_t << "<formula id=\"" << f->id() << "\">";
+  m_t << "<formula id=\"" << f->id();
+  if (f->isFig()) m_t << "\" fig=\"yes";
+  m_t << "\">";
   filter(f->text());
   m_t << "</formula>";
 }

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -491,6 +491,7 @@
 
   <xsd:complexType name="docFormulaType" mixed="true">
     <xsd:attribute name="id" type="xsd:string" />
+    <xsd:attribute name="fig" type="DoxBool" use="optional"/>
   </xsd:complexType>
 
   <xsd:complexType name="docIndexEntryType">


### PR DESCRIPTION
The idea was born during fixing "Crop png formula environment problem for HTML output (Origin: bugzilla #674005)" (issue #4465, pull request #7251) as the mentioned Tikz picture was shown in the LaTeX  version but not in the HTML version with images (parts converted to white) and in the MathJax version the image does not appear as MathJax doesn't know e.g. the figure environment, see http://docs.mathjax.org/en/latest/input/tex/macros/index.html#environments).
Furthermore formulas like `\f$ \color{yellow} A = \color{blue}{B} \mathbin{\color{red}{-}} \color{green}{C} \f$` were not shown properly as some letters (B) were converted to white characters.
This patch will with the new commands `\fig..` (analogous to the `\f...` commands) create images, but will not convert them to b/w images. The choice for a new set of commands is made as options would interfere with the environment version`\f{` command.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3662696/example.tar.gz)
