### PR TITLE
issue #7274 Subpages no longer possible under mainpage

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2475,11 +2475,11 @@ static bool handlePage(const QCString &, const QCStringList &)
 static bool handleMainpage(const QCString &, const QCStringList &)
 {
   bool stop=makeStructuralIndicator(Entry::MAINPAGEDOC_SEC);
+  current->name = "";
   if (!stop) 
   {
     current->name = "mainpage";
   }
-  current->name = "";
   BEGIN( PageDocArg2 );
   return stop;
 }


### PR DESCRIPTION
Regression on #7050 / #7053 (Physical newlines (^^) not working in group names and without spaces in 1.8.15), in case the current name was explicitly set to mainpage it was still overwritten.