### PR TITLE
Fix typos

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -8446,7 +8446,7 @@ TemplateVariant NamespaceMembersIndexContext::get(const char *name) const
 
 //------------------------------------------------------------------------
 
-//%% struct InheritanceGraph: a connected graph reprenting part of the overall interitance tree
+//%% struct InheritanceGraph: a connected graph reprenting part of the overall inheritance tree
 //%% {
 class InheritanceGraphContext::Private
 {

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -289,7 +289,7 @@ void DotGraph::writeGraphHeader(FTextStream &t,const QCString &title)
   {
     t << " // INTERACTIVE_SVG=YES\n";
   }
-  t << " // LATEX_PDF_SIZE\n"; // write placeholder for LaTeX PDF bounding box size repacement
+  t << " // LATEX_PDF_SIZE\n"; // write placeholder for LaTeX PDF bounding box size replacement
   if (Config_getBool(DOT_TRANSPARENT))
   {
     t << "  bgcolor=\"transparent\";" << endl;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2588,7 +2588,7 @@ static MemberDef *addVariableToFile(
           addMemberDocs(root,md,def,0,FALSE);
           md->setRefItems(root->sli);
           // if md is a variable forward declaration and root is the definition that
-          // turn md into the defintion
+          // turn md into the definition
           if (!root->explicitExternal && md->isExternal())
           {
             md->setDeclFile(md->getDefFileName(),md->getDefLine(),md->getDefColumn());

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -521,7 +521,7 @@ static bool getGenericProcedureLink(const ClassDef *cd,
   return FALSE;
 }
 
-static bool getLink(UseSDict *usedict, // dictonary with used modules
+static bool getLink(UseSDict *usedict, // dictionary with used modules
                     const char *memberText,  // exact member text
 		    CodeOutputInterface &ol,
 		    const char *text)

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1840,7 +1840,7 @@ static QCString extractFromParens(const QCString name)
   return extracted;
 }
 
-/*! remove non usefull spaces from bind statement */
+/*! remove unuseful spaces from bind statement */
 static QCString extractBind(const QCString name)
 {
   QCString parensPart = extractFromParens(name);

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -239,7 +239,7 @@ class MemberDef : virtual public Definition
     virtual bool hasCallGraph() const = 0;
     virtual bool hasCallerGraph() const = 0;
     virtual bool visibleMemberGroup(bool hideNoHeader) const = 0;
-    // refrenced related members
+    // referenced related members
     virtual bool hasReferencesRelation() const = 0;
     virtual bool hasReferencedByRelation() const = 0;
 

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -457,7 +457,7 @@ bool portable_isAbsolutePath(const char *fileName)
 /**
  * Correct a possible wrong PATH variable
  *
- * This routine was inspired by the cause for bug 766059 was that in the Windows path there were forward slahes.
+ * This routine was inspired by the cause for bug 766059 was that in the Windows path there were forward slashes.
  */
 void portable_correct_path(void)
 {

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1316,7 +1316,7 @@ TARGET           ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBUT
     \\{B}\n                    { // line continuation
   		                 codifyLines(yytext);
                                }
-    \\.			       { // espaced char
+    \\.			       { // escaped char
   		                 codify(yytext);
                                }
     {STRINGPREFIX}?{TRIDOUBLEQUOTE} { // triple double quotes
@@ -1339,7 +1339,7 @@ TARGET           ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBUT
     \\{B}\n                    { // line continuation
   		                 codifyLines(yytext);
                                }
-    \\.			       { // espaced char
+    \\.			       { // escaped char
   		                 codify(yytext);
                                }
     {STRINGPREFIX}?{TRISINGLEQUOTE} { // triple single quotes

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1619,7 +1619,7 @@ STARTDOCSYMS      "##"
       			  incLineNr();
 			  docBlock += yytext;
       			}
-    \\.		        { // espaced char
+    \\.		        { // escaped char
 			  docBlock += yytext;
       			}
     .			{
@@ -1654,7 +1654,7 @@ STARTDOCSYMS      "##"
       			         addToString(yytext);
       				 incLineNr();
                                }
-    \\.			       { // espaced char
+    \\.			       { // escaped char
       			         addToString(yytext);
                                }
     "\"\"\""		       { // triple double quotes
@@ -1677,7 +1677,7 @@ STARTDOCSYMS      "##"
       			         addToString(yytext);
       				 incLineNr();
                                }
-    \\.			       { // espaced char
+    \\.			       { // escaped char
       			         addToString(yytext);
                                }
     "'''"		       { // triple single quotes

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2001,7 +2001,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  current->name=removeRedundantWhiteSpace(substitute(yytext,"\\","::"));
   					  //printf("PHP: adding use relation: %s\n",current->name.data());
                                           current->fileName = yyFileName; 
-                                          // add a using declaraton
+                                          // add a using declaration
   					  current->section=Entry::USINGDECL_SEC;
 					  current_root->addSubEntry(current);
 					  current = new Entry(*current);

--- a/src/sortdict.h
+++ b/src/sortdict.h
@@ -128,7 +128,7 @@ class SDict
 
     /*! Appends an element to the dictionary. The element is owned by the
      *  dictionary.
-     *  \param key The unique key to use to quicky find the item later on.
+     *  \param key The unique key to use to quickly find the item later on.
      *  \param d The compound to add.
      *  \sa find()
      */
@@ -146,7 +146,7 @@ class SDict
 
     /*! Prepends an element to the dictionary. The element is owned by the
      *  dictionary.
-     *  \param key The unique key to use to quicky find the item later on.
+     *  \param key The unique key to use to quickly find the item later on.
      *  \param d The compound to add.
      *  \sa find()
      */
@@ -190,7 +190,7 @@ class SDict
       m_list->sort();
     }
     /*! Inserts a compound into the dictionary in a sorted way.
-     *  \param key The unique key to use to quicky find the item later on.
+     *  \param key The unique key to use to quickly find the item later on.
      *  \param d The compound to add.
      *  \sa find()
      */
@@ -470,7 +470,7 @@ class SIntDict
 
     /*! Appends a compound to the dictionary. The element is owned by the
      *  dictionary.
-     *  \param key The unique key to use to quicky find the item later on.
+     *  \param key The unique key to use to quickly find the item later on.
      *  \param d The compound to add.
      *  \sa find()
      */
@@ -488,7 +488,7 @@ class SIntDict
 
     /*! Prepend a compound to the dictionary. The element is owned by the
      *  dictionary.
-     *  \param key The unique key to use to quicky find the item later on.
+     *  \param key The unique key to use to quickly find the item later on.
      *  \param d The compound to add.
      *  \sa find()
      */
@@ -521,7 +521,7 @@ class SIntDict
     }
 
     /*! Inserts a compound into the dictionary in a sorted way.
-     *  \param key The unique key to use to quicky find the item later on.
+     *  \param key The unique key to use to quickly find the item later on.
      *  \param d The compound to add.
      *  \sa find()
      */

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -343,7 +343,7 @@ void VhdlParser::addCompInst(const char *n, const char* instName, const char* co
   {
     current->args=lastCompound->name;             // architecture name
   }
-  current->includeName=comp;                    // component/enity/configuration
+  current->includeName=comp;                    // component/entity/configuration
   int u=genLabels.find("|",1);
   if (u>0)
   {
@@ -584,7 +584,7 @@ void VhdlParser::addProto(const char *s1,const char *s2,const char *s3,
  * .....
  * library
  * package
- * enity zzz
+ * entity zzz
  * .....
  * and so on..
  */

--- a/templates/latex/tabu_doxygen.sty
+++ b/templates/latex/tabu_doxygen.sty
@@ -78,7 +78,7 @@
 \TMP@EnsureCode 58 = 12 % : (for siunitx)
 \TMP@EnsureCode124 = 12 % |
 \TMP@EnsureCode 36 =  3 % $ = math shift
-\TMP@EnsureCode 38 =  4 % & = tab alignmment character
+\TMP@EnsureCode 38 =  4 % & = tab alignment character
 \TMP@EnsureCode 32 = 10 % space
 \TMP@EnsureCode 94 =  7 % ^
 \TMP@EnsureCode 95 =  8 % _
@@ -840,7 +840,7 @@
 }% \tabu@reset
 \def\tabu@setsave #1{\expandafter\tabu@sets@ve #1\@nil{#1}}
 \long\def\tabu@sets@ve #1\@nil #2{\@temptokena\expandafter{\the\@temptokena \def#2{#1}}}
-%% The Rewritting Process -------------------------------------------
+%% The Rewriting Process -------------------------------------------
 \def\tabu@newcolumntype #1{%
     \expandafter\tabu@new@columntype
         \csname NC@find@\string#1\expandafter\endcsname
@@ -1056,7 +1056,7 @@
    \else #2\tabucolX
    \fi
 }% \tabu@hsize
-%% \usetabu  and  \preamble: rewritting process ---------------------
+%% \usetabu  and  \preamble: rewriting process ---------------------
 \tabu@privatecolumntype \usetabu [1]{%
     \ifx\\#1\\\tabu@saveerr{}\else
         \@ifundefined{tabu@saved@\string#1}
@@ -1072,7 +1072,7 @@
             {\csname tabu@saved@\string#1\expandafter\endcsname\expandafter\z@}%
     \fi
 }% \NC@rewrite@\preamble
-%% Controlling the rewritting process -------------------------------
+%% Controlling the rewriting process -------------------------------
 \tabu@newcolumntype \tabu@rewritefirst{%
     \iftabu@long    \aftergroup \tabu@longpream  % <the whole implementation is here !>
     \else           \aftergroup \tabu@pream
@@ -2388,7 +2388,7 @@
         \PackageWarning{tabu}
         {\string\@arrayright\space is missing from the
         \MessageBreak definition of \string\endarray.
-        \MessageBreak Comptability with delarray.sty is broken.}%
+        \MessageBreak Compatibility with delarray.sty is broken.}%
     \fi\fi
 }% \tabu@fix@arrayright
 \def\tabu@adl@xarraydashrule #1#2#3{%


### PR DESCRIPTION
Found via  
```
codespell -q 3 -S *.js,*.po,./src/translator*,*.eps,./doc/changelog.doc -L ang,ans,attribs,ba,behaviour,classe,colour,german,iff,initialise,nam,nd,que,russian,statics,te,tim,uint
```