### PR TITLE
Bug 335614 - HTML link incorrect when using tagfile

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -545,7 +545,7 @@ void DefinitionImpl::writeDocAnchorsToTagFile(FTextStream &tagFile) const
       {
         //printf("write an entry!\n");
         if (definitionType()==TypeMember) tagFile << "  ";
-        tagFile << "    <docanchor file=\"" << si->fileName << "\"";
+        tagFile << "    <docanchor file=\"" << si->fileName << (hasExtension(si->fileName) ? "" : Doxygen::htmlFileExtension) << "\"";
         if (!si->title.isEmpty())
         {
           tagFile << " title=\"" << convertToXML(si->title) << "\"";

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -349,7 +349,7 @@ void FileDefImpl::writeTagFile(FTextStream &tagFile)
   tagFile << "  <compound kind=\"file\">" << endl;
   tagFile << "    <name>" << convertToXML(name()) << "</name>" << endl;
   tagFile << "    <path>" << convertToXML(getPath()) << "</path>" << endl;
-  tagFile << "    <filename>" << convertToXML(getOutputFileBase()) << "</filename>" << endl;
+  tagFile << "    <filename>" << convertToXML(getOutputFileBase()) << (hasExtension(getOutputFileBase()) ? "" : Doxygen::htmlFileExtension) << "</filename>" << endl;
   if (m_includeList && m_includeList->count()>0)
   {
     QListIterator<IncludeInfo> ili(*m_includeList);

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1913,11 +1913,7 @@ void HtmlDocVisitor::visitPre(DocSecRefItem *ref)
 {
   if (m_hide) return;
   QCString refName=ref->file();
-  if (refName.right(Doxygen::htmlFileExtension.length())!=
-      QCString(Doxygen::htmlFileExtension))
-  {
-    refName+=Doxygen::htmlFileExtension;
-  }
+  refName+=(hasExtension(refName) ? "" : Doxygen::htmlFileExtension);
   m_t << "<li><a href=\"" << refName << "#" << ref->anchor() << "\">";
 
 }
@@ -2098,7 +2094,7 @@ void HtmlDocVisitor::visitPre(DocXRefItem *x)
   {
     m_t << "<dl" << getDirHtmlClassOfNode(getTextDirByConfig(x), x->key())  
         << "><dt><b><a class=\"el\" href=\""
-        << x->relPath() << x->file() << Doxygen::htmlFileExtension 
+        << x->relPath() << x->file() << (hasExtension(x->file()) ? "" : Doxygen::htmlFileExtension)
         << "#" << x->anchor() << "\">";
   }
   else 
@@ -2262,7 +2258,10 @@ void HtmlDocVisitor::startLink(const QCString &ref,const QCString &file,
   }
   m_t << "href=\"";
   m_t << externalRef(relPath,ref,TRUE);
-  if (!file.isEmpty()) m_t << file << Doxygen::htmlFileExtension;
+  if (!file.isEmpty())
+  {
+    m_t << file << (hasExtension(file) ? "" : Doxygen::htmlFileExtension);
+  }
   if (!anchor.isEmpty()) m_t << "#" << anchor;
   m_t << "\"";
   if (!tooltip.isEmpty()) m_t << " title=\"" << convertToHtml(tooltip) << "\"";

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -575,7 +575,7 @@ void HtmlCodeGenerator::_writeCodeLink(const char *className,
   }
   m_t << "href=\"";
   m_t << externalRef(m_relPath,ref,TRUE);
-  if (f) m_t << f << Doxygen::htmlFileExtension;
+  if (f) m_t << f << (hasExtension(f) ? "" : Doxygen::htmlFileExtension);
   if (anchor) m_t << "#" << anchor;
   m_t << "\"";
   if (tooltip) m_t << " title=\"" << convertToHtml(tooltip) << "\"";
@@ -596,7 +596,7 @@ void HtmlCodeGenerator::writeTooltip(const char *id, const DocLinkInfo &docInfo,
   {
     m_t << "<a href=\"";
     m_t << externalRef(m_relPath,docInfo.ref,TRUE);
-    m_t << docInfo.url << Doxygen::htmlFileExtension;
+    m_t << docInfo.url << (hasExtension(docInfo.url) ? "" : Doxygen::htmlFileExtension);
     if (!docInfo.anchor.isEmpty())
     {
       m_t << "#" << docInfo.anchor;
@@ -628,7 +628,7 @@ void HtmlCodeGenerator::writeTooltip(const char *id, const DocLinkInfo &docInfo,
     {
       m_t << "<a href=\"";
       m_t << externalRef(m_relPath,defInfo.ref,TRUE);
-      m_t << defInfo.url << Doxygen::htmlFileExtension;
+      m_t << defInfo.url << (hasExtension(docInfo.url) ? "" : Doxygen::htmlFileExtension);
       if (!defInfo.anchor.isEmpty())
       {
         m_t << "#" << defInfo.anchor;
@@ -649,7 +649,7 @@ void HtmlCodeGenerator::writeTooltip(const char *id, const DocLinkInfo &docInfo,
     {
       m_t << "<a href=\"";
       m_t << externalRef(m_relPath,declInfo.ref,TRUE);
-      m_t << declInfo.url << Doxygen::htmlFileExtension;
+      m_t << declInfo.url << (hasExtension(docInfo.url) ? "" : Doxygen::htmlFileExtension);
       if (!declInfo.anchor.isEmpty())
       {
         m_t << "#" << declInfo.anchor;
@@ -912,10 +912,7 @@ void HtmlGenerator::startFile(const char *name,const char *,
   lastTitle=title;
   relPath = relativePathToRoot(fileName);
 
-  if (fileName.right(Doxygen::htmlFileExtension.length())!=Doxygen::htmlFileExtension)
-  {
-    fileName+=Doxygen::htmlFileExtension;
-  }
+  fileName+=(hasExtension(fileName) ? "" : Doxygen::htmlFileExtension);
   startPlainFile(fileName);
   m_codeGen.setTextStream(t);
   m_codeGen.setRelativePath(relPath);
@@ -1149,7 +1146,7 @@ void HtmlGenerator::startIndexItem(const char *ref,const char *f)
     }
     t << "href=\"";
     t << externalRef(relPath,ref,TRUE);
-    if (f) t << f << Doxygen::htmlFileExtension;
+    if (f) t << f << (hasExtension(f) ? "" : Doxygen::htmlFileExtension);
     t << "\">";
   }
   else
@@ -1176,7 +1173,7 @@ void HtmlGenerator::writeStartAnnoItem(const char *,const char *f,
 {
   t << "<li>";
   if (path) docify(path);
-  t << "<a class=\"el\" href=\"" << f << Doxygen::htmlFileExtension << "\">";
+  t << "<a class=\"el\" href=\"" << f << (hasExtension(f) ? "" : Doxygen::htmlFileExtension) << "\">";
   docify(name);
   t << "</a> ";
 }
@@ -1195,7 +1192,7 @@ void HtmlGenerator::writeObjectLink(const char *ref,const char *f,
   }
   t << "href=\"";
   t << externalRef(relPath,ref,TRUE);
-  if (f) t << f << Doxygen::htmlFileExtension;
+  if (f) t << f << (hasExtension(f) ? "" : Doxygen::htmlFileExtension);
   if (anchor) t << "#" << anchor;
   t << "\">";
   docify(name);
@@ -1205,7 +1202,7 @@ void HtmlGenerator::writeObjectLink(const char *ref,const char *f,
 void HtmlGenerator::startTextLink(const char *f,const char *anchor)
 {
   t << "<a href=\"";
-  if (f)   t << relPath << f << Doxygen::htmlFileExtension;
+  if (f)   t << relPath << f << (hasExtension(f) ? "" : Doxygen::htmlFileExtension);
   if (anchor) t << "#" << anchor;
   t << "\">";
 }
@@ -2369,7 +2366,7 @@ QCString HtmlGenerator::writeSplitBarAsString(const char *name,const char *relpa
 											"<script type=\"text/javascript\">\n"
 											"/* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&amp;dn=gpl-2.0.txt GPL-v2 */\n"
 											"$(document).ready(function(){initNavTree('") +
-			QCString(name) + Doxygen::htmlFileExtension +
+			QCString(name) + (hasExtension(name) ? "" : Doxygen::htmlFileExtension) +
 			QCString("','") + relpath +
 			QCString("');});\n"
 							 "/* @license-end */\n"
@@ -2807,7 +2804,7 @@ void HtmlGenerator::writeInheritedSectionTitle(
     classLink += "href=\"";
     classLink+=relPath;
   }
-  classLink+=file+Doxygen::htmlFileExtension+a;
+  classLink=classLink+file+(hasExtension(file) ? "" : Doxygen::htmlFileExtension)+a;
   classLink+=QCString("\">")+convertToHtml(name,FALSE)+"</a>";
   t << "<tr class=\"inherit_header " << id << "\">"
     << "<td colspan=\"2\" onclick=\"javascript:toggleInherit('" << id << "')\">"
@@ -2830,7 +2827,7 @@ void HtmlGenerator::writeSummaryLink(const char *file,const char *anchor,const c
   if (file)
   {
     t << relPath << file;
-    t << Doxygen::htmlFileExtension;
+    t << (hasExtension(file) ? "" : Doxygen::htmlFileExtension);
   }
   else
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7220,6 +7220,19 @@ bool checkExtension(const char *fName, const char *ext)
   return (QCString(fName).right(QCString(ext).length())==ext);
 }
 
+bool hasExtension(const char *fName)
+{
+  return !(QFileInfo(fName).extension(FALSE).isEmpty());
+}
+bool hasExtension(QCString fName)
+{
+  return !(QFileInfo(fName).extension(FALSE).isEmpty());
+}
+bool hasExtension(QString fName)
+{
+  return !(QFileInfo(fName).extension(FALSE).isEmpty());
+}
+
 QCString stripExtensionGeneral(const char *fName, const char *ext)
 {
   QCString result=fName;

--- a/src/util.h
+++ b/src/util.h
@@ -363,6 +363,10 @@ QCString linkToText(SrcLangExt lang,const char *link,bool isFileName);
 
 bool checkExtension(const char *fName, const char *ext);
 
+bool hasExtension(const char *fName);
+bool hasExtension(QCString fName);
+bool hasExtension(QString fName);
+
 QCString stripExtensionGeneral(const char *fName, const char *ext);
 
 QCString stripExtension(const char *fName);


### PR DESCRIPTION
- See to it that when an extension is already present this extension is used and not a second extension is added
- let the tag file know what the original extension was.