### PR TITLE
issue #7285 git executable required

### DIFF
--- a/cmake/git_watcher.cmake
+++ b/cmake/git_watcher.cmake
@@ -69,7 +69,7 @@ CHECK_OPTIONAL_VARIABLE(GIT_WORKING_DIR "${CMAKE_SOURCE_DIR}")
 # Check the optional git variable.
 # If it's not set, we'll try to find it using the CMake packaging system.
 if(NOT DEFINED GIT_EXECUTABLE)
-    find_package(Git QUIET REQUIRED)
+    find_package(Git QUIET)
 endif()
 CHECK_REQUIRED_VARIABLE(GIT_EXECUTABLE)
 


### PR DESCRIPTION
Test showed that the REQUIRED is not necessary for the doxygen build process. The git version available will not be available.