### PR TITLE
Incorrect warning for ALIASES

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1495,7 +1495,7 @@ void Config::checkAndCorrect()
     alias=alias.stripWhiteSpace();
     if (alias.find(re1)!=0 && alias.find(re2)!=0)
     {
-      err("Illegal alias format '%s'. Use \"name=value\" or \"name(n)=value\", where n is the number of arguments\n",
+      err("Illegal alias format '%s'. Use \"name=value\" or \"name{n}=value\", where n is the number of arguments\n",
 	  alias.data());
     }
     s=aliasList.next();


### PR DESCRIPTION
In case we have an alias in the form: `mine_err(1)=\1` we get the warning:
```
error: Illegal alias format 'mine_err(1)=\1'. Use "name=value" or "name(n)=value", where n is the number of arguments
```
Note the round brackets in the explanation, these have to be curly brackets.