### PR TITLE
Bug 570798 - \\\< does not work for php constants

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2770,7 +2770,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           current->name += yytext ;  
   					  addType( current );
 					}
-<FindMembers,MemberSpec,Function,NextSemi,EnumBaseType,BitFields,ReadInitializer,OldStyleArgs>";"{BN}*("/**"|"//!"|"/*!"|"///")"<" {
+<FindMembers,MemberSpec,Function,NextSemi,EnumBaseType,BitFields,ReadInitializer,OldStyleArgs,DefinePHPEnd>";"{BN}*("/**"|"//!"|"/*!"|"///")"<" {
 					  if (current->bodyLine==-1)
 					  {
 					    current->bodyLine=yyLineNr;


### PR DESCRIPTION
Handle comment for define analogous to a normal php variable, the closing part is automatically done when the comment is finished (rule: `<DefinePHPEnd>";"`).