### PR TITLE
introduce resolveTypeDefsLimit to improve perf

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -316,7 +316,7 @@ QCString stripTemplateSpecifiersFromScope(const QCString &fullName,
                                           bool parentOnly=TRUE,
                                           QCString *lastScopeStripped=0);
 
-QCString resolveTypeDef(const Definition *d,const QCString &name,
+QCString resolveTypeDef(unsigned int *counter,const Definition *d,const QCString &name,
                         const Definition **typedefContext=0);
 
 QCString mergeScopes(const QCString &leftScope,const QCString &rightScope);


### PR DESCRIPTION
This constant set to 2000000 will prevent almost-endless processing of complex code files especially related to heavy usage of templates/generics, usually associated to files generated with gtest/gmock. This optimization has been improving performance greatly in those files, while not affecting to generated outputs at all.