### PR TITLE
issue 7302: Parsing of template args in single-quotes is incorrect.

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -751,6 +751,8 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 %x	GCopyCurly
 %x	SkipUnionSwitch
 %x	Specialization
+%x	SpecializationSingleQuote
+%x	SpecializationDoubleQuote
 %x	FuncPtrInit
 %x	FuncFunc
 %x	FuncFuncEnd
@@ -6145,6 +6147,19 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <Specialization>"typename"{BN}+		{ lineCount(); }
 <Specialization>"("			{ *specName += *yytext; roundCount++; }
 <Specialization>")"			{ *specName += *yytext; roundCount--; }
+
+<Specialization>"\\\\"			{ *specName += *yytext;}
+<Specialization>"\\'"			{ *specName += *yytext;}
+<Specialization>"\\\""			{ *specName += *yytext;}
+<Specialization>"'"			{ *specName += *yytext;BEGIN(SpecializationSingleQuote);}
+<Specialization>"\""			{ *specName += *yytext;BEGIN(SpecializationDoubleQuote);}
+<SpecializationSingleQuote,SpecializationDoubleQuote>"\\\\"       { *specName += *yytext;}
+<SpecializationSingleQuote>"\\'"        { *specName += *yytext;}
+<SpecializationSingleQuote>"'"          { *specName += *yytext; BEGIN(Specialization);}
+<SpecializationDoubleQuote>"\\\""       { *specName += *yytext;}
+<SpecializationDoubleQuote>"\""         { *specName += *yytext; BEGIN(Specialization);}
+<SpecializationSingleQuote,SpecializationDoubleQuote>.          { *specName += *yytext;}
+
 <Specialization>.			{
   					  *specName += *yytext;
   					}


### PR DESCRIPTION
In case we encounter an unescaped single or double quote during specialization we search for the closing quote.
We are cionnsidering potential escape sequences in the strings as well.