### PR TITLE
Problem with round brackets in PS output

### DIFF
--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -247,7 +247,7 @@ static void writeVectorBox(FTextStream &t,DiagramItem *di,
                            float x,float y,bool children=FALSE)
 {
   if (di->virtualness()==Virtual) t << "dashed\n";
-  t << " (" << di->label() << ") " << x << " " << y << " box\n";
+  t << " (" << convertToPSString(di->label()) << ") " << x << " " << y << " box\n";
   if (children) t << x << " " << y << " mark\n";
   if (di->virtualness()==Virtual) t << "solid\n";
 }
@@ -1297,7 +1297,7 @@ void ClassDiagram::writeFigure(FTextStream &output,const char *path,
     for (;(di=rit.current());++rit)
     {
       done=di->isInList();
-      t << "(" << di->label() << ") cw\n";
+      t << "(" << convertToPSString(di->label()) << ") cw\n";
     }
   }
   QListIterator<DiagramRow> sit(*super);
@@ -1310,7 +1310,7 @@ void ClassDiagram::writeFigure(FTextStream &output,const char *path,
     for (;(di=rit.current());++rit)
     {
       done=di->isInList();
-      t << "(" << di->label() << ") cw\n";
+      t << "(" << convertToPSString(di->label()) << ") cw\n";
     }
   }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6183,6 +6183,26 @@ QCString convertToJSString(const char *s, bool applyTextDir)
   return convertCharEntitiesToUTF8(growBuf.get());
 }
 
+QCString convertToPSString(const char *s)
+{
+  static GrowBuf growBuf;
+  growBuf.clear();
+  if (s==0) return "";
+  const char *p=s;
+  char c;
+  while ((c=*p++))
+  {
+    switch (c)
+    {
+      case '(':  growBuf.addStr("\\("); break;
+      case ')': growBuf.addStr("\\)"); break;
+      default:   growBuf.addChar(c);   break;
+    }
+  }
+  growBuf.addChar(0);
+  return growBuf.get();
+}
+
 QCString convertToLaTeX(const QCString &s,bool insideTabbing,bool keepSpaces)
 {
   QGString result;

--- a/src/util.h
+++ b/src/util.h
@@ -291,6 +291,8 @@ QCString convertToDocBook(const char *s);
 
 QCString convertToJSString(const char *s, bool applyTextDir = true);
 
+QCString convertToPSString(const char *s);
+
 QCString getOverloadDocs();
 
 void addMembersToMemberGroup(/* in,out */ MemberList *ml,


### PR DESCRIPTION
In case we use the doxygen inheritance diagrams in doxygen (i.e. `HAVE_DOT=NO`) for a construct like (based on #7302):
```
template <char C>
struct one { };
/// The struct str_040
struct str_040 : one<'('> { };
```
this will lead to a postscript error (epstopdf) as the `(` (and analogous the `)`) have to be escaped.