### PR TITLE
Determination of anonymous is to restrictive

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -753,7 +753,23 @@ void ClassDefImpl::IMPL::init(const char *defFileName, const char *name,
     isLocal=FALSE;
   }
   isGeneric = (lang==SrcLangExt_CSharp || lang==SrcLangExt_Java) && QCString(name).find('<')!=-1;
-  isAnonymous = QCString(name).find('@')!=-1;
+  
+  isAnonymous = false;
+  bool inSingle = false;
+  bool inDouble = false;
+  const char *p = name;
+  while (*p && !isAnonymous)
+  {
+    switch (*p)
+    {
+      case '\'': if (!inDouble) inSingle= !inSingle; break;
+      case '"':  if (!inSingle) inDouble= !inDouble; break;
+      case '\\': p++; break; // escaped character
+      case '@':  if (!inDouble && !inSingle) isAnonymous = true; break;
+      default: break;
+    }
+    p++;
+  }
 }
 
 ClassDefImpl::IMPL::IMPL() : vhdlSummaryTitles(17)


### PR DESCRIPTION
In case we have a construct like (taken from #7302):
```
/// @file
/// Something

template <char C>
struct one { };

/// The struct str_063
struct str_063 : one<'?'> { };
/// The struct str_064
struct str_064 : one<'@'> { };
```
the resulting inheritance graph for `'@'` is not correct, compare with the output for `'?'`.
The determination of the anonymous / searching for `@` has to exclude parts inside a string.