### PR TITLE
Code links.

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2357,6 +2357,12 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
   					  g_code->codify(yytext);
 					  g_insideProtocolList=FALSE;
   					}
+<SkipSharp>"\""((\\0[Xx0-9]+)|(\\.)|(.))*"\""	{
+  					  g_code->codify(yytext);
+  					}
+<SkipSharp>"'"((\\0[Xx0-9]+)|(\\.)|(.))"'"	{
+  					  g_code->codify(yytext);
+  					}
 <SkipSharp>"<"                          {
   					  g_code->codify(yytext);
   					  ++g_sharpCount; 


### PR DESCRIPTION
In case we have an example like (based on issue #7302):
```
/// @file
/// Something

template <char C>
struct one { };

/// The struct single_009 the char
struct single_009 : one<'       '> { };
/// The struct single_010 the char

struct single_039 : one<'\''> { };
/// The struct single_040 the char (
struct single_040 : one<'('> { };
/// The struct single_041 the char )
struct single_041 : one<')'> { };
/// The struct single_042 the char *
struct single_042 : one<'*'> { };

struct single_058 : one<':'> { };
/// The struct single_059 the char ;
struct single_059 : one<';'> { };
/// The struct single_060 the char <
struct single_060 : one<'<'> { };
/// The struct single_061 the char =
struct single_061 : one<'='> { };
/// The struct single_062 the char >
struct single_062 : one<'>'> { };
/// The struct single_063 the char ?
struct single_063 : one<'?'> { };
```
The result is that in the code section there are no links to the structs 41, 61, 62 as the `(` and `<` block it till the corresponding `)` and `>` is found.
Analogous problem for the double quote version.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3711470/example.tar.gz)
