### PR TITLE
Small improvement of line counting

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2325,6 +2325,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  }
   					}
 <CopyHereDocEnd>\n			{ 
+                                          lineCount();
                                           *pCopyHereDocGString += yytext;
                                         }
 <CopyHereDocEnd>{ID}			{ 
@@ -7268,7 +7269,9 @@ static void parseMain(const char *fileName,
   inputFile.setName(fileName);
   if (inputFile.open(IO_ReadOnly))
   {
-    yyLineNr= 1 ; 
+    yyLineNr = 1;
+    yyBegLineNr = 1;
+    yyBegColNr = 0;
     yyFileName = fileName;
     setContext();
     bool processWithClang = insideCpp || insideObjC;


### PR DESCRIPTION
In the file rdma.h of the glusterfs-5.10 package (https://download.gluster.org/pub/gluster/glusterfs/5/5.10/glusterfs-5.10.tar.gz, see also https://www.gluster.org/) there is a reference warning like:
```
glusterfs-5.10/rpc/rpc-transport/rdma/src/rdma.h:4826: warning: no uniquely matching class member found for
  struct @57::@60 @57::__attribute__((packed))
```
though the file just has 384 lines. The problem is the recognition of the `__attribute__((packed))` in a line like:
```
struct __gf_rdma_write_chunk {
...
} __attribute__((packed));
```
the fix improves the line number, not yet optimal but inside the file.