### PR TITLE
Also span entire line in case of a memTemplItemRight

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -535,7 +535,7 @@ table.memberdecls {
         white-space: nowrap;
 }
 
-.memItemRight {
+.memItemRight, .memTemplItemRight {
 	width: 100%;
 }
 


### PR DESCRIPTION
Based on the CGAL issue https://github.com/CGAL/cgal/issues/2095 (and pull request https://github.com/CGAL/cgal/pull/4282) to see to it that all relevant table span the page.