### PR TITLE
Properly close quotes in warning

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -6405,6 +6405,8 @@ static void findMember(const Entry *root,
                     warnMsg+="' at line "+QCString().setNum(md->getDefLine()) +
                              " of file "+md->getDefFileName();
                   }
+		  else
+                    warnMsg += "'";
 
                   warnMsg+='\n';
                 }


### PR DESCRIPTION
Found warning like:
```
Possible candidates:
  'template < T >
  gmic::gmic(const T &pixel_type=(T) 0)
  'template < T >
  gmic::gmic(const char *const commands_line, const char *const custom_commands=0, const bool include_stdlib=true, float *const p_progress=0, bool *const p_is_abort=0, const T &pixel_type=(T) 0)
  'template < T >
  gmic::gmic(const char *const commands_line, cimg_library::CImgList< T > &images, cimg_library::CImgList< char > &images_names, const char *const custom_commands=0, const bool include_stdlib=true, float *const p_progress=0, bool *const p_is_abort=0)
```
Note the starting quote `'` but there is no closing quote (in case of a file and line the closing quote is present.