### PR TITLE
Skip empty HTML tag

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5900,6 +5900,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
   switch (tagId)
   {
     case HTML_UL: 
+      if (!g_token->emptyTag)
       {
         DocHtmlList *list = new DocHtmlList(this,tagHtmlAttribs,DocHtmlList::Unordered);
         m_children.append(list);
@@ -5907,6 +5908,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       }
       break;
     case HTML_OL: 
+      if (!g_token->emptyTag)
       {
         DocHtmlList *list = new DocHtmlList(this,tagHtmlAttribs,DocHtmlList::Ordered);
         m_children.append(list);
@@ -5914,6 +5916,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       }
       break;
     case HTML_LI:
+      if (g_token->emptyTag) break;
       if (!insideUL(this) && !insideOL(this))
       {
         warn_doc_error(g_fileName,doctokenizerYYlineno,"lonely <li> tag found");
@@ -5924,21 +5927,22 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       }
       break;
     case HTML_BOLD:
-      handleStyleEnter(this,m_children,DocStyleChange::Bold,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Bold,&g_token->attribs);
       break;
     case HTML_STRIKE:
-      handleStyleEnter(this,m_children,DocStyleChange::Strike,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Strike,&g_token->attribs);
       break;
     case HTML_DEL:
-      handleStyleEnter(this,m_children,DocStyleChange::Del,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Del,&g_token->attribs);
       break;
     case HTML_UNDERLINE:
-      handleStyleEnter(this,m_children,DocStyleChange::Underline,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Underline,&g_token->attribs);
       break;
     case HTML_INS:
-      handleStyleEnter(this,m_children,DocStyleChange::Ins,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Ins,&g_token->attribs);
       break;
     case HTML_CODE:
+      if (g_token->emptyTag) break;
       if (/*getLanguageFromFileName(g_fileName)==SrcLangExt_CSharp ||*/ g_xmlComment) 
         // for C# source or inside a <summary> or <remark> section we 
         // treat <code> as an XML tag (so similar to @code)
@@ -5952,27 +5956,28 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       }
       break;
     case HTML_EMPHASIS:
-      handleStyleEnter(this,m_children,DocStyleChange::Italic,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Italic,&g_token->attribs);
       break;
     case HTML_DIV:
-      handleStyleEnter(this,m_children,DocStyleChange::Div,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Div,&g_token->attribs);
       break;
     case HTML_SPAN:
-      handleStyleEnter(this,m_children,DocStyleChange::Span,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Span,&g_token->attribs);
       break;
     case HTML_SUB:
-      handleStyleEnter(this,m_children,DocStyleChange::Subscript,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Subscript,&g_token->attribs);
       break;
     case HTML_SUP:
-      handleStyleEnter(this,m_children,DocStyleChange::Superscript,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Superscript,&g_token->attribs);
       break;
     case HTML_CENTER:
-      handleStyleEnter(this,m_children,DocStyleChange::Center,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Center,&g_token->attribs);
       break;
     case HTML_SMALL:
-      handleStyleEnter(this,m_children,DocStyleChange::Small,&g_token->attribs);
+      if (!g_token->emptyTag) handleStyleEnter(this,m_children,DocStyleChange::Small,&g_token->attribs);
       break;
     case HTML_PRE:
+      if (g_token->emptyTag) break;
       handleStyleEnter(this,m_children,DocStyleChange::Preformatted,&g_token->attribs);
       setInsidePreformatted(TRUE);
       doctokenizerYYsetInsidePre(TRUE);
@@ -5981,6 +5986,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       retval=TK_NEWPARA;
       break;
     case HTML_DL:
+      if (!g_token->emptyTag)
       {
         DocHtmlDescList *list = new DocHtmlDescList(this,tagHtmlAttribs);
         m_children.append(list);
@@ -5994,6 +6000,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       warn_doc_error(g_fileName,doctokenizerYYlineno,"Unexpected tag <dd> found");
       break;
     case HTML_TABLE:
+      if (!g_token->emptyTag)
       {
         DocHtmlTable *table = new DocHtmlTable(this,tagHtmlAttribs);
         m_children.append(table);
@@ -6028,22 +6035,22 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       retval=handleAHref(this,m_children,tagHtmlAttribs);
       break;
     case HTML_H1:
-      retval=handleHtmlHeader(tagHtmlAttribs,1);
+      if (!g_token->emptyTag) retval=handleHtmlHeader(tagHtmlAttribs,1);
       break;
     case HTML_H2:
-      retval=handleHtmlHeader(tagHtmlAttribs,2);
+      if (!g_token->emptyTag) retval=handleHtmlHeader(tagHtmlAttribs,2);
       break;
     case HTML_H3:
-      retval=handleHtmlHeader(tagHtmlAttribs,3);
+      if (!g_token->emptyTag) retval=handleHtmlHeader(tagHtmlAttribs,3);
       break;
     case HTML_H4:
-      retval=handleHtmlHeader(tagHtmlAttribs,4);
+      if (!g_token->emptyTag) retval=handleHtmlHeader(tagHtmlAttribs,4);
       break;
     case HTML_H5:
-      retval=handleHtmlHeader(tagHtmlAttribs,5);
+      if (!g_token->emptyTag) retval=handleHtmlHeader(tagHtmlAttribs,5);
       break;
     case HTML_H6:
-      retval=handleHtmlHeader(tagHtmlAttribs,6);
+      if (!g_token->emptyTag) retval=handleHtmlHeader(tagHtmlAttribs,6);
       break;
     case HTML_IMG:
       {
@@ -6051,6 +6058,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       }
       break;
     case HTML_BLOCKQUOTE:
+      if (!g_token->emptyTag)
       {
         DocHtmlBlockQuote *block = new DocHtmlBlockQuote(this,tagHtmlAttribs);
         m_children.append(block);


### PR DESCRIPTION
Due to the fact that an empty HTML tag (like `<strike/>` is seen as a start tag the rest of a documentation block is handled with the strikethrough. Same problem occurs for other tags as well, in most cases empty HTML tags should be left out of the output (and just give the warning about the empty tag).

Mentioned example:
```
/**
Before a strike:
<strike/>
after strike
*/
void fie_b_strike(void);
```