### PR TITLE
Incorrect display of multiline #define value

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1468,7 +1468,14 @@ void addDefine()
     while ((c=*p++) && (c==' ' || c=='\t')) k++;
     g_defLitText=g_defLitText.mid(l+1,k-l-1)+g_defLitText.stripWhiteSpace();
   }
-  md->setInitializer(g_defLitText.stripWhiteSpace());
+  if (g_defLitText.stripWhiteSpace().contains('\n')>=1)
+  {
+    md->setInitializer(g_defLitText);
+  }
+  else
+  {
+    md->setInitializer(g_defLitText.stripWhiteSpace());
+  }
 
   //printf("pre.l: md->setFileDef(%p)\n",g_inputFileDef);
   md->setFileDef(g_inputFileDef);


### PR DESCRIPTION
In case we have a `#define` like:
```
#define define_2 \
  2              \
  3
```
we see that the line with the `2` is not indented and shown as `2              \`, the line with the `3` is shown as `  3`. especially with more complex constructs this is distracting.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3734221/example.tar.gz)
this example shows also the distraction better in `define_3`
