### PR TITLE
Support for <a id="label">

### DIFF
--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -25,6 +25,8 @@ of a HTML tag are passed on to the HTML output only
 <ul>
 <li><tt>\<A HREF="..."\></tt> Starts a hyperlink 
                        (if supported by the output format). 
+<li><tt>\<A ID="..."\></tt> Starts a named anchor 
+                       (if supported by the output format).
 <li><tt>\<A NAME="..."\></tt> Starts a named anchor 
                        (if supported by the output format).
 <li><tt>\</A\></tt>    Ends a link or anchor 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -966,7 +966,7 @@ static int handleAHref(DocNode *parent,QList<DocNode> &children,const HtmlAttrib
   int retval = RetVal_OK;
   for (li.toFirst();(opt=li.current());++li,++index)
   {
-    if (opt->name=="name") // <a name=label> tag
+    if (opt->name=="name" || opt->name=="id") // <a name=label> or <a id=label> tag
     {
       if (!opt->value.isEmpty())
       {


### PR DESCRIPTION
Support besides `<a name="label">` also `<a id="label">` as `id=` is the HTML attribute to define an id for an HTML element.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3734684/example.tar.gz)
