### PR TITLE
RTF extension file to standard output, make according documentation consistent.

### DIFF
--- a/doc/doxygen.1
+++ b/doc/doxygen.1
@@ -10,8 +10,6 @@ You can use doxygen in a number of ways:
 1) Use doxygen to generate a template configuration file:
 .IP
 doxygen [-s] \fB\-g\fR [configName]
-.IP
-If - is used for configName doxygen will write to standard output.
 .TP 
 2) Use doxygen to update an old configuration file:
 .IP
@@ -20,34 +18,44 @@ doxygen [-s] \fB\-u\fR [configName]
 3) Use doxygen to generate documentation using an existing configuration file:
 .IP
 doxygen [configName]
-.IP
-If - is used for configName doxygen will read from standard input.
 .TP
 4) Use doxygen to generate a template file controlling the layout of the generated documentation:
 .IP
-doxygen -l [layoutFileName.xml]
+doxygen -l [layoutFileName]
+.IP
+In case layoutFileName is omitted layoutFileName.xml will be used as filename.
+If - is used for layoutFileName doxygen will write to standard output.
 .TP
 5) Use doxygen to generate a template style sheet file for RTF, HTML or Latex.
-.TP
+.IP
 RTF:
 doxygen \fB\-w\fR rtf styleSheetFile
-.TP
+.IP
 HTML:
 doxygen \fB\-w\fR html headerFile footerFile styleSheetFile [configFile]
-.TP
+.IP
 LaTeX: doxygen \fB\-w\fR latex headerFile footerFile styleSheetFile [configFile]
 .TP
 6) Use doxygen to generate an rtf extensions file
-.TP
+.IP
 RTF:
 doxygen \fB\-e\fR rtf extensionsFile
+.IP
+If - is used for extensionsFile doxygen will write to standard output.
 .TP
 7) Use doxygen to compare the used configuration file with the template configuration file
-.TP
+.IP
 doxygen \fB\-x\fR [configFile]
+.TP
+8) Use doxygen to show a list of built-in emojis.
+.IP
+doxygen \fB\-f\fR emoji outputFileName
+.IP
+If - is used for outputFileName doxygen will write to standard output.
 .PP
 If \fB\-s\fR is specified the comments in the config file will be omitted.
 If configName is omitted `Doxyfile' will be used as a default.
+If - is used for configFile doxygen will write / read the configuration to /from standard output / input.
 .SH AUTHOR
 Doxygen version @VERSION@, Copyright Dimitri van Heesch 1997-2019
 .SH SEE ALSO

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10116,29 +10116,31 @@ static void usage(const char *name,const char *versionString)
   msg("You can use doxygen in a number of ways:\n\n");
   msg("1) Use doxygen to generate a template configuration file:\n");
   msg("    %s [-s] -g [configName]\n\n",name);
-  msg("    If - is used for configName doxygen will write to standard output.\n\n");
   msg("2) Use doxygen to update an old configuration file:\n");
   msg("    %s [-s] -u [configName]\n\n",name);
   msg("3) Use doxygen to generate documentation using an existing ");
   msg("configuration file:\n");
   msg("    %s [configName]\n\n",name);
-  msg("    If - is used for configName doxygen will read from standard input.\n\n");
   msg("4) Use doxygen to generate a template file controlling the layout of the\n");
   msg("   generated documentation:\n");
-  msg("    %s -l [layoutFileName.xml]\n\n",name);
+  msg("    %s -l [layoutFileName]\n\n",name);
+  msg("    In case layoutFileName is omitted layoutFileName.xml will be used as filename.\n");
+  msg("    If - is used for layoutFileName doxygen will write to standard output.\n\n");
   msg("5) Use doxygen to generate a template style sheet file for RTF, HTML or Latex.\n");
   msg("    RTF:        %s -w rtf styleSheetFile\n",name);
   msg("    HTML:       %s -w html headerFile footerFile styleSheetFile [configFile]\n",name);
   msg("    LaTeX:      %s -w latex headerFile footerFile styleSheetFile [configFile]\n\n",name);
   msg("6) Use doxygen to generate a rtf extensions file\n");
   msg("    RTF:   %s -e rtf extensionsFile\n\n",name);
+  msg("    If - is used for extensionsFile doxygen will write to standard output.\n\n");
   msg("7) Use doxygen to compare the used configuration file with the template configuration file\n");
   msg("    %s -x [configFile]\n\n",name);
   msg("8) Use doxygen to show a list of built-in emojis.\n");
   msg("    %s -f emoji outputFileName\n\n",name);
   msg("    If - is used for outputFileName doxygen will write to standard output.\n\n");
   msg("If -s is specified the comments of the configuration items in the config file will be omitted.\n");
-  msg("If configName is omitted 'Doxyfile' will be used as a default.\n\n");
+  msg("If configName is omitted 'Doxyfile' will be used as a default.\n");
+  msg("If - is used for configFile doxygen will write / read the configuration to /from standard output / input.\n\n");
   msg("-v print version string\n");
 }
 
@@ -10365,9 +10367,14 @@ void readConfiguration(int argc, char **argv)
         genConfig=TRUE;
         break;
       case 'l':
-        layoutName=getArg(argc,argv,optind);
-        if (!layoutName)
-        { layoutName="DoxygenLayout.xml"; }
+        if (optind+1>=argc)
+        {
+          layoutName="DoxygenLayout.xml";
+        }
+        else
+        {
+          layoutName=argv[optind+1];
+        }
         writeDefaultLayoutFile(layoutName);
         cleanUpDoxygen();
         exit(0);


### PR DESCRIPTION
Create possibility to write rtf extension file to standard output as well, see to it that same technique is used on different places
Update documentation and make it consistent.

(was initiated by #7328 where we wanted to write to standard output)