### PR TITLE
issue #7313 VHDL attribute 'subtype is not supported and breaks parser

### DIFF
--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -1614,6 +1614,9 @@ QCString name_ext1() : {QCString s,s1,s2;}
  {
 
   (
+ LOOKAHEAD(<APOSTROPHE_T><SUBTYPE_T>)
+ <APOSTROPHE_T><SUBTYPE_T>{s+="'subtype";}
+|
  LOOKAHEAD(<DOT_T> suffix())
  <DOT_T> s1=suffix(){s+=".";s+=s1;}
 |


### PR DESCRIPTION
Add the `'subtype` construct for variables etc.