### PR TITLE
Adding possibility to automatically build vhdlparser from vhdlparser.jj file

### DIFF
--- a/cmake/FindJavacc.cmake
+++ b/cmake/FindJavacc.cmake
@@ -1,0 +1,11 @@
+
+find_program(JAVACC_EXECUTABLE NAMES javacc javaCC Javacc JavaCC javacc.bat DOC "path to the javacc executable")
+message("The path: $ENV{PATH}\n")
+mark_as_advanced(JAVACC_EXECUTABLE)
+if(JAVACC_EXECUTABLE)
+  set(JAVACC_FOUND 1)
+  message(STATUS "The javacc executable: ${JAVACC_EXECUTABLE}")
+else()
+  set(JAVACC_FOUND 0)
+  message(STATUS "The javacc executable not found, using existing files")
+endif()

--- a/vhdlparser/CMakeLists.txt
+++ b/vhdlparser/CMakeLists.txt
@@ -1,3 +1,13 @@
+find_package(Javacc)
+if (JAVACC_FOUND)
+    add_custom_command(
+        COMMAND ${JAVACC_EXECUTABLE} -OUTPUT_DIRECTORY=${CMAKE_SOURCE_DIR}/vhdlparser ${CMAKE_SOURCE_DIR}/vhdlparser/vhdlparser.jj
+        DEPENDS ${CMAKE_SOURCE_DIR}/vhdlparser/vhdlparser.jj
+        OUTPUT ${CMAKE_SOURCE_DIR}/vhdlparser/CharStream.cc ${CMAKE_SOURCE_DIR}/vhdlparser/CharStream.h ${CMAKE_SOURCE_DIR}/vhdlparser/ErrorHandler.h ${CMAKE_SOURCE_DIR}/vhdlparser/JavaCC.h ${CMAKE_SOURCE_DIR}/vhdlparser/ParseException.cc ${CMAKE_SOURCE_DIR}/vhdlparser/ParseException.h ${CMAKE_SOURCE_DIR}/vhdlparser/Token.cc ${CMAKE_SOURCE_DIR}/vhdlparser/Token.h ${CMAKE_SOURCE_DIR}/vhdlparser/TokenManager.h ${CMAKE_SOURCE_DIR}/vhdlparser/TokenMgrError.cc ${CMAKE_SOURCE_DIR}/vhdlparser/TokenMgrError.h ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParser.cc ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParser.h ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParserConstants.h ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.cc ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.h
+    )
+
+endif()
+
 include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/qtools ${GENERATED_SRC})
 add_library(vhdlparser STATIC
 CharStream.cc


### PR DESCRIPTION
- possibility to find the javacc program / script
- creating command to compile javaparser.jj with javacc and place files in the right directory when javacc is present.