### PR TITLE
Problem when having doxygen commands in the description of a HTML 'a' tag

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -829,7 +829,7 @@ inline void errorHandleDefaultToken(DocNode *parent,int tok,
 
 //---------------------------------------------------------------------------
 // forward declaration
-static bool defaultHandleToken(DocNode *parent,int tok, 
+static bool defaultHandleToken(DocNode *parent,int &tok,
                                QList<DocNode> &children,bool
                                handleWord=TRUE);
 
@@ -1319,7 +1319,7 @@ static void defaultHandleTitleAndSize(const int cmd, DocNode *parent, QList<DocN
  * @retval TRUE      The token was handled.
  * @retval FALSE     The token was not handled.
  */
-static bool defaultHandleToken(DocNode *parent,int tok, QList<DocNode> &children,bool
+static bool defaultHandleToken(DocNode *parent,int &tok, QList<DocNode> &children,bool
     handleWord)
 {
   DBG(("token %s at %d",tokToString(tok),doctokenizerYYlineno));


### PR DESCRIPTION
When we have following file (both lines are identical the first line is a translation of the second):
```

<a href="http://www.doxygen.nl">normal @b bold</a>

[normal @b bold](http://www.doxygen.nl)
```
we get the warnings:
```
.../aa.md:3: warning: Illegal command @a as part of a <a>..</a> block
.../aa.md:6: warning: Unexpected html tag <a> found within <a href=...> context
.../aa.md:6: warning: Illegal command @a as part of a <a>..</a> block
.../aa.md:7: warning: Unexpected end of comment while inside <a href=...> tag
```

the output looks OK, but the warning is a bit strange:
- getting a warning
- warning referring to `@a` instead of `@b`.

Problem is that the change of tokens inside the defaulHandleToken is not given back to the calling environment.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3746702/example.tar.gz)
