### PR TITLE
Small improvements of TCL output

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -233,7 +233,7 @@ void DocbookCodeGenerator::writeLineNumber(const char *ref,const char *fileName,
   {
     m_t << l << " ";
   }
-
+  m_col=0;
 }
 void DocbookCodeGenerator::setCurrentDoc(const Definition *,const char *,bool)
 {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -548,6 +548,7 @@ void HtmlCodeGenerator::writeLineNumber(const char *ref,const char *filename,
   }
   m_t << "</span>";
   m_t << "&#160;";
+  m_col=0;
 }
 
 void HtmlCodeGenerator::writeCodeLink(const char *ref,const char *f,

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -223,6 +223,7 @@ void LatexCodeGenerator::writeLineNumber(const char *ref,const char *fileName,co
   {
     m_t << l << " ";
   }
+  m_col=0;
 }
 
 

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -132,7 +132,7 @@ class ManGenerator : public OutputGenerator
     void writeAnchor(const char *,const char *) {}
     void startCodeFragment();
     void endCodeFragment();
-    void writeLineNumber(const char *,const char *,const char *,int l) { t << l << " "; }
+    void writeLineNumber(const char *,const char *,const char *,int l) { t << l << " "; col=0; }
     void startCodeLine(bool) {}
     void endCodeLine() { codify("\n"); col=0; }
     void startEmphasis() { t << "\\fI"; firstCol=FALSE; }

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -3052,6 +3052,7 @@ void RTFGenerator::writeLineNumber(const char *,const char *,const char *,int l)
   QCString lineNumber;
   lineNumber.sprintf("%05d",l);
   t << lineNumber << " ";
+  col=0;
 }
 void RTFGenerator::startCodeLine(bool)
 {

--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -486,6 +486,8 @@ Entry* tcl_entry_new()
 //  myEntry->mtype      = Method;
 //  myEntry->virt       = Normal;
 //  myEntry->stat       = FALSE;
+  myEntry->docFile    = tcl.file_name;
+  myEntry->inbodyFile = tcl.file_name;
   myEntry->fileName   = tcl.file_name;
   myEntry->lang       = SrcLangExt_Tcl;
   Doxygen::docGroup.initGroupInfo(myEntry);
@@ -1458,19 +1460,16 @@ tcl_inf("<- %s\n",text);
   }
   else if (what==1)
   { // start new comment
-    if (tcl.comment)
-    {
-      tcl_comment(99,""); // inbody
-    }
     tcl.string_comment=text;
+    tcl_comment(99,"");
+    tcl.string_comment="";
     tcl.comment=1;
   }
   else if (what==2)
   { // add to comment
-    if (tcl.comment)
-    {
-      tcl.string_comment+=text;
-    }
+    tcl.string_comment=text;
+    tcl_comment(99,"");
+    tcl.string_comment="";
   }
   else if (what==-1 || what == -2)
   { // end of comment without/with command
@@ -1549,6 +1548,7 @@ tcl_inf("-> %s\n",(const char *)tcl.string_comment);
               myEntry1=tcl_entry_namespace(tcl.scan.at(0)->ns);
             }
             processedDoc = preprocessCommentBlock(myDoc,tcl.file_name,myLine0);
+            if (!myEntry1->doc.isEmpty() && tcl.comment==0) processedDoc = "<BR>" + processedDoc; // to separate comment blocks
             parseCommentBlock(tcl.this_parser, myEntry1, processedDoc, tcl.file_name,
               myLine0, FALSE, tcl.config_autobrief, FALSE, myProt, myPos0, myNew);
           }
@@ -1571,6 +1571,7 @@ tcl_inf("-> %s\n",(const char *)tcl.string_comment);
             myEntry1=tcl_entry_namespace(tcl.scan.at(0)->ns);
           }
           processedDoc = preprocessCommentBlock(myDoc,tcl.file_name,myLine0);
+          if (!myEntry1->doc.isEmpty() && tcl.comment==0) processedDoc = "<BR>" + processedDoc; // to separate comment blocks
           parseCommentBlock(tcl.this_parser, myEntry1, processedDoc, tcl.file_name,
             myLine0, FALSE, tcl.config_autobrief, FALSE, myProt, myPos0, myNew);
         }
@@ -2151,6 +2152,8 @@ D
   tcl.entry_current->mtype = Method;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl_protection(tcl.entry_current);
@@ -2193,6 +2196,8 @@ D
   tcl.entry_current->mtype = Method;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl_protection(tcl.entry_current);
@@ -2230,6 +2235,8 @@ D
   tcl.entry_current->mtype = Method;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl_protection(tcl.entry_current);
@@ -2265,6 +2272,8 @@ D
   tcl.entry_current->mtype = Method;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl_protection(tcl.entry_current);
@@ -2298,6 +2307,8 @@ D
   tcl.entry_current->section = Entry::NAMESPACE_SEC;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl.entry_main->moveToSubEntryAndKeep(tcl.entry_current);
@@ -2336,6 +2347,8 @@ D
   tcl.entry_current->section = Entry::CLASS_SEC;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl.entry_main->moveToSubEntryAndKeep(tcl.entry_current);
@@ -2368,6 +2381,8 @@ D
   tcl.entry_current->section = Entry::CLASS_SEC;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl.entry_main->moveToSubEntryAndKeep(tcl.entry_current);
@@ -2420,6 +2435,8 @@ D
     tcl.entry_current->mtype = Method;
     tcl.entry_current->name = myMethod;
     tcl.entry_current->startLine = tcl.line_command;
+    tcl.entry_current->docLine = tcl.line_comment;
+    tcl.entry_current->inbodyLine = tcl.line_comment;
     tcl.entry_current->bodyLine = tcl.line_body0;
     tcl.entry_current->endBodyLine = tcl.line_body1;
     tcl_protection(tcl.entry_current);
@@ -2490,6 +2507,8 @@ D
   tcl.entry_current->section = Entry::VARIABLE_SEC;
   tcl.entry_current->name = myName;
   tcl.entry_current->startLine = tcl.line_command;
+  tcl.entry_current->docLine = tcl.line_comment;
+  tcl.entry_current->inbodyLine = tcl.line_comment;
   tcl.entry_current->bodyLine = tcl.line_body0;
   tcl.entry_current->endBodyLine = tcl.line_body1;
   tcl_protection(tcl.entry_current);

--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -1460,16 +1460,19 @@ tcl_inf("<- %s\n",text);
   }
   else if (what==1)
   { // start new comment
+    if (tcl.comment)
+    {
+      tcl_comment(99,""); // inbody
+    }
     tcl.string_comment=text;
-    tcl_comment(99,"");
-    tcl.string_comment="";
     tcl.comment=1;
   }
   else if (what==2)
   { // add to comment
-    tcl.string_comment=text;
-    tcl_comment(99,"");
-    tcl.string_comment="";
+    if (tcl.comment)
+    {
+      tcl.string_comment+=text;
+    }
   }
   else if (what==-1 || what == -2)
   { // end of comment without/with command
@@ -1548,7 +1551,6 @@ tcl_inf("-> %s\n",(const char *)tcl.string_comment);
               myEntry1=tcl_entry_namespace(tcl.scan.at(0)->ns);
             }
             processedDoc = preprocessCommentBlock(myDoc,tcl.file_name,myLine0);
-            if (!myEntry1->doc.isEmpty() && tcl.comment==0) processedDoc = "<BR>" + processedDoc; // to separate comment blocks
             parseCommentBlock(tcl.this_parser, myEntry1, processedDoc, tcl.file_name,
               myLine0, FALSE, tcl.config_autobrief, FALSE, myProt, myPos0, myNew);
           }
@@ -1571,7 +1573,6 @@ tcl_inf("-> %s\n",(const char *)tcl.string_comment);
             myEntry1=tcl_entry_namespace(tcl.scan.at(0)->ns);
           }
           processedDoc = preprocessCommentBlock(myDoc,tcl.file_name,myLine0);
-          if (!myEntry1->doc.isEmpty() && tcl.comment==0) processedDoc = "<BR>" + processedDoc; // to separate comment blocks
           parseCommentBlock(tcl.this_parser, myEntry1, processedDoc, tcl.file_name,
             myLine0, FALSE, tcl.config_autobrief, FALSE, myProt, myPos0, myNew);
         }


### PR DESCRIPTION
- handling of the used filename, sometimes the filename was not set resulting in case of a warning with file `<unknown>`, also improving, slightly, the line reference.
- <strike>in case of `##` comment blocks the last line was not always show</strike>
- <strike>in case of multiple comment blocks, properly separate them</strike>
- correct handling tab character in source code output (*gen)