### PR TITLE
Better warning in case a graph would have been to large

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1720,9 +1720,10 @@ void ClassDefImpl::writeInheritanceGraph(OutputList &ol) const
     // write class diagram using dot
   {
     DotClassGraph inheritanceGraph(this,Inheritance);
-    if (inheritanceGraph.isTooBig())
+    int numNodes;
+    if (inheritanceGraph.isTooBig(numNodes))
     {
-       warn_uncond("Inheritance graph for '%s' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.\n",name().data());
+       warn_uncond("Inheritance graph for '%s' not generated, too many nodes (%d). Consider increasing DOT_GRAPH_MAX_NODES.\n",name().data(),numNodes);
     }
     else if (!inheritanceGraph.isTrivial())
     {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1954,7 +1954,8 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
       if (haveDot && (classDiagrams || classGraph))
       {
         DotClassGraph *cg = getClassGraph();
-        result = !cg->isTrivial() && !cg->isTooBig();
+        int numNodes;
+        result = !cg->isTrivial() && !cg->isTooBig(numNodes);
       }
       else if (classDiagrams)
       {
@@ -3107,7 +3108,8 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
     {
       static bool haveDot = Config_getBool(HAVE_DOT);
       DotInclDepGraph *incGraph = getIncludeGraph();
-      return (haveDot && !incGraph->isTooBig() && !incGraph->isTrivial());
+      int numNodes;
+      return (haveDot && !incGraph->isTooBig(numNodes) && !incGraph->isTrivial());
     }
     TemplateVariant includeGraph() const
     {
@@ -3159,7 +3161,8 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
     {
       static bool haveDot = Config_getBool(HAVE_DOT);
       DotInclDepGraph *incGraph = getIncludedByGraph();
-      return (haveDot && !incGraph->isTooBig() && !incGraph->isTrivial());
+      int numNodes;
+      return (haveDot && !incGraph->isTooBig(numNodes) && !incGraph->isTrivial());
     }
     TemplateVariant includedByGraph() const
     {
@@ -5020,7 +5023,8 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
           (m_memberDef->isFunction() || m_memberDef->isSlot() || m_memberDef->isSignal()))
       {
         DotCallGraph *cg = getCallGraph();
-        return !cg->isTooBig() && !cg->isTrivial();
+        int numNodes;
+        return !cg->isTooBig(numNodes) && !cg->isTrivial();
       }
       return TemplateVariant(FALSE);
     }
@@ -5092,7 +5096,8 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
           (m_memberDef->isFunction() || m_memberDef->isSlot() || m_memberDef->isSignal()))
       {
         DotCallGraph *cg = getCallerGraph();
-        return !cg->isTooBig() && !cg->isTrivial();
+        int numNodes;
+        return !cg->isTooBig(numNodes) && !cg->isTrivial();
       }
       return TemplateVariant(FALSE);
     }

--- a/src/dotcallgraph.cpp
+++ b/src/dotcallgraph.cpp
@@ -210,8 +210,8 @@ bool DotCallGraph::isTrivial() const
   return m_startNode->children()==0;
 }
 
-bool DotCallGraph::isTooBig() const
+bool DotCallGraph::isTooBig(int &numNodes) const
 {
-  int numNodes = m_startNode->children() ? m_startNode->children()->count() : 0;
+  numNodes = m_startNode->children() ? m_startNode->children()->count() : 0;
   return numNodes>=DOT_GRAPH_MAX_NODES;
 }

--- a/src/dotcallgraph.h
+++ b/src/dotcallgraph.h
@@ -27,7 +27,7 @@ class DotCallGraph : public DotGraph
     DotCallGraph(const MemberDef *md,bool inverse);
     ~DotCallGraph();
     bool isTrivial() const;
-    bool isTooBig() const;
+    bool isTooBig(int &numNodes) const;
     QCString writeGraph(FTextStream &t, GraphOutputFormat gf, EmbeddedOutputFormat ef,
                         const char *path,const char *fileName,
                         const char *relPath,bool writeImageMap=TRUE,

--- a/src/dotclassgraph.cpp
+++ b/src/dotclassgraph.cpp
@@ -418,10 +418,9 @@ bool DotClassGraph::isTrivial() const
     return !UML_LOOK && m_startNode->children()==0;
 }
 
-bool DotClassGraph::isTooBig() const
+bool DotClassGraph::isTooBig(int &numNodes) const
 {
-  int numNodes = 0;
-  numNodes+= m_startNode->children() ? m_startNode->children()->count() : 0;
+  numNodes= m_startNode->children() ? m_startNode->children()->count() : 0;
   if (m_graphType==Inheritance)
   {
     numNodes+= m_startNode->parents() ? m_startNode->parents()->count() : 0;

--- a/src/dotclassgraph.h
+++ b/src/dotclassgraph.h
@@ -27,7 +27,7 @@ public:
   DotClassGraph(const ClassDef *cd,GraphType t);
   ~DotClassGraph();
   bool isTrivial() const;
-  bool isTooBig() const;
+  bool isTooBig(int &numNodes) const;
   QCString writeGraph(FTextStream &t,GraphOutputFormat gf,EmbeddedOutputFormat ef,
     const char *path, const char *fileName, const char *relPath,
     bool TBRank=TRUE,bool imageMap=TRUE,int graphId=-1);

--- a/src/dotincldepgraph.cpp
+++ b/src/dotincldepgraph.cpp
@@ -211,9 +211,9 @@ bool DotInclDepGraph::isTrivial() const
   return m_startNode->children()==0;
 }
 
-bool DotInclDepGraph::isTooBig() const
+bool DotInclDepGraph::isTooBig(int &numNodes) const
 {
-  int numNodes = m_startNode->children() ? m_startNode->children()->count() : 0;
+  numNodes = m_startNode->children() ? m_startNode->children()->count() : 0;
   return numNodes>=Config_getInt(DOT_GRAPH_MAX_NODES);
 }
 

--- a/src/dotincldepgraph.h
+++ b/src/dotincldepgraph.h
@@ -31,7 +31,7 @@ class DotInclDepGraph : public DotGraph
                         const char *path,const char *fileName,const char *relPath,
                         bool writeImageMap=TRUE,int graphId=-1);
     bool isTrivial() const;
-    bool isTooBig() const;
+    bool isTooBig(int &numNodes) const;
     void writeXML(FTextStream &t);
     void writeDocbook(FTextStream &t);
 

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -662,9 +662,10 @@ void FileDefImpl::writeIncludeGraph(OutputList &ol)
   {
     //printf("Graph for file %s\n",name().data());
     DotInclDepGraph incDepGraph(this,FALSE);
-    if (incDepGraph.isTooBig())
+    int numNodes;
+    if (incDepGraph.isTooBig(numNodes))
     {
-       warn_uncond("Include graph for '%s' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.\n",name().data());
+       warn_uncond("Include graph for '%s' not generated, too many nodes(%d). Consider increasing DOT_GRAPH_MAX_NODES.\n",name().data(),numNodes);
     }
     else if (!incDepGraph.isTrivial())
     {
@@ -686,9 +687,10 @@ void FileDefImpl::writeIncludedByGraph(OutputList &ol)
   {
     //printf("Graph for file %s\n",name().data());
     DotInclDepGraph incDepGraph(this,TRUE);
-    if (incDepGraph.isTooBig())
+    int numNodes;
+    if (incDepGraph.isTooBig(numNodes))
     {
-       warn_uncond("Included by graph for '%s' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.\n",name().data());
+       warn_uncond("Included by graph for '%s' not generated, too many nodes(%d). Consider increasing DOT_GRAPH_MAX_NODES.\n",name().data(),numNodes);
     }
     else if (!incDepGraph.isTrivial())
     {

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2928,9 +2928,10 @@ void MemberDefImpl::_writeCallGraph(OutputList &ol) const
      )
   {
     DotCallGraph callGraph(this,FALSE);
-    if (callGraph.isTooBig())
+    int numNodes;
+    if (callGraph.isTooBig(numNodes))
     {
-       warn_uncond("Call graph for '%s' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.\n",qPrint(qualifiedName()));
+       warn_uncond("Call graph for '%s' not generated, too many nodes(%d). Consider increasing DOT_GRAPH_MAX_NODES.\n",qPrint(qualifiedName()),numNodes);
     }
     else if (!callGraph.isTrivial())
     {
@@ -2951,9 +2952,10 @@ void MemberDefImpl::_writeCallerGraph(OutputList &ol) const
      )
   {
     DotCallGraph callerGraph(this, TRUE);
-    if (callerGraph.isTooBig())
+    int numNodes;
+    if (callerGraph.isTooBig(numNodes))
     {
-       warn_uncond("Caller graph for '%s' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.\n",qPrint(qualifiedName()));
+       warn_uncond("Caller graph for '%s' not generated, too many nodes(%d). Consider increasing DOT_GRAPH_MAX_NODES.\n",qPrint(qualifiedName()),numNodes);
     }
     else if (!callerGraph.isTrivial())
     {


### PR DESCRIPTION
When a graph is to large we get a message like:
```
warning: Included by graph for 'tile.h' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.
```
but the user has no idea how big the graph really is so the value is added to the warning, so the user can decide to set a value larger than this value.