### PR TITLE
Warnings with quoted strings and underscores (emphasis) in markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -254,7 +254,25 @@ static int findEmphasisChar(const char *data, int size, char c, int c_size)
   {
     while (i<size && data[i]!=c    && data[i]!='`' && 
                      data[i]!='\\' && data[i]!='@' &&
-                     data[i]!='\n') i++;
+                     data[i]!='\n')
+    {
+      switch (data[i])
+      {
+        case '"':
+          i++;
+          while(i < size && data[i] !='"') i++;
+          if (data[i] == '"') i++;
+          break;
+        case '\'':
+          i++;
+          while(i < size && data[i] !='\'') i++;
+          if (data[i] == '\'') i++;
+          break;
+        default:
+          i++;
+          break;
+      }
+    }
     //printf("findEmphasisChar: data=[%s] i=%d c=%c\n",data,i,data[i]);
 
     // not counting escaped chars or characters that are unlikely 


### PR DESCRIPTION
When having an example like:
```
/** @file

<b>;_f</b>
<b>;_s</b>

<b>;_t</b>
<a name="i1_"></a><b>;_w</b>
*/
```
we get the warnings like:
```
.../example.cpp:6: warning: found </b> tag while expecting </em>
.../example.cpp:8: warning: end of comment block while expecting command </em>
.../example.cpp:8: warning: end of comment block while expecting command </b>
```
When having a non finished emphasis and a string is detected the string is not handled as of "higher order" (like brackets in mathematical calculations).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3772403/example.tar.gz)
