### PR TITLE
issue #7119 Doxygen does not link to C# snippets - regression

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -986,7 +986,7 @@ static void generateClassOrGlobalLink(CodeOutputInterface &ol,const char *clName
       }
     }
     const NamespaceDef *nd = getResolvedNamespace(className);
-    if (nd && nd->isLinkableInProject())
+    if (nd && nd->isLinkable())
     {
       g_theCallContext.setScope(nd);
       addToSearchIndex(className);


### PR DESCRIPTION
Looks like the `isLinkableIeInProject` is a bit to strict and `isLinkable` has to be used (also the original pull request #6489 still works OK).