### PR TITLE
Properly open quotes in warning

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -6298,13 +6298,14 @@ static void findMember(const Entry *root,
                 if (cd!=0 && rightScopeMatch(cd->name(),className))
                 {
                   const ArgumentList &templAl = md->templateArguments();
+                  warnMsg+="  '";
                   if (templAl.hasParameters())
                   {
-                    warnMsg+="  'template ";
+                    warnMsg+="template ";
                     warnMsg+=tempArgListToString(templAl,root->lang);
                     warnMsg+='\n';
+                    warnMsg+="  ";
                   }
-                  warnMsg+="  ";
                   if (md->typeString())
                   {
                     warnMsg+=md->typeString();


### PR DESCRIPTION
Commit 78b5c44 'Properly close quotes in warning' https://github.com/doxygen/doxygen/pull/7312 handled the case that a closing quote was missing in case of a missing closing quote.

I case the word template is missing it is possible to miss the opening quote, resulting in:
```
wxWidgets-3.1.3/src/x11/brush.cpp:66: warning: no matching class member found for
  wxBrush::wxBrush(const wxColour &col, int style)
Possible candidates:
  wxBrush::wxBrush()'
  wxBrush::wxBrush(const wxColour &colour, wxBrushStyle style=wxBRUSHSTYLE_SOLID)'
```

this is fixed here.