### PR TITLE
issue #7358: Ternary conditional and null-coalescing operator in constructor results in faulty warning

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6923,7 +6923,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  }
   					}
 <*>\?                                   {
-  					  if (insideCS) 
+  					  if (insideCS && (YY_START != SkipRound)) 
 					  {
 					    if (current->type.isEmpty())
 					    {


### PR DESCRIPTION
Problem due to the implementation of "Support for C# nullable types (Origin: bugzilla #638606)" (issue #4064, pull request #645). The used condition was a bit to stringent so later on the function was not recognized as constructor.