### PR TITLE
bug fix of g_bracketCount in case of if( myobject.getPair() )

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2775,7 +2775,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
   					    g_name.resize(0);
 					  }
 					  g_type.resize(0);
-					  g_bracketCount=0;
+					  // g_bracketCount=0; // ex.  when we parse this syntax " if( myobject.getPair()) " , we have problem that g_braceCount has wrong value as zero at "getPair(".
 					  if (g_memCallContext==Body)
 					  {
 					    BEGIN(FuncCall);


### PR DESCRIPTION
# bug fix of g_bracketCount in case of if( myobject.getPair() )
- when we parse it , we will have the tokens with lex rule in code.l
```bison
[token]    :    [lex rule]
if              :   <Body>{FLOWCONDITION}/{BN}*"("
(               : <MemberCall2,FuncCall>"("
aa            : <MemberCall2,FuncCall>{ID}(({B}"<"[^\n\\{}<>]">")?({B}"::"{B}{ID})?)*
<              : <MemberCall2,FuncCall>{OPERATOR}
myobject : <FuncCall>{ID}/("."|"->")
.               : <MemberCall2>"->"|"."
getPair    : <MemberCall>{SCOPETNAME}/{BN}*"("         set g_bracketCount=0;
(               : <MemberCall2,FuncCall>"("
```
- when we meet ```<MemberCall>{SCOPETNAME}/{BN}*"("``` , g_bracketCount is set to zero. It has wrong value of g_bracketCount.
  - remove this line to get right value of g_bracketCount
- I need more accurate value of g_bracketCount (bracket count) to make the following flow chart and sequence diagram.
  - ![result](https://github.com/cheoljoo/doxygen/blob/master/doc/FC_SD2.png?raw=true)
  - refer to [FlowChart & SequenceDiagram From Source code](https://github.com/cheoljoo/doxygen/blob/master/README.md)
