### PR TITLE
QGDict::hashAsciiKey: Invalid null key due to empty procedure name

### DIFF
--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -535,6 +535,13 @@ static void tcl_name(const QCString &ns0, const QCString &name0, QCString &ns, Q
     ns = "";
     name = myNm;
   }
+  else if (myNm.length()-myStart == 2)
+  {
+    // ending with :: so get name equal to last component
+    ns = myNm.mid(0,myStart);
+    myStart = ns.findRev("::");
+    name = myNm.mid(myStart+2);
+  }
   else
   {
     ns = myNm.mid(0,myStart);


### PR DESCRIPTION
When having a problem like:
```
namespace eval ::tk::dialog {}
namespace eval ::tk::dialog::file {}

namespace eval ::tk::dialog::file::chooseDir {
    namespace import -force ::tk::msgcat::*
}

proc ::tk::dialog::file::chooseDir:: {args} {
}
```
This will lead to the following warnings:
```
QGDict::hashAsciiKey: Invalid null key
.../aa.tcl:9: warning: Illegal member name found.
```
this is due to the fact that the procedure name definition ends with `::` and thus actually has an empty procedure name (this is legal in TCL).
(see also: https://stackoverflow.com/questions/58683103/meaning-of-a-proc-name-ending-with).

In case of an empty name the last component is taken for the name too.

example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3803835/example.tar.gz)
