### PR TITLE
Spelling corrections for vhdl directory

### DIFF
--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -134,7 +134,7 @@ TOKEN [IGNORE_CASE] :
 | <ARRAY_T: "array"> {VhdlParser::setLineParsed(ARRAY_T);}
 | <ASSERT_T: "assert">
 | <ASSUME_T: "assume">
-| <ASSUME_GUARANTEE_T: "assume_guarentee">
+| <ASSUME_GUARANTEE_T: "assume_guarantee">
 | <ATTRIBUTE_T: "attribute"> {::vhdl::parser::VhdlParser::setLineParsed(ATTRIBUTE_T);}
 | <BEGIN_T: "begin">
 | <BLOCK_T: "block">


### PR DESCRIPTION
Spelling corrections as found by codespell and in #561.

`assume_guarentee` is not a vhdl keyword, `assume_guarantee` is.
A number of spelling errors are in generated code (through javacc) and have been reported upstrean (https://github.com/javacc/javacc/pull/118)
Corection of `guarded_signal_specificatio` to `guarded_signal_specification` is not possible as `guarded_signal_specification` exists as well.