### PR TITLE
Spelling corrections for templates directory

### DIFF
--- a/templates/html/htmllayout.tpl
+++ b/templates/html/htmllayout.tpl
@@ -98,7 +98,7 @@
 {# write the file sources #}
 {% for compound in fileList %}
   {% with page=compound %}
-    {# TODO: to deal with clang optimisation, we need to write the sources in a different order! #}
+    {# TODO: to deal with clang optimization, we need to write the sources in a different order! #}
     {% if compound.hasSourceFile %}
       {% create compound.sourceFileName|append:config.HTML_FILE_EXTENSION from 'htmlsource.tpl' %}
     {% endif %}

--- a/templates/html/htmltypeconstraints.tpl
+++ b/templates/html/htmltypeconstraints.tpl
@@ -1,6 +1,6 @@
 {# obj should be a class or member #}
 {% if obj.typeConstraints %}
-  <div class="typecontraint">
+  <div class="typeconstraint">
   <dl><dt><b>{{ tr.typeConstraints }}</b></dt>
   <dd><table border="0" cellspacing="2" cellpadding="0">
   {% for arg in obj.typeConstraints %}


### PR DESCRIPTION
Spelling corrections as found by codespell and in #561.

One reported problem was already fixed, others are fixed here.