### PR TITLE
Spelling corrections for examples directory

### DIFF
--- a/examples/templ.cpp
+++ b/examples/templ.cpp
@@ -27,9 +27,9 @@ template<class T,int i> Test<T,i>::Test() {}
 /*! The copy constructor */
 template<class T,int i> Test<T,i>::Test(const Test &t) {}
 
-/*! The constructor of the partial specilization */
+/*! The constructor of the partial specialization */
 template<class T> Test<T *>::Test() {}
 
-/*! The constructor of the specilization */
+/*! The constructor of the specialization */
 template<> Test<void *,200>::Test() {}
 


### PR DESCRIPTION
Spelling corrections as found by codespell and in #561.

The dbusxml.xml file is not part of the doxygen distribution anymore.
Other problems are fixed here.