### PR TITLE
Spelling corrections for doc directory

### DIFF
--- a/doc/changelog.doc
+++ b/doc/changelog.doc
@@ -178,7 +178,7 @@
 <li>Forgot to comment out debug print [<a href="https://github.com/doxygen/doxygen/commit/9ef21db5efbd521c570121cc7638de8d4d487536">view</a>]</li>
 <li>Give warning when a retval is used multiple times [<a href="https://github.com/doxygen/doxygen/commit/e6fb6ea2017e3245a6b45b6c8e73472829215b09">view</a>]</li>
 <li>Handling digraph versus label [<a href="https://github.com/doxygen/doxygen/commit/f3a08615439a4e82f14a5dc9d1a758b401905e30">view</a>]</li>
-<li>High consequence coverity mesages [<a href="https://github.com/doxygen/doxygen/commit/5059d796ea951d06cebc55f1a9158a8dd001af0e">view</a>]</li>
+<li>High consequence coverity messages [<a href="https://github.com/doxygen/doxygen/commit/5059d796ea951d06cebc55f1a9158a8dd001af0e">view</a>]</li>
 <li>Image not seen as svg image [<a href="https://github.com/doxygen/doxygen/commit/a3d574ecf12c71bc25579b38670f17ef663b82a6">view</a>]</li>
 <li>Implement a new EXTRACT_PRIVATE_VIRTUAL option. [<a href="https://github.com/doxygen/doxygen/commit/d18b3eaf3486e224fa9de7e77b536883952b40b9">view</a>]</li>
 <li>Implementing `&lt;hr&gt;` for LaTeX [<a href="https://github.com/doxygen/doxygen/commit/dbddf36cd10c3e6cd9419a08d688f8cbfd57f9c3">view</a>]</li>
@@ -224,7 +224,7 @@
 <li>Option for &#39;input buffer overflow&#39; [<a href="https://github.com/doxygen/doxygen/commit/efc67de9d1a4e36ab94164352778fd19f33652b3">view</a>]</li>
 <li>Option syntax for commands is unclear [<a href="https://github.com/doxygen/doxygen/commit/9ecbe35ae2826b2404f37cc7e5d4377e39430b51">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/bd645c0e3ee05582adf30dcd91af5eafec7733c4">view</a>]</li>
 <li>PLANTUML_RUN_JAVA_ONCE is working well.  But some specific plantuml has error on ver 1.8.15 [<a href="https://github.com/doxygen/doxygen/commit/aeff95e38dca51f4a9ace9af8aa0387ad683f7f0">view</a>]</li>
-<li>Portuguse translators updated to Doxygen 1.8.16. [<a href="https://github.com/doxygen/doxygen/commit/6b4fd5000c6f6787155743dc93d67a249ca2b881">view</a>]</li>
+<li>Portuguese translators updated to Doxygen 1.8.16. [<a href="https://github.com/doxygen/doxygen/commit/6b4fd5000c6f6787155743dc93d67a249ca2b881">view</a>]</li>
 <li>Possibility to show converted fixed form [<a href="https://github.com/doxygen/doxygen/commit/1659f94a4c8acff1c2564226db21afbd2bc04736">view</a>]</li>
 <li>Problem with just an asterisks on a `\code` line [<a href="https://github.com/doxygen/doxygen/commit/3088ae34eda1fbeab287e2271a7f1804de2c784f">view</a>]</li>
 <li>Problem with with comment recognition for group open and closing commands [<a href="https://github.com/doxygen/doxygen/commit/ef5af7618fbec3ac240e7a1099607d9ff2b3cc4f">view</a>]</li>
@@ -306,7 +306,7 @@ href="https://github.com/doxygen/doxygen/commit/9d83d43f0d8b7058e2f89371a6ab276c
 <li>constexp.l: group the flex options [<a href="https://github.com/doxygen/doxygen/commit/306e3051b1374cf180b1464700ae79662ced95c2">view</a>]</li>
 <li>constexp.y: drop the = from name-prefix [<a href="https://github.com/doxygen/doxygen/commit/a18e967baabf5a9a234627e677d866bcf45741d4">view</a>]</li>
 <li>declinfo.l: enable reentrant [<a href="https://github.com/doxygen/doxygen/commit/2513172db2942a364e8af4a0d21d0fb2de328af1">view</a>]</li>
-<li>declinfo.l: group flex options toghether [<a href="https://github.com/doxygen/doxygen/commit/49c97e860a97615995eed4f58dec58d9a2a9339f">view</a>]</li>
+<li>declinfo.l: group flex options together [<a href="https://github.com/doxygen/doxygen/commit/49c97e860a97615995eed4f58dec58d9a2a9339f">view</a>]</li>
 <li>declinfo.l: move function declarations before [<a href="https://github.com/doxygen/doxygen/commit/44f678794f5338881620525a5e0fbe25962c7690">view</a>]</li>
 <li>delayed creation and update of .md5 files after successful creation of output files [<a href="https://github.com/doxygen/doxygen/commit/572035ffcd0e4f7313bab23d375d63008ebbe5a3">view</a>], [<a href="http://github.com/doxygen/doxygen/commit/9dda0c6ddc5117f800afcb19fb8c6be031fe6c27">view</a>]</li>
 <li>do not clobber version placeholder [<a href="https://github.com/doxygen/doxygen/commit/faafe83a69d2f3c27daca0974c9a063bdb81ecdc">view</a>]</li>
@@ -664,7 +664,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Problems and some enhancements for LaTeX tables [<a href="https://github.com/doxygen/doxygen/commit/d984f7dd21863fc01a1a6ede0878d3dd14af157a">view</a>]</li>
 <li>RTF layout regarding References and Referenced by [<a href="https://github.com/doxygen/doxygen/commit/c90505681054d51da05fd476d08c610d3e20ca38">view</a>]</li>
 <li>RTF lists more levels and removing extra paragraphs [<a href="https://github.com/doxygen/doxygen/commit/8fc23878b4375546bfb6a9149f009fbe0f7da42f">view</a>]</li>
-<li>Readded missing &quot;Span&quot; case to DocStyleChange::styleString [<a href="https://github.com/doxygen/doxygen/commit/6a3d1b3d12e353d0c6ebd642b691e5e2608f8df2">view</a>]</li>
+<li>Re-added missing &quot;Span&quot; case to DocStyleChange::styleString [<a href="https://github.com/doxygen/doxygen/commit/6a3d1b3d12e353d0c6ebd642b691e5e2608f8df2">view</a>]</li>
 <li>Redundant whitespace removal breaks some C++ links [with test case and Git bisect] (Origin: bugzilla #791942) [<a href="https://github.com/doxygen/doxygen/commit/449a7e2b4ff114a72be573013558bae19672ebbc">view</a>]</li>
 <li>Refactored code a bit [<a href="https://github.com/doxygen/doxygen/commit/4ed08b969b575d6dc1a49bca936a43eb43d337e2">view</a>]</li>
 <li>Refactored code a bit (use const references and made global functions members) [<a href="https://github.com/doxygen/doxygen/commit/3820f6a841115bd66ed409221c73824ec41ae6ab">view</a>]</li>
@@ -766,7 +766,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6139">6139</a> - Menu does not work without Javascript [<a href="https://github.com/doxygen/doxygen/commit/1be97720b7820361e85242d08d4cac3e46570bfe">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6141">6141</a> - Too greedy behavior of @ref const matching [<a href="https://github.com/doxygen/doxygen/commit/04001c8926fb0f37dfcf284b3637b182125bba75">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6169">6169</a> - doxygen build fails [<a href="https://github.com/doxygen/doxygen/commit/bb5c8dd29782ecbb05a4ef9788f2507e9a156848">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6170">6170</a> - Add &quot;\~&quot; command to internatioalization article [<a href="https://github.com/doxygen/doxygen/commit/e204b982eebd54bd15148a520da6608935e33e50">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/6170">6170</a> - Add &quot;\~&quot; command to internationalization article [<a href="https://github.com/doxygen/doxygen/commit/e204b982eebd54bd15148a520da6608935e33e50">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6223">6223</a> - Problem RTF output: The class list &quot;classes&quot; within the namespace report is wrong indicated. [<a href="https://github.com/doxygen/doxygen/commit/753c06281f6b2e9172c449157fc9f863063232e3">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/6238">6238</a> - parsing error in Fortran file with preprocessing [<a href="https://github.com/doxygen/doxygen/commit/2f5e22a4be9d237a150d04659bf6abec1349fbd9">view</a>]
 , [<a href="https://github.com/doxygen/doxygen/commit/ec12eb659d8c8e78ad4bb15d1a941ac3153a0f66">view</a>]</li>
@@ -844,7 +844,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Use hidden symbol visibility by default [<a href="https://github.com/doxygen/doxygen/commit/dcb3b2d0b888902a062eefd8200ea194ed1c42d6">view</a>]</li>
 <li>Use language identifier instead of file extension for language attribute [<a href="https://github.com/doxygen/doxygen/commit/ed9acb6e1bb81a2eec334180f7b8c1bf0598b444">view</a>]</li>
 <li>Use language in stead of lang for language name attribute [<a href="https://github.com/doxygen/doxygen/commit/4e4741221f4290412ef4a6b6bbfe9799abafaf6c">view</a>]</li>
-<li>Update of the Brazillian translation [<a href="https://github.com/doxygen/doxygen/commit/d283dfcdcaa0837e84d7995676d436fa04e96d1f">view</a>]</li>
+<li>Update of the Brazilian translation [<a href="https://github.com/doxygen/doxygen/commit/d283dfcdcaa0837e84d7995676d436fa04e96d1f">view</a>]</li>
 <li>[preprocessing.doc] typo amended [<a href="https://github.com/doxygen/doxygen/commit/6b67a64bd0bd1c6759294c323433dbd7d37df6ac">view</a>]</li>
 <li>add decimal to base identifier [<a href="https://github.com/doxygen/doxygen/commit/9cbc1a04e584e83d91ff3f7501f38b0a825e1953">view</a>]</li>
 <li>add the number of conditionals path and bugfix [<a href="https://github.com/doxygen/doxygen/commit/20af63f43e583a31dfe93f78807aa868f9b9ff14">view</a>]</li>
@@ -944,7 +944,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/1662">1662</a> - Fix missing title in non-page docanchors from tag files [<a href="https://github.com/doxygen/doxygen/commit/616b392e9bc8984251d969577a5b63974efb1eef">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/2763">2763</a> - FILTER_PATTERNS won&#39;t take command with arguments [<a href="https://github.com/doxygen/doxygen/commit/ce7a983c2849e4c8fa72189a896e594a8497dd4c">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/4691">4691</a> - Uses &lt;img&gt; instead of &lt;object&gt; html tag for SVG images [<a href="https://github.com/doxygen/doxygen/commit/8ccd98643a3b88aaa3245b76202666900a2cd401">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5174">5174</a> - error state 21 with fortran code (fixed format) [<a href="https://github.com/doxygen/doxygen/commit/fdee5e9fade0ff5a578817048c6205f2a9acbced">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5174">5174</a> - error state 21 with Fortran code (fixed format) [<a href="https://github.com/doxygen/doxygen/commit/fdee5e9fade0ff5a578817048c6205f2a9acbced">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5323">5323</a> - Missing Page References in the Index Chapters of the LaTex/PDF output [<a href="https://github.com/doxygen/doxygen/commit/efd49dacfbae1ad55d7922a748e2c1d60068b014">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5411">5411</a> - Inherited member of template class issues warning and is not documented [<a href="https://github.com/doxygen/doxygen/commit/4dfc5887660284b345eb93b6c07dc1f91e780fac">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5711">5711</a> - Fortran: attributes after a blank line are ignored / Bug <a href="https://github.com/doxygen/doxygen/issues/3880">3880</a> - FORTRAN: comment in subroutine argument list [<a href="https://github.com/doxygen/doxygen/commit/e9ebf43585bffee80c31dd69538feae2a4525178">view</a>]</li>
@@ -959,7 +959,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5933">5933</a> - Phantom variables/functions in XML, created from non-code files [<a href="https://github.com/doxygen/doxygen/commit/7dc9b378a107b1ccae2245b3f3f3d628db2bd008">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5937">5937</a> - CASE_SENSE_NAMES ignored [<a href="https://github.com/doxygen/doxygen/commit/fab854a10f358c15a69291a59388ea0c184bce20">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5938">5938</a> - Spaces between the closing bracket of the typename and the opening bracket of the parameter list cause detection issues. [<a href="https://github.com/doxygen/doxygen/commit/622d18637f9d633b184e43fd3594b661cf4e9375">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5941">5941</a> - python unicode docstrings are ignored [<a href="https://github.com/doxygen/doxygen/commit/936f242956350825d870f7396ae5d6106fe3081d">view</a>]
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5941">5941</a> - python Unicode docstrings are ignored [<a href="https://github.com/doxygen/doxygen/commit/936f242956350825d870f7396ae5d6106fe3081d">view</a>]
 , [<a href="https://github.com/doxygen/doxygen/commit/be100f882604a23d94025fee6d059bdb5ec28d3e">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5945">5945</a> - Do not allow ligatures in log output [<a href="https://github.com/doxygen/doxygen/commit/894bdfdf268ba24a268fa72d7b33899a9f3a126b">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5958">5958</a> - References for one function can inherit References from subsequent non documented function [<a href="https://github.com/doxygen/doxygen/commit/9abcad810b8d41d338d501ff5b32524e1ced7f33">view</a>]</li>
@@ -977,7 +977,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5981">5981</a> - quick link index in alphabetical class list in classes.html doesn&#39;t work [<a href="https://github.com/doxygen/doxygen/commit/ec1ef7b4971540bbe042b16d7ebd3f2a0e0e57f1">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5982">5982</a> - Bad character escaping scheme in HTML anchor generation. [<a href="https://github.com/doxygen/doxygen/commit/6136cf9e3ad70d58cac4d8022cce8c8729805119">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5983">5983</a> - `@addindex`entries fail to link to the exact location in Compiled HTML Help. [<a href="https://github.com/doxygen/doxygen/commit/8dea6e11faf3969c3b6b17b700533f43c9ca73f8">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5985">5985</a> - Java: final keyword on a parameter brakes docs inherinance [<a href="https://github.com/doxygen/doxygen/commit/dfd0336f1a97e189d49e29860db1c43915aced76">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5985">5985</a> - Java: final keyword on a parameter brakes docs inheritance [<a href="https://github.com/doxygen/doxygen/commit/dfd0336f1a97e189d49e29860db1c43915aced76">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5991">5991</a> - Using `@page` to add title to Markdown file generates surplus empty page. [<a href="https://github.com/doxygen/doxygen/commit/42c7d88ffc11651d1fb6b997fd23cc938bce4a39">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5998">5998</a> - DOT_PATH not expanded [<a href="https://github.com/doxygen/doxygen/commit/752523cd122d6ffdd72c89955005d77819740675">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5999">5999</a> - Files with incorrect extensions (.doc) are picked up by doxygen [<a href="https://github.com/doxygen/doxygen/commit/14b04be2af279e1093f17d6b933d1e9ab530e128">view</a>]</li>
@@ -1023,17 +1023,17 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Documentation for extensions .f95, .f03 and .f08 [<a href="https://github.com/doxygen/doxygen/commit/4c2e91c10dc6d007c410cd282a00fc7a42d38a0d">view</a>]</li>
 <li>Doxygen fails to copy logo image to LaTex output dir [<a href="https://github.com/doxygen/doxygen/commit/711c6c0bee87d47d70b3ffa9ca8b39b704e91723">view</a>]</li>
 <li>FORTRAN determination string in preprocessing [<a href="https://github.com/doxygen/doxygen/commit/4a7673fed2f28a24e0c7e8bb94621b0e14ac9ed5">view</a>]</li>
-<li>Feature: Translations for german language (changes since 1.8.4) [<a href="https://github.com/doxygen/doxygen/commit/261077497f2bcc3364e182e338d914c470a0a235">view</a>]</li>
+<li>Feature: Translations for German language (changes since 1.8.4) [<a href="https://github.com/doxygen/doxygen/commit/261077497f2bcc3364e182e338d914c470a0a235">view</a>]</li>
 <li>Fix STRIP_FROM_PATH when running from drive root [<a href="https://github.com/doxygen/doxygen/commit/fd808ae3c1e37a8d476d250cf6b4325624a9eccb">view</a>]</li>
 <li>Fix Windows build instructions. [<a href="https://github.com/doxygen/doxygen/commit/eec8d0a31161746041fc94ccbba5a54aecd8cf93">view</a>]</li>
 <li>Fix documentation typos [<a href="https://github.com/doxygen/doxygen/commit/770adb37b2072bbea5412f9cc2058d98d1de60e4">view</a>]</li>
 <li>Fix for HTML output when using server side search and the new menu bar [<a href="https://github.com/doxygen/doxygen/commit/0faf45600c6c640bfaf11b017d43a4b9de193ebf">view</a>]</li>
-<li>Fix for changed references due to different removeRedudantWhiteSpace() implementation [<a href="https://github.com/doxygen/doxygen/commit/f26cc41d0d3d436c809c293a56c66c1f5f953745">view</a>]</li>
+<li>Fix for changed references due to different removeRedundantWhiteSpace() implementation [<a href="https://github.com/doxygen/doxygen/commit/f26cc41d0d3d436c809c293a56c66c1f5f953745">view</a>]</li>
 <li>Fix for empty file name [<a href="https://github.com/doxygen/doxygen/commit/0fead5249b8ef2c3c5cbbbd712855bae877aa27b">view</a>]</li>
 <li>Fix for error in travis.yml [<a href="https://github.com/doxygen/doxygen/commit/81cf39f249c58db66368d60d596ac164d886ae90">view</a>]</li>
 <li>Fix issue escaping backslash inside markdown style code span [<a href="https://github.com/doxygen/doxygen/commit/402970f77f961b85b6371c8e53bd69981435c2d7">view</a>]</li>
 <li>Fix linker flags for building with clang on Windows [<a href="https://github.com/doxygen/doxygen/commit/41846b467bea58b904e26ce139394f7371ea5870">view</a>]</li>
-<li>Fix order of member initilaization [<a href="https://github.com/doxygen/doxygen/commit/6b1ebb6bcb345d8997054492c21276dc2dc36416">view</a>]</li>
+<li>Fix order of member initialization [<a href="https://github.com/doxygen/doxygen/commit/6b1ebb6bcb345d8997054492c21276dc2dc36416">view</a>]</li>
 <li>Fix return-type warnings with -DNDEBUG [<a href="https://github.com/doxygen/doxygen/commit/f4574baf118da6aa2051b865040a9948bb0d22c9">view</a>]</li>
 <li>Fix search box rendering in HTML when menu bar is disabled [<a href="https://github.com/doxygen/doxygen/commit/ee9a0664c03c306d0aeb127295ced29f8078ae03">view</a>]</li>
 <li>Fix uppercase letters B-Z being unnecessarily escaped in index HTML anchors. [<a href="https://github.com/doxygen/doxygen/commit/0f699ab17cb88beff0ae4aa9b10042c0ccaff937">view</a>]</li>
@@ -1209,7 +1209,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Moved creation of inline class documentation to separate template file [<a href="https://github.com/doxygen/doxygen/commit/4bd50c9f0dc1d7b1413a6bda587b8a5999cd7a19">view</a>]</li>
 <li>RTF improvement: Example section was merged with next function title [<a href="https://github.com/doxygen/doxygen/commit/ca617e1e1cd42ee0080c8c13ce3884c8671629dd">view</a>]</li>
 <li>Remove obsolete py files [<a href="https://github.com/doxygen/doxygen/commit/183f36fe97cb95636f1947c2c4be61f7b78f87e0">view</a>]</li>
-<li>Removed BOM marker from greek translator to avoid Visual C warnings [<a href="https://github.com/doxygen/doxygen/commit/9ee8f777f5a4b7a49e644c2da5247fa509038feb">view</a>]</li>
+<li>Removed BOM marker from Greek translator to avoid Visual C warnings [<a href="https://github.com/doxygen/doxygen/commit/9ee8f777f5a4b7a49e644c2da5247fa509038feb">view</a>]</li>
 <li>Repaired breaking @include for LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/ab861c197c596f78c7aea4f45c0e1252de10fc1f">view</a>]</li>
 <li>Revert &quot;Spelling correction for error message with USE_HTAGS usage&quot; [<a href="https://github.com/doxygen/doxygen/commit/a888543ca5f3fd28121f7eea4dbd25898fa7be57">view</a>]</li>
 <li>Revert using container-based infra as sudo is needed :-( [<a href="https://github.com/doxygen/doxygen/commit/f089c3fa4f47dc8bedd25d9d857d004525ee82c0">view</a>]</li>
@@ -1236,7 +1236,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Using tabu package for LaTeX tables [<a href="https://github.com/doxygen/doxygen/commit/647b6ac8669cd8ba1e8c60eeb3c2de961c7d6a1b">view</a>]</li>
 <li>[Bug <a href="https://github.com/doxygen/doxygen/issues/5872">5872</a>] On Windows, generated layout is with UNIX EOL [<a href="https://github.com/doxygen/doxygen/commit/78a80001223af290c7c7321ad2d210fb3cd16f11">view</a>]</li>
 <li>[Doxygen-users] plugin / filter not behaving as expected [<a href="https://github.com/doxygen/doxygen/commit/0c7f182016c7c2604a484367738e76cb40c0541b">view</a>]</li>
-<li>add spaces like &quot;Doyxgen&quot;CN_SPC-&gt;&quot;Doyxgen&quot; CN_SPC [<a href="https://github.com/doxygen/doxygen/commit/35d1aa8bf9208302601fa96462e246c98aa0b0e5">view</a>]</li>
+<li>add spaces like &quot;Doxygen&quot;CN_SPC-&gt;&quot;Doxygen&quot; CN_SPC [<a href="https://github.com/doxygen/doxygen/commit/35d1aa8bf9208302601fa96462e246c98aa0b0e5">view</a>]</li>
 <li>allow building with custom iconv on Windows [<a href="https://github.com/doxygen/doxygen/commit/3d684f6d123abdbf630bb19bc6095cc9d69efb68">view</a>]</li>
 <li>doc: generate doxygen&#39;s documentation. [<a href="https://github.com/doxygen/doxygen/commit/3c4a1ea2ee56f2604c2277f13737d53b3a0b0353">view</a>]</li>
 <li>doc: put man pages under share/man/man1 [<a href="https://github.com/doxygen/doxygen/commit/95d28153779810dc95afafa38ed838f32516a1f4">view</a>]</li>
@@ -1293,7 +1293,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5720">5720</a> - &lt;CAPTION&gt; inside &lt;TABLE&gt; no longer works for LaTex output [<a href="https://github.com/doxygen/doxygen/commit/0599f92d06ff433446f34136ffe2f3d65d6bd109">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5726">5726</a> - Duplicate anchors from tagfiles [<a href="https://github.com/doxygen/doxygen/commit/1f21c23c57c91ba6901c0de38bb236f7246e88c9">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5727">5727</a> - Tagfile anchors not generated for enumeration values [<a href="https://github.com/doxygen/doxygen/commit/1d4f37cb13a75ca8bdc49be3558438104e7eef19">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5728">5728</a> - Non-ascii characters are not emphasised [<a href="https://github.com/doxygen/doxygen/commit/8f67d4f63efd45b0d38502bdf68987d7fc1e92e9">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5728">5728</a> - Non-ascii characters are not emphasized [<a href="https://github.com/doxygen/doxygen/commit/8f67d4f63efd45b0d38502bdf68987d7fc1e92e9">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5744">5744</a> - Using TAGFILES prevents symbol extraction [<a href="https://github.com/doxygen/doxygen/commit/a735498be5a572236755cc3da65bf4774cbac25c">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5753">5753</a> - PATCH: please consider making doxygen output byte for byte identical between individual runs by default [<a href="https://github.com/doxygen/doxygen/commit/3f2e8a3067712b025623e4420e6eb161febfd42b">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5754">5754</a> - Doxygen generates bad &quot;More...&quot; file links for functions within a namespace [<a href="https://github.com/doxygen/doxygen/commit/ea202be55d68af33917658e3fec169da3a7fa7a8">view</a>]</li>
@@ -1518,9 +1518,9 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5690">5690</a> - Crash when building gtkmm documentation [<a href="https://github.com/doxygen/doxygen/commit/050fce2b73d6e4455808ab86da2fddcf2f26e9b5">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5694">5694</a> - \cite confused by labels ending with a dot (improved warning message) [<a href="https://github.com/doxygen/doxygen/commit/78fd02dc41384d81baddf17ff0bb3431267452fc">view</a>]</li>
 <li>fix docbook output [<a href="https://github.com/doxygen/doxygen/commit/1a403d80160458091bab7c442e54f836c0b90bca">view</a>]
-    <ol><li>support other than english</li>
+    <ol><li>support other than English</li>
         <li>fix broken example link id</li>
-        <li>fix incomplete TOC : no Classe etc.</li>
+        <li>fix incomplete TOC : no Classes etc.</li>
         <li>add brief description for Functions etc.</li>
         <li>Comply with REPEAT_BRIEF </li>
         <li>Do not output duplicated contents when detailed description is missing.</li>
@@ -1793,7 +1793,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5456">5456</a> - Crash on \addindex \term [<a href="https://github.com/doxygen/doxygen/commit/653a2a8b123b79835af9f684f8b92ef7f88712aa">view</a>]</li>
 <li>A new files have been added but is not incorporated in the windows build part [<a href="https://github.com/doxygen/doxygen/commit/d9dd873e25fba968ddcbcc79d6643f5df669b626">view</a>]</li>
 <li>Add docbook directory to be removed as well [<a href="https://github.com/doxygen/doxygen/commit/08ea10029e705a388ab14ee29544d496a203f23f">view</a>]</li>
-<li>Add extra (documenattion) directories to ignore pattern [<a href="https://github.com/doxygen/doxygen/commit/db358b1f219fecf0d7df96d8c70b47b245471c66">view</a>]</li>
+<li>Add extra (documentation) directories to ignore pattern [<a href="https://github.com/doxygen/doxygen/commit/db358b1f219fecf0d7df96d8c70b47b245471c66">view</a>]</li>
 <li>Add index support to context [<a href="https://github.com/doxygen/doxygen/commit/12cd22f4c32ed8b92da7b5a03181aa6735018a5b">view</a>]</li>
 <li>Add line numbers in case comment is not closed properly. [<a href="https://github.com/doxygen/doxygen/commit/b1d513b2ac65fe26ceec2fa494867713efa01cd5">view</a>]</li>
 <li>Add template context for annotated class index [<a href="https://github.com/doxygen/doxygen/commit/9434ecb13e1f3e2901b78d3e41e7f1d7d9469434">view</a>]</li>
@@ -1832,7 +1832,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Fix id parsing for atx markdown headers [<a href="https://github.com/doxygen/doxygen/commit/ee830bb8888535ac48c0c4fd90580542e7f70481">view</a>]</li>
 <li>Fix segfault on invalid bounding FIG when patching dot [<a href="https://github.com/doxygen/doxygen/commit/1bd2e38a2ce2d0823557381c48fe47cb53d6fba8">view</a>]</li>
 <li>Fix to VHDL scanner. [<a href="https://github.com/doxygen/doxygen/commit/5ca7d423a11337d5c31082f52a287a3dc0986642">view</a>]</li>
-<li>Fix typos in russian translation [<a href="https://github.com/doxygen/doxygen/commit/8ce2b0d7aec1d4398b5b4f365a7d3abbe75daf5f">view</a>]</li>
+<li>Fix typos in Russian translation [<a href="https://github.com/doxygen/doxygen/commit/8ce2b0d7aec1d4398b5b4f365a7d3abbe75daf5f">view</a>]</li>
 <li>Fixed Tidy&#39;s &#39;empty span&#39; warning in HTML output [<a href="https://github.com/doxygen/doxygen/commit/8cfac90d6c8632436db1a6b650a05a8dfcfab5d0">view</a>]</li>
 <li>Fixed compiler warnings in section.h [<a href="https://github.com/doxygen/doxygen/commit/683ef76f7bf1ba929f9c263064bb5f6c8e377275">view</a>]</li>
 <li>Fixed difference between generated XML schema and XML files for HTML entities [<a href="https://github.com/doxygen/doxygen/commit/836af2f9510d10f2dd7d832025f214983387b3c6">view</a>]</li>
@@ -1847,7 +1847,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Fixed typo in doxyindexer.vcproj [<a href="https://github.com/doxygen/doxygen/commit/2bc8a820b3e2fefaedb10a3129eed35581a1ea5b">view</a>]</li>
 <li>Fixes for missing build dependencies [<a href="https://github.com/doxygen/doxygen/commit/62379ff8fdb13d95c7651419d92db47150e15bcc">view</a>]</li>
 <li>Give message when PROJECT_LOGO cannot be found or cannot be converted [<a href="https://github.com/doxygen/doxygen/commit/164864d9bc8ea7e32a69fbc0e47cff54dc678a48">view</a>]</li>
-<li>Handlingh of -- by \c and &lt;code&gt; results in - adjusted documentation [<a href="https://github.com/doxygen/doxygen/commit/73d12cc5cf0656e94125baea62cdb19b67908b3d">view</a>]</li>
+<li>Handling of -- by \c and &lt;code&gt; results in - adjusted documentation [<a href="https://github.com/doxygen/doxygen/commit/73d12cc5cf0656e94125baea62cdb19b67908b3d">view</a>]</li>
 <li>Improve rendering of sub and superscripts in LaTeX [<a href="https://github.com/doxygen/doxygen/commit/a7c7f36ea2a67969bf3916c7600fe487e34438c0">view</a>]</li>
 <li>Improved handling of percent symbol [<a href="https://github.com/doxygen/doxygen/commit/0e080f486f67008ef427c834f6ab6ebca7578124">view</a>]</li>
 <li>Improved performance of rendering large index pages, by replacing images in the tables by spans [<a href="https://github.com/doxygen/doxygen/commit/956a7fb004e72923f737e387d053812f99b7bda2">view</a>]</li>
@@ -1893,7 +1893,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Use hook arrow for hyphens in symbol names in the LaTeX output. [<a href="https://github.com/doxygen/doxygen/commit/ac813134a85ba9bd999fb4cf8271c74e02cd4ebb">view</a>]</li>
 <li>Wrong UTF 8 codes [<a href="https://github.com/doxygen/doxygen/commit/fd4beb272e5f1a760a71ab8d85463b8356c6f786">view</a>]</li>
 <li>Fix broken links to subpages in LaTeX output [<a href="https://github.com/doxygen/doxygen/commit/10189681dcb46e543a287827e2096cef3dbc42ae">view</a>]</li>
-<li>\xmlonly aoppeared twice in see also section of \htmlonly and \docbookonly [<a href="https://github.com/doxygen/doxygen/commit/f1cdb27194dd180f1bff1fbdd87874bb0d15758d">view</a>]</li>
+<li>\xmlonly appeared twice in see also section of \htmlonly and \docbookonly [<a href="https://github.com/doxygen/doxygen/commit/f1cdb27194dd180f1bff1fbdd87874bb0d15758d">view</a>]</li>
 <li>add css-escape to avoid jquery based xss [<a href="https://github.com/doxygen/doxygen/commit/7fea82094723ecfb4e9b3ea6819137b99d7dfa9c">view</a>]</li>
 <li>add parameter [<a href="https://github.com/doxygen/doxygen/commit/c5bc9fc8c407aac845d594b2685d0c92699727d8">view</a>]</li>
 <li>add search.py, a client for doxygen_sqlite3.db [<a href="https://github.com/doxygen/doxygen/commit/697ac97aad7fa045b6cc205050b69cf3f22408ad">view</a>]</li>
@@ -2004,7 +2004,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li> Allow links to other markdown pages of the form [link text](page.md)</li>
 <li> Avoid accessing uninitialized memory in fileToString</li>
 <li> Build problem with unistd.h and Cygwin The standard g++ compiler under windows (win32-g++) has unistd.gh file; Microsoft windows does not have it, therefore it is better to use the winbuild directory in case of windows and no dependency otherwise</li>
-<li> Consistency in language part of the documentation Made documentation more inline with other parts of the documentation (regarding the way e.g. filenames are presented) Corrected some spelling errors Corrected the warning in the language.doc by placing ta reference to the files from which language.doc is generated Corrected the color for the languages that are still v1.4.6 (language name now also red  in stead of a pink background, was confusing with languages that were 1.5 / 1.6 compatible)</li>
+<li> Consistency in language part of the documentation Made documentation more inline with other parts of the documentation (regarding the way e.g. filenames are presented) Corrected some spelling errors Corrected the warning in the language.doc by placing a reference to the files from which language.doc is generated Corrected the color for the languages that are still v1.4.6 (language name now also red  in stead of a pink background, was confusing with languages that were 1.5 / 1.6 compatible)</li>
 <li> Corrected some inconsistencies in the comments</li>
 <li> Debug output for lexical analyzer</li>
 <li> Deleted generated files from source repository</li>
@@ -2109,7 +2109,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li> Bug <a href="https://github.com/doxygen/doxygen/issues/5225">5225</a> - Segmentation fault parsing a fortran file</li>
 <li> Bug <a href="https://github.com/doxygen/doxygen/issues/5226">5226</a> - Can't use @ref instead of \ref with msc</li>
 <li> Bug <a href="https://github.com/doxygen/doxygen/issues/5228">5228</a> - Misleading warning about DOT font</li>
-<li> Bug <a href="https://github.com/doxygen/doxygen/issues/5233">5233</a> - Out-of-line docs for class template specialisations failing</li>
+<li> Bug <a href="https://github.com/doxygen/doxygen/issues/5233">5233</a> - Out-of-line docs for class template specializations failing</li>
 <li> Bug <a href="https://github.com/doxygen/doxygen/issues/5234">5234</a> - Generated XML is malformed</li>
 <li> Bug <a href="https://github.com/doxygen/doxygen/issues/5239">5239</a> - Nested Aliases fail when the nested alias has two or more arguments.</li>
 <li> Bug <a href="https://github.com/doxygen/doxygen/issues/5242">5242</a> - doxygen don't hide private Inherited Members</li>
@@ -2206,7 +2206,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/5056">5056</a>: Added support for processing DocSets with Dash (thanks to
        Bogdan Popescu for the patch </li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4900">4900</a>: Added option EXTERNAL_PAGES which can be used to determine
-       whether or not pages importated via tags will appear under related 
+       whether or not pages imported via tags will appear under related 
        pages (similar to EXTERNAL_GROUPS).</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/5042">5042</a>: Added new MathJax command MATHJAX_CODEFILE which supports
        including a file with MathJax related scripting to be inserted before
@@ -2253,7 +2253,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4650">4650</a>: Replaced "echo -n" with "printf" in the configure script.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4684">4684</a>: Removed warning when using \endinternal</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4696">4696</a>: Added &amp;, @, and # as allowed characters for commands that</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/4788">4788</a>: Included patch by Abert to correctly link pages in the manual</li>
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/4788">4788</a>: Included patch by Albert to correctly link pages in the manual</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4850">4850</a>: Added support for single column Markdown tables.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4855">4855</a>: Incomplete documentation on doxygen -w latex</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4877">4877</a>: Doxygen crashed when structural commands (like \var) appeared 
@@ -2267,7 +2267,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
        rather than the file name.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/5059">5059</a>: build using ./configure ; make did not work if the path
        contained a space.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/5060">5060</a>: Tag files are now identfied by the full path instead of
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/5060">5060</a>: Tag files are now identified by the full path instead of
        only the name of the tag file.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/5086">5086</a>: In some cases members were missing from the tag file.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/5079">5079</a>: Fortran: derive intent from documentation in case no 
@@ -2501,7 +2501,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/5001">5001</a>: Fixed case where doxygen would during preprocessing.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/5002">5002</a>: A file specified using HTML_EXTRA_STYLEHSHEET did not end
        up in the Qt Help index.</li>
-<li>   Improved the way enum's are rendered in the HTML output.</li>
+<li>   Improved the way enums are rendered in the HTML output.</li>
 <li>   When inlining structs (INLINE_SIMPLE_STRUCTS=YES) a &lt;p&gt; was missing
        for members with a detailed description, causing invalid XHTML.</li>
 <li>   Fixed problem loading the navigation tree when using .xhtml as the
@@ -2583,7 +2583,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>   Added option AUTOLINK_SUPPORT which can be used to enable/disable
        autolinking globally.</li>
 <li>   Included language updates for Czech, Spanish, Greek, Slovak, and 
-       Esparanto.</li>
+       Esperanto.</li>
 </ul>
 <h3>Bug fixes</h3>
 <ul>
@@ -2870,8 +2870,8 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4651">4651</a>: Included patch by Ryan Schmidt to make the Mac versions
        in qglobal.h match that of Apple header files.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4659">4659</a>: Added C++11 classes when BUILTIN_STL_SUPPORT is enabled.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/4662">4662</a>: Using a backslash in a section cause 026E30F to appear in the
-       latex TOC.</li>
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/4662">4662</a>: Using a backslash in a section causes 026E30F to appear in the
+       LaTeX TOC.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4675">4675</a>: Fortran: case sensitiveness for routines and functions 
        did not work</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4676">4676</a>: Fortran: continuation by ampersand not placed in code output.</li>
@@ -2934,7 +2934,7 @@ make sure you add the following:
             (amount of &gt;'s determine the indentation level).</li>
        <li> emphasis using *emphasize this* or _emphasis this_ or
             strong emphasis using **emphasis this**. Unlike classic
-            Markdown 'some_great_indentifier' is not touched.</li>
+            Markdown 'some_great_identifier' is not touched.</li>
        <li> code spans can be created using back-ticks, i.e. `here's an example`</li>
        <li> Using three or more -'s or *'s alone on a line with only spaces
             will produce a horizontal ruler.</li>
@@ -3254,7 +3254,7 @@ make sure you add the following:
        depending on the code page (thanks to Hirao for the patch).</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/2867">2867</a>: The .spec file in the source distribution did not get
        updated to the latest version.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/2872">2872</a>: Fortran: Continuation character was not recognised in 
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/2872">2872</a>: Fortran: Continuation character was not recognized in 
        fixed format code.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/2887">2887</a>: Fortran: @param checking was not case insensitive.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3168">3168</a>: Fixed problem combining @cond with preprocessor directives.</li>
@@ -3290,7 +3290,7 @@ make sure you add the following:
        GENERATE_TREEVIEW was enabled.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4242">4242</a>: Linking to a section on the main page could result in a
        broken link when GENERATE_TREEVIEW was enabled.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/4243">4243</a>: Fixed invalid warning when using @deparated method with
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/4243">4243</a>: Fixed invalid warning when using @deprecated method with
        default values for parameters.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4245">4245</a>: A function made related using @relates could end up in
        the wrong class if there was already a method with a matching
@@ -3378,7 +3378,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4085">4085</a>: using @dot...@endot produced an image referenced with
                   absolute path.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4091">4091</a>: \mscfile did not work properly for LaTeX output.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/4095">4095</a>: Fixed problem where #include's could cause phantom __pad__
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/4095">4095</a>: Fixed problem where #include could cause phantom __pad__
                   members to appear in the output (appeared on Windows only).</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4103">4103</a>: Options PROJECT_LOGO and PROJECT_BRIEF were missing
                   from the manual.</li>
@@ -3402,7 +3402,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4128">4128</a>: Included patch to fix broken hyperlink to page entry 
                   in xreflists.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4136">4136</a>: Header of \page was wrong in Man page output.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/4137">4137</a>: #include's to other directories were not always linked.</li>
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/4137">4137</a>: #include to other directories were not always linked.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4140">4140</a>: Using "use Foo\Foo;" in PHP could cause doxygen to hang.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4142">4142</a>: In some cases the HTML output could contain an extra &lt;/p&gt;.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4147">4147</a>: Tooltips with HTML entities could be wrongly truncated.</li>
@@ -3428,7 +3428,7 @@ make sure you add the following:
 <h3>Changes</h3>
 <ul>
 <li>   Added a header for each HTML page above the navigation menu, 
-       showing the project name and logo and a short descriptin (all optional).
+       showing the project name and logo and a short description (all optional).
        Disabling the index (with DISABLE_INDEX) still shows the new header
        (you can still customize this using HTML_HEADER). This now works
        nicely in combination with GENERATE_TREEVIEW = YES and/or
@@ -3471,7 +3471,7 @@ make sure you add the following:
        (thanks to Albert).</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3731">3731</a>: Fixed problem handling @cond..@endcond in Fortran code.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3779">3779</a>: Scope was missing in Tokens.xml when using docsets.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/3870">3870</a>, <a href="https://github.com/doxygen/doxygen/issues/2891">2891</a>: Applied patch tp avoid stripping prefixes for Fortran 
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/3870">3870</a>, <a href="https://github.com/doxygen/doxygen/issues/2891">2891</a>: Applied patch to avoid stripping prefixes for Fortran 
        subroutines.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3895">3895</a>: allow label before end statement in Fortran</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3956">3956</a>: &lt;/see&gt; was not handled properly in comment block.</li>
@@ -3543,7 +3543,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/2097">2097</a>, <a href="https://github.com/doxygen/doxygen/issues/2669">2669</a>: /// were not stripped from formulas and \dot..\enddot</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3190">3190</a>: dropped support for a4wide paper format for LaTeX, since
        it is on the LaTeX taboo list.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/3261">3261</a>: Behaviour of CLASS_DIAGRAM=NO in combination with
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/3261">3261</a>: Behavior of CLASS_DIAGRAM=NO in combination with
        HAVE_DOT=YES, was not properly documented.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3332">3332</a>: Python comments for next class or method could end up in
        code of a method/class when enabling INLINE_SOURCES.</li>
@@ -3583,7 +3583,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3877">3877</a>: In the HTML output &lt;/div&gt; was missing for built-in
        class diagrams.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3876">3876</a>: References in example files with underscores were wrong.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/"></a>: When using Japanese characters mixed with ascii characters
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/"></a>: When using Japanese characters mixed with ASCII characters
        doxygen incorrectly ended the brief description with a dot.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3886">3886</a>: setting MULTILINE_CPP_IS_BRIEF to YES, cause /// to appear
        in the output.</li>
@@ -3595,7 +3595,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3898">3898</a>: \copydoc did not work for array type arguments (e.g. int[]).</li>
 <li>   Use \dotfile did not produce the correct map file, so URLs in dot
        files did not work.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/3907">3907</a>: #define's in files only found via INCLUDE_PATH were not
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/3907">3907</a>: #define in files only found via INCLUDE_PATH were not
        correctly handled.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3918">3918</a>: auto brief description ending with .) cause the ) to
        end up in the detailed part.</li>
@@ -3607,7 +3607,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3937">3937</a>: Latex makefile clean target used rm command also for Windows.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3939">3939</a>: the EXCLUDE_SYMBOLS option was missing form the online docs.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3962">3962</a>: \htmlinclude and \verbinclude ended the brief description.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/3963">3963</a>: Inconsistent behaviour when a brief description was given 
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/3963">3963</a>: Inconsistent behavior when a brief description was given 
        following by a detailed comment block with JAVADOC_AUTOBRIEF enabled.</li>
 <li>   Fixed a number of typos in the documentation 
        (thanks to Albert)</li>
@@ -3683,7 +3683,7 @@ make sure you add the following:
        and HTML_COLORSTYLE_GAMMA, which control respectively the hue, 
        saturation, and gamma of all elements in the HTML output.</li>
 <li>   Moved dot invocations to the end of a doxygen run. Doxygen will now
-       run multiple instances of dot in parallel (for better CPU utilisation
+       run multiple instances of dot in parallel (for better CPU utilization
        on multi-core systems). The new config option DOT_NUM_THREADS 
        determines the number of threads used (were 0 is auto-detect).</li>
 <li>   Added option EXT_LINKS_IN_WINDOW which controls whether or not
@@ -3698,7 +3698,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/2255">2255</a>, <a href="https://github.com/doxygen/doxygen/issues/3796">3796</a>: \if and \endif did not work properly inside auto lists.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3139">3139</a>: No warning for missing return type documentation even though
        WARN_NO_PARAMDOC was set to YES.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/3341">3341</a>: Handling of nesting \defgroup's was not always working
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/3341">3341</a>: Handling of nesting \defgroup was not always working
        properly.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3355">3355</a>: &oslash; was not translated correctly in the LaTeX output.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3401">3401</a>: Use relative paths for mscgen diagrams to avoid errors in the
@@ -4063,7 +4063,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3457">3457</a>: Fixed problem handling strings like a"\b" within a comment.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3459">3459</a>: Fixed problem matching explicitly scoped parameter in a 
        template class.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/3473">3473</a>: A namespaced with name "internal" (C++/CLI keyword)
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/3473">3473</a>: A namespace with name "internal" (C++/CLI keyword)
        could confuse doxygen's C++ parser.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3477">3477</a>: @optional/@required attributes for Objective-C were missing
        from the XML output.</li>
@@ -4183,8 +4183,8 @@ make sure you add the following:
 <li>   id 437346: Fixed issue handling multibyte characters in the RTF output.</li>
 <li>   id 475377: Improved error handling in case of character encoding
        problems.</li>
-<li>   id 486747: Inherited typedefs were not resolved propertly.</li>
-<li>   id 508752: Add support for BLOCK DATA to the fortran parser.</li>
+<li>   id 486747: Inherited typedefs were not resolved properly.</li>
+<li>   id 508752: Add support for BLOCK DATA to the Fortran parser.</li>
 <li>   id 532695: included documentation update about the use of \public
        and friends for object-oriented programming in C.</li>
 <li>   id 532808: References to class variables in PHP code did not already work.</li>
@@ -4206,7 +4206,7 @@ make sure you add the following:
        wrong line counting and missing cross-references.</li>
 <li>   id 545128: \overload didn't work if it was the last statement in a
        comment and not followed by a newline.</li>
-<li>   id 553380: Removed bogus warning refering to a namespace member from
+<li>   id 553380: Removed bogus warning referring to a namespace member from
        with a brief description that was converted to a tooltip.</li>
 <li>   id 553968: Added support for JavaDoc command {@code ... }</li>
 <li>   id 554444: Bullet lists were no longer correctly indented when using
@@ -4318,7 +4318,7 @@ make sure you add the following:
        <code>INCLUDED_BY_GRAPH</code>.
        Run doxygen with the -l option to generate the default layout file.</li>
 <li>   Included update for the Macedonian, Catalan, Brazilian, and Serbian 
-       translation and also support for Serbian with Cyrilic characters.</li>
+       translation and also support for Serbian with Cyrillic characters.</li>
 </ul>
 <h3>Bug fixes</h3>
 <ul>
@@ -4358,14 +4358,14 @@ make sure you add the following:
        from multi-byte UTF-8 characters.</li>
 <li>   id 544479: <code>SORT_MEMBER_DOCS</code> did not work for class members.</li>
 <li>   id 546621: Fixed makefile so that .svn stuff is removed from the 
-       tarball when doing "make archive".</li>
+       tar-ball when doing "make archive".</li>
 <li>   id 546812: Using a table with row span greater than 1 did not 
        produce correct LaTeX output.</li>
 <li>   id 545098: Fixed problem parsing where clauses in combination with C#
        generics.</li>
 <li>   id 545503: Nameless parameters of type "struct A" could end up wrongly
        in the XML output.</li>
-<li>   id 545970: Refering to the main page did not work as advertised.</li>
+<li>   id 545970: Referring to the main page did not work as advertised.</li>
 <li>   id 546158: The variable defined inside a foreach statement in C# code 
        was not considered for source linking, cause potentially incomplete call
        graphs.</li>
@@ -4396,7 +4396,7 @@ make sure you add the following:
 <li>   id 553616: One can now remove the automatic line breaks in the type 
        part of a declaration by using a custom stylesheet with
        BR.typebreak { display: none; }</li>
-<li>   id 553663: Aliases did not work in Fortan comments.</li>
+<li>   id 553663: Aliases did not work in Fortran comments.</li>
 <li>   id 549022: Reimplemented in links could be wrong in case of 
        overloaded members.</li>
 <li>   id 553225: Parser was confused by arrays inside an Obj-C message.</li>
@@ -4432,7 +4432,7 @@ make sure you add the following:
 <li>   id 519573: Included patch to make the font-size button visible in the
        CHM output.</li>
 <li>   id 521288: Added new options SHOW_NAMESPACES and SHOW_FILES to 
-       Suppress Namepace and Files Pages.</li>
+       Suppress Namespace and Files Pages.</li>
 <li>   id 521495: Included a patch that makes it easy to modify the root of
        the html treeview with an image using style sheets.</li>
 <li>   id 522300: Added option IDL_PROPERTY_SUPPORT to enable/disable special 
@@ -4461,8 +4461,8 @@ make sure you add the following:
 <li>   id 495687: Replaced MAX_DOT_GRAPH_MAX_NODES with DOT_GRAPH_MAX_NODES 
        in the docs &amp; config file.</li>
 <li>   id 508694 Fixed problem with mixed simple and double quotes in 
-       fortran format declaration</li>
-<li>   id 508752: Fixed problem where the fortran scanner didn't recognize END</li>
+       Fortran format declaration</li>
+<li>   id 508752: Fixed problem where the Fortran scanner didn't recognize END</li>
 <li>   id 510971: Fortran: parser was confused by double REAL() in processed 
        statements.</li>
 <li>   id 514488: Fixed problem matching argument lists with const qualifiers.</li>
@@ -4503,7 +4503,7 @@ make sure you add the following:
 <li>   id 524473: Removed incorrect warnings about parameters in VHDL.</li>
 <li>   id 525140: Improved handling of Objective-C 2.0 properties.</li>
 <li>   id 525143: Properties are now listed as attributes in the UML diagrams.</li>
-<li>   id 525144: GENERATE_DOCSET option greyed out in doxywizard.</li>
+<li>   id 525144: GENERATE_DOCSET option grayed out in doxywizard.</li>
 <li>   id 526155: Removed warning about QFile::setName when parsing VHDL files.</li>
 <li>   id 527781: Template arguments for bases class not shown in a consistent
        way.</li>
@@ -4545,7 +4545,7 @@ make sure you add the following:
        #define C(S,m) /** container S */ struct S { /** value m */ int m; }
        </code></li>
 <li>   id 493923: The options SOURCE_BROWSER, CALL_GRAPH, CALLER_GRAPH, 
-       REFERENCES_RELATION, and REFERENCED_BY_RELATION can now be indepently
+       REFERENCES_RELATION, and REFERENCED_BY_RELATION can now be independently
        enabled and disabled. By default the relations are now disabled.</li>
 </ul>
 <h3>New features</h3>
@@ -4553,7 +4553,7 @@ make sure you add the following:
 <li>   Added support for VHDL (.vhd or .vhdl extension) based on a patch by
        Martin Kreis. Use OPTIMIZE_OUTPUT_VHDL when parsing VHDL code. </li>
 <li>   id 374699: Added support for Objective-C 2.0 properties.</li>
-<li>   Added compilation support for MacOSX 10.5 (Leopard) incombination with 
+<li>   Added compilation support for MacOSX 10.5 (Leopard) in combination with 
        Xcode 3</li>
 <li>   Added support for docsets, which allow integration of doxygen generated 
        API documentation in Xcode 3. new options: 
@@ -4572,7 +4572,7 @@ make sure you add the following:
        the second and third argument of a \class command, when
        the documentation is already in front of a class definition.</li>
 <li>   Added translator support for Macedonian.</li>
-<li>   Added language updates for German, Perian, Spanish, Taiwanese,  
+<li>   Added language updates for German, Persian, Spanish, Taiwanese,  
        and Chinese, Korean, Croatian.</li>
 </ul>
 <h3>Bug fixes</h3>
@@ -4607,7 +4607,7 @@ make sure you add the following:
        some compilers.</li>
 <li>   id 492027: Ampersand (&amp;) in front of parameter stops documenting 
        of PHP source</li>
-<li>   id 493249: using a namespace (or fortran module) caused the namespace
+<li>   id 493249: using a namespace (or Fortran module) caused the namespace
        to appear in the documentation as if it was defined.</li>
 <li>   id 493434: Nested C# style XML lists in a comment block were not
        handled correctly.            </li>
@@ -4631,7 +4631,7 @@ make sure you add the following:
 <li>   id 500635: Project name is no longer placed before each top level 
        item in the treeview and other indices.</li>
 <li>   id 500465: Fixed some issues compiling for AIX.</li>
-<li>   id 500928: Fixed parser issue handling a tripple quoted 
+<li>   id 500928: Fixed parser issue handling a tipple quoted 
                   string when used to initialize a Python variable.</li>
 <li>   id 500944: Python variables with package scope were only extracted if
        EXTRACT_STATIC was enabled.</li>
@@ -4650,7 +4650,7 @@ make sure you add the following:
 <li>   id 507603: Enabling FILTER_SOURCE_FILES caused strange warnings when
        INPUT_FILTER is empty.</li>
 <li>   id 508740: Using upper case port mode specifiers did not work correctly.</li>
-<li>   id 508753: Fortran: Added .f as allowed fortran extension.</li>
+<li>   id 508753: Fortran: Added .f as allowed Fortran extension.</li>
 <li>   id 508759: Fortran: fixed potential memory corruption while scanning 
        parameter lists.</li>
 <li>   id 507528: XML output was not correct for pointer arrays.</li>
@@ -4659,7 +4659,7 @@ make sure you add the following:
        documentation.</li>
 <li>   id 509582: Fortran: Spaces in function return type were not parsed 
        properly.</li>
-<li>   id 510387: Fortran scanner didn't parse initialisation of complex type
+<li>   id 510387: Fortran scanner didn't parse initialization of complex type
        correctly. </li>
 <li>   id 511921: @file command ended brief description even when
        JAVADOC_AUTOBRIEF was enabled.</li>
@@ -4692,7 +4692,7 @@ make sure you add the following:
        (used for Python to C++ bindings).</li>
 <li>   id 475828: Added support for CLI/C++ style indexed properties.</li>
 <li>   Added config option TYPEDEF_HIDES_STRUCT which when enabled treats a typedef
-       of a struct as a struct with the name of the typedef. This behavious was
+       of a struct as a struct with the name of the typedef. This behavior was
        coupled to OPTIMIZE_OUTPUT_FOR_C in the previous version and is now an independent
        option.</li>
 <li>   Included updates for the Korean, Brazilian and Chinese translations.</li>
@@ -4784,7 +4784,7 @@ make sure you add the following:
 <li>   When <code>OPTIMIZE_OUTPUT_FOR_C</code> is enabled then a struct definition of the
        form <code>typedef struct _S { ... } S_t</code> will be shown in the output as a
        struct of type <code>S_t</code> and the typedef itself is omitted 
-       (previousily <code>_S</code> was shown
+       (previously <code>_S</code> was shown
        as well as a typedef of the form <code>typedef _S S_t</code>). </li>
 <li>   Improved the line-breaking rules for members whose return types have many characters
        (for example a function returning a pointer to a template class).</li>
@@ -4970,7 +4970,7 @@ make sure you add the following:
 <li>   id 390821: Fixed problem parsing Java 1.5 enums with initializers.</li>
 <li>   id 391619: When dot produces an non-zero return code, doxygen now prints the
                   return code and the command it tried to execute.</li>
-<li>   id 407815: Doxygen's got confused by certain combinations of " and ' s in PHP code.</li>
+<li>   id 407815: Doxygen got confused by certain combinations of " and ' in PHP code.</li>
 <li>   id 409935: Fixed bug in qcstring.cpp</li>
 <li>   id 411300: PDF/Latex output was broken for operator[] documentation.</li>
 <li>   id 411328: Fixed Accessibility/Section 508 Compliance issue.</li>
@@ -5034,7 +5034,7 @@ make sure you add the following:
 <li>   id 131445: Fixed autolinking for related functions.</li>
 <li>   id 137236: Updated documentation to make it clear that a lower-case only word
        is not a candidate for autolinking.</li>
-<li>   id 141758: Fixed a problem parsing &lt;?=...?&gt; contructs outside of functions in PHP.</li>
+<li>   id 141758: Fixed a problem parsing &lt;?=...?&gt; constructs outside of functions in PHP.</li>
 <li>   id 319169: Second level index not shown when DISABLE_INDEX=YES.</li>
 <li>   id 325337: Added "optimize output for C#" option to Doxywizard.</li>
 <li>   id 325426: Partial C# class inside a namespace where not handled properly.</li>
@@ -5068,7 +5068,7 @@ make sure you add the following:
        an anonymous namespace  </li>
 <li>   id 349867: Fixed issue handling brief and detailed description when
        both are positioned after an item. </li>
-<li>   id 350168: Doxygen didn't parse C# type contraints properly.</li>
+<li>   id 350168: Doxygen didn't parse C# type constraints properly.</li>
 <li>   id 351890: In some cases C# attributes were treated as properties.</li>
 <li>   id 353044: C99 style variadic macros were not handled properly by doxygen.</li>
 <li>   id 353195: Member grouping with SUBGROUPING = YES now works the same for files
@@ -5249,7 +5249,7 @@ make sure you add the following:
                   set.</li>
 <li>   id 318460: Multiply-defined labels if two function specializations 
        differ only on the name of a template parameter.</li>
-<li>   id 319219: Spurious space was inserted after inlined math formulae.</li>
+<li>   id 319219: Spurious space was inserted after inlined math formulas.</li>
 <li>   id 319826: The file name for template classes could become too 
        long causing files that cannot be created by some file systems.</li>
 <li>   id 320026: undocumented "typedef struct foo baz" causes subsequent 
@@ -5362,7 +5362,7 @@ make sure you add the following:
 <li>   id 311198: If JAVADOC_AUTOBRIEF was set to YES, a \todo or \bug like
        command always ended at the first dot.</li>
 <li>   id 311207: The /* and */ inside a \code ... \endcode code fragment 
-       were stipped.</li>
+       were stripped.</li>
 <li>   id 311577: Putting a documentated class name in the title of the main
        page caused a LaTeX error if pdf hyperlinks were enabled.</li>
 <li>   id 311665: Fixed compile issue for Solaris.</li>
@@ -5464,13 +5464,13 @@ make sure you add the following:
 <li>   id 304598: Using operator-- in resulted in broken HTML output due to the
                   embedded doxytag that include the end of a HTML comment.</li>
 <li>   id 304623: Spreading a @fn command over multiple lines didn't work
-                  anymore without using line-contination characters.</li>
+                  anymore without using line-continuation characters.</li>
 <li>   id 304666: Attributes of the same class appeared separated with \n in 
                   collaboration diagrams</li>
-<li>   id 304751: A define "foo()" was indisguishable from a define "foo" in
+<li>   id 304751: A define "foo()" was indistinguishable from a define "foo" in
                   the XML output.</li>
 <li>   id 304752: XML location tag attribute "file" could have the
-                  syntactially wrong value "&lt;generated&gt;" in some cases.</li>
+                  syntactically wrong value "&lt;generated&gt;" in some cases.</li>
 <li>   id 305334: INPUT_FILTER tag did not work properly anymore due to
                   additional quotes.</li>
 <li>   id 305364: Improved argument matching routine to avoid cases where
@@ -5581,12 +5581,12 @@ make sure you add the following:
                   CASE_SENSE_NAME was set to NO.</li>
 <li>   id 170592: Using \ref for Objective-C methods did not work if the
                   name contained a colon.</li>
-<li>   id 171795: Refering to Objective-C methods now follows Apple's
+<li>   id 171795: Referring to Objective-C methods now follows Apple's
                   conventions. </li>
 <li>   id 171878: When JAVADOC_AUTOBRIEF = YES and there was no blank line 
                   after a page command, the first sentence did not appear in
                   the documentation.</li>
-<li>   id 171923: Doxygen failed to match arguments for a function documentated
+<li>   id 171923: Doxygen failed to match arguments for a function documented
                   out-of-line with @fn and using @relatesalso.</li>
 <li>   id 172118: Doxywizard now shows the version of doxygen it is for.</li>
 <li>   id 172133: Doxygen did not longer ignore preceding C++ comments inside a
@@ -5596,7 +5596,7 @@ make sure you add the following:
 <li>   id 172329: The index of the CHM did not always link to groups correctly.</li>
 <li>   id 172456: Fixed case where doxygen had problems differentiating const 
                   and non-const member functions.</li>
-<li>   id 172494: @code blocks were not poperly ignored by the preprocessor 
+<li>   id 172494: @code blocks were not properly ignored by the preprocessor 
                   in some cases.</li>
 <li>   id 172622: Fixed parse problem for Objective-C method implementations 
                   whole declaration part ended with a semicolon.</li>
@@ -5754,7 +5754,7 @@ make sure you add the following:
                an anonymous namespace.</li>
 <li>id 169549: Previous fixes introduced flattening of the class hierarchy.</li>
 <li>id 169640: File suffix check for the D language was broken.</li>
-<li>id 169641: D contructors and destructors were not detected.</li>
+<li>id 169641: D constructors and destructors were not detected.</li>
 <li>is 169657: Fixed the way import is treated in D to prevent recursive
                lockup.</li>
 <li>id 169784: Objective-C methods with a variable number of arguments were
@@ -5881,7 +5881,7 @@ make sure you add the following:
 <li>   id 155272: Image filenames in RTF output were not quoted causing problem
                   with custom images whose name contained spaces.</li>
 <li>   id 155322: Fixed parse problem for php code containing '#'.  </li>
-<li>   id 155224: Java interfaces did't resolve across packages w/o FQN.</li>
+<li>   id 155224: Java interfaces didn't resolve across packages w/o FQN.</li>
 <li>   id 156411: Return type of a function was not hyperlinked in some cases 
                   (typical with nested namespaces or Java packages).</li>
 <li>   id 156445: function seen first in header and doc'ed in 
@@ -6129,7 +6129,7 @@ make sure you add the following:
 <li>   Included patch that removes some cosmetic annoyances in the man page 
        output (thanks to Chris Croughton).</li>
 <li>   Added internationalization support for Afrikaans and
-       Lithanian.  Included language updates for Dutch, 
+       Lithuanian.  Included language updates for Dutch, 
        Czech, Italian, Brazilian, Croatian, Japanese, Norwegian and
        Russian.</li>
 </ul>
@@ -6146,7 +6146,7 @@ make sure you add the following:
 <li>   id 138394: C style comments placed on the same line after a macro 
        definition appeared as part of the macro's value.</li>
 <li>   id 138429: Fixed language setting for HTML output when using 
-       traditional chinese.</li>
+       traditional Chinese.</li>
 <li>   id 140259: Using @dotfile in a comment block could cause broken @refs
        to sections defined after the @dotfile command.</li>
 <li>   id 141915: Fixed a couple of problems with the RTF output.</li>
@@ -6309,7 +6309,7 @@ make sure you add the following:
 <li>   Examples (documented via \example) are now included in the XML output.</li>
 <li>   New option SORT_BRIEF_DOCS which when enabled will list the
        declaration section of the documentation (with the brief descriptions)
-       in alpabetical order, instead of declaration order (thanks to 
+       in alphabetical order, instead of declaration order (thanks to 
        Akos Kiss for the patch).</li>
 <li>   Included patch for Hungarian translation (thanks to Akos Kiss)
        and for the Serbian language. Added support for mixed Korean/english 
@@ -6364,7 +6364,7 @@ make sure you add the following:
 <h3>New features</h3>
 <ul>
 <li>   Added support for parsing K&amp;R style function prototypes. 
-       Please try it on your favourite legacy C project and report any 
+       Please try it on your favorite legacy C project and report any 
        problems.</li>
 <li>   Included languages updates for Traditional Chinese, 
        Danish, German, Korian translation.</li>
@@ -6374,7 +6374,7 @@ make sure you add the following:
        generating source code listings as part of the XML output (thanks to
        Paul Ross for the patch).  </li>
 <li>   Added new config option ABBREVIATE_BRIEF which makes the
-       abbration process of brief descriptions configurable and language
+       aberration process of brief descriptions configurable and language
        independent (thanks to Jake Colman for the patch).</li>
 <li>   The alphabetical class list now comes with a quick index
        (thanks to Marcin Zukowski for the patch).</li>
@@ -6396,7 +6396,7 @@ make sure you add the following:
        was produced.</li>
 <li>   id 123206: Fixed problem in qtools when opening files in text mode.</li>
 <li>   id 123322: The search page did not honor DISABLE_INDEX.</li>
-<li>   id 123420: Functions with a brief description caused bugus &lt;/em&gt; tags 
+<li>   id 123420: Functions with a brief description caused bogus &lt;/em&gt; tags 
                   in the HTML output.</li>
 <li>   id 124114: typo in the generated PHP search script could cause errors
        in the search result page.</li>
@@ -6436,7 +6436,7 @@ make sure you add the following:
 <li>   Fixed problem that HTML image maps ended up in the RTF output.</li>
 <li>   Fixed bug in code fragment parser that could cause memory corruption
        in certain cases.</li>
-<li>   Fixed problem matching definition and declation of functions, which
+<li>   Fixed problem matching definition and declaration of functions, which
        could cause bogus warnings for functions with the same name but in 
        different namespaces.</li>
 <li>   Using "/// @file" to document a file quickly was not possible, while
@@ -6679,7 +6679,7 @@ make sure you add the following:
 <li>   Links to groups imported via tag files were broken.</li>
 <li>   Fixed problem resolving class relations for nested classes within
        namespaces.</li>
-<li>   Static members can now be documentated in a separate file using \fn
+<li>   Static members can now be documented in a separate file using \fn
        as long as they have unique names. If the names are not unique the 
        documentation must be located in the same file (as was required before).</li>
 <li>   In arguments and return types of the form NA::A were not linked if NA 
@@ -6704,7 +6704,7 @@ make sure you add the following:
 <li>   Fixed problem handling omission of the optional arguments of 
        the \image command.</li>
 <li>   Enabling HIDE_IN_BODY_DOCS did not work properly if C++-style special
-       comments were used inside the body of a fucntion.</li>
+       comments were used inside the body of a function.</li>
 <li>   Fixed problem cross-referencing variables used as a
        guard (i.e. if (var) ...) </li>
 <li>   Setting ENUM_VALUES_PER_LINE to 0 caused a division by 0 error.</li>
@@ -6776,7 +6776,7 @@ make sure you add the following:
 <li>   Fixed preprocessor problem with parsing /*//*/</li>
 <li>   URL's in the docs using &lt;a href=""&gt; caused a nested link. </li>
 <li>   "using namespace A::B;" confused the code parser.</li>
-<li>   Interface keyword was not recognised in C# (thanks to Onorio Catenacci
+<li>   Interface keyword was not recognized in C# (thanks to Onorio Catenacci
        for the patch).</li>
 <li>   Line counting was incorrect when parsing multi-line formulas.</li>
 <li>   \section's in a \mainpage are now correctly numbered in the LaTeX
@@ -6829,7 +6829,7 @@ make sure you add the following:
        if they were documented.</li>
 <li>   The treeview page was not rendered with the right character set (it was
        always English).</li>
-<li>   Explicit template instantations appeared as a variable in the output.</li>
+<li>   Explicit template instances appeared as a variable in the output.</li>
 <li>   Java instance and static initializer blocks are now correctly parsed
        and can be documented.</li>
 <li>   Fixed bug in the LATEX_HIDE_INDICES option.</li>
@@ -6897,7 +6897,7 @@ make sure you add the following:
        was already suggested in the docs).</li>
 <li>   source code line in the XML output didn't escape special characters 
        like &amp; anymore.</li>
-<li>   Fixed small bug in german translation (thanks to Jens Seidel).</li>
+<li>   Fixed small bug in German translation (thanks to Jens Seidel).</li>
 <li>   e-mail addresses with multiple dots got truncated when linked.</li>
 <li>   Attributes of html commands with value "" where not properly parsed
        causing the image in the legend page not to appear.</li>
@@ -6931,7 +6931,7 @@ make sure you add the following:
 <li>   Fixed problem in code browser that prevented linking to global 
        variables defined in other files.</li>
 <li>   When putting a "using namespace X" in a header file doxygen did not
-       recognise this in files that included the header file.</li>
+       recognize this in files that included the header file.</li>
 <li>   Fixed bug in parsing sections without title.</li>
 <li>   doxytag did not include anchor in the search index. Thanks to 
        Joerg Schlichenmaier for the fix.</li>
@@ -6978,7 +6978,7 @@ make sure you add the following:
 <li>   RCS/CVS tags did not appear in the output.</li>
 <li>   @note section result in section with type "bug" in the XML output.</li>
 <li>   Dot graphs were truncated too quickly in some cases.</li>
-<li>   Files with a .php4 extension are now recognised as PHP files.</li>
+<li>   Files with a .php4 extension are now recognized as PHP files.</li>
 <li>   Source browser could get out of sync causing wrong cross references.</li>
 <li>   Text after @} could end up in another documentation block.</li>
 <li>   Putting a style command such as \c or \b at the end of a line, before
@@ -7020,7 +7020,7 @@ make sure you add the following:
 <li>   Included language updates for French, Czech, and Russian.</li>
 <li>   Included a number of enhancements to the xml parser (thanks to 
        a patch by Tree).</li>
-<li>   Locally documentated parameters now appear in the XML output
+<li>   Locally documented parameters now appear in the XML output
        (thanks to Cormac Twomey for the patch). </li>
 <li>   The preprocessor now inserts line control commands where appropriate.</li>
 </ul>
@@ -7028,7 +7028,7 @@ make sure you add the following:
 <ul>
 <li>   Aliased \if .. \endif commands around a \brief section were not handled
        properly.</li>
-<li>   Warnings for undocumentation members were not generated anymore
+<li>   Warnings for undocumented members were not generated anymore
        in certain cases.</li>
 <li>   A member of a group linked with \ref showed the group's title 
        as link text instead of the member's name.</li>
@@ -7111,7 +7111,7 @@ make sure you add the following:
        <li> Undocumented private friend classes no longer cause warnings</li>
        <li> Undocumented private classes no longer cause warnings</li>
        <li> Undocumented members are now hidden if they are 
-            default constuctors, destructors or reimplemented.</li>
+            default constructors, destructors or reimplemented.</li>
        </ul></li>
 <li>   Pages introduced via \page are now context aware. This means that
        if you put them inside a class or namespace, names do not have
@@ -7126,11 +7126,11 @@ make sure you add the following:
        that a list of all deprecated items is generated.
        Thanks to Angela Marshall for the patch.</li>
 <li>   Enum value documentation was added to the XML output.</li>
-<li>   Files ending with ".inc" are now recognised as PHP files
+<li>   Files ending with ".inc" are now recognized as PHP files
        (thanks to Marcus Ahlfors).</li>
 <li>   Included updated documentation for language translators 
        (thanks to Petr Prikryl).</li>
-<li>   Included language updates for Czech, Slovak, Brazillan, Croatian,
+<li>   Included language updates for Czech, Slovak, Brazilian, Croatian,
        Portuguese, Russian, Polish, Japanese and Serbian. 
        Include language support for Catalan (thanks to Albert Mora)</li>
 <li>   Included .dsp update by Simon Goodwin (already needs to be updated 
@@ -7218,12 +7218,12 @@ make sure you add the following:
        of some item and paste it in another documentation block.</li>
 <li>   i18n: Added support for the Serbian language (thanks to Dejan Milosavljevic).
        Included a new language option Japanese-en for combined Japanese 
-       and english.</li>
+       and English.</li>
 <li>   Included patch for dealing with variable argument macros in @param 
        (thanks to Alfred Heggestad).</li>
 <li>   Added new option MULTILINE_CPP_IS_BRIEF to make doxygen treat
        a multi-line brief comment block as a brief description. Set this to
-       YES to obtain the behaviour of version 1.2.15 and earlier. Default as
+       YES to obtain the behavior of version 1.2.15 and earlier. Default as
        of version 1.2.16 is to treat multi-line C++ comment block as a 
        detailed description.</li>
 <li>   New option CHM_FILE to set the .chm file (and path) to use for
@@ -7298,7 +7298,7 @@ make sure you add the following:
        </ul></li>
 <li>   operator|() caused invalid entries in the latex index.</li>
 <li>   Fixed bug parsing URLs with curly braces in documentation blocks.</li>
-<li>   Html help output now uses the correct language code if non english
+<li>   Html help output now uses the correct language code if non English
        language is selected.</li>
 <li>   Fixed bug in generate makefile for latex output (thanks to Petr 
        Prikryl)</li>
@@ -7306,7 +7306,7 @@ make sure you add the following:
        confused the parser.</li>
 <li>   Fixed problem handling function typedefs.</li>
 <li>   \endif appeared in output when used via ALIASES in a brief description.</li>
-<li>   Included heuristic to distiguish between a variable definition 
+<li>   Included heuristic to distinguish between a variable definition 
        with initialization via a constructor and a function prototype 
        (e.g. "Test var(initVal);", v.s. "Test func(SomeType);").</li>
 <li>   Fixed lock-up problem when to @brief were put after each other in a
@@ -7373,10 +7373,10 @@ make sure you add the following:
        Please report any problems that remain.</li>
 <li>   Alias commands put in separate parameter documentation blocks 
        were not resolved.</li>
-<li>   The documentation for arguments, documented with a seperate 
+<li>   The documentation for arguments, documented with a separate 
        documentation block, was not consistently shown in source and header 
        files, depending on the order of the input files. </li>
-<li>   The characters '(', ')', '$', ''', and ';' were not recognised 
+<li>   The characters '(', ')', '$', ''', and ';' were not recognized 
        as part of an URL.</li>
 <li>   Grouped enum values could not share the same documentation block
        even when DISTRIBUTE_GROUP_DOC is YES. </li>
@@ -7397,7 +7397,7 @@ make sure you add the following:
        classes, imported via using declarations, as their parameter type.</li>
 <li>   Fixed bug in conditional section handling for cases like:
        @if guard text @else more text @endif</li>
-<li>   The html help files did not honour the HTML_FILE_EXTENSION settings.</li>
+<li>   The html help files did not honor the HTML_FILE_EXTENSION settings.</li>
 <li>   Removed bogus warning when using @param for function-type 
        parameters.</li>
 <li>   Include statements in the source browser output now link to the 
@@ -7470,7 +7470,7 @@ make sure you add the following:
        with full access to documentation blocks. 
        Made inheritance/collaboration diagrams accessible via the
        XML parser API (see addon/doxmlparser/include/doxmlintf.h).
-       Reorganised the internals of the XML parser so the API does
+       Reorganized the internals of the XML parser so the API does
        not require destructors. Made the parser more portable (it should
        compile with gcc and M$ visual C++ now).</li>
 </ul>
@@ -7493,7 +7493,7 @@ make sure you add the following:
 <li>   In some cases the tree view showed leaf elements as non-leafs. </li>
 <li>   Fixed a number of cases where illegal characters could end up in 
        the XML output.</li>
-<li>   If a function in a base class was (re)implemented by serveral classes
+<li>   If a function in a base class was (re)implemented by several classes
        only one of them appeared in the "(re)implemented in" list. </li>
 <li>   graph_legend.gif was hardcoded in translator_*.h files. 
        Note to translators: this has affected all translator files, so please
@@ -7560,7 +7560,7 @@ make sure you add the following:
             this tag switches off the language filter...
        */
        </pre>
-       Which of the language specific fragments is outputed depends
+       Which of the language specific fragments is outputted depends
        on the setting of OUTPUT_LANGUAGE (Thanks to Milan Rusek for the patch).</li>
 <li>   Added build support for Cygwin (thanks to Ryunosuke Sato).        </li>
 <li>   Added new option HTML_FILE_EXTENSION to allow different file extension
@@ -7595,7 +7595,7 @@ make sure you add the following:
 <li>   Undocumented classes exposed when setting EXTRACT_ALL to YES, could
        result in broken links in the class hierarchy.</li>
 <li>   Exception specifications in Java were not parsed properly.</li>
-<li>   If INLINE_INHERITED_MEMB was YES, pure vitual members of base classes
+<li>   If INLINE_INHERITED_MEMB was YES, pure virtual members of base classes
        reachable via multiple paths appeared more than once in the 
        documentation.</li>
 <li>   Removed potential recursive loop when computing reimplements relations
@@ -7856,7 +7856,7 @@ make sure you add the following:
 <li>   Fixed a number of XML output bugs (thanks to Christian Hammond).</li>
 <li>   Fixed bug parsing character literals.</li>
 <li>   Fixed bug in RTF output (bracket mismatch).</li>
-<li>   Inializer of the last enum value of an enum did not always appear.</li>
+<li>   Initializer of the last enum value of an enum did not always appear.</li>
 <li>   Dots were removed from return types in Java.</li>
 <li>   In some cases a broken "More..." link was generated after 
        a brief class description.</li>
@@ -7965,10 +7965,10 @@ make sure you add the following:
 <ul>
 <li>   Friend class declarations are now treated as normal members.</li>
 <li>   Completely rewrote the way templates are handled. 
-       Doxygen now (internally) computes all template instances it encounters. 
+       Doxygen now (internally) computes all template instantiations it encounters. 
        This has the following advantages:
        <ul>
-       <li>Template instances are now shown in the hierarchical index
+       <li>Template instantiations are now shown in the hierarchical index
            and in all class diagrams in a uniform way.</li>
        <li>The list of all members is now correct for classes deriving
            from a template.</li>
@@ -7986,7 +7986,7 @@ make sure you add the following:
 <li>   Added GNU install tool auto detection to the configure script.</li>
 <li>   Included update for French translation (thanks to Xavier Outhier)
        Olexij Tkatchenko has added support for the Ukrainian language.
-       Included update for Portuguese and Brazillian.</li>
+       Included update for Portuguese and Brazilian.</li>
 <li>   Added --docdir option to the configure script.</li>
 <li>   Using the non-commercial version of Qt for windows, it is now
        possible to build doxywizard for windows.</li>
@@ -8001,7 +8001,7 @@ make sure you add the following:
 <li>   Removed bogus warnings when parsing tag files.</li>
 <li>   The detailed description in a @name block can now be more than 
        plain text.</li>
-<li>   Included fix for the tree view script for the mozilla browser
+<li>   Included fix for the tree view script for the Mozilla browser
        (thanks to Alec Panovici).</li>
 <li>   Grouping members with the same signature but with a different scopes
        is now possible.</li>
@@ -8036,7 +8036,7 @@ make sure you add the following:
        list of all members, while they were accessible from the derived class.</li>
 <li>   Reworked part of the template handling. Doxygen should now be
        capable of handling nested template classes correctly. Please test
-       this if you are using these contructs. Thanks to Christoph Koegl
+       this if you are using these constructs. Thanks to Christoph Koegl
        for providing some difficult test cases.</li>
 <li>   Fixed parse problem when parsing &lt;&lt; as part of the first 
        argument of a typedef.</li>
@@ -8088,7 +8088,7 @@ make sure you add the following:
 <h3>New features</h3>
 <ul>
 <li>   The dot generated inheritance and collaboration graphs for classes
-       should now show the proper template instantation for the derived/used
+       should now show the proper template instantiation for the derived/used
        classes. For instance it should show that class S uses class V 
        (indirectly) in the following example:
        <pre>
@@ -8127,7 +8127,7 @@ make sure you add the following:
 
        \defgroup must be used exactly once for a group, so you should
        provide a title. Without the title you will get a warning and
-       doxygen will use the name as title (this is the old behaviour).
+       doxygen will use the name as title (this is the old behavior).
        <pre>
        /** \addtogroup name */
        </pre> 
@@ -8176,7 +8176,7 @@ make sure you add the following:
 <h3>Bug fixes</h3>
 <ul>
 <li>   Fixed a bug in the LaTeX output generation (empty lists).</li>
-<li>   Doxygen can now distiguishing f(const A) from f(const B)
+<li>   Doxygen can now distinguishing f(const A) from f(const B)
        even though they match from a syntactical point of view.</li>
 <li>   A template base class that is actually an inherited template 
        argument of the derived class is no longer shown in the output 
@@ -8265,7 +8265,7 @@ make sure you add the following:
 <li>   Setting OPTIMIZE_OUTPUT_FOR_C still produced some C++-ish 
        sentences for the list of all struct/union fields.</li>
 <li>   Undocumented friend functions were listed as friend classes.</li>
-<li>   A CORBA IDL union with a switch was not always recognised correctly.  </li>
+<li>   A CORBA IDL union with a switch was not always recognized correctly.  </li>
 <li>   doxygen did not handle try-function-blocks with multiple catch clauses
        properly.</li>
 <li>   \bug and co. were not working for static members.</li>
@@ -8320,8 +8320,8 @@ make sure you add the following:
        <ul>
        <li> the addin no longer requires administrator privileges to work 
          (thanks to Michael Beck)</li>
-       <li> the existance of files is now checked (thanks to Pekka Pessi).</li>
-       <li> .odl and .inl files are recognised (thanks to Pekka Pessi).</li>
+       <li> the existence of files is now checked (thanks to Pekka Pessi).</li>
+       <li> .odl and .inl files are recognized (thanks to Pekka Pessi).</li>
        </ul></li>
 </ul>
 
@@ -8351,7 +8351,7 @@ make sure you add the following:
        if EXTRACT_PRIVATE is set to YES, instead of just the non-inherited
        private members.</li>
 <li>   Fixed autolink problem for grouped members.</li>
-<li>   Mutliple static global functions with the same name (but in different
+<li>   Multiple static global functions with the same name (but in different
        files), which were forward declared, could make doxygen put 
        the wrong documentation block at the wrong global function.</li>
 <li>   Support for Norwegian was not enabled.</li>
@@ -8378,7 +8378,7 @@ make sure you add the following:
 <li>   Putting &lt;a href="..."&gt;&lt;img src="..."&gt;&lt;/a&gt; in the 
        docs will now work as expected for HTML.</li>
 <li>   Fixed problems with &gt;pre&gt;...&gt;/pre&gt; block in LaTeX.</li>
-<li>   Putting &amp;ccedil; in the docs now preduces a c-cedille.</li>
+<li>   Putting &amp;ccedil; in the docs now produces a c-cedille.</li>
 </ul>
 
 
@@ -8430,7 +8430,7 @@ make sure you add the following:
 <h3>Bug fixes</h3>
 <ul>
 <li>   Fixed 0-pointer bug that could crash doxygen in some cases.</li>
-<li>   Starting a list in a brief JavaDoc-style description splitted
+<li>   Starting a list in a brief JavaDoc-style description split
        the list into two invalid parts if a list item ended with a dot.</li>
 <li>   Fixed a problem with linking to grouped class members.</li>
 <li>   Indenting of code fragment in LaTeX output was not always correct.
@@ -8517,7 +8517,7 @@ make sure you add the following:
 <li>   \ingroup can now be put in a one line comments (thanks to Patrick Ohly)</li>
 <li>   \ingroup in a comment block before a comma separated list of  
        variables is now applied to all variables (as is the documentation 
-       itself). (thanke to Patrick Ohly for the patch)</li>
+       itself). (thanks to Patrick Ohly for the patch)</li>
 <li>   @{ .. @} blocks can now be used for normal groups as well
        (thanks to Trevor Robinson for the patch). Here is an example:
        <pre>
@@ -8623,7 +8623,7 @@ make sure you add the following:
 <ul>
 <li>   Support for the Slovene language (thanks to Matjaz Ostroversnik)</li>
 <li>   Bit fields for struct members are now shown in the documentation.</li>
-<li>   Enabled "favourites" and "Full text-search" for the generated
+<li>   Enabled "favorites" and "Full text-search" for the generated
        HTML Help browser files. </li>
 <li>   Added support for M$-IDL properties. The "methods:" section
        now also works.</li>
@@ -8678,9 +8678,9 @@ make sure you add the following:
        now always pointing to the correct file (thanks to Bill Soudan
        for the patch).</li>
 <li>   Fixed HTML bug in non-indexed namespace member lists. </li>
-<li>   Using `:' inside ID's caused problems for some
-       XML parsers. I'm now using "__" instead. Also removed @ from appearing
-       in the output when annonymous compounds were used.</li>
+<li>   Using ':' inside ID's caused problems for some
+       XML parsers, I'm now using "__" instead. Also removed @ from appearing
+       in the output when anonymous compounds were used.</li>
 <li>   Fixed output bug that is caused by nesting paragraph commands
        inside autolists.</li>
 <li>   Doxygen no longer generates source files for input files that
@@ -8731,7 +8731,7 @@ make sure you add the following:
 <li>   Added support for namespace aliases.</li>
 <li>   Added RTF patch from Alexander Bartolich. Here is his description of
        the changes:
-       "The following patch of rtgen.cpp allows to read *complete* style 
+       "The following patch of rtfgen.cpp allows to read *complete* style 
         definitions from rtfstyle. This includes \sbasedon, \snext, \additive 
         and actual style names.
 
@@ -8758,7 +8758,7 @@ make sure you add the following:
        and <code>a[2]-&gt;func()</code>.</li>
 <li>   \em %className did not remove the %</li>
 <li>   In some cases namespace members ended up multiple times in the
-       documentatation.</li>
+       documentation.</li>
 <li>   Fixed a bug in the auto list generation.</li>
 <li>   \latexonly inside brief description did not work properly.</li>
 <li>   "Referenced By" list did not include constructors with 
@@ -8785,7 +8785,7 @@ make sure you add the following:
        item indicating where the todo item was found. The todo list (and
        all todo items) can be disabled by setting GENERATE_TODOLIST to NO.</li>
 <li>   &lt;pre&gt; ... &lt;/pre&gt; blocks now behave as in plain HTML instead of
-       \code ... \endcode blocks. This also works for LaTeX ofcourse. 
+       \code ... \endcode blocks. This also works for LaTeX of course. 
        These blocks differ from \verbatim ... \endverbatim blocks in that 
        commands can be used inside these blocks.</li>
 </ul>
@@ -8824,7 +8824,7 @@ make sure you add the following:
        </pre>
        Credits go to Joerg Baumann.</li>
 <li>   Included French and Czech language updates from Mathieu Despriée and
-       Petr Prikryl. Also included a language update for german from 
+       Petr Prikryl. Also included a language update for German from 
        Raimund Klein.</li>
 <li>   Doxygen will now do give proper warnings for formulas that do not 
        end properly.</li>
@@ -8896,7 +8896,7 @@ make sure you add the following:
        graphicx package instead of epsfig to simplify the use of pdflatex 
        (thanks to Pier Giorgio for showing me how that works).</li>
 <li>   Reimplemented the <code>system()</code> call for Unix, so doxygen becomes
-       interruptable when calling external tools such as dot.</li>
+       interruptible when calling external tools such as dot.</li>
 <li>   Changed the way <code>-w</code> works. It can now also be used to generate
        template header and footers.</li>
 </ul>
@@ -8932,7 +8932,7 @@ make sure you add the following:
        set the file patterns for the include files (if left empty the 
        <code>FILE_PATTERNS</code> will be used, which was also the old 
        behaviour). </li>
-<li>   Added a couple of commands for kdoc compatability: <code>@p</code>, 
+<li>   Added a couple of commands for kdoc compatibility: <code>@p</code>, 
        <code>@li</code>, <code>@em</code>.
        Also made @ref a bit less strict.</li>
 <li>   Portuguese translation by Rui Lopes.  </li>
@@ -8964,12 +8964,12 @@ make sure you add the following:
 <li>   Global functions within anonymous namespace scopes did appear
        in the documentation with the anonymous scope marker used internally
        by doxygen.</li>
-<li>   "namespace{}",so without space was not recognised as a namespace.</li>
+<li>   "namespace{}",so without space was not recognized as a namespace.</li>
 <li>   If the search engine was used then running installdox on the generated
        html resulted in bogus links to the search engine.</li>
 <li>   Fixed some compiler warning on Solaris.</li>
 <li>   Changed grey by grey50 in dot.cpp to avoid PDF conversion problems.</li>
-<li>   A &lt;/pre&gt; that was not preceeded by a whitespace was ignored </li>
+<li>   A &lt;/pre&gt; that was not preceded by a whitespace was ignored </li>
 <li>   The methods operator&lt;() and operator&lt;&lt;() were not 
        automatically linked anymore.</li>
 <li>   Some special characters in LaTeX were eating up the blanks that 
@@ -9041,7 +9041,7 @@ make sure you add the following:
        which files #include (i.e. depend on) a given file. This graph is 
        enabled by setting HAVE_DOT and INCLUDED_BY_GRAPH to YES.</li>
 <li>   added new configuration option EXTRACT_STATIC that can be used
-       to enable/disable the extraction of static file members. The behaviour
+       to enable/disable the extraction of static file members. The behavior
        of this option used to be linked with EXTRACT_PRIVATE.</li>
 <li>   Added two new configuration options MAX_DOT_GRAPH_WIDTH and 
        MAX_DOT_GRAPH_HEIGHT that let the user configure how big the
@@ -9100,7 +9100,7 @@ make sure you add the following:
 </ul>
 <h3>Bug fixes</h3>
 <ul>
-<li>   the warning message in case of ambigous file matches was containing
+<li>   the warning message in case of ambiguous file matches was containing
        a bogus <code>%s</code>, which could even crash doxygen.</li>
 <li>   An autolist followed by a \retval, \param, or \exception did 
        produced invalid output, resulting in a compile error in LaTeX. </li>
@@ -9113,7 +9113,7 @@ make sure you add the following:
 <li>   The hierarchy shown in the "Contents" part of the html help
        browser did not properly show the hierarchy when it contained
        undocumented classes. </li>
-<li>   explict compound specifiers in the return type could lead to 
+<li>   explicit compound specifiers in the return type could lead to 
        parse problems. Example:
        <pre>
        enum SomeEnumType_e Func()
@@ -9128,8 +9128,8 @@ make sure you add the following:
        and links to the correct reimplemented member are generated.</li>
 <li>   \ingroup did not work when grouping enums</li>
 <li>   members of a module were not cross-referenced with the sources.</li>
-<li>   Function pointers like <code>void ( *func )()</code> where not c
-       orrectly parsed because of the extra spacing between 
+<li>   Function pointers like <code>void ( *func )()</code> where not 
+       correctly parsed because of the extra spacing between 
        the `(' and the `*'. </li>
 <li>   The const in void <code>func(int * const val /*&lt; a value. */);</code>
        was named part of the name, instead of the type.</li>
@@ -9389,7 +9389,7 @@ make sure you add the following:
          template &lt;class T&gt; class S&lt;C&lt;T&gt; &gt; : public SB&lt;C&lt;T&gt; &gt; {};
        </pre> </li>
 <li>   #includes in code fragments where not hyperlinked. Operator
-       methods were also not correctly recognised.</li>
+       methods were also not correctly recognized.</li>
 <li>   C/C++ comments inside initializers where not handled properly.</li>
 <li>   If the type of an argument of a member definition was prefixed 
        with a (redudant) scope name of an indirect base class, 
@@ -9418,7 +9418,7 @@ make sure you add the following:
        case file names with space were used.</li>
 <li>   back-references from source-lines to documentation only worked for
        those members of a member group that were explicitly documented.</li>
-<li>   doxygen did not distriguish between func(int a) and func(int a[])
+<li>   doxygen did not distinguish between func(int a) and func(int a[])
        which could cause documentation to end up at the wrong member
        in case over overloading. </li>
 </ul>
@@ -9502,7 +9502,7 @@ make sure you add the following:
 <li>   Since 1.1.2, environment variable expansion in the config 
        file always resulted in a single string for each expanded variable
        (just as if quotes were put around the environment variable).
-       The old behaviour is restored again.</li>
+       The old behavior is restored again.</li>
 <li>   removed redundant spaces in the man page output and fixed the
        tab alignment in code fragments.</li>
 <li>   <code>typedef ( bla::*proc)();</code> was not properly parsed because of the
@@ -9524,7 +9524,7 @@ make sure you add the following:
        dot graphs. The cause was likely to be multiple frees of the same 
        pointer (but I have not been able to reproduce the crash myself). 
        I've now reimplemented the deletion routine of the dot graph
-       respresentation, which hopefully fixes this problem.</li>
+       representation, which hopefully fixes this problem.</li>
 <li>   Elements of the configuration options in lists, which used quotes 
        were broken up into smaller pieces anyway. This most notably broke
        PREDEFINED in some cases that worked before.</li>
@@ -9553,7 +9553,7 @@ make sure you add the following:
        of the LaTeX output (doxygen.sty a.o.) was not generated 
        (Thanks to Markus Lepper for reporting this).</li>
 <li>   Doxygen can now match arguments containing an explicit namespace
-       qualifier against arguments containing an implicit qualitifier 
+       qualifier against arguments containing an implicit qualifier 
        (i.e. imported via a using directive). 
        An example (thanks to Karl Stroetmann):
        <pre>
@@ -9619,7 +9619,7 @@ make sure you add the following:
        <p>
        <b>Usage:</b> A group is defined by a <code>//@{ .. //@}</code> block 
        (or <code>/*@{*/../*@}*/</code> if 
-       you're addited to C style comments :-) Nesting of groups is not 
+       you're addicted to C style comments :-) Nesting of groups is not 
        allowed. Before the opening marker of a block a separate comment 
        block should be placed. This block should contain the @name 
        (or \name) command to specify the header of the group.
@@ -9757,7 +9757,7 @@ make sure you add the following:
 <li>   Fixed a bug in structure of the graphical class hierarchy
        (thanks to Paul Bohme for pointing me at this bug)</li>
 <li>   Non-function members can now also be documented if they
-       are inside annonymous namespaces, which themselves are nested in 
+       are inside anonymous namespaces, which themselves are nested in 
        named namespaces.</li>
 <li>   #defines can now grouped with \defgroup and \ingroup as well.</li>
 <li>   fixed a bug in the latex output of groups (thanks to Gregory Kurz
@@ -9929,7 +9929,7 @@ make sure you add the following:
        /*! let's go to the bar */
        class foo::bar { };
        </pre></li>
-<li>   Members inside annonymous namespaces nested inside named namespaces 
+<li>   Members inside anonymous namespaces nested inside named namespaces 
        were not properly handled. </li>
 <li>   When documenting template specializations with the \class command,
        the second argument was not interpreted correctly.</li>
@@ -10089,7 +10089,7 @@ make sure you add the following:
        </pre></li>
 <li>   Three new section commands <code>\pre</code>, <code>\post</code> and 
        <code>\invariant</code> are added to describe
-       preconditions, postcondictions and invariants respectively.</li>
+       preconditions, postconditions and invariants respectively.</li>
 <li>   Variable/enum initializers and define definitions are 
        now included in documentation (unless the initializer/definition 
        is more than 30 lines long)</li>
@@ -10113,7 +10113,7 @@ make sure you add the following:
 <li>   Autolinks to #defines looked like function macro even if they weren't.</li>
 <li>   Members that were hidden deep in an inheritance tree, got multiple
        scope prefixes in the "all members list", while a scope prefix to
-       the member in the base class was enough to use it unambiguishly.</li>
+       the member in the base class was enough to use it unambiguously.</li>
 <li>   <code>\latexonly ... \endlatexonly</code> in the main page produced 
        erroneous text in refman.tex</li>
 <li>   The keywords in header and footer were only evaluated once.</li>

--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -304,7 +304,7 @@ The list of entities with their descriptions has been taken from <a href="http:/
 <li><tt>\&notin;</tt>`&nbsp;&nbsp;&nbsp;`                 not an element of: &notin;
 <li><tt>\&ni;</tt>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`  contains as member: &ni;
 <li><tt>\&prod;</tt>`&nbsp;&nbsp;&nbsp;&nbsp;`            n-ary product = product sign: &prod;
-<li><tt>\&sum;</tt>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`       n-ary sumation: &sum;
+<li><tt>\&sum;</tt>`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`       n-ary summation: &sum;
 <li><tt>\&minus;</tt>`&nbsp;&nbsp;&nbsp;`                 minus sign: &minus;
 <li><tt>\&lowast;</tt>`&nbsp;&nbsp;`                      asterisk operator: &lowast;
 <li><tt>\&radic;</tt>`&nbsp;&nbsp;&nbsp;`                 square root = radical sign: &radic;

--- a/doc/translator.py
+++ b/doc/translator.py
@@ -141,8 +141,8 @@ class Transl:
         self.baseClassId = None
         self.readableStatus = None   # 'up-to-date', '1.2.3', '1.3', etc.
         self.status = None           # '', '1.2.03', '1.3.00', etc.
-        self.lang = None             # like 'Brasilian'
-        self.langReadable = None     # like 'Brasilian Portuguese'
+        self.lang = None             # like 'Brazilian'
+        self.langReadable = None     # like 'Brazilian Portuguese'
         self.note = None             # like 'should be cleaned up'
         self.prototypeDic = {}       # uniPrototype -> prototype
         self.translateMeText = 'translate me!'


### PR DESCRIPTION
Spelling corrections as found by codespell and in #561.

Some reported problems were already fixed, others are fixed here.
There are a few that are not corrected as they signal a documentation correction.