### PR TITLE
Spelling corrections for src directory

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -151,7 +151,7 @@ void CiteDict::generatePage() const
           p=s+1;
 
 	  int i;
-          if ((i = line.find("crossref")) != -1) /* assumption crossreference is on one line and the only item */
+          if ((i = line.find("crossref")) != -1) /* assumption cross reference is on one line and the only item */
           {
             int j=line.find("{",i);
             int k=line.find("}",i);

--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -87,7 +87,7 @@ static QCString detab(const QCString &s)
           while (stop--) out.addChar(' '); 
         }
         break;
-      case '\n': // reset colomn counter
+      case '\n': // reset column counter
         out.addChar(c);
         col=0;
         break;

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -3315,7 +3315,7 @@ bool ClassDefImpl::hasExamples() const
 
 void ClassDefImpl::addTypeConstraint(const QCString &typeConstraint,const QCString &type)
 {
-  //printf("addTypeContraint(%s,%s)\n",type.data(),typeConstraint.data());
+  //printf("addTypeConstraint(%s,%s)\n",type.data(),typeConstraint.data());
   static bool hideUndocRelation = Config_getBool(HIDE_UNDOC_RELATIONS);
   if (typeConstraint.isEmpty() || type.isEmpty()) return;
   ClassDef *cd = const_cast<ClassDef*>(getResolvedClass(this,getFileDef(),typeConstraint));
@@ -3655,7 +3655,7 @@ void ClassDefImpl::mergeMembers()
             {
               MemberDef *srcMd = srcMi->memberDef;
               bool found=FALSE;
-              bool ambigue=FALSE;
+              bool ambiguous=FALSE;
               bool hidden=FALSE;
               MemberNameInfoIterator dstMnii(*dstMni);
               MemberInfo *dstMi;
@@ -3694,7 +3694,7 @@ void ClassDefImpl::mergeMembers()
                     QCString scope=dstMi->scopePath.left(dstMi->scopePath.find(sep)+sepLen);
                     if (scope!=dstMi->ambiguityResolutionScope.left(scope.length()))
                       dstMi->ambiguityResolutionScope.prepend(scope);
-                    ambigue=TRUE;
+                    ambiguous=TRUE;
                   }
                 }
                 else // same members
@@ -3723,12 +3723,12 @@ void ClassDefImpl::mergeMembers()
                     {
                       dstMi->ambiguityResolutionScope.prepend(scope);
                     }
-                    ambigue=TRUE;
+                    ambiguous=TRUE;
                   }
                 }
               }
-              //printf("member %s::%s hidden %d ambigue %d srcMi->ambigClass=%p\n",
-              //    srcCd->name().data(),srcMd->name().data(),hidden,ambigue,srcMi->ambigClass);
+              //printf("member %s::%s hidden %d ambiguous %d srcMi->ambigClass=%p\n",
+              //    srcCd->name().data(),srcMd->name().data(),hidden,ambiguous,srcMi->ambigClass);
 
               // TODO: fix the case where a member is hidden by inheritance
               //       of a member with the same name but with another prototype,
@@ -3757,7 +3757,7 @@ void ClassDefImpl::mergeMembers()
 
                 MemberInfo *newMi = new MemberInfo(srcMd,prot,virt,TRUE);
                 newMi->scopePath=bClass->name()+sep+srcMi->scopePath;
-                if (ambigue)
+                if (ambiguous)
                 {
                   //printf("$$ New member %s %s add scope %s::\n",
                   //     srcMi->ambiguityResolutionScope.data(),
@@ -4733,7 +4733,7 @@ int ClassDefImpl::countAdditionalInheritedMembers() const
       }
     }
   }
-  //printf("countAdditonalInheritedMembers()=%d\n",totalCount);
+  //printf("countAdditionalInheritedMembers()=%d\n",totalCount);
   return totalCount;
 }
 

--- a/src/code.l
+++ b/src/code.l
@@ -1147,7 +1147,7 @@ static bool generateClassMemberLink(CodeOutputInterface &ol,MemberDef *xmd,const
   if (xd && xd->isLinkable())
   {
 
-    //printf("g_currentDefiniton=%p g_currentMemberDef=%p xmd=%p g_insideBody=%d\n",g_currentDefinition,g_currentMemberDef,xmd,g_insideBody);
+    //printf("g_currentDefinition=%p g_currentMemberDef=%p xmd=%p g_insideBody=%d\n",g_currentDefinition,g_currentMemberDef,xmd,g_insideBody);
 
     if (xmd->templateMaster()) xmd = xmd->templateMaster();
 

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -496,7 +496,7 @@ void replaceComment(int offset);
 				     g_lastCommentContext = YY_START;
                                      BEGIN(Verbatim);
                                    }
-<Scan>.                            { /* any ather character */
+<Scan>.                            { /* any other character */
                                      copyToOutput(yytext,(int)yyleng); 
                                    }
 <Verbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"f$"|"f]"|"f}") { /* end of verbatim block */

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1970,7 +1970,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
   					  BEGIN(Comment);
   					}
 <GuardParamEnd>{B}*			{
-  					  if (!g_spaceBeforeIf.isEmpty()) // needed for 665313 in combation with bug620924
+  					  if (!g_spaceBeforeIf.isEmpty()) // needed for 665313 in combination with bug620924
 					  {
 					    addOutput(g_spaceBeforeIf);
 					  }

--- a/src/condparser.h
+++ b/src/condparser.h
@@ -13,7 +13,7 @@
  * Documents produced by Doxygen are derivative works derived from the
  * input used in their production; they are not affected by this license.
  *
- * C++ Expression parser for EXTABLED_SETIONS in Doxygen
+ * C++ Expression parser for ENABLED_SECTIONS in Doxygen
  *
  * Features used:
  *     Operators:

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1079,7 +1079,7 @@ class TranslateContext::Private
         s_inst.addProperty("fileMembers",       &Private::fileMembers);
         //%% string fileMembersDescription
         s_inst.addProperty("fileMembersDescription", &Private::fileMembersDescription);
-        //%% string relatedPagesDescripiton
+        //%% string relatedPagesDescription
         s_inst.addProperty("relatedPagesDesc",  &Private::relatedPagesDesc);
         //%% string more
         s_inst.addProperty("more",              &Private::more);
@@ -1133,7 +1133,7 @@ class TranslateContext::Private
         s_inst.addProperty("referencesRelation",   &Private::referencesRelation);
         //%% markerstring inheritedFrom
         s_inst.addProperty("inheritedFrom",      &Private::inheritedFrom);
-        //%% string addtionalInheritedMembers
+        //%% string additionalInheritedMembers
         s_inst.addProperty("additionalInheritedMembers",&Private::additionalInheritedMembers);
         //%% string includeDependencyGraph:container_name
         s_inst.addProperty("includeDependencyGraph",&Private::includeDependencyGraph);
@@ -8432,7 +8432,7 @@ TemplateVariant NamespaceMembersIndexContext::get(const char *name) const
 
 //------------------------------------------------------------------------
 
-//%% struct InheritanceGraph: a connected graph reprenting part of the overall inheritance tree
+//%% struct InheritanceGraph: a connected graph representing part of the overall inheritance tree
 //%% {
 class InheritanceGraphContext::Private
 {
@@ -10297,7 +10297,7 @@ void generateOutputViaTemplate()
       ctx->set("classMembersIndex",classMembersIndex.get());
       //%% NamespaceMembersIndex namespaceMembersIndex:
       ctx->set("namespaceMembersIndex",namespaceMembersIndex.get());
-      //%% SearchIndicaes searchindicaes
+      //%% SearchIndices searchIndices
       ctx->set("searchIndices",searchIndices.get());
       //%% string space
       ctx->set("space"," ");

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -290,7 +290,7 @@ void parseFuncDecl(const QCString &decl,const SrcLangExt lang,QCString &cl,QCStr
   //        yyextra->type.data(),yyextra->scope.data(),yyextra->name.data(),yyextra->args.data());
 
   int nb = yyextra->name.findRev('[');
-  if (nb!=-1 && yyextra->args.isEmpty()) // correct for [] in yyextra->name ambigity (due to Java return yyextra->type allowing [])
+  if (nb!=-1 && yyextra->args.isEmpty()) // correct for [] in yyextra->name ambiguity (due to Java return yyextra->type allowing [])
   {
     yyextra->args.prepend(yyextra->name.right(yyextra->name.length()-nb));
     yyextra->name=yyextra->name.left(nb);

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1001,7 +1001,7 @@ bool readCodeFragment(const char *fileName,
   }
   result = transcodeCharacterStringToUTF8(result);
   if (!result.isEmpty() && result.at(result.length()-1)!='\n') result += "\n";
-  //fprintf(stderr,"readCodeFragement(%d-%d)=%s\n",startLine,endLine,result.data());
+  //printf("readCodeFragment(%d-%d)=%s\n",startLine,endLine,result.data());
   return found;
 }
 

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -107,7 +107,7 @@ class DiagramRowIterator : public QListIterator<DiagramRow>
       : QListIterator<DiagramRow>(d) {}
 };
 
-/** Class represeting the tree layout for the built-in class diagram. */
+/** Class representing the tree layout for the built-in class diagram. */
 class TreeDiagram : public QList<DiagramRow>
 {
   public:
@@ -308,7 +308,7 @@ QCString DiagramItem::label() const
   QCString result;
   if (!templSpec.isEmpty())
   {
-    // we use classDef->name() here and not diplayName() in order
+    // we use classDef->name() here and not displayName() in order
     // to get the name used in the inheritance relation.
     QCString n = classDef->name();
     if (/*n.right(2)=="-g" ||*/ n.right(2)=="-p")

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -94,7 +94,7 @@ static int g_dirCount=0;
 DirDefImpl::DirDefImpl(const char *path) : DefinitionImpl(path,1,1,path)
 {
   bool fullPathNames = Config_getBool(FULL_PATH_NAMES);
-  // get display name (stipping the paths mentioned in STRIP_FROM_PATH)
+  // get display name (stripping the paths mentioned in STRIP_FROM_PATH)
   // get short name (last part of path)
   m_shortName = path;
   m_diskName = path;

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -4562,7 +4562,7 @@ void DocSimpleSect::appendLinkWord(const QCString &word)
   {
     p = (DocPara *)m_children.getLast();
     
-    // Comma-seperate <seealso> links.
+    // Comma-separate <seealso> links.
     p->injectToken(TK_WORD,",");
     p->injectToken(TK_WHITESPACE," ");
   }

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -329,8 +329,8 @@ static int yyread(char *buf,int max_size)
 
 //--------------------------------------------------------------------------
 //#define REAL_YY_DECL int doctokenizerYYlex (void)
-//#define YY_DECL static int local_doctokinizer(void)
-//#define LOCAL_YY_DECL local_doctokinizer()
+//#define YY_DECL static int local_doctokenizer(void)
+//#define LOCAL_YY_DECL local_doctokenizer()
 
 %}
 

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -140,8 +140,8 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
     for (udi.toFirst();(udir=udi.current());++udi) // foreach used dir
     {
       const DirDef *usedDir=udir->dir();
-      if ((dir!=dd || !udir->inherited()) &&     // only show direct dependendies for this dir
-        (usedDir!=dd || !udir->inherited()) && // only show direct dependendies for this dir
+      if ((dir!=dd || !udir->inherited()) &&     // only show direct dependencies for this dir
+        (usedDir!=dd || !udir->inherited()) && // only show direct dependencies for this dir
         !usedDir->isParentOf(dir) &&             // don't point to own parent
         dirsInGraph.find(usedDir->getOutputFileBase())) // only point to nodes that are in the graph
       {

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -117,7 +117,7 @@ QCString DotGraph::writeGraph(
         EmbeddedOutputFormat ef,  // html, latex, ...
         const char* path,         // output folder
         const char* fileName,     // name of the code file (for code patcher)
-        const char* relPath,      // output folder relativ to code file
+        const char* relPath,      // output folder relative to code file
         bool generateImageMap,    // in case of bitmap, shall there be code generated?
         int graphId)              // number of this graph in the current code, used in svg code
 {

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1317,7 +1317,7 @@ static void addClassToContext(const Entry *root)
     //printf("ClassDict.insert(%s)\n",fullName.data());
     Doxygen::classSDict->append(fullName,cd);
 
-    if (cd->isGeneric()) // generics are also stored in a separate dictionary for fast lookup of instantions
+    if (cd->isGeneric()) // generics are also stored in a separate dictionary for fast lookup of instances
     {
       //printf("inserting generic '%s' cd=%p\n",fullName.data(),cd);
       Doxygen::genericsDict->insert(fullName,cd);
@@ -6540,7 +6540,7 @@ static void findMember(const Entry *root,
 
           // first note that we pass:
           //   (root->tArgLists ? root->tArgLists->last() : 0)
-          // for the template arguments fo the new "member."
+          // for the template arguments for the new "member."
           // this accurately reflects the template arguments of
           // the related function, which don't have to do with
           // those of the related class.
@@ -9497,7 +9497,7 @@ static void parseFiles(const std::unique_ptr<Entry> &root)
       }
     }
   }
-  else // normal pocessing
+  else // normal processing
 #endif
   {
     StringListIterator it(g_inputFiles);
@@ -9588,7 +9588,7 @@ static QDict<void> g_pathsVisited(1009);
 //----------------------------------------------------------------------------
 // Read all files matching at least one pattern in 'patList' in the
 // directory represented by 'fi'.
-// The directory is read iff the recusiveFlag is set.
+// The directory is read iff the recursiveFlag is set.
 // The contents of all files is append to the input string
 
 int readDir(QFileInfo *fi,
@@ -11924,7 +11924,7 @@ void generateOutput()
 
   cleanUpDoxygen();
 
-  finializeSearchIndexer();
+  finalizeSearchIndexer();
 //  Doxygen::symbolStorage->close();
   QDir thisDir;
   thisDir.remove(Doxygen::objDBFileName);

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -735,7 +735,7 @@ void FileDefImpl::writeClassDeclarations(OutputList &ol,const QCString &title,Cl
 
 void FileDefImpl::writeInlineClasses(OutputList &ol)
 {
-  // temporarily undo the disbling could be done by startMemberDocumentation()
+  // temporarily undo the disabling could be done by startMemberDocumentation()
   // as a result of setting SEPARATE_MEMBER_PAGES to YES; see bug730512
   bool isEnabled = ol.isEnabled(OutputGenerator::Html);
   ol.enable(OutputGenerator::Html);

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -17,7 +17,7 @@
  */
 
 /**
- @todo - continutation lines not always recognized
+ @todo - continuation lines not always recognized
        - merging of use-statements with same module name and different only-names
        - rename part of use-statement
        - links to interface functions 

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -141,7 +141,7 @@ static const char *     inputString;
 static int		inputPosition;
 static bool             isFixedForm;
 static QCString         inputStringPrepass; ///< Input string for prepass of line cont. '&'
-static QCString         inputStringSemi; ///< Input string after command separetor ';'
+static QCString         inputStringSemi; ///< Input string after command separator ';'
 static unsigned int     inputPositionPrepass;
 static int              lineCountPrepass = 0;
 
@@ -1841,7 +1841,7 @@ static QCString extractFromParens(const QCString name)
   return extracted;
 }
 
-/*! remove unuseful spaces from bind statement */
+/*! remove useless spaces from bind statement */
 static QCString extractBind(const QCString name)
 {
   QCString parensPart = extractFromParens(name);
@@ -2540,7 +2540,7 @@ static void subrHandleCommentBlock(const QCString &doc,bool brief)
       // strip direction
       loc_doc = loc_doc.right(loc_doc.length()-strlen(directionParam[SymbolModifiers::IN]));
       loc_doc.stripWhiteSpace();
-      // in case of empty documentation or (now) just name, consider it as no documemntation
+      // in case of empty documentation or (now) just name, consider it as no documentation
       if (!loc_doc.isEmpty() && (loc_doc.lower() != argName.lower()))
       {
         handleCommentBlock(QCString("\n\n@param ") + directionParam[SymbolModifiers::IN] + " " + 

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -93,7 +93,7 @@ HtmlHelpIndex::~HtmlHelpIndex()
 }
 
 /*! Stores an item in the index if it is not already present. 
- *  Items are stored in alphetical order, by sorting on the
+ *  Items are stored in alphabetical order, by sorting on the
  *  concatenation of \a level1 and \a level2 (if present).
  *
  *  \param level1 the string at level 1 in the index.

--- a/src/languages.py
+++ b/src/languages.py
@@ -74,7 +74,7 @@ for f in new_list:
         tmp = tmp.replace("\n","")
         l = re.sub('[^"]*"([^"]*)".*','\\1',tmp)
         l1 = l.replace("-","")
-        # capatalize first letter
+        # capitalize first letter
         l = l.title()
         print("""\
                                    <EnumProperty

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1919,7 +1919,7 @@ void LatexGenerator::endMemberDescription()
 
 void LatexGenerator::writeNonBreakableSpace(int) 
 {
-  //printf("writeNonBreakbleSpace()\n");
+  //printf("writeNonBreakableSpace()\n");
   if (insideTabbing)
   {
     t << "\\>";

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2021,7 +2021,7 @@ static int writeBlockQuote(GrowBuf &out,const char *data,int size)
         out.addStr("<blockquote>\n");
       }
     }
-    else if (level<curLevel) // quote level descreased => add end markers
+    else if (level<curLevel) // quote level decreased => add end markers
     {
       for (l=level;l<curLevel;l++)
       {
@@ -2470,7 +2470,7 @@ static QCString detab(const QCString &s,int &refIndent)
           while (stop--) out.addChar(' '); 
         }
         break;
-      case '\n': // reset colomn counter
+      case '\n': // reset column counter
         out.addChar(c);
         col=0;
         break;

--- a/src/pre.l
+++ b/src/pre.l
@@ -87,7 +87,7 @@ struct FileState
 };  
 
 /** @brief Singleton that manages the defines available while 
- *  proprocessing files. 
+ *  preprocessing files. 
  */
 class DefineManager
 {

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1276,7 +1276,7 @@ TARGET           ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBUT
 
     {BB}/({NONEMPTY}|{EXPCHAR}) {
                                  // This implements poor
-				 // indendation-tracking;
+				 // indentation-tracking;
                                  // should be improved.
 				 // (translate tabs to space, etc)
   		                 codifyLines(yytext);

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1952,7 +1952,7 @@ void RTFGenerator::endCodeFragment()
 {
   //newParagraph();
   //styleStack.pop();
-  //printf("RTFGenerator::endCodeFrament() top=%s\n",styleStack.top());
+  //printf("RTFGenerator::endCodeFragment() top=%s\n",styleStack.top());
   //t << rtf_Style_Reset << styleStack.top() << endl;
   //endCodeLine checks is there is still an open code line, if so closes it.
   endCodeLine();

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -283,7 +283,7 @@ class RTFGenerator : public OutputGenerator
     bool m_prettyCode;
 
     bool m_bstartedBody;  // has startbody been called yet?
-    int  m_listLevel; // // RTF does not really have a addative indent...manually set list level.
+    int  m_listLevel; // // RTF does not really have a additive indent...manually set list level.
     bool m_omitParagraph; // should a the next paragraph command be ignored?
     int  m_numCols; // number of columns in a table
     QCString relPath;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3230,7 +3230,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					  *pCopyRoundGString+=*yytext;
   					}
 
-  /* generic square bracket list copy rules for growable strings, we should only enter here in case of php, left the test part as in GCopyRound to keep it compatible with te round bracket version */
+  /* generic square bracket list copy rules for growable strings, we should only enter here in case of php, left the test part as in GCopyRound to keep it compatible with the round bracket version */
 <GCopySquare>\"                         {
                                           *pCopySquareGString+=*yytext;
                                             pCopyQuotedGString=pCopySquareGString;

--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -1372,7 +1372,7 @@ void initSearchIndexer()
   }
 }
 
-void finializeSearchIndexer()
+void finalizeSearchIndexer()
 {
   delete Doxygen::searchIndex;
 }

--- a/src/searchindex.h
+++ b/src/searchindex.h
@@ -34,7 +34,7 @@ class MemberDef;
 /*! Initialize the search indexer */
 void initSearchIndexer();
 /*! Cleanup the search indexer */
-void finializeSearchIndexer();
+void finalizeSearchIndexer();
 
 //------- server side search index ----------------------
 

--- a/src/sortdict.h
+++ b/src/sortdict.h
@@ -244,7 +244,7 @@ class SDict
       return m_list->find(item);
     }
 
-    /*! Equavalent to find(). */
+    /*! Equivalent to find(). */
     T *operator[](const char *key) const
     {
       return m_dict->find(key);
@@ -553,7 +553,7 @@ class SIntDict
       return m_dict->find(key);
     }
 
-    /*! Equavalent to find(). */
+    /*! Equivalent to find(). */
     T *operator[](int key) const
     {
       return m_dict->find(key);

--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -1099,7 +1099,7 @@ static void insertMemberFunctionParams(int memberdef_id, const MemberDef *md, co
 static void insertMemberDefineParams(int memberdef_id,const MemberDef *md, const Definition *def)
 {
     if (md->argumentList().empty()) // special case for "foo()" to
-                                    // disguish it from "foo".
+                                    // distinguish it from "foo".
     {
       DBG_CTX(("no params\n"));
     }

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -4693,7 +4693,7 @@ void TemplateLexer::tokenize(QList<TemplateToken> &tokens)
         {
           state=StateBeginTemplate;
         }
-        else if (c!=' ' && c!='\t' && c!='\n') // non-whitepace text
+        else if (c!=' ' && c!='\t' && c!='\n') // non-whitespace text
         {
           emptyOutputLine=FALSE;
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -955,7 +955,7 @@ class AccessStack
  */
 int isAccessibleFrom(const Definition *scope,const FileDef *fileScope,const Definition *item)
 {
-  //printf("<isAccesibleFrom(scope=%s,item=%s itemScope=%s)\n",
+  //printf("<isAccessibleFrom(scope=%s,item=%s itemScope=%s)\n",
   //    scope->name().data(),item->name().data(),item->getOuterScope()->name().data());
 
   static AccessStack accessStack;

--- a/src/vhdldocgen.h
+++ b/src/vhdldocgen.h
@@ -194,7 +194,6 @@ class VhdlDocGen
     static void correctMemberProperties(MemberDef *md);
     
     static void writeSource(const MemberDef *mdef,OutputList& ol,const QCString & cname);
-    static void writeAlphbeticalClass(OutputList& ol,const ClassDef* cd,const QCString &);
 
     static QCString  parseForConfig(QCString & entity,QCString & arch);
     static QCString  parseForBinding(QCString & entity,QCString & arch);

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -347,7 +347,7 @@ void VhdlParser::addCompInst(const char *n, const char* instName, const char* co
     current->write=genLabels.right(genLabels.length()-u);
     current->read=genLabels.left(u);
   }
-  //printf  (" \n genlable: [%s]  inst: [%s]  name: [%s] %d\n",n,instName,comp,iLine);
+  //printf  (" \n genlabel: [%s]  inst: [%s]  name: [%s] %d\n",n,instName,comp,iLine);
 
   if (lastCompound)
   {

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -430,7 +430,7 @@ void writeXMLCodeBlock(FTextStream &t,FileDef *fd)
                 fd,          // fileDef
                 -1,          // startLine
                 -1,          // endLine
-                FALSE,       // inlineFragement
+                FALSE,       // inlineFragment
                 0,           // memberDef
                 TRUE         // showLineNumbers
                 );
@@ -900,7 +900,7 @@ static void generateXMLForMember(const MemberDef *md,FTextStream &ti,FTextStream
           md->argsString()) // define
   {
     if (md->argumentList().empty())     // special case for "foo()" to
-                                        // disguish it from "foo".
+                                        // distinguish it from "foo".
     {
       t << "        <param></param>" << endl;
     }


### PR DESCRIPTION
Spelling corrections as found by codespell and in #561.

Some reported problems were already fixed, others are fixed here, with some exceptions (a,o.):
- "referenceby" in defgen.cpp as this is in the output and I cannot oversee the consequences (looks like none, but ...)
- "HANGEUL_CHARSET" left as is as in some MS documentation is written: 'HANGUL_CHARSET: Also spelled "Hangeul". Specifies the Hangul Korean character set.' (https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/0d0b32ac-a836-4bd2-a112-b6000a1b4fc9).