### PR TITLE
Spelling corrections for libmscgen directory

### DIFF
--- a/libmscgen/gd.h
+++ b/libmscgen/gd.h
@@ -333,7 +333,7 @@ typedef double (* interpolation_method )(double);
      <Accessor Macros>
 
    (Previous versions of this library encouraged directly manipulating
-   the contents ofthe struct but we are attempting to move away from
+   the contents of the struct but we are attempting to move away from
    this practice so the fields are no longer documented here.  If you
    need to poke at the internals of this struct, feel free to look at
    *gd.h*.)
@@ -1572,7 +1572,7 @@ BGD_DECLARE(int) gdTransformAffineBoundingBox(gdRectPtr src, const double affine
  *
  * Constants:
  *   GD_CMP_IMAGE       - Actual image IS different
- *   GD_CMP_NUM_COLORS  - Number of colors in pallette differ
+ *   GD_CMP_NUM_COLORS  - Number of colors in palette differ
  *   GD_CMP_COLOR       - Image colors differ
  *   GD_CMP_SIZE_X      - Image width differs
  *   GD_CMP_SIZE_Y      - Image heights differ

--- a/libmscgen/mscgen_adraw.h
+++ b/libmscgen/mscgen_adraw.h
@@ -253,7 +253,7 @@ ADraw;
  * image functions to be executed.
  *
  * \param[in] w                The width of the output image.
- * \param[in] h                The height of the ouput image.
+ * \param[in] h                The height of the oupput image.
  * \param[in] file             The file to which the image should be written.
  * \param[in] fontName         The name of the font to use for rendering.
  * \param[in] type             The output type to generate.

--- a/libmscgen/mscgen_adraw_int.h
+++ b/libmscgen/mscgen_adraw_int.h
@@ -29,7 +29,7 @@
  * Preprocessor Macros
  ***************************************************************************/
 
-/* Define macro to supress unused parameter warnings */
+/* Define macro to suppress unused parameter warnings */
 #ifndef UNUSED
 # ifdef __GNUC__
 #  define UNUSED __attribute__((unused))

--- a/libmscgen/mscgen_api.c
+++ b/libmscgen/mscgen_api.c
@@ -662,7 +662,7 @@ static char *getLine(const char        *string,
  * \param  x           The x position at which the entity text should be centered.
  * \param  y           The y position where the text should be placed.
  * \param  entLabel    The label to render, which maybe \a NULL in which case
- *                       no ouput is produced.
+ *                       no output is produced.
  * \param  entUrl      The URL for rendering the label as a hyperlink.  This
  *                       maybe \a NULL if not required.
  * \param  entId       The text identifier for the arc.
@@ -704,7 +704,7 @@ static void entityText(Context          *ctx,
             /* Check if a URL is associated */
             if(entUrl)
             {
-                /* If no explict colour has been set, make URLS blue */
+                /* If no explicit colour has been set, make URLS blue */
                 ctx->drw.setPen(&ctx->drw, ADRAW_COL_BLUE);
 
                 /* Image map output */
@@ -1431,7 +1431,7 @@ static void arcLine(Context          *ctx,
  */
 static Boolean checkMsc(Msc m)
 {
-    /* Check all arc entites are known */
+    /* Check all arc entities are known */
     MscResetArcIterator(m);
     do
     {
@@ -1710,7 +1710,7 @@ int mscgen_generate(const char *inputFile,
         assert(startCol != -1);
         assert(endCol != -1 || isBroadcastArc(MscGetCurrentArcDest(m)));
 
-        /* Check for entity colouring if not set explicity on the arc */
+        /* Check for entity colouring if not set explicitly on the arc */
         if (arcTextColour == NULL)
         {
           arcTextColour = MscGetEntAttrib(m, startCol, MSC_ATTR_ARC_TEXT_COLOUR);

--- a/libmscgen/mscgen_gd_out.c
+++ b/libmscgen/mscgen_gd_out.c
@@ -119,7 +119,7 @@ static int getGdoPen(struct ADrawTag *ctx)
 
 
 /** Given a colour value, convert to a gd colour reference.
- * This searches the current pallette of colours for the passed colour and
+ * This searches the current palette of colours for the passed colour and
  * returns an existing reference if possible.  Otherwise a new colour reference
  * is allocated and returned.
  */

--- a/libmscgen/mscgen_lexer.l
+++ b/libmscgen/mscgen_lexer.l
@@ -142,7 +142,7 @@ NOTE|note                             yylval.arctype = MSC_ARC_NOTE;     return 
 %%
 
 /* Handle a new line of input.
- *  This counts the line number and duplicates the string incase we need
+ *  This counts the line number and duplicates the string in case we need
  *  it for error reporting.  The line is then returned back for parsing
  *  without the newline characters prefixed.
  */

--- a/libmscgen/mscgen_msc.h
+++ b/libmscgen/mscgen_msc.h
@@ -217,7 +217,7 @@ int           MscGetEntityIndex(struct MscTag *m, const char *label);
  * @{
  */
 
-/** Reset the entity interator.
+/** Reset the entity iterator.
  * This moves the pointer to the current entity to the head of the list.
  */
 void          MscResetEntityIterator(Msc m);
@@ -249,7 +249,7 @@ const char   *MscGetEntAttrib(Msc m, unsigned int entIdx, MscAttribType a);
  * @{
  */
 
-/** Reset the arc interator.
+/** Reset the arc iterator.
  * This moves the pointer to the current arc to the head of the list.
  */
 void          MscResetArcIterator   (Msc m);

--- a/libmscgen/mscgen_usage.c
+++ b/libmscgen/mscgen_usage.c
@@ -61,7 +61,7 @@ void Usage(void)
 "              to write output directly to stdout.\n"
 #ifdef USE_FREETYPE
 " -F <font>   Use specified font for PNG output.  This must be a font specifier\n"
-"              compatbile with fontconfig (see 'fc-list'), and overrides the\n"
+"              compatible with fontconfig (see 'fc-list'), and overrides the\n"
 "              MSCGEN_FONT environment variable if also set.\n"
 #endif
 " -p          Print parsed msc output (for parser debug).\n"

--- a/libmscgen/mscgen_utf8.c
+++ b/libmscgen/mscgen_utf8.c
@@ -95,7 +95,7 @@ Boolean Utf8Decode(const char *s, unsigned int *r, unsigned int *bytes)
             }
         }
 
-        /* Success if no NULL was encoutered */
+        /* Success if no NULL was encountered */
         return t == *bytes;
     }
 }


### PR DESCRIPTION
Spelling corrections as found by codespell.

The original package was written by UK-English writing person so left the words in UK-English (upon request this can be changed as well to US-English spelling).