### PR TITLE
Spelling corrections for qtools directory

### DIFF
--- a/qtools/qcstring.h
+++ b/qtools/qcstring.h
@@ -329,7 +329,7 @@ public:
       return m_rep.at(i);
     }
 
-    /** Indexing operator. Equavalent to at(). */
+    /** Indexing operator. Equivalent to at(). */
     char &operator[]( int i ) const
     {
       return m_rep.at((uint)i);

--- a/qtools/qdict.doc
+++ b/qtools/qdict.doc
@@ -175,7 +175,7 @@
 
   Setting \e caseSensitive to TRUE will treat "abc" and "Abc" as different
   keys.  Setting it to FALSE will make the dictionary ignore case.
-  Case insensitive comparison includes the whole Unicode alphabeth.
+  Case insensitive comparison includes the whole Unicode alphabet.
 */
 
 /*!

--- a/qtools/qglobal.h
+++ b/qtools/qglobal.h
@@ -175,7 +175,7 @@
 //
 
 
-// Should be sorted most-authorative to least-authorative
+// Should be sorted most-authoritative to least-authoritative
 
 #if defined(__SC__)
 #define _CC_SYM_

--- a/qtools/qlist.doc
+++ b/qtools/qlist.doc
@@ -858,7 +858,7 @@
 
 /*!
   \fn type *QListIterator::operator*()
-  Asterix operator. Returns a pointer to the current iterator item.
+  Asterisk operator. Returns a pointer to the current iterator item.
   Same as current().
 */
 

--- a/qtools/qstring.cpp
+++ b/qtools/qstring.cpp
@@ -11538,7 +11538,7 @@ static inline bool format(QChar::Decomposition tag, QString & str,
   Applies possible ligatures to a QString, useful when composition-rich
   text requires rendering with glyph-poor fonts, but also
   makes compositions such as QChar(0x0041) ('A') and QChar(0x0308)
-  (Unicode accent diaresis) giving QChar(0x00c4) (German A Umlaut).
+  (Unicode accent diaeresis) giving QChar(0x00c4) (German A Umlaut).
 */
 void QString::compose()
 {

--- a/qtools/qtextcodec.cpp
+++ b/qtools/qtextcodec.cpp
@@ -280,7 +280,7 @@ int QTextCodec::heuristicNameMatch(const char* hint) const
 }
 
 
-// returns a string cotnaining the letters and numbers from input,
+// returns a string containing the letters and numbers from input,
 // with a space separating run of a character class.  e.g. "iso8859-1"
 // becomes "iso 8859 1"
 static QString lettersAndNumbers( const char * input )

--- a/qtools/qtl.doc
+++ b/qtools/qtl.doc
@@ -38,7 +38,7 @@
 
 \title Qt Template library
 
-Thq Qt Template Library is a set of templates within Qt dealing with
+The Qt Template Library is a set of templates within Qt dealing with
 containers of objects.  It provides a list of objects, a stack of
 objects, a map (or dictionary) from one type to another, and
 associated iterators and algorithms.

--- a/qtools/qvaluelist.doc
+++ b/qtools/qvaluelist.doc
@@ -615,12 +615,12 @@
 
 /*!
   \fn T& QValueListIterator::operator*()
-  Asterix operator. Returns a reference to the current iterator item.
+  Asterisk operator. Returns a reference to the current iterator item.
 */
 
 /*!
   \fn const T& QValueListIterator::operator*() const
-  Asterix operator. Returns a reference to the current iterator item.
+  Asterisk operator. Returns a reference to the current iterator item.
 */
 
 /*!
@@ -726,7 +726,7 @@
 
 /*!
   \fn const T& QValueListConstIterator::operator*() const
-  Asterix operator. Returns a reference to the current iterator item.
+  Asterisk operator. Returns a reference to the current iterator item.
 */
 
 /*!

--- a/qtools/qxml.cpp
+++ b/qtools/qxml.cpp
@@ -778,7 +778,7 @@ void QXmlInputSource::setData( const QString& dat )
 }
 
 /*!
-  Read the XML file from the byte array; try to recoginize the encoding.
+  Read the XML file from the byte array; try to recognize the encoding.
 */
 // ### The input source should not do the encoding detection!
 void QXmlInputSource::readInput( QByteArray& rawData )
@@ -1895,7 +1895,7 @@ private:
   <a href="xml-sax.html#quickStart">Quick start</a>.
 */
 
-//guaranteed not to be a characater
+//guaranteed not to be a character
 const QChar QXmlSimpleReader::QEOF = QChar((ushort)0xffff);
 
 /*!
@@ -2609,7 +2609,7 @@ bool QXmlSimpleReader::parseElementAttribute( QString &prefix, QString &uri, QSt
 		}
 	    }
 	} else {
-	    // no namespace delcaration
+	    // no namespace declaration
 	    d->namespaceSupport.processName( name(), TRUE, uri, lname );
 	    d->attList.qnameList.append( name() );
 	    d->attList.uriList.append( uri );
@@ -3036,7 +3036,7 @@ parseError:
   Precondition: the beginning '<' of the PI is already read and the head stand
   on the '?' of '<?'.
 
-  If this funktion was successful, the head-position is on the first
+  If this function was successful, the head-position is on the first
   character after the PI.
 */
 bool QXmlSimpleReader::parsePI( bool xmldecl )
@@ -3258,7 +3258,7 @@ parseError:
   Precondition: the beginning '<!' of the doctype is already read the head
   stands on the 'D' of '<!DOCTYPE'.
 
-  If this funktion was successful, the head-position is on the first
+  If this function was successful, the head-position is on the first
   character after the document type definition.
 */
 bool QXmlSimpleReader::parseDoctype()
@@ -3915,7 +3915,7 @@ bool QXmlSimpleReader::parseAttlistDecl()
 	{ -1,      Done,    Attdef,  Attdef,   Attdef,  Attdef,  Attdef,  Attdef  }, // Ws1
 	{ Ws2,     -1,      -1,      -1,       -1,      -1,      -1,      -1      }, // Attdef
 	{ -1,      Atttype, Atttype, Atttype,  Atttype, Atttype, Atttype, Atttype }, // Ws2
-	{ Ws3,     -1,      -1,      -1,       -1,      -1,      -1,      -1      }, // Attype
+	{ Ws3,     -1,      -1,      -1,       -1,      -1,      -1,      -1      }, // Atttype
 	{ -1,      Attval,  DDecH,   Attval,   Attval,  Attval,  Attval,  Attval  }, // Ws3
 	{ -1,      -1,      -1,      -1,       DefImp,  DefFix,  DefReq,  -1      }, // DDecH
 	{ Ws4,     Ws4,     -1,      -1,       -1,      -1,      -1,      -1      }, // DefReq
@@ -5291,7 +5291,7 @@ parseError:
   Precondition: the beginning '<!' of the comment is already read and the head
   stands on the first '-' of '<!--'.
 
-  If this funktion was successful, the head-position is on the first
+  If this function was successful, the head-position is on the first
   character after the comment.
 */
 bool QXmlSimpleReader::parseComment()


### PR DESCRIPTION
Spelling corrections as found by codespell and in #561.

Some reported problems were already fixed, others are fixed here.