### PR TITLE
Simple no spam email address

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -345,6 +345,7 @@ CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
 CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]
 CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*"\""
 MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z_A-Z0-9\-]+
+MAILADR2  {BLANK}*[a-z_A-Z0-9+-]+({BLANK}*[Dd][Oo][Tt]{BLANK}*[a-z_A-Z0-9+-]+)?{BLANK}*[Aa][Tt]{BLANK}*[a-z_A-Z0-9-]+({BLANK}*[Dd][Oo][Tt]{BLANK}*[a-z_A-Z0-9\-]+)+{BLANK}*[a-z_A-Z0-9\-]+{BLANK}*
 OPTSTARS  ("//"{BLANK}*)?"*"*{BLANK}*
 LISTITEM  {BLANK}*[-]("#")?{WS}
 MLISTITEM {BLANK}*[+*]{WS}
@@ -654,6 +655,10 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                          g_token->name.stripPrefix("mailto:");
 			 g_token->isEMailAddr=TRUE;
 			 return TK_URL;
+                       }
+<St_Para>"<"{MAILADR2}">" { // anti spame mail address
+                         g_token->name=yytext;
+			 return TK_WORD;
                        }
 <St_Para>"$"{ID}":"[^:\n$][^\n$]*"$" { /* RCS tag */
                          QCString tagName(yytext+1);


### PR DESCRIPTION
When having a simple no spam email address coded like:
```
/** \file
 * Big Unknown <big at none dot com>
 */
```
this results in the warning:
```
aa.c:2: warning: Unsupported xml/html tag <big> found
```
and in the HTML output it looks like:
```
Big Unknown <big at="" none="" dot="" com=""> 
```
instead of:
```
Big Unknown <big at none dot com>
```

(Found in a couple of open source projects).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3810537/example.tar.gz)
