### PR TITLE
Better warning in case of `@form`

### DIFF
--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -55,7 +55,7 @@ CommandMap cmdMap[] =
   { "endverbatim",   CMD_ENDVERBATIM },
   { "endxmlonly",    CMD_ENDXMLONLY },
   { "exception",     CMD_EXCEPTION },
-  { "form",          CMD_FORMULA },
+  { "_fakeform",     CMD_FORMULA },
   { "htmlinclude",   CMD_HTMLINCLUDE },
   { "htmlonly",      CMD_HTMLONLY },
   { "image",         CMD_IMAGE },

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -622,12 +622,12 @@ static QCString addFormula()
     f = new Formula(fText);
     Doxygen::formulaList->append(f);
     Doxygen::formulaDict->insert(fText,f);
-    formLabel.sprintf("\\form#%d",f->getId());
+    formLabel.sprintf("\\_fakeform#%d",f->getId());
     Doxygen::formulaNameDict->insert(formLabel,f);
   }
   else
   {
-    formLabel.sprintf("\\form#%d",f->getId());
+    formLabel.sprintf("\\_fakeform#%d",f->getId());
   }
   int i;
   for (i=0;i<formulaNewLines;i++) formLabel+="@_fakenl"; // add fake newlines to

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2207,7 +2207,7 @@ DocFormula::DocFormula(DocNode *parent,int id) :
 {
   m_parent = parent; 
   QCString formCmd;
-  formCmd.sprintf("\\form#%d",id);
+  formCmd.sprintf("\\_fakeform#%d",id);
   Formula *formula=Doxygen::formulaNameDict->find(formCmd);
   if (formula)
   {
@@ -2215,7 +2215,7 @@ DocFormula::DocFormula(DocNode *parent,int id) :
     m_name.sprintf("form_%d",m_id);
     m_text = formula->getFormulaText();
   }
-  else // wrong \form#<n> command
+  else // wrong \_fakeform#<n> command
   {
     warn_doc_error(g_fileName,doctokenizerYYlineno,"Wrong formula id %d",id);
     m_id = -1;

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -363,7 +363,7 @@ LINKMASK  [^ \t\n\r\\@<&${}]+("("[^\n)]*")")?({BLANK}*("const"|"volatile"){BLANK
 VERBATIM  "verbatim"{BLANK}*
 SPCMD1    {CMD}([a-z_A-Z][a-z_A-Z0-9]*|{VERBATIM}|"--"|"---")
 SPCMD2    {CMD}[\\@<>&$#%~".+=|-]
-SPCMD3    {CMD}form#[0-9]+
+SPCMD3    {CMD}_fakeform#[0-9]+
 SPCMD4    {CMD}"::"
 SPCMD5    {CMD}":"
 INOUT	  "inout"|"in"|"out"|("in"{BLANK}*","{BLANK}*"out")|("out"{BLANK}*","{BLANK}*"in")
@@ -578,9 +578,9 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                              yylineno++; 
   		          }
 <St_Para>{SPCMD3}      {
-  			 g_token->name = "form";
+  			 g_token->name = "_fakeform";
 			 bool ok;
-			 g_token->id = QCString(yytext).right((int)yyleng-6).toInt(&ok);
+			 g_token->id = QCString(yytext).right((int)yyleng-11).toInt(&ok);
 			 ASSERT(ok);
 			 return TK_COMMAND_SEL();
   		       }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9824,7 +9824,7 @@ void readFormulaRepository(QCString dir, bool cmp)
             exit(1);
           }
           QCString formLabel;
-          formLabel.sprintf("\\form#%d",f->getId());
+          formLabel.sprintf("\\_fakeform#%d",f->getId());
           if (formLabel != formName)
           {
             err("discrepancy between formula repositories! Remove "

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -317,7 +317,7 @@ void FormulaList::generateBitmaps(const char *path)
     FTextStream t(&f);
     for (fli.toFirst();(formula=fli.current());++fli)
     {
-      t << "\\form#" << formula->getId() << ":" << formula->getFormulaText() << endl;
+      t << "\\_fakeform#" << formula->getId() << ":" << formula->getFormulaText() << endl;
     }
     f.close();
   }


### PR DESCRIPTION
When having a problem like:
```
/** \file */

/**
 * The fie
 *
 * @form: the new format
 * @content: the content of the form
 *
 * Sets @form content to be @content.
 *
 * \f$ \alpha \f$ \f[ \beta \f]
 */
void fie(char *form, char *content);
```
we get warnings like:
```
.../aa.h:5: warning: Wrong formula id -1
.../aa.h:6: warning: Found unknown command '\content'
.../aa.h:8: warning: Wrong formula id -1
.../aa.h:8: warning: Found unknown command '\content'
```

The `@form:` is in RST analogue to the doxygen `@param form` but not understood by doxygen.
The result is that it is seen as a formula as doxygen translates the formula commands to `\form`.
`@content` is handled properly as this is not a doxygen command.

In this patch a more unique name is chosen so these type of conflicts don't appear (that easy). The resulting, better, warnings are now:
```
.../aa.h:5: warning: Found unknown command '\form'
.../aa.h:6: warning: Found unknown command '\content'
.../aa.h:8: warning: Found unknown command '\form'
.../aa.h:8: warning: Found unknown command '\content'
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3814659/example.tar.gz)
