### PR TITLE
feature: HTML_HEADING_ANCHOR

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1773,6 +1773,15 @@ to disable this feature.
 ]]>
       </docs>
     </option>
+    <option type='string' id='HTML_HEADING_ANCHOR' format='string' defval='' depends='GENERATE_HTML'>
+      <docs>
+<![CDATA[
+ The \c HTML_HEADING_ANCHOR entry specifies the (encoded) anchor character to
+ use before all headings so that they provide a clickable anchor.
+ You can use encoded characters here, e.g. `&#128279;` for printing the link symbol emoji.
+]]>
+      </docs>
+    </option>
     <option type='string' id='HTML_FILE_EXTENSION' format='string' defval='.html' depends='GENERATE_HTML'>
       <docs>
 <![CDATA[

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -281,6 +281,7 @@ HtmlDocVisitor::HtmlDocVisitor(FTextStream &t,CodeOutputInterface &ci,
                                  m_hide(FALSE), m_ctx(ctx)
 {
   if (ctx) m_langExt=ctx->getDefFileExtension();
+  m_anchorHtml = Config_getString(HTML_HEADING_ANCHOR);
 }
 
   //--------------------------------------
@@ -1439,9 +1440,19 @@ void HtmlDocVisitor::visitPre(DocSection *s)
   if (m_hide) return;
   forceEndParagraph(s);
   m_t << "<h" << s->level() << getDirHtmlClassOfNode(getTextDirByConfig(s->title())) << ">";
-  m_t << "<a class=\"anchor\" id=\"" << s->anchor();
-  m_t << "\"></a>" << endl;
-  filter(convertCharEntitiesToUTF8(s->title().data()));
+  if( m_anchorHtml.length() )
+  {
+    m_t << "<span class=\"permalink\">";
+    m_t << "<a class=\"anchor\" id=\"" << s->anchor();
+    m_t << "\" href=\"#" << s->anchor();
+    m_t << "\">" << m_anchorHtml.data() << "</a></span>" << endl;
+  }
+  else
+  {
+    m_t << "<a class=\"anchor\" id=\"" << s->anchor();
+    m_t << "\"></a>" << endl;
+  }
+  m_t << convertCharEntitiesToUTF8(s->title().data()) << endl;
   m_t << "</h" << s->level() << ">\n";
 }
 

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -171,6 +171,7 @@ class HtmlDocVisitor : public DocVisitor
     QStack<bool> m_enabled;
     const Definition *m_ctx;
     QCString m_langExt;
+    QCString m_anchorHtml;
 };
 
 #endif


### PR DESCRIPTION
`HTML_HEADING_ANCHOR` lets you specify a text (or HTML code) that is inserted before all headings in order to produce clickable anchors for the headings.

Helpful if you want to share links to your docs: without this enhancement, you need to open the browser debugger, look up your heading in the HTML, copy the heading ID and create your URL manually.

With this, you get a clickable anchor right next to your heading that is configurable. Example for setting `HTML_HEADING_ANCHOR` to `&#128279;` (https://emojipedia.org/link-symbol/):

![image](https://user-images.githubusercontent.com/32699439/68485195-1ebb2d80-023f-11ea-9ccd-fce438de6f65.png)
