### PR TITLE
Bug 163640 - Want INCLUDE_GRAPH_DEPTH configuration option

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -116,6 +116,8 @@ documentation:
 \refitem cmdhiderefs \\hiderefs
 \refitem cmdhideinitializer \\hideinitializer
 \refitem cmdhtmlinclude \\htmlinclude
+\refitem cmdhideincludedbygraph \\hideincludedbygraph
+\refitem cmdhideincludegraph \\hideincludegraph
 \refitem cmdhtmlonly \\htmlonly
 \refitem cmdidlexcept \\idlexcept 
 \refitem cmdif \\if
@@ -123,7 +125,9 @@ documentation:
 \refitem cmdimage \\image
 \refitem cmdimplements \\implements
 \refitem cmdinclude \\include
+\refitem cmdincludedbygraph \\includedbygraph
 \refitem cmdincludedoc \\includedoc
+\refitem cmdincludegraph \\includegraph
 \refitem cmdincludelineno \\includelineno
 \refitem cmdingroup \\ingroup
 \refitem cmdinternal \\internal
@@ -278,7 +282,7 @@ Structural indicators
   \ref cmdweakgroup "\\weakgroup".
 
 <hr>
-\section cmdcallgraph \\callgraph
+\section cmdcallgraph \\callgraph['{'[option:value][,option:value]*'}']
 
   \addindex \\callgraph
   When this command is put in a comment block of a function or method
@@ -286,20 +290,29 @@ Structural indicators
   generate a call graph for that function (provided the implementation of the
   function or method calls other documented functions). The call graph will be
   generated regardless of the value of \ref cfg_call_graph "CALL_GRAPH".
+  The maximum number of nodes in the graph can be steered by means of 
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and the depth of the graph by means
+  of \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH". The graph can be refined
+  or extended by means of the `options` `maxnodes` and `maxdepth` in case of a
+  positive value that value is used otherwise the value from
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and
+  \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH" are taken.
   \note The completeness (and correctness) of the call graph depends on the
   doxygen code parser which is not perfect.
 
   \sa section \ref cmdcallergraph "\\callergraph",
       section \ref cmdhidecallgraph "\\hidecallgraph",
-      section \ref cmdhidecallergraph "\\hidecallergraph" and
-      option \ref cfg_call_graph "CALL_GRAPH"
+      section \ref cmdhidecallergraph "\\hidecallergraph",
+      option \ref cfg_call_graph "CALL_GRAPH",
+      option \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES and
+      option \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH"
 
 <hr>
 \section cmdhidecallgraph \\hidecallgraph
 
   \addindex \\hidecallgraph
   When this command is put in a comment block of a function or method
-  and then doxygen will not generate a call graph for that function. The
+  then doxygen will not generate a call graph for that function. The
   call graph will not be generated regardless of the value of
   \ref cfg_call_graph "CALL_GRAPH".
   \note The completeness (and correctness) of the call graph depends on the
@@ -311,7 +324,7 @@ Structural indicators
       option \ref cfg_call_graph "CALL_GRAPH"
 
 <hr>
-\section cmdcallergraph \\callergraph
+\section cmdcallergraph \\callergraph['{'[option:value][,option:value]*'}']
 
   \addindex \\callergraph
   When this command is put in a comment block of a function or method
@@ -319,20 +332,29 @@ Structural indicators
   generate a caller graph for that function (provided the implementation of the
   function or method is called by other documented functions). The caller graph will be
   generated regardless of the value of \ref cfg_caller_graph "CALLER_GRAPH".
+  The maximum number of nodes in the graph can be steered by means of 
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and the depth of the graph by means
+  of \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH". The graph can be refined
+  or extended by means of the `options` `maxnodes` and `maxdepth` in case of a
+  positive value that value is used otherwise the value from
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and
+  \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH" are taken.
   \note The completeness (and correctness) of the caller graph depends on the
   doxygen code parser which is not perfect.
 
   \sa section \ref cmdcallgraph "\\callgraph",
       section \ref cmdhidecallgraph "\\hidecallgraph",
-      section \ref cmdhidecallergraph "\\hidecallergraph" and
-      option \ref cfg_caller_graph "CALLER_GRAPH"
+      section \ref cmdhidecallergraph "\\hidecallergraph",
+      option \ref cfg_caller_graph "CALLER_GRAPH",
+      option \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES and
+      option \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH"
 
 <hr>
 \section cmdhidecallergraph \\hidecallergraph
 
   \addindex \\hidecallergraph
   When this command is put in a comment block of a function or method
-  and then doxygen will not generate a caller graph for that function. The
+  then doxygen will not generate a caller graph for that function. The
   caller graph will not be generated regardless of the value of
   \ref cfg_caller_graph "CALLER_GRAPH".
   \note The completeness (and correctness) of the caller graph depends on the
@@ -342,6 +364,88 @@ Structural indicators
       section \ref cmdcallgraph "\\callgraph",
       section \ref cmdhidecallgraph "\\hidecallgraph" and
       option \ref cfg_caller_graph "CALLER_GRAPH"
+
+<hr>
+\section cmdincludegraph \\includegraph['{'[option:value][,option:value]*'}']
+
+  \addindex \\includegraph
+  When this command is put in a comment block of a file
+  and \ref cfg_have_dot "HAVE_DOT" is set to \c YES, then doxygen will
+  generate a include graph for that file. The include graph will be
+  generated regardless of the value of \ref cfg_include_graph "INCLUDE_GRAPH".
+  The maximum number of nodes in the graph can be steered by means of 
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and the depth of the graph by means
+  of \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH". The graph can be refined
+  or extended by means of the `options` `maxnodes` and `maxdepth` in case of a
+  positive value that value is used otherwise the value from
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and
+  \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH" are taken.
+  \note The completeness (and correctness) of the include graph depends on the
+  doxygen code parser which is not perfect.
+
+  \sa section \ref cmdincludedbygraph "\\includedbygraph",
+      section \ref cmdhideincludegraph "\\hideincludegraph",
+      section \ref cmdhideincludedbygraph "\\hideincludedbygraph",
+      option \ref cfg_include_graph "INCLUDE_GRAPH",
+      option \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES and
+      option \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH"
+
+<hr>
+\section cmdhideincludegraph \\hideincludegraph
+
+  \addindex \\hideincludegraph
+  When this command is put in a comment block of a file
+  then doxygen will not generate a include graph for that file. The
+  include graph will not be generated regardless of the value of
+  \ref cfg_include_graph "INCLUDE_GRAPH".
+  \note The completeness (and correctness) of the include graph depends on the
+  doxygen code parser which is not perfect.
+
+  \sa section \ref cmdincludedbygraph "\\includedbygraph",
+      section \ref cmdincludegraph "\\includegraph",
+      section \ref cmdhideincludedbygraph "\\hideincludedbygraph" and
+      option \ref cfg_include_graph "INCLUDE_GRAPH"
+
+<hr>
+\section cmdincludedbygraph \\includedbygraph['{'[option:value][,option:value]*'}']
+
+  \addindex \\includedbygraph
+  When this command is put in a comment block of a file
+  and \ref cfg_have_dot "HAVE_DOT" is set to \c YES, then doxygen will
+  generate a included by graph for that file. The included by graph will be
+  generated regardless of the value of \ref cfg_included_by_graph "INCLUDED_BY_GRAPH".
+  The maximum number of nodes in the graph can be steered by means of 
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and the depth of the graph by means
+  of \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH". The graph can be refined
+  or extended by means of the `options` `maxnodes` and `maxdepth` in case of a
+  positive value that value is used otherwise the value from
+  \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES" and
+  \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH" are taken.
+  \note The completeness (and correctness) of the included by graph depends on the
+  doxygen code parser which is not perfect.
+
+  \sa section \ref cmdincludegraph "\\includegraph",
+      section \ref cmdhideincludegraph "\\hideincludegraph",
+      section \ref cmdhideincludedbygraph "\\hideincludedbygraph",
+      option \ref cfg_included_by_graph "INCLUDED_BY_GRAPH",
+      option \ref cfg_dot_graph_max_nodes "DOT_GRAPH_MAX_NODES and
+      option \ref cfg_max_dot_graph_depth "MAX_DOT_GRAPH_DEPTH"
+
+<hr>
+\section cmdhideincludedbygraph \\hideincludedbygraph
+
+  \addindex \\hideincludedbygraph
+  When this command is put in a comment block of a file
+  then doxygen will not generate a included by graph for that function. The
+  included by graph will not be generated regardless of the value of
+  \ref cfg_included_by_graph "INCLUDED_BY_GRAPH".
+  \note The completeness (and correctness) of the included by graph depends on the
+  doxygen code parser which is not perfect.
+
+  \sa section \ref cmdincludedbygraph "\\includedbygraph",
+      section \ref cmdincludegraph "\\includegraph",
+      section \ref cmdhideincludegraph "\\hideincludegraph" and
+      option \ref cfg_included_by_graph "INCLUDED_BY_GRAPH"
 
 <hr>
 \section cmdshowrefby \\showrefby

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2676,6 +2676,7 @@ void ClassDefImpl::writeDocumentationContents(OutputList &ol,const QCString & /*
   LayoutDocEntry *lde;
   for (eli.toFirst();(lde=eli.current());++eli)
   {
+    if (!((LayoutDocEntry *)lde)->isVisible()) continue;
     switch (lde->kind())
     {
       case LayoutDocEntry::BriefDesc:

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -108,6 +108,10 @@ static bool handleCallgraph(const QCString &, const QCStringList &);
 static bool handleHideCallgraph(const QCString &, const QCStringList &);
 static bool handleCallergraph(const QCString &, const QCStringList &);
 static bool handleHideCallergraph(const QCString &, const QCStringList &);
+static bool handleIncludegraph(const QCString &, const QCStringList &);
+static bool handleHideIncludegraph(const QCString &, const QCStringList &);
+static bool handleIncludedBygraph(const QCString &, const QCStringList &);
+static bool handleHideIncludedBygraph(const QCString &, const QCStringList &);
 static bool handleReferencedByRelation(const QCString &, const QCStringList &);
 static bool handleHideReferencedByRelation(const QCString &, const QCStringList &);
 static bool handleReferencesRelation(const QCString &, const QCStringList &);
@@ -221,6 +225,10 @@ static DocCmdMap docCmdMap[] =
   { "hidecallgraph",   &handleHideCallgraph,    FALSE },
   { "callergraph",     &handleCallergraph,      FALSE },
   { "hidecallergraph", &handleHideCallergraph,  FALSE },
+  { "includegraph",    &handleIncludegraph,     FALSE },
+  { "hideincludegraph",&handleHideIncludegraph, FALSE },
+  { "includedbygraph", &handleIncludedBygraph,  FALSE },
+  { "hideincludedbygraph", &handleHideIncludedBygraph,  FALSE },
   { "showrefby",       &handleReferencedByRelation,     FALSE },
   { "hiderefby",       &handleHideReferencedByRelation, FALSE },
   { "showrefs",        &handleReferencesRelation,       FALSE },
@@ -2847,27 +2855,101 @@ static bool handleHideInitializer(const QCString &, const QCStringList &)
   return FALSE;
 }
 
-static bool handleCallgraph(const QCString &, const QCStringList &)
+static void handleGraphSettings(const QCString &cmd, const QCStringList &optList, graphSettings &gs)
 {
-  current->callGraph = TRUE; // ON
+  static int max_dot_graph_depth = Config_getInt(MAX_DOT_GRAPH_DEPTH);
+  static int dot_graph_max_nodes = Config_getInt(DOT_GRAPH_MAX_NODES);
+  QCStringList::ConstIterator it;
+  for ( it = optList.begin(); it != optList.end(); ++it )
+  {
+    QCString opt = (*it).stripWhiteSpace().lower();
+    char dum;
+    int val;
+    int i = opt.find(':');
+    if (i>0)  // found ':' but not on position 0 what would mean just a value
+    {
+      if (sscanf(opt.right(opt.length() - i - 1).data(),"%d%c",&val,&dum) != 1)
+      {
+        warn(yyFileName,yyLineNr,"Unknown option:value specified with '\\%s': '%s'", qPrint(cmd),(*it).stripWhiteSpace().data());
+        opt = "";
+      }
+      else
+      {
+        opt = opt.left(i).stripWhiteSpace();
+        if (opt == "maxdepth")
+        {
+          if (val <= 0)  gs.maxDepth=max_dot_graph_depth;
+          else gs.maxDepth=val;
+        }
+        else if (opt == "maxnodes")
+        {
+          if (val <= 0)  gs.maxNodes=dot_graph_max_nodes;
+          else gs.maxNodes=val;
+        }
+        else
+        {
+          warn(yyFileName,yyLineNr,"Unknown option specified with '\\%s': '%s'", qPrint(cmd),(*it).stripWhiteSpace().data());
+        }
+      }
+    }
+    else
+    {
+      warn(yyFileName,yyLineNr,"No option specified with '\\%s': '%s'", qPrint(cmd),(*it).stripWhiteSpace().data());
+    }
+  }
+  gs.isExplicit = TRUE;
+  gs.hasGraph = TRUE; // ON
+}
+
+static bool handleCallgraph(const QCString &cmd, const QCStringList &optList)
+{
+  handleGraphSettings(cmd, optList, current->callGraph);
   return FALSE;
 }
 
 static bool handleHideCallgraph(const QCString &, const QCStringList &)
 {
-  current->callGraph = FALSE; // OFF
+  current->callGraph.isExplicit = TRUE;
+  current->callGraph.hasGraph = FALSE; // OFF
   return FALSE;
 }
 
-static bool handleCallergraph(const QCString &, const QCStringList &)
+static bool handleCallergraph(const QCString &cmd, const QCStringList &optList)
 {
-  current->callerGraph = TRUE; // ON
+  handleGraphSettings(cmd, optList, current->callerGraph);
   return FALSE;
 }
 
 static bool handleHideCallergraph(const QCString &, const QCStringList &)
 {
-  current->callerGraph = FALSE; // OFF
+  current->callerGraph.isExplicit = TRUE;
+  current->callerGraph.hasGraph = FALSE; // OFF
+  return FALSE;
+}
+
+static bool handleIncludegraph(const QCString &cmd, const QCStringList &optList)
+{
+  handleGraphSettings(cmd, optList, current->includeGraph);
+  return FALSE;
+}
+
+static bool handleHideIncludegraph(const QCString &, const QCStringList &)
+{
+  current->includeGraph.isExplicit = TRUE;
+  current->includeGraph.hasGraph = FALSE; // OFF
+  return FALSE;
+}
+
+static bool handleIncludedBygraph(const QCString &cmd, const QCStringList &optList)
+{
+  handleGraphSettings(cmd, optList, current->includedByGraph);
+  return FALSE;
+}
+
+static bool handleHideIncludedBygraph(const QCString &, const QCStringList &)
+{
+  current->includedByGraph.isExplicit = TRUE;
+  current->includedByGraph.hasGraph = FALSE; // OFF
   return FALSE;
 }
 

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -527,6 +527,7 @@ void DirDefImpl::writeDocumentation(OutputList &ol)
   LayoutDocEntry *lde;
   for (eli.toFirst();(lde=eli.current());++eli)
   {
+    if (!((LayoutDocEntry *)lde)->isVisible()) continue;
     switch (lde->kind())
     {
       case LayoutDocEntry::BriefDesc: 

--- a/src/dotcallgraph.h
+++ b/src/dotcallgraph.h
@@ -45,6 +45,8 @@ class DotCallGraph : public DotGraph
     DotNode        *m_startNode;
     QDict<DotNode> *m_usedNodes;
     bool            m_inverse;
+    int             m_maxDepth;
+    int             m_maxNodes;
     QCString        m_diskName;
     const Definition * m_scope;
 };

--- a/src/dotincldepgraph.h
+++ b/src/dotincldepgraph.h
@@ -51,6 +51,8 @@ class DotInclDepGraph : public DotGraph
     QCString        m_inclDepFileName;
     QCString        m_inclByDepFileName;
     bool            m_inverse;
+    int             m_maxDepth;
+    int             m_maxNodes;
 };
 
 #endif

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -758,6 +758,8 @@ static void buildFileList(const Entry *root)
       fd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
       fd->addSectionsToDefinition(root->anchors);
       fd->setRefItems(root->sli);
+      fd->enableIncludeGraph(root->includeGraph);
+      fd->enableIncludedByGraph(root->includedByGraph);
       for (const Grouping &g : root->groups)
       {
         GroupDef *gd=0;
@@ -3633,8 +3635,9 @@ static void buildFunctionList(const Entry *root)
 
                   md->addSectionsToDefinition(root->anchors);
 
-                  md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-                  md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
+                  md->enableCallGraph(root->callGraph);
+                  md->enableCallerGraph(root->callerGraph);
+
                   md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
                   md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
 
@@ -3900,13 +3903,15 @@ static void findFriends()
             }
             mmd->setDocsForDefinition(fmd->isDocsForDefinition());
 
-            mmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
-            mmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
+            mmd->enableCallGraph(fmd->callGraph());
+            fmd->enableCallGraph(mmd->callGraph());
+
+            mmd->enableCallerGraph(fmd->callerGraph());
+            fmd->enableCallerGraph(mmd->callerGraph());
+
             mmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
             mmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
 
-            fmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
-            fmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
             fmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
             fmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
           }
@@ -5332,8 +5337,9 @@ static void addMemberDocs(const Entry *root,
     md->setRefItems(root->sli);
   }
 
-  md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-  md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
+  md->enableCallGraph(root->callGraph);
+  md->enableCallerGraph(root->callerGraph);
+
   md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
   md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
 

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -24,6 +24,7 @@
 #include "doxygen.h"
 #include "arguments.h"
 #include "config.h"
+#include "layout.h"
 //------------------------------------------------------------------
 
 #define HEADER ('D'<<24)+('O'<<16)+('X'<<8)+'!'
@@ -67,6 +68,8 @@ Entry::Entry(const Entry &e)
   subGrouping = e.subGrouping;
   callGraph   = e.callGraph;
   callerGraph = e.callerGraph;
+  includeGraph   = e.includeGraph;
+  includedByGraph = e.includedByGraph;
   referencedByRelation = e.referencedByRelation;
   referencesRelation   = e.referencesRelation;
   virt        = e.virt;
@@ -199,6 +202,12 @@ void Entry::reset()
 {
   static bool entryCallGraph   = Config_getBool(CALL_GRAPH);
   static bool entryCallerGraph = Config_getBool(CALLER_GRAPH);
+  static bool entryIncludeGraph            = LayoutDocManager::instance().isVisible(LayoutDocManager::File,LayoutDocEntry::FileIncludeGraph);
+  static bool entryIncludedByGraph         = LayoutDocManager::instance().isVisible(LayoutDocManager::File,LayoutDocEntry::FileIncludedByGraph);
+  static int  entryIncludeGraphMaxDepth    = Config_getBool(MAX_DOT_GRAPH_DEPTH);
+  static int  entryIncludedByGraphMaxDepth = Config_getBool(MAX_DOT_GRAPH_DEPTH);
+  static int  entryIncludeGraphMaxNodes    = Config_getBool(DOT_GRAPH_MAX_NODES);
+  static int  entryIncludedByGraphMaxNodes = Config_getBool(DOT_GRAPH_MAX_NODES);
   static bool entryReferencedByRelation = Config_getBool(REFERENCED_BY_RELATION);
   static bool entryReferencesRelation   = Config_getBool(REFERENCES_RELATION);
   //printf("Entry::reset()\n");
@@ -230,8 +239,22 @@ void Entry::reset()
   bodyLine = -1;
   endBodyLine = -1;
   mGrpId = -1;
-  callGraph   = entryCallGraph;
-  callerGraph = entryCallerGraph;
+  callGraph.isExplicit = false;
+  callGraph.hasGraph   = entryCallGraph;
+  callGraph.maxDepth   = -1;
+  callGraph.maxNodes   = -1;
+  callerGraph.isExplicit = false;
+  callerGraph.hasGraph   = entryCallerGraph;
+  callerGraph.maxDepth   = -1;
+  callerGraph.maxNodes   = -1;
+  includeGraph.isExplicit = false;
+  includeGraph.hasGraph   = entryIncludeGraph;
+  includeGraph.maxDepth   = entryIncludeGraphMaxDepth;
+  includeGraph.maxNodes   = entryIncludeGraphMaxNodes;
+  includedByGraph.isExplicit = false;
+  includedByGraph.hasGraph   = entryIncludedByGraph;
+  includedByGraph.maxDepth   = entryIncludedByGraphMaxDepth;
+  includedByGraph.maxNodes   = entryIncludedByGraphMaxNodes;
   referencedByRelation = entryReferencedByRelation;
   referencesRelation   = entryReferencesRelation;
   section = EMPTY_SEC;

--- a/src/entry.h
+++ b/src/entry.h
@@ -254,8 +254,10 @@ class Entry
     bool explicitExternal;    //!< explicitly defined as external?
     bool proto;               //!< prototype ?
     bool subGrouping;         //!< automatically group class members?
-    bool callGraph;           //!< do we need to draw the call graph?
-    bool callerGraph;         //!< do we need to draw the caller graph?
+    graphSettings callGraph;       //!< settings for the call graph
+    graphSettings callerGraph;     //!< settings for the caller graph
+    graphSettings includeGraph;    //!< settings for the include graph
+    graphSettings includedByGraph; //!< settings for the included by graph
     bool referencedByRelation;//!< do we need to show the referenced by relation?
     bool referencesRelation;  //!< do we need to show the references relation?
     Specifier    virt;        //!< virtualness of the entry

--- a/src/filedef.h
+++ b/src/filedef.h
@@ -182,6 +182,15 @@ class FileDef : virtual public Definition
 
     virtual void setVisited(bool v) = 0;
     virtual bool isVisited() const = 0;
+
+    virtual void enableIncludeGraph(graphSettings gs) = 0;
+    virtual void enableIncludedByGraph(graphSettings gs) = 0;
+    virtual bool hasIncludeGraph() const = 0;
+    virtual int maxIncludeGraphDepth() const = 0;
+    virtual int maxIncludeGraphNodes() const = 0;
+    virtual bool hasIncludedByGraph() const = 0;
+    virtual int maxIncludedByGraphDepth() const = 0;
+    virtual int maxIncludedByGraphNodes() const = 0;
 };
 
 FileDef *createFileDef(const char *p,const char *n,const char *ref=0,const char *dn=0);

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1267,6 +1267,7 @@ void GroupDefImpl::writeDocumentation(OutputList &ol)
   LayoutDocEntry *lde;
   for (eli.toFirst();(lde=eli.current());++eli)
   {
+    if (!((LayoutDocEntry *)lde)->isVisible()) continue;
     switch (lde->kind())
     {
       case LayoutDocEntry::BriefDesc: 

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -890,10 +890,10 @@ class LayoutParser : public QXmlDefaultHandler
     void startSimpleEntry(LayoutDocEntry::Kind k,const QXmlAttributes &attrib)
     {
       bool isVisible = elemIsVisible(attrib);
-      if (m_part!=-1 && isVisible)
+      if (m_part!=-1 && (isVisible || k == LayoutDocEntry::FileIncludeGraph || k == LayoutDocEntry::FileIncludedByGraph))
       {
         LayoutDocManager::instance().addEntry((LayoutDocManager::LayoutPart)m_part,
-                                              new LayoutDocEntrySimple(k));
+                                              new LayoutDocEntrySimple(k,isVisible));
       }
     }
 
@@ -1523,6 +1523,16 @@ const QList<LayoutDocEntry> &LayoutDocManager::docEntries(LayoutDocManager::Layo
   return d->docEntries[(int)part];
 }
 
+bool LayoutDocManager::isVisible(LayoutPart part, LayoutDocEntry::Kind kind)
+{
+  QListIterator<LayoutDocEntry> eli(docEntries(part));
+  LayoutDocEntry *lde;
+  for (eli.toFirst();(lde=eli.current());++eli)
+  {
+    if (lde->kind() == kind) return ((LayoutDocEntry *)lde)->isVisible();
+  }
+  return false;
+}
 LayoutNavEntry* LayoutDocManager::rootNavEntry() const
 {
   return d->rootNav;

--- a/src/layout.h
+++ b/src/layout.h
@@ -65,16 +65,19 @@ struct LayoutDocEntry
 
             };
   virtual Kind kind() const = 0;
+  virtual bool isVisible() const { return true; }
 };
 
 /** @brief Represents of a piece of a documentation page without configurable parts */
 struct LayoutDocEntrySimple : LayoutDocEntry
 {
   public:
-    LayoutDocEntrySimple(Kind k) : m_kind(k) {}
+    LayoutDocEntrySimple(Kind k, bool isVis = true) : m_kind(k), m_isVisible(isVis) {}
     Kind kind() const { return m_kind; }
+    bool isVisible() const { return m_isVisible; }
   private:
     Kind m_kind;
+    bool m_isVisible;
 };
 
 struct LayoutDocEntrySection: public LayoutDocEntrySimple
@@ -196,6 +199,7 @@ class LayoutDocManager
 
     /** Returns the list of LayoutDocEntry's in representation order for a given page identified by @a part. */
     const QList<LayoutDocEntry> &docEntries(LayoutPart part) const;
+    bool isVisible(LayoutPart part, LayoutDocEntry::Kind kind);
 
     /** returns the (invisible) root of the navigation tree. */
     LayoutNavEntry *rootNavEntry() const;

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -238,8 +238,14 @@ class MemberDef : virtual public Definition
     virtual MemberDef *fromAnonymousMember() const = 0;
 
     // callgraph related members
+    virtual graphSettings callGraph() const = 0;
     virtual bool hasCallGraph() const = 0;
+    virtual int maxCallGraphDepth() const = 0;
+    virtual int maxCallGraphNodes() const = 0;
+    virtual graphSettings callerGraph() const = 0;
     virtual bool hasCallerGraph() const = 0;
+    virtual int maxCallerGraphDepth() const = 0;
+    virtual int maxCallerGraphNodes() const = 0;
     virtual bool visibleMemberGroup(bool hideNoHeader) const = 0;
     // referenced related members
     virtual bool hasReferencesRelation() const = 0;
@@ -351,8 +357,8 @@ class MemberDef : virtual public Definition
     // anonymous scope members
     virtual void setFromAnonymousMember(MemberDef *m) = 0;
 
-    virtual void enableCallGraph(bool e) = 0;
-    virtual void enableCallerGraph(bool e) = 0;
+    virtual void enableCallGraph(graphSettings gs) = 0;
+    virtual void enableCallerGraph(graphSettings gs) = 0;
 
     virtual void enableReferencedByRelation(bool e) = 0;
     virtual void enableReferencesRelation(bool e) = 0;

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -995,6 +995,7 @@ void NamespaceDefImpl::writeDocumentation(OutputList &ol)
   LayoutDocEntry *lde;
   for (eli.toFirst();(lde=eli.current());++eli)
   {
+    if (!((LayoutDocEntry *)lde)->isVisible()) continue;
     switch (lde->kind())
     {
       case LayoutDocEntry::BriefDesc: 

--- a/src/types.h
+++ b/src/types.h
@@ -278,4 +278,12 @@ class LocalToc
     int m_level[numTocTypes];
 };
 
+struct graphSettings
+{
+    bool isExplicit; //!< are settings done explicitly?
+    bool hasGraph;   //!< do we need to draw the graph?
+    int  maxDepth;   //!< maximum depth of the graph
+    int  maxNodes;   //!< maximum number of nodes of graph
+};
+
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -9015,4 +9015,37 @@ int usedTableLevels()
 
 //------------------------------------------------------
 
+void mergeGraphSettings(QCString &nam,graphSettings &dst,graphSettings gs,char *cmdShow,char *cmdHide)
+{
+  if (!dst.isExplicit)
+  {
+    dst=gs;
+  }
+  else if (gs.isExplicit)
+  {
+    // both are explicit
+    if (dst.hasGraph != gs.hasGraph)
+    {
+      warn_uncond("'\\%s' and '\\%s' given for file '%s', using '\\%s'.\n",
+                  cmdShow,cmdHide,nam.data(),cmdShow);
+      if (gs.hasGraph) dst = gs;
+    }
+    else if (gs.hasGraph)
+    {
+      // both have hasGraph
+      if (dst.maxDepth != gs.maxDepth)
+      {
+        warn_uncond("Multile definitions of maximal depth with '\\%s' for file '%s', using maximum.\n",
+                    cmdShow,nam.data());
+        dst.maxDepth = QMAX(dst.maxDepth,gs.maxDepth);
+      }
+      if (dst.maxNodes != gs.maxNodes)
+      {
+        warn_uncond("Multile definitions of maximal number of nodes with '\\%s' for file '%s', using maximum.\n",
+                    cmdShow,nam.data());
+        dst.maxNodes = QMAX(dst.maxNodes,gs.maxNodes);
+      }
+    }
+  }
+}
 

--- a/src/util.h
+++ b/src/util.h
@@ -496,4 +496,5 @@ int usedTableLevels();
 void incUsedTableLevels();
 void decUsedTableLevels();
 
+void mergeGraphSettings(QCString &nam,graphSettings &dst,graphSettings gs,char *cmdShow,char *cmdHide);
 #endif


### PR DESCRIPTION
The request for a separate configuration option, from `MAX_DOT_GRAPH_DEPTH` and `DOT_GRAPH_MAX_NODES`, has not been fulfilled but based on the remarks about the functions / methods the commands `\callgraph` and `\callergraph` have been extended with the options `maxdepth` and `maxnodes`.
Analogous to the `\callgraph` `\hidecallgraph` the commands `\includegraph` `\hideincludegraph`, `\includedbygraph` and `\hideincludedbygraph` have been defined.

In case of usage multiple of the 'show' commands with the same name for an entity and confliction option values the maximum value is used (and a warning given).
In case the 'show' and 'hide' function are explicitly used for an entity also a warning is given.
In case an explicit command is given and the default is still valid (so non explicit command given) the explicit command values are taken.

The layout handling had to be extended slightly for the new commands as the entry regarding `includegraph` and `includedbygraph` not only is used to signal if a graph is visible but also the position in the output. Now we can have that generally no `includegrap` / `includedbygraph` is specified but that they are enabled by means of  `\includegraph` and `\includedbygraph`. in the old situation the layout element was not necessary but now we need the element to signal the right place (and hence need isVisible functionality also to set the proper default)