### PR TITLE
Fix line count after multiline close group

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2852,6 +2852,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <FindMembers,FindFields,ReadInitializer>"//"([!/]){B}*{CMD}"}".*|"/*"([!*]){B}*{CMD}"}"[^*]*"*/"	{
                                           bool insideEnum = YY_START==FindFields || (YY_START==ReadInitializer && lastInitializerContext==FindFields); // see bug746226
   					  Doxygen::docGroup.close(current.get(),yyFileName,yyLineNr,insideEnum);
+  					  lineCount();
   					}
 <FindMembers>"="			{ // in PHP code this could also be due to "<?="
   					  current->bodyLine = yyLineNr;


### PR DESCRIPTION
Fix for issue #7393

When closing a group on multiple lines, like:

```cpp
/*! @}
 */
```

The line count of subsequent lines was wrong (it's one line less than it
should be).