### PR TITLE
Problem with horizontal ruler directly after fenced code section

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2176,7 +2176,7 @@ static void writeFencedCodeBlock(GrowBuf &out,const char *data,const char *lng,
   }
   out.addStr(data+blockStart,blockEnd-blockStart);
   out.addStr("\n");
-  out.addStr("@endcode");
+  out.addStr("@endcode\n");
 }
 
 static QCString processQuotations(const QCString &s,int refIndent)


### PR DESCRIPTION
When having a fenced code block directly followed by a horizontal ruler like:
```
~~~
B
~~~
---
```
we get the warning:
```
bb.md:5: warning: unexpected command endcode
```
due to the fact that the markdown parser replaces the `~~~` by a `@code` / `@endcode` block and then handles the horizontal ruler `---` but this is seen as a level 2 header on the previous part resulting in the markdown code:
```
@page md_bb bb

@subsection autotoc_md0 @code
B
@endcode
```

The problem also occurs when a fenced code block is created with back tics.

By adding a `\n` this problem is fixed.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3837369/example.tar.gz)
