### PR TITLE
HHC and directory elements starting with "."

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11862,6 +11862,7 @@ void generateOutput()
     g_s.begin("Running html help compiler...\n");
     QString oldDir = QDir::currentDirPath();
     QDir::setCurrent(Config_getString(HTML_OUTPUT));
+    portable_setShortDir();
     portable_sysTimerStart();
     if (portable_system(Config_getString(HHC_LOCATION), "index.hhp", Debug::isFlagSet(Debug::ExtCmd))!=1)
     {

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -478,3 +478,20 @@ void portable_unlink(const char *fileName)
 #endif
 }
 
+void portable_setShortDir(void)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  long     length = 0;
+  TCHAR*   buffer = NULL;
+  // First obtain the size needed by passing NULL and 0.
+  length = GetShortPathName(QDir::currentDirPath().data(), NULL, 0);
+  // Dynamically allocate the correct size
+  // (terminating null char was included in length)
+  buffer = new TCHAR[length];
+  // Now simply call again using same (long) path.
+  length = GetShortPathName(QDir::currentDirPath().data(), buffer, length);
+  // Set the correct directory (short name)
+  QDir::setCurrent(buffer);
+  delete [] buffer;
+#endif
+}

--- a/src/portable.h
+++ b/src/portable.h
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <qglobal.h>
+#include <qdir.h>
 
 #if defined(_WIN32)
 typedef __int64 portable_off_t;
@@ -37,6 +38,7 @@ double         portable_getSysElapsedTime();
 void           portable_sleep(int ms);
 bool           portable_isAbsolutePath(const char *fileName);
 void           portable_correct_path(void);
+void           portable_setShortDir(void);
 
 extern "C" {
   void *         portable_iconv_open(const char* tocode, const char* fromcode);


### PR DESCRIPTION
Based on the question 'Doxygen failed to run html help compiler, hhc.exe error HHC5010 when running from folder that has a parent folder that starts with “.”/ (https://stackoverflow.com/questions/58861908/doxygen-failed-to-run-html-help-compiler-hhc-exe-error-hhc5010-when-running-fro).

In we https://social.msdn.microsoft.com/Forums/en-US/0681145c-223b-498c-b7bf-be83209cbf4e/issue-with-html-workshop-in-a-windows-container?forum=visualstudiogeneral see:
HTML Help 1.x command line compiler hhc.exe cannot compile CHM file to folder whose full path contains folder name starting with dot. If you have that problem, you probably specified output path with folder starting with dot, e.g. "d:\My files.NET\documentation". You can use dots in folder names but not at the beginning.

We first convert the current path to a short name path and set this as current directory, this is only done on Windows other systems are not touched.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/3851942/example.tar.gz)

