### PR TITLE
Consider a svg the same as a png if non-interractive

### DIFF
--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -225,7 +225,7 @@ void DotGraph::generateCode(FTextStream &t)
   }
   else if (m_graphFormat==GOF_BITMAP && m_generateImageMap) // produce HTML to include the image
   {
-    if (imgExt=="svg") // add link to SVG file without map file
+    if (imgExt=="svg" && Config_getBool(INTERACTIVE_SVG)) // add link to SVG file without map file
     {
       if (!m_noDivTag) t << "<div class=\"center\">";
       if (m_regenerate || !DotFilePatcher::writeSVGFigureLink(t,m_relPath,m_baseName,absImgName())) // need to patch the links in the generated SVG file


### PR DESCRIPTION
The html server where I am trying to publish the doxygen-generated documentation is very restrictive. It uses Content-Security-Policy to block all frames (`frame-src 'none'`) and does not provide a way to change that as a "normal user".

I could not find a working configuration using the Doxyfile to enable the use of a svg as if they were png (using MAPs). This patch lets me do that.
Please treat this PR as a "works for me". I did not test anything else then my personal use case. I did not add an option to the Doxyfile to configure the behavior, I only check if INTERACTIVE_SVG is set or not.