### PR TITLE
Fix: Fixing some memory leakages due to missing deletes

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -235,14 +235,14 @@ void CiteDict::generatePage() const
   // 5. run bib2xhtml perl script on the generated file which will insert the
   //    bibliography in citelist.doc
   int exitCode;
-  portable_sysTimerStop();
-  if ((exitCode=portable_system("perl","\""+bib2xhtmlFile+"\" "+bibOutputFiles+" \""+
+  Portables::sysTimerStop();
+  if ((exitCode=Portables::system("perl","\""+bib2xhtmlFile+"\" "+bibOutputFiles+" \""+
                          citeListFile+"\"")) != 0)
   {
     err("Problems running bibtex. Verify that the command 'perl --version' works from the command line. Exit code: %d\n",
         exitCode);
   }
-  portable_sysTimerStop();
+  Portables::sysTimerStop();
 
   QDir::setCurrent(oldDir);
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -953,7 +953,7 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
-    <option type='bool' id='CASE_SENSE_NAMES' defval='0' altdefval='portable_fileSystemIsCaseSensitive()'>
+    <option type='bool' id='CASE_SENSE_NAMES' defval='0' altdefval='Portables::fileSystemIsCaseSensitive()'>
       <docs>
 <![CDATA[
  If the \c CASE_SENSE_NAMES tag is set to \c NO then doxygen

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -603,7 +603,7 @@ static FILE *tryPath(const char *path,const char *fileName)
   QFileInfo fi(absName);
   if (fi.exists() && fi.isFile())
   {
-    FILE *f=portable_fopen(absName,"r");
+    FILE *f=Portables::fopen(absName,"r");
     if (!f) config_err("could not open file %s for reading\n",absName.data());
     return f;
   }
@@ -619,7 +619,7 @@ static FILE *findFile(const char *fileName)
   {
     return 0;
   }
-  if (portable_isAbsolutePath(fileName))
+  if (Portables::isAbsolutePath(fileName))
   {
     return tryPath(NULL, fileName);
   }
@@ -1012,7 +1012,7 @@ static void substEnvVarsInString(QCString &s)
   while ((i=re.match(s,p,&l))!=-1 || (i=re2.match(s,p,&l))!=-1)
   {
     //printf("Found environment var s.mid(%d,%d)='%s'\n",i+2,l-3,s.mid(i+2,l-3).data());
-    QCString env=portable_getenv(s.mid(i+2,l-3));
+    QCString env=Portables::getenv(s.mid(i+2,l-3));
     substEnvVarsInString(env); // recursively expand variables if needed.
     s = s.left(i)+env+s.right(s.length()-i-l);
     p=i+env.length(); // next time start at the end of the expanded string
@@ -1579,7 +1579,7 @@ void Config::checkAndCorrect()
     }
     else
     {
-      QFileInfo dp(dotPath+"/dot"+portable_commandExtension());
+      QFileInfo dp(dotPath+"/dot"+Portables::commandExtension());
       if (!dp.exists() || !dp.isFile())
       {
 	warn_uncond("the dot tool could not be found at %s\n",dotPath.data());
@@ -1607,10 +1607,10 @@ void Config::checkAndCorrect()
     QFileInfo pu(plantumlJarPath);
     if (pu.exists() && pu.isDir()) // PLANTUML_JAR_PATH is directory
     {
-      QFileInfo jar(plantumlJarPath+portable_pathSeparator()+"plantuml.jar");
+      QFileInfo jar(plantumlJarPath+Portables::pathSeparator()+"plantuml.jar");
       if (jar.exists() && jar.isFile())
       {
-        plantumlJarPath = jar.dirPath(TRUE).utf8()+portable_pathSeparator();
+        plantumlJarPath = jar.dirPath(TRUE).utf8()+Portables::pathSeparator();
       }
       else
       {
@@ -1621,7 +1621,7 @@ void Config::checkAndCorrect()
     }
     else if (pu.exists() && pu.isFile() && plantumlJarPath.right(4)==".jar") // PLANTUML_JAR_PATH is file
     {
-      plantumlJarPath = pu.dirPath(TRUE).utf8()+portable_pathSeparator();
+      plantumlJarPath = pu.dirPath(TRUE).utf8()+Portables::pathSeparator();
     }
     else
     {
@@ -1635,7 +1635,7 @@ void Config::checkAndCorrect()
   QCString &diaPath = Config_getString(DIA_PATH);
   if (!diaPath.isEmpty())
   {
-    QFileInfo dp(diaPath+"/dia"+portable_commandExtension());
+    QFileInfo dp(diaPath+"/dia"+Portables::commandExtension());
     if (!dp.exists() || !dp.isFile())
     {
       warn_uncond("dia could not be found at %s\n",diaPath.data());

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1978,7 +1978,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
             {
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                              g_globals.outputDir,
-                             g_globals.outputDir+portable_pathSeparator()+m_classDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                             g_globals.outputDir+Portables::pathSeparator()+m_classDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                              relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
                             );
             }
@@ -1987,7 +1987,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
             {
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                              g_globals.outputDir,
-                             g_globals.outputDir+portable_pathSeparator()+m_classDef->getOutputFileBase()+".tex",
+                             g_globals.outputDir+Portables::pathSeparator()+m_classDef->getOutputFileBase()+".tex",
                              relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
                             );
             }
@@ -2077,7 +2077,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
             {
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                              g_globals.outputDir,
-                             g_globals.outputDir+portable_pathSeparator()+m_classDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                             g_globals.outputDir+Portables::pathSeparator()+m_classDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                              relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
                             );
             }
@@ -2086,7 +2086,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
             {
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                              g_globals.outputDir,
-                             g_globals.outputDir+portable_pathSeparator()+m_classDef->getOutputFileBase()+".tex",
+                             g_globals.outputDir+Portables::pathSeparator()+m_classDef->getOutputFileBase()+".tex",
                              relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
                             );
             }
@@ -3123,7 +3123,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
             {
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_fileDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                  g_globals.outputDir+Portables::pathSeparator()+m_fileDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -3132,7 +3132,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
             {
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_fileDef->getOutputFileBase()+".tex",
+                  g_globals.outputDir+Portables::pathSeparator()+m_fileDef->getOutputFileBase()+".tex",
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -3175,7 +3175,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
             {
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_fileDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                  g_globals.outputDir+Portables::pathSeparator()+m_fileDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -3184,7 +3184,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
             {
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_fileDef->getOutputFileBase()+".tex",
+                  g_globals.outputDir+Portables::pathSeparator()+m_fileDef->getOutputFileBase()+".tex",
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -3613,7 +3613,7 @@ class DirContext::Private : public DefinitionContext<DirContext::Private>
               graph->writeGraph(t,GOF_BITMAP,
                                 EOF_Html,
                                 g_globals.outputDir,
-                                g_globals.outputDir+portable_pathSeparator()+m_dirDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                                g_globals.outputDir+Portables::pathSeparator()+m_dirDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                                 relPathAsString(),
                                 TRUE,
                                 g_globals.dynSectionId,
@@ -3625,7 +3625,7 @@ class DirContext::Private : public DefinitionContext<DirContext::Private>
               graph->writeGraph(t,GOF_EPS,
                                 EOF_LaTeX,
                                 g_globals.outputDir,
-                                g_globals.outputDir+portable_pathSeparator()+m_dirDef->getOutputFileBase()+".tex",
+                                g_globals.outputDir+Portables::pathSeparator()+m_dirDef->getOutputFileBase()+".tex",
                                 relPathAsString(),
                                 TRUE,
                                 g_globals.dynSectionId,
@@ -5026,7 +5026,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
             {
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_memberDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                  g_globals.outputDir+Portables::pathSeparator()+m_memberDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -5035,7 +5035,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
             {
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_memberDef->getOutputFileBase()+".tex",
+                  g_globals.outputDir+Portables::pathSeparator()+m_memberDef->getOutputFileBase()+".tex",
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -5098,7 +5098,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
             {
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_memberDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                  g_globals.outputDir+Portables::pathSeparator()+m_memberDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -5107,7 +5107,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
             {
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
-                  g_globals.outputDir+portable_pathSeparator()+m_memberDef->getOutputFileBase()+".tex",
+                  g_globals.outputDir+Portables::pathSeparator()+m_memberDef->getOutputFileBase()+".tex",
                   relPathAsString(),TRUE,g_globals.dynSectionId
                   );
             }
@@ -5368,7 +5368,7 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
               graph->writeGraph(t,GOF_BITMAP,
                                 EOF_Html,
                                 g_globals.outputDir,
-                                g_globals.outputDir+portable_pathSeparator()+m_groupDef->getOutputFileBase()+Doxygen::htmlFileExtension,
+                                g_globals.outputDir+Portables::pathSeparator()+m_groupDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                                 relPathAsString(),
                                 TRUE,
                                 g_globals.dynSectionId);
@@ -5379,7 +5379,7 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
               graph->writeGraph(t,GOF_EPS,
                                 EOF_LaTeX,
                                 g_globals.outputDir,
-                                g_globals.outputDir+portable_pathSeparator()+m_groupDef->getOutputFileBase()+".tex",
+                                g_globals.outputDir+Portables::pathSeparator()+m_groupDef->getOutputFileBase()+".tex",
                                 relPathAsString(),
                                 TRUE,
                                 g_globals.dynSectionId);
@@ -8461,7 +8461,7 @@ class InheritanceGraphContext::Private
                           /*GOF_BITMAP,
                           EOF_Html,*/
                           g_globals.outputDir,
-                          g_globals.outputDir+portable_pathSeparator()+"inherits"+Doxygen::htmlFileExtension,
+                          g_globals.outputDir+Portables::pathSeparator()+"inherits"+Doxygen::htmlFileExtension,
                           m_id);
       }
       return TemplateVariant(result.data(),TRUE);

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -744,12 +744,12 @@ class FilterCache
         // file already processed, get the results after filtering from the tmp file
         Debug::print(Debug::FilterOutput,0,"Reusing filter result for %s from %s at offset=%d size=%d\n",
                qPrint(fileName),qPrint(Doxygen::filterDBFileName),(int)item->filePos,(int)item->fileSize);
-        f = portable_fopen(Doxygen::filterDBFileName,"rb");
+        f = Portables::fopen(Doxygen::filterDBFileName,"rb");
         if (f)
         {
           bool success=TRUE;
           str.resize(item->fileSize+1);
-          if (portable_fseek(f,item->filePos,SEEK_SET)==-1)
+          if (Portables::fseek(f,item->filePos,SEEK_SET)==-1)
           {
             err("Failed to seek to position %d in filter database file %s\n",(int)item->filePos,qPrint(Doxygen::filterDBFileName));
             success=FALSE;
@@ -780,8 +780,8 @@ class FilterCache
         // filter file
         QCString cmd=filter+" \""+fileName+"\"";
         Debug::print(Debug::ExtCmd,0,"Executing popen(`%s`)\n",qPrint(cmd));
-        f = portable_popen(cmd,"r");
-        FILE *bf = portable_fopen(Doxygen::filterDBFileName,"a+b");
+        f = Portables::popen(cmd,"r");
+        FILE *bf = Portables::fopen(Doxygen::filterDBFileName,"a+b");
         FilterCacheItem *item = new FilterCacheItem;
         item->filePos = m_endPos;
         if (bf==0)
@@ -790,7 +790,7 @@ class FilterCache
           err("Error opening filter database file %s\n",qPrint(Doxygen::filterDBFileName));
           str.addChar('\0');
           delete item;
-          portable_pclose(f);
+          Portables::pclose(f);
           return FALSE;
         }
         // append the filtered output to the database file
@@ -806,7 +806,7 @@ class FilterCache
                 qPrint(Doxygen::filterDBFileName),bytesWritten,bytesRead);
             str.addChar('\0');
             delete item;
-            portable_pclose(f);
+            Portables::pclose(f);
             fclose(bf);
             return FALSE;
           }
@@ -821,14 +821,14 @@ class FilterCache
                qPrint(fileName),qPrint(Doxygen::filterDBFileName),(int)item->filePos,(int)item->fileSize);
         // update end of file position
         m_endPos += size;
-        portable_pclose(f);
+        Portables::pclose(f);
         fclose(bf);
       }
       else // no filtering
       {
         // normal file
         //printf("getFileContents(%s): no filter\n",qPrint(fileName));
-        f = portable_fopen(fileName,"r");
+        f = Portables::fopen(fileName,"r");
         while (!feof(f))
         {
           int bytesRead = fread(buf,1,blockSize,f);

--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -29,7 +29,7 @@ void writeDiaGraphFromFile(const char *inFile,const char *outDir,
                            const char *outFile,DiaOutputFormat format)
 {
   QCString absOutFile = outDir;
-  absOutFile+=portable_pathSeparator();
+  absOutFile+=Portables::pathSeparator();
   absOutFile+=outFile;
 
   // chdir to the output dir, so dot can find the font file.
@@ -37,7 +37,7 @@ void writeDiaGraphFromFile(const char *inFile,const char *outDir,
   // go to the html output directory (i.e. path)
   QDir::setCurrent(outDir);
   //printf("Going to dir %s\n",QDir::currentDirPath().data());
-  QCString diaExe = Config_getString(DIA_PATH)+"dia"+portable_commandExtension();
+  QCString diaExe = Config_getString(DIA_PATH)+"dia"+Portables::commandExtension();
   QCString diaArgs;
   QCString extension;
   diaArgs+="-n ";
@@ -62,26 +62,26 @@ void writeDiaGraphFromFile(const char *inFile,const char *outDir,
 
   int exitCode;
   //printf("*** running: %s %s outDir:%s %s\n",diaExe.data(),diaArgs.data(),outDir,outFile);
-  portable_sysTimerStart();
-  if ((exitCode=portable_system(diaExe,diaArgs,FALSE))!=0)
+  Portables::sysTimerStart();
+  if ((exitCode=Portables::system(diaExe,diaArgs,FALSE))!=0)
   {
     err("Problems running %s. Check your installation or look typos in you dia file %s\n",
         diaExe.data(),inFile);
-    portable_sysTimerStop();
+    Portables::sysTimerStop();
     goto error;
   }
-  portable_sysTimerStop();
+  Portables::sysTimerStop();
   if ( (format==DIA_EPS) && (Config_getBool(USE_PDFLATEX)) )
   {
     QCString epstopdfArgs(maxCmdLine);
     epstopdfArgs.sprintf("\"%s.eps\" --outfile=\"%s.pdf\"",
                          outFile,outFile);
-    portable_sysTimerStart();
-    if (portable_system("epstopdf",epstopdfArgs)!=0)
+    Portables::sysTimerStart();
+    if (Portables::system("epstopdf",epstopdfArgs)!=0)
     {
       err("Problems running epstopdf. Check your TeX installation!\n");
     }
-    portable_sysTimerStop();
+    Portables::sysTimerStop();
   }
 
 error:

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -1338,14 +1338,14 @@ void ClassDiagram::writeFigure(FTextStream &output,const char *path,
     epstopdfArgs.sprintf("\"%s.eps\" --outfile=\"%s.pdf\"",
                    epsBaseName.data(),epsBaseName.data());
     //printf("Converting eps using '%s'\n",epstopdfArgs.data());
-    portable_sysTimerStart();
-    if (portable_system("epstopdf",epstopdfArgs)!=0)
+    Portables::sysTimerStart();
+    if (Portables::system("epstopdf",epstopdfArgs)!=0)
     {
        err("Problems running epstopdf. Check your TeX installation!\n");
-       portable_sysTimerStop();
+       Portables::sysTimerStop();
        return;
     }
-    portable_sysTimerStop();
+    Portables::sysTimerStop();
   }
 }
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -369,12 +369,12 @@ static QCString findAndCopyImage(const char *fileName,DocImage::Type type, bool 
       epstopdfArgs.sprintf("\"%s/%s.eps\" --outfile=\"%s/%s.pdf\"",
                            outputDir.data(), baseName.data(),
 			   outputDir.data(), baseName.data());
-      portable_sysTimerStart();
-      if (portable_system("epstopdf",epstopdfArgs)!=0)
+      Portables::sysTimerStart();
+      if (Portables::system("epstopdf",epstopdfArgs)!=0)
       {
 	err("Problems running epstopdf. Check your TeX installation!\n");
       }
-      portable_sysTimerStop();
+      Portables::sysTimerStop();
       return baseName;
     }
   }
@@ -1818,7 +1818,7 @@ static int internalValidatingParseDoc(DocNode *parent,QList<DocNode> &children,
 
 static void readTextFileByName(const QCString &file,QCString &text)
 {
-  if (portable_isAbsolutePath(file.data()))
+  if (Portables::isAbsolutePath(file.data()))
   {
     QFileInfo fi(file);
     if (fi.exists())
@@ -1831,7 +1831,7 @@ static void readTextFileByName(const QCString &file,QCString &text)
   char *s=examplePathList.first();
   while (s)
   {
-    QCString absFileName = QCString(s)+portable_pathSeparator()+file;
+    QCString absFileName = QCString(s)+Portables::pathSeparator()+file;
     QFileInfo fi(absFileName);
     if (fi.exists())
     {

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -674,7 +674,7 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 <St_Para,St_HtmlOnly,St_ManOnly,St_LatexOnly,St_RtfOnly,St_XmlOnly,St_DbOnly>"$("{ID}"("{ID}"))"   { /* environment variable */
                          QCString name = &yytext[2];
 			 name = name.left(name.length()-1);
-			 QCString value = portable_getenv(name);
+			 QCString value = Portables::getenv(name);
 			 for (int i=value.length()-1;i>=0;i--) unput(value.at(i));
                        }
 <St_Para>{HTMLTAG}     { /* html tag */ 

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -38,12 +38,12 @@ static QCString g_dotFontPath;
 static void setDotFontPath(const char *path)
 {
   ASSERT(g_dotFontPath.isEmpty());
-  g_dotFontPath = portable_getenv("DOTFONTPATH");
+  g_dotFontPath = Portables::getenv("DOTFONTPATH");
   QCString newFontPath = Config_getString(DOT_FONTPATH);
   QCString spath = path;
   if (!newFontPath.isEmpty() && !spath.isEmpty())
   {
-    newFontPath.prepend(spath+portable_pathListSeparator());
+    newFontPath.prepend(spath+Portables::pathListSeparator());
   }
   else if (newFontPath.isEmpty() && !spath.isEmpty())
   {
@@ -51,21 +51,21 @@ static void setDotFontPath(const char *path)
   }
   else
   {
-    portable_unsetenv("DOTFONTPATH");
+    Portables::unsetenv("DOTFONTPATH");
     return;
   }
-  portable_setenv("DOTFONTPATH",newFontPath);
+  Portables::setenv("DOTFONTPATH",newFontPath);
 }
 
 static void unsetDotFontPath()
 {
   if (g_dotFontPath.isEmpty())
   {
-    portable_unsetenv("DOTFONTPATH");
+    Portables::unsetenv("DOTFONTPATH");
   }
   else
   {
-    portable_setenv("DOTFONTPATH",g_dotFontPath);
+    Portables::setenv("DOTFONTPATH",g_dotFontPath);
   }
   g_dotFontPath="";
 }
@@ -183,7 +183,7 @@ bool DotManager::run() const
     setDotFontPath(Config_getString(DOCBOOK_OUTPUT));
     setPath=TRUE;
   }
-  portable_sysTimerStart();
+  Portables::sysTimerStart();
   // fill work queue with dot operations
   DotRunner *dr;
   int prev=1;
@@ -211,7 +211,7 @@ bool DotManager::run() const
         msg("Running dot for graph %d/%d\n",prev,numDotRuns);
         prev++;
       }
-      portable_sleep(100);
+      Portables::sleep(100);
     }
     while ((int)numDotRuns>=prev)
     {
@@ -229,7 +229,7 @@ bool DotManager::run() const
       m_workers.at(i)->wait();
     }
   }
-  portable_sysTimerStop();
+  Portables::sysTimerStop();
   if (setPath)
   {
     unsetDotFontPath();

--- a/src/dotgroupcollaboration.cpp
+++ b/src/dotgroupcollaboration.cpp
@@ -42,6 +42,16 @@ DotGroupCollaboration::DotGroupCollaboration(const GroupDef* gd)
 
 DotGroupCollaboration::~DotGroupCollaboration()
 {
+  // delete all created Nodes saved in m_usedNodes:QDict
+  if(m_usedNodes != NULL)
+  {
+    QDictIterator<DotNode> it(*m_usedNodes);
+    for(;it.current(); ++it)
+    {
+      delete it.current();
+    }
+  }
+
   delete m_usedNodes;
 }
 

--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -34,7 +34,7 @@
 // support the PNG format, we need to check the result.
 static void checkPngResult(const char *imgName)
 {
-  FILE *f = portable_fopen(imgName,"rb");
+  FILE *f = Portables::fopen(imgName,"rb");
   if (f)
   {
     char data[4];
@@ -115,7 +115,7 @@ bool DotRunner::readBoundingBox(const char *fileName,int *width,int *height,bool
 {
   const char *bb = isEps ? "%%PageBoundingBox:" : "/MediaBox [";
   int bblen = strlen(bb);
-  FILE *f = portable_fopen(fileName,"rb");
+  FILE *f = Portables::fopen(fileName,"rb");
   if (!f) 
   {
     //printf("readBoundingBox: could not open %s\n",fileName);
@@ -191,14 +191,14 @@ bool DotRunner::run()
       dotArgs+=' ';
       dotArgs+=s->args.data();
     }
-    if ((exitCode=portable_system(m_dotExe.data(),dotArgs,FALSE))!=0) goto error;
+    if ((exitCode=Portables::system(m_dotExe.data(),dotArgs,FALSE))!=0) goto error;
   }
   else
   {
     for (li.toFirst();(s=li.current());++li)
     {
       dotArgs=QCString("\"")+m_file.data()+"\" "+s->args.data();
-      if ((exitCode=portable_system(m_dotExe.data(),dotArgs,FALSE))!=0) goto error;
+      if ((exitCode=Portables::system(m_dotExe.data(),dotArgs,FALSE))!=0) goto error;
     }
   }
 
@@ -214,7 +214,7 @@ bool DotRunner::run()
       {
         if (!resetPDFSize(width,height,getBaseNameOfOutput(s->output.data()))) goto error;
         dotArgs=QCString("\"")+m_file.data()+"\" "+s->args.data();
-        if ((exitCode=portable_system(m_dotExe.data(),dotArgs,FALSE))!=0) goto error;
+        if ((exitCode=Portables::system(m_dotExe.data(),dotArgs,FALSE))!=0) goto error;
       }
     }
 
@@ -228,14 +228,14 @@ bool DotRunner::run()
   if (m_cleanUp) 
   {
     //printf("removing dot file %s\n",m_file.data());
-    portable_unlink(m_file.data());
+    Portables::unlink(m_file.data());
   }
 
   // create checksum file
   if (!m_md5Hash.isEmpty()) 
   {
     QCString md5Name = getBaseNameOfOutput(m_file.data()) + ".md5";
-    FILE *f = portable_fopen(md5Name,"w");
+    FILE *f = Portables::fopen(md5Name,"w");
     if (f)
     {
       fwrite(m_md5Hash.data(),1,32,f); 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10070,13 +10070,13 @@ static const char *getArg(int argc,char **argv,int &optind)
 void initDoxygen()
 {
   initResources();
-  const char *lang = portable_getenv("LC_ALL");
-  if (lang) portable_setenv("LANG",lang);
+  const char *lang = Portables::getenv("LC_ALL");
+  if (lang) Portables::setenv("LANG",lang);
   setlocale(LC_ALL,"");
   setlocale(LC_CTYPE,"C"); // to get isspace(0xA0)==0, needed for UTF-8
   setlocale(LC_NUMERIC,"C");
 
-  portable_correct_path();
+  Portables::correct_path();
 
   Doxygen::runningTime.start();
   Doxygen::preprocessor = new Preprocessor();
@@ -11103,7 +11103,7 @@ void parseInput()
   signal(SIGINT, stopDoxygen);
 #endif
 
-  uint pid = portable_pid();
+  uint pid = Portables::pid();
   Doxygen::objDBFileName.sprintf("doxygen_objdb_%d.tmp",pid);
   Doxygen::objDBFileName.prepend(outputDirectory+"/");
   Doxygen::entryDBFileName.sprintf("doxygen_entrydb_%d.tmp",pid);
@@ -11163,18 +11163,18 @@ void parseInput()
     QCString curFontPath = Config_getString(DOT_FONTPATH);
     if (curFontPath.isEmpty())
     {
-      portable_getenv("DOTFONTPATH");
+      Portables::getenv("DOTFONTPATH");
       QCString newFontPath = ".";
       if (!curFontPath.isEmpty())
       {
-        newFontPath+=portable_pathListSeparator();
+        newFontPath+=Portables::pathListSeparator();
         newFontPath+=curFontPath;
       }
-      portable_setenv("DOTFONTPATH",newFontPath);
+      Portables::setenv("DOTFONTPATH",newFontPath);
     }
     else
     {
-      portable_setenv("DOTFONTPATH",curFontPath);
+      Portables::setenv("DOTFONTPATH",curFontPath);
     }
   }
 
@@ -11800,7 +11800,7 @@ void generateOutput()
       {
         searchDataFile="searchdata.xml";
       }
-      if (!portable_isAbsolutePath(searchDataFile))
+      if (!Portables::isAbsolutePath(searchDataFile))
       {
         searchDataFile.prepend(Config_getString(OUTPUT_DIRECTORY)+"/");
       }
@@ -11862,13 +11862,13 @@ void generateOutput()
     g_s.begin("Running html help compiler...\n");
     QString oldDir = QDir::currentDirPath();
     QDir::setCurrent(Config_getString(HTML_OUTPUT));
-    portable_setShortDir();
-    portable_sysTimerStart();
-    if (portable_system(Config_getString(HHC_LOCATION), "index.hhp", Debug::isFlagSet(Debug::ExtCmd))!=1)
+    Portables::setShortDir();
+    Portables::sysTimerStart();
+    if (Portables::system(Config_getString(HHC_LOCATION), "index.hhp", Debug::isFlagSet(Debug::ExtCmd))!=1)
     {
       err("failed to run html help compiler on index.hhp\n");
     }
-    portable_sysTimerStop();
+    Portables::sysTimerStop();
     QDir::setCurrent(oldDir);
     g_s.end();
   }
@@ -11883,12 +11883,12 @@ void generateOutput()
     QCString const args = QCString().sprintf("%s -o \"%s\"", qhpFileName.data(), qchFileName.data());
     QString const oldDir = QDir::currentDirPath();
     QDir::setCurrent(Config_getString(HTML_OUTPUT));
-    portable_sysTimerStart();
-    if (portable_system(Config_getString(QHG_LOCATION), args.data(), FALSE))
+    Portables::sysTimerStart();
+    if (Portables::system(Config_getString(QHG_LOCATION), args.data(), FALSE))
     {
       err("failed to run qhelpgenerator on index.qhp\n");
     }
-    portable_sysTimerStop();
+    Portables::sysTimerStop();
     QDir::setCurrent(oldDir);
     g_s.end();
   }
@@ -11909,7 +11909,7 @@ void generateOutput()
   {
     msg("Total elapsed time: %.3f seconds\n(of which %.3f seconds waiting for external tools to finish)\n",
          ((double)Doxygen::runningTime.elapsed())/1000.0,
-         portable_getSysElapsedTime()
+         Portables::getSysElapsedTime()
         );
     g_s.print();
   }

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -2015,7 +2015,7 @@ void FileDefImpl::acquireFileVersion()
     msg("Version of %s : ",m_filePath.data());
     QCString cmd = vercmd+" \""+m_filePath+"\"";
     Debug::print(Debug::ExtCmd,0,"Executing popen(`%s`)\n",qPrint(cmd));
-    FILE *f=portable_popen(cmd,"r");
+    FILE *f=Portables::popen(cmd,"r");
     if (!f)
     {
       err("could not execute %s\n",vercmd.data());
@@ -2024,7 +2024,7 @@ void FileDefImpl::acquireFileVersion()
     const int bufSize=1024;
     char buf[bufSize];
     int numRead = (int)fread(buf,1,bufSize-1,f);
-    portable_pclose(f);
+    Portables::pclose(f);
     if (numRead>0 && numRead<bufSize)
     {
       buf[numRead]='\0';

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -100,15 +100,15 @@ void FormulaList::generateBitmaps(const char *path)
     //printf("Running latex...\n");
     //system("latex _formulas.tex </dev/null >/dev/null");
     QCString latexCmd = "latex";
-    portable_sysTimerStart();
-    if (portable_system(latexCmd,"_formulas.tex")!=0)
+    Portables::sysTimerStart();
+    if (Portables::system(latexCmd,"_formulas.tex")!=0)
     {
       err("Problems running latex. Check your installation or look "
           "for typos in _formulas.tex and check _formulas.log!\n");
       formulaError=TRUE;
       //return;
     }
-    portable_sysTimerStop();
+    Portables::sysTimerStop();
     //printf("Running dvips...\n");
     QListIterator<int> pli(pagesToGenerate);
     int *pagePtr;
@@ -125,27 +125,27 @@ void FormulaList::generateBitmaps(const char *path)
       // postscript file.
       sprintf(dviArgs,"-q -D 600 -n 1 -p %d -o %s_tmp.ps _formulas.dvi",
           pageIndex,formBase.data());
-      portable_sysTimerStart();
-      if (portable_system("dvips",dviArgs)!=0)
+      Portables::sysTimerStart();
+      if (Portables::system("dvips",dviArgs)!=0)
       {
         err("Problems running dvips. Check your installation!\n");
-        portable_sysTimerStop();
+        Portables::sysTimerStop();
         QDir::setCurrent(oldDir);
         return;
       }
-      portable_sysTimerStop();
+      Portables::sysTimerStop();
       // run ps2epsi to convert to an encapsulated postscript file with
       // boundingbox (dvips with -E has some problems here).
       sprintf(psArgs,"%s_tmp.ps %s.eps",formBase.data(),formBase.data()); 
-      portable_sysTimerStart();
-      if (portable_system("ps2epsi",psArgs)!=0)
+      Portables::sysTimerStart();
+      if (Portables::system("ps2epsi",psArgs)!=0)
       {
         err("Problems running ps2epsi. Check your installation!\n");
-        portable_sysTimerStop();
+        Portables::sysTimerStop();
         QDir::setCurrent(oldDir);
         return;
       }
-      portable_sysTimerStop();
+      Portables::sysTimerStop();
       // now we read the generated postscript file to extract the bounding box
       QFileInfo fi(formBase+".eps");
       if (fi.exists())
@@ -198,15 +198,15 @@ void FormulaList::generateBitmaps(const char *path)
                     gx,gy,(int)(scaleFactor*72),(int)(scaleFactor*72),
                     formBase.data(),formBase.data()
              );
-      portable_sysTimerStart();
-      if (portable_system(portable_ghostScriptCommand(),gsArgs)!=0)
+      Portables::sysTimerStart();
+      if (Portables::system(Portables::ghostScriptCommand(),gsArgs)!=0)
       {
-        err("Problem running ghostscript %s %s. Check your installation!\n",portable_ghostScriptCommand(),gsArgs);
-        portable_sysTimerStop();
+        err("Problem running ghostscript %s %s. Check your installation!\n",Portables::ghostScriptCommand(),gsArgs);
+        Portables::sysTimerStop();
         QDir::setCurrent(oldDir);
         return;
       }
-      portable_sysTimerStop();
+      Portables::sysTimerStop();
       f.setName(formBase+".pnm");
       uint imageX=0,imageY=0;
       // we read the generated image again, to obtain the pixel data.

--- a/src/htags.cpp
+++ b/src/htags.cpp
@@ -89,13 +89,13 @@ bool Htags::execute(const QCString &htmldir)
   QCString oldDir = QDir::currentDirPath().utf8();
   QDir::setCurrent(g_inputDir.absPath());
   //printf("CommandLine=[%s]\n",commandLine.data());
-  portable_sysTimerStart();
-  bool result=portable_system("htags",commandLine,FALSE)==0;
+  Portables::sysTimerStart();
+  bool result=Portables::system("htags",commandLine,FALSE)==0;
   if (!result)
   {
     err("Problems running %s. Check your installation\n", "htags");
   }
-  portable_sysTimerStop();
+  Portables::sysTimerStop();
   QDir::setCurrent(oldDir);
   return result;
 }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -90,7 +90,7 @@ void initWarningFormat()
 
   if (!Config_getString(WARN_LOGFILE).isEmpty())
   {
-    warnFile = portable_fopen(Config_getString(WARN_LOGFILE),"w");
+    warnFile = Portables::fopen(Config_getString(WARN_LOGFILE),"w");
   }
   if (!warnFile) // point it to something valid, because warn() relies on it
   {

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -95,7 +95,7 @@ void writeMscGraphFromFile(const char *inFile,const char *outDir,
                            const char *outFile,MscOutputFormat format)
 {
   QCString absOutFile = outDir;
-  absOutFile+=portable_pathSeparator();
+  absOutFile+=Portables::pathSeparator();
   absOutFile+=outFile;
 
   mscgen_format_t msc_format;
@@ -130,12 +130,12 @@ void writeMscGraphFromFile(const char *inFile,const char *outDir,
     QCString epstopdfArgs(maxCmdLine);
     epstopdfArgs.sprintf("\"%s.eps\" --outfile=\"%s.pdf\"",
                          absOutFile.data(),absOutFile.data());
-    portable_sysTimerStart();
-    if (portable_system("epstopdf",epstopdfArgs)!=0)
+    Portables::sysTimerStart();
+    if (Portables::system("epstopdf",epstopdfArgs)!=0)
     {
       err("Problems running epstopdf. Check your TeX installation!\n");
     }
-    portable_sysTimerStop();
+    Portables::sysTimerStop();
   }
 
   Doxygen::indexList->addImageFile(imgName);

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -210,7 +210,7 @@ static void runPlantumlContent(const QDict< QList <QCString> > &plantumlFiles,
   }
   while (s)
   {
-    pumlArgs += portable_pathListSeparator();
+    pumlArgs += Portables::pathListSeparator();
     pumlArgs += s;
     s = pumlIncludePathList.next(); 
   }
@@ -227,7 +227,7 @@ static void runPlantumlContent(const QDict< QList <QCString> > &plantumlFiles,
     pumlArgs += "-graphvizdot \"";
     pumlArgs += dotPath;
     pumlArgs += "dot";
-    pumlArgs += portable_commandExtension();
+    pumlArgs += Portables::commandExtension();
     pumlArgs += "\" ";
   }
   switch (format)
@@ -283,8 +283,8 @@ static void runPlantumlContent(const QDict< QList <QCString> > &plantumlFiles,
       file.close();
       Debug::print(Debug::Plantuml,0,"*** %s Running Plantuml arguments:%s\n","PlantumlManager::runPlantumlContent",qPrint(pumlArguments));
 
-      portable_sysTimerStart();
-      if ((exitCode=portable_system(pumlExe,pumlArguments,TRUE))!=0)
+      Portables::sysTimerStart();
+      if ((exitCode=Portables::system(pumlExe,pumlArguments,TRUE))!=0)
       {
         err("Problems running PlantUML. Verify that the command 'java -jar \"%splantuml.jar\" -h' works from the command line. Exit code: %d\n",
             plantumlJarPath.data(),exitCode);
@@ -294,7 +294,7 @@ static void runPlantumlContent(const QDict< QList <QCString> > &plantumlFiles,
         Debug::print(Debug::Plantuml,0,"*** %s Remove %s file\n","PlantumlManager::runPlantumlContent",qPrint(puFileName));
         file.remove();
       }
-      portable_sysTimerStop();
+      Portables::sysTimerStop();
 
       if ( (format==PlantumlManager::PUML_EPS) && (Config_getBool(USE_PDFLATEX)) )
       {
@@ -309,12 +309,12 @@ static void runPlantumlContent(const QDict< QList <QCString> > &plantumlFiles,
             const int maxCmdLine = 40960;
             QCString epstopdfArgs(maxCmdLine);
             epstopdfArgs.sprintf("\"%s%s.eps\" --outfile=\"%s%s.pdf\"",qPrint(pumlOutDir),qPrint(*nb),qPrint(pumlOutDir),qPrint(*nb));
-            portable_sysTimerStart();
-            if ((exitCode=portable_system("epstopdf",epstopdfArgs))!=0)
+            Portables::sysTimerStart();
+            if ((exitCode=Portables::system("epstopdf",epstopdfArgs))!=0)
             {
               err("Problems running epstopdf. Check your TeX installation! Exit code: %d\n",exitCode);
             }
-            portable_sysTimerStop();
+            Portables::sysTimerStop();
           }
         }
       }

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -1,36 +1,43 @@
+#include "portable.h"
+
 #include <stdlib.h>
-#include <ctype.h>
+#include <stdio.h>
+
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #undef UNICODE
 #define _WIN32_DCOM
 #include <windows.h>
 #else
 #include <unistd.h>
-#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <errno.h>
 extern char **environ;
 #endif
 
+#include <ctype.h>
 #include <qglobal.h>
 #include <qdatetime.h>
+#include <qglobal.h>
+#include <qdir.h>
+#include <map>
+#include <string>
 
-#if defined(_MSC_VER) || defined(__BORLANDC__)
-#define popen _popen
-#define pclose _pclose
-#endif
-
-#include "portable.h"
 #include "util.h"
 #ifndef NODEBUG
 #include "debug.h"
 #endif
 
+#if !defined(_WIN32) || defined(__CYGWIN__)
+static bool environmentLoaded = false;
+static std::map<std::string,std::string> proc_env = std::map<std::string,std::string>();
+#endif
+
 static double  g_sysElapsedTime;
 static QTime   g_time;
 
-int portable_system(const char *command,const char *args,bool commandHasConsole)
+
+int Portables::system(const char *command,const char *args,bool commandHasConsole)
 {
 
   if (command==0) return 1;
@@ -127,7 +134,7 @@ int portable_system(const char *command,const char *args,bool commandHasConsole)
 #else // Win32 specific
   if (commandHasConsole)
   {
-    return system(fullCmd);
+    return ::system(fullCmd);
   }
   else
   {
@@ -189,13 +196,13 @@ int portable_system(const char *command,const char *args,bool commandHasConsole)
 
 }
 
-uint portable_pid()
+unsigned int Portables::pid(void)
 {
-  uint pid;
+  unsigned int pid;
 #if !defined(_WIN32) || defined(__CYGWIN__)
-  pid = (uint)getpid();
+  pid = (unsigned int)getpid();
 #else
-  pid = (uint)GetCurrentProcessId();
+  pid = (unsigned int)GetCurrentProcessId();
 #endif
   return pid;
 }
@@ -205,88 +212,50 @@ uint portable_pid()
   static char **last_environ;
 #endif
 
-void portable_setenv(const char *name,const char *value)
+#if !defined(_WIN32) || defined(__CYGWIN__)
+void loadEnvironment()
+{
+  if(environ != NULL)
+  {
+    unsigned int i = 0;
+    char* current = environ[i];
+
+    while(current != NULL)                            // parse all strings contained by environ til the last element (NULL)
+    {
+      std::string env_var(current);                   // load current environment variable string
+      size_t pos = env_var.find("=");
+      if(pos != std::string::npos)                    // only parse the variable, if it is a valid environment variable...
+      {                                               // ...which has to contain an equal sign as delimiter by definition
+        std::string name = env_var.substr(0,pos);     // the string til the equal sign contains the name
+        std::string value = env_var.substr(pos + 1);  // the string from the equal sign contains the value
+
+        proc_env[name] = value;                       // save the value by the name as its key in the classes map
+      }
+      i++;
+      current = environ[i];
+    }
+  }
+
+  environmentLoaded = true;
+}
+#endif
+
+void Portables::setenv(const char *name,const char *value)
 {
     if (value==0) value="";
 #if defined(_WIN32) && !defined(__CYGWIN__)
     SetEnvironmentVariable(name,value);
 #else
-    char **ep = 0;
-    size_t size;
-    const size_t namelen=qstrlen(name);
-    const size_t vallen=qstrlen(value) + 1;
-
-    size = 0;
-    if (environ!=0)
-    {
-      for (ep = environ; *ep; ++ep)
-      {
-        if (!qstrncmp (*ep, name, (uint)namelen) &&
-            (*ep)[namelen] == '=')
-          break;
-        else
-          ++size;
-      }
+    if(!environmentLoaded) // if the environment variables are not loaded already...
+    {                                 // ...call loadEnvironment to store them in class
+      loadEnvironment();
     }
 
-    if (environ==0 || *ep==0) /* add new string */
-    {
-      char **new_environ;
-      if (environ == last_environ && environ!=0)
-      {
-        // We allocated this space; we can extend it. 
-        new_environ = (char **) realloc (last_environ, (size + 2) * sizeof (char *));
-      }
-      else
-      {
-        new_environ = (char **) malloc ((size + 2) * sizeof (char *));
-      }
-
-      if (new_environ==0) // no more memory 
-      {
-        return;
-      }
-
-      new_environ[size] = (char *)malloc (namelen + 1 + vallen);
-      if (new_environ[size]==0)
-      {
-        free (new_environ);
-        return;
-      }
-
-      if (environ != last_environ)
-      {
-        memcpy ((char *) new_environ, environ, size * sizeof (char *));
-      }
-
-      memcpy(new_environ[size], name, namelen);
-      new_environ[size][namelen] = '=';
-      memcpy(&new_environ[size][namelen + 1], value, vallen);
-      new_environ[size + 1] = 0;
-      last_environ = environ = new_environ;
-    }
-    else /* replace existing string */
-    {
-      size_t len = qstrlen (*ep);
-      if (len + 1 < namelen + 1 + vallen)
-      {
-        /* The existing string is too short; malloc a new one.  */
-        char *newString = (char *)malloc(namelen + 1 + vallen);
-        if (newString==0)
-        {
-          return;
-        }
-        *ep = newString;
-      }
-      memcpy(*ep, name, namelen);
-      (*ep)[namelen] = '=';
-      memcpy(&(*ep)[namelen + 1], value, vallen);
-    }
-
+    proc_env[name] = std::string(value); // create or replace exisiting value
 #endif
 }
 
-void portable_unsetenv(const char *variable)
+void Portables::unsetenv(const char *variable)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
     SetEnvironmentVariable(variable,0);
@@ -300,32 +269,35 @@ void portable_unsetenv(const char *variable)
       return; // not properly formatted
     }
 
-    len = qstrlen(variable);
-
-    ep = environ;
-    while (*ep != NULL)
+    if(proc_env.find(variable) != proc_env.end())
     {
-      if (!qstrncmp(*ep, variable, (uint)len) && (*ep)[len]=='=')
-      {
-        /* Found it.  Remove this pointer by moving later ones back.  */
-        char **dp = ep;
-        do dp[0] = dp[1]; while (*dp++);
-        /* Continue the loop in case NAME appears again.  */
-      }
-      else
-      {
-        ++ep;
-      }
+      proc_env[variable].erase();
     }
 #endif
 }
 
-const char *portable_getenv(const char *variable)
-{
-  return getenv(variable);
+const char *Portables::getenv(const char *variable)
+{  
+#if defined(_WIN32) && !defined(__CYGWIN__)
+    return ::getenv(variable);
+#else
+    if(!environmentLoaded) // if the environment variables are not loaded already...
+    {                                 // ...call loadEnvironment to store them in class
+      loadEnvironment();
+    }
+
+    if(proc_env.find(variable) != proc_env.end())
+    {
+      return proc_env[variable].c_str();
+    }
+    else
+    {
+      return NULL;
+    }
+#endif
 }
 
-portable_off_t portable_fseek(FILE *f,portable_off_t offset, int whence)
+portable_off_t Portables::fseek(FILE *f,portable_off_t offset, int whence)
 {
 #if defined(__MINGW32__)
   return fseeko64(f,offset,whence);
@@ -336,7 +308,7 @@ portable_off_t portable_fseek(FILE *f,portable_off_t offset, int whence)
 #endif
 }
 
-portable_off_t portable_ftell(FILE *f)
+portable_off_t Portables::ftell(FILE *f)
 {
 #if defined(__MINGW32__)
   return ftello64(f);  
@@ -347,18 +319,18 @@ portable_off_t portable_ftell(FILE *f)
 #endif
 }
 
-FILE *portable_fopen(const char *fileName,const char *mode)
+FILE *Portables::fopen(const char *fileName,const char *mode)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   QString fn(fileName);
   QString m(mode);
   return _wfopen((wchar_t*)fn.ucs2(),(wchar_t*)m.ucs2());
 #else
-  return fopen(fileName,mode);
+  return ::fopen(fileName,mode);
 #endif
 }
 
-char  portable_pathSeparator()
+char  Portables::pathSeparator(void)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   return '\\';
@@ -367,7 +339,7 @@ char  portable_pathSeparator()
 #endif
 }
 
-char  portable_pathListSeparator()
+char  Portables::pathListSeparator(void)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   return ';';
@@ -376,7 +348,7 @@ char  portable_pathListSeparator()
 #endif
 }
 
-const char *portable_ghostScriptCommand()
+const char *Portables::ghostScriptCommand(void)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
     return "gswin32c.exe";
@@ -385,7 +357,7 @@ const char *portable_ghostScriptCommand()
 #endif
 }
 
-const char *portable_commandExtension()
+const char *Portables::commandExtension(void)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
     return ".exe";
@@ -394,7 +366,7 @@ const char *portable_commandExtension()
 #endif
 }
 
-bool portable_fileSystemIsCaseSensitive()
+bool Portables::fileSystemIsCaseSensitive(void)
 {
 #if defined(_WIN32) || defined(macintosh) || defined(__MACOSX__) || defined(__APPLE__) || defined(__CYGWIN__)
   return FALSE;
@@ -403,32 +375,40 @@ bool portable_fileSystemIsCaseSensitive()
 #endif
 }
 
-FILE * portable_popen(const char *name,const char *type)
+FILE * Portables::popen(const char *name,const char *type)
 {
-  return popen(name,type);
+  #if defined(_MSC_VER) || defined(__BORLANDC__)
+  return ::_popen(name,type);
+  #else
+  return ::popen(name,type);
+  #endif
 }
 
-int portable_pclose(FILE *stream)
+int Portables::pclose(FILE *stream)
 {
-  return pclose(stream);
+  #if defined(_MSC_VER) || defined(__BORLANDC__)
+  return ::_pclose(stream);
+  #else
+  return ::pclose(stream);
+  #endif
 }
 
-void portable_sysTimerStart()
+void Portables::sysTimerStart(void)
 {
   g_time.start();
 }
 
-void portable_sysTimerStop()
+void Portables::sysTimerStop(void)
 {
   g_sysElapsedTime+=((double)g_time.elapsed())/1000.0;
 }
 
-double portable_getSysElapsedTime()
+double Portables::getSysElapsedTime(void)
 {
   return g_sysElapsedTime;
 }
 
-void portable_sleep(int ms)
+void Portables::sleep(int ms)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   Sleep(ms);
@@ -437,7 +417,7 @@ void portable_sleep(int ms)
 #endif
 }
 
-bool portable_isAbsolutePath(const char *fileName)
+bool Portables::isAbsolutePath(const char *fileName)
 {
 # ifdef _WIN32
   if (isalpha (fileName [0]) && fileName[1] == ':')
@@ -459,26 +439,26 @@ bool portable_isAbsolutePath(const char *fileName)
  *
  * This routine was inspired by the cause for bug 766059 was that in the Windows path there were forward slashes.
  */
-void portable_correct_path(void)
+void Portables::correct_path(void)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
-  const char *p = portable_getenv("PATH");
+  const char *p = Portables::getenv("PATH");
   if (!p) return; // no path nothing to correct
   QCString result = substitute(p,'/','\\');
-  if (result!=p) portable_setenv("PATH",result.data());
+  if (result!=p) Portables::setenv("PATH",result.data());
 #endif
 }
 
-void portable_unlink(const char *fileName)
+void Portables::unlink(const char *fileName)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   _unlink(fileName);
 #else
-  unlink(fileName);
+  ::unlink(fileName);
 #endif
 }
 
-void portable_setShortDir(void)
+void Portables::setShortDir(void)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   long     length = 0;

--- a/src/portable.h
+++ b/src/portable.h
@@ -1,10 +1,11 @@
 #ifndef PORTABLE_H
 #define PORTABLE_H
 
-#include <sys/types.h>
 #include <stdio.h>
-#include <qglobal.h>
-#include <qdir.h>
+#include <sys/types.h>
+
+
+
 
 #if defined(_WIN32)
 typedef __int64 portable_off_t;
@@ -16,29 +17,33 @@ typedef off_t portable_off_t;
  *  @brief Portable versions of functions that are platform dependent.
  */
 
-int            portable_system(const char *command,const char *args,bool commandHasConsole=TRUE);
-uint           portable_pid();
-const char *   portable_getenv(const char *variable);
-void           portable_setenv(const char *variable,const char *value);
-void           portable_unsetenv(const char *variable);
-portable_off_t portable_fseek(FILE *f,portable_off_t offset, int whence);
-portable_off_t portable_ftell(FILE *f);
-FILE *         portable_fopen(const char *fileName,const char *mode);
-void           portable_unlink(const char *fileName);
-char           portable_pathSeparator();
-char           portable_pathListSeparator();
-const char *   portable_ghostScriptCommand();
-const char *   portable_commandExtension();
-bool           portable_fileSystemIsCaseSensitive();
-FILE *         portable_popen(const char *name,const char *type);
-int            portable_pclose(FILE *stream);
-void           portable_sysTimerStart();
-void           portable_sysTimerStop();
-double         portable_getSysElapsedTime();
-void           portable_sleep(int ms);
-bool           portable_isAbsolutePath(const char *fileName);
-void           portable_correct_path(void);
-void           portable_setShortDir(void);
+namespace Portables
+{
+  int            system(const char *command,const char *args,bool commandHasConsole=true);
+  unsigned int   pid(void);
+  const char *   getenv(const char *variable);
+  void           setenv(const char *variable,const char *value);
+  void           unsetenv(const char *variable);
+  portable_off_t fseek(FILE *f,portable_off_t offset, int whence);
+  portable_off_t ftell(FILE *f);
+  FILE *         fopen(const char *fileName,const char *mode);
+  void           unlink(const char *fileName);
+  char           pathSeparator(void);
+  char           pathListSeparator(void);
+  const char *   ghostScriptCommand(void);
+  const char *   commandExtension(void);
+  bool           fileSystemIsCaseSensitive();
+  FILE *         popen(const char *name,const char *type);
+  int            pclose(FILE *stream);
+  void           sysTimerStart(void);
+  void           sysTimerStop(void);
+  double         getSysElapsedTime(void);
+  void           sleep(int ms);
+  bool           isAbsolutePath(const char *fileName);
+  void           correct_path(void);
+  void           setShortDir(void);
+}
+
 
 extern "C" {
   void *         portable_iconv_open(const char* tocode, const char* fromcode);

--- a/src/pre.l
+++ b/src/pre.l
@@ -1826,7 +1826,7 @@ static FileState *findFile(yyscan_t yyscanner, const char *fileName,bool localIn
 {
   YY_EXTRA_TYPE state = preYYget_extra(yyscanner);
   //printf("** findFile(%s,%d) state->yyFileName=%s\n",fileName,localInclude,state->yyFileName.data());
-  if (portable_isAbsolutePath(fileName))
+  if (Portables::isAbsolutePath(fileName))
   {
     FileState *fs = checkAndOpenFile(yyscanner,fileName,alreadyIncluded);
     if (fs)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2428,7 +2428,7 @@ static QCString getFilterFromList(const char *name,const QStrList &filterList,bo
     if (i_equals!=-1)
     {
       QCString filterPattern = fs.left(i_equals);
-      QRegExp fpat(filterPattern,portable_fileSystemIsCaseSensitive(),TRUE); 
+      QRegExp fpat(filterPattern,Portables::fileSystemIsCaseSensitive(),TRUE); 
       if (fpat.match(name)!=-1) 
       {
         // found a match!
@@ -2589,7 +2589,7 @@ QCString fileToString(const char *name,bool filter,bool isSourceCode)
 static QDateTime getCurrentDateTime()
 {
   QDateTime current = QDateTime::currentDateTime();
-  QCString sourceDateEpoch = portable_getenv("SOURCE_DATE_EPOCH");
+  QCString sourceDateEpoch = Portables::getenv("SOURCE_DATE_EPOCH");
   if (!sourceDateEpoch.isEmpty())
   {
     bool ok;
@@ -7928,14 +7928,22 @@ void stackTrace()
     p += sprintf(p,"%p ", backtraceFrames[x]);
   }
   fprintf(stderr,"========== STACKTRACE START ==============\n");
-  if (FILE *fp = popen(cmd, "r"))
+  #if defined(_WIN32) && !defined(__CYGWIN__)
+  if (FILE *fp = _popen(cmd, "r"))
+  #else
+  if (FILE *fp = ::popen(cmd, "r"))
+  #endif
   {
     char resBuf[512];
     while (size_t len = fread(resBuf, 1, sizeof(resBuf), fp))
     {
       fwrite(resBuf, 1, len, stderr);
     }
-    pclose(fp);
+    #if defined(_WIN32) && !defined(__CYGWIN__)
+    _pclose(fp);
+    #else
+    ::pclose(fp);
+    #endif
   }
   fprintf(stderr,"============ STACKTRACE END ==============\n");
   //fprintf(stderr,"%s\n", frameStrings[x]);
@@ -8011,7 +8019,7 @@ bool readInputFile(const char *fileName,BufStr &inBuf,bool filter,bool isSourceC
   {
     QCString cmd=filterName+" \""+fileName+"\"";
     Debug::print(Debug::ExtCmd,0,"Executing popen(`%s`)\n",qPrint(cmd));
-    FILE *f=portable_popen(cmd,"r");
+    FILE *f=Portables::popen(cmd,"r");
     if (!f)
     {
       err("could not execute filter %s\n",filterName.data());
@@ -8025,7 +8033,7 @@ bool readInputFile(const char *fileName,BufStr &inBuf,bool filter,bool isSourceC
       //printf(">>>>>>>>Reading %d bytes\n",numRead);
       inBuf.addArray(buf,numRead),size+=numRead;
     }
-    portable_pclose(f);
+    Portables::pclose(f);
     inBuf.at(inBuf.curPos()) ='\0';
     Debug::print(Debug::FilterOutput, 0, "Filter output\n");
     Debug::print(Debug::FilterOutput,0,"-------------\n%s\n-------------\n",qPrint(inBuf));

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -169,7 +169,7 @@ static void createSVG()
 
     QCString vlargs="-Tsvg \""+ov+"\" "+dir ;
 
-    if (portable_system(Config_getString(DOT_PATH) + "dot",vlargs)!=0)
+    if (Portables::system(Config_getString(DOT_PATH) + "dot",vlargs)!=0)
     {
       err("could not create dot file");
     }
@@ -3796,7 +3796,7 @@ void FlowChart::createSVG()
 
   QCString vlargs="-Tsvg \""+ov+"\" "+dir ;
 
-  if (portable_system(Config_getString(DOT_PATH) + "dot",vlargs)!=0)
+  if (Portables::system(Config_getString(DOT_PATH) + "dot",vlargs)!=0)
   {
     err("could not create dot file");
   }


### PR DESCRIPTION
Refactoring of portable.h and portable.cpp functions to be contained in a namespace
Fixing some memory issues caused by not correctly freed pointers

The issue is that a dictionary holding pointers to processed dot files is freed without freeing the contained pointers. This causes for many processed dots a enourmous wastage of memory, until the doxygen app is closed.

The portables module was refactored to make use of c++ garbage colection to remove the path pointer in linux, if it was extended, to remove another orphaned pointer.