### PR TITLE
Correct style in table header in case of paragraph is used

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -66,6 +66,11 @@ p.startli, p.startdd {
 	margin-top: 2px;
 }
 
+th p.starttd, p.intertd, p.endtd {
+        font-size: 100%;
+        font-weight: 700;
+}
+
 p.starttd {
 	margin-top: 0px;
 }


### PR DESCRIPTION
In case a paragraph is used in a table header (quite unusual but can happen with 2 lines and an empty line in between), a `<p class="starttd">` tag is added and therewith the layout is incorrect.
This problem was detected based on #7409
This has been corrected (and tested with some available browsers FF, IE, Chrome, Opera).