### PR TITLE
Incorrect warning "yyextra->inside" instead of "inside"

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4307,7 +4307,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <CopyArgComment,CopyArgVerbatim>.	{ yyextra->fullArgString+=*yytext; }
 <CopyArgComment>{CMD}("brief"|"short"){B}+ {
   					  warn(yyextra->yyFileName,yyextra->yyLineNr,
-					      "Ignoring %cbrief command yyextra->inside argument documentation",*yytext
+					      "Ignoring %cbrief command inside argument documentation",*yytext
 					     );
                                           yyextra->fullArgString+=' ';
                                         }
@@ -6421,7 +6421,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					}
 <DocCopyBlock><<EOF>>			{
   					  warn(yyextra->yyFileName,yyextra->yyLineNr,
-					      "reached end of file while yyextra->inside a '%s' block!\n"
+					      "reached end of file while inside a '%s' block!\n"
 					      "The command that should end the block seems to be missing!\n",
 					      yyextra->docBlockName.data());
   					  yyterminate();


### PR DESCRIPTION
We get warnings like:
```
warning: reached end of file while yyextra->inside a 'code' block!

warning: Ignoring \brief command yyextra->inside argument documentation
```
this is due to the fact that the scanner has been made reentrant (inside becomes yyextra->inside and this slipped into the warning strings as well)