### PR TITLE
Warning with Windows compilation using NMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ if (WIN32)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # needed for language.cpp on 64bit
         add_definitions(-DLIBICONV_STATIC -D_CRT_SECURE_NO_WARNINGS)
     endif()
+    if (CMAKE_GENERATOR MATCHES "NMake Makefiles")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+    endif()
 endif()
 
 if(POLICY CMP0063)


### PR DESCRIPTION
When using NMake Makefiles on windows we get messages like:
```
D:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\vector(960): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
```
From the help information of `cl`:
```
/EHs enable C++ EH (no SEH exceptions)
/EHc extern "C" defaults to nothrow
```

Looking at the usage with the `msbuild / vsxproj` type builds (as done on appveyor), here the option `/EHsc` is used.