### PR TITLE
Tests 86  with check against xsd gives error

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -414,6 +414,7 @@
       <xsd:element name="underline" type="docMarkupType" />
       <xsd:element name="emphasis" type="docMarkupType" />
       <xsd:element name="computeroutput" type="docMarkupType" />
+      <xsd:element name="ins" type="docMarkupType" />
       <xsd:element name="subscript" type="docMarkupType" />
       <xsd:element name="superscript" type="docMarkupType" />
       <xsd:element name="center" type="docMarkupType" />


### PR DESCRIPTION
When running test 86 with check against the xsd we get the error message:
```
not ok 1 - [086_style_tags.h]: test different HTML style tags
-------------------------------------
Element 'ins': This element is not expected. Expected is one of ( ulink, bold, strike, underline, emphasis, computeroutput, subscript, superscript, center, small ).
test_output_086/out/086__style__tags_8h.xml fails to validate
```

The element `ins` has been added.