### PR TITLE
Tests 31 for XHTML output

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1725,7 +1725,7 @@ void HtmlDocVisitor::visitPre(DocImage *img)
     }
     if (typeSVG)
     {
-      m_t << "<object type=\"image/svg+xml\" data=\"" << src
+      m_t << "<object type=\"image/svg+xml\" data=\"" << convertToHtml(src)
         << "\"" << sizeAttribs << attrs;
       if (inlineImage)
       {


### PR DESCRIPTION
When running test 31 for XHTML output, we get the error:
```
not ok 1 - [031_image.dox]: test the \image command
-------------------------------------
.../testing/test_output_031/html/index.xhtml:107: parser error : EntityRef: expecting ';'
"image/svg+xml" data="https://img.shields.io/badge/docs-Doxygen-blue.svg?foo&bar

```

For the SVG output the `src` was not properly converted (see also the other formats a few lines lower).