### PR TITLE
Double entry for ins in compound.xsd

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -415,7 +415,6 @@
       <xsd:element name="underline" type="docMarkupType" />
       <xsd:element name="emphasis" type="docMarkupType" />
       <xsd:element name="computeroutput" type="docMarkupType" />
-      <xsd:element name="ins" type="docMarkupType" />
       <xsd:element name="subscript" type="docMarkupType" />
       <xsd:element name="superscript" type="docMarkupType" />
       <xsd:element name="center" type="docMarkupType" />


### PR DESCRIPTION
Pull request #7458 added `ins` and pull request #7203 corrected `inc` to `ins` resulting in double `ins`, corrected.