### PR TITLE
issue #7468 Markdown table - </td> does not terminate character formatting (@c, @e)

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -652,6 +652,16 @@ static bool insideOL(DocNode *n)
 
 //---------------------------------------------------------------------------
 
+static bool insideTD(DocNode *n)
+{
+  while (n)
+  {
+    if (n->kind()==DocNode::Kind_HtmlCell) return TRUE;
+    n=n->parent();
+  }
+  return FALSE;
+}
+
 static bool insideTable(DocNode *n)
 {
   while (n)
@@ -860,8 +870,9 @@ static int handleStyleArgument(DocNode *parent,QList<DocNode> &children,
       switch (tok)
       {
         case TK_HTMLTAG:
-          if (insideLI(parent) && Mappers::htmlTagMapper->map(g_token->name) && g_token->endTag)
-          { // ignore </li> as the end of a style command
+          if ((insideLI(parent) && Mappers::htmlTagMapper->map(g_token->name) && g_token->endTag) ||
+              (insideTD(parent) && Mappers::htmlTagMapper->map(g_token->name) && g_token->endTag))
+          { // ignore </li> and </td> as the end of a style command
             continue; 
           }
           return tok;


### PR DESCRIPTION
The basic problem is the combination of formatting codes inside a table, the same problem is shown with:
```
<table>
<tr> <td> \c ELEMENT_\e X</td> </tr>
</table>
```
the problem did now surface when fixing: issue #7228 "Using markdown causes wrong error and warning line numbers - v. 1.8.16" as pull request #7231.

The `</td>` is now handled similar to `</li>`.