### PR TITLE
Showing information from all \*only commands in XML output

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2498,6 +2498,7 @@ Commands for displaying examples
   Files or directories that doxygen should look for can be specified using the
   \ref cfg_example_path "EXAMPLE_PATH" tag of doxygen's configuration file.
 
+  \sa section \ref cmdlatexonly "\\latexonly". 
 <hr>
 
 \htmlonly</p><center><p>\endhtmlonly
@@ -2697,8 +2698,9 @@ only copy the detailed documentation, not the brief description.
 \section cmddocbookonly \\docbookonly
 
   \addindex \\docbookonly
-  Starts a block of text that will be verbatim included in the
-  generated DocBook documentation only. The block ends with a
+  Starts a block of text that only will be verbatim included in the
+  generated DocBook documentation and tagged with `<docbookonly>` in the generated
+  XML output. The block ends with a
   \ref cmdenddocbookonly "\\enddocbookonly" command.
 
   \sa section \ref cmdmanonly "\\manonly", 
@@ -3142,8 +3144,9 @@ class Receiver
 \section cmdhtmlonly \\htmlonly ["[block]"]
 
   \addindex \\htmlonly
-  Starts a block of text that will be verbatim included in the
-  generated HTML documentation only. The block ends with a
+  Starts a block of text that only will be verbatim included in the
+  generated HTML documentation and tagged with `<htmlonly>` in the generated
+  XML output. The block ends with a
   \ref cmdendhtmlonly "\\endhtmlonly" command.
 
   This command can be used to include HTML code that is too complex
@@ -3233,8 +3236,9 @@ class Receiver
 \section cmdlatexonly \\latexonly
 
   \addindex \\latexonly
-  Starts a block of text that will be verbatim included in the
-  generated \LaTeX documentation only. The block ends with a
+  Starts a block of text that only will be verbatim included in the
+  generated \LaTeX documentation and tagged with `<latexonly>` in the generated
+  XML output. The block ends with a
   \ref cmdendlatexonly "\\endlatexonly" command.
 
   This command can be used to include \LaTeX code that is too
@@ -3249,15 +3253,17 @@ class Receiver
   \sa sections \ref cmdrtfonly "\\rtfonly",
                \ref cmdxmlonly "\\xmlonly",
                \ref cmdmanonly "\\manonly",
-               \ref cmdhtmlonly "\\htmlonly", and
-               \ref cmdhtmlonly "\\docbookonly".
+               \ref cmdhtmlonly "\\htmlonly",
+               \ref cmddocbookonly "\\docbookonly", and
+               \ref cmdlatexinclude "\\latexinclude".
 
 <hr>
 \section cmdmanonly \\manonly
 
   \addindex \\manonly
-  Starts a block of text that will be verbatim included in the
-  generated MAN documentation only. The block ends with a
+  Starts a block of text that only will be verbatim included in the
+  generated MAN documentation and tagged with `<manonly>` in the generated
+  XML output. The block ends with a
   \ref cmdendmanonly "\\endmanonly" command.
 
   This command can be used to include groff code directly into
@@ -3334,8 +3340,9 @@ class Receiver
 \section cmdrtfonly \\rtfonly
 
   \addindex \\rtfonly
-  Starts a block of text that will be verbatim included in the
-  generated RTF documentation only. The block ends with a
+  Starts a block of text that only will be verbatim included in the
+  generated RTF documentation and tagged with `<rtfonly>` in the generated
+  XML output. The block ends with a
   \ref cmdendrtfonly "\\endrtfonly" command.
 
   This command can be used to include RTF code that is too complex
@@ -3371,8 +3378,8 @@ class Receiver
 \section cmdxmlonly \\xmlonly
 
   \addindex \\xmlonly
-  Starts a block of text that will be verbatim included in the
-  generated XML output only. The block ends with a
+  Starts a block of text that only will be verbatim included in the
+  generated XML output. The block ends with a
   \ref cmdendxmlonly "\\endxmlonly" command.
 
   This command can be used to include custom XML tags.

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -265,11 +265,36 @@ void XmlDocVisitor::visit(DocVerbatim *s)
       m_t << "</verbatim>"; 
       break;
     case DocVerbatim::HtmlOnly: 
+      if (s->isBlock())
+      {
+        m_t << "<htmlonly block=\"yes\">";
+      }
+      else
+      {
+        m_t << "<htmlonly>";
+      }
+      filter(s->text());
+      m_t << "</htmlonly>";
+      break;
     case DocVerbatim::RtfOnly: 
+      m_t << "<rtfonly>";
+      filter(s->text());
+      m_t << "</rtfonly>";
+      break;
     case DocVerbatim::ManOnly: 
+      m_t << "<manonly>";
+      filter(s->text());
+      m_t << "</manonly>";
+      break;
     case DocVerbatim::LatexOnly: 
+      m_t << "<latexonly>";
+      filter(s->text());
+      m_t << "</latexonly>";
+      break;
     case DocVerbatim::DocbookOnly:
-      /* nothing */ 
+      m_t << "<docbookonly>";
+      filter(s->text());
+      m_t << "</docbookonly>";
       break;
     case DocVerbatim::XmlOnly: 
       m_t << s->text();

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -426,6 +426,7 @@
       <xsd:element name="xmlonly" type="xsd:string" />
       <xsd:element name="rtfonly" type="xsd:string" />
       <xsd:element name="latexonly" type="xsd:string" />
+      <xsd:element name="docbookonly" type="xsd:string" />
       <xsd:element name="image" type="docImageType" />
       <xsd:element name="dot" type="docImageType" />
       <xsd:element name="msc" type="docImageType" />

--- a/testing/020/indexpage.xml
+++ b/testing/020/indexpage.xml
@@ -6,9 +6,21 @@
     <briefdescription>
     </briefdescription>
     <detaileddescription>
-      <para>Text.       
+      <para>Text. <htmlonly> 
+HTML
+</htmlonly> <htmlonly block="yes">
+HTML with block
+</htmlonly> <rtfonly> 
+RTF
+</rtfonly> <manonly> 
+Man
+</manonly> <latexonly> 
+LaTeX
+</latexonly>  
 XML
-  More text. </para>
+ <docbookonly> 
+DocBook
+</docbookonly> More text. </para>
     </detaileddescription>
   </compounddef>
 </doxygen>

--- a/testing/020_only.dox
+++ b/testing/020_only.dox
@@ -1,4 +1,4 @@
-// objective: test the \*only and \*endonly commands
+// objective: test the \*only and \end*only commands
 // check: indexpage.xml
 /** \mainpage
  * Text.


### PR DESCRIPTION
This fix reverts the changes from #381 (i.e issue #4214 "htmlonly content appears in generated XML output (Origin: bugzilla 646002)", as XML is seen as an output format that can be further processed and therefore should contain all possible information.