### PR TITLE
Remove double entry of rtfonly command from list of commands

### DIFF
--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -83,7 +83,6 @@ CommandMap cmdMap[] =
   { "return",        CMD_RETURN },
   { "returns",       CMD_RETURN },
   { "retval",        CMD_RETVAL },
-  { "rtfonly",       CMD_RTFONLY },
   { "sa",            CMD_SA },
   { "secreflist",    CMD_SECREFLIST },
   { "section",       CMD_SECTION },


### PR DESCRIPTION
Remove double entry of rtfonly command from list of commands