### PR TITLE
Correction behavior of make clean in respect to version files

### DIFF
--- a/cmake/git_watcher.cmake
+++ b/cmake/git_watcher.cmake
@@ -178,6 +178,7 @@ function(SetupGitMonitoring)
         ALL
 	DEPENDS ${PRE_CONFIGURE_GIT_VERSION_FILE}
 	BYPRODUCTS ${POST_CONFIGURE_GIT_VERSION_FILE}
+	BYPRODUCTS ${GIT_STATE_FILE}
         COMMENT "Checking the git repository for changes..."
         COMMAND
             ${CMAKE_COMMAND}

--- a/libversion/CMakeLists.txt
+++ b/libversion/CMakeLists.txt
@@ -7,6 +7,7 @@ set(POST_CONFIGURE_DOXYGEN_VERSION_FILE "${GENERATED_SRC}/doxyversion.cpp")
 # setup information for git version handling
 set(PRE_CONFIGURE_GIT_VERSION_FILE "${CMAKE_SOURCE_DIR}/libversion/gitversion.cpp.in")
 set(POST_CONFIGURE_GIT_VERSION_FILE "${GENERATED_SRC}/gitversion.cpp")
+set(GIT_STATE_FILE "${GENERATED_SRC}/git_state")
 
 include(${CMAKE_SOURCE_DIR}/cmake/git_watcher.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/doxygen_version.cmake)
@@ -25,3 +26,4 @@ add_dependencies( doxygen_version check_doxygen_version )
 
 set_source_files_properties(${POST_CONFIGURE_GIT_VERSION_FILE} PROPERTIES GENERATED 1)
 set_source_files_properties(${POST_CONFIGURE_DOXYGEN_VERSION_FILE} PROPERTIES GENERATED 1)
+set_source_files_properties(${GIT_STATE_FILE} PROPERTIES GENERATED 1)


### PR DESCRIPTION
I case we ran `make clean` it was not possible anymore to generate doxygen as the generated file `generated_src/gitversion.cpp` was not present any more and it was not re-generated.
The generation of the `generated_src/gitversion.cpp` depends on teh `generated_src/git_state` file and this file was still present. This has been corrected.