### PR TITLE
Possibility to use gswin64c on Windows

### DIFF
--- a/doc/install.doc
+++ b/doc/install.doc
@@ -251,7 +251,7 @@ Ghostscript can be <a href="https://sourceforge.net/projects/ghostscript/">downl
 from Sourceforge.
 
 After installing \LaTeX and Ghostscript you'll need to make sure the tools
-latex.exe, pdflatex.exe, and gswin32c.exe are present in the search path of a
+latex.exe, pdflatex.exe, and gswin32c.exe (or gswin64c.exe) are present in the search path of a
 command box. Follow <a href="https://www.computerhope.com/issues/ch000549.htm">these</a>
 instructions if you are unsure and run the commands from a command box to verify it works.
 

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -42,6 +42,7 @@
 #include "namespacedef.h"
 #include "filename.h"
 #include "resourcemgr.h"
+#include "portable.h"
 
 static bool DoxyCodeOpen = FALSE;
 static bool DoxyCodeLineOpen = FALSE;

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -421,7 +421,8 @@ static void writeMakeBat()
     t << mkidx_command << " refman.idx\n";
     t << "%LATEX_CMD% refman.tex\n";
     t << "dvips -o refman.ps refman.dvi\n";
-    t << "gswin32c -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite "
+    t << Portable::ghostScriptCommand();
+    t << " -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite "
          "-sOutputFile=refman.pdf -c save pop -f refman.ps\n";
   }
   else // use pdflatex


### PR DESCRIPTION
On windows the 32 bit executable is called gswin32c, but for the 64-bit systems also a gswin64c exists.
The path is checked for the existing of these executables (with a preference for the 32 bit version).