### PR TITLE
Warning due to empty row in a table

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -3473,6 +3473,7 @@ int DocHtmlRow::parse()
   g_nodeStack.push(this);
   DBG(("DocHtmlRow::parse() start\n"));
 
+restartrow:
   bool isHeading=FALSE;
   bool isFirst=TRUE;
   DocHtmlCell *cell=0;
@@ -3492,10 +3493,14 @@ int DocHtmlRow::parse()
     {
       isHeading=TRUE;
     }
+    else if (tagId==HTML_TR) // found <tr> or </tr>, signalling a row withour columns, skip it, skip it
+    {
+      goto restartrow;
+    }
     else // found some other tag
     {
       warn_doc_error(g_fileName,doctokenizerYYlineno,"expected <td> or <th> tag but "
-          "found <%s> instead!",qPrint(g_token->name));
+          "found <%s> instead!",qPrint((g_token->endTag ? "/" : "")+g_token->name));
       doctokenizerYYpushBackHtmlTag(g_token->name);
       goto endrow;
     }


### PR DESCRIPTION
In case we have a `<table>` with an empty row, either
- `<tr></tr>`
- `<tr><tr>`

we get a warning:
```
 warning: expected <td> or <th> tag but found <tr> instead!
```

When looking at the same table as native HTML the table is shown and the empty row is skipped / not shown.
This is now also been done by means of this patch.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4031719/example.tar.gz)
