### PR TITLE
issue #7484 Error: /undefined in getenv

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -151,13 +151,13 @@ void FormulaList::generateBitmaps(const char *path)
         return;
       }
       Portable::sysTimerStop();
-      // run ps2epsi to convert to an encapsulated postscript file with
+      // run eps2eps to convert to an encapsulated postscript file with
       // boundingbox (dvips with -E has some problems here).
       sprintf(psArgs,"%s_tmp.ps %s.eps",formBase.data(),formBase.data()); 
       Portable::sysTimerStart();
-      if (Portable::system("ps2epsi",psArgs)!=0)
+      if (Portable::system("eps2eps",psArgs)!=0)
       {
-        err("Problems running ps2epsi. Check your installation!\n");
+        err("Problems running eps2eps. Check your installation!\n");
         Portable::sysTimerStop();
         QDir::setCurrent(oldDir);
         return;


### PR DESCRIPTION
The command `ps2epsi` also uses the `gs` command and this gives some problems with the gs9.50 version.
An alternative is the `eps2eps` command that doesn't have these problems with the gs9.50 version.

See also:
- #7290
- https://bugs.ghostscript.com/show_bug.cgi?id=702024