### PR TITLE
Adding commands `\rtfinclude`, `\docbookinclude`, `\maninclude` and `\xmlinclude`

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -72,6 +72,7 @@ documentation:
 \refitem cmddetails \\details
 \refitem cmddiafile \\diafile
 \refitem cmddir \\dir
+\refitem cmddocbookinclude \\docbookinclude
 \refitem cmddocbookonly \\docbookonly
 \refitem cmddontinclude \\dontinclude
 \refitem cmddot \\dot
@@ -135,6 +136,7 @@ documentation:
 \refitem cmdline \\line
 \refitem cmdlink \\link
 \refitem cmdmainpage \\mainpage
+\refitem cmdmaninclude \\maninclude
 \refitem cmdmanonly \\manonly
 \refitem cmdmemberof \\memberof
 \refitem cmdmsc \\msc
@@ -175,6 +177,7 @@ documentation:
 \refitem cmdreturn \\return
 \refitem cmdreturns \\returns
 \refitem cmdretval \\retval
+\refitem cmdrtfinclude \\rtfinclude
 \refitem cmdrtfonly \\rtfonly
 \refitem cmdsa \\sa
 \refitem cmdsecreflist \\secreflist
@@ -211,6 +214,7 @@ documentation:
 \refitem cmdvhdlflow \\vhdlflow
 \refitem cmdwarning \\warning
 \refitem cmdweakgroup \\weakgroup
+\refitem cmdxmlinclude \\xmlinclude
 \refitem cmdxmlonly \\xmlonly
 \refitem cmdxrefitem \\xrefitem
 \refitem cmddollar \\\$
@@ -2457,8 +2461,8 @@ Commands for displaying examples
 \section cmdverbinclude \\verbinclude <file-name>
 
   \addindex \\verbinclude
-  This command includes the file \<file-name\> verbatim in the documentation.
-  The command is equivalent to pasting the file in the documentation and
+  This command includes the contents of the file \<file-name\> verbatim in the documentation.
+  The command is equivalent to pasting the contents of the file in the documentation and
   placing \ref cmdverbatim "\\verbatim" and \ref cmdendverbatim "\\endverbatim"
   commands around it.
 
@@ -2469,8 +2473,9 @@ Commands for displaying examples
 \section cmdhtmlinclude \\htmlinclude ["[block]"] <file-name>
 
   \addindex \\htmlinclude
-  This command includes the file \<file-name\> as is in the HTML documentation.
-  The command is equivalent to pasting the file in the documentation and
+  This command includes the contents of the file \<file-name\> as is in the HTML documentation
+  and tagged with `<htmlonly>` in the generated XML output.
+  The command is equivalent to pasting the contents of the file in the documentation and
   placing \ref cmdhtmlonly "\\htmlonly" and \ref cmdendhtmlonly "\\endhtmlonly"
   commands around it.
 
@@ -2490,8 +2495,9 @@ Commands for displaying examples
 \section cmdlatexinclude \\latexinclude <file-name>
 
   \addindex \\latexinclude
-  This command includes the file \<file-name\> as is in the \LaTeX documentation.
-  The command is equivalent to pasting the file in the documentation and
+  This command includes the contents of the file \<file-name\> as is in the \LaTeX documentation
+  and tagged with `<latexonly>` in the generated XML output.
+  The command is equivalent to pasting the contents of the file in the documentation and
   placing \ref cmdlatexonly "\\latexonly" and \ref cmdendlatexonly "\\endlatexonly"
   commands around it.
 
@@ -2499,6 +2505,65 @@ Commands for displaying examples
   \ref cfg_example_path "EXAMPLE_PATH" tag of doxygen's configuration file.
 
   \sa section \ref cmdlatexonly "\\latexonly". 
+<hr>
+
+\section cmdrtfinclude \\rtfinclude <file-name>
+
+  \addindex \\rtfinclude
+  This command includes the contents of the file \<file-name\> as is in the RTF documentation
+  and tagged with `<rtfonly>` in the generated XML output.
+  The command is equivalent to pasting the contents of the file in the documentation and
+  placing \ref cmdrtfonly "\\rtfonly" and \ref cmdendrtfonly "\\endrtfonly"
+  commands around it.
+
+  Files or directories that doxygen should look for can be specified using the
+  \ref cfg_example_path "EXAMPLE_PATH" tag of doxygen's configuration file.
+
+  \sa section \ref cmdrtfonly "\\rtfonly". 
+<hr>
+
+\section cmdmaninclude \\maninclude <file-name>
+
+  \addindex \\maninclude
+  This command includes the contents of the file \<file-name\> as is in the MAN documentation
+  and tagged with `<manonly>` in the generated XML output.
+  The command is equivalent to pasting the contents of the file in the documentation and
+  placing \ref cmdmanonly "\\manonly" and \ref cmdendmanonly "\\endmanonly"
+  commands around it.
+
+  Files or directories that doxygen should look for can be specified using the
+  \ref cfg_example_path "EXAMPLE_PATH" tag of doxygen's configuration file.
+
+  \sa section \ref cmdmanonly "\\manonly". 
+<hr>
+
+\section cmddocbookinclude \\docbookinclude <file-name>
+
+  \addindex \\docbookinclude
+  This command includes the contents of the file \<file-name\> as is in the DocBook documentation
+  and tagged with `<docbookonly>` in the generated XML output.
+  The command is equivalent to pasting the contents of the file in the documentation and
+  placing \ref cmddocbookonly "\\docbookonly" and \ref cmdenddocbookonly "\\enddocbookonly"
+  commands around it.
+
+  Files or directories that doxygen should look for can be specified using the
+  \ref cfg_example_path "EXAMPLE_PATH" tag of doxygen's configuration file.
+
+  \sa section \ref cmddocbookonly "\\docbookonly". 
+<hr>
+
+\section cmdxmlinclude \\xmlinclude <file-name>
+
+  \addindex \\xmlinclude
+  This command includes contents of the the file \<file-name\> as is in the XML documentation.
+  The command is equivalent to pasting the contents of the file in the documentation and
+  placing \ref cmdxmlonly "\\xmlonly" and \ref cmdendxmlonly "\\endxmlonly"
+  commands around it.
+
+  Files or directories that doxygen should look for can be specified using the
+  \ref cfg_example_path "EXAMPLE_PATH" tag of doxygen's configuration file.
+
+  \sa section \ref cmdxmlonly "\\xmlonly". 
 <hr>
 
 \htmlonly</p><center><p>\endhtmlonly

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -149,6 +149,10 @@ CommandMap cmdMap[] =
   { "---",           CMD_MDASH },
   { "_setscope",     CMD_SETSCOPE },
   { "emoji",         CMD_EMOJI },
+  { "rtfinclude",    CMD_RTFINCLUDE },
+  { "docbookinclude",CMD_DOCBOOKINCLUDE },
+  { "maninclude",    CMD_MANINCLUDE },
+  { "xmlinclude",    CMD_XMLINCLUDE },
   { 0,               0 },
 };
 

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -138,7 +138,11 @@ enum CommandType
   CMD_SNIPPETDOC   = 108,
   CMD_SNIPWITHLINES= 109,
   CMD_EMOJI        = 110,
-  CMD_EQUAL        = 111
+  CMD_EQUAL        = 111,
+  CMD_RTFINCLUDE   = 112,
+  CMD_DOCBOOKINCLUDE= 113,
+  CMD_MANINCLUDE   = 114,
+  CMD_XMLINCLUDE   = 115
 };
 
 enum HtmlTagType

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -286,6 +286,10 @@ static DocCmdMap docCmdMap[] =
   { "snippet",         0,                       TRUE  },
   { "snippetlineno",   0,                       TRUE  },
   { "noop",            &handleNoop,             TRUE },
+  { "rtfinclude",      0,                       FALSE },
+  { "docbookinclude",  0,                       FALSE },
+  { "maninclude",      0,                       FALSE },
+  { "xmlinclude",      0,                       FALSE },
   { 0, 0, FALSE }
 };
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -434,6 +434,12 @@ DB_VIS_C
     case DocInclude::DontIncWithLines:
     case DocInclude::HtmlInclude:
     case DocInclude::LatexInclude:
+    case DocInclude::RtfInclude:
+    case DocInclude::ManInclude:
+    case DocInclude::XmlInclude:
+      break;
+    case DocInclude::DocbookInclude:
+      m_t << inc->text();
       break;
     case DocInclude::VerbInclude:
       m_t << "<literallayout>";

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2000,9 +2000,11 @@ void DocInclude::parse()
     case VerbInclude: 
       // fall through
     case HtmlInclude:
-      readTextFileByName(m_file,m_text);
-      break;
     case LatexInclude:
+    case DocInclude::RtfInclude:
+    case DocInclude::ManInclude:
+    case DocInclude::XmlInclude:
+    case DocInclude::DocbookInclude:
       readTextFileByName(m_file,m_text);
       break;
     case Snippet:
@@ -5775,6 +5777,18 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       break;
     case CMD_LATEXINCLUDE:
       handleInclude(cmdName,DocInclude::LatexInclude);
+      break;
+    case CMD_RTFINCLUDE:
+      handleInclude(cmdName,DocInclude::RtfInclude);
+      break;
+    case CMD_MANINCLUDE:
+      handleInclude(cmdName,DocInclude::ManInclude);
+      break;
+    case CMD_XMLINCLUDE:
+      handleInclude(cmdName,DocInclude::XmlInclude);
+      break;
+    case CMD_DOCBOOKINCLUDE:
+      handleInclude(cmdName,DocInclude::DocbookInclude);
       break;
     case CMD_VERBINCLUDE:
       handleInclude(cmdName,DocInclude::VerbInclude);

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -583,7 +583,7 @@ class DocInclude : public DocNode
   public:
   enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude,
 	      IncWithLines, Snippet , IncludeDoc, SnippetDoc, SnipWithLines,
-	      DontIncWithLines};
+	      DontIncWithLines, RtfInclude, ManInclude, DocbookInclude, XmlInclude};
     DocInclude(DocNode *parent,const QCString &file,
                const QCString context, Type t,
                bool isExample,const QCString exampleFile,

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -180,6 +180,10 @@ static bool isDocIncludeVisible(DocInclude *s)
   {
     case DocInclude::DontInclude:
     case DocInclude::LatexInclude:
+    case DocInclude::RtfInclude:
+    case DocInclude::ManInclude:
+    case DocInclude::XmlInclude:
+    case DocInclude::DocbookInclude:
       return FALSE;
     default:
       return TRUE;
@@ -715,6 +719,10 @@ void HtmlDocVisitor::visit(DocInclude *inc)
       break;
     case DocInclude::DontInclude:
     case DocInclude::LatexInclude:
+    case DocInclude::RtfInclude:
+    case DocInclude::ManInclude:
+    case DocInclude::XmlInclude:
+    case DocInclude::DocbookInclude:
     case DocInclude::DontIncWithLines:
       break;
     case DocInclude::HtmlInclude:

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -503,6 +503,10 @@ void LatexDocVisitor::visit(DocInclude *inc)
     case DocInclude::DontInclude:
     case DocInclude::DontIncWithLines:
     case DocInclude::HtmlInclude:
+    case DocInclude::RtfInclude:
+    case DocInclude::ManInclude:
+    case DocInclude::XmlInclude:
+    case DocInclude::DocbookInclude:
       break;
     case DocInclude::LatexInclude:
       m_t << inc->text();

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -304,6 +304,12 @@ void ManDocVisitor::visit(DocInclude *inc)
     case DocInclude::DontIncWithLines:
     case DocInclude::HtmlInclude:
     case DocInclude::LatexInclude:
+    case DocInclude::RtfInclude:
+    case DocInclude::XmlInclude:
+    case DocInclude::DocbookInclude:
+      break;
+    case DocInclude::ManInclude:
+      m_t << inc->text();
       break;
     case DocInclude::VerbInclude: 
       if (!m_firstCol) m_t << endl;

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -733,6 +733,10 @@ void PerlModDocVisitor::visit(DocInclude *inc)
   case DocInclude::DontIncWithLines: return;
   case DocInclude::HtmlInclude:	type = "htmlonly"; break;
   case DocInclude::LatexInclude: type = "latexonly"; break;
+  case DocInclude::RtfInclude: type = "rtfonly"; break;
+  case DocInclude::ManInclude: type = "manonly"; break;
+  case DocInclude::XmlInclude: type = "xmlonly"; break;
+  case DocInclude::DocbookInclude: type = "docbookonly"; break;
   case DocInclude::VerbInclude:	type = "preformatted"; break;
   case DocInclude::Snippet: return;
   case DocInclude::SnipWithLines: return;

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -202,6 +202,10 @@ class PrintDocVisitor : public DocVisitor
                if (inc->isBlock()) printf(" block=\"yes\"");
                break;
         case DocInclude::LatexInclude: printf("latexinclude"); break;
+        case DocInclude::RtfInclude: printf("rtfinclude"); break;
+        case DocInclude::DocbookInclude: printf("docbookinclude"); break;
+        case DocInclude::ManInclude: printf("maninclude"); break;
+        case DocInclude::XmlInclude: printf("xmlinclude"); break;
         case DocInclude::VerbInclude: printf("verbinclude"); break;
         case DocInclude::Snippet: printf("snippet"); break;
         case DocInclude::SnipWithLines: printf("snipwithlines"); break;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -473,6 +473,12 @@ void RTFDocVisitor::visit(DocInclude *inc)
     case DocInclude::DontIncWithLines:
     case DocInclude::HtmlInclude:
     case DocInclude::LatexInclude:
+    case DocInclude::ManInclude:
+    case DocInclude::XmlInclude:
+    case DocInclude::DocbookInclude:
+      break;
+    case DocInclude::RtfInclude:
+      m_t << inc->text();
       break;
     case DocInclude::VerbInclude: 
       m_t << "{" << endl;

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -388,6 +388,24 @@ void XmlDocVisitor::visit(DocInclude *inc)
       filter(inc->text());
       m_t << "</latexonly>";
       break;
+    case DocInclude::RtfInclude:
+      m_t << "<rtfonly>";
+      filter(inc->text());
+      m_t << "</rtfonly>";
+      break;
+    case DocInclude::ManInclude:
+      m_t << "<manonly>";
+      filter(inc->text());
+      m_t << "</manonly>";
+      break;
+    case DocInclude::XmlInclude:
+      filter(inc->text());
+      break;
+    case DocInclude::DocbookInclude:
+      m_t << "<docbookonly>";
+      filter(inc->text());
+      m_t << "</docbookonly>";
+      break;
     case DocInclude::VerbInclude: 
       m_t << "<verbatim>";
       filter(inc->text());


### PR DESCRIPTION
Adding for consistency with `\*only`, `\htmlinclude` and `\latexinclude` the commands: `\rtfinclude`, `\docbookinclude`, `\maninclude` and `\xmlinclude`