### PR TITLE
CMake and examples

### DIFF
--- a/doc/index.hhp.txt
+++ b/doc/index.hhp.txt
@@ -102,7 +102,7 @@ examples/tag/html/tab_a.png
 examples/tag/html/tab_b.png
 examples/tag/html/tab_h.png
 examples/tag/html/tab_s.png
-examples/template/html/tab_a.png
-examples/template/html/tab_b.png
-examples/template/html/tab_h.png
-examples/template/html/tab_s.png
+examples/templ/html/tab_a.png
+examples/templ/html/tab_b.png
+examples/templ/html/tab_h.png
+examples/templ/html/tab_s.png

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,234 +16,54 @@ foreach (f  ${EXAMPLE_FILES})
     list(APPEND OUT_EXAMPLE_FILES "${PROJECT_BINARY_DIR}/examples/${f}")
 endforeach()
 
+set(BASIC_EXAMPLES
+                class:h
+                define:h
+                enum:h
+                file:h
+                func:h
+                javadoc-banner:h
+                structcmd:h
+                afterdoc:h
+                relates:cpp
+                author:cpp
+                par:cpp
+                overload:cpp
+                example:cpp
+                include:cpp
+                qtstyle:cpp
+                jdstyle:cpp
+                autolink:cpp
+                restypedef:cpp
+                tag:cpp
+                group:cpp
+                memgrp:cpp
+                templ:cpp
+                page:doc
+                docstring:py
+                pyexample:py
+                tclexample:tcl
+                manual:c
+                mux:vhdl
+)
+
+foreach (f_inp  ${BASIC_EXAMPLES})
+        string(REGEX REPLACE ".*:" "" f_ext ${f_inp})
+        string(REGEX REPLACE ":.*" "" f ${f_inp})
+    add_custom_command(
+	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen ${f}.cfg
+        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/${f}/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/${f}/latex/refman_doc.tex
+	DEPENDS doxygen ${f}.${f_ext} ${f}.cfg ${TOP}/examples/strip_example.py
+	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/${f}/html/index.html ${PROJECT_BINARY_DIR}/html/examples/${f}/latex/refman_doc.tex
+    )
+    set(EXAMPLES_RES ${EXAMPLES_RES} "" ${PROJECT_BINARY_DIR}/html/examples/${f}/html/index.html)
+endforeach()
+
 add_custom_target(examples
   DEPENDS ${OUT_EXAMPLE_FILES}
-                ${PROJECT_BINARY_DIR}/html/examples/class/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/define/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/enum/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/file/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/func/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/javadoc-banner/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/page/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/relates/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/author/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/par/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/overload/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/example/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/include/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/qtstyle/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/jdstyle/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/structcmd/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/autolink/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/restypedef/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/afterdoc/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/template/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/tag/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/group/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/memgrp/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/docstring/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/pyexample/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/tclexample/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/mux/html/index.html
-                ${PROJECT_BINARY_DIR}/html/examples/manual/html/index.html
+                ${EXAMPLES_RES}
                 ${DIAGRAM_EXAMPLE}
 	WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/examples
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen class.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/class/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/class/latex/refman_doc.tex
-	DEPENDS doxygen class.h class.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/class/html/index.html ${PROJECT_BINARY_DIR}/html/examples/class/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen define.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/define/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/define/latex/refman_doc.tex
-	DEPENDS doxygen define.h define.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/define/html/index.html ${PROJECT_BINARY_DIR}/html/examples/define/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen enum.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/enum/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/enum/latex/refman_doc.tex
-	DEPENDS doxygen enum.h enum.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/enum/html/index.html ${PROJECT_BINARY_DIR}/html/examples/enum/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen file.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/file/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/file/latex/refman_doc.tex
-	DEPENDS doxygen file.h file.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/file/html/index.html ${PROJECT_BINARY_DIR}/html/examples/file/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen func.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/func/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/func/latex/refman_doc.tex
-	DEPENDS doxygen func.h func.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/func/html/index.html ${PROJECT_BINARY_DIR}/html/examples/func/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen javadoc-banner.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/javadoc-banner/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/javadoc-banner/latex/refman_doc.tex
-	DEPENDS doxygen javadoc-banner.h javadoc-banner.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/javadoc-banner/html/index.html ${PROJECT_BINARY_DIR}/html/examples/javadoc-banner/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen page.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/page/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/page/latex/refman_doc.tex
-	DEPENDS doxygen page.doc page.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/page/html/index.html ${PROJECT_BINARY_DIR}/html/examples/page/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen relates.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/relates/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/relates/latex/refman_doc.tex
-	DEPENDS doxygen relates.cpp relates.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/relates/html/index.html ${PROJECT_BINARY_DIR}/html/examples/relates/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen author.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/author/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/author/latex/refman_doc.tex
-	DEPENDS doxygen author.cpp author.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/author/html/index.html ${PROJECT_BINARY_DIR}/html/examples/author/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen par.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/par/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/par/latex/refman_doc.tex
-	DEPENDS doxygen par.cpp par.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/par/html/index.html ${PROJECT_BINARY_DIR}/html/examples/par/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen overload.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/overload/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/overload/latex/refman_doc.tex
-	DEPENDS doxygen overload.cpp overload.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/overload/html/index.html ${PROJECT_BINARY_DIR}/html/examples/overload/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen example.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/example/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/example/latex/refman_doc.tex
-	DEPENDS doxygen example.cpp example_test.cpp example.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/example/html/index.html ${PROJECT_BINARY_DIR}/html/examples/example/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen include.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/include/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/include/latex/refman_doc.tex
-	DEPENDS doxygen include.cpp include_test.cpp include.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/include/html/index.html ${PROJECT_BINARY_DIR}/html/examples/include/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen qtstyle.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/qtstyle/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/qtstyle/latex/refman_doc.tex
-	DEPENDS doxygen qtstyle.cpp qtstyle.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/qtstyle/html/index.html ${PROJECT_BINARY_DIR}/html/examples/qtstyle/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen jdstyle.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/jdstyle/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/jdstyle/latex/refman_doc.tex
-	DEPENDS doxygen jdstyle.cpp jdstyle.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/jdstyle/html/index.html ${PROJECT_BINARY_DIR}/html/examples/jdstyle/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen structcmd.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/structcmd/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/structcmd/latex/refman_doc.tex
-	DEPENDS doxygen structcmd.h structcmd.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/structcmd/html/index.html ${PROJECT_BINARY_DIR}/html/examples/structcmd/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen autolink.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/autolink/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/autolink/latex/refman_doc.tex
-	DEPENDS doxygen autolink.cpp autolink.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/autolink/html/index.html ${PROJECT_BINARY_DIR}/html/examples/autolink/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen tag.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/tag/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/tag/latex/refman_doc.tex
-	DEPENDS doxygen tag.cpp tag.cfg ${PROJECT_BINARY_DIR}/html/examples/example/html/index.html ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/tag/html/index.html ${PROJECT_BINARY_DIR}/html/examples/tag/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen restypedef.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/restypedef/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/restypedef/latex/refman_doc.tex
-	DEPENDS doxygen restypedef.cpp restypedef.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/restypedef/html/index.html ${PROJECT_BINARY_DIR}/html/examples/restypedef/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen afterdoc.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/afterdoc/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/afterdoc/latex/refman_doc.tex
-	DEPENDS doxygen afterdoc.h afterdoc.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/afterdoc/html/index.html ${PROJECT_BINARY_DIR}/html/examples/afterdoc/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen templ.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/template/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/template/latex/refman_doc.tex
-	DEPENDS doxygen templ.cpp templ.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/template/html/index.html ${PROJECT_BINARY_DIR}/html/examples/template/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen group.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/group/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/group/latex/refman_doc.tex
-	DEPENDS doxygen group.cpp group.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/group/html/index.html ${PROJECT_BINARY_DIR}/html/examples/group/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen memgrp.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/memgrp/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/memgrp/latex/refman_doc.tex
-	DEPENDS doxygen memgrp.cpp memgrp.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/memgrp/html/index.html ${PROJECT_BINARY_DIR}/html/examples/memgrp/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen pyexample.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/pyexample/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/pyexample/latex/refman_doc.tex
-	DEPENDS doxygen pyexample.py pyexample.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/pyexample/html/index.html ${PROJECT_BINARY_DIR}/html/examples/pyexample/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen tclexample.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/tclexample/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/tclexample/latex/refman_doc.tex
-	DEPENDS doxygen tclexample.tcl tclexample.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/tclexample/html/index.html ${PROJECT_BINARY_DIR}/html/examples/tclexample/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen mux.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/mux/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/mux/latex/refman_doc.tex
-	DEPENDS doxygen mux.vhdl mux.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/mux/html/index.html ${PROJECT_BINARY_DIR}/html/examples/mux/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen manual.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/manual/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/manual/latex/refman_doc.tex
-	DEPENDS doxygen manual.c manual.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/manual/html/index.html ${PROJECT_BINARY_DIR}/html/examples/manual/latex/refman_doc.tex
-)
-
-add_custom_command(
-	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen docstring.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/docstring/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/docstring/latex/refman_doc.tex
-	DEPENDS doxygen docstring.py docstring.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/docstring/html/index.html ${PROJECT_BINARY_DIR}/html/examples/docstring/latex/refman_doc.tex
 )
 
 if (DOT)

--- a/examples/templ.cfg
+++ b/examples/templ.cfg
@@ -1,5 +1,5 @@
 PROJECT_NAME     = "Template Test"
-OUTPUT_DIRECTORY = ../html/examples/template
+OUTPUT_DIRECTORY = ../html/examples/templ
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO


### PR DESCRIPTION
Making more use of arrays in CMake to create the documentation of examples.
Renaming the template/templ example to have a more consistent naming with the other examples.