### PR TITLE
A mainpage doesn't have an anchor to jump to

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2660,11 +2660,13 @@ void MarkdownOutlineParser::parseInput(const char *fileName,
          QFileInfo(mdfileAsMainPage).absFilePath()) // file reference with path
        )
     {
+      docs.prepend("@anchor " + id + "\n");
       docs.prepend("@mainpage "+title+"\n");
     }
     else if (id=="mainpage" || id=="index")
     {
       if (title.isEmpty()) title = titleFn;
+      docs.prepend("@anchor " + id + "\n");
       docs.prepend("@mainpage "+title+"\n");
     }
     else


### PR DESCRIPTION
Based on the question: https://stackoverflow.com/questions/59685012/doxygen-markdown-links-to-main-page-do-not-work?noredirect=1#comment105616212_59685012
The markdown mainpage has no anchor so it is not possible to link to it, added an anchor so it is consistent with other page commands.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4059437/example.tar.gz)
