### PR TITLE
issue #7512 Initial asterisks in <pre> block are replaced by spaces

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6332,9 +6332,19 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  {
 					    REJECT;
 					  }
+  					  else if (yyextra->docBlockName=="<pre>")
+					  {
+                                            // don't reject when it is just one '*', is a "lineup" in a comment block or
+                                            // translated by doxygen from a "///" block
+					    if (QCString(yytext).stripWhiteSpace().length() != 1) REJECT;
+					  }
   					  else if (yyextra->docBlockName=="code")
 					  {
 					    REJECT;
+					  }
+  					  else if (yyextra->docBlockName=="<code>")
+					  {
+					    if (QCString(yytext).stripWhiteSpace().length() != 1) REJECT;
 					  }
                                           else
                                           {


### PR DESCRIPTION
Besides `\verbatim` and `\code` blocks also `<pre>` and `<code>` blocks should be excluded here