### PR TITLE
issue #7512 Initial asterisks in <pre> block are replaced by spaces

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -514,14 +514,14 @@ such label you can simple use the file name of the page, e.g.
 Markdown is quite strict in the way it processes block-level HTML:
 
 > block-level HTML elements — e.g. 
-> `<div>`, `<table>`, `<pre>`, `<p>`, etc. — 
+> `<div>`, `<table>`, \c \<pre\>, `<p>`, etc. — 
 > must be separated from surrounding content by blank lines, 
 > and the start and end tags of the block should not be indented 
 > with tabs or spaces.
 
 Doxygen does not have this requirement, and will also process 
 Markdown formatting inside such HTML blocks. The only exception is
-`<pre>` blocks, which are passed untouched (handy for ASCII art).
+\c \<pre\> blocks, which are passed untouched (handy for ASCII art).
 
 Doxygen will not process Markdown formatting inside verbatim or code blocks,
 and in other sections that need to be processed without changes

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -121,6 +121,8 @@ static void replaceComment(yyscan_t yyscanner,int offset);
 %}
 
 MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z_A-Z0-9\-]+
+PRE       [pP][rR][eE]
+CODE      [cC][oO][dD][eE]
 
 %option noyywrap
 
@@ -363,6 +365,13 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
                                      }
                                      BEGIN(VerbatimCode);
   				   }
+<CComment,ReadLine>"<"{CODE}">"/[^a-z_A-Z0-9] { /* start of a verbatim block */
+                                     copyToOutput(yyscanner,yytext,(int)yyleng); 
+				     yyextra->blockName=&yytext[1];
+				     yyextra->blockName=yyextra->blockName.lower();
+				     yyextra->lastCommentContext = YY_START;
+                                     BEGIN(VerbatimCode);
+                                   }
 <CComment,ReadLine>[\\@]("f$"|"f["|"f{") {
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
 				     yyextra->blockName=&yytext[1];
@@ -434,6 +443,13 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 				       BEGIN(yyextra->lastCommentContext);
 				     }
                                    }
+<VerbatimCode>"</"{CODE}">" { /* end of verbatim block */
+                                     copyToOutput(yyscanner,yytext,(int)yyleng);
+				     if (QCString(&yytext[2]).lower()==yyextra->blockName)
+				     {
+				       BEGIN(yyextra->lastCommentContext);
+				     }
+				   }
 <VerbatimCode>^[ \t]*"//"[\!\/]?   { /* skip leading comments */
   				     if (!yyextra->inSpecialComment)
 				     {
@@ -457,7 +473,7 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
                                        }
                                      }
   				   }
-<Verbatim,VerbatimCode>[^@\/\\\n{}]* { /* any character not a backslash or new line or } */
+<Verbatim,VerbatimCode>[^<@\/\\\n{}]* { /* any character not a backslash or new line or } */
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
 <Verbatim,VerbatimCode>\n	   { /* new line in verbatim block */
@@ -737,13 +753,27 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 <ReadLine>"*"                      {
 				     copyToOutput(yyscanner,yytext,(int)yyleng);
 				   }
-<ReadLine>[^\\@\n\*/]*             {
+<ReadLine>[^<\\@\n\*/]*             {
 				     copyToOutput(yyscanner,yytext,(int)yyleng);
 				   }
-<ReadLine>[^\\@\n\*/]*/\n          {
+<ReadLine>[^<\\@\n\*/]*/\n          {
 				     copyToOutput(yyscanner,yytext,(int)yyleng);
 				     BEGIN(yyextra->readLineCtx);
 				   }
+<CComment,ReadLine>"<"{PRE}">"/[^a-z_A-Z0-9] { /* start of a verbatim block */
+                                     copyToOutput(yyscanner,yytext,(int)yyleng); 
+				     yyextra->blockName=&yytext[1];
+				     yyextra->blockName=yyextra->blockName.lower();
+				     yyextra->lastCommentContext = YY_START;
+                                     BEGIN(Verbatim);
+                                   }
+<Verbatim>"</"{PRE}">" { /* end of verbatim block */
+                                     copyToOutput(yyscanner,yytext,(int)yyleng);
+				     if (QCString(&yytext[2]).lower()==yyextra->blockName)
+				     {
+				       BEGIN(yyextra->lastCommentContext);
+				     }
+                                   }
 <CComment,ReadLine>[\\@][\\@][~a-z_A-Z][a-z_A-Z0-9]*[ \t]* { // escaped command
 				     copyToOutput(yyscanner,yytext,(int)yyleng);
   				   }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6332,10 +6332,18 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  {
 					    REJECT;
 					  }
-  					  else if (yyextra->docBlockName=="code")
-					  {
-					    REJECT;
-					  }
+                                          else if (yyextra->docBlockName=="<pre>")
+                                          {
+                                            REJECT;
+                                          }
+                                          else if (yyextra->docBlockName=="code")
+                                          {
+                                            REJECT;
+                                          }
+                                          else if (yyextra->docBlockName=="<code>")
+                                          {
+                                            REJECT;
+                                          }
                                           else
                                           {
                                             QCString indent;


### PR DESCRIPTION
Besides `\verbatim` and `\code` blocks also `<pre>` and `<code>` blocks should be excluded.
This implementation is more consistent  with `\verbatim` and `\code` than the implementation in #7513

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4071791/example.tar.gz)
