### PR TITLE
issue #7520 Missing link in code of `#define`

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -399,6 +399,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 %x	SkipCPP
 %x	SkipComment
 %x	SkipCxxComment
+%x	PreDefine
 %x	RemoveSpecialCComment
 %x	StripSpecialCComment
 %x	Body
@@ -605,22 +606,32 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  endFontClass(yyscanner);
 					  BEGIN( Body );
   					}
+<Body,Bases>^[ \t]*"#"[ \t]*"define"	{ 
+  					  startFontClass(yyscanner,"preprocessor");
+					  yyextra->lastSkipCppContext = YY_START;
+  					  yyextra->code->codify(yytext);
+  					  BEGIN( PreDefine ) ; 
+					}
 <Body,Bases>^[ \t]*"#"			{ 
   					  startFontClass(yyscanner,"preprocessor");
 					  yyextra->lastSkipCppContext = YY_START;
   					  yyextra->code->codify(yytext);
   					  BEGIN( SkipCPP ) ; 
 					}
-<SkipCPP>.				{ 
+<PreDefine>{ID} 			{
+					  generateFunctionLink(yyscanner,*yyextra->code,yytext);
+  					  BEGIN( SkipCPP ) ; 
+					}
+<PreDefine,SkipCPP>.			{ 
   					  yyextra->code->codify(yytext);
 					}
 <SkipCPP>[^\n\/\\]+			{
   					  yyextra->code->codify(yytext);
   					}
-<SkipCPP>\\[\r]?\n			{ 
+<PreDefine,SkipCPP>\\[\r]?\n		{ 
   					  codifyLines(yyscanner,yytext);
 					}
-<SkipCPP>"//"				{ 
+<PreDefine,SkipCPP>"//"			{ 
   					  yyextra->code->codify(yytext);
 					}
 <Body,FuncCall>"{"			{ 


### PR DESCRIPTION
Handle #define so that the argument can have a link.