### PR TITLE
Bug 744244 - @callgraph has no effect

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2483,56 +2483,56 @@ static bool handleHideInitializer(yyscan_t yyscanner,const QCString &, const QCS
 static bool handleCallgraph(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->callGraph = TRUE; // ON
+  yyextra->current->callGraph |= Entry::CALL_SHOW; // ON
   return FALSE;
 }
 
 static bool handleHideCallgraph(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->callGraph = FALSE; // OFF
+  yyextra->current->callGraph |= Entry::CALL_HIDE; // OFF
   return FALSE;
 }
 
 static bool handleCallergraph(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->callerGraph = TRUE; // ON
+  yyextra->current->callerGraph |= Entry::CALL_SHOW; // ON
   return FALSE;
 }
 
 static bool handleHideCallergraph(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->callerGraph = FALSE; // OFF
+  yyextra->current->callerGraph |= Entry::CALL_HIDE; // OFF
   return FALSE;
 }
 
 static bool handleReferencedByRelation(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->referencedByRelation = TRUE; // ON
+  yyextra->current->referencedByRelation |= Entry::CALL_SHOW; // ON
   return FALSE;
 }
 
 static bool handleHideReferencedByRelation(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->referencedByRelation = FALSE; // OFF
+  yyextra->current->referencedByRelation |= Entry::CALL_HIDE; // OFF
   return FALSE;
 }
 
 static bool handleReferencesRelation(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->referencesRelation = TRUE; // ON
+  yyextra->current->referencesRelation |= Entry::CALL_SHOW; // ON
   return FALSE;
 }
 
 static bool handleHideReferencesRelation(yyscan_t yyscanner,const QCString &, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->referencesRelation = FALSE; // OFF
+  yyextra->current->referencesRelation |= Entry::CALL_HIDE; // OFF
   return FALSE;
 }
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -576,6 +576,51 @@ static void checkUnOrMultipleDocumentedParams()
     }
   }
 }
+/*! Checks if members don't have commands like \\callgraph and \\hidecallgraph
+ *  at the same time
+ */
+static void checkInconsistentGraphCalls()
+{
+  static bool haveDot = Config_getBool(HAVE_DOT);
+  if (g_memberDef && Config_getBool(WARN_IF_DOC_ERROR))
+  {
+    if (haveDot)
+    {
+      if ((g_memberDef->getCallGraph() & Entry::CALL_SHOW) &&
+          (g_memberDef->getCallGraph() & Entry::CALL_HIDE))
+      {
+        warn_doc_error(g_memberDef->getDefFileName(),
+                       g_memberDef->getDefLine(),
+                       QCString(g_memberDef->qualifiedName()) +
+                       " has @callgraph as well as @hidecallgraph, using @callgraph");
+      }
+      if ((g_memberDef->getCallerGraph() & Entry::CALL_SHOW) &&
+          (g_memberDef->getCallerGraph() & Entry::CALL_HIDE))
+      {
+        warn_doc_error(g_memberDef->getDefFileName(),
+                       g_memberDef->getDefLine(),
+                       QCString(g_memberDef->qualifiedName()) +
+                       " has @callergraph as well as @hidecallergraph, using @callergraph");
+      }
+    }
+    if ((g_memberDef->getReferencesRelation() & Entry::CALL_SHOW) &&
+        (g_memberDef->getReferencesRelation() & Entry::CALL_HIDE))
+    {
+      warn_doc_error(g_memberDef->getDefFileName(),
+                     g_memberDef->getDefLine(),
+                     QCString(g_memberDef->qualifiedName()) +
+                     " has @showrefs as well as @hiderefs, using @showrefs");
+    }
+    if ((g_memberDef->getReferencedByRelation() & Entry::CALL_SHOW) &&
+        (g_memberDef->getReferencedByRelation() & Entry::CALL_HIDE))
+    {
+      warn_doc_error(g_memberDef->getDefFileName(),
+                     g_memberDef->getDefLine(),
+                     QCString(g_memberDef->qualifiedName()) +
+                     " has @showrefs as well as @hiderefs, using @showrefs");
+    }
+  }
+}
 
 //---------------------------------------------------------------------------
 
@@ -7777,6 +7822,7 @@ DocRoot *validatingParseDoc(const char *fileName,int startLine,
 
   checkUnOrMultipleDocumentedParams();
   if (g_memberDef) g_memberDef->detectUndocumentedParams(g_hasParamCommand,g_hasReturnCommand);
+  checkInconsistentGraphCalls();
 
   // TODO: These should be called at the end of the program.
   //doctokenizerYYcleanup();

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3419,10 +3419,10 @@ static void buildFunctionList(const Entry *root)
 
                   md->addSectionsToDefinition(root->anchors);
 
-                  md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-                  md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
-                  md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
-                  md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+                  md->enableCallGraph(root->callGraph);
+                  md->enableCallerGraph(root->callerGraph);
+                  md->enableReferencedByRelation(root->referencedByRelation);
+                  md->enableReferencesRelation(root->referencesRelation);
 
                   // merge ingroup specifiers
                   if (md->getGroupDef()==0 && !root->groups.empty())
@@ -3686,15 +3686,15 @@ static void findFriends()
             }
             mmd->setDocsForDefinition(fmd->isDocsForDefinition());
 
-            mmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
-            mmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
-            mmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
-            mmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
+            mmd->enableCallGraph(fmd->getCallGraph());
+            mmd->enableCallerGraph(fmd->getCallerGraph());
+            mmd->enableReferencedByRelation(fmd->getReferencedByRelation());
+            mmd->enableReferencesRelation(fmd->getReferencesRelation());
 
-            fmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
-            fmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
-            fmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
-            fmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
+            fmd->enableCallGraph(mmd->getCallGraph());
+            fmd->enableCallerGraph(mmd->getCallerGraph());
+            fmd->enableReferencedByRelation(mmd->getReferencedByRelation());
+            fmd->enableReferencesRelation(mmd->getReferencesRelation());
           }
         }
       }
@@ -5022,10 +5022,6 @@ static void addMemberDocs(const Entry *root,
   // strip extern specifier
   fDecl.stripPrefix("extern ");
   md->setDefinition(fDecl);
-  md->enableCallGraph(root->callGraph);
-  md->enableCallerGraph(root->callerGraph);
-  md->enableReferencedByRelation(root->referencedByRelation);
-  md->enableReferencesRelation(root->referencesRelation);
   ClassDef *cd=md->getClassDef();
   const NamespaceDef *nd=md->getNamespaceDef();
   QCString fullName;
@@ -5118,10 +5114,10 @@ static void addMemberDocs(const Entry *root,
     md->setRefItems(root->sli);
   }
 
-  md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-  md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
-  md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
-  md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+  md->enableCallGraph(root->callGraph);
+  md->enableCallerGraph(root->callerGraph);
+  md->enableReferencedByRelation(root->referencedByRelation);
+  md->enableReferencesRelation(root->referencesRelation);
 
   md->mergeMemberSpecifiers(spec);
   md->addSectionsToDefinition(root->anchors);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -215,10 +215,10 @@ void Entry::reset()
   bodyLine = -1;
   endBodyLine = -1;
   mGrpId = -1;
-  callGraph   = entryCallGraph;
-  callerGraph = entryCallerGraph;
-  referencedByRelation = entryReferencedByRelation;
-  referencesRelation   = entryReferencesRelation;
+  callGraph   = (entryCallGraph ? CALL_CONFIG : 0);
+  callerGraph = (entryCallerGraph ? CALL_CONFIG : 0);
+  referencedByRelation = (entryReferencedByRelation ? CALL_CONFIG : 0);
+  referencesRelation   = (entryReferencesRelation ? CALL_CONFIG : 0);
   section = EMPTY_SEC;
   mtype   = Method;
   virt    = Normal;

--- a/src/entry.h
+++ b/src/entry.h
@@ -117,6 +117,25 @@ class Entry
       EXAMPLE_LINENO_SEC     = 0x1B000000,
     };
 
+    /*! Kind of call / hide combination supported
+     * for commands:
+     * - \\callgraph \\hidecallgraph
+     * - \\callergraph \\hidecallergraph
+     * - \\showby \\hideby
+     * - \\showrefs \\hiderefs
+     *
+     * and the commands:
+     * - CALL_GRAPH
+     * - CALLER_GRAPH
+     * - REFERENCED_BY_RELATION
+     * - REFERENCES_RELATION
+     */
+    enum ShowHide {
+       CALL_SHOW   = 0x00000001,  //! explicit call... / show... command
+       CALL_HIDE   = 0x00000002,  //! explicit hide... command
+       CALL_CONFIG = 0x00000004,  //! config set with YES
+    };
+
     // class specifiers (add new items to the end)
     static const uint64 Template        = (1ULL<<0);
     static const uint64 Generic         = (1ULL<<1);
@@ -251,10 +270,10 @@ class Entry
     bool explicitExternal;    //!< explicitly defined as external?
     bool proto;               //!< prototype ?
     bool subGrouping;         //!< automatically group class members?
-    bool callGraph;           //!< do we need to draw the call graph?
-    bool callerGraph;         //!< do we need to draw the caller graph?
-    bool referencedByRelation;//!< do we need to show the referenced by relation?
-    bool referencesRelation;  //!< do we need to show the references relation?
+    unsigned char callGraph;           //!< do we need to draw the call graph?
+    unsigned char callerGraph;         //!< do we need to draw the caller graph?
+    unsigned char referencedByRelation;//!< do we need to show the referenced by relation?
+    unsigned char referencesRelation;  //!< do we need to show the references relation?
     Specifier    virt;        //!< virtualness of the entry
     QCString     args;        //!< member argument string
     QCString     bitfields;   //!< member's bit fields

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -240,10 +240,14 @@ class MemberDef : virtual public Definition
     // callgraph related members
     virtual bool hasCallGraph() const = 0;
     virtual bool hasCallerGraph() const = 0;
+    virtual unsigned char getCallGraph() const = 0;
+    virtual unsigned char getCallerGraph() const = 0;
     virtual bool visibleMemberGroup(bool hideNoHeader) const = 0;
     // referenced related members
     virtual bool hasReferencesRelation() const = 0;
     virtual bool hasReferencedByRelation() const = 0;
+    virtual unsigned char getReferencesRelation() const = 0;
+    virtual unsigned char getReferencedByRelation() const = 0;
 
     virtual MemberDef *templateMaster() const = 0;
     virtual QCString getScopeString() const = 0;
@@ -351,11 +355,11 @@ class MemberDef : virtual public Definition
     // anonymous scope members
     virtual void setFromAnonymousMember(MemberDef *m) = 0;
 
-    virtual void enableCallGraph(bool e) = 0;
-    virtual void enableCallerGraph(bool e) = 0;
+    virtual void enableCallGraph(unsigned char e) = 0;
+    virtual void enableCallerGraph(unsigned char e) = 0;
 
-    virtual void enableReferencedByRelation(bool e) = 0;
-    virtual void enableReferencesRelation(bool e) = 0;
+    virtual void enableReferencedByRelation(unsigned char e) = 0;
+    virtual void enableReferencesRelation(unsigned char e) = 0;
 
     virtual void setTemplateMaster(MemberDef *mt) = 0;
     virtual void addListReference(Definition *d) = 0;


### PR DESCRIPTION
To be able to distinguish between explicit setting of callgraph / hidecallgraph (etc.) compared to the configuration setting it is necessary to record what has been used and handle this (otherwise duringe a combine of a definition and declaration .
- entry.h, memberdef.h create possibility to record config / explicit setting
- entry.cpp set initial value
- memberdef.cpp, commentscan.l enable / disable functions have to "or" values to record the "history".
- memberdef.cpp when checking for use check individual values
- memberdef.cpp create functions to output "raw" value of call... / hide...
- doxygen.cpp properly initialize the members
- docparser.cpp warn in case use call... / hide... for the same member

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4082662/example.tar.gz)
