### PR TITLE
Correct handling of error / removed debug statement

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -200,7 +200,7 @@ void VhdlDocGen::writeOverview()
 
   if (!f.open(IO_WriteOnly))
   {
-    fprintf(stderr,"Warning: Cannot open file %s for writing\n",fileName.data());
+    err("Warning: Cannot open file %s for writing\n",fileName.data());
     return;
   }
 
@@ -2932,14 +2932,14 @@ ferr:
   md->setBodyDef(fd);
 
 
-  QCString info="Info: Elaborating entity "+n1;
-  fd=ar->getFileDef();
-  info+=" for hierarchy ";
-  QRegExp epr("[|]");
-  QCString label=cur->type+":"+cur->write+":"+cur->name;
-  label.replace(epr,":");
-  info+=label;
-  fprintf(stderr,"\n[%s:%d:%s]\n",fd->fileName().data(),cur->startLine,info.data());
+  //QCString info="Info: Elaborating entity "+n1;
+  //fd=ar->getFileDef();
+  //info+=" for hierarchy ";
+  //QRegExp epr("[|]");
+  //QCString label=cur->type+":"+cur->write+":"+cur->name;
+  //label.replace(epr,":");
+  //info+=label;
+  //fprintf(stderr,"\n[%s:%d:%s]\n",fd->fileName().data(),cur->startLine,info.data());
 
 
   ar->insertMember(md);


### PR DESCRIPTION
In the vhdldocgen:
- error should be handled in a doxygen consistent way (in this case with an err call)
- removed left over debug statement (found through #7528)