### PR TITLE
Bug 791390 - Table formatting information ignored in Doxygen XML output

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1119,6 +1119,10 @@ DB_VIS_C
       {
         m_t << " align='center'";
       }
+      else if (!opt->value.isEmpty())
+      {
+        m_t << " " << opt->name << "='" << opt->value << "'";
+      }
     }
     else if (opt->name=="style")
     {

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -806,7 +806,52 @@ void XmlDocVisitor::visitPost(DocHtmlRow *)
 void XmlDocVisitor::visitPre(DocHtmlCell *c)
 {
   if (m_hide) return;
-  if (c->isHeading()) m_t << "<entry thead=\"yes\">"; else m_t << "<entry thead=\"no\">";
+  if (c->isHeading()) m_t << "<entry thead=\"yes\""; else m_t << "<entry thead=\"no\"";
+  HtmlAttribListIterator li(c->attribs());
+  HtmlAttrib *opt;
+  for (li.toFirst();(opt=li.current());++li)
+  {
+    if (opt->name=="class")
+    {
+      if (opt->value == "markdownTableBodyRight")
+      {
+        m_t << " align=\"right\"";
+      }
+      else if (opt->value == "markdownTableBodyLeftt")
+      {
+        m_t << " align=\"left\"";
+      }
+      else if (opt->value == "markdownTableBodyCenter")
+      {
+        m_t << " align=\"center\"";
+      }
+      else if (opt->value == "markdownTableHeadRight")
+      {
+        m_t << " align=\"right\"";
+      }
+      else if (opt->value == "markdownTableHeadLeftt")
+      {
+        m_t << " align=\"left\"";
+      }
+      else if (opt->value == "markdownTableHeadCenter")
+      {
+        m_t << " align=\"center\"";
+      }
+      else if (!opt->value.isEmpty())
+      {
+        m_t << " " << opt->name << "=\"" << opt->value << "\"";
+      }
+    }
+    else if (opt->name=="nowrap" && opt->value.isEmpty())
+    {
+      m_t << " " << opt->name << "=\"nowrap\"";
+    }
+    else if (!opt->value.isEmpty())
+    {
+      m_t << " " << opt->name << "=\"" << opt->value << "\"";
+    }
+  }
+  m_t << ">";
 }
 
 void XmlDocVisitor::visitPost(DocHtmlCell *) 

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -570,6 +570,10 @@
       <xsd:element name="para" type="docParaType" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="thead" type="DoxBool" />
+    <xsd:attribute name="colspan" type="xsd:integer" />
+    <xsd:attribute name="rowspan" type="xsd:integer" />
+    <!-- maybe other attributes can be listed as well -->
+    <xsd:anyAttribute processContents="skip"/>
   </xsd:complexType>
 
   <xsd:complexType name="docCaptionType" mixed="true">


### PR DESCRIPTION
- added possibility (and checks) for xml
- added missing case for class in docbook

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4103470/example.tar.gz)
