### PR TITLE
Bug 780630 - Nested @ingroup generates bad breadclumb list

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6754,11 +6754,11 @@ bool recursivelyAddGroupListToTitle(OutputList &ol,const Definition *d,bool root
     bool first=true;
     for (gli.toFirst();(gd=gli.current());++gli)
     {
+      if (!first) { ol.writeString(" &#124; "); } else first=false;
       if (recursivelyAddGroupListToTitle(ol, gd, FALSE))
       {
         ol.writeString(" &raquo; ");
       }
-      if (!first) { ol.writeString(" &#124; "); } else first=FALSE;
       ol.writeObjectLink(gd->getReference(),gd->getOutputFileBase(),0,gd->groupTitle());
     }
     if (root)


### PR DESCRIPTION
The writing of the "pipe" symbol was done at the wrong moment.

(Extended) example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4104371/example.tar.gz)
