### PR TITLE
Fix Perlmod generation issues #7490, #7494, #7495, #7547 and #7556 

### DIFF
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1574,6 +1574,7 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
   //     (templateArguments(), definitionTemplateParameterLists())
  
   QCString memType;
+  QCString name;
   bool isFunc=FALSE;
   switch (md->memberType())
   {
@@ -1595,9 +1596,13 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
     case MemberType_Dictionary:  memType="dictionary"; break;
   }
 
+  /* DGA fix #7556 ANSI-C anonymous (unnamed) struct/unions have duplicated names (__unnamed__) */
+  name = md->name();
+  if (md->isAnonymous()) name = "__unnamed__" + name.right(name.length() - 1); /* DGA: ensure unique name */
+
   m_output.openHash()
     .addFieldQuotedString("kind", memType)
-    .addFieldQuotedString("name", md->name())
+    .addFieldQuotedString("name", name)
     .addFieldQuotedString("virtualness", getVirtualnessName(md->virtualness()))
     .addFieldQuotedString("protection", getProtectionName(md->protection()))
     .addFieldBoolean("static", md->isStatic());


### PR DESCRIPTION
Fix following issues with PerlMod generation (ANSI-C):
#7490 multiple grouped functions (member groups)
#7494 grouped members from files ("user-defined")
#7495 generate "bitfield"
#7547 "kind" information to discriminate struct/union
#7556 ANSI-C anonymous (unnamed) struct/unions duplicated names