### PR TITLE
Improved Makefile for PdfLaTeX

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -296,6 +296,7 @@ static void writeLatexMakefile()
   QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME);
   // end insertion by KONNO Akihisa <konno@researchers.jp> 2002-03-05
   FTextStream t(&file);
+  t << "CLEAN_FILES := *.ps *.dvi *.aux *.toc *.idx *.ind *.ilg *.log *.out *.brf *.blg *.bbl refman.pdf";
   if (!Config_getBool(USE_PDFLATEX)) // use plain old latex
   {
     t << "LATEX_CMD=" << latex_command << endl
@@ -346,11 +347,12 @@ static void writeLatexMakefile()
   }
   else // use pdflatex for higher quality output
   {
-    t << "LATEX_CMD=" << latex_command << endl
+    t << "LATEX_CMD:=" << latex_command << " -interaction=batchmode -halt-on-error" << endl
       << endl;
     t << "all: refman.pdf" << endl << endl
       << "pdf: refman.pdf" << endl << endl;
-    t << "refman.pdf: clean refman.tex" << endl;
+    t << "refman.pdf: refman.tex" << endl;
+    t << "\trm -f $(CLEAN_FILES)" << endl;
     t << "\t$(LATEX_CMD) refman" << endl;
     t << "\t" << mkidx_command << " refman.idx" << endl;
     if (generateBib)
@@ -373,7 +375,7 @@ static void writeLatexMakefile()
   t << endl
     << "clean:" << endl
     << "\trm -f " 
-    << "*.ps *.dvi *.aux *.toc *.idx *.ind *.ilg *.log *.out *.brf *.blg *.bbl refman.pdf" << endl;
+    << "rm -f $(CLEAN_FILES)" << endl;
 }
 
 static void writeMakeBat()

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -296,7 +296,8 @@ static void writeLatexMakefile()
   QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME);
   // end insertion by KONNO Akihisa <konno@researchers.jp> 2002-03-05
   FTextStream t(&file);
-  t << "CLEAN_FILES := *.ps *.dvi *.aux *.toc *.idx *.ind *.ilg *.log *.out *.brf *.blg *.bbl refman.pdf";
+  t << "CLEAN_FILES := *.ps *.dvi *.aux *.toc *.idx *.ind *.ilg *.log *.out *.brf *.blg *.bbl refman.pdf" << endl
+   << endl;
   if (!Config_getBool(USE_PDFLATEX)) // use plain old latex
   {
     t << "LATEX_CMD=" << latex_command << endl

--- a/templates/latex/latexmakefile.tpl
+++ b/templates/latex/latexmakefile.tpl
@@ -1,22 +1,28 @@
+CLEAN_FILES := *.ps *.dvi *.aux *.toc *.idx *.ind *.ilg *.log *.out *.brf *.blg *.bbl refman.pdf
+
 {% if config.USE_PDFLATEX %}
+
+LATEX_CMD := pdflatex -interaction=batchmode -halt-on-error 
+
 all: refman.pdf
 
 pdf: refman.pdf
 
-refman.pdf: clean refman.tex
-	pdflatex refman
+refman.pdf: refman.tex
+	rm -f $(CLEAN_FILES)
+	$(LATEX_CMD) refman
 	{{ config.MAKEINDEX_CMD_NAME }} refman.idx
 {# TODO: generateBib #}
-	pdflatex refman
+	$(LATEX_CMD) refman
 	latex_count=8 ; \
 	while egrep -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$latex_count -gt 0 ] ;\
 	    do \
 	      echo "Rerunning latex...." ;\
-	      pdflatex refman ;\
+	      $(LATEX_CMD) refman ;\
 	      latex_count=`expr $$latex_count - 1` ;\
 	    done
 	{{ config.MAKEINDEX_CMD_NAME }} refman.idx
-	pdflatex refman
+	$(LATEX_CMD) refman
 {% else %}
 all: refman.dvi
 
@@ -60,5 +66,5 @@ refman_2on1.pdf: refman_2on1.ps
 {% endif %}
 
 clean:
-	rm -f *.ps *.dvi *.aux *.toc *.idx *.ind *.ilg *.log *.out *.brf *.blg *.bbl refman.pdf
+	rm -f $(CLEAN_FILES)
 


### PR DESCRIPTION
Makefile for pdflatex: Parallel executation (make -j 2) is now possible. PdfLaTeX will not hang, if there are LaTeX errors.