### PR TITLE
More accurate warning message.

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5402,7 +5402,7 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
   {
     case CMD_UNKNOWN:
       m_children.append(new DocWord(this,TK_COMMAND_CHAR(tok) + cmdName));
-      warn_doc_error(g_fileName,doctokenizerYYlineno,"Found unknown command '\\%s'",qPrint(cmdName));
+      warn_doc_error(g_fileName,doctokenizerYYlineno,"Found unknown command '%c%s'",TK_COMMAND_CHAR(tok),qPrint(cmdName));
       break;
     case CMD_EMPHASIS:
       m_children.append(new DocStyleChange(this,g_nodeStack.count(),DocStyleChange::Italic,cmdName,TRUE));


### PR DESCRIPTION
in code like `this command @unkn` would give (whilst all information is present)
```
warning: Found unknown command '\unkn'
```
instead of
```
warning: Found unknown command '@unkn'
```