### PR TITLE
Plantuml has problems with output directories ending with directory separator

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -27,15 +27,21 @@
 #include <qlist.h>
 
 
-QCString PlantumlManager::writePlantUMLSource(const QCString &outDir,const QCString &fileName,const QCString &content,OutputFormat format)
+QCString PlantumlManager::writePlantUMLSource(const QCString &outDirArg,const QCString &fileName,const QCString &content,OutputFormat format)
 {
   QCString baseName;
   QCString puName;
   QCString imgName;
+  QCString outDir(outDirArg);
   static int umlindex=1;
 
   Debug::print(Debug::Plantuml,0,"*** %s fileName: %s\n","writePlantUMLSource",qPrint(fileName));
   Debug::print(Debug::Plantuml,0,"*** %s outDir: %s\n","writePlantUMLSource",qPrint(outDir));
+
+  while ((outDir.findRev('/') == outDir.length()-1) || (outDir.findRev('\\') == outDir.length()-1))
+  {
+    outDir = outDir.left(outDir.length()-1);
+  }
 
   if (fileName.isEmpty()) // generate name
   {


### PR DESCRIPTION
Based on the message in #7558
In case a `HTML_OUTPUT` directory (or other `*_OUTPUT` directory ends with a directory separator we get the message:
```
QGDict::hashAsciiKey: Invalid null key
```
by stripping the directory separator this problem can be overcome.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4142632/example.tar.gz)
