### PR TITLE
Plantuml and full windows output path

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -73,7 +73,9 @@ QCString PlantumlManager::writePlantUMLSource(const QCString &outDir,const QCStr
   text+="\n@enduml\n";
 
   QCString qcOutDir(outDir);
-  uint pos = qcOutDir.findRev("/");
+  int posf = qcOutDir.findRev("/");
+  int posb = qcOutDir.findRev("\\");
+  uint pos = (posf>posb ? posf : posb);
   QCString generateType(qcOutDir.right(qcOutDir.length() - (pos + 1)) );
   Debug::print(Debug::Plantuml,0,"*** %s generateType: %s\n","writePlantUMLSource",qPrint(generateType));
   PlantumlManager::instance()->insert(generateType,puName,format,text);
@@ -91,8 +93,10 @@ void PlantumlManager::generatePlantUMLOutput(const char *baseName,const char *ou
   QCString imgName = baseName;
   // The basename contains path, we need to strip the path from the filename in order
   // to create the image file name which should be included in the index.qhp (Qt help index file).
-  int i;
-  if ((i=imgName.findRev('/'))!=-1) // strip path
+  int posf = imgName.findRev('/');
+  int posb = imgName.findRev('\\');
+  int i = (posf>posb ? posf : posb);
+  if (i!=-1) // strip path
   {
     imgName=imgName.right(imgName.length()-i-1);
   }


### PR DESCRIPTION
Based on the problems as reported in #7558
In case we use as `HTML_OUTPUT` a windows path like `HTML_OUTPUT=D:\speeltuin\issue_7558\full_path_problem\html` this results in problems like:
```
error: Could not open file D:/speeltuin/issue_7558/full_path_problem/D:\speeltuin\issue_7558\full_path_problem\html/inline_umlgraph_pngD:\speeltuin\issue_7558\full_path_problem\html.pu for writing
QFile::writeBlock: File not open
No diagram found
error: Problems running PlantUML. Verify that the command 'java -jar "E:/Downloads/plantuml/plantuml_last\plantuml.jar" -h' works from the command line. Exit code: 100
```
We should not only handle the forward slash but also the backward slash.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4142683/example.tar.gz)
