### PR TITLE
Fix #7490 and #7494

### DIFF
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1534,6 +1534,7 @@ public:
   inline PerlModGenerator(bool pretty) : m_output(pretty) { }
 
   void generatePerlModForMember(const MemberDef *md, const Definition *);
+  void generatePerlUserDefinedSection(const Definition *d, const MemberGroupSDict *gsd);
   void generatePerlModSection(const Definition *d, MemberList *ml,
 			      const char *name, const char *header=0);
   void addListOfAllMembers(const ClassDef *cd);
@@ -1776,6 +1777,38 @@ void PerlModGenerator::addListOfAllMembers(const ClassDef *cd)
   m_output.closeList();
 }
 
+/* DGA: fix #7490 Perlmod generation issue with multiple grouped functions (member groups) */
+void PerlModGenerator::generatePerlUserDefinedSection(const Definition *d, const MemberGroupSDict *gsd)
+{
+	if (gsd)
+	{
+		MemberGroupSDict::Iterator mgli(*gsd);
+		MemberGroup *mg;
+		m_output.openList("user_defined");
+		for (; (mg = mgli.current()); ++mgli)
+		{
+			m_output.openHash();
+			if (mg->header())
+				m_output.addFieldQuotedString("header", mg->header());
+
+			if (mg->members())
+			{
+				m_output.openList("members");
+				MemberListIterator mli(*mg->members());
+				const MemberDef *md;
+				for (mli.toFirst(); (md = mli.current()); ++mli)
+				{
+					generatePerlModForMember(md, d);
+				}
+				m_output.closeList();
+			}
+			m_output.closeHash();
+		}
+		m_output.closeList();
+	}
+}
+/* DGA: end of fix #7490 */
+
 void PerlModGenerator::generatePerlModForClass(const ClassDef *cd)
 {
   // + brief description
@@ -1862,13 +1895,7 @@ void PerlModGenerator::generatePerlModForClass(const ClassDef *cd)
 
   addTemplateList(cd,m_output);
   addListOfAllMembers(cd);
-  if (cd->getMemberGroupSDict())
-  {
-    MemberGroupSDict::Iterator mgli(*cd->getMemberGroupSDict());
-    MemberGroup *mg;
-    for (;(mg=mgli.current());++mgli)
-      generatePerlModSection(cd,mg->members(),"user_defined",mg->header());
-  }
+  generatePerlUserDefinedSection(cd, cd->getMemberGroupSDict());
 
   generatePerlModSection(cd,cd->getMemberList(MemberListType_pubTypes),"public_typedefs");
   generatePerlModSection(cd,cd->getMemberList(MemberListType_pubMethods),"public_methods");
@@ -1968,13 +1995,7 @@ void PerlModGenerator::generatePerlModForNamespace(const NamespaceDef *nd)
     m_output.closeList();
   }
 
-  if (nd->getMemberGroupSDict())
-  {
-    MemberGroupSDict::Iterator mgli(*nd->getMemberGroupSDict());
-    const MemberGroup *mg;
-    for (;(mg=mgli.current());++mgli)
-      generatePerlModSection(nd,mg->members(),"user-defined",mg->header());
-  }
+  generatePerlUserDefinedSection(nd, nd->getMemberGroupSDict());
 
   generatePerlModSection(nd,nd->getMemberList(MemberListType_decDefineMembers),"defines");
   generatePerlModSection(nd,nd->getMemberList(MemberListType_decProtoMembers),"prototypes");
@@ -2045,6 +2066,9 @@ void PerlModGenerator::generatePerlModForFile(const FileDef *fd)
   }
   m_output.closeList();
   
+  /* DGA: fix #7494 Perlmod does not generate grouped members from files */
+  generatePerlUserDefinedSection(fd, fd->getMemberGroupSDict());
+
   generatePerlModSection(fd,fd->getMemberList(MemberListType_decDefineMembers),"defines");
   generatePerlModSection(fd,fd->getMemberList(MemberListType_decProtoMembers),"prototypes");
   generatePerlModSection(fd,fd->getMemberList(MemberListType_decTypedefMembers),"typedefs");
@@ -2143,13 +2167,7 @@ void PerlModGenerator::generatePerlModForGroup(const GroupDef *gd)
     m_output.closeList();
   }
 
-  if (gd->getMemberGroupSDict())
-  {
-    MemberGroupSDict::Iterator mgli(*gd->getMemberGroupSDict());
-    MemberGroup *mg;
-    for (;(mg=mgli.current());++mgli)
-      generatePerlModSection(gd,mg->members(),"user-defined",mg->header());
-  }
+  generatePerlUserDefinedSection(gd, gd->getMemberGroupSDict());
 
   generatePerlModSection(gd,gd->getMemberList(MemberListType_decDefineMembers),"defines");
   generatePerlModSection(gd,gd->getMemberList(MemberListType_decProtoMembers),"prototypes");


### PR DESCRIPTION
Fix following issues:
#7490 multiple grouped functions (member groups)
#7494 grouped members from files ("user-defined")