### PR TITLE
Fix issue #7547

### DIFF
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1800,7 +1800,9 @@ void PerlModGenerator::generatePerlModForClass(const ClassDef *cd)
 
   m_output.openHash()
     .addFieldQuotedString("name", cd->name());
-  
+  /* DGA: fix # #7547 Perlmod does not generate "kind" information to discriminate struct/union */
+  m_output.addFieldQuotedString("kind", cd->compoundTypeString());
+ 
   if (cd->baseClasses())
   {
     m_output.openList("base");


### PR DESCRIPTION
Add "kind" property information in PerlMod to discriminate struct/union (like XML output)