### PR TITLE
issue #7558 PlantUML: Different behavior whether LATEX_OUTPUT has a final slash or not.

### DIFF
--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -24,6 +24,17 @@
 #define MIN_PLANTUML_COUNT      8
 
 class QCString;
+struct PlantumlContent
+{
+  QCString outDir;
+  QCString content;
+  PlantumlContent(const QCString Content, const QCString OutDir)
+  {
+    outDir = OutDir;
+    content = Content;
+  };
+  ~PlantumlContent(){};
+};
 
 /** Singleton that manages plantuml relation actions */
 class PlantumlManager
@@ -58,15 +69,16 @@ class PlantumlManager
     ~PlantumlManager();
     void insert(const QCString &key, 
                 const QCString &value,
+                const QCString &outDir,
                 OutputFormat format,
                 const QCString &puContent);
     static PlantumlManager     *m_theInstance;
     QDict< QList<QCString> >    m_pngPlantumlFiles;
     QDict< QList<QCString> >    m_svgPlantumlFiles;
     QDict< QList<QCString> >    m_epsPlantumlFiles;
-    QDict< QCString >           m_pngPlantumlContent;     // use circular queue for using multi-processor (multi threading)
-    QDict< QCString >           m_svgPlantumlContent;
-    QDict< QCString >           m_epsPlantumlContent;
+    QDict< PlantumlContent >    m_pngPlantumlContent;     // use circular queue for using multi-processor (multi threading)
+    QDict< PlantumlContent >    m_svgPlantumlContent;
+    QDict< PlantumlContent >    m_epsPlantumlContent;
     QCString                    m_cachedPlantumlAllContent;         // read from CACHE_FILENAME file
     QCString                    m_currentPlantumlAllContent;        // processing plantuml then write it into CACHE_FILENAME to reuse the next time as cache information
 };


### PR DESCRIPTION
The problem is that full qualified paths in `*_OUTPUT` were not handled properly they were handled as it were relative paths.
In the documentation it is stated for e.g. LATEX_OUTPUT:

> The LATEX_OUTPUT tag is used to specify where the LATEX docs will be put. If a relative path is entered the value of OUTPUT_DIRECTORY will be put in front of it.

So in case of a non relative path the given path should be used and this path can be unrelated to `OUTPUT_DIRECTORY`, so we have to store the designated output path as well.

Small example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4149054/example.tar.gz)
