### PR TITLE
issue #7570 Comments replaced by block comments inside Markdown code block

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -401,11 +401,13 @@ more tilde (~) characters on a line. The end of the block should have the
 same number of tildes. Here is an example:
 
 
-    This is a paragraph introducing:
+@verbatim
+This is a paragraph introducing:
 
-    ~~~~~~~~~~~~~~~~~~~~~
-    a one-line code block
-    ~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
+a one-line code block
+~~~~~~~~~~~~~~~~~~~~~
+@endverbatim
 
 By default the output is the same as for a normal code block.
 
@@ -414,12 +416,13 @@ appear with syntax highlighting. To do so you need to
 indicate the typical file extension that corresponds to the 
 programming language after the opening fence. For highlighting according
 to the Python language for instance, you would need to write the following:
-
-    ~~~~~~~~~~~~~{.py}
-    # A class
-    class Dummy:
-        pass
-    ~~~~~~~~~~~~~
+@verbatim
+~~~~~~~~~~~~~{.py}
+# A class
+class Dummy:
+    pass
+~~~~~~~~~~~~~
+@endverbatim
 
 which will produce:
 ~~~~~~~~~~~~~{.py}
@@ -429,10 +432,11 @@ class Dummy:
 ~~~~~~~~~~~~~
 
 and for C you would write:
-
-    ~~~~~~~~~~~~~~~{.c}
-    int func(int a,int b) { return a*b; }
-    ~~~~~~~~~~~~~~~
+@verbatim
+~~~~~~~~~~~~~~~{.c}
+int func(int a,int b) { return a*b; }
+~~~~~~~~~~~~~~~
+@endverbatim
 
 which will produce:
 
@@ -443,10 +447,11 @@ int func(int a,int b) { return a*b; }
 The curly braces and dot are optional by the way.
 
 Another way to denote fenced code blocks is to use 3 or more backticks (```):
-
-    ```
-    also a fenced code block
-    ```
+@verbatim
+```
+also a fenced code block
+```
+@endverbatim
 
 \subsection md_header_id Header Id Attributes
 

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -70,6 +70,7 @@ struct commentcnvYY_state
   int      col = 0;
   int      blockHeadCol = 0;
   bool     mlBrief = FALSE;
+  bool     mdSupport = FALSE;
   int      readLineCtx = 0;
   bool     skip = FALSE;
   QCString fileName;
@@ -131,6 +132,7 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 %x CComment
 %x Verbatim
 %x VerbatimCode
+%x VerbatimSpaceCode
 %x ReadLine
 %x CondLine
 %x ReadAliasArgs
@@ -349,6 +351,28 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 				     yyextra->blockName=&yytext[1];
                                      BEGIN(VerbatimCode);
   				   }
+<CComment,ReadLine>"```"[`]* {
+                               if (!yyextra->mdSupport) 
+                               {
+                                 REJECT;
+                               }
+                               copyToOutput(yyscanner,yytext,(int)yyleng); 
+			       yyextra->lastCommentContext = YY_START;
+			       yyextra->javaBlock=0;
+			       yyextra->blockName="```";
+                               BEGIN(VerbatimCode);
+                             }
+<CComment,ReadLine>"~~~"[~]* {
+                               if (!yyextra->mdSupport) 
+                               {
+                                 REJECT;
+                               }
+                               copyToOutput(yyscanner,yytext,(int)yyleng); 
+			       yyextra->lastCommentContext = YY_START;
+			       yyextra->javaBlock=0;
+			       yyextra->blockName="~~~";
+                               BEGIN(VerbatimCode);
+                             }
 <CComment,ReadLine>[\\@]("dot"|"code"|"msc"|"startuml")/[^a-z_A-Z0-9] { /* start of a verbatim block */
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
 				     yyextra->lastCommentContext = YY_START;
@@ -427,9 +451,19 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 				       }
 				     }
   				   }
+<VerbatimCode>"```"[`]* |
+<VerbatimCode>"~~~"[~]* |
 <VerbatimCode>[\\@]("enddot"|"endcode"|"endmsc"|"enduml") { /* end of verbatim block */
                                      copyToOutput(yyscanner,yytext,(int)yyleng);
-				     if (&yytext[4]==yyextra->blockName)
+                                     if (yytext[0] == '`' && yyextra->blockName =="```")
+                                     {
+				       BEGIN(yyextra->lastCommentContext);
+				     }
+                                     else if (yytext[0] == '~' && yyextra->blockName =="~~~")
+                                     {
+				       BEGIN(yyextra->lastCommentContext);
+				     }
+				     else if (&yytext[4]==yyextra->blockName)
 				     {
 				       BEGIN(yyextra->lastCommentContext);
 				     }
@@ -1106,6 +1140,7 @@ void convertCppComments(BufStr *inBuf,BufStr *outBuf,const char *fileName)
   yyextra->inBufPos = 0;
   yyextra->col      = 0;
   yyextra->mlBrief = Config_getBool(MULTILINE_CPP_IS_BRIEF);
+  yyextra->mdSupport = Config_getBool(MARKDOWN_SUPPORT);
   yyextra->skip     = FALSE;
   yyextra->fileName = fileName;
   yyextra->lang = getLanguageFromFileName(fileName);

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -132,7 +132,6 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 %x CComment
 %x Verbatim
 %x VerbatimCode
-%x VerbatimSpaceCode
 %x ReadLine
 %x CondLine
 %x ReadAliasArgs


### PR DESCRIPTION
Fenced codeblocks with backticks or tildes should be handled in a similar way as the `@code`  (etc.) command .
Due to the changed handling of fenced code blocks where is a small interaction with blocks starting with spaces, to overcome this those blocks have been rewritten (and are compatible with the old situation).
(Note; Proper of "spaced blocs" would require quite a bit of effort as spaces can be dependent on the context (not all "spaced blocks" are "spaced blocks" but can be a natural indentation for commands.)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4154757/example.tar.gz)
