### PR TITLE
Linking in PHP

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4744,6 +4744,7 @@ bool resolveLink(/* in */ const char *scName,
   *resContext=0;
 
   QCString linkRef=lr;
+  QCString linkRefPHP=substitute(lr,"\\","::"); // PHP substitution
   QCString linkRefWithoutTemplates = stripTemplateSpecifiersFromScope(linkRef,FALSE);
   //printf("ResolveLink linkRef=%s\n",lr);
   const FileDef  *fd;
@@ -4796,6 +4797,12 @@ bool resolveLink(/* in */ const char *scName,
     return TRUE;
   }
   else if ((cd=getClass(linkRef))) // class link
+  {
+    *resContext=cd;
+    resAnchor=cd->anchor();
+    return TRUE;
+  }
+  else if ((cd=getClass(linkRefPHP)) && (SrcLangExt_PHP==cd->getLanguage())) // class link
   {
     *resContext=cd;
     resAnchor=cd->anchor();


### PR DESCRIPTION
In PHP the scope separator is the double backslash, but this was not considered here.
When having e.g.
```
@ref DigitalPublications\MidasWPX\Interfaces\PathsManagerInterface "PathsManagerInterface"
```
we got the message:
```
 warning: unable to resolve reference to 'DigitalPublications\MidasWPX\Interfaces\PathsManagerInterface' for \ref command
```
whilst the version with the double colon was OK.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4170711/example.tar.gz)
