### PR TITLE
Problem with links from search index files

### DIFF
--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -1052,7 +1052,7 @@ void writeJavaScriptSearchIndex()
             QCString anchor = d->anchor();
 
             ti << "'" << externalRef("../",d->getReference(),TRUE)
-              << d->getOutputFileBase() << Doxygen::htmlFileExtension;
+              << addHtmlExtensionIfMissing(d->getOutputFileBase());
             if (!anchor.isEmpty())
             {
               ti << "#" << anchor;
@@ -1109,7 +1109,7 @@ void writeJavaScriptSearchIndex()
                 ti << "],[";
               }
               ti << "'" << externalRef("../",d->getReference(),TRUE)
-                << d->getOutputFileBase() << Doxygen::htmlFileExtension;
+                << addHtmlExtensionIfMissing(d->getOutputFileBase());
               if (!anchor.isEmpty())
               {
                 ti << "#" << anchor;


### PR DESCRIPTION
The format of the tag file has been slightly changed in the past so that the original HTML_FILE_EXTENSION was preserved by adding the HTML_FILE_EXTENSION to the items in the tag file.
This change has not been reflected in the search files like `files_0.js` resulting in lines like
```
  ['core_5fbigfloat_2eh_8971',['CORE_BigFloat.h',['../../Number_types/CORE__BigFloat_8h.html.html',1,'']]],
```
this has been corrected.

(Found in the CGAL code).