### PR TITLE
Unknown configuration enum values

### DIFF
--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -158,6 +158,7 @@ class ConfigEnum : public ConfigOption
     QCString *valueRef() { return &m_value; }
     void substEnvVars();
     void writeTemplate(FTextStream &t,bool sl,bool);
+    void convertStrToVal();
     void compareDoxyfile(FTextStream &t);
     void init() { m_value = m_defValue.copy(); }
 

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -221,6 +221,25 @@ void ConfigBool::convertStrToVal()
   }
 }
 
+void ConfigEnum::convertStrToVal()
+{
+  QCString val = m_value.stripWhiteSpace().lower();
+  const char *s=m_valueRange.first();
+  while (s)
+  {
+    if (QCString(s).lower() == val)
+    {
+       m_value = s;
+       return;
+    }
+    s = m_valueRange.next();
+  }
+
+  config_warn("argument '%s' for option %s is not a valid enum value\n"
+              "Using the default: %s!\n",m_value.data(),m_name.data(),m_defValue.data());
+  m_value = m_defValue;
+}
+
 QCString &ConfigImpl::getString(const char *fileName,int num,const char *name) const
 {
   ConfigOption *opt = m_dict->find(name);


### PR DESCRIPTION
In case we set for instance `DOT_IMAGE_FORMAT       = SVG` (and generate call graphs) we get messages from the `dot` tool like:
```
error: Problems running dot: exit code=1, command='dot', arguments='".../example/html/test_8cpp_a764ac60c654173eb1a0afd0906ad5a12_icgraph.dot" -TSVG -o ".../example/html/test_8cpp_a764ac60c654173eb1a0afd0906ad5a12_icgraph.SVG"'
```
on other places (e.g `HTML_FORMULA_FORMAT`) and an unknown or enum value with a wrong case, the default value is (silently) taken.

We now check:
- is the enum value of the correct case otherwise (silently) set it to the correct case.
- in case of an unknown enum value a warning is given and the default value is used

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4200243/example.tar.gz)
