### PR TITLE
Creation of svg images for formulas with inkscape

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2361,7 +2361,8 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
       <docs>
 <![CDATA[
  If the \c HTML_FORMULA_FORMAT option is set to \c svg, doxygen will use the pdf2svg
- tool (see https://github.com/dawbarton/pdf2svg) to generate formulas as SVG images instead of
+ tool (see https://github.com/dawbarton/pdf2svg) or inkscape (see https://inkscape.org)
+ to generate formulas as SVG images instead of
  PNGs for the HTML output. These images will generally look nicer at scaled resolutions.
 ]]>
       </docs>

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -348,7 +348,6 @@ char  Portable::pathListSeparator(void)
 #endif
 }
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
 static const bool ExistsOnPath(const char *fileName)
 {
   QFileInfo fi1(fileName);
@@ -380,7 +379,20 @@ static const bool ExistsOnPath(const char *fileName)
   }
   return false;
 }
+
+const bool Portable::checkForExecutable(const char *fileName)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  char *extensions[] = {".bat",".com",".exe"};
+  for (int i = 0; i < sizeof(extensions) / sizeof(*extensions); i++)
+  {
+    if (ExistsOnPath(QCString(fileName) + extensions[i])) return true;
+  }
+  return false;
+#else
+  return ExistsOnPath(fileName);
 #endif
+}
 
 const char *Portable::ghostScriptCommand(void)
 {

--- a/src/portable.h
+++ b/src/portable.h
@@ -44,6 +44,7 @@ namespace Portable
   void           setShortDir(void);
   const char *   strnstr(const char *haystack, const char *needle, size_t haystack_len);
   const char *   devNull();
+  const bool     checkForExecutable(const char *fileName);
 }
 
 


### PR DESCRIPTION
Based on the implementation as mentioned in #7578 to add the possibilities to generated svg images for formulas

- When running with inkscape 92.3 / 92.4 on Cygwin /Windows there were no images generated as the `-o` flag didn't exist, the output file had to be specified as part of the `-l`  (or `--export-plain-svg`) option
- For more flexibility the system is checked on existence of the `pdf2svg` and `inkscape` executables, so no compilations flags are necessary