### PR TITLE
Warnings in case of a VHDL error

### DIFF
--- a/vhdlparser/VhdlParserErrorHandler.hpp
+++ b/vhdlparser/VhdlParserErrorHandler.hpp
@@ -18,21 +18,21 @@ class VhdlErrorHandler: public ErrorHandler
   public:
     VhdlErrorHandler(const char *fileName) : m_fileName(fileName) {}
 
-    virtual void handleUnexpectedToken(int expectedKind, JAVACC_STRING_TYPE expectedToken, Token *actual, VhdlParser *parser)
+    virtual void handleUnexpectedToken(int expectedKind, const JJString& expectedToken, Token *actual, VhdlParser *parser)
     {
       warn(m_fileName,actual->beginLine,"syntax error '%s'",actual->image.data());
       error_count++;
       throw std::exception();
     }
 
-    virtual void handleParseError(Token *last, Token *unexpected, JAVACC_SIMPLE_STRING production, VhdlParser *parser)
+    virtual void handleParseError(Token *last, Token *unexpected, const JJSimpleString& production, VhdlParser *parser)
     {
       warn(m_fileName,last->beginLine,"unexpected token: '%s'", unexpected->image.data());
       error_count++;
       throw std::exception();
     }
 
-    virtual void handleOtherError(JAVACC_STRING_TYPE message, VhdlParser *parser)
+    virtual void handleOtherError(const JJString& message, VhdlParser *parser)
     {
       warn(m_fileName, -1, "unexpected error: '%s'", (char*)message.c_str());
       error_count++;
@@ -48,12 +48,12 @@ class VhdlTokenManagerErrorHandler: public TokenManagerErrorHandler
   public:
     VhdlTokenManagerErrorHandler(const char *fileName) : m_fileName(fileName) {}
 
-    virtual void lexicalError(bool EOFSeen, int lexState, int errorLine, int errorColumn, JAVACC_STRING_TYPE errorAfter, JAVACC_CHAR_TYPE curChar, VhdlParserTokenManager* token_manager)
+    virtual void lexicalError(bool EOFSeen, int lexState, int errorLine, int errorColumn, const JJString& errorAfter, JJChar curChar, VhdlParserTokenManager* token_manager)
     {
       warn(m_fileName,errorLine,"Lexical error, Encountered: '%c' after: '%s'",curChar, (EOFSeen? "EOF" : (const char*)errorAfter.c_str()));
     }
 
-    virtual void lexicalError(JAVACC_STRING_TYPE errorMessage, VhdlParserTokenManager* token_manager)
+    virtual void lexicalError(const JJString& errorMessage, VhdlParserTokenManager* token_manager)
     {
       warn(m_fileName,-1,"Unknown error: '%s'", (char*)errorMessage.c_str());
     }


### PR DESCRIPTION
When having a vhdl construct like:
```
entity _H_ is
```
we get the, a bit unclear, warnings like:
```
Lexical error at: 16:8. Encountered: _ after: .
```
with version 1.8.17 we got the warning:
```
.../vhdl.vhd:16: warning: Lexical error, Encountered: '_' after: ''
```
not 100% clear either but at least clear which file is involved and what the meaning of the '16' is.
Also the message didn't conform the doxygen style / place / handling of warnings / errors anymore (didn't go to the WARN_LOGFILE anymore).
(The message is correct as a vhdl identifier cannot start or end with an underscore.

Between the used javaCC versions (now 7.05) and the previously used version 6.xx apparently a small in the error handler prototypes has been introduces, and thus not finding the doxygen version anymore.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4209831/example.tar.gz)
