### PR TITLE
Disappearing words in RTF output after a list

### DIFF
--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -677,7 +677,7 @@ void RTFDocVisitor::visitPost(DocAutoList *)
   if (!m_lastIsPara) m_t << "\\par";
   m_t << "}" << endl;
   m_lastIsPara=TRUE;
-  if (!m_indentLevel) m_t << "\\par";
+  if (!m_indentLevel) m_t << "\\par" << endl;
 }
 
 void RTFDocVisitor::visitPre(DocAutoListItem *)


### PR DESCRIPTION
When having the simple example:
```
First list
    -  Item 1 1

Second list
    -  Item 2 1
```
in the RTF output the word `Second` disappears due to the fact that the is no space between a `\par` command and the word `Second`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4219786/example.tar.gz)

