### PR TITLE
Compilation warnings

### DIFF
--- a/src/definition.h
+++ b/src/definition.h
@@ -38,7 +38,7 @@ class MemberDef;
 class GroupDef;
 class GroupList;
 struct ListItemInfo;
-struct SectionInfo;
+class SectionInfo;
 class Definition;
 class FTextStream;
   

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -32,7 +32,6 @@ class DocNode;
 class MemberDef;
 class Definition;
 class MemberGroup;
-class SectionDict;
 
 //---------------------------------------------------------------------------
 QString::Direction getTextDirByConfig(const QString &text);

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -58,7 +58,6 @@ class IndexList;
 class FormulaList;
 class FormulaDict;
 class FormulaNameDict;
-class SectionDict;
 class Preprocessor;
 struct MemberGroupInfo;
 

--- a/src/entry.h
+++ b/src/entry.h
@@ -26,7 +26,7 @@
 #include "types.h"
 #include "arguments.h"
 
-struct SectionInfo;
+class SectionInfo;
 class QFile;
 class FileDef;
 struct ListItemInfo;

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -45,7 +45,6 @@ class DotClassGraph;
 class DotDirDeps;
 class DotInclDepGraph;
 class DotGfxHierarchyTable;
-class SectionDict;
 class DotGroupCollaboration;
 class DocRoot;
 

--- a/src/util.h
+++ b/src/util.h
@@ -51,7 +51,7 @@ struct TagInfo;
 class MemberNameInfoSDict;
 struct ListItemInfo;
 class PageDef;
-struct SectionInfo;
+class SectionInfo;
 class QDir;
 class Definition;
 class BufStr;


### PR DESCRIPTION
Due to
```
Commit: 1a56a39b4a97452a5c7c2d8e9d39ab28ca33dff0 [1a56a39]
Commit Date: Friday, February 21, 2020 9:07:13 PM

Restructure section handling
```
a number of compilation warnings (Windows) appeared:
```
c:\projects\doxygen\src\section.h(51): warning C4099: 'SectionInfo': type name first seen using 'struct' now seen using 'class' [C:\projects\doxygen\build\src\_doxygen.vcxproj]
  c:\projects\doxygen\src\section.h(50): note: see declaration of 'SectionInfo'
```