### PR TITLE
Possibility to show non documented namespaces

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -923,6 +923,17 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='bool' id='HIDE_UNDOC_NAMESPACES' defval='1'>
+      <docs>
+<![CDATA[
+ If the \c HIDE_UNDOC_NAMESPACES tag is set to \c YES, doxygen will hide all
+ undocumented namespaces that are normally visible in the namespace hierarchy.
+ If set to \c NO, these namespaces will be included in the
+ various overviews.
+ This option has no effect if \ref cfg_extract_all "EXTRACT_ALL" is enabled.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='HIDE_FRIEND_COMPOUNDS' defval='0'>
       <docs>
 <![CDATA[

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -4795,6 +4795,31 @@ static void computeClassRelations()
   }
 }
 
+static void warnUndocumentedNamespaces()
+{
+  NamespaceSDict::Iterator nsi(*Doxygen::namespaceSDict);
+  NamespaceDef *nd;
+  for (nsi.toFirst();nd=nsi.current();++nsi)
+  {
+    if (!nd->hasDocumentation())
+    {
+      if ((guessSection(nd->getDefFileName())==Entry::HEADER_SEC ||
+           nd->getLanguage() == SrcLangExt_Fortran) && // Fortran doesn't have header files.
+          !Config_getBool(HIDE_UNDOC_NAMESPACES) // undocumented class are visible
+         )
+      {
+        char *t = 0;
+        if (nd->getLanguage() == SrcLangExt_Fortran)
+          t="Module";
+        else
+          t="Namespace";
+        warn_undoc(nd->getDefFileName(),nd->getDefLine(), "%s %s is not documented.",t,
+                   nd->name().data());
+      }
+    }
+  }
+}
+
 static void computeTemplateClassRelations()
 {
   for (const auto &kv : g_classEntries)
@@ -11119,6 +11144,10 @@ void parseInput()
 
   g_s.begin("Flushing cached template relations that have become invalid...\n");
   flushCachedTemplateRelations();
+  g_s.end();
+
+  g_s.begin("Warn for undocumented namespacs...\n");
+  warnUndocumentedNamespaces();
   g_s.end();
 
   g_s.begin("Computing class relations...\n");

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -1553,6 +1553,7 @@ bool NamespaceDefImpl::isLinkableInProject() const
   int i = name().findRev("::");
   if (i==-1) i=0; else i+=2;
   static bool extractAnonNs = Config_getBool(EXTRACT_ANON_NSPACES);
+  static bool hideUndoc     = Config_getBool(HIDE_UNDOC_NAMESPACES);
   if (extractAnonNs &&                             // extract anonymous ns
       name().mid(i,20)=="anonymous_namespace{"     // correct prefix
      )                                             // not disabled by config
@@ -1560,7 +1561,7 @@ bool NamespaceDefImpl::isLinkableInProject() const
     return TRUE;
   }
   return !name().isEmpty() && name().at(i)!='@' && // not anonymous
-    (hasDocumentation() || getLanguage()==SrcLangExt_CSharp) &&  // documented
+    (hasDocumentation() || !hideUndoc || getLanguage()==SrcLangExt_CSharp) &&  // documented
     !isReference() &&      // not an external reference
     !isHidden() &&         // not hidden
     !isArtificial();       // or artificial

--- a/testing/077_no_xml_namespace_members_in_file_scope.h
+++ b/testing/077_no_xml_namespace_members_in_file_scope.h
@@ -1,6 +1,9 @@
 // objective: test that namespace members are not put to file docs by default
 // check: 077__no__xml__namespace__members__in__file__scope_8h.xml
 
+/**
+@brief A namespace
+*/
 namespace Namespace {
 
 /**

--- a/testing/078/078__xml__namespace__members__in__file__scope_8h.xml
+++ b/testing/078/078__xml__namespace__members__in__file__scope_8h.xml
@@ -4,7 +4,7 @@
     <compoundname>078_xml_namespace_members_in_file_scope.h</compoundname>
     <innernamespace refid="namespace_namespace">Namespace</innernamespace>
     <sectiondef kind="enum">
-      <memberdef kind="enum" id="078__xml__namespace__members__in__file__scope_8h_1add172b93283b1ab7612c3ca6cc5dcfea" prot="public" static="no" strong="yes">
+      <memberdef kind="enum" id="namespace_namespace_1add172b93283b1ab7612c3ca6cc5dcfea" prot="public" static="no" strong="yes">
         <type/>
         <name>Enum</name>
         <briefdescription>
@@ -14,11 +14,11 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="078_xml_namespace_members_in_file_scope.h" line="15" column="16" bodyfile="078_xml_namespace_members_in_file_scope.h" bodystart="15" bodyend="15"/>
+        <location file="078_xml_namespace_members_in_file_scope.h" line="19" column="16" bodyfile="078_xml_namespace_members_in_file_scope.h" bodystart="19" bodyend="19"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="func">
-      <memberdef kind="function" id="078__xml__namespace__members__in__file__scope_8h_1a0f1fe1a972c7c4196988a1bdde63ec77" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+      <memberdef kind="function" id="namespace_namespace_1a0f1fe1a972c7c4196988a1bdde63ec77" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>
         <definition>void Namespace::foo</definition>
         <argsstring>()</argsstring>
@@ -31,7 +31,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="078_xml_namespace_members_in_file_scope.h" line="12" column="6" declfile="078_xml_namespace_members_in_file_scope.h" declline="12" declcolumn="6"/>
+        <location file="078_xml_namespace_members_in_file_scope.h" line="16" column="6" declfile="078_xml_namespace_members_in_file_scope.h" declline="16" declcolumn="6"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/078_xml_namespace_members_in_file_scope.h
+++ b/testing/078_xml_namespace_members_in_file_scope.h
@@ -1,7 +1,11 @@
 // objective: test that namespace members are put to file docs when enabled
 // check: 078__xml__namespace__members__in__file__scope_8h.xml
 // config: XML_NS_MEMB_FILE_SCOPE = YES
+// config: HIDE_UNDOC_NAMESPACES = NO
 
+/**
+@brief A namespace
+*/
 namespace Namespace {
 
 /**


### PR DESCRIPTION
With classes (though quite different from namespaces) we have to possibility to show non-documented classes or not (`HIDE_UNDOC_CLASSES`), with namespaces the non-documented names spaces are not shown (only when using `EXTRACT_ALL`).

- Creating possibility to hide / show all non-documented namespaces (default set so that compatibility with old situation is preserved).
- adjusting test cases so that they work with and without `HIDE_UNDOC_NAMESPACES`).