### PR TITLE
issue #7583 External Links in Inheritance Diagrams open in the Image Frame.

### DIFF
--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -261,7 +261,7 @@ static void writeMapArea(FTextStream &t,const ClassDef *cd,QCString relPath,
     t << "<area ";
     if (!ref.isEmpty()) 
     {
-      t << externalLinkTarget();
+      t << externalLinkTarget(true);
     }
     t << "href=\"";
     t << externalRef(relPath,ref,TRUE);

--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -173,7 +173,7 @@ static QCString replaceRef(const QCString &buf,const QCString relPath,
         QCString url = link.mid(marker+1);
         if (!ref.isEmpty())
         {
-          result = externalLinkTarget();
+          result = externalLinkTarget(true);
           if (result != "") setTarget = TRUE;
         }
         result+= href+"=\"";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8163,10 +8163,15 @@ void writeSummaryLink(OutputList &ol,const char *label,const char *title,
 }
 #endif
 
-QCString externalLinkTarget()
+QCString externalLinkTarget(const bool parent)
 {
   static bool extLinksInWindow = Config_getBool(EXT_LINKS_IN_WINDOW);
-  if (extLinksInWindow) return "target=\"_blank\" "; else return "";
+  if (extLinksInWindow)
+    return "target=\"_blank\" ";
+  else if (parent)
+    return "target=\"_parent\" ";
+  else
+    return "";
 }
 
 QCString externalRef(const QCString &relPath,const QCString &ref,bool href)

--- a/src/util.h
+++ b/src/util.h
@@ -437,7 +437,7 @@ QCString filterTitle(const QCString &title);
 
 bool patternMatch(const QFileInfo &fi,const QStrList *patList);
 
-QCString externalLinkTarget();
+QCString externalLinkTarget(const bool parent = false);
 QCString externalRef(const QCString &relPath,const QCString &ref,bool href);
 int nextUtf8CharPosition(const QCString &utf8Str,int len,int startPos);
 const char *writeUtf8Char(FTextStream &t,const char *s);


### PR DESCRIPTION
When having a function it opens in the current frame and uses the complete frame. Images (e.g. inherited diagrams) are displayed in a small "sub frame" and when displaying the link here it is not readable and furthermore the user doesn't know anything about the "sub frame". In case of an image the link should be displayed in the parent frame of the image.