### PR TITLE
Removing warnings from doxygen internal documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -102,7 +102,7 @@ WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text "
-WARN_LOGFILE           =
+WARN_LOGFILE           = warnings.log
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ USE_MDFILE_AS_MAINPAGE =
 #---------------------------------------------------------------------------
 SOURCE_BROWSER         = YES
 INLINE_SOURCES         = NO
-STRIP_CODE_COMMENTS    = YES
+STRIP_CODE_COMMENTS    = NO
 REFERENCED_BY_RELATION = YES
 REFERENCES_RELATION    = YES
 REFERENCES_LINK_SOURCE = YES
@@ -323,7 +323,7 @@ DIAFILE_DIRS           =
 PLANTUML_JAR_PATH      =
 PLANTUML_CFG_FILE      =
 PLANTUML_INCLUDE_PATH  =
-DOT_GRAPH_MAX_NODES    = 50
+DOT_GRAPH_MAX_NODES    = 100
 MAX_DOT_GRAPH_DEPTH    = 0
 DOT_TRANSPARENT        = NO
 DOT_MULTI_TARGETS      = NO

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -114,20 +114,28 @@ static void writeServerSearchBox(FTextStream &t,const char *relPath,bool highlig
 }
 
 //------------------------------------------------------------------------
-/// Convert a set of LaTeX `\(re)newcommand` to a form readable by MathJax
+/// Convert a set of LaTeX  commands `\(re)newcommand`  to a form readable by MathJax
 /// LaTeX syntax:
+/// ```
 ///       \newcommand{\cmd}{replacement}
 ///         or
 ///       \renewcommand{\cmd}{replacement}
+/// ```
 /// MathJax syntax:
+/// ```
 ///        cmd: "{replacement}"
+/// ```
 ///
 /// LaTeX syntax:
+/// ```
 ///       \newcommand{\cmd}[nr]{replacement}
 ///         or
 ///       \renewcommand{\cmd}[nr]{replacement}
+/// ```
 /// MathJax syntax:
+/// ```
 ///        cmd: ["{replacement}",nr]
+/// ```
 static QCString getConvertLatexMacro()
 {
   QCString macrofile = Config_getString(FORMULA_MACROFILE);

--- a/src/parserintf.h
+++ b/src/parserintf.h
@@ -178,10 +178,12 @@ class ParserManager
     }
 
     /** Registers an additional parser.
-     *  @param[in] name      A symbolic name of the parser, i.e. "c",
-     *                       "python", "fortran", "vhdl", ...
-     *  @param[in] parser    The parser that is to be used for the
-     *                       given name.
+     *  @param[in] name          A symbolic name of the parser, i.e. "c",
+     *                           "python", "fortran", "vhdl", ...
+     *  @param[in] outlineParser The language parser (scanner) that is to be used for the
+     *                           given name.
+     *  @param[in] codeParser    The code parser that is to be used for the
+     *                           given name.
      */
     void registerParser(const char *name,std::unique_ptr<OutlineParserInterface> outlineParser,
                                          std::unique_ptr<CodeParserInterface> codeParser)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6445,9 +6445,9 @@ QCString substituteTemplateArgumentsInString(
 /*! Strips template specifiers from scope \a fullName, except those 
  *  that make up specialized classes. The switch \a parentOnly 
  *  determines whether or not a template "at the end" of a scope 
- *  should be considered, e.g. with \a parentOnly is \c TRUE, A<T>::B<S> will 
- *  try to strip \<T\> and not \<S\>, while \a parentOnly is \c FALSE will 
- *  strip both unless A<T> or B<S> are specialized template classes. 
+ *  should be considered, e.g. with \a parentOnly is \c TRUE, \c A<T>::B<S> will 
+ *  try to strip `<T>` and not `<S>`, while \a parentOnly is \c FALSE will 
+ *  strip both unless `A<T>` or `B<S>` are specialized template classes. 
  */
 QCString stripTemplateSpecifiersFromScope(const QCString &fullName,
     bool parentOnly,


### PR DESCRIPTION
Although there is not a lot of doxygen internal documentation, it still should not produce warnings.