### PR TITLE
Incorrect handling of typedef in combination with const

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1029,9 +1029,16 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  yyextra->current->explicitExternal = TRUE;
 					  lineCount(yyscanner);
   					}
-<FindMembers>{B}*"const"{BN}+    	{ yyextra->current->type += " const ";
-					  if (yyextra->insideCS) yyextra->current->stat = TRUE;
-					  lineCount(yyscanner);
+<FindMembers>{B}*"const"{BN}+    	{ if (yyextra->insideCS)
+					  {
+					    yyextra->current->type += " const ";
+					    if (yyextra->insideCS) yyextra->current->stat = TRUE;
+					    lineCount(yyscanner);
+					  }
+					  else
+					  {
+					    REJECT;
+					  }
 					}
 <FindMembers>{B}*"virtual"{BN}+    	{ yyextra->current->type += " virtual ";
 					  yyextra->current->virt = Virtual;


### PR DESCRIPTION
In issue #7060 and example was given with
```
typedef const char m_msgEvtName;
```
we see that
-    1.8.15, listed under Typedefs:
    ` typedef const char m_msgEvtName`
-    1.8.16 and up, listed under Variables:
    `const typedef char m_msgEvtName`

so mentioned:
-    wrong "header"
-    const at the wrong place

This is a regression on:
C# consts incorrectly placed under instance variables (Origin: bugzilla #535853)  (issue #2976)
and the pull request #7048
The fix should only be used for C#

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4250303/example.tar.gz)
