### PR TITLE
Problem with temporary / intermediate directory  in doxyparse

### DIFF
--- a/addon/doxyparse/doxyparse.cpp
+++ b/addon/doxyparse/doxyparse.cpp
@@ -44,6 +44,7 @@
 #include <qcstring.h>
 #include <qregexp.h>
 #include "namespacedef.h"
+#include "portable.h"
 
 class Doxyparse : public CodeOutputInterface
 {
@@ -449,12 +450,14 @@ int main(int argc,char **argv) {
 
   // we need a place to put intermediate files
   std::ostringstream tmpdir;
-#if !defined(_WIN32) || defined(__CYGWIN__)
-  unsigned int pid = (uint)getpid();
-#else
-  unsigned int pid = (uint)GetCurrentProcessId();
-#endif
-  tmpdir << "/tmp/doxyparse-" << pid;
+  unsigned int pid = Portable::pid();
+  if (Portable::getenv("TMP"))
+    tmpdir << Portable::getenv("TMP") << "/doxyparse-" << pid;
+  else if (Portable::getenv("TEMP"))
+    tmpdir << Portable::getenv("TEMP") << "/doxyparse-" << pid;
+  else
+    tmpdir << "doxyparse-" << pid;
+
   Config_getString(OUTPUT_DIRECTORY)= tmpdir.str().c_str();
   // enable HTML (fake) output to omit warning about missing output format
   Config_getBool(GENERATE_HTML)=TRUE;


### PR DESCRIPTION
When we want to use doxyparse under Windows we get the message like:
```
error: tag OUTPUT_DIRECTORY: Output directory '/tmp/doxyparse-9848' does not exist and cannot be created
```
as this is a *nix type path and the '/tmp', normally doesn't exists on Windows, better to see what is the real temporary directory (on all systems) and make everything system independent.