### PR TITLE
Problem in case using PREDEFINED with comma and using +=

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -832,7 +832,14 @@ static void readIncludeFile(const char *incName)
 					      case ConfigOption::O_List:
 					        l = ((ConfigList *)option)->valueRef();
 						elemStr="";
-					        BEGIN(GetStrList);
+						if (cmd == "PREDEFINED")
+						{
+					          BEGIN(GetStrList1);
+						}
+						else
+						{
+					          BEGIN(GetStrList);
+						}
 					        break;
 					      case ConfigOption::O_Enum:
 					      case ConfigOption::O_String:


### PR DESCRIPTION
In pull request #7603 the problem regarding `PREDEFINED = A(x,y)`, but the same patch must be applied to the construct `PREDEFINED += A(x,y)`