### PR TITLE
issue #7060 Function pointer typedefs render strangely in HTML documentation

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2308,14 +2308,29 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
 
   // *** write type
   QCString ltype(m_impl->type);
+  QCString preTypedefString;
   if (isTypedef() && getLanguage() != SrcLangExt_Slice)
   {
     ltype.prepend("typedef ");
+    if (m_impl->args.at(0) == ')') // to be on the safe side and to exclude variable like "int (*bla)[10]"
+    {
+      int lastOpen = -1;
+      for (uint i = 0; i < ltype.length(); i++)
+      {
+        if (ltype.at(i) == '(') lastOpen = i;
+      }
+      if (lastOpen != -1)
+      {
+        preTypedefString=ltype.right(ltype.length()-lastOpen);
+        ltype=ltype.left(lastOpen);
+      }
+    }
   }
   if (isTypeAlias())
   {
     ltype="using";
   }
+
   // strip 'friend' keyword from ltype
   ltype.stripPrefix("friend ");
   static QRegExp r("@[0-9]+");
@@ -2422,6 +2437,10 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
   else
   {
     ol.insertMemberAlign(m_impl->tArgList.hasParameters());
+  }
+  if (!preTypedefString.isEmpty())
+  {
+    ol.docify(preTypedefString);
   }
 
   // *** write name


### PR DESCRIPTION
typedefs like:
```
typedef void *(*pMsgCntrSubscriberAction)(const void* theContext);
```
place the `(*` part with the type, though it should be in front of the name., especially in HTML this gives a strange layout..
Splitting of this part and show it just before the name instead of with the type. The closing `)` has been split off and added to the arguments before.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4270344/example.tar.gz)
