### PR TITLE
issue #7626 "warning: documentation for unknown define ... found" without newline at end of file

### DIFF
--- a/src/bufstr.h
+++ b/src/bufstr.h
@@ -98,6 +98,10 @@ class BufStr
     { 
       return m_writeOffset; 
     }
+    void backupPos(const uint num)
+    {
+      m_writeOffset -= num;
+    }
     void dropFromStart(uint bytes)
     {
       if (bytes>m_size) bytes=m_size;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9162,6 +9162,15 @@ static void parseFile(OutlineParserInterface &parser,
     BufStr inBuf(fi.size()+4096);
     msg("Preprocessing %s...\n",fn);
     readInputFile(fileName,inBuf);
+    if (inBuf.data() && inBuf.curPos()>0)
+    {
+      while (*(inBuf.data()+inBuf.curPos()-1)=='\0') inBuf.backupPos(1);
+      if (*(inBuf.data()+inBuf.curPos()-1)!='\n')
+      {
+        inBuf.addChar('\n'); // add extra newline to help preprocessor
+      }
+      inBuf.addChar('\0'); // add terminate character
+    }
     Doxygen::preprocessor->processFile(fileName,inBuf,preBuf);
   }
   else // no preprocessing
@@ -9169,9 +9178,14 @@ static void parseFile(OutlineParserInterface &parser,
     msg("Reading %s...\n",fn);
     readInputFile(fileName,preBuf);
   }
-  if (preBuf.data() && preBuf.curPos()>0 && *(preBuf.data()+preBuf.curPos()-1)!='\n')
+  if (preBuf.data() && preBuf.curPos()>0)
   {
-    preBuf.addChar('\n'); // add extra newline to help parser
+    while (*(preBuf.data()+preBuf.curPos()-1)=='\0') preBuf.backupPos(1);
+    if (*(preBuf.data()+preBuf.curPos()-1)!='\n')
+    {
+      preBuf.addChar('\n'); // add extra newline to help parser
+    }
+    preBuf.addChar('\0'); // add terminate character
   }
 
   BufStr convBuf(preBuf.curPos()+1024);


### PR DESCRIPTION
In case of non preprocessed code there was already a `\n` added when not present at the end. This has now been done in case of preprocessing as well.

The current code had a small flaw as it added the `\n` after the last character and this character could be a `\0` so we has to backup a little.