### PR TITLE
Fixed the problem character string between '<' and '>' is not output in doxywizard log.

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -548,7 +548,11 @@ void MainWindow::readStdout()
     {
       text1 += text;
       m_outputLog->clear();
-      m_outputLog->append(APPQT(text1.trimmed()));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+      m_outputLog->append(APPQT(text1.toHtmlEscaped().trimmed()));
+#else
+      m_outputLog->append(APPQT(Qt::escape(text1).trimmed()));
+#endif
     }
   }
 }


### PR DESCRIPTION
Character string between '<' and '>' is not output in doxywizard log.

As a sample, I attached the doxywizard log and the command line doxygen log when analyzing qtools/qlist.h of doxygen 1.8.17 source code.
[sample.zip](https://github.com/doxygen/doxygen/files/4302099/sample.zip)
"doxywizard_log.txt" is doxywizard log. 
And "doxygen_log_stdout.txt" and "doxygen_log_stderr.txt" are the logs when executed the command `doxygen Doxyfile > doxygen_log_stdout.txt 2> doxygen_log_stderr.txt`.

For example, in line 3 of "doxygen_log_stderr.txt", the output is correct as follows,

    C:/doxygen-1.8.17/qtools/qlist.h:93: warning: Member QList(const QList< type > &l) (function) of class QList is not documented.

On the other hand in line 76 of "doxywizard_log.txt", that is, the corresponding doxywizard log, "< type >" is not output as shown below.

    C:/doxygen-1.8.17/qtools/qlist.h:93: warning: Member QList(const QList &l) (function) of class QList is not documented.

The cause is strings passed to m_outputLog->append() in MainWindow::readStdout() are treated as HTML.
Therefore I added the escape processing for strings passed to m_outputLog->append().
As the escape processing, I used QString::ToHtmlEscaped() in Qt5 environment and used Qt::escape() in Qt4 environment,
because QString::ToHtmlEscaped() was introduced in Qt5. 



