### PR TITLE
Fortran function definitions at begin of a line

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -376,6 +376,7 @@ struct preYY_state
   bool               skip;
   QStack<CondCtx>    condStack;
   bool               insideCS; // C# has simpler preprocessor
+  bool               insideFtn;
   bool               isSource;
 
   int                fenceSize = 0;
@@ -495,7 +496,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
 					  name=name.left(name.find('(')).stripWhiteSpace();
 
 					  Define *def=0;
-					  if (skipFuncMacros && 
+					  if (skipFuncMacros && !yyextra->insideFtn &&
 					      name!="Q_PROPERTY" &&
 					      !(
 					         (yyextra->includeStack.isEmpty() || yyextra->curlyCount>0) &&
@@ -1711,6 +1712,7 @@ static void setFileName(yyscan_t yyscanner,const char *name)
   //    name,state->yyFileName.data(),state->yyFileDef);
   if (state->yyFileDef && state->yyFileDef->isReference()) state->yyFileDef=0;
   state->insideCS = getLanguageFromFileName(state->yyFileName)==SrcLangExt_CSharp;
+  state->insideFtn = getLanguageFromFileName(state->yyFileName)==SrcLangExt_Fortran;
   state->isSource = guessSection(state->yyFileName);
 }
 


### PR DESCRIPTION
When we have an Fortran source that needs preprocessing like:
```
       INTEGER FUNCTION &
            BI()
       END FUNCTION BI
```
the preprocessor will output:
```
00001        INTEGER FUNCTION &
00002
00003        END FUNCTION BI
```
we see that the function name (and argumentlist (`BI()`) are gone, resulting in the error:
```
Error in file .../test.F90 line: 4, state: 4(SubprogBody)
```

The original problem came from the `BIND` attribute (as found by Fossies in the HDF5 package), but the example has been reduced to the above example.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4303139/example.tar.gz)
