### PR TITLE
Fix C compiler warnings about C++ flags

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -1,5 +1,5 @@
 Doxygen uses cmake (http://www.cmake.org/) to build executables for various platforms.
-It's required at least cmake version 3.1.3
+It's required at least cmake version 3.3.
 
 The first step is to create a build directory where the output should be stored.
 Doxygen can be fully build outside of the source tree.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Documents produced by Doxygen are derivative works derived from the
 # input used in their production; they are not affected by this license.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 project(doxygen)
 
 option(build_wizard    "Build the GUI frontend for doxygen." OFF)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -41,14 +41,15 @@ function(set_project_warnings project_name)
       -Wextra # reasonable and standard
       -Wshadow # warn the user if a variable declaration shadows one from a
                # parent context
-      -Wnon-virtual-dtor # warn the user if a class with virtual functions has a
-                         # non-virtual destructor. This helps catch hard to
-                         # track down memory errors
+      $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>
+               # warn the user if a class with virtual functions has a
+               # non-virtual destructor. This helps catch hard to
+               # track down memory errors
 #      -Wold-style-cast # warn for c-style casts
       -Wcast-align # warn for potential performance problem casts
       -Wunused # warn on anything being unused
-      -Woverloaded-virtual # warn if you overload (not override) a virtual
-                           # function
+      $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
+               # warn if you overload (not override) a virtual function
       -Wpedantic # warn if non-standard C++ is used
       -Wconversion # warn on type conversions that may lose data
       -Wnull-dereference # warn if a null dereference is detected
@@ -72,14 +73,15 @@ function(set_project_warnings project_name)
       -Wextra # reasonable and standard
       #-Wshadow # warn the user if a variable declaration shadows one from a
       #         # parent context
-      -Wnon-virtual-dtor # warn the user if a class with virtual functions has a
-                         # non-virtual destructor. This helps catch hard to
-                         # track down memory errors
+      $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>
+               # warn the user if a class with virtual functions has a
+               # non-virtual destructor. This helps catch hard to
+               # track down memory errors
 #      -Wold-style-cast # warn for c-style casts
       -Wcast-align # warn for potential performance problem casts
       -Wunused # warn on anything being unused
-      -Woverloaded-virtual # warn if you overload (not override) a virtual
-                           # function
+      $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
+               # warn if you overload (not override) a virtual function
       -Wpedantic # warn if non-standard C++ is used
       #-Wconversion # warn on type conversions that may lose data
       #-Wnull-dereference # warn if a null dereference is detected


### PR DESCRIPTION
This patch will fix the following warnings:
```
cc1: warning: command line option ‘-Wnon-virtual-dtor’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C
```

... using the generator expression `$<COMPILE_LANGUAGE:CXX>` to enable the warning flags only for C++ compilation units, and not for C. 
