### PR TITLE
issue #7406 Objective-C class and instance methods with the same name have the same refid

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -341,15 +341,18 @@ static bool getLinkInScope(yyscan_t yyscanner,const QCString &c,  // scope
 			   const char *memberText, // exact text
 			   CodeOutputInterface &ol,
 			   const char *text,
-			   bool varOnly=FALSE
+			   bool varOnly=FALSE,
+                           const objCMethod objCMeth=NoObjCMeth
 			  );
 static bool getLink(yyscan_t yyscanner,const char *className,
                     const char *memberName,
 		    CodeOutputInterface &ol,
 		    const char *text=0,
-		    bool varOnly=FALSE);
+		    bool varOnly=FALSE,
+                    const objCMethod objCMeth=NoObjCMeth
+                   );
 static void generateClassOrGlobalLink(yyscan_t yyscanner,CodeOutputInterface &ol,const char *clName,
-                                      bool typeOnly=FALSE,bool varOnly=FALSE);
+                                      bool typeOnly=FALSE,bool varOnly=FALSE, const objCMethod objCMeth=NoObjCMeth);
 static bool generateClassMemberLink(yyscan_t yyscanner,CodeOutputInterface &ol,MemberDef *xmd,const char *memName);
 static bool generateClassMemberLink(yyscan_t yyscanner,CodeOutputInterface &ol,const Definition *def,const char *memName);
 static void generateMemberLink(yyscan_t yyscanner,CodeOutputInterface &ol,const QCString &varName,
@@ -425,7 +428,8 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 %x      TemplDecl
 %x      TemplCast
 %x	CallEnd
-%x      ObjCMethod
+%x      ObjCMethodStat
+%x      ObjCMethodInst
 %x	ObjCParams
 %x	ObjCParamType
 %x      ObjCCall
@@ -493,10 +497,13 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  {
 					    //printf("Method!\n");
   					    yyextra->code->codify(yytext);
-					    BEGIN(ObjCMethod);
+                                            if (*yytext == '+')
+					      BEGIN(ObjCMethodStat);
+                                            else
+					      BEGIN(ObjCMethodInst);
 					  }
   					}
-<ObjCMethod>":"				{
+<ObjCMethodStat,ObjCMethodInst>":"				{
   					  yyextra->code->codify(yytext);
 					  BEGIN(ObjCParams);
   					}
@@ -504,7 +511,7 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
   					  yyextra->code->codify(yytext);
   					  BEGIN(ObjCParamType);
 					}
-<ObjCParams,ObjCMethod>";"|"{"		{
+<ObjCParams,ObjCMethodStat,ObjCMethodInst>";"|"{"		{
   					  yyextra->code->codify(yytext);
 					  if (*yytext=='{')
 					  {
@@ -548,13 +555,18 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					  yyextra->theVarContext.addVariable(yyscanner,yyextra->parmType,yyextra->parmName);
 					  yyextra->parmType.resize(0);yyextra->parmName.resize(0);
   					}
-<ObjCMethod,ObjCParams,ObjCParamType>{ID} {
-					  generateClassOrGlobalLink(yyscanner,*yyextra->code,yytext);
+<ObjCMethodStat,ObjCMethodInst,ObjCParams,ObjCParamType>{ID} {
+                                          if (YY_START == ObjCMethodStat)
+					    generateClassOrGlobalLink(yyscanner,*yyextra->code,yytext,FALSE,FALSE,ObjCMethStat);
+                                          else if (YY_START == ObjCMethodInst)
+					    generateClassOrGlobalLink(yyscanner,*yyextra->code,yytext,FALSE,FALSE,ObjCMethInst);
+                                          else
+					    generateClassOrGlobalLink(yyscanner,*yyextra->code,yytext);
   					}
-<ObjCMethod,ObjCParams,ObjCParamType>.	{
+<ObjCMethodStat,ObjCMethodInst,ObjCParams,ObjCParamType>.	{
   					  yyextra->code->codify(yytext);
   					}
-<ObjCMethod,ObjCParams,ObjCParamType>\n	{
+<ObjCMethodStat,ObjCMethodInst,ObjCParams,ObjCParamType>\n	{
   					  codifyLines(yyscanner,yytext);
   					}
 <ReadInclude>[^\n\"\>]+/(">"|"\"")  	{
@@ -1097,14 +1109,14 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 					    BEGIN(FuncCall);
 					  }
   					}
-<Body,TemplDecl,ObjCMethod>{TYPEKW}/{B}* {
+<Body,TemplDecl,ObjCMethodStat,ObjCMethodInst>{TYPEKW}/{B}* {
   					  startFontClass(yyscanner,"keywordtype");
 					  yyextra->code->codify(yytext);
 					  endFontClass(yyscanner);
 					  addType(yyscanner);
   					  yyextra->name+=yytext; 
   					}
-<Body,TemplDecl,ObjCMethod>{TYPEKWSL}/{B}* {
+<Body,TemplDecl,ObjCMethodStat,ObjCMethodInst>{TYPEKWSL}/{B}* {
                                           if (yyextra->lang!=SrcLangExt_Slice)
                                           {
                                             REJECT;
@@ -2820,7 +2832,8 @@ static bool getLinkInScope(yyscan_t yyscanner,
 			   const char *memberText, // exact text
 			   CodeOutputInterface &ol,
 			   const char *text,
-			   bool varOnly
+		           bool varOnly,
+                           const objCMethod objCMeth
 			  )
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
@@ -2830,7 +2843,7 @@ static bool getLinkInScope(yyscan_t yyscanner,
   const NamespaceDef *nd = 0;
   const GroupDef     *gd = 0;
   DBG_CTX((stderr,"getLinkInScope: trying '%s'::'%s' varOnly=%d\n",c.data(),m.data(),varOnly));
-  if (getDefs(c,m,"()",md,cd,fd,nd,gd,FALSE,yyextra->sourceFileDef,FALSE,yyextra->forceTagReference) && 
+  if (getDefs(c,m,"()",md,cd,fd,nd,gd,FALSE,yyextra->sourceFileDef,FALSE,yyextra->forceTagReference,objCMeth) && 
       (!varOnly || md->isVariable()))
   {
     if (md->isLinkable())
@@ -2885,19 +2898,20 @@ static bool getLink(yyscan_t yyscanner,
                     const char *memberName,
 		    CodeOutputInterface &ol,
 		    const char *text,
-		    bool varOnly)
+		    bool varOnly,
+                    const objCMethod objCMeth)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   //printf("getLink(%s,%s) yyextra->curClassName=%s\n",className,memberName,yyextra->curClassName.data());
   QCString m=removeRedundantWhiteSpace(memberName);
   QCString c=className;
-  if (!getLinkInScope(yyscanner,c,m,memberName,ol,text,varOnly))
+  if (!getLinkInScope(yyscanner,c,m,memberName,ol,text,varOnly,objCMeth))
   {
     if (!yyextra->curClassName.isEmpty())
     {
       if (!c.isEmpty()) c.prepend("::");
       c.prepend(yyextra->curClassName);
-      return getLinkInScope(yyscanner,c,m,memberName,ol,text,varOnly);
+      return getLinkInScope(yyscanner,c,m,memberName,ol,text,varOnly,objCMeth);
     }
     return FALSE;
   }
@@ -2908,7 +2922,8 @@ static void generateClassOrGlobalLink(yyscan_t yyscanner,
                                       CodeOutputInterface &ol,
                                       const char *clName,
                                       bool typeOnly,
-                                      bool varOnly)
+                                      bool varOnly,
+                                      const objCMethod objCMeth)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   int i=0;
@@ -2967,7 +2982,7 @@ static void generateClassOrGlobalLink(yyscan_t yyscanner,
           nd?nd->name().data():"<null>"));
     if (cd==0 && md==0) // also see if it is variable or enum or enum value
     {
-      if (getLink(yyscanner,yyextra->classScope,clName,ol,clName,varOnly))
+      if (getLink(yyscanner,yyextra->classScope,clName,ol,clName,varOnly,objCMeth))
       {
 	return;
       }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4300,6 +4300,12 @@ void MemberDefImpl::setAnchor()
     memAnchor.prepend(buf);
   }
 
+  // an ObjectC method can exist in 2 versions, with a "+" and with a "-", but the
+  // names are the same, so the linking would result in the same anchor
+  if (isObjCMethod())
+  {
+    if (isStatic()) memAnchor.prepend("+ "); else memAnchor.prepend("- ");
+  }
   // convert to md5 hash
   uchar md5_sig[16];
   QCString sigStr(33);

--- a/src/types.h
+++ b/src/types.h
@@ -272,4 +272,10 @@ class LocalToc
     int m_level[numTocTypes];
 };
 
+enum objCMethod
+{
+   NoObjCMeth   = 0,
+   ObjCMethStat = 1,
+   ObjCMethInst = 2
+};
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1838,7 +1838,7 @@ QCString removeRedundantWhiteSpace(const QCString &s)
         {
           if (nc != '=')
           // avoid splitting operator&=
-	  {
+          {
             *dst++=' ';
           }
         }
@@ -3464,7 +3464,8 @@ bool getDefs(const QCString &scName,
              bool forceEmptyScope,
              const FileDef *currentFile,
              bool checkCV,
-             const char *forceTagFile
+             const char *forceTagFile,
+             const objCMethod objCMeth
             )
 {
   fd=0, md=0, cd=0, nd=0, gd=0;
@@ -3558,6 +3559,14 @@ bool getDefs(const QCString &scName,
               matchArguments2(mmd->getOuterScope(),mmd->getFileDef(),mmdAl,
                              fcd,                  fcd->getFileDef(),argList,
                              checkCV);
+            if (match)
+            {
+              if (mmd->isObjCMethod() && (objCMeth != NoObjCMeth))
+              {
+                 if (objCMeth == ObjCMethStat) { match = mmd->isStatic(); }
+                 else { match = !mmd->isStatic(); }
+              }
+            }
             //printf("match=%d\n",match);
             if (match)
             {

--- a/src/util.h
+++ b/src/util.h
@@ -150,7 +150,8 @@ bool getDefs(const QCString &scopeName,
                     bool forceEmptyScope=FALSE,
                     const FileDef *currentFile=0,
                     bool checkCV=FALSE,
-                    const char *forceTagFile=0
+                    const char *forceTagFile=0,
+                    const objCMethod objCMeth=NoObjCMeth
                    );
 
 QCString getFileFilter(const char* name,bool isSourceCode);

--- a/testing/011/category_integer_07_arithmetic_08.xml
+++ b/testing/011/category_integer_07_arithmetic_08.xml
@@ -3,7 +3,7 @@
   <compounddef id="category_integer_07_arithmetic_08" kind="category" language="Objective-C" prot="public">
     <compoundname>Integer(Arithmetic)</compoundname>
     <sectiondef kind="public-func">
-      <memberdef kind="function" id="category_integer_07_arithmetic_08_1a12f411c5872ba3bafb8ea7dd1826cf2a" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
+      <memberdef kind="function" id="category_integer_07_arithmetic_08_1ab4f131468dbe9d450ea70efe116c771c" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
         <type>id</type>
         <definition>id Integer(Arithmetic)::add:</definition>
         <argsstring>(Integer *addend)</argsstring>
@@ -21,7 +21,7 @@
         </inbodydescription>
         <location file="011_category.m" line="8" column="6"/>
       </memberdef>
-      <memberdef kind="function" id="category_integer_07_arithmetic_08_1ae4ff0b0c62b6809e8f5bcee9baa6e521" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
+      <memberdef kind="function" id="category_integer_07_arithmetic_08_1acbe7112676cc9a125bdc53e297228fcf" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
         <type>id</type>
         <definition>id Integer(Arithmetic)::sub:</definition>
         <argsstring>(Integer *subtrahend)</argsstring>
@@ -47,11 +47,11 @@
     </detaileddescription>
     <location file="011_category.m" line="17" column="19" bodyfile="011_category.m" bodystart="17" bodyend="-1"/>
     <listofallmembers>
-      <member refid="category_integer_07_arithmetic_08_1a12f411c5872ba3bafb8ea7dd1826cf2a" prot="public" virt="virtual">
+      <member refid="category_integer_07_arithmetic_08_1ab4f131468dbe9d450ea70efe116c771c" prot="public" virt="virtual">
         <scope>Integer(Arithmetic)</scope>
         <name>add:</name>
       </member>
-      <member refid="category_integer_07_arithmetic_08_1ae4ff0b0c62b6809e8f5bcee9baa6e521" prot="public" virt="virtual">
+      <member refid="category_integer_07_arithmetic_08_1acbe7112676cc9a125bdc53e297228fcf" prot="public" virt="virtual">
         <scope>Integer(Arithmetic)</scope>
         <name>sub:</name>
       </member>

--- a/testing/011/interface_integer.xml
+++ b/testing/011/interface_integer.xml
@@ -20,7 +20,7 @@
       </memberdef>
     </sectiondef>
     <sectiondef kind="public-func">
-      <memberdef kind="function" id="interface_integer_1a7b55035e1b0e8e7d4c8587f54a760819" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
+      <memberdef kind="function" id="interface_integer_1a38588240d29ef9ff5a3217a03fc1acc7" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
         <type>int</type>
         <definition>int Integer::integer</definition>
         <argsstring>()</argsstring>
@@ -34,7 +34,7 @@
         </inbodydescription>
         <location file="011_category.m" line="8" column="6"/>
       </memberdef>
-      <memberdef kind="function" id="interface_integer_1ad2f47761103b2442ff7b3fbfe33ec6c9" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
+      <memberdef kind="function" id="interface_integer_1ac6b178632e55f634e3a9249b7b39aa56" prot="public" static="no" const="no" explicit="no" inline="no" virt="virtual">
         <type>id</type>
         <definition>id Integer::integer:</definition>
         <argsstring>(int _integer)</argsstring>
@@ -86,11 +86,11 @@
         <scope>Integer</scope>
         <name>integer</name>
       </member>
-      <member refid="interface_integer_1a7b55035e1b0e8e7d4c8587f54a760819" prot="public" virt="virtual">
+      <member refid="interface_integer_1a38588240d29ef9ff5a3217a03fc1acc7" prot="public" virt="virtual">
         <scope>Integer</scope>
         <name>integer</name>
       </member>
-      <member refid="interface_integer_1ad2f47761103b2442ff7b3fbfe33ec6c9" prot="public" virt="virtual">
+      <member refid="interface_integer_1ac6b178632e55f634e3a9249b7b39aa56" prot="public" virt="virtual">
         <scope>Integer</scope>
         <name>integer:</name>
       </member>


### PR DESCRIPTION
Methods in objectC can have a "+ " for static methods and "-" for instance methods, this distinction was not taken into account.
In memberdef.cpp the distinction is made between both types so the correct anchor is created.
The changes in code.l are to get the right (member) definition in case of an objectC method (otherwise in e.g. the tooltip the reference went always to the first one found. This has also consequences for types.h, util.h and util.cpp as we need to add the information when searching for the right method.

Due to the incorporation of the "+ " and "- " also the test example has to be updated