### PR TITLE
Tcl has a problem with a case statement with just {} inside the switch statement

### DIFF
--- a/src/tclscanner.l
+++ b/src/tclscanner.l
@@ -1173,6 +1173,7 @@ tcl_inf("line=%d type=%d '%s'\n",tcl.line_body0,type,content.data());
       myScan->type[0] = type;
       break;
     case '?':
+      if (content.isEmpty()) break;
       if (content[0]=='"' && content[content.length()-1]=='"') myScan->type[0]='"';
       if (content[0]=='{' && content[content.length()-1]=='}') myScan->type[0]='{';
       if (content[0]=='[' && content[content.length()-1]==']') myScan->type[0]='[';


### PR DESCRIPTION
In case we have a (reduced) case like:
```
## ::tkcon::Init - inits tkcon
proc ::tkcon::Init {} {
            switch -glob -- $arg {
                -root           { set PRIV(root) $val }
                -font           { set OPT(font) $val }
                -rcfile {}
            }
}
```
and a default doxygen configuration file, doxygen will crash in the tcl scanner as the `{}` results in an empty string.

Some notes, crash only happens when compilation for 'Release' or 'RelWithDebInfo' as 'CMAKE_BUILD_TYPE'.

(Found by Fossies for magic 8.2.195).