### PR TITLE
Remove warnings from doxywizard

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -343,7 +343,10 @@ void MainWindow::clearRecent()
     m_recentFiles.clear();
     for (int i=0;i<MAX_RECENT_FILES;i++)
     {
-      m_settings.setValue(QString().sprintf("recent/config%d",i++),QString::fromLatin1(""));
+      QString res;
+      QTextStream out(&res);
+      out << "recent/config" << i++;
+      m_settings.setValue(res,QString::fromLatin1(""));
     }
     m_settings.sync();
   }
@@ -389,7 +392,10 @@ void MainWindow::loadSettings()
   /* due to prepend use list in reversed order */
   for (int i=MAX_RECENT_FILES;i>=0;i--)
   {
-    QString entry = m_settings.value(QString().sprintf("recent/config%d",i)).toString();
+    QString res;
+    QTextStream out(&res);
+    out << "recent/config" << i;
+    QString entry = m_settings.value(res).toString();
     if (!entry.isEmpty() && QFileInfo(entry).exists())
     {
       addRecentFileList(entry);
@@ -447,12 +453,18 @@ void MainWindow::updateRecentFile(void)
   int i=0;
   foreach( QString str, m_recentFiles ) 
   {
+    QString res;
+    QTextStream out(&res);
+    out << "recent/config" << i++;
     m_recentMenu->addAction(str);
-    m_settings.setValue(QString().sprintf("recent/config%d",i++),str);
+    m_settings.setValue(res,str);
   }
   for (;i<MAX_RECENT_FILES;i++)
   {
-    m_settings.setValue(QString().sprintf("recent/config%d",i++),QString::fromLatin1(""));
+    QString res;
+    QTextStream out(&res);
+    out << "recent/config" << i;
+    m_settings.setValue(res,QString::fromLatin1(""));
   }
 }
 
@@ -689,16 +701,22 @@ int main(int argc,char **argv)
   {
     if (!qstrcmp(argv[1],"--help"))
     {
+      QString res;
+      QTextStream out(&res);
+      out << "Usage: " << argv[0] << " [config file]";
       QMessageBox msgBox;
-      msgBox.setText(QString().sprintf("Usage: %s [config file]",argv[0]));
+      msgBox.setText(res);
       msgBox.exec();
       exit(0);
     }
   }
   if (argc > 2)
   {
+    QString res;
+    QTextStream out(&res);
+    out << "Too many arguments specified\n\nUsage: " << argv[0] << " [config file]";
     QMessageBox msgBox;
-    msgBox.setText(QString().sprintf("Too many arguments specified\n\nUsage: %s [config file]",argv[0]));
+    msgBox.setText(res);
     msgBox.exec();
     exit(1);
   }

--- a/addon/doxywizard/wizard.cpp
+++ b/addon/doxywizard/wizard.cpp
@@ -369,8 +369,8 @@ void ColorPicker::paintEvent(QPaintEvent*)
   p.drawPixmap(1, coff, *m_pix);
   const QPalette &g = palette();
   qDrawShadePanel(&p, r, g, true);
-  p.setPen(g.foreground().color());
-  p.setBrush(g.foreground());
+  p.setPen(g.windowText().color());
+  p.setBrush(g.windowText());
   QPolygon a;
   int y = m_mode==Hue ?        hue2y(m_hue) : 
           m_mode==Saturation ? sat2y(m_sat) :


### PR DESCRIPTION
With newer versions of qt5 (e.g. 5.14.0), we get warnings like:
```
...\doxygen\addon\doxywizard\doxywizard.cpp(346): warning C4996: 'QString::sprintf': Use asprintf(), arg() or QTextStream instead
D:\Qt\qt-everywhere-src-5.14.0\install_nmake_2017_32\include\QtCore/qstring.h(382): note: see declaration of 'QString::sprintf'

...\doxygen\addon\doxywizard\wizard.cpp(372): warning C4996: 'QPalette::foreground': Use QPalette::windowText() instead
D:\Qt\qt-everywhere-src-5.14.0\install_nmake_2017_32\include\QtGui/qpalette.h(147): note: see declaration of 'QPalette::foreground'
```
this has been corrected (ran compilation  with qt4 as well).