### PR TITLE
Missing anchors in RTF code output

### DIFF
--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -32,6 +32,8 @@ class RTFGenerator : public OutputGenerator
     static void writeStyleSheetFile(QFile &f);
     static void writeExtensionsFile(QFile &file);
 
+    void setRelativePath(const QCString &path);
+    void setSourceFileName(const QCString &sourceFileName);
     void enable() 
     { if (m_genStack->top()) m_active=*m_genStack->top(); else m_active=TRUE; }
     void disable() { m_active=FALSE; }
@@ -279,6 +281,7 @@ class RTFGenerator : public OutputGenerator
     const char *rtf_Code_DepthStyle();
     void incrementIndentLevel();
     void decrementIndentLevel();
+    QCString m_sourceFileName;
     int  m_col;
     bool m_prettyCode;
 


### PR DESCRIPTION
When having the RTF_SOURCE_CODE and RTF_HYPERLINKS set the links to the code are generated (e.g. in "Definition at line") but the corresponding anchor is missing.
The corresponding anchors are created (in a similar way as it is done for LaTeX).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4344358/example.tar.gz)
