### PR TITLE
Incorrect RTF link generated for cite and xref

### DIFF
--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1107,14 +1107,30 @@ void RTFDocVisitor::visitPre(DocHRef *href)
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocHRef)}\n");
   if (Config_getBool(RTF_HYPERLINKS))
   {
-    m_t << "{\\field "
-             "{\\*\\fldinst "
-               "{ HYPERLINK \"" << href->url() << "\" "
-               "}{}"
-             "}"
-             "{\\fldrslt "
-               "{\\cs37\\ul\\cf2 ";
-
+    if (href->url().startsWith("#CITEREF"))
+    {
+      // when starting with #CITEREF it is a doxygen generated "url"a
+      // so a local link
+      QCString cite;
+      cite = "citelist_" + href->url().right(href->url().length()-1);
+      m_t << "{\\field "
+               "{\\*\\fldinst "
+                 "{ HYPERLINK \\\\l \"" << rtfFormatBmkStr(cite) << "\" "
+                 "}{}"
+               "}"
+               "{\\fldrslt "
+                 "{\\cs37\\ul\\cf2 ";
+    }
+    else
+    {
+      m_t << "{\\field "
+                 "{\\*\\fldinst "
+                 "{ HYPERLINK \"" << href->url() << "\" "
+                 "}{}"
+               "}"
+               "{\\fldrslt "
+                 "{\\cs37\\ul\\cf2 ";
+    }
   }
   else
   {
@@ -1621,7 +1637,7 @@ void RTFDocVisitor::visitPre(DocXRefItem *x)
 
     m_t << "{\\field "
              "{\\*\\fldinst "
-               "{ HYPERLINK  \\\\l \"" << refName << "\" "
+               "{ HYPERLINK  \\\\l \"" << rtfFormatBmkStr(refName) << "\" "
                "}{}"
              "}"
              "{\\fldrslt "

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6585,6 +6585,7 @@ QCString rtfFormatBmkStr(const char *name)
     }
   }
 
+  //printf("Name = %s RTF_tag = %s\n",name,(*tag).data());
   return *tag;
 }
 


### PR DESCRIPTION
Incorrect links were generated for the cite and xref commands, the link text was not translated to a RTF link label.

Example (based on the default doxygen tests): [example.tar.gz](https://github.com/doxygen/doxygen/files/4349096/example.tar.gz)
