### PR TITLE
issue #7652 folder in file list has file icon

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -451,6 +451,10 @@ void FTVHelp::generateTree(FTextStream &t, const QList<FTVNode> &nl,int level,in
         char icon=compoundIcon(dynamic_cast<const ClassDef*>(n->def));
         t << "<span class=\"icona\"><span class=\"icon\">" << icon << "</span></span>";
       }
+      else if (n->def && n->def->definitionType()==Definition::TypeDir)
+      {
+        t << "<span class=\"iconfclosed\"></span>";
+      }
       else
       {
         t << "<span class=\"icondoc\"></span>";


### PR DESCRIPTION
When a directory has no source files or sub-directories in it (with the exception of markdown file(s)) the directory is seen as a file withe a definition type `TypeDir` but this was not handled properly on output, should have a closed folder icon.