### PR TITLE
Correction due to removal of Tcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Doxygen
 Doxygen is the de facto standard tool for generating documentation from
 annotated C++ sources, but it also supports other popular programming
 languages such as C, Objective-C, C#, PHP, Java, Python, IDL
-(Corba, Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL, Tcl,
+(Corba, Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL,
 and to some extent D.
 
 Doxygen can help you in three ways:

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -18,7 +18,7 @@ set(CPACK_PACKAGE_VENDOR   "Dimitri van Heesch")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Generate documentation from C, C++, Java, Python and other languages")
 set(CPACK_PACKAGE_DESCRIPTION "Doxygen is the de facto standard tool for generating documentation from annotated C++ sources.
  But many other popular programming languages are supported:
- C, Objective-C, C#, PHP, Java, Python, Fortran, VHDL, Tcl, D (some extent) and IDL (Corba, Microsoft, and UNO/OpenOffice flavors).
+ C, Objective-C, C#, PHP, Java, Python, Fortran, VHDL, D (some extent) and IDL (Corba, Microsoft, and UNO/OpenOffice flavors).
  .
  Three usages:
  .

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -777,7 +777,6 @@
       <xsd:enumeration value="VHDL" />
       <xsd:enumeration value="XML" />
       <xsd:enumeration value="SQL" />
-      <xsd:enumeration value="Tcl" />
       <xsd:enumeration value="Markdown" />
     </xsd:restriction>
   </xsd:simpleType>


### PR DESCRIPTION
The word tcl was still present at some places.