### PR TITLE
Incorrect determination of fixed form Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1496,7 +1496,6 @@ void truncatePrepass(yyscan_t yyscanner,int index)
 }
 
 // simplified way to know if this is fixed form
-// duplicate in fortrancode.l
 bool recognizeFixedForm(const char* contents, FortranFormat format)
 {
   int column=0;
@@ -1532,7 +1531,7 @@ bool recognizeFixedForm(const char* contents, FortranFormat format)
         break;
       default:
         if (skipLine) break;
-        if (column==7) return TRUE;
+        if (column>=7) return TRUE;
         return FALSE;
     }
   }


### PR DESCRIPTION
When we have the following small example, we see that the word `subroutine` doesn't start in column 7 but in column 8.
```
       subroutine expan()
c2345678  "          "     lb        "                "          "
       end
```
so the code is not converted from fixed form to free form Fortran and in the example (due to the odd number of double quotes) result in:
```
********************************************************************
Error in file D:/speeltuin/bug_ftn_quote/small.f line: 5, state: 22(String)
********************************************************************
```

The condition regarding the column number was to restrictive.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4382520/example.tar.gz)
