### PR TITLE
issue #7672 Request: use <img> tags instead of <object> tags for SVG images

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1750,7 +1750,7 @@ void HtmlDocVisitor::visitPre(DocImage *img)
     {
       src = correctURL(url,img->relPath());
     }
-    if (typeSVG)
+    if (typeSVG && !inlineImage)
     {
       m_t << "<object type=\"image/svg+xml\" data=\"" << convertToHtml(src)
         << "\"" << sizeAttribs << attrs;
@@ -1789,14 +1789,7 @@ void HtmlDocVisitor::visitPre(DocImage *img)
     }
     else if (inlineImage)
     {
-      if (typeSVG)
-      {
-        m_t << ">" << alt << "</object>";
-      }
-      else
-      {
-        m_t << "/>";
-      }
+      m_t << "/>";
     }
   }
   else // other format -> skip
@@ -1816,16 +1809,7 @@ void HtmlDocVisitor::visitPost(DocImage *img)
     {
       if (inlineImage)
       {
-        if (img->isSVG())
-        {
-          QCString alt;
-          QCString attrs = htmlAttribsToString(img->attribs(),&alt);
-          m_t << "\">" << alt << "</object>";
-        }
-        else
-        {
-          m_t << "\"/>";
-        }
+        m_t << "\"/>";
       }
       else // end <div class="caption">
       {

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -652,7 +652,7 @@ static int processEmphasis(GrowBuf &out,const char *data,int offset,int size)
 
 static void writeMarkdownImage(GrowBuf &out, const char *fmt, bool explicitTitle, QCString title, QCString content, QCString link, FileDef *fd)
 {
-  out.addStr("@image ");
+  out.addStr("@image{inline} ");
   out.addStr(fmt);
   out.addStr(" ");
   out.addStr(link.mid(fd ? 0 : 5));


### PR DESCRIPTION
In case of svg and inline images we have to follow a little bit another strategy.
In markdown we also have to declare all markdown images to inline images (which is also consistent with the handling on github)