### PR TITLE
Remove duplicate xsd fields for `docMarkupType`.

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -447,7 +447,6 @@
   <xsd:group name="docCmdGroup">
     <xsd:choice>
       <xsd:group ref="docTitleCmdGroup"/>
-      <xsd:element name="linebreak" type="docEmptyType" />
       <xsd:element name="hruler" type="docEmptyType" />
       <xsd:element name="preformatted" type="docMarkupType" />
       <xsd:element name="programlisting" type="listingType" />
@@ -460,7 +459,6 @@
       <xsd:element name="variablelist" type="docVariableListType" />
       <xsd:element name="table" type="docTableType" />
       <xsd:element name="heading" type="docHeadingType" />
-      <xsd:element name="image" type="docImageType" />
       <xsd:element name="dotfile" type="docImageType" />
       <xsd:element name="mscfile" type="docImageType" />
       <xsd:element name="diafile" type="docImageType" />


### PR DESCRIPTION
The `docTitleCmdGroup` group defines choices `image` and `linebreak` (among others). The `docMarkupType` type inherits from `docTitleCmdGroup`, but includes redefinitions of `image` and `linebreak` in its definition. This is mostly harmless, but it violates the ["unique particle attribution rule"](https://www.w3.org/wiki/UniqueParticleAttribution).

Some xsd tools (in particular the `xsd` command from [code synthesis](https://www.codesynthesis.com/projects/xsd/)) complain about the duplicate fields, and error out.

This is my first PR to doxygen, so if there is anything additional that you need, please let me know! Thank you!