### PR TITLE
Fix html file ext in external docs

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10535,6 +10535,7 @@ static void writeTagFile()
                      << "</title>" << endl
                      << "    <filename>"
                      << convertToXML(Doxygen::mainPage->getOutputFileBase())
+                     << Doxygen::htmlFileExtension
                      << "</filename>" << endl;
 
     mainPage->writeDocAnchorsToTagFile();

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -349,7 +349,7 @@ void FileDefImpl::writeTagFile(FTextStream &tagFile)
   tagFile << "  <compound kind=\"file\">" << endl;
   tagFile << "    <name>" << convertToXML(name()) << "</name>" << endl;
   tagFile << "    <path>" << convertToXML(getPath()) << "</path>" << endl;
-  tagFile << "    <filename>" << convertToXML(addHtmlExtensionIfMissing(getOutputFileBase())) << "</filename>" << endl;
+  tagFile << "    <filename>" << convertToXML(getOutputFileBase()) << Doxygen::htmlFileExtension << "</filename>" << endl;
   if (m_includeList && m_includeList->count()>0)
   {
     QListIterator<IncludeInfo> ili(*m_includeList);

--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -259,7 +259,7 @@ static QCString node2URL(const FTVNode *n,bool overruleFile=FALSE,bool srcLink=F
         url = fd->getOutputFileBase();
       }
     }
-    url+=Doxygen::htmlFileExtension;
+    url = addHtmlExtensionIfMissing(url);
     if (!n->anchor.isEmpty()) url+="#"+n->anchor;
   }
   return url;

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4544,7 +4544,7 @@ void MemberDefImpl::writeTagFile(FTextStream &tagFile) const
     tagFile << "      <type>" << convertToXML(typeString()) << "</type>" << endl;
   }
   tagFile << "      <name>" << convertToXML(name()) << "</name>" << endl;
-  tagFile << "      <anchorfile>" << convertToXML(getOutputFileBase()+Doxygen::htmlFileExtension) << "</anchorfile>" << endl;
+  tagFile << "      <anchorfile>" << convertToXML(getOutputFileBase()) << Doxygen::htmlFileExtension << "</anchorfile>" << endl;
   tagFile << "      <anchor>" << convertToXML(anchor()) << "</anchor>" << endl;
   QCString idStr = id();
   if (!idStr.isEmpty())

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -162,7 +162,7 @@ void PageDefImpl::writeTagFile(FTextStream &tagFile)
     tagFile << "  <compound kind=\"page\">" << endl;
     tagFile << "    <name>" << name() << "</name>" << endl;
     tagFile << "    <title>" << convertToXML(title()) << "</title>" << endl;
-    tagFile << "    <filename>" << convertToXML(getOutputFileBase()) << "</filename>" << endl;
+    tagFile << "    <filename>" << convertToXML(getOutputFileBase())<< Doxygen::htmlFileExtension << "</filename>" << endl;
     writeDocAnchorsToTagFile(tagFile);
     tagFile << "  </compound>" << endl;
   }

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -1877,7 +1877,7 @@ void VhdlDocGen::writeTagFile(MemberDef *mdef,FTextStream &tagFile)
   tagFile << "\">" << endl;
   tagFile << "      <type>" << convertToXML(mdef->typeString()) << "</type>" << endl;
   tagFile << "      <name>" << convertToXML(mdef->name()) << "</name>" << endl;
-  tagFile << "      <anchorfile>" << convertToXML(mdef->getOutputFileBase()+Doxygen::htmlFileExtension) << "</anchorfile>" << endl;
+  tagFile << "      <anchorfile>" << convertToXML(mdef->getOutputFileBase()) << Doxygen::htmlFileExtension << "</anchorfile>" << endl;
   tagFile << "      <anchor>" << convertToXML(mdef->anchor()) << "</anchor>" << endl;
 
   if (VhdlDocGen::isVhdlFunction(mdef))


### PR DESCRIPTION
This pull request solves following problem:

- project A generates tag list
- project B references external documentation from project B

In case of enabled tree view and 'Files List' entry in it, all links to project A are invalid, following pattern `somefile_8hpp.html.html`.

Root cause is in that `node2URL` always adds html extension, even for filenames that come from tag file.

Looking how htmlFileExtension is used, fixed several inconsistencies in writeTagFile methods and fixed missed extension for page definition filename output.