### PR TITLE
issue #7678 Not all functions are created

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6349,7 +6349,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					    REJECT;
 					  }
   					}
-<DocBlock>[^@*~\/\\\n]+			{ // any character that isn't special
+<DocBlock>[^@*~`\/\\\n]+			{ // any character that isn't special
   					  yyextra->docBlock+=yytext;
   					}
 <DocBlock>\n				{ // newline


### PR DESCRIPTION
Fenced code blocks with tildes and backticks were not handled in the same way in the respect that when after the backticks a language was given the complete sequence was handled by another rule.
By adding the backtick to the rule  where also the tilde was excluded fixes the problem.

This was also the case in the original problem, but was hidden as the `WARNINGS=NO` was set and thus messages like:
```
warning: reached end of file while inside a '```' block!
The command that should end the block seems to be missing!
```
where not shown.

Minimal example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4421749/example.tar.gz)
