### PR TITLE
Images and OUTPUT_TEXT_DIRECTION=LTR

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1765,7 +1765,7 @@ void HtmlDocVisitor::visitPre(DocImage *img)
     }
     else
     {
-      m_t << "<img src=\"" << convertToHtml(src) << "\" alt=\"" << alt << "\"" << sizeAttribs << attrs;
+      m_t << "<img src=\"" << convertToHtml(src,TRUE,FALSE) << "\" alt=\"" << alt << "\"" << sizeAttribs << attrs;
       if (inlineImage)
       {
         m_t << " class=\"inline\"";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5501,12 +5501,12 @@ QCString convertToDocBook(const char *s)
 }
 
 /*! Converts a string to a HTML-encoded string */
-QCString convertToHtml(const char *s,bool keepEntities)
+QCString convertToHtml(const char *s,bool keepEntities,bool applyTextDir)
 {
   static GrowBuf growBuf;
   growBuf.clear();
   if (s==0) return "";
-  growBuf.addStr(getHtmlDirEmbeddingChar(getTextDirByConfig(s)));
+  if (applyTextDir) growBuf.addStr(getHtmlDirEmbeddingChar(getTextDirByConfig(s)));
   const char *p=s;
   char c;
   while ((c=*p++))

--- a/src/util.h
+++ b/src/util.h
@@ -280,7 +280,7 @@ QCString stripScope(const char *name);
 
 QCString convertToId(const char *s);
 
-QCString convertToHtml(const char *s,bool keepEntities=TRUE);
+QCString convertToHtml(const char *s,bool keepEntities=TRUE,bool applyTextDir=TRUE);
 
 QCString convertToLaTeX(const QCString &s,bool insideTabbing=FALSE,bool keepSpaces=FALSE);
 


### PR DESCRIPTION
Based on an "answer" in https://stackoverflow.com/questions/42703273/incorrect-image-paths-for-doxygen the problem regarding the "In html documentation, images were replaced with the broken image icon. " it appeared that the code `&#202A;` (i.e. LTR unicode setting) appeared in the name of the image. This code has been removed.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4450222/example.tar.gz)
