### PR TITLE
Link in case of comma at end of URL

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -637,6 +637,11 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 			 }
 			 return TK_COMMAND_SEL();
   		       }
+<St_Para>{URLPROTOCOL}{URLMASK}/, { // URL,
+                         g_token->name=yytext;
+			 g_token->isEMailAddr=FALSE;
+			 return TK_URL;
+                       }
 <St_Para>{URLPROTOCOL}{URLMASK}/\. { // URL.
                          g_token->name=yytext;
 			 g_token->isEMailAddr=FALSE;


### PR DESCRIPTION
When having a text like:
```
https://storm-irit.github.io/OpenGR/, 2017.
```
the corresponding link will contain the comma as well although this is not intended.

The original problem comes from CGAL, where we have a bibliography entry:
```
@misc{ cgal:m-ogr-17,
  author = {Nicolas Mellado and others},
  title = {OpenGR: A C++ library for 3D Global Registration},
  howpublished = {https://storm-irit.github.io/OpenGR/},
  year = {2017}
}
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4450628/example.tar.gz)
