### PR TITLE
Missing break statement

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1566,6 +1566,7 @@ reparsetoken:
             {
               handleStyleLeave(parent,children,DocStyleChange::S,tokenName);
             }
+            break;
           case HTML_STRIKE:
             if (!g_token->endTag)
             {


### PR DESCRIPTION
The break statement was unintentional left out (found by coverity).