### PR TITLE
Text show as formula when USE_MATHJAX=YES

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2226,6 +2226,11 @@ void HtmlDocVisitor::filter(const char *str)
       case '<':  m_t << "&lt;"; break;
       case '>':  m_t << "&gt;"; break;
       case '&':  m_t << "&amp;"; break;
+      case '\\': if ((*p == '(') || (*p == ')'))
+                   m_t << "\\&zwj;" << *p++;
+                 else
+                   m_t << c;
+                 break;
       default:   m_t << c;
     }
   }
@@ -2247,6 +2252,11 @@ void HtmlDocVisitor::filterQuotedCdataAttr(const char* str)
       case '"':  m_t << "&quot;"; break;
       case '<':  m_t << "&lt;"; break;
       case '>':  m_t << "&gt;"; break;
+      case '\\': if ((*p == '(') || (*p == ')'))
+                   m_t << "\\&zwj;" << *p++;
+                 else
+                   m_t << c;
+                 break;
       default:   m_t << c;
     }
   }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -668,6 +668,10 @@ void HtmlCodeGenerator::codify(const char *str)
                      { m_t << "&lt;"; p++; }
                    else if (*p=='>')
                      { m_t << "&gt;"; p++; }
+		   else if (*p=='(')
+                     { m_t << "\\&zwj;("; m_col++;p++; }
+                   else if (*p==')')
+                     { m_t << "\\&zwj;)"; m_col++;p++; }
                    else
                      m_t << "\\";
                    m_col++;
@@ -702,6 +706,10 @@ void HtmlCodeGenerator::docify(const char *str)
                      { m_t << "&lt;"; p++; }
                    else if (*p=='>')
                      { m_t << "&gt;"; p++; }
+		   else if (*p=='(')
+                     { m_t << "\\&zwj;("; p++; }
+                   else if (*p==')')
+                     { m_t << "\\&zwj;)"; p++; }
                    else
                      m_t << "\\";
                    break;
@@ -1502,6 +1510,10 @@ void HtmlGenerator::docify(const char *str,bool inHtmlComment)
                      { t << "&lt;"; p++; }
                    else if (*p=='>')
                      { t << "&gt;"; p++; }
+		   else if (*p=='(')
+                     { t << "\\&zwj;("; p++; }
+                   else if (*p==')')
+                     { t << "\\&zwj;)"; p++; }
                    else
                      t << "\\";
                    break;


### PR DESCRIPTION
When having a line of code like:
```
callback_check = re.compile(r'([^\(]*\(.*)(\* *)(\).*\(.*\))')
```
this is seen as an incomplete formula when using MathJax, the `\(` is seen as start of a MathJax  formula.
Replacing the backslash by the corresponding code `&#92;` didn't work as this is already translated by the browser and still picked up by MathJax, so we need `&zwj;` to separate the backslash and the bracket without any spacing.

The problem was found in opencv and checked against opencv and CGAL.

The incorrect situation:

![error_docu](https://user-images.githubusercontent.com/5223533/79074739-5ea2a700-7cee-11ea-83d7-b2658325b08a.jpg)

and

![error_source](https://user-images.githubusercontent.com/5223533/79074750-68c4a580-7cee-11ea-9e79-721cb1d989b9.jpg)

The correct(ed) situation:

![OK_code](https://user-images.githubusercontent.com/5223533/79074762-7417d100-7cee-11ea-8c77-2aa169c2a2a2.jpg)

and 

![OK_source](https://user-images.githubusercontent.com/5223533/79074766-7a0db200-7cee-11ea-926a-fe06141c4d81.jpg)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4466690/example.tar.gz)


