### PR TITLE
make declArgumentList be from declaration, and argumentList from definition

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3445,7 +3445,7 @@ static void buildFunctionList(const Entry *root)
                 {
                   // merge argument lists
                   ArgumentList mergedArgList = root->argList;
-                  mergeArguments(mdAl,mergedArgList,!root->doc.isEmpty());
+                  mergeArguments(mdAl,mergedArgList,!root->proto);
                   // merge documentation
                   if (md->documentation().isEmpty() && !root->doc.isEmpty())
                   {
@@ -4969,7 +4969,7 @@ static void addMemberDocs(const Entry *root,
   {
     ArgumentList mergedAl = *al;
     //printf("merging arguments (1) docs=%d\n",root->doc.isEmpty());
-    mergeArguments(mdAl,mergedAl,!root->doc.isEmpty());
+    mergeArguments(mdAl,mergedAl,!root->proto);
   }
   else
   {
@@ -4982,7 +4982,7 @@ static void addMemberDocs(const Entry *root,
     {
       //printf("merging arguments (2)\n");
       ArgumentList mergedArgList = root->argList;
-      mergeArguments(mdAl,mergedArgList,!root->doc.isEmpty());
+      mergeArguments(mdAl,mergedArgList,!root->proto);
     }
   }
   if (over_load)  // the \overload keyword was used


### PR DESCRIPTION
When parsing the xml outputs of doxygen, I noticed that in many cases the `<defname>` tag was not being generated for some parameters, even if the names in the definition differed from the declaration.

After doing some digging, it seems like what controls whether or not
the `<defname>` is included is this line:

https://github.com/doxygen/doxygen/blob/341f860ab7ae3e5255891b0984bec8b36e7557ef/src/doxygen.cpp#L4985

...or more specifically, the `!root->doc.isEmpty()` bit, which sets the
`forceNameOverwrite` arg for `mergeArguments`.

Given that the `MemberDef` object already supports separate declaration
args and definition args (via `declArgumentList` and `argumentList`,
respectively), and that at this point it the code the `declArgumentList` is
already set, it seems odd that setting of `argumentList` is controlled by
whether or not the current root has a doc.  Ideally, I would think we'd
always put the declaration arguments in the `declArgumentList`, and the
definition arguments in `argumentList` - ie, have `forceNameOverwrite` set
to `!root->proto`... so I've done that here.

Alternatively, if we are going to try to make some fancier logic /
decisions at this point, we should take the `brief` into account as well,
and not just the `doc`.  For instance, it seems particularly odd to not
even include the definition args if the definition has a brief (though no
detail doc), and the declaration has no documentation whatsoever.

Also open to other suggestions - but I need to be able to get access to the names from the definition.  Thanks!