### PR TITLE
Undefined control sequence for formula using MathJax

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1090,6 +1090,9 @@ RAWEND    ")"[^ \t\(\)\\]{0,16}\"
                                           yyextra->parmType = yyextra->name;
 					  BEGIN(FuncCall);
                                         }
+<Body>"\\)"|"\\("                       {
+                                          yyextra->code->codify(yytext);
+                                        }
 <Body>[\\|\)\+\-\/\%\~\!]		{
   					  yyextra->code->codify(yytext);
   				          yyextra->name.resize(0);yyextra->type.resize(0);


### PR DESCRIPTION
When having a code comment like:
```
@code
sub postprocess
{
    s/\(?\@xref\{(?:[^\}]*)\}(?:[^.<]|(?:<[^<>]*>))*\.\)?//g;
    s/\s+\(\@pxref\{(?:[^\}]*)\}\)//g;
}
@endcode
```

and using MathJax the `/(` is seen as a the beginning of a formula, but should be seen as text and can now lead to "Undefined control sequence".
(The problem comes originally from code as generated by the doxygen-perl-filter for converting perl code in something doxygen does understand).
This problem is similar to the problems solved in pull request #7697, but not handled here.
This pull request will see `\(` (and its counter part `\)`) as complete entities and replace them in a similar way as done in #7697 (but now in an earlier stage but the `&zwj;` will be properly filtered in the different output formats.

The erroneous version:
![err](https://user-images.githubusercontent.com/5223533/79747020-41cc2c00-830b-11ea-9b9b-232d35f6c189.jpg)

the correct version:
![ok](https://user-images.githubusercontent.com/5223533/79747007-3b3db480-830b-11ea-93b4-d83028b3e93a.jpg)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4503128/example.tar.gz)
