### PR TITLE
Add doxygen version information to tag file

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10361,6 +10361,13 @@ static void writeTagFile()
   FTextStream tagFile(&tag);
   tagFile << "<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>" << endl;
   tagFile << "<tagfile>" << endl;
+  tagFile << "  <doxygen";
+  tagFile << "  version=\"" << getDoxygenVersion() << "\"";
+  if (strlen(getGitVersion())>0)
+  {
+    tagFile << "  gitid=\"" << getGitVersion() << "\"";
+  }
+  tagFile << "></doxygen>" << endl;
 
   // for each file
   for (const auto &fn : *Doxygen::inputNameLinkedMap)

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -860,6 +860,7 @@ class TagFileParser : public QXmlDefaultHandler
       m_startElementHandlers.insert("tagfile",     new StartElementHandler(this,&TagFileParser::startIgnoreElement));
       m_startElementHandlers.insert("templarg",    new StartElementHandler(this,&TagFileParser::startStringValue));
       m_startElementHandlers.insert("type",        new StartElementHandler(this,&TagFileParser::startStringValue));
+      m_startElementHandlers.insert("doxygen",     new StartElementHandler(this,&TagFileParser::startIgnoreElement));
 
       m_endElementHandlers.insert("compound",    new EndElementHandler(this,&TagFileParser::endCompound));
       m_endElementHandlers.insert("member",      new EndElementHandler(this,&TagFileParser::endMember));
@@ -884,6 +885,7 @@ class TagFileParser : public QXmlDefaultHandler
       m_endElementHandlers.insert("tagfile",     new EndElementHandler(this,&TagFileParser::endIgnoreElement));
       m_endElementHandlers.insert("templarg",    new EndElementHandler(this,&TagFileParser::endTemplateArg));
       m_endElementHandlers.insert("type",        new EndElementHandler(this,&TagFileParser::endType));
+      m_endElementHandlers.insert("doxygen",     new EndElementHandler(this,&TagFileParser::endIgnoreElement));
 
       return TRUE;
     }


### PR DESCRIPTION
Add doxygen version information to doxygen tag file.
currently this information is not used inside doxygen , but is useful for checking with which version of doxygen is used when debugging problems.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4503545/example.tar.gz)
