### PR TITLE
Wrong message in case of svg formulas for HTML

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -220,7 +220,7 @@ void FormulaManager::generateImages(const char *path,Format format,HighDPI hd) c
     int pageIndex=1;
     for (int pageNum : formulasToGenerate)
     {
-      msg("Generating image form_%d.png for formula\n",pageNum);
+      msg("Generating image form_%d.%s for formula\n",pageNum,(format==Format::Vector) ? "svg" : "png");
       QCString formBase;
       formBase.sprintf("_form%d",pageNum);
       // run dvips to convert the page with number pageIndex to an


### PR DESCRIPTION
When we have set `HTML_FORMULA_FORMAT = svg` we still get the message:
```
Generating image form_0.png for formula
```
instead of
```
Generating image form_0.svg for formula
```