### PR TITLE
Incorrect text for HTML_FORMULA_FORMAT in documentation / Doxyfile

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2356,8 +2356,8 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
  PNGs for the HTML output. These images will generally look nicer at scaled resolutions.
 ]]>
       </docs>
-      <value name="png" desc="The default"/>
-      <value name="svg" desc="Looks nicer but requires the pdf2svg tool"/>
+      <value name="png" desc="(the default)"/>
+      <value name="svg" desc="(looks nicer but requires the pdf2svg or inkscape tool)"/>
     </option>
     <option type='int' id='FORMULA_FONTSIZE' minval='8' maxval='50' defval='10' depends='GENERATE_HTML'>
       <docs>


### PR DESCRIPTION
For the configuration setting `HTML_FORMULA_FORMAT` the text reads:
> Possible values are: png The default and svg Looks nicer but requires the pdf2svg tool.

this is not quite understandable and has been reformulated to:
> Possible values are: png (the default) and svg (looks nicer but requires the pdf2svg or inkscape tool).

this concerns automatically generated texts from config.xml to the different formats.