### PR TITLE
Inconsistent behavior between `///` and `//!` for formulas

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -488,7 +488,7 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 <Verbatim,VerbatimCode>\n	   { /* new line in verbatim block */
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
-<Verbatim>^[ \t]*"///"             {
+<Verbatim>^[ \t]*"//"[/!]          {
   				     if (yyextra->blockName=="dot" || yyextra->blockName=="msc" || yyextra->blockName=="uml" || yyextra->blockName.at(0)=='f')
 				     {
 				       // see bug 487871, strip /// from dot images and formulas.


### PR DESCRIPTION
When we have code like:
```
//!
//! \f$a \times
//! c \f$
//!
```
this will throw a warning like:
```
warning: End of comment block while inside formula.
```
due to the fact that after the comment conversion the code is like:
```
/**
 *  \f$a \times
//! c \f$
 *  */
```
Comparing to the `///` comments:
```
///
/// \f$a \times
/// c \f$
///
```
we get
```
/**
 *  \f$a \times
    c \f$
 *  */
```

This discrepancy has been removed.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4532984/example.tar.gz)
