### PR TITLE
Change container type of DirList from QList to STL container

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -3532,10 +3532,7 @@ class DirContext::Private : public DefinitionContext<DirContext::Private>
       if (!cache.dirs)
       {
         cache.dirs.reset(TemplateList::alloc());
-        const DirList &subDirs = m_dirDef->subDirs();
-        QListIterator<DirDef> it(subDirs);
-        const DirDef *dd;
-        for (it.toFirst();(dd=it.current());++it)
+        for(const auto dd : m_dirDef->subDirs())
         {
           DirContext *dc = new DirContext(dd);
           cache.dirs->append(dc);
@@ -5465,9 +5462,7 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
         TemplateList *dirList = TemplateList::alloc();
         if (m_groupDef->getDirs())
         {
-          QListIterator<DirDef> it(*m_groupDef->getDirs());
-          const DirDef *dd;
-          for (it.toFirst();(dd=it.current());++it)
+          for(const auto dd : *(m_groupDef->getDirs()))
           {
             dirList->append(DirContext::alloc(dd));
           }
@@ -6599,9 +6594,7 @@ class NestingContext::Private : public GenericNodeListContext
     }
     void addDirs(const DirList &dirList)
     {
-      QListIterator<DirDef> li(dirList);
-      const DirDef *dd;
-      for (li.toFirst();(dd=li.current());++li)
+      for(const auto dd : dirList)
       {
         append(NestingNodeContext::alloc(m_parent,dd,m_index,m_level,FALSE,FALSE,FALSE));
         m_index++;

--- a/src/context.h
+++ b/src/context.h
@@ -20,6 +20,7 @@
 #include "template.h"
 #include <qlist.h>
 #include <stdio.h>
+#include "dirdef.h"
 
 class Definition;
 class ClassDef;
@@ -34,7 +35,6 @@ class FileDef;
 class FileList;
 class FileNameLinkedMap;
 class DirSDict;
-class DirList;
 class DirDef;
 class PageSDict;
 class GroupSDict;

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -142,7 +142,7 @@ bool DirDefImpl::isLinkable() const
 
 void DirDefImpl::addSubDir(DirDef *subdir)
 {
-  m_subdirs.append(subdir);
+  m_subdirs.push_back(subdir);
   subdir->setOuterScope(this);
   subdir->setParent(this);
 }

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -15,6 +15,7 @@
 #include "docparser.h"
 #include "definitionimpl.h"
 #include "filedef.h"
+#include <algorithm>
 
 //----------------------------------------------------------------------
 
@@ -159,7 +160,7 @@ void DirDefImpl::addFile(FileDef *fd)
 
 void DirDefImpl::sort()
 {
-  m_subdirs.sort();
+  std::sort(m_subdirs.begin(), m_subdirs.end(), &compareDirDefs);
   m_fileList->sort();
 }
 
@@ -1092,3 +1093,7 @@ void generateDirDocs(OutputList &ol)
   }
 }
 
+bool compareDirDefs(const DirDef *item1, const DirDef *item2)
+{
+  return qstricmp(item1->shortName(),item2->shortName()) < 0;
+}

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -307,9 +307,7 @@ void DirDefImpl::writeDirectoryGraph(OutputList &ol)
 void DirDefImpl::writeSubDirList(OutputList &ol)
 {
   int numSubdirs = 0;
-  QListIterator<DirDef> it(m_subdirs);
-  DirDef *dd;
-  for (it.toFirst();(dd=it.current());++it)
+  for(const auto dd : m_subdirs)
   {
     if (dd->hasDocumentation() || dd->getFiles()->count()>0)
     {
@@ -324,7 +322,7 @@ void DirDefImpl::writeSubDirList(OutputList &ol)
     ol.parseText(theTranslator->trDir(TRUE,FALSE));
     ol.endMemberHeader();
     ol.startMemberList();
-    for (it.toFirst();(dd=it.current());++it)
+    for(const auto dd : m_subdirs)
     {
       if (dd->hasDocumentation() || dd->getFiles()->count()==0)
       {
@@ -462,9 +460,7 @@ void DirDefImpl::writeTagFile(FTextStream &tagFile)
         {
           if (m_subdirs.count()>0)
           {
-            DirDef *dd;
-            QListIterator<DirDef> it(m_subdirs);
-            for (;(dd=it.current());++it)
+            for(const auto dd : m_subdirs)
             {
               tagFile << "    <dir>" << convertToXML(dd->displayName()) << "</dir>" << endl;
             }

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -35,7 +35,7 @@ class DirDefImpl : public DefinitionImpl, public DirDef
     virtual FileList *   getFiles() const        { return m_fileList; }
     virtual void addFile(FileDef *fd);
     virtual const DirList &subDirs() const { return m_subdirs; }
-    virtual bool isCluster() const { return m_subdirs.count()>0; }
+    virtual bool isCluster() const { return m_subdirs.size()>0; }
     virtual int level() const { return m_level; }
     virtual DirDef *parent() const { return m_parent; }
     virtual int dirCount() const { return m_dirCount; }
@@ -458,7 +458,7 @@ void DirDefImpl::writeTagFile(FTextStream &tagFile)
     {
       case LayoutDocEntry::DirSubDirs:
         {
-          if (m_subdirs.count()>0)
+          if (m_subdirs.size()>0)
           {
             for(const auto dd : m_subdirs)
             {

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -1097,3 +1097,13 @@ bool compareDirDefs(const DirDef *item1, const DirDef *item2)
 {
   return qstricmp(item1->shortName(),item2->shortName()) < 0;
 }
+
+void sortInDirList(DirList& list, DirDef *const newItem)
+{
+  auto potentialSuccessor = list.begin();
+  while (potentialSuccessor != list.cend() && compareDirDefs(*potentialSuccessor, newItem))
+  {
+    potentialSuccessor++;
+  }
+  list.insert(potentialSuccessor, newItem);
+}

--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -21,7 +21,9 @@
 #include "sortdict.h"
 #include "definition.h"
 
-#include <qlist.h>
+#include <deque>
+#include <qglobal.h>
+#include <qcstring.h>
 
 class FileList;
 class ClassSDict;
@@ -34,11 +36,7 @@ class FTextStream;
 class DirDef;
 
 /** A list of directories. */
-class DirList : public QList<DirDef>
-{
-  public:
-   int compareValues(const DirDef *item1,const DirDef *item2) const;
-};
+typedef std::deque<DirDef*> DirList;
 
 /** A model of a directory symbol. */
 class DirDef : virtual public Definition

--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -38,6 +38,9 @@ class DirDef;
 /** A list of directories. */
 typedef std::deque<DirDef*> DirList;
 
+/** Compare referenced objects. */
+bool compareDirDefs(const DirDef *item1,const DirDef *item2);
+
 /** A model of a directory symbol. */
 class DirDef : virtual public Definition
 {
@@ -135,11 +138,6 @@ class DirRelation
     const DirDef  *m_src;
     UsedDir *m_dst;
 };
-
-inline int DirList::compareValues(const DirDef *item1,const DirDef *item2) const
-{
-  return qstricmp(item1->shortName(),item2->shortName());
-}
 
 /** A sorted dictionary of DirDef objects. */
 class DirSDict : public SDict<DirDef>

--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -41,6 +41,13 @@ typedef std::deque<DirDef*> DirList;
 /** Compare referenced objects. */
 bool compareDirDefs(const DirDef *item1,const DirDef *item2);
 
+/**
+ * Sorts the list by the result of the compareDirDefs() function.
+ * @param list in which item to be inserted
+ * @param newItem to be inserted
+ */
+void sortInDirList(DirList &list, DirDef *const newItem);
+
 /** A model of a directory symbol. */
 class DirDef : virtual public Definition
 {

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -55,11 +55,9 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
       << dd->shortName() << "\"];\n";
 
     // add nodes for sub directories
-    QListIterator<DirDef> sdi(dd->subDirs());
-    const DirDef *sdir;
-    for (sdi.toFirst();(sdir=sdi.current());++sdi)
+    for(const auto sdir : dd->subDirs())
     {
-      t << "    " << sdir->getOutputFileBase() << " [shape=box label=\"" 
+      t << "    " << sdir->getOutputFileBase() << " [shape=box label=\""
         << sdir->shortName() << "\"";
       if (sdir->isCluster())
       {
@@ -70,7 +68,7 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
         t << " color=\"black\"";
       }
       t << " fillcolor=\"white\" style=\"filled\"";
-      t << " URL=\"" << sdir->getOutputFileBase() 
+      t << " URL=\"" << sdir->getOutputFileBase()
         << Doxygen::htmlFileExtension << "\"";
       t << "];\n";
       dirsInGraph.insert(sdir->getOutputFileBase(),sdir);

--- a/src/dotgroupcollaboration.cpp
+++ b/src/dotgroupcollaboration.cpp
@@ -163,7 +163,7 @@ void DotGroupCollaboration::buildGraph(const GroupDef* gd)
   }
 
   // Add directories
-  if ( gd->getDirs() && gd->getDirs()->count() )
+  if ( gd->getDirs() && gd->getDirs()->size() )
   {
     for(const auto def : *(gd->getDirs()))
     {

--- a/src/dotgroupcollaboration.cpp
+++ b/src/dotgroupcollaboration.cpp
@@ -165,9 +165,7 @@ void DotGroupCollaboration::buildGraph(const GroupDef* gd)
   // Add directories
   if ( gd->getDirs() && gd->getDirs()->count() )
   {
-    QListIterator<DirDef> defli(*gd->getDirs());
-    const DirDef *def;
-    for (;(def=defli.current());++defli)
+    for(const auto def : *(gd->getDirs()))
     {
       tmp_url = def->getReference()+"$"+def->getOutputFileBase()+Doxygen::htmlFileExtension;
       addCollaborationMember( def, tmp_url, DotGroupCollaboration::tdir );          

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -782,9 +782,7 @@ void GroupDefImpl::writeTagFile(FTextStream &tagFile)
         {
           if (m_dirList)
           {
-            QListIterator<DirDef> it(*m_dirList);
-            DirDef *dd;
-            for (;(dd=it.current());++it)
+            for(const auto dd : *m_dirList)
             {
               if (dd->isLinkableInProject())
               {
@@ -1055,9 +1053,7 @@ void GroupDefImpl::writeDirs(OutputList &ol,const QCString &title)
     ol.parseText(title);
     ol.endMemberHeader();
     ol.startMemberList();
-    QListIterator<DirDef> it(*m_dirList);
-    DirDef *dd;
-    for (;(dd=it.current());++it)
+    for(const auto dd : *m_dirList)
     {
       if (!dd->hasDocumentation()) continue;
       ol.startMemberDeclaration();

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -64,7 +64,7 @@ class GroupDefImpl : public DefinitionImpl, public GroupDef
     virtual void addGroup(const GroupDef *def);
     virtual void addPage(PageDef *def);
     virtual void addExample(const PageDef *def);
-    virtual void addDir(const DirDef *dd);
+    virtual void addDir(DirDef *const dd);
     virtual bool insertMember(MemberDef *def,bool docOnly=FALSE);
     virtual void removeMember(MemberDef *md);
     virtual bool findGroup(const GroupDef *def) const; // true if def is a subgroup of this group
@@ -327,7 +327,7 @@ bool GroupDefImpl::addNamespace(const NamespaceDef *def)
   return FALSE;
 }
 
-void GroupDefImpl::addDir(const DirDef *def)
+void GroupDefImpl::addDir(DirDef *const def)
 {
   if (def->isHidden()) return;
   if (Config_getBool(SORT_BRIEF_DOCS))

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -332,8 +332,7 @@ void GroupDefImpl::addDir(const DirDef *def)
   if (def->isHidden()) return;
   if (Config_getBool(SORT_BRIEF_DOCS))
   {
-    m_dirList->push_back(def);
-    m_dirList->sort();
+    sortInDirList(*m_dirList, def);
   }
   else
     m_dirList->push_back(def);

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1047,7 +1047,7 @@ void GroupDefImpl::writeNestedGroups(OutputList &ol,const QCString &title)
 void GroupDefImpl::writeDirs(OutputList &ol,const QCString &title)
 {
   // write list of directories
-  if (m_dirList->count()>0)
+  if (m_dirList->size()>0)
   {
     ol.startMemberHeader("dirs");
     ol.parseText(title);
@@ -1183,7 +1183,7 @@ void GroupDefImpl::writeSummaryLinks(OutputList &ol) const
         (lde->kind()==LayoutDocEntry::GroupNamespaces && m_namespaceSDict->declVisible()) ||
         (lde->kind()==LayoutDocEntry::GroupFiles && m_fileList->count()>0) ||
         (lde->kind()==LayoutDocEntry::GroupNestedGroups && m_groupList->count()>0) ||
-        (lde->kind()==LayoutDocEntry::GroupDirs && m_dirList->count()>0)
+        (lde->kind()==LayoutDocEntry::GroupDirs && m_dirList->size()>0)
        )
     {
       LayoutDocEntrySection *ls = (LayoutDocEntrySection*)lde;

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -331,9 +331,12 @@ void GroupDefImpl::addDir(const DirDef *def)
 {
   if (def->isHidden()) return;
   if (Config_getBool(SORT_BRIEF_DOCS))
-    m_dirList->inSort(def);
+  {
+    m_dirList->push_back(def);
+    m_dirList->sort();
+  }
   else
-    m_dirList->append(def);
+    m_dirList->push_back(def);
 }
 
 void GroupDefImpl::addPage(PageDef *def)

--- a/src/groupdef.h
+++ b/src/groupdef.h
@@ -22,6 +22,7 @@
 
 #include "sortdict.h"
 #include "definition.h"
+#include "dirdef.h"
 
 class MemberList;
 class FileList;
@@ -37,7 +38,6 @@ class MemberNameInfoSDict;
 class PageSDict;
 class PageDef;
 class DirDef;
-class DirList;
 class FTVHelp;
 class Entry;
 class MemberDef;

--- a/src/groupdef.h
+++ b/src/groupdef.h
@@ -62,7 +62,7 @@ class GroupDef : virtual public Definition
     virtual void addGroup(const GroupDef *def) = 0;
     virtual void addPage(PageDef *def) = 0;
     virtual void addExample(const PageDef *def) = 0;
-    virtual void addDir(const DirDef *dd) = 0;
+    virtual void addDir(DirDef *const dd) = 0;
     virtual bool insertMember(MemberDef *def,bool docOnly=FALSE) = 0;
     virtual void removeMember(MemberDef *md) = 0;
     virtual bool findGroup(const GroupDef *def) const = 0;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -587,9 +587,7 @@ static bool dirHasVisibleChildren(DirDef *dd)
     }
   }
 
-  QListIterator<DirDef> dli(dd->subDirs());
-  DirDef *subdd;
-  for (dli.toFirst();(subdd=dli.current());++dli)
+  for(const auto subdd : dd->subDirs())
   {
     if (dirHasVisibleChildren(subdd))
     {
@@ -649,9 +647,7 @@ static void writeDirTreeNode(OutputList &ol, DirDef *dd, int level, FTVHelp* ftv
   if (dd->subDirs().count()>0)
   {
     startIndexHierarchy(ol,level+1);
-    QListIterator<DirDef> dli(dd->subDirs());
-    DirDef *subdd = 0;
-    for (dli.toFirst();(subdd=dli.current());++dli)
+    for(const auto subdd : dd->subDirs())
     {
       writeDirTreeNode(ol,subdd,level+1,ftv,addToIndex);
     }
@@ -4125,9 +4121,7 @@ static void writeGroupTreeNode(OutputList &ol, GroupDef *gd, int level, FTVHelp*
       }
       else if (lde->kind()==LayoutDocEntry::GroupDirs && addToIndex)
       {
-        QListIterator<DirDef> it(*gd->getDirs());
-        DirDef *dd;
-        for (;(dd=it.current());++it)
+        for(const auto dd : *(gd->getDirs()))
         {
           if (dd->isVisible())
           {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -615,7 +615,7 @@ static void writeDirTreeNode(OutputList &ol, DirDef *dd, int level, FTVHelp* ftv
   }
 
   static bool tocExpand = TRUE; //Config_getBool(TOC_EXPAND);
-  bool isDir = dd->subDirs().count()>0 || // there are subdirs
+  bool isDir = dd->subDirs().size()>0 || // there are subdirs
                (tocExpand &&              // or toc expand and
                 dd->getFiles() && dd->getFiles()->count()>0 // there are files
                );
@@ -644,7 +644,7 @@ static void writeDirTreeNode(OutputList &ol, DirDef *dd, int level, FTVHelp* ftv
   }
 
   // write sub directories
-  if (dd->subDirs().count()>0)
+  if (dd->subDirs().size()>0)
   {
     startIndexHierarchy(ol,level+1);
     for(const auto subdd : dd->subDirs())
@@ -3988,7 +3988,7 @@ static void writeGroupTreeNode(OutputList &ol, GroupDef *gd, int level, FTVHelp*
       numSubItems += gd->getNamespaces()->count();
       numSubItems += gd->getClasses()->count();
       numSubItems += gd->getFiles()->count();
-      numSubItems += gd->getDirs()->count();
+      numSubItems += gd->getDirs()->size();
       numSubItems += gd->getPages()->count();
     }
 

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -1214,9 +1214,7 @@ static void writeInnerDirs(const DirList *dl,FTextStream &t)
 {
   if (dl)
   {
-    QListIterator<DirDef> subdirs(*dl);
-    DirDef *subdir;
-    for (subdirs.toFirst();(subdir=subdirs.current());++subdirs)
+    for(const auto subdir : *dl)
     {
       t << "    <innerdir refid=\"" << subdir->getOutputFileBase()
         << "\">" << convertToXML(subdir->displayName()) << "</innerdir>" << endl;


### PR DESCRIPTION
Effort to reduce (outdated) Qt dependencies (similar to #7651) in order to simplify modern C++ coding.

Chosen `std::list` as container type as it brings the used `sort()` member function.

Note:
 - Implementation of `QList::inSort()` was copied to `DirList::inSort()` as there is no equivalent in the STL container
 - Signature of `GroupDefImpl::addDir()` and `GroupDefImpl::addDir()` needed a minor change.

- [ ] Testing the [`sortInDirList`](https://github.com/doxygen/doxygen/pull/7728/files#diff-c0b61dd85e8f538c4e4e369f0e52cb4cR1101-R1109)