### PR TITLE
add a boolean configuration IGNORE_MISSING_PARAMDOC.

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1292,6 +1292,15 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
 ]]>
       </docs>
     </option>
+    <option type='bool' id='IGNORE_MISSING_PARAMDOC' defval='0'>
+      <docs>
+<![CDATA[
+ This \c IGNORE_MISSING_PARAMDOC option can be enabled to ignore warnings
+ about missing parameter documentation in a documented function.
+ It is only effective if \c WARN_IF_DOC_ERROR tag is set to \c YES.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='WARN_AS_ERROR' defval='0'>
       <docs>
 <![CDATA[

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -535,7 +535,7 @@ static void checkUnOrMultipleDocumentedParams()
                          " has multiple @param documentation sections").data());
         }
       }
-      if (notArgCnt>0)
+      if (notArgCnt > 0 && !Config_getBool(IGNORE_MISSING_PARAMDOC))
       {
         bool first=TRUE;
         QCString errMsg=


### PR DESCRIPTION
If this boolean is true, doxygen will not output messages
about missing function parameter documentation.

This is my first change for doxygen. It's possible that there are other places where it is useful to check this new configuration option. For my use case it did ignore the messages I was not interested in.