### PR TITLE
issue #7738 \todo ignores EXCLUDE_SYMBOLS

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -40,11 +40,14 @@ void RefList::generatePage()
             { return qstricmp(left->title(),left->title()); });
   //RefItem *item;
   QCString doc;
+  int cnt = 0;
   doc += "<dl class=\"reflist\">";
   QCString lastGroup;
   bool first=true;
   for (const std::unique_ptr<RefItem> &item : m_entries)
   {
+    if (!item->name()) continue;
+    cnt++;
     bool startNewGroup = item->group()!=lastGroup;
     if (startNewGroup)
     {
@@ -96,6 +99,6 @@ void RefList::generatePage()
   }
   doc += "</dl>\n";
   //printf("generatePage('%s')\n",doc.data());
-  addRelatedPage(m_listName,m_pageTitle,doc,m_fileName,1,std::vector<RefItem*>(),0,0,TRUE);
+  if (cnt) addRelatedPage(m_listName,m_pageTitle,doc,m_fileName,1,std::vector<RefItem*>(),0,0,TRUE);
 }
 


### PR DESCRIPTION
In case a xref item has no reference the name is empty and thus the item should not be displayed.
As it is possible that none of the items have a reference the page should only be added when there are item available to display