### PR TITLE
issue #7734 Incorrect parsing of Q_PROPERTY

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2000,33 +2000,37 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					  unput(';');
 					  BEGIN(FindMembers);
   					}
-<QtPropType>"const"|"volatile"|"unsigned"|"signed"|"long"|"short" {
-  				          yyextra->current->type+=yytext;
-  					}
 <QtPropType>{B}+			{
-  				          yyextra->current->type+=yytext;
+  				          yyextra->current->name+=yytext;
+  					}
+<QtPropType>"*"				{
+  					  yyextra->current->type+= yyextra->current->name;
+  					  yyextra->current->type+= yytext;
+  				          yyextra->current->name="";
   					}
 <QtPropType>({TSCOPE}"::")*{TSCOPE}	{
-  					  yyextra->current->type+=yytext;
-                                          BEGIN(QtPropName);
-  					}
-<QtPropName>{ID}			{
+  					  yyextra->current->type+= yyextra->current->name;
   					  yyextra->current->name=yytext;
-  					  BEGIN(QtPropAttr);
   					}
-<QtPropAttr>"READ"			{
+<QtPropType,QtPropAttr>{B}+"READ"{B}+	{
   					  yyextra->current->spec |= Entry::Readable;
 					  BEGIN(QtPropRead);
   					}
-<QtPropAttr>"WRITE"			{
+<QtPropType,QtPropAttr>{B}+"WRITE"{B}+	{
   					  yyextra->current->spec |= Entry::Writable;
 					  BEGIN(QtPropWrite);
   					}
-<QtPropAttr>"RESET"{B}+{ID}		{ // reset method => not supported yet
-  					}
-<QtPropAttr>"SCRIPTABLE"{B}+{ID}	{ // scriptable property => not supported yet
-  					}
-<QtPropAttr>"DESIGNABLE"{B}+{ID}	{ // designable property => not supported yet
+<QtPropType,QtPropAttr>{B}+"MEMBER"{B}+{ID}	| // member property => not supported yet
+<QtPropType,QtPropAttr>{B}+"RESET"{B}+{ID}	| // reset method => not supported yet
+<QtPropType,QtPropAttr>{B}+"SCRIPTABLE"{B}+{ID}	| // scriptable property => not supported yet
+<QtPropType,QtPropAttr>{B}+"DESIGNABLE"{B}+{ID}	| // designable property => not supported yet
+<QtPropType,QtPropAttr>{B}+"NOTIFY"{B}+{ID}	| // notify property => not supported yet
+<QtPropType,QtPropAttr>{B}+"REVISION"{B}+{ID}	| // revision property => not supported yet
+<QtPropType,QtPropAttr>{B}+"STORED"{B}+{ID}	| // stored property => not supported yet
+<QtPropType,QtPropAttr>{B}+"USER"{B}+{ID}	| // user property => not supported yet
+<QtPropType,QtPropAttr>{B}+"CONSTANT"{B}	| // constant property => not supported yet
+<QtPropType,QtPropAttr>{B}+"FINAL"{B}		{ // final property => not supported yet
+  					  BEGIN(QtPropAttr);
   					}
 <QtPropRead>{ID}			{
   					  yyextra->current->read = yytext;


### PR DESCRIPTION
The parsing of the type / name was not done correctly as the name `{ID}` is also part of the `{TSCOPE}` and hence the name was seen as a type.
The name is the last part before an attribute is present.
Missing other parts:
- parsing of `*`
- not parsing of a number of (not supported attributes)

The definition of `Q_PROPERTY` is:
```
Q_PROPERTY(type name
           (READ getFunction [WRITE setFunction] |
            MEMBER memberName [(READ getFunction | WRITE setFunction)])
           [RESET resetFunction]
           [NOTIFY notifySignal]
           [REVISION int]
           [DESIGNABLE bool]
           [SCRIPTABLE bool]
           [STORED bool]
           [USER bool]
           [CONSTANT]
           [FINAL])
```
Note: in the implementation we do not enforce the order of the attributes.