### PR TITLE
issue #7753: SVG formula all with zero width

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -98,10 +98,10 @@ void FormulaManager::readFormulas(const char *dir,bool doCompare)
         int w=-1,h=-1;
         if (ei!=-1 && ei>hi && ei<se) // new format
         {
-          int xi=formName.find('x',hi);
+          int xi=formName.find('x',ei);
           if (xi!=-1)
           {
-            w=formName.mid(hi+1,xi-hi-1).toInt();
+            w=formName.mid(ei+1,xi-ei-1).toInt();
             h=formName.mid(xi+1).toInt();
           }
           formName = formName.left(ei);


### PR DESCRIPTION
The wrong index to determine the old size was used. (index for `#` instead of `=`).
Problem was not just for SVG but also for PNG.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4585875/example.tar.gz)

Run doxygen twice and see `html/formula.repository` after each run.
