### PR TITLE
issue #7762 C# mode completely broken

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4872,6 +4872,7 @@ QCString escapeCharsInString(const char *name,bool allowDots,bool allowUnderscor
       case '@': growBuf.addStr("_0d"); break;
       case ']': growBuf.addStr("_0e"); break;
       case '[': growBuf.addStr("_0f"); break;
+      case '#': growBuf.addStr("_0g"); break;
       default:
                 if (c<0)
                 {
@@ -4986,6 +4987,7 @@ QCString unescapeCharsInString(const char *s)
                case 'd': result+='@'; p+=2; break; // _0d -> '@'
                case 'e': result+=']'; p+=2; break; // _0e -> ']'
                case 'f': result+='['; p+=2; break; // _0f -> '['
+               case 'g': result+='#'; p+=2; break; // _0g -> '#'
                default: // unknown escape, just pass underscore character as-is
                  result+=c;
                  break;


### PR DESCRIPTION
In case a `#` is used in the path this is not escaped and this gives a problem in label names for LaTeX and in file references for HTML.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4603768/example.tar.gz)
