### PR TITLE
issue #7778 Build fails with javacc 5.0

### DIFF
--- a/cmake/FindJavacc.cmake
+++ b/cmake/FindJavacc.cmake
@@ -4,6 +4,20 @@ mark_as_advanced(JAVACC_EXECUTABLE)
 if(JAVACC_EXECUTABLE)
   set(JAVACC_FOUND 1)
   message(STATUS "The javacc executable: ${JAVACC_EXECUTABLE}")
+  if(JAVACC_EXECUTABLE)
+    execute_process(
+      COMMAND "${JAVACC_EXECUTABLE}" --version
+      OUTPUT_VARIABLE JAVACC_TEMP_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE _JavaCC_version_result
+    )
+    if(_JavaCC_version_result)
+      message(WARNING "Unable to determine JavaCC version: ${_JavaCC_version_result}")
+      set(JAVACC_FOUND 0)
+    else()
+      string(REGEX REPLACE ".*([0-9]+\.[0-9]\.[0-9]+).*" "\\1" JAVACC_VERSION ${JAVACC_TEMP_VERSION})
+    endif()
+  endif()
 else()
   set(JAVACC_FOUND 0)
   message(STATUS "The javacc executable not found, using existing files")

--- a/vhdlparser/CMakeLists.txt
+++ b/vhdlparser/CMakeLists.txt
@@ -1,11 +1,17 @@
 find_package(Javacc)
 if (JAVACC_FOUND)
+    if (JAVACC_VERSION VERSION_LESS 7.0.5)
+        message(STATUS "  Doxygen requires at least JavaCC version 7.0.5 (installed: ${JAVACC_VERSION})")
+	message(STATUS "  Fall back to JavaCC not installed.")
+    else()
+
     add_custom_command(
         COMMAND ${JAVACC_EXECUTABLE} ${JAVACC_FLAGS} -OUTPUT_DIRECTORY=${CMAKE_SOURCE_DIR}/vhdlparser ${CMAKE_SOURCE_DIR}/vhdlparser/vhdlparser.jj
         DEPENDS ${CMAKE_SOURCE_DIR}/vhdlparser/vhdlparser.jj
         OUTPUT ${CMAKE_SOURCE_DIR}/vhdlparser/CharStream.cc ${CMAKE_SOURCE_DIR}/vhdlparser/CharStream.h ${CMAKE_SOURCE_DIR}/vhdlparser/ErrorHandler.h ${CMAKE_SOURCE_DIR}/vhdlparser/ParseException.cc ${CMAKE_SOURCE_DIR}/vhdlparser/ParseException.h ${CMAKE_SOURCE_DIR}/vhdlparser/Token.cc ${CMAKE_SOURCE_DIR}/vhdlparser/Token.h ${CMAKE_SOURCE_DIR}/vhdlparser/TokenManager.h ${CMAKE_SOURCE_DIR}/vhdlparser/TokenMgrError.cc ${CMAKE_SOURCE_DIR}/vhdlparser/TokenMgrError.h ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParser.cc ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParser.h ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParserConstants.h ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.cc ${CMAKE_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.h
     )
 
+    endif()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/qtools ${GENERATED_SRC})


### PR DESCRIPTION
At the moment doxygen works with javaCC version 7.0.5 but no test is done for the version. The minimum requirement has been set to 7.0.5
javacc does not have an option to retrieve the version though when giving `--version` a bit more information is given, this information is filtered.
(an issue has been submitted to javacc to obtain the version information: https://github.com/javacc/javacc/issues/172).