### PR TITLE
issue #7783 Markdown formatting of emphasis does not work with parentheses

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -65,7 +65,8 @@
 #define extraChar(i) \
   (data[i]=='-' || data[i]=='+' || data[i]=='!' || \
    data[i]=='?' || data[i]=='$' || data[i]=='@' || \
-   data[i]=='&' || data[i]=='*' || data[i]=='%')
+   data[i]=='&' || data[i]=='*' || data[i]=='%' || \
+   data[i]=='[' || data[i]=='(' || data[i]=='{' || data[i]=='<')
 
 // is character at position i in data allowed before an emphasis section
 #define isOpenEmphChar(i) \
@@ -611,8 +612,8 @@ static int processHtmlTag(GrowBuf &out,const char *data,int offset,int size)
 static int processEmphasis(GrowBuf &out,const char *data,int offset,int size)
 {
   if ((offset>0 && !isOpenEmphChar(-1)) || // invalid char before * or _
-      (size>1 && data[0]!=data[1] && !(isIdChar(1) || extraChar(1) || data[1]=='[')) || // invalid char after * or _
-      (size>2 && data[0]==data[1] && !(isIdChar(2) || extraChar(2) || data[2]=='[')))   // invalid char after ** or __
+      (size>1 && data[0]!=data[1] && !(isIdChar(1) || extraChar(1))) || // invalid char after * or _
+      (size>2 && data[0]==data[1] && !(isIdChar(2) || extraChar(2))))   // invalid char after ** or __
   {
     return 0;
   }


### PR DESCRIPTION
With bug fix "Bug 752845 - Non-alphanumeric characters in Markdown links don't work properly" (December 28, 2015: e89eb77b14810649c679dc7d377ddb4e6a942d82 ) the `[` was added as possible character and later on with "Bug 772574 - `__xxx__` not interpreted as markdown when xxx begins with a non-word character (e.g. `__-1__`)" (October 17, 2016: a95c07ecc0a2f1205883d8420a8280c5701c901c ) some other characters were added in `extraChar`

In this patch the opening "brackets" are all added as `extraChar`