### PR TITLE
issue #7787 Doxygen 1.8.18: Markdown tables not working in ALIASES anymore?

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -80,6 +80,15 @@
    data[i]=='\\' || \
    data[i]=='@')
 
+inline int isNewline(const char *data)
+{
+  // plain return
+  if (data[0] == '\n') return(1);
+  // doxygen return from ^^ in ALIASES
+  if (data[0] == '\\' && data[1] == '\\' && data[2] == '_' && data[3] == 'l' && data[4] == 'i' && 
+      data[5] == 'n'  && data[6] == 'e'  && data[7] == 'b' && data[8] == 'r') return(9);
+  return(0);
+}
 //----------
 
 struct LinkRef
@@ -1594,8 +1603,10 @@ int findTableColumns(const char *data,int size,int &start,int &end,int &columns)
   start = i;
 
   // find end character of the table line
-  while (i<size && data[i]!='\n') i++;
-  eol=i+1;
+  int j = 0;
+  while (i<size && !(j = isNewline(data + i))) i++;
+  eol=i+j;
+
   i--;
   while (i>0 && data[i]==' ') i--;
   if (i>0 && data[i-1]!='\\' && data[i]=='|') i--,n++; // trailing or escaped | does not count
@@ -2120,7 +2131,9 @@ static void findEndOfLine(GrowBuf &out,const char *data,int size,
   // find end of the line
   int nb=0;
   end=i+1;
-  while (end<=size && data[end-1]!='\n')
+  //while (end<=size && data[end-1]!='\n')
+  int j = 0;
+  while (end<=size && !(j = isNewline(data+end-1)))
   {
     // while looking for the end of the line we might encounter a block
     // that needs to be passed unprocessed.
@@ -2181,6 +2194,7 @@ static void findEndOfLine(GrowBuf &out,const char *data,int size,
       end++;
     }
   }
+  if (j) end += j-1;
   //printf("findEndOfLine pi=%d i=%d end=%d {%s}\n",pi,i,end,QCString(data+i).left(end-i).data());
 }
 


### PR DESCRIPTION
The artificial newline characters in ALIASES (`^^`) or better said its doxygen replacements (`\\_linebr`) were not seen by the markdown parser as line terminator and as a consequence there was no table seen (it was just 1 long line, without header / data lines).