### PR TITLE
issue #7796 Backticks (`) in Doxygen-markup-in-C in Markdown collapses

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1500,7 +1500,7 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
       if (i==size || data[i]=='\n')
       {
         if (endTildes==startTildes)
-	{
+        {
           offset=i;
           return TRUE;
         }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1499,8 +1499,11 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
       while (i<size && data[i]==' ') i++;
       if (i==size || data[i]=='\n')
       {
-        offset=i;
-        return endTildes==startTildes;
+        if (endTildes==startTildes)
+	{
+          offset=i;
+          return TRUE;
+        }
       }
     }
     i++;


### PR DESCRIPTION
The problem occurs when the backtick is just before the end of line.
The fenced block will only terminate when the same number of fence characters are present, otherwise the search will continue.