### PR TITLE
Missing instance

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2383,7 +2383,7 @@ void VhdlDocGen::writeSource(const MemberDef *mdef,OutputList& ol,const QCString
                        0,                // scope
                        codeFragment,     // input
                        SrcLangExt_VHDL,  // lang
-                       FALSE,            // isExample
+                       TRUE,            // isExample
                        0,               // exampleName
                        const_cast<FileDef*>(mdef->getFileDef()), // fileDef
                        mdef->getStartBodyLine(),      // startLine

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -292,8 +292,7 @@ int VHDLOutlineParser::checkInlineCode(QCString & doc)
        qcs = qcs.simplifyWhiteSpace();
        if (qcs.contains("\\code"))
        {
-	     std::string val1=qcs.data();
-       int i=qcs.find('{');
+	     int i=qcs.find('{');
 	     int j=qcs.find('}');
 	     if(i>0 && j>0 && j>i){
 	       nna = qcs.mid(i+1,(j-i-1));

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -287,10 +287,19 @@ int VHDLOutlineParser::checkInlineCode(QCString & doc)
      VhdlDocGen::prepareComment(p->strComment);
      QCStringList ql = QCStringList::split('\n', p->strComment);
      QCString co ;
+     QCString nna;
      for (QCString qcs : ql) {
        qcs = qcs.simplifyWhiteSpace();
        if (qcs.contains("\\code"))
-         continue;
+       {
+	     std::string val1=qcs.data();
+       int i=qcs.find('{');
+	     int j=qcs.find('}');
+	     if(i>0 && j>0 && j>i){
+	       nna = qcs.mid(i+1,(j-i-1));
+	    }
+	     continue;
+	   }
        qcs.stripPrefix("\\brief");
        co += qcs;
        co += '\n';
@@ -299,6 +308,9 @@ int VHDLOutlineParser::checkInlineCode(QCString & doc)
      VhdlDocGen::prepareComment(co);
      
      Entry gBlock;
+     if(!nna.isEmpty())
+      gBlock.name=nna;
+      else
      gBlock.name = "misc" + VhdlDocGen::getRecordNumber();
      gBlock.startLine = p->yyLineNr-1;
      gBlock.bodyLine = p->yyLineNr-1;

--- a/src/vhdljjparser.h
+++ b/src/vhdljjparser.h
@@ -71,6 +71,7 @@ class VHDLOutlineParser : public OutlineParserInterface
     void setMultCommentLine();
     bool checkMultiComment(QCString& qcs,int line);
     void insertEntryAtLine(std::shared_ptr<Entry> ce,int line);
+    int checkInlineCode(QCString & doc);
     QString getNameID();
   private:
     struct Private;

--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -783,7 +783,7 @@ block_statement()
 LOOKAHEAD([identifier() ":"] [<POSTPONED_T>] <PROCESS_T>)
 process_statement()
 |
-LOOKAHEAD(generate_statement())
+LOOKAHEAD(3)
 generate_statement()
 |
 case_scheme()


### PR DESCRIPTION
 this pull request fixed bug #7774 

 --! Define V1
    V1 : entity work.Test
    
   --! Define V2
    V2 : entity work.Test
        ...
        
    should work now 



Any piece of code  now can be described with

 \code [{title}]
  .......
 \endcode
 


comb : process(ahbi, dmai, rst, clk)

--!\code {var_definition} 
--!  starts variable .....
  
  variable v       : reg_type;
  variable ready   : std_ulogic;
  variable retry   : std_ulogic;
  variable mexc    : std_ulogic;

--!\endcode
