### PR TITLE
Compilation error on debug compilation of  constexp.l

### DIFF
--- a/src/constexp.l
+++ b/src/constexp.l
@@ -137,7 +137,7 @@ bool ConstExpressionParser::parse(const char *fileName,int lineNr,const QCString
   struct yyguts_t *yyg = (struct yyguts_t*)p->yyscanner;
 
 #ifdef FLEX_DEBUG
-  yyset_debug(1,yyscanner);
+  constexpYYset_debug(1,p->yyscanner);
 #endif
 
   yyextra->constExpFileName = fileName;


### PR DESCRIPTION
I case we use `LEX_FLAGS=-d` to compile `constexp.l` we get the error:
```
constexp.l: In member function ‘bool ConstExpressionParser::parse(const char*, int, const QCString&)’:
constexp.l:140:17: error: ‘yyscanner’ was not declared in this scope; did you mean ‘yyscan_t’?
  140 |   yyset_debug(1,yyscanner);
      |                 ^~~~~~~~~
      |                 yyscan_t
make[2]: *** [src/CMakeFiles/doxymain.dir/build.make:455: src/CMakeFiles/doxymain.dir/__/generated_src/constexp.cpp.o] Error 1
```