### PR TITLE
Warning in case of multiple python documentation sections.

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1618,6 +1618,10 @@ static void handleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief
   // TODO: Fix me
   yyextra->docBlockInBody=FALSE;
   
+  if (!yyextra->current->doc.isEmpty())
+  {
+    yyextra->current->doc=yyextra->current->doc.stripWhiteSpace()+"\n\n";
+  }
   if (yyextra->docBlockInBody && yyextra->previous && !yyextra->previous->doc.isEmpty())
   {
     yyextra->previous->doc=yyextra->previous->doc.stripWhiteSpace()+"\n\n";


### PR DESCRIPTION
In special cases when having multiple documentation section for 1 item in python it is possible that they are concatenated in a wrong way and result in a warning.
Each documentation section should be seen as a separate section and be separated from other sections.

the example:
```
#####################################################################
# # Modify Install Stage  ############################################
#####################################################################

class install(_install):
    """Specialised python package installer.

    It does some required chown calls in addition to the usual stuff.
    """
```
gives a warning like:
```
warning: unexpected command endverbatim
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4689910/example.tar.gz)
(Example based on cobbler 3.1.2 and found by Fossies)
