### PR TITLE
Vhdl improvements (ALIAS, translation)

### DIFF
--- a/src/translator.h
+++ b/src/translator.h
@@ -646,6 +646,12 @@ class Translator
     virtual QCString trOperationDocumentation() = 0;
     virtual QCString trDataMembers() = 0;
     virtual QCString trDataMemberDocumentation() = 0;
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.19
+//////////////////////////////////////////////////////////////////////////
+
+    virtual QCString trDesignUnitDocumentation() = 0;
 };
 
 #endif

--- a/src/translator_adapter.h
+++ b/src/translator_adapter.h
@@ -41,7 +41,17 @@ class TranslatorAdapterBase : public Translator
 
 };
 
-class TranslatorAdapter_1_8_15 : public TranslatorAdapterBase
+class TranslatorAdapter_1_8_19 : public TranslatorAdapterBase
+{
+  public:
+    virtual QCString updateNeededMessage()
+    { return createUpdateNeededMessage(idLanguage(),"release 1.8.19"); }
+
+    virtual QCString trDesignUnitDocumentation()
+    { return english.trDesignUnitDocumentation(); }
+};
+
+class TranslatorAdapter_1_8_15 : public TranslatorAdapter_1_8_19
 {
   public:
     virtual QCString updateNeededMessage()

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -49,7 +49,7 @@
 #ifndef TRANSLATOR_BR_H
 #define TRANSLATOR_BR_H
 
-class TranslatorBrazilian : public Translator
+class TranslatorBrazilian : public TranslatorAdapter_1_8_19
 {
   public:
 

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -480,7 +480,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
       }
       else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
       {
-          return "Entwurfseinheiten-Dokumentation";
+          return trDesignUnitDocumentation();
       }
       else
       {
@@ -2253,6 +2253,14 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     }
     virtual QCString trCustomReference(const char *name)
     { return QCString(name)+"-Referenz"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.19
+//////////////////////////////////////////////////////////////////////////
+
+    /** VHDL design unit documentation */
+    virtual QCString trDesignUnitDocumentation()
+    { return "Entwurfseinheiten-Dokumentation"; }
 
     //////////////////////////////////////////////////////////////////////////
 

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -396,7 +396,7 @@ class TranslatorEnglish : public Translator
       }
       else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
       {
-          return "Design Unit Documentation";
+          return trDesignUnitDocumentation();
       }
       else
       {
@@ -2256,6 +2256,14 @@ class TranslatorEnglish : public Translator
     {
         return "Data Member Documentation";
     }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.19
+//////////////////////////////////////////////////////////////////////////
+
+    /** VHDL design unit documentation */
+    virtual QCString trDesignUnitDocumentation()
+    { return "Design Unit Documentation"; }
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -394,6 +394,10 @@ class TranslatorEnglish : public Translator
       {
         return "Data Structure Documentation";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return "Design Unit Documentation";
+      }
       else
       {
         return "Class Documentation";

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -18,7 +18,7 @@
 #ifndef TRANSLATOR_NL_H
 #define TRANSLATOR_NL_H
 
-class TranslatorDutch : public Translator
+class TranslatorDutch : public TranslatorAdapter_1_8_19
 {
   public:
     QCString idLanguage()

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -59,7 +59,7 @@
 #define TRANSLATOR_PT_H
 
 
-class TranslatorPortuguese : public Translator
+class TranslatorPortuguese : public TranslatorAdapter_1_8_19
 {
   public:
 

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -143,7 +143,7 @@ I left use clause untouched as I didn't find a suitable translation for it.
 #ifndef TRANSLATOR_SE_H
 #define TRANSLATOR_SE_H
 
-class TranslatorSwedish : public Translator
+class TranslatorSwedish : public TranslatorAdapter_1_8_19
 {
   public:
 

--- a/vhdlparser/VhdlParserTokenManager.cc
+++ b/vhdlparser/VhdlParserTokenManager.cc
@@ -3540,7 +3540,7 @@ void  VhdlParserTokenManager::TokenLexicalActions(Token *matchedToken){
    {
       case 14 : {
         image.append(input_stream->GetSuffix(jjimageLen + (lengthOfMatch = jjmatchedPos + 1)));
-                      VhdlParser::setLineParsed(ALIAS_T);
+                      parser->outlineParser()->setLineParsed(ALIAS_T);
          break;
        }
       case 17 : {

--- a/vhdlparser/VhdlParserTokenManager.cc
+++ b/vhdlparser/VhdlParserTokenManager.cc
@@ -3538,6 +3538,11 @@ void  VhdlParserTokenManager::SkipLexicalActions(Token *matchedToken){
 void  VhdlParserTokenManager::TokenLexicalActions(Token *matchedToken){
    switch(jjmatchedKind)
    {
+      case 14 : {
+        image.append(input_stream->GetSuffix(jjimageLen + (lengthOfMatch = jjmatchedPos + 1)));
+                      VhdlParser::setLineParsed(ALIAS_T);
+         break;
+       }
       case 17 : {
         image.append(input_stream->GetSuffix(jjimageLen + (lengthOfMatch = jjmatchedPos + 1)));
                                     parser->outlineParser()->setLineParsed(ARCHITECTURE_T);

--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -143,7 +143,7 @@ TOKEN [IGNORE_CASE] :
  <ABS_T: "abs">
 | <ACCESS_T: "access">
 | <AFTER_T: "after">
-| <ALIAS_T: "alias"> {VhdlParser::setLineParsed(ALIAS_T);}
+| <ALIAS_T: "alias"> {parser->outlineParser()->setLineParsed(ALIAS_T);}
 | <ALL_T: "all">
 | <AND_T: "and">
 | <ARCHITECTURE_T: "architecture"> {parser->outlineParser()->setLineParsed(ARCHITECTURE_T);}

--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -143,7 +143,7 @@ TOKEN [IGNORE_CASE] :
  <ABS_T: "abs">
 | <ACCESS_T: "access">
 | <AFTER_T: "after">
-| <ALIAS_T: "alias">
+| <ALIAS_T: "alias"> {VhdlParser::setLineParsed(ALIAS_T);}
 | <ALL_T: "all">
 | <AND_T: "and">
 | <ARCHITECTURE_T: "architecture"> {parser->outlineParser()->setLineParsed(ARCHITECTURE_T);}


### PR DESCRIPTION
Adds support for documenting VHDL alias constructs. Also adds a translation for classes: "Design Unit"
Example:
[test_alias.zip](https://github.com/doxygen/doxygen/files/4702283/test_alias.zip)
Without the patch the documentation of the alias is missing.