### PR TITLE
Empty enum setting in configuration file

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -234,6 +234,11 @@ void ConfigBool::convertStrToVal()
 
 void ConfigEnum::convertStrToVal()
 {
+  if (m_value.isEmpty())
+  {
+    m_value = m_defValue;
+    return;
+  }
   QCString val = m_value.stripWhiteSpace().lower();
   const char *s=m_valueRange.first();
   while (s)


### PR DESCRIPTION
In case we have an empty setting in the doxygen configuration file, where an enum value is expected like:
```
OUTPUT_LANGUAGE =
```
we get the warning:
```
warning: argument '(null)' for option OUTPUT_LANGUAGE is not a valid enum value
Using the default: English!
```

The default value should immediately have been used.

Example: [Doxyfile.tar.gz](https://github.com/doxygen/doxygen/files/4702855/Doxyfile.tar.gz)
test by e.g. `doxygen -x`
