### PR TITLE
Creating chm files for doxygen tests

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1620,6 +1620,11 @@ void Config::checkAndCorrect()
     err("When enabling GENERATE_HTMLHELP the tree view (GENERATE_TREEVIEW) should be disabled. I'll do it for you.\n");
     Config_getBool(GENERATE_TREEVIEW)=FALSE;
   }
+  if (!(Config_getString(HTML_FILE_EXTENSION) == ".html") && Config_getBool(GENERATE_HTMLHELP))
+  {
+    err("When enabling GENERATE_HTMLHELP the HTML_FILE_EXTENSION should be \".html\". I'll do it for you.\n");
+    Config_getString(HTML_FILE_EXTENSION)=".html";
+  }
   if (Config_getBool(SEARCHENGINE) && Config_getBool(GENERATE_HTMLHELP))
   {
     err("When enabling GENERATE_HTMLHELP the search engine (SEARCHENGINE) should be disabled. I'll do it for you.\n");

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -23,6 +23,7 @@
 #include <qdict.h>
 #include <qregexp.h>
 #include <qfile.h>
+#include <qfileinfo.h>
 
 #include "qtextcodec.h"
 #include "sortdict.h"
@@ -74,6 +75,7 @@ class HtmlHelpIndex
                  const char *url, const char *anchor,
                  bool hasLink,bool reversed);
     void writeFields(FTextStream &t);
+    int dictCount(void) {return dict->count();};
   private:
     IndexFieldSDict *dict;   
     HtmlHelp *m_help;
@@ -376,20 +378,20 @@ void HtmlHelp::initialize()
      0x404 Chinese (Taiwan)
 
      New LCIDs:
-	 0x421 Indonesian
-	 0x41A Croatian
-	 0x418 Romanian
-	 0x424 Slovenian
-	 0x41B Slovak
-	 0x422 Ukrainian
-	 0x81A Serbian (Serbia, Latin)
-	 0x403 Catalan
-	 0x426 Latvian
-	 0x427 Lithuanian
-	 0x436 Afrikaans
-	 0x42A Vietnamese
-	 0x429 Persian (Iran)
-	 0xC01 Arabic (Egypt) - I don't know which version of arabic is used inside translator_ar.h ,
+     0x421 Indonesian
+     0x41A Croatian
+     0x418 Romanian
+     0x424 Slovenian
+     0x41B Slovak
+     0x422 Ukrainian
+     0x81A Serbian (Serbia, Latin)
+     0x403 Catalan
+     0x426 Latvian
+     0x427 Lithuanian
+     0x436 Afrikaans
+     0x42A Vietnamese
+     0x429 Persian (Iran)
+     0xC01 Arabic (Egypt) - I don't know which version of arabic is used inside translator_ar.h ,
      so I have chosen Egypt at random
 
   */
@@ -469,6 +471,12 @@ void HtmlHelp::createProjectFile()
   {
     FTextStream t(&f);
     
+    char *hhcFile = "\"index.hhc\"";
+    char *hhkFile = "\"index.hhk\"";
+    int hhkPresent = index->dictCount();
+    if (!ctsItemPresent) hhcFile = "";
+    if (!hhkPresent) hhkFile = "";
+
     QCString indexName="index"+Doxygen::htmlFileExtension;
     t << "[OPTIONS]\n";
     if (!Config_getString(CHM_FILE).isEmpty())
@@ -476,12 +484,12 @@ void HtmlHelp::createProjectFile()
       t << "Compiled file=" << Config_getString(CHM_FILE) << "\n";
     }
     t << "Compatibility=1.1\n"
-         "Full-text search=Yes\n"
-         "Contents file=index.hhc\n"
-         "Default Window=main\n"
-         "Default topic=" << indexName << "\n"
-         "Index file=index.hhk\n"
-         "Language=" << getLanguageString() << endl;
+         "Full-text search=Yes\n";
+    if (ctsItemPresent) t << "Contents file=index.hhc\n";
+    t << "Default Window=main\n"
+         "Default topic=" << indexName << "\n";
+    if (hhkPresent) t << "Index file=index.hhk\n";
+    t << "Language=" << getLanguageString() << endl;
     if (Config_getBool(BINARY_TOC)) t << "Binary TOC=YES\n";
     if (Config_getBool(GENERATE_CHI)) t << "Create CHI file=YES\n";
     t << "Title=" << recode(Config_getString(PROJECT_NAME)) << endl << endl;
@@ -500,14 +508,14 @@ void HtmlHelp::createProjectFile()
     //       Value has been taken from htmlhelp.h file of the HTML Help Workshop
     if (Config_getBool(BINARY_TOC))
     {
-      t << "main=\"" << recode(Config_getString(PROJECT_NAME)) << "\",\"index.hhc\","
-         "\"index.hhk\",\"" << indexName << "\",\"" << 
+      t << "main=\"" << recode(Config_getString(PROJECT_NAME)) << "\"," << hhcFile << ","
+         << hhkFile << ",\"" << indexName << "\",\"" <<
          indexName << "\",,,,,0x23520,,0x70387e,,,,,,,,0" << endl << endl;
     }
     else
     {
-      t << "main=\"" << recode(Config_getString(PROJECT_NAME)) << "\",\"index.hhc\","
-         "\"index.hhk\",\"" << indexName << "\",\"" << 
+      t << "main=\"" << recode(Config_getString(PROJECT_NAME)) << "\"," << hhcFile << ","
+         << hhkFile << ",\"" << indexName << "\",\"" <<
          indexName << "\",,,,,0x23520,,0x10387e,,,,,,,,0" << endl << endl;
     }
     
@@ -521,7 +529,7 @@ void HtmlHelp::createProjectFile()
     uint i;
     for (i=0;i<imageFiles.count();i++)
     {
-      t << imageFiles.at(i) << endl;
+      t << QFileInfo(imageFiles.at(i)).fileName().data() << endl;
     }
     f.close();
   }
@@ -640,6 +648,7 @@ void HtmlHelp::addContentsItem(bool isDir,
     //file = 0;
     //anchor = 0;
   //}
+  ctsItemPresent = true;
   int i; for (i=0;i<dc;i++) cts << "  ";
   cts << "<LI><OBJECT type=\"text/sitemap\">";
   cts << "<param name=\"Name\" value=\"" << convertToHtml(recode(name),TRUE) << "\">";

--- a/src/htmlhelp.h
+++ b/src/htmlhelp.h
@@ -92,6 +92,7 @@ class HtmlHelp  : public IndexIntf
 
     QFile *cf,*kf; 
     FTextStream cts,kts;
+    bool ctsItemPresent = false;
     HtmlHelpIndex *index;
     int dc;
     QStrList indexFiles;


### PR DESCRIPTION
By means of  `nmake tests TEST_FLAGS="--xhtml --keep --cfg GENERATE_HTMLHELP=YES --cfg HHC_LOCATION=C:/PROGRA~2/HTMLHE~1/hhc.exe  --cfg SEARCHENGINE=NO"` it is possible to generate for each doxygen test an index.chm, but there are a number of problems:
- it is only possible to use extension `.html` so this is now automatically done (configimpl.l) otherwise when opening the file an error is displayed.
- it is not [possible to use "empty" hhc / hhk file (i.e. no `<li>` elements), in this case the files are still generated but not used anymore (error like `error: failed to run html help compiler on index.hhp` e.g. for test 1).
- a full qualified / absolute is not allowed for e.g msc images (test 37) the files should anyway be on the "html" directory so just using the filename in the "hhp" file (`     t << QFileInfo(imageFiles.at(i)).fileName().data() << endl;`)