### PR TITLE
Add `const` qualifier to UsedDir::m_dir.

### DIFF
--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -750,7 +750,7 @@ int FilePairDict::compareValues(const FilePair *left,const FilePair *right) cons
 
 //----------------------------------------------------------------------
 
-UsedDir::UsedDir(DirDef *dir,bool inherited) :
+UsedDir::UsedDir(const DirDef *dir,bool inherited) :
    m_dir(dir), m_filePairs(7), m_inherited(inherited)
 {
   m_filePairs.setAutoDelete(TRUE);

--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -104,7 +104,7 @@ class FilePairDict : public SDict<FilePair>
 class UsedDir
 {
   public:
-    UsedDir(DirDef *dir,bool inherited);
+    UsedDir(const DirDef *dir,bool inherited);
     virtual ~UsedDir();
     void addFileDep(FileDef *srcFd,FileDef *dstFd);
     FilePair *findFilePair(const char *name);
@@ -114,7 +114,7 @@ class UsedDir
     void sort();
 
   private:
-    DirDef *m_dir;
+    const DirDef *m_dir;
     FilePairDict m_filePairs;
     bool m_inherited;
 };


### PR DESCRIPTION
This allows (for future use) to create `UsedDir` objects using a pointer to `const DirDef`. As `UsedDir` objects are only used to build the directory dependency graphs the pointed to `DirDef` objects do not need to be changed.

The member is not changed and only given as `const DirDef*` already.