### PR TITLE
remove boxes around nodes in call graphs

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3335,6 +3335,14 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    <option type='string' id='DOT_SHAPE' format='string' defval='plain' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ Define 'record' to have a box around nodes.
+ More shapes are described here: https://www.graphviz.org/doc/info/shapes.html
+]]>
+      </docs>
+    </option>
     <option type='bool' id='CLASS_GRAPH' defval='1' depends='HAVE_DOT'>
       <docs>
 <![CDATA[

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -289,7 +289,7 @@ void DotGraph::writeGraphHeader(FTextStream &t,const QCString &title)
          "labelfontname=\"" << fontName << "\","
          "labelfontsize=\"" << fontSize << "\"];\n";
   t << "  node [fontname=\"" << fontName << "\","
-         "fontsize=\"" << fontSize << "\",shape=record];\n";
+         "fontsize=\"" << fontSize << "\",shape=" << Config_getString(DOT_SHAPE) << "];\n";
 }
 
 void DotGraph::writeGraphFooter(FTextStream &t)


### PR DESCRIPTION
to make call graphs more clean and readable

```
before:
┌────────┐     ┌────────┐
│ caller │────►│ callee │
└────────┘     └────────┘
after:
    caller────►callee
```