### PR TITLE
Incorrect label in map of dot files in xhtml

### DIFF
--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -460,7 +460,7 @@ bool DotFilePatcher::run() const
         convertMapFile(tt,map->mapFile,map->relPath,map->urlOnly,map->context);
         if (!result.isEmpty())
         {
-          t << "<map name=\"" << map->label << "\" id=\"" << map->label << "\">" << endl;
+          t << "<map name=\"" << map->label << "\" id=\"" << correctId(map->label) << "\">" << endl;
           t << result;
           t << "</map>" << endl;
         }

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -236,7 +236,7 @@ void DotGraph::generateCode(FTextStream &t)
     else // add link to bitmap file with image map
     {
       if (!m_noDivTag) t << "<div class=\"center\">";
-      t << "<img src=\"" << relImgName() << "\" border=\"0\" usemap=\"#" << getMapLabel() << "\" alt=\"" << getImgAltText() << "\"/>";
+      t << "<img src=\"" << relImgName() << "\" border=\"0\" usemap=\"#" << correctId(getMapLabel()) << "\" alt=\"" << getImgAltText() << "\"/>";
       if (!m_noDivTag) t << "</div>";
       t << endl;
       if (m_regenerate || !insertMapFile(t, absMapName(), m_relPath, getMapLabel()))

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5272,6 +5272,16 @@ QCString convertToId(const char *s)
   return growBuf.get();
 }
 
+/*! Some strings have been corrected but the requirement regarding the fact
+ *  that an id cannot have a digit at the first position. To overcome problems
+ *  with double labels we always place an "a" in front
+ */
+QCString correctId(QCString s)
+{
+  if (s.isEmpty()) return s;
+  return "a" + s;
+}
+
 /*! Converts a string to an XML-encoded string */
 QCString convertToXML(const char *s, bool keepEntities)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -278,6 +278,7 @@ QCString insertTemplateSpecifierInScope(const QCString &scope,const QCString &te
 QCString stripScope(const char *name);
 
 QCString convertToId(const char *s);
+QCString correctId(QCString s);
 
 QCString convertToHtml(const char *s,bool keepEntities=TRUE);
 


### PR DESCRIPTION
When a filename of a file starts with a digit the mapping of the resulting dot files results in message like:
```
Syntax of value for attribute id of map is not valid
```
an id cannot start with a digit, so an "a" is placed in front of it (unconditionally to overcome problems with a double label id i.e filename 087.cpp and a087.cpp).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4757882/example.tar.gz)
(To get the warnings: `xmllint --noout --path dtd --nonet --postvalid html/*xhtml`)