### PR TITLE
Number of translatable terms (like Chapter) are in English instead of Greek

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -544,6 +544,8 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\\usepackage{ifpdf,ifxetex}\n"
        "\n";
 
+  t << "\\newboolean{DoxyFontSet}\n"
+       "\\setboolean{DoxyFontSet}{false}\n";
   // Language support
   QCString languageSupport = theTranslator->latexLanguageSupportCommand();
   if (!languageSupport.isEmpty())
@@ -564,7 +566,7 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\\usepackage{courier}\n"
        "\\usepackage{amssymb}\n"
        "\\usepackage{sectsty}\n"
-       "\\renewcommand{\\familydefault}{\\sfdefault}\n"
+       "\\ifthenelse{\\not \\boolean{DoxyFontSet}}{\\renewcommand{\\familydefault}{\\sfdefault}}{}\n"
        "\\allsectionsfont{%\n"
        "  \\fontseries{bc}\\selectfont%\n"
        "  \\color{darkgray}%\n"

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -544,8 +544,6 @@ static void writeDefaultHeaderPart1(FTextStream &t)
        "\\usepackage{ifpdf,ifxetex}\n"
        "\n";
 
-  t << "\\newboolean{DoxyFontSet}\n"
-       "\\setboolean{DoxyFontSet}{false}\n";
   // Language support
   QCString languageSupport = theTranslator->latexLanguageSupportCommand();
   if (!languageSupport.isEmpty())
@@ -562,11 +560,13 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   {
     t << "\\usepackage[" << fontenc << "]{fontenc}\n";
   }
-  t << "\\usepackage[scaled=.90]{helvet}\n"
-       "\\usepackage{courier}\n"
-       "\\usepackage{amssymb}\n"
+  QCString font = theTranslator->latexFont();
+  if (!font.isEmpty())
+  {
+    t << font;
+  }
+  t << "\\usepackage{amssymb}\n"
        "\\usepackage{sectsty}\n"
-       "\\ifthenelse{\\not \\boolean{DoxyFontSet}}{\\renewcommand{\\familydefault}{\\sfdefault}}{}\n"
        "\\allsectionsfont{%\n"
        "  \\fontseries{bc}\\selectfont%\n"
        "  \\color{darkgray}%\n"

--- a/src/translator.h
+++ b/src/translator.h
@@ -50,6 +50,11 @@ class Translator
      * can be returned.
      */
     virtual QCString latexFontenc() { return "T1"; }
+    virtual QCString latexFont() {
+      return "\\usepackage[scaled=.90]{helvet}\n"
+             "\\usepackage{courier}\n"
+             "\\renewcommand{\\familydefault}{\\sfdefault}\n";
+    }
     /*!
      * Sets the commands to be inserted directly after the `\\begin{document}`
      * in the LaTeX document.

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -60,14 +60,17 @@ class TranslatorGreek : public TranslatorAdapter_1_8_15
     virtual QCString latexLanguageSupportCommand()
     {
       return "\\usepackage{fontspec}\n"
-             "\\usepackage[greek]{babel}\n"
-             "\\setmainfont{Libertinus Sans}\n"
-             "\\setboolean{DoxyFontSet}{true}\n";
+             "\\usepackage[greek]{babel}\n";
     }
 
     virtual QCString latexFontenc()
     {
       return "";
+    }
+    virtual QCString latexFont()
+    {
+      return "\\setmainfont{Libertinus Sans}\n"
+             "\\setmonofont{Courier New}\n";
     }
 
     // --- Language translation methods -------------------

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -59,8 +59,15 @@ class TranslatorGreek : public TranslatorAdapter_1_8_15
 
     virtual QCString latexLanguageSupportCommand()
     {
-      return "\\usepackage[greek,english]{babel}\n"
-             "\\usepackage{alphabeta}\n";
+      return "\\usepackage{fontspec}\n"
+             "\\usepackage[greek]{babel}\n"
+             "\\setmainfont{Libertinus Sans}\n"
+             "\\setboolean{DoxyFontSet}{true}\n";
+    }
+
+    virtual QCString latexFontenc()
+    {
+      return "";
     }
 
     // --- Language translation methods -------------------
@@ -1159,6 +1166,16 @@ class TranslatorGreek : public TranslatorAdapter_1_8_15
       return "1253";
     }
 
+    virtual QCString latexCommandName()
+    {
+      QCString latex_command = Config_getString(LATEX_CMD_NAME);
+      if (latex_command.isEmpty()) latex_command = "latex";
+      if (Config_getBool(USE_PDFLATEX))
+      {
+        if (latex_command == "latex") latex_command = "xelatex";
+      }
+      return latex_command;
+    }
 
     /*! Used as ansicpg for RTF fcharset
      */


### PR DESCRIPTION
When running tests in Greek OUTPUT_LANGUAGE mode for LaTeX a number of terms like Chapter were still in English instead of Greek.

Some used references:
https://tex.stackexchange.com/questions/548584/ascii-text-set-in-greek-script-when-using-usepackagegreekbabel
https://tex.stackexchange.com/questions/548761/missing-characters-in-output-due-to-renewcommand-familydefault-sfdefault
https://tex.stackexchange.com/questions/58624/variables-for-hiding-or-showing-text-in-latex