### PR TITLE
Catch all wrong mkdir calls (coverity)

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -203,7 +203,11 @@ void CitationManager::generatePage()
   QCString bibOutputDir = outputDir+"/"+bibTmpDir;
   QCString bibOutputFiles = "";
   QDir thisDir;
-  thisDir.mkdir(bibOutputDir);
+  if (!thisDir.exists(bibOutputDir) && !thisDir.mkdir(bibOutputDir))
+  {
+    err("Failed to create temorary output directory '%s', skiping citations\n",bibOutputDir.data());
+    return;
+  }
   int i = 0;
   for (const auto &bibdata : citeDataList)
   {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -10343,7 +10343,7 @@ void generateTemplateFiles(const char *templateDir)
   QCString outDir = QCString(templateDir)+"/html";
   if (!thisDir.exists(outDir) && !thisDir.mkdir(outDir))
   {
-    err("Failed to create output directory '%s'\n",templateDir);
+    err("Failed to create output directory '%s'\n",outDir.data());
     return;
   }
   ResourceMgr::instance().writeCategory("html",outDir);

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -2843,7 +2843,11 @@ template<class T> class TemplateNodeCreator : public TemplateNode
         if (d.exists())
         {
           bool ok = d.mkdir(fileName.mid(j,i-j));
-          if (!ok) break;
+          if (!ok) 
+          {
+            err("Failed to create directory '%s'\n",(fileName.mid(j,i-j)).data());
+            break;
+          }
           QCString dirName = outputDir+'/'+fileName.left(i);
           d = QDir(dirName);
           j = i+1;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5022,10 +5022,16 @@ void createSubDirs(QDir &d)
     int l1,l2;
     for (l1=0;l1<16;l1++)
     {
-      d.mkdir(QCString().sprintf("d%x",l1));
+      if (!d.mkdir(QCString().sprintf("d%x",l1)))
+      {
+        term("Failed to create output directory '%s'\n",(QCString().sprintf("d%x",l1)).data());
+      }
       for (l2=0;l2<256;l2++)
       {
-        d.mkdir(QCString().sprintf("d%x/d%02x",l1,l2));
+        if (!d.mkdir(QCString().sprintf("d%x/d%02x",l1,l2)))
+        {
+          term("Failed to create output directory '%s'\n",(QCString().sprintf("d%x/d%02x",l1,l2)).data());
+        }
       }
     }
   }


### PR DESCRIPTION
- Always catch the output of `mkdir`
- corrected an incorrect message (context.cpp)