### PR TITLE
Coverity uninitialized variable in mscgen_api.c

### DIFF
--- a/libmscgen/mscgen_api.c
+++ b/libmscgen/mscgen_api.c
@@ -457,6 +457,7 @@ static RowInfo *computeCanvasSize(Context      *ctx,
     nextYmin = ymin = ctx->opts.entityHeadGap;
     yskipmax = 0;
 
+    ymax  = 0;
     MscResetArcIterator(m);
     do
     {

--- a/testing/037/037__msc_8cpp.xml
+++ b/testing/037/037__msc_8cpp.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="">
+  <compounddef id="037__msc_8cpp" kind="file" language="C++">
+    <compoundname>037_msc.cpp</compoundname>
+    <innerclass refid="class_sender" prot="public">Sender</innerclass>
+    <innerclass refid="class_receiver" prot="public">Receiver</innerclass>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+      <para>A bit more complex msc diagram, with also parallel events. <msc>
+Sender_1,Receiver_1,Sender1_1,
+Sender,Receiver,Sender1,
+Sender_2,Receiver_2,Sender1_2;
+
+Sender_1-&gt;Receiver_1 [label="Command()", URL="nref Receiver::Command()"],
+Sender1_1&lt;-Receiver_1 [label="Ack()", URL="nref Ack()", ID="1"];
+
+Sender-&gt;Receiver [label="Command()", URL="nref Receiver::Command()"];
+Sender1&lt;-Receiver [label="Ack()", URL="nref Ack()", ID="1"];
+Sender_2-&gt;Receiver_2 [label="Command()", URL="nref Receiver::Command()"],
+Sender1_2&lt;-Receiver_2 [label="Ack()", URL="nref Ack()", ID="1"];
+</msc>
+ </para>
+    </detaileddescription>
+    <location file="037_msc.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/037/class_receiver.xml
+++ b/testing/037/class_receiver.xml
@@ -19,7 +19,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="037_msc.cpp" line="32" column="10"/>
+        <location file="037_msc.cpp" line="50" column="10"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
@@ -32,7 +32,7 @@
 </msc>
  </para>
     </detaileddescription>
-    <location file="037_msc.cpp" line="28" column="1" bodyfile="037_msc.cpp" bodystart="29" bodyend="33"/>
+    <location file="037_msc.cpp" line="46" column="1" bodyfile="037_msc.cpp" bodystart="47" bodyend="51"/>
     <listofallmembers>
       <member refid="class_receiver_1a162099741e0324e6254c9bc570566e40" prot="public" virt="non-virtual">
         <scope>Receiver</scope>

--- a/testing/037/class_sender.xml
+++ b/testing/037/class_sender.xml
@@ -19,7 +19,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="037_msc.cpp" line="17" column="10"/>
+        <location file="037_msc.cpp" line="35" column="10"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
@@ -32,7 +32,7 @@
 </msc>
  </para>
     </detaileddescription>
-    <location file="037_msc.cpp" line="13" column="1" bodyfile="037_msc.cpp" bodystart="14" bodyend="18"/>
+    <location file="037_msc.cpp" line="31" column="1" bodyfile="037_msc.cpp" bodystart="32" bodyend="36"/>
     <listofallmembers>
       <member refid="class_sender_1a8ad2c6f9baa4e798868fe4a4d45f8fda" prot="public" virt="non-virtual">
         <scope>Sender</scope>

--- a/testing/037_msc.cpp
+++ b/testing/037_msc.cpp
@@ -1,6 +1,24 @@
 // objective: test the \msc and \endmsc commands
 // check: class_sender.xml
 // check: class_receiver.xml
+// check: 037__msc_8cpp.xml
+
+/** \file
+ * A bit more complex msc diagram, with also parallel events.
+ * \msc
+ * Sender_1,Receiver_1,Sender1_1,
+ * Sender,Receiver,Sender1,
+ * Sender_2,Receiver_2,Sender1_2;
+ * 
+ * Sender_1->Receiver_1 [label="Command()", URL="nref Receiver::Command()"],
+ * Sender1_1<-Receiver_1 [label="Ack()", URL="nref Ack()", ID="1"];
+ * 
+ * Sender->Receiver [label="Command()", URL="nref Receiver::Command()"];
+ * Sender1<-Receiver [label="Ack()", URL="nref Ack()", ID="1"];
+ * Sender_2->Receiver_2 [label="Command()", URL="nref Receiver::Command()"],
+ * Sender1_2<-Receiver_2 [label="Ack()", URL="nref Ack()", ID="1"];
+ * \endmsc
+ */
 
 /** Sender class. Can be used to send a command to the server.
  *  The receiver will acknowledge the command by calling Ack().


### PR DESCRIPTION
- Initialize the variable ymax
- add an extended example with "parallel events" triggered by a `,` instead of `;` between events