### PR TITLE
issue #7849 Multiple paragraphs within table cells (td) are formatted wrong

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -66,7 +66,7 @@ p.startli, p.startdd {
 	margin-top: 2px;
 }
 
-th p.starttd, p.intertd, p.endtd {
+th p.starttd, th p.intertd, th p.endtd {
         font-size: 100%;
         font-weight: 700;
 }


### PR DESCRIPTION
Correcting css setting from:
```
th p.starttd, p.intertd, p.endtd {
```
to
```
th p.starttd, th p.intertd, th p.endtd {
```

the `th` has to be repeated.