### PR TITLE
Updated formatting rules for paragraphs within table header cells.

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -66,7 +66,7 @@ p.startli, p.startdd {
 	margin-top: 2px;
 }
 
-th p.starttd, p.intertd, p.endtd {
+th p.starttd, th p.intertd, th p.endtd {
         font-size: 100%;
         font-weight: 700;
 }


### PR DESCRIPTION
Only present paragraphs within table headers (th) with font weight strong, keep normal table cells (td) unaffected.
Resolves #7849 