### PR TITLE
Show doxywizard version by means of --version

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -698,6 +698,13 @@ int main(int argc,char **argv)
       msgBox.exec();
       exit(0);
     }
+    else if (!qstrcmp(argv[1],"--version"))
+    {
+      QMessageBox msgBox;
+      msgBox.setText(QString::fromLatin1("Doxywizard version: %1").arg(QString::fromLatin1(getFullVersion())));
+      msgBox.exec();
+      exit(0);
+    }
   }
   if (argc > 2)
   {


### PR DESCRIPTION
Analogous to show help information (`--help`) also show the, full, version of the doxywizard (in the about box only the short version is shown).