### PR TITLE
Setting correct babel packages for some languages

### DIFF
--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -72,7 +72,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     virtual QCString latexLanguageSupportCommand()
     {
       return "\\usepackage[T2A]{fontenc}\n"
-             "\\usepackage[russian]{babel}\n";
+             "\\usepackage[serbianc]{babel}\n";
     }
     virtual QCString latexFontenc()
     {

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -71,7 +71,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     virtual QCString latexLanguageSupportCommand()
     {
-      return "";
+      return "\\usepackage[turkish]{babel}\n";
     }
 
     // --- Language translation methods -------------------

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -57,9 +57,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     virtual QCString latexLanguageSupportCommand()
     {
-      //should we use return "\\usepackage[afrikaans]{babel}\n";
-      // not sure - for now return an empty string
-      return "";
+      return "\\usepackage[afrikaans]{babel}\n";
     }
 
     // --- Language translation methods -------------------


### PR DESCRIPTION
Setting the correct babel language packages so the words like "Chapter" are automatically translated into the right language.