### PR TITLE
improve using plantuml for  vhdl flowcharts

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3642,7 +3642,7 @@ void FlowChart::writeFlowChart()
 #endif
   const MemberDef *p=VhdlDocGen::getFlowMember();
 
-  if (p->isStatic())
+  if (!Config_getString(PLANTUML_JAR_PATH).isEmpty())
   {
     printUmlTree();
     delFlowList();

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -397,14 +397,7 @@ void VHDLOutlineParser::handleCommentBlock(const char *doc1, bool brief)
     s->current->docLine = p->yyLineNr;
   }
 
-  int j = doc.find("[plant]");
-  if (j >= 0)
-  {
-    doc = doc.remove(j, 7);
-    s->current->stat = true;
-  }
-
-  //int position=0;
+ 
 
   Markdown markdown(p->yyFileName,p->iDocLine);
   QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc) : doc;


### PR DESCRIPTION
if  Plantuml  is installed we should use it for VHDL flowcharts without 
--!\vhdlflow [plant]   