### PR TITLE
Corrections for terms like Chapter in Korean and Japanese in LaTeX

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -307,7 +307,7 @@ void LatexDocVisitor::visit(DocStyleChange *s)
       if (s->enable()) m_t << "{\\itshape ";     else m_t << "}";
       break;
     case DocStyleChange::Code:
-      if (s->enable()) m_t << "{\\ttfamily ";   else m_t << "}";
+      if (s->enable()) m_t << "{\\doxyttfamily ";   else m_t << "}";
       break;
     case DocStyleChange::Subscript:
       if (s->enable()) m_t << "\\textsubscript{";    else m_t << "}";

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1688,10 +1688,10 @@ void LatexGenerator::startMemberDoc(const char *clname,
   }
   if (memTotal>1)
   {
-    t << "\\hspace{0.1cm}{\\footnotesize\\ttfamily [" << memCount << "/" << memTotal << "]}";
+    t << "\\hspace{0.1cm}{\\footnotesize\\doxyttfamily [" << memCount << "/" << memTotal << "]}";
   }
   t << "}";
-  t << "\n{\\footnotesize\\ttfamily ";
+  t << "\n{\\footnotesize\\doxyttfamily ";
   //m_disableLinks=TRUE;
 }
 
@@ -2366,7 +2366,7 @@ void LatexGenerator::startLabels()
 
 void LatexGenerator::writeLabel(const char *l,bool isLast)
 {
-  t << "{\\ttfamily [" << l << "]}";
+  t << "{\\doxyttfamily [" << l << "]}";
   if (!isLast) t << ", ";
 }
 

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -159,7 +159,7 @@ class LatexGenerator : public OutputGenerator
     void endTextLink();
     void startHtmlLink(const char *url);
     void endHtmlLink();
-    void startTypewriter() { t << "{\\ttfamily "; }
+    void startTypewriter() { t << "{\\doxyttfamily "; }
     void endTypewriter()   { t << "}";      }
     void startGroupHeader(int);
     void endGroupHeader(int);

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -77,19 +77,36 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
 
     virtual QCString latexLanguageSupportCommand()
     {
-      return "\\usepackage{CJKutf8}\n";
+      return "\\usepackage{polyglossia}\n"
+             "\\makeatletter\n"
+             "\\AtBeginOfPackageFile*{polyglossia}{\n"
+             "  \\@ifpackagelater{polyglossia}{2020/04/09}{}{\n"
+             "    \\renewcommand{\\doxyrmfamily}{\\protect \\rmfamily}\n"
+             "    \\renewcommand{\\doxysffamily}{\\protect \\sffamily}\n"
+             "    \\renewcommand{\\doxyttfamily}{\\protect \\ttfamily}\n"
+             "  }\n"
+             "}\n"
+             "\\makeatother\n"
+             "\\setdefaultlanguage{japanese}\n";
+    }
+    virtual QCString latexCommandName()
+    {
+      QCString latex_command = Config_getString(LATEX_CMD_NAME);
+      if (latex_command.isEmpty()) latex_command = "latex";
+      if (Config_getBool(USE_PDFLATEX))
+      {
+        if (latex_command == "latex") latex_command = "xelatex";
+      }
+      return latex_command;
     }
     virtual QCString latexFontenc()
     {
       return "";
     }
-    virtual QCString latexDocumentPre()
+    virtual QCString latexFont()
     {
-      return "\\begin{CJK}{UTF8}{min}\n";
-    }
-    virtual QCString latexDocumentPost()
-    {
-      return "\\end{CJK}\n";
+      return "\\setmainfont{Noto Sans CJK JP}\n"
+             "\\setmonofont{Noto Sans Mono CJK JP}\n";
     }
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -83,10 +83,17 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     virtual QCString latexLanguageSupportCommand()
     {
-      // I'm not sure what this should be.
-      // When I figure it out, I'll update this.
-      // see http://www.ktug.or.kr/jsboard/read.php?table=operate&no=4422&page=1
-      return "\\usepackage{kotex}\n";
+      return "\\usepackage{polyglossia}\n"
+             "\\makeatletter\n"
+             "\\AtBeginOfPackageFile*{polyglossia}{\n"
+             "  \\@ifpackagelater{polyglossia}{2020/04/09}{}{\n"
+             "    \\renewcommand{\\doxyrmfamily}{\\protect \\rmfamily}\n"
+             "    \\renewcommand{\\doxysffamily}{\\protect \\sffamily}\n"
+             "    \\renewcommand{\\doxyttfamily}{\\protect \\ttfamily}\n"
+             "  }\n"
+             "}\n"
+             "\\makeatother\n"
+             "\\setdefaultlanguage{korean}\n";
     }
     virtual QCString latexCommandName()
     {
@@ -97,6 +104,15 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
         if (latex_command == "latex") latex_command = "xelatex";
       }
       return latex_command;
+    }
+    virtual QCString latexFontenc()
+    {
+      return "";
+    }
+    virtual QCString latexFont()
+    {
+      return "\\setmainfont{Noto Sans CJK KR}\n"
+             "\\setmonofont{Noto Sans Mono CJK KR}\n";
     }
 
     // --- Language translation methods -------------------

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -574,3 +574,11 @@
 \refstepcounter{figure}%
 \@dblarg{\@caption{figure}}}
 \makeatother
+
+
+% the polyglossia package before 1.50 has a bug in respect to the robustness of \ttfamily
+% for non latin sets
+% setting here the default version and when using polyglossia resetting the commands when necessary
+\newcommand \doxyrmfamily \rmfamily
+\newcommand \doxysffamily \sffamily
+\newcommand \doxyttfamily \ttfamily


### PR DESCRIPTION
Setting the correct language packages so the words like "Chapter" are automatically translated into the right language.
- As the Korean language is not available in the distributions of babel (and would also be incomplete, no translation for e.g. Chapter) and the Japanese language missing the translations for e.g. Chapter a switch is made to the polyglossia package for these languages.
- Also we need to choose the right font as not all fonts contain characters for Korean / Japanese
- The polyglossia package contains a problem regarding the the `\ttfamily` command, this is solved in the mean time but for compatibility with current and older LaTeX distributions a small workaround is necessary for the older packages.

Some links:
- Fonts:
  - https://www.google.com/get/noto/  some free font packages
  - https://www.google.com/get/noto/help/cjk/ some notes on Noto font packages
- Solving problems regarding fonts and code
  - https://tex.stackexchange.com/questions/550268/typewriter-font-for-korean-language
  - https://tex.stackexchange.com/questions/550286/problem-polyglossia-and-verbatim-in-korean-language
    - ttfamily in the chapter title of Korean language document: https://github.com/reutenauer/polyglossia/issues/428

Problem have been tested with the doxygen tests