### PR TITLE
issue #7867 JAVADOC_AUTOBRIEF and @File regression

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -667,9 +667,12 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                             yyextra->spaceBeforeCmd = QCString(yytext).left(i);
                                             if (it->second.endsBrief && !(yyextra->inContext==OutputXRef && cmdName=="parblock"))
                                             {
-                                              yyextra->briefEndsAtDot=FALSE;
-                                              // this command forces the end of brief description
-                                              setOutput(yyscanner,OutputDoc);
+                                              if ((yyextra->inContext == OutputBrief) && !yyextra->current->doc.stripWhiteSpace().isEmpty())
+                                              {
+                                                yyextra->briefEndsAtDot=FALSE;
+                                                // this command forces the end of brief description
+                                                setOutput(yyscanner,OutputDoc);
+                                              }
                                             }
                                             //if (i>0) addOutput(yyscanner,QCString(yytext).left(i)); // removed for bug 689341
                                             if (it->second.handler && it->second.handler(yyscanner, cmdName, optList))


### PR DESCRIPTION
The restriction of a command terminating a brief description is a bit to stringent, it should only be valid when the current mode is brief description and the brief descriptin is not empty.