### PR TITLE
No default rule present in commentcnv.l

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -870,6 +870,9 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
   				     copyToOutput(yyscanner,yytext,(int)yyleng);
   				   }
 
+<*>.                               {
+  				     copyToOutput(yyscanner,yytext,(int)yyleng);
+                                   }
 %%
 
 static void replaceCommentMarker(yyscan_t yyscanner,const char *s,int len)


### PR DESCRIPTION
In the file `commentcnv.l` there is no default rule present, resulting in the, non understandable, output as indicated in https://github.com/doxygen/doxygen/issues/7873#issuecomment-650100405
(this is not the cause of the problem as reported with issue https://github.com/doxygen/doxygen/issues/7873, but quite annoying)