### PR TITLE
issue #7873 Combining `///`-style comments with macros containing @cond/@endcond causes a preprocessor error

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -753,6 +753,8 @@ MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z
 				     copyToOutput(yyscanner,yytext,(int)yyleng); 
 				     yyextra->inSpecialComment=FALSE;
 				     yyextra->inRoseComment=FALSE;
+                                     yyextra->readLineCtx = Scan; // reset, otherwise ther will be problems with:
+                                                                  //   static void handleCondSectionId
 				     BEGIN(Scan); 
                                    }
 <ReadLine>"/**"                    {


### PR DESCRIPTION
At the end of a mult-line `///` section the state of readlineCtx not reset so the subsequent `@cond` block thought we were still in a `///` block`