### PR TITLE
issue #7879 Inline parameter documentation not working as expected

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3761,7 +3761,7 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
       {
         QCString docsWithoutDir = a.docs;
         QCString direction = extractDirection(docsWithoutDir);
-        paramDocs+="@param"+direction+" "+a.name+" "+a.docs;
+        paramDocs+="@param"+direction+" "+a.name+" "+docsWithoutDir;
       }
     }
     // feed the result to the documentation parser


### PR DESCRIPTION
The direction was not stripped from the description when transforming to a `@param` command.

(fix as indicated by OP in the issue description)