### PR TITLE
More flexible and correct detection of direction of an argument

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -378,7 +378,7 @@ SPCMD2    {CMD}[\\@<>&$#%~".+=|-]
 SPCMD3    {CMD}_form#[0-9]+
 SPCMD4    {CMD}"::"
 SPCMD5    {CMD}":"
-INOUT	  "inout"|"in"|"out"|("in"{BLANK}*","{BLANK}*"out")|("out"{BLANK}*","{BLANK}*"in")
+INOUT	  "in"|"out"|("in"{BLANK}*","?{BLANK}*"out")|("out"{BLANK}*","?{BLANK}*"in")
 PARAMIO   {CMD}param{BLANK}*"["{BLANK}*{INOUT}{BLANK}*"]"
 VARARGS   "..."
 TEMPCHAR  [a-z_A-Z0-9.,: \t\*\&\(\)\[\]]

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8138,10 +8138,25 @@ QCString extractDirection(QCString &docs)
   int l=0;
   if (re.match(docs,0,&l)==0)
   {
-    int  inPos  = docs.find("in", 1,FALSE);
-    int outPos  = docs.find("out",1,FALSE);
-    bool input  =  inPos!=-1 &&  inPos<l;
-    bool output = outPos!=-1 && outPos<l;
+    QRegExp re_in("\\[ *in *\\]"); // [in]
+    QRegExp re_out("\\[ *out *\\]"); // [out]
+    QRegExp re_inout("\\[ *in *[,]? *out *\\]"); // [in,out]
+    QRegExp re_outin("\\[ *out *[,]? *in *\\]"); // [out,in]
+    int l_in = 0;
+    int l_out = 0;
+    int l_inout = 0;
+    int l_outin = 0;
+    int inPos = re_in.match(docs,0,&l_in);
+    int outPos = re_out.match(docs,0,&l_out);
+    int inoutPos = re_inout.match(docs,0,&l_inout);
+    int outinPos = re_outin.match(docs,0,&l_outin);
+    // we only take the first occurrence into account
+    bool input  =  (inPos!=-1    &&  l==l_in) ||
+                   (inoutPos!=-1 &&  l==l_inout) ||
+                   (outinPos!=-1 &&  l==l_outin);
+    bool output =  (outPos!=-1   &&  l==l_out) ||
+                   (inoutPos!=-1 &&  l==l_inout) ||
+                   (outinPos!=-1 &&  l==l_outin);
     if (input || output) // in,out attributes
     {
       docs = docs.mid(l); // strip attributes


### PR DESCRIPTION
In the current version a line like:
```
uint8_t innInstances,       ///< [inn]Number of CIP node instances.
```
was seen as an input parameter.
Also not all combinations were checked (`[inout]` was OK but `[outin]` wasn't although `[in,out]` and `[out,in]` were working in the tokenizer.
Line up the detection of the direction between the tokenizer and the method `extractDirection`

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4842215/example.tar.gz)

Note: this problem was found when working on #7879.