### PR TITLE
Missing links in Fortran in case use statement with upper case characters in name

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -467,6 +467,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 <Use>{ID}                               { 
                                           DBG_CTX((stderr,"using dir %s\n",yytext));
                                           yyextra->current->name=yytext;
+                                          yyextra->current->name=yyextra->current->name.lower();
                                           yyextra->current->fileName = yyextra->fileName; 
                                           yyextra->current->section=Entry::USINGDIR_SEC;
                                           yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
@@ -475,12 +476,14 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                         }
 <Use>{ID}/,                             { 
                                           yyextra->useModuleName=yytext;
+                                          yyextra->useModuleName=yyextra->useModuleName.lower();
                                         }
 <Use>,{BS}"ONLY"                        { BEGIN(UseOnly); 
                                         }           
 <UseOnly>{BS},{BS}                      {}
 <UseOnly>{ID}                           {
                                           yyextra->current->name= yyextra->useModuleName+"::"+yytext;
+                                          yyextra->current->name=yyextra->current->name.lower();
                                           yyextra->current->fileName = yyextra->fileName; 
                                           yyextra->current->section=Entry::USINGDECL_SEC;
                                           yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);


### PR DESCRIPTION
Based on the question: https://stackoverflow.com/questions/62557644/automatic-link-to-fortran-classes-in-method-arguments-description-in-doxygen#62595302
The problem regarding the missing linking was checked and contrary to the idea that it was depending on the `ONLY` clause it was due to the fact that a conversion to lower case was missing.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4846707/example.tar.gz)
