### PR TITLE
Misleading compiler warning

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3174,20 +3174,18 @@ void  FlowChart::printFlowTree()
 
 void  FlowChart::colTextNodes()
 {
-  QCString text;
-  FlowChart *flno;
+  FlowChart *flno = NULL;
   bool found=FALSE;
   for (uint j=0;j<flowList.count();j++)
   {
     FlowChart *flo=flowList.at(j);
     if (flo->type&TEXT_NO)
     {
-      text+=flo->text+'\n';
       if (!found)
       {
         flno=flo;
       }
-      if (found)
+      else
       {
         flno->text+=flo->text;
         flowList.remove(flo);


### PR DESCRIPTION
When compiling on Cygwin (gcc version 9.3.0 (GCC)) in release mode we get:
```
In file included from /cygdrive/d/Programs/Doxygen/fork/doxygen/src/vhdldocgen.cpp:27:
/cygdrive/d/Programs/Doxygen/fork/doxygen/qtools/qcstring.h: In static member function ‘static void FlowChart::colTextNodes()’:
/cygdrive/d/Programs/Doxygen/fork/doxygen/qtools/qcstring.h:364:23: warning: ‘flno’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  364 |       if (str) m_rep+=str;
      |                       ^~~
/cygdrive/d/Programs/Doxygen/fork/doxygen/src/vhdldocgen.cpp:3178:14: note: ‘flno’ was declared here
 3178 |   FlowChart *flno;
      |              ^~~~

```
The compiler doesn't "understand" that `flno` is guarded by `found` and this would be initialized.
Local variable `text` is not used so removed.