### PR TITLE
Missing last item in htmlhelp level2 index

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -171,7 +171,7 @@ void HtmlHelpIndex::writeFields(FTextStream &t)
   dict->sort();
   IndexFieldSDict::Iterator ifli(*dict);
   IndexField *f;
-  QCString lastLevel1;
+  QCString prevLevel1;
   bool level2Started=FALSE;
   for (;(f=ifli.current());++ifli)
   {
@@ -187,7 +187,6 @@ void HtmlHelpIndex::writeFields(FTextStream &t)
       level1  = f->name.copy();
     }
 
-    //if (level1!=lastLevel1)
     { // finish old list at level 2
       if (level2Started) t << "  </UL>" << endl;
       level2Started=FALSE;
@@ -206,10 +205,11 @@ void HtmlHelpIndex::writeFields(FTextStream &t)
         nextLevel1 = fnext->name.left(fnext->name.find('?'));
         --ifli;
       }
-      if (level1 != nextLevel1)
+      if (!(level1 == prevLevel1 || level1 == nextLevel1))
       {
         level2 = "";
       }
+      prevLevel1 = level1.copy();
       // </Antony>
 
       if (level2.isEmpty())
@@ -257,7 +257,6 @@ void HtmlHelpIndex::writeFields(FTextStream &t)
       t << "<param name=\"Name\" value=\"" << m_help->recode(level2) << "\">"
          "</OBJECT>\n";
     }
-    lastLevel1 = level1.copy();
   } 
   if (level2Started) t << "  </UL>" << endl;
 }


### PR DESCRIPTION
At every second level index part the last item is missing.
We should not only forward but also backward

Old situation:
![err](https://user-images.githubusercontent.com/5223533/86256233-5c970880-bbb8-11ea-9e62-1045c6afa366.jpg)

New situation:
![OK](https://user-images.githubusercontent.com/5223533/86256241-60c32600-bbb8-11ea-805a-ddc1adcc1b54.jpg)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4858462/example.tar.gz)
