### PR TITLE
Superfluous space in "TEST_FLAGS"

### DIFF
--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -487,6 +487,8 @@ def split_and_keep(s, sep):
 		vv = val.split(" ",1)
 		if ((len(vv) == 1) and not vv[0] == ''):
 			retVal += vv
+		if (len(vv) == 2):
+			vv[1] = vv[1].strip()
 		if ((len(vv) == 2) and not vv[1] == ''):
 			retVal += vv
 		if ((len(vv) == 2) and vv[1] == ''):


### PR DESCRIPTION
When having extra spaces in TEST_FLAGS like(note the double space before `--ip`):
```
make tests TEST_FLAGS="--keep  --id=1"
```
or
```
make tests TEST_FLAGS="--id=1  --id=2"
```
we get a message like;
```
[100%] Running doxygen tests...
usage: runtests.py [-h] [--updateref] [--doxygen [DOXYGEN]]
                   [--xmllint [XMLLINT]] [--id IDS [IDS ...]]
                   [--start_id START_ID] [--end_id END_ID] [--all]
                   [--inputdir [INPUTDIR]] [--outputdir [OUTPUTDIR]]
                   [--noredir] [--pool [POOL]] [--xml] [--rtf] [--docbook]
                   [--xhtml] [--xmlxsd] [--pdf] [--subdirs] [--clang] [--keep]
                   [--cfg CFGS [CFGS ...]]
runtests.py: error: unrecognized arguments:
NMAKE : fatal error U1077: 'D:\Programs\Python\Python37\python.exe' : return code '0x2'
Stop.
```

By stripping the spaces in the arguments this can be overcome