### PR TITLE
Compilation warning  in debug.cpp

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -114,11 +114,11 @@ class Timer
     {
       m_startTime = std::chrono::system_clock::now();
     }
-    int elapsedTimeMs()
+    double elapsedTimeS()
     {
-      return std::chrono::duration_cast<
+      return (std::chrono::duration_cast<
                   std::chrono::milliseconds>(
-                  std::chrono::system_clock::now() - m_startTime).count();
+                  std::chrono::system_clock::now() - m_startTime).count()) / 1000.0;
     }
   private:
     std::chrono::time_point<std::chrono::system_clock> m_startTime;
@@ -131,8 +131,8 @@ void Debug::startTimer()
   g_runningTime.start();
 }
 
-int Debug::elapsedTime()
+double Debug::elapsedTime()
 {
-  return g_runningTime.elapsedTimeMs();
+  return g_runningTime.elapsedTimeS();
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -47,7 +47,7 @@ class Debug
     static void setPriority(int p);
 
     static void startTimer();
-    static int  elapsedTime();
+    static double elapsedTime();
 
   private:
     static DebugMask curMask;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11583,7 +11583,7 @@ void generateOutput()
   if (Debug::isFlagSet(Debug::Time))
   {
     msg("Total elapsed time: %.3f seconds\n(of which %.3f seconds waiting for external tools to finish)\n",
-         ((double)Debug::elapsedTime())/1000.0,
+         ((double)Debug::elapsedTime()),
          Portable::getSysElapsedTime()
         );
     g_s.print();

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -117,7 +117,7 @@ void msg(const char *fmt, ...)
 #endif
     if (Debug::isFlagSet(Debug::Time))
     {
-      printf("%.3f sec: ",((double)Debug::elapsedTime())/1000.0);
+      printf("%.3f sec: ",((double)Debug::elapsedTime()));
     }
     va_list args;
     va_start(args, fmt);


### PR DESCRIPTION
When compiling debug.cpp on a 32-bit Windows system we get the warning:
```
...\doxygen\src\debug.cpp(121): warning C4244: 'return': conversion from '_Rep' to 'int', possible loss of data
        with
        [
            _Rep=__int64
        ]
```

as we only use the seconds representation of the elapsed time we can do the conversion to seconds in the Timer class.