### PR TITLE
src: fix bug #7901

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1906,7 +1906,6 @@ static bool handleDefGroup(yyscan_t yyscanner,const QCString &, const QCStringLi
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool stop=makeStructuralIndicator(yyscanner,Entry::GROUPDOC_SEC);
   yyextra->current->groupDocType = Entry::GROUPDOC_NORMAL;
-  setOutput(yyscanner,OutputBrief);
   BEGIN( GroupDocArg1 );
   return stop;
 }

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1207,6 +1207,7 @@ void GroupDefImpl::writeDocumentation(OutputList &ol)
   ol.pushGeneratorState();
   ol.disableAllBut(OutputGenerator::Man);
   ol.endTitleHead(getOutputFileBase(),name());
+  ol.parseText(m_title);
   ol.popGeneratorState();
   ol.endHeaderSection();
   ol.startContents();

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -173,7 +173,7 @@ void ManGenerator::endTitleHead(const char *,const char *name)
   t << ".ad l" << endl;
   t << ".nh" << endl;
   t << ".SH NAME" << endl;
-  t << name;
+  t << name << " \\- ";
   m_firstCol=FALSE;
   m_paragraph=TRUE;
   m_inHeader=TRUE;


### PR DESCRIPTION
Modified:

 src/commentscan.l: 0ef84d5 duplicated Detailed Description

 src/groupdef.cpp: 98d3f8e stopped outputting Brief Description

 src/mangen.cpp: 98d3f8e stopped outputting minus sign before B.D.

Signed-off-by: Duncan Roe <duncan_roe@optusnet.com.au>