### PR TITLE
Unused variable in code (VHDL)

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3636,7 +3636,6 @@ void FlowChart::writeFlowChart()
 #ifdef DEBUGFLOW
    printFlowTree();
 #endif
-  const MemberDef *p=VhdlDocGen::getFlowMember();
 
   if (!Config_getString(PLANTUML_JAR_PATH).isEmpty())
   {


### PR DESCRIPTION
Due to #7864 the variable p is unused (and getFlowMember is just an access function to a flowMember).