### PR TITLE
issue #7911 markdown table add extra test to "\copybrief"

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1846,7 +1846,7 @@ int Markdown::writeTableBlock(const char *data,int size)
       }
       // need at least one space on either side of the cell text in
       // order for doxygen to do other formatting
-      m_out.addStr("> " + cellText + "</" + cellTag + ">");
+      m_out.addStr("> " + cellText + " </" + cellTag + ">");
     }
     cellTag = "td";
     cellClass = "class=\"markdownTableBody";


### PR DESCRIPTION
The comment in the code speaks of:
>      // need at least one space on either side of the cell text in
>      // order for doxygen to do other formatting

but in the implementation the end space is missing.
Looks like the problem is introduced in version 1.8.17 when some work is done on the line counting (removing artificial `\n`).