### PR TITLE
issue #7923 source line numbers in warnings output by parser are off by 1

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2518,7 +2518,9 @@ static void handleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief
   int position=0;
   bool needsEntry = FALSE;
   Markdown markdown(yyextra->fileName,lineNr);
-  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc) : doc;
+  int startNewlines = 0;
+  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc,startNewlines) : doc;
+  lineNr += startNewlines;
   while (yyextra->commentScanner.parseCommentBlock(
         yyextra->thisParser,
         yyextra->docBlockInBody ? yyextra->subrCurrent.back().get() : yyextra->current.get(),

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2457,7 +2457,7 @@ QCString Markdown::detab(const QCString &s,int &refIndent)
 
 //---------------------------------------------------------------------------
 
-QCString Markdown::process(const QCString &input)
+QCString Markdown::process(const QCString &input, int &startNewlines)
 {
   if (input.isEmpty()) return input;
   int refIndent;
@@ -2488,7 +2488,7 @@ QCString Markdown::process(const QCString &input)
   if (p)
   {
     while (*p==' ')  p++; // skip over spaces
-    while (*p=='\n') p++; // skip over newlines
+    while (*p=='\n') {startNewlines++;p++;}; // skip over newlines
     if (qstrncmp(p,"<br>",4)==0) p+=4; // skip over <br>
   }
   if (p>result.data())
@@ -2576,7 +2576,9 @@ void MarkdownOutlineParser::parseInput(const char *fileName,
   Protection prot=Public;
   bool needsEntry = FALSE;
   int position=0;
-  QCString processedDocs = markdown.process(docs);
+  int startNewlines;
+  QCString processedDocs = markdown.process(docs,startNewlines);
+  lineNr += startNewlines;
   while (p->commentScanner.parseCommentBlock(
         this,
         current.get(),

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -33,7 +33,7 @@ class Markdown
 {
   public:
     Markdown(const char *fileName,int lineNr,int indentLevel=0);
-    QCString process(const QCString &input);
+    QCString process(const QCString &input, int &startNewlines);
     QCString extractPageTitle(QCString &docs,QCString &id);
     void setIndentLevel(int level) { m_indentLevel = level; }
 

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1631,7 +1631,9 @@ static void handleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief
   bool needsEntry;
   int lineNr = brief ? yyextra->current->briefLine : yyextra->current->docLine;
   Markdown markdown(yyextra->yyFileName,lineNr);
-  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc) : doc;
+  int startNewlines = 0;
+  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc,startNewlines) : doc;
+  lineNr += startNewlines;
   while (yyextra->commentScanner.parseCommentBlock(
         yyextra->thisParser,
         (yyextra->docBlockInBody && yyextra->previous) ? yyextra->previous.get() : yyextra->current.get(),

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7020,7 +7020,9 @@ static void handleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief
   bool needsEntry=FALSE;
   Markdown markdown(yyextra->yyFileName,lineNr);
   QCString strippedDoc = stripIndentation(doc);
-  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(strippedDoc) : strippedDoc;
+  int startNewlines = 0;
+  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(strippedDoc,startNewlines) : strippedDoc;
+  lineNr += startNewlines;
   while (yyextra->commentScanner.parseCommentBlock(
 	yyextra->thisParser,
 	yyextra->docBlockInBody && yyextra->previous ? yyextra->previous.get() : yyextra->current.get(),

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -400,7 +400,8 @@ void VHDLOutlineParser::handleCommentBlock(const char *doc1, bool brief)
  
 
   Markdown markdown(p->yyFileName,p->iDocLine);
-  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc) : doc;
+  int startNewlines = 0;
+  QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc,startNewlines) : doc;
 
    while (p->commentScanner.parseCommentBlock(
       p->thisParser,


### PR DESCRIPTION
Explicit counting of the removed newlines at the beginning of a documentation block (markdown.cpp) so this number can be added to get a better line number in case of warnings.