### PR TITLE
crossref citations are shown unconditionally

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -139,6 +139,7 @@ void CitationManager::generatePage()
         input.at(fi.size())='\0';
         int pos=0;
         int s;
+        QCString label1;
         while ((s=input.find('\n',pos))!=-1)
         {
           QCString line = input.mid((uint)pos,(uint)(s-pos));
@@ -152,9 +153,45 @@ void CitationManager::generatePage()
             if (j!=-1 && k!=-1)
             {
               QCString label = line.mid((uint)(j+1),(uint)(k-j-1));
-              if (p->entries.find(label.data())==p->entries.end()) // not found yet
+              // check if the reference with the cross reference is used
+              // insert cross refererence when cross reference has not yet been added.
+              if ((p->entries.find(label1.data())!=p->entries.end()) &&
+                  (p->entries.find(label.data())==p->entries.end())) // not found yet
               {
                 insert(label);
+              }
+            }
+          }
+          else if (line.stripWhiteSpace().startsWith("@"))
+          {
+            // assumption entry like: "@book { name," or "@book { name" (spaces optional)
+            int j=line.find("{",0);
+            // when no {, go hunting for it
+            while (j==-1 && (s=input.find('\n',pos))!=-1)
+            {
+              line = input.mid((uint)pos,(uint)(s-pos));
+              j=line.find("{",0);
+              pos=s+1;
+            }
+            // search for the name
+            label1 = "";
+            while (label1.isEmpty())
+            {
+              int k=line.find(",",j);
+              if (k != -1)
+              {
+                label1 = line.mid((uint)(j+1),(uint)(k-j-1));
+              }
+              else
+              {
+                label1 = line.mid((uint)(j+1));
+              }
+              label1 = label1.stripWhiteSpace();
+              j = -1;
+              if (label1.isEmpty() && (s=input.find('\n',pos))!=-1)
+              {
+                line = input.mid((uint)pos,(uint)(s-pos));
+                pos=s+1;
               }
             }
           }

--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -175,28 +175,31 @@ void CitationManager::generatePage()
             }
             // search for the name
             citeName = "";
-            if (j != -1) // to prevent something like "@manual ," and no { found
+            if (s != -1 && j!= -1) // to prevent something like "@manual ," and no { found
             {
+              int k=line.find(",",j);
+              j++;
               while (s != -1 && citeName.isEmpty())
               {
-                int k=line.find(",",j);
                 if (k != -1)
                 {
-                  citeName = line.mid((uint)(j+1),(uint)(k-j-1));
+                  citeName = line.mid((uint)(j),(uint)(k-j));
                 }
                 else
                 {
-                  citeName = line.mid((uint)(j+1));
+                  citeName = line.mid((uint)(j));
                 }
                 citeName = citeName.stripWhiteSpace();
-                j = -1;
+                j = 0;
                 if (citeName.isEmpty() && (s=input.find('\n',pos))!=-1)
                 {
                   line = input.mid((uint)pos,(uint)(s-pos));
                   pos=s+1;
+                  k=line.find(",");
                 }
               }
             }
+            //printf("citeName = #%s#\n",citeName.data());
           }
         }
       }

--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -139,7 +139,7 @@ void CitationManager::generatePage()
         input.at(fi.size())='\0';
         int pos=0;
         int s;
-        QCString label1;
+        QCString citeName;
         while ((s=input.find('\n',pos))!=-1)
         {
           QCString line = input.mid((uint)pos,(uint)(s-pos));
@@ -152,46 +152,49 @@ void CitationManager::generatePage()
             int k=line.find("}",i);
             if (j!=-1 && k!=-1)
             {
-              QCString label = line.mid((uint)(j+1),(uint)(k-j-1));
+              QCString crossrefName = line.mid((uint)(j+1),(uint)(k-j-1));
               // check if the reference with the cross reference is used
               // insert cross refererence when cross reference has not yet been added.
-              if ((p->entries.find(label1.data())!=p->entries.end()) &&
-                  (p->entries.find(label.data())==p->entries.end())) // not found yet
+              if ((p->entries.find(citeName.data())!=p->entries.end()) &&
+                  (p->entries.find(crossrefName.data())==p->entries.end())) // not found yet
               {
-                insert(label);
+                insert(crossrefName);
               }
             }
           }
           else if (line.stripWhiteSpace().startsWith("@"))
           {
             // assumption entry like: "@book { name," or "@book { name" (spaces optional)
-            int j=line.find("{",0);
+            int j=line.find("{");
             // when no {, go hunting for it
             while (j==-1 && (s=input.find('\n',pos))!=-1)
             {
               line = input.mid((uint)pos,(uint)(s-pos));
-              j=line.find("{",0);
+              j=line.find("{");
               pos=s+1;
             }
             // search for the name
-            label1 = "";
-            while (label1.isEmpty())
+            citeName = "";
+            if (j != -1) // to prevent something like "@manual ," and no { found
             {
-              int k=line.find(",",j);
-              if (k != -1)
+              while (s != -1 && citeName.isEmpty())
               {
-                label1 = line.mid((uint)(j+1),(uint)(k-j-1));
-              }
-              else
-              {
-                label1 = line.mid((uint)(j+1));
-              }
-              label1 = label1.stripWhiteSpace();
-              j = -1;
-              if (label1.isEmpty() && (s=input.find('\n',pos))!=-1)
-              {
-                line = input.mid((uint)pos,(uint)(s-pos));
-                pos=s+1;
+                int k=line.find(",",j);
+                if (k != -1)
+                {
+                  citeName = line.mid((uint)(j+1),(uint)(k-j-1));
+                }
+                else
+                {
+                  citeName = line.mid((uint)(j+1));
+                }
+                citeName = citeName.stripWhiteSpace();
+                j = -1;
+                if (citeName.isEmpty() && (s=input.find('\n',pos))!=-1)
+                {
+                  line = input.mid((uint)pos,(uint)(s-pos));
+                  pos=s+1;
+                }
               }
             }
           }


### PR DESCRIPTION
The crossref items in a bib file are unconditionally added to the list of used citations although the the citation to which the crossref belongs to is not used.
This has been fixed. The problem was seen in the CGAL output.

Note: a crossref in LaTeX is a bit different from the normal understanding of cross-reference, from https://tex.stackexchange.com/questions/401138/what-is-the-bibtex-crossref-field-used-for: "crossref can be used if you have multiple entries referring to the same proceeding, book or similar."

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/4995973/example.tar.gz)
