### PR TITLE
Prefer more inclusive language

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2156,7 +2156,7 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
 <![CDATA[
  The \c GENERATE_CHI flag
  controls if a separate `.chi` index file is generated (\c YES) or that
- it should be included in the master `.chm` file (\c NO).
+ it should be included in the main `.chm` file (\c NO).
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
Doxygen is used for some Android API documentation, hence:

Update language to comply with Android’s inclusive language guidance.
See https://source.android.com/setup/contribute/respectful-code for reference