### PR TITLE
Incorrect representation of citation

### DIFF
--- a/templates/html/bib2xhtml.pl
+++ b/templates/html/bib2xhtml.pl
@@ -198,7 +198,7 @@ while (<BBLFILE>) {
 	next loop;
     }
     $nentry++;
-    ($bcite, $blabel) = m+<dt><a name=\"([^\"]*)\">\[([^\]]*)\]</a></dt><dd>+;
+    ($bcite, $blabel) = m+<dt><a[ \n][ \n]*name=\"([^\"]*)\">\[([^\]]*)\]</a></dt><dd>+;
     $blabel = "$nentry";
     $bibcite{$bcite} = $blabel;
 }
@@ -222,7 +222,7 @@ while (<BBLFILE>) {
     }
     s/\%\n//g;
     s/(\.(<\/cite>|<\/a>|\')+)\./$1/g;
-    s:(<dt><a name=\"[^\"]*\">\[)[^\]]*(\]</a></dt><dd>):$1$nentry$2:;
+    s:(<dt><a[ \n][ \n]*name=\"[^\"]*\">\[)[^\]]*(\]</a></dt><dd>):$1$nentry$2:;
     while (m/(\\(cite(label)?)(\001\d+)\{([^\001]+)\4\})/) {
 	$old = $1;
 	$cmd = $2;


### PR DESCRIPTION
In case we have a bibtex entry like:
```
@manual{ cgal:as-lum
  ,author       = {Algorithmic Solutions}
  ,title        = {The {LEDA} {U}ser {M}anual}
  ,organization = {Algorithmic Solutions}
  ,address      = {66123 Saarbr\"ucken, Germany}
  ,url         =  {http://www.algorithmic-solutions.info/leda_manual/MANUAL.html}
}
```
this is rendered / referenced like:
```
[Solutions] Algorithmic Solutions. The LEDA User Manual. Algorithmic Solutions, 66123 Saarbrücken, Germany.
```
instead of
```
[2] Algorithmic Solutions. The LEDA User Manual. Algorithmic Solutions, 66123 Saarbrücken, Germany.
```

The problem is that in the resulting "bbl" file from the bibtex command we have the line:
```
<dt><a
  name="CITEREF_cgal:as-lum">[Solutions]</a></dt><dd>\bibxhtmlname{Algorithmic
  Solutions}.
```
instead of (from another entry):
```
<dt><a name="CITEREF_cgal:mog-vbcfe-11">[Merigot et~al.,
  2011]</a></dt><dd>\bibxhtmlname{Quentin Merigot}, \bibxhtmlname{Maks
```

Note the `\n` after the `<a` instead of the (expected) space.

This has been corrected in the regular expression (Note: we need to use `[ \n][ \n]*` as we cannot use the equivalent `[ \n]+` as the `+`- sign has here a different meaning).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5006457/example.tar.gz)
(Found in CGAL Number_typesBibliography).
