### PR TITLE
Debug facility for the \cite command

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -22,6 +22,7 @@
 #include "portable.h"
 #include "resourcemgr.h"
 #include "util.h"
+#include "debug.h"
 
 #include <qfile.h>
 #include <qfileinfo.h>
@@ -29,10 +30,6 @@
 
 #include <map>
 #include <string>
-
-// Remove the temporary files
-#define RM_TMP_FILES (true)
-//#define RM_TMP_FILES (false)
 
 const char *bibTmpFile = "bibTmpFile_";
 const char *bibTmpDir  = "bibTmpDir/";
@@ -114,6 +111,8 @@ void CitationManager::generatePage()
 
   // do not generate an empty citations page
   if (isEmpty()) return; // nothing to cite
+
+  bool citeDebug = Debug::isFlagSet(Debug::Cite);
 
   // 0. add cross references from the bib files to the cite dictionary
   QFile f;
@@ -233,7 +232,7 @@ void CitationManager::generatePage()
   int exitCode;
   Portable::sysTimerStop();
   if ((exitCode=Portable::system("perl","\""+bib2xhtmlFile+"\" "+bibOutputFiles+" \""+
-                         citeListFile+"\"")) != 0)
+                         citeListFile+"\"" + (citeDebug ? " -d" : ""))) != 0)
   {
     err("Problems running bibtex. Verify that the command 'perl --version' works from the command line. Exit code: %d\n",
         exitCode);
@@ -327,7 +326,7 @@ void CitationManager::generatePage()
   }
 
   // 9. Remove temporary files
-  if (RM_TMP_FILES)
+  if (!citeDebug)
   {
     thisDir.remove(citeListFile);
     thisDir.remove(doxygenBstFile);

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -42,7 +42,8 @@ static std::map< std::string, Debug::DebugMask > s_labels =
   { "filteroutput",      Debug::FilterOutput      },
   { "lex",               Debug::Lex               },
   { "plantuml",          Debug::Plantuml          },
-  { "fortranfixed2free", Debug::FortranFixed2Free }
+  { "fortranfixed2free", Debug::FortranFixed2Free },
+  { "cite",              Debug::Cite              }
 };
 
 //------------------------------------------------------------------------

--- a/src/debug.h
+++ b/src/debug.h
@@ -36,7 +36,8 @@ class Debug
                      FilterOutput = 0x00001000,
                      Lex          = 0x00002000,
                      Plantuml     = 0x00004000,
-                     FortranFixed2Free = 0x00008000
+                     FortranFixed2Free = 0x00008000,
+                     Cite         = 0x00010000
                    };
     static void print(DebugMask mask,int prio,const char *fmt,...);
 

--- a/templates/html/bib2xhtml.pl
+++ b/templates/html/bib2xhtml.pl
@@ -118,11 +118,14 @@ sub html_ent {
 	s/\\lfloor\b/&lfloor;/g;
 	s/\\rfloor\b/&rfloor;/g;
 }
+$bdebug = 0;
 foreach (@ARGV) {
   if (/\.bib$/) {
     $bibfile = $_;
     $bibfile =~ s/\.bib$//;
     push(@bibfiles,$bibfile);
+  } elsif ("$_" eq "-d") {
+    $bdebug = 1;
   } else {
     $htmlfile = $_;
   }
@@ -315,5 +318,7 @@ close (OHTMLFILE);
 close(HTMLFILE);
 chmod($mode, "$htmlfile$$");
 rename("$htmlfile$$", $htmlfile);
-unlink(@tmpfiles);
+if ($bdebug == 0) {
+  unlink(@tmpfiles);
+}
 exit(0);


### PR DESCRIPTION
When issuing doxygen with `-d cite` the temporary (copied) files / directory are not removed, i.e.:
- bib*.aux
- bib*.bbl
- bib*.blg
- bib2xhtml.pl
- citelist.doc
- doxygen.bst
- bibTmpDir (directory)

Example to test: [example.tar.gz](https://github.com/doxygen/doxygen/files/5006645/example.tar.gz)
