### PR TITLE
Compiler warning in htmlhelp.cpp

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -470,8 +470,8 @@ void HtmlHelp::createProjectFile()
   {
     FTextStream t(&f);
     
-    char *hhcFile = "\"index.hhc\"";
-    char *hhkFile = "\"index.hhk\"";
+    const char *hhcFile = "\"index.hhc\"";
+    const char *hhkFile = "\"index.hhk\"";
     int hhkPresent = index->dictCount();
     if (!ctsItemPresent) hhcFile = "";
     if (!hhkPresent) hhkFile = "";


### PR DESCRIPTION
We get the warning like:
```
src/htmlhelp.cpp:473:21: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
  473 |     char *hhcFile = "\"index.hhc\"";                                                                                              |                     ^~~~~~~~~~~~~~~
```