### PR TITLE
Travis does not terminate on error on non last command inside if construct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,9 @@ script:
     - cmake --version;
     - cmake -G "Unix Makefiles" -Dbuild_doc=ON -Dbuild_wizard=ON ..
     - make
-    - if [ ! "${TRAVIS_OS_NAME}" == "osx" ]; then
-        make tests;
+    - if [ ! "${TRAVIS_OS_NAME}" == "osx" ] && [ ! "${TRAVIS_COMPILER}" == "clang" ]; then
+        make tests docs;
+      fi;
+    - if [ ! "${TRAVIS_OS_NAME}" == "osx" ] && [ "${TRAVIS_COMPILER}" == "clang" ]; then
         make docs;
       fi;


### PR DESCRIPTION
In case we have an `if` construct with multiple statements and the non last statement gives an error this is ignored by travis.
- In the mentioned case we can take the 2 statements (`make tests` and `make docs` together), so no construct with a script and `set -e` is required.
- due to a problem with the shared libraries in the case we compile with `clang` compiler and the `xmllint` program we need to exclude the `make tests` here as well.

Tests were don with the test pull request #7939