### PR TITLE
Empty python comment gives problems

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1253,9 +1253,12 @@ STARTDOCSYMS      "##"
 			      QCString actualDoc=yyextra->docBlock;
 			      if (!yyextra->docBlockSpecial) // legacy unformatted docstring
 			      {
-                                stripIndentation(actualDoc,yyextra->commentIndent);
-			        actualDoc.prepend("\\verbatim\n");
-			        actualDoc.append("\\endverbatim ");
+                                if (!actualDoc.isEmpty())
+                                {
+                                  stripIndentation(actualDoc,yyextra->commentIndent);
+			          actualDoc.prepend("\\verbatim\n");
+			          actualDoc.append("\\endverbatim ");
+			        }
 			      }
 			      //printf("-------> yyextra->current=%p yyextra->bodyEntry=%p\n",yyextra->current,yyextra->bodyEntry);
 			      handleCommentBlock(yyscanner, actualDoc, FALSE);
@@ -1265,9 +1268,12 @@ STARTDOCSYMS      "##"
 			      QCString actualDoc=yyextra->docBlock;
 			      if (!yyextra->docBlockSpecial) // legacy unformatted docstring
 			      {
-                                stripIndentation(actualDoc,yyextra->commentIndent);
-			        actualDoc.prepend("\\verbatim\n");
-			        actualDoc.append("\\endverbatim ");
+                                if (!actualDoc.isEmpty())
+                                {
+                                  stripIndentation(actualDoc,yyextra->commentIndent);
+			          actualDoc.prepend("\\verbatim\n");
+			          actualDoc.append("\\endverbatim ");
+			        }
 			      }
 			      actualDoc.prepend("\\namespace "+yyextra->moduleScope+" ");
 			      handleCommentBlock(yyscanner, actualDoc, FALSE);


### PR DESCRIPTION
In case we have an empty python comment like: `"""""""` (i.e. 6 double quotes) doxygen will crash in the pyscanner.l  version of `stripIndentation`.
```
class Translator(nodes.NodeVisitor):
    """"""

    ## the var
    words_and_spaces = re.compile(r'\S+| +|\n')
```
In case of an empty comment we should not call `stripIndentation` and not place `\verbatim` / `\endverbatim` around the empty comment (the later would give an non-understandable empty comment block).
An empty comment should be handled as no comment.

Found by Fossies whilst generating documentation for Mercural 5.5).

Example: [example.tag.gz](https://github.com/doxygen/doxygen/files/5021790/example.tag.gz)
