### PR TITLE
Support commented out argument names in declarations

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -916,6 +916,14 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='bool' id='EXTRACT_ANON_ARGUMENTS' defval='0'>
+      <docs>
+<![CDATA[
+ If this flag is set to \c YES, the name of anonymous arguments in declarations will be
+ extracted from the definitions. By default anonymous arguments will stay nameless.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='HIDE_UNDOC_MEMBERS' defval='0'>
       <docs>
 <![CDATA[

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -277,6 +277,7 @@ class MemberDefImpl : public DefinitionImpl, public MemberDef
     virtual void setDeclFile(const QCString &df,int line,int column);
     virtual void moveArgumentList(std::unique_ptr<ArgumentList> al);
     virtual void moveDeclArgumentList(std::unique_ptr<ArgumentList> al);
+    virtual void extractArgumentNames(const MemberDef& md);
     virtual void setDefinitionTemplateParameterLists(const ArgumentLists &lists);
     virtual void setTypeConstraints(const ArgumentList &al);
     virtual void setType(const char *t);
@@ -789,6 +790,7 @@ class MemberDefAliasImpl : public DefinitionAliasImpl, public MemberDef
     virtual void setDeclFile(const QCString &df,int line,int column) {}
     virtual void moveArgumentList(std::unique_ptr<ArgumentList> al) {}
     virtual void moveDeclArgumentList(std::unique_ptr<ArgumentList> al) {}
+    virtual void extractArgumentNames(const MemberDef& md) {}
     virtual void setDefinitionTemplateParameterLists(const ArgumentLists &lists) {}
     virtual void setTypeConstraints(const ArgumentList &al) {}
     virtual void setType(const char *t) {}
@@ -5483,6 +5485,54 @@ const ArgumentList &MemberDefImpl::declArgumentList() const
   return m_impl->declArgList;
 }
 
+void MemberDefImpl::extractArgumentNames(const MemberDef& md)
+{
+  ArgumentList &decAl = m_impl->declArgList;
+  ArgumentList &defAl = m_impl->defArgList;
+  const ArgumentList &decAlSrc = md.declArgumentList();
+  const ArgumentList &defAlSrc = md.argumentList();
+  auto decSrc = decAlSrc.begin(), defSrc = defAlSrc.begin();
+  for (auto decIt = decAl.begin(), defIt = defAl.begin();
+       decIt != decAl.end() && defIt != defAl.end() && decSrc != decAlSrc.end() && defSrc != defAlSrc.end();
+       ++decIt, ++defIt, ++decSrc, ++defSrc++)
+  {
+    Argument &decA = *decIt;
+    Argument &defA = *defIt;
+    const Argument &decAS = *decSrc;
+    const Argument &defAS = *defSrc;
+    if (decA.name.isEmpty())
+    {
+      if (!defA.name.isEmpty())
+      {
+        decA.name = defA.name;
+      }
+      else if (!decAS.name.isEmpty())
+      {
+        decA.name = decAS.name;
+      }
+      else if (!defAS.name.isEmpty())
+      {
+        decA.name = defAS.name;
+      }
+    }
+    if (defA.name.isEmpty())
+    {
+      if (!decA.name.isEmpty())
+      {
+        defA.name = decA.name;
+      }
+      else if (!decAS.name.isEmpty())
+      {
+        defA.name = decAS.name;
+      }
+      else if (!defAS.name.isEmpty())
+      {
+        defA.name = defAS.name;
+      }
+    }
+  }
+}
+
 const ArgumentList &MemberDefImpl::templateArguments() const
 {
   return m_impl->tArgList;
@@ -5949,6 +5999,14 @@ static void transferArgumentDocumentation(ArgumentList &decAl,ArgumentList &defA
     {
       defA.docs = decA.docs;
     }
+    if (decA.name.isEmpty() && !defA.name.isEmpty())
+    {
+        decA.name = defA.name;
+    }
+    else if (defA.name.isEmpty() && !decA.name.isEmpty())
+    {
+        defA.name = decA.name;
+    }
   }
 }
 
@@ -5979,6 +6037,11 @@ void combineDeclarationAndDefinition(MemberDef *mdec,MemberDef *mdef)
       //    mdef->getFileDef()->name().data(),mdef->documentation().data(),
       //    mdec->getFileDef()->name().data(),mdec->documentation().data()
       //    );
+
+      if (Config_getBool(EXTRACT_ANON_ARGUMENTS))
+      {
+        mdec->extractArgumentNames(*mdef);
+      }
 
       // first merge argument documentation
       transferArgumentDocumentation(mdecAl,mdefAl);
@@ -6040,7 +6103,6 @@ void combineDeclarationAndDefinition(MemberDef *mdec,MemberDef *mdef)
       }
       mdec->mergeMemberSpecifiers(mdef->getMemberSpecifiers());
       mdef->mergeMemberSpecifiers(mdec->getMemberSpecifiers());
-
 
       // copy group info.
       if (mdec->getGroupDef()==0 && mdef->getGroupDef()!=0)

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -336,6 +336,7 @@ class MemberDef : virtual public Definition
     // argument related members
     virtual void moveArgumentList(std::unique_ptr<ArgumentList> al) = 0;
     virtual void moveDeclArgumentList(std::unique_ptr<ArgumentList> al) = 0;
+    virtual void extractArgumentNames(const MemberDef& md) = 0;
     virtual void setDefinitionTemplateParameterLists(const ArgumentLists &lists) = 0;
     virtual void setTypeConstraints(const ArgumentList &al) = 0;
     virtual void setType(const char *t) = 0;


### PR DESCRIPTION
The functionality is controlled by a new configuration EXTRACT_ANON_ARGUMENTS.

There are coding styles where function declarations, especially in headers, use commented out argument names or no argument names at all. In this case adding documentation of the function and its arguments to the header doesn't give the required/expected results. The arguments cannot be documented as named ones as the names are missing leading to warnings during output generation and also the resulting documentation will not be perfect, as the function prototype will show no names for the arguments, but there will be description for named parameters. The reader must then rely solely on order of the documented arguments.

This change adds a new config point (EXTRACT_ANON_ARGUMENTS) which by default is off, so functionality is 100% backward compatible. When it gets enabled, any parameter name from a function definition gets copied to the declaration of the function.