### PR TITLE
Improvement of line count for e.g. warnings

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -440,7 +440,6 @@ static void addCite(yyscan_t yyscanner);
 
 //-----------------------------------------------------------------------------
 
-
 #undef        YY_INPUT
 #define        YY_INPUT(buf,result,max_size) result=yyread(yyscanner,buf,max_size);
 
@@ -860,7 +859,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           else // yyextra->inContext==OutputBrief
                                           { // only go to the detailed description if we have
                                             // found some brief description and not just whitespace
-                                            endBrief(yyscanner,FALSE);
+                                            endBrief(yyscanner,TRUE);
                                           }
                                           lineCount(yyscanner);
                                         }
@@ -2128,8 +2127,8 @@ static bool handleDetails(yyscan_t yyscanner,const QCString &, const QCStringLis
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (yyextra->inContext!=OutputBrief)
   {
-    addOutput(yyscanner,"\n\n"); // treat @details outside brief description
-                       // as a new paragraph
+    addOutput(yyscanner,"\\ilinebr\\ilinebr "); // treat @details outside brief description
+                                                // as a new paragraph
   }
   setOutput(yyscanner,OutputDoc);
   return FALSE;
@@ -3235,6 +3234,7 @@ bool CommentScanner::parseCommentBlock(/* in */     OutlineParserInterface *pars
   yyextra->guards = std::stack<GuardedSection>();
   yyextra->langParser     = parser;
   yyextra->current        = curEntry;
+  yyextra->current->docLine = (lineNr > 1 ? lineNr-1: 1);
   if (comment.isEmpty()) return FALSE; // avoid empty strings
   yyextra->inputString    = comment;
   yyextra->inputString.append(" ");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6580,7 +6580,7 @@ QCString stripLeadingAndTrailingEmptyLines(const QCString &s,int &docLine)
   while ((c=*p))
   {
     if (c==' ' || c=='\t' || c=='\r') i++,p++;
-    else if (c=='\\' && qstrncmp(p,"\\ilinebr",8)==0) i+=8,li=i,docLine++,p+=8;
+    else if (c=='\\' && qstrncmp(p,"\\ilinebr",8)==0) i+=8,li=i,p+=8;
     else if (c=='\n') i++,li=i,docLine++,p++;
     else break;
   }


### PR DESCRIPTION
When having a file like (but extended example based on a problem found in CGAL where line numbers were a bit off):
```
/*!  The <hr2> class `Face_filtered_graph` is an adaptor that creates a filtered view of a graph */
struct Face_filtered_graph_no_det
{
 /*!
   * \brief constructs an empty face filtered graph (no face is selected)
   *
   *
   *
   *
   *
   *
   *
   *
   * <table class="params">
   *   something
   *   something
   * </table>
   *
   *
   *
   *
   *
   *
   *
   *
   * <table class="params">
   *   something
   *   something
   * </table>
   */
  Face_filtered_graph_no_det();
}
```
we get:
```
.../no_det.h:1: warning: Unsupported xml/html tag <hr2> found
.../no_det.h:5: warning: expected <tr> tag but found TK_LNKWORD token instead!
.../no_det.h:17: warning: expected <tr> tag but found TK_LNKWORD token instead!
```
instead of:
```
.../no_det.h:1: warning: Unsupported xml/html tag <hr2> found
.../no_det.h:14: warning: expected <tr> tag but found TK_LNKWORD token instead!
.../no_det.h:26: warning: expected <tr> tag but found TK_LNKWORD token instead!
```

Line counting is in an interpreter, especially when merging blocks etc.) a difficult situation.

- `util.cpp`: `\ilinebr` is an internal newline, but the line count should not be increased
- `commentscan.l`
   - put empty lines in output as well otherwise they are missing in the line count
   - don't insert `\n` to separate blocks, but use the artificial `\ilinebr`
   - properly initialize the `docLine` (important for examples were at the beginning of the block there are a number of newlines)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5078540/example.tar.gz)

