### PR TITLE
Building documentation after changing language files

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -93,16 +93,17 @@ if (build_doc_chm)
         Doxyfile_chm
 )
 endif ()
-file(GLOB LANG_FILES "${TOP}/src/translator_??.h")
+
+if (${CMAKE_VERSION} VERSION_EQUAL "3.11.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.11.0")
+    file(GLOB LANG_FILES CONFIGURE_DEPENDS "${TOP}/src//translator_??.h")
+else()
+    file(GLOB LANG_FILES "${TOP}/src//translator_??.h")
+endif()
+
 
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/man
                     ${PROJECT_BINARY_DIR}/src
                     ${PROJECT_BINARY_DIR}/doc)
-
-file(COPY ${TOP}/VERSION                  DESTINATION ${PROJECT_BINARY_DIR}/)
-file(COPY ${TOP}/src/translator.h         DESTINATION ${PROJECT_BINARY_DIR}/src/)
-file(COPY ${TOP}/src/translator_adapter.h DESTINATION ${PROJECT_BINARY_DIR}/src/)
-file(COPY ${LANG_FILES}                   DESTINATION ${PROJECT_BINARY_DIR}/src/)
 
 foreach (f  ${DOC_FILES})
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/doc/${f}
@@ -132,7 +133,7 @@ configure_file(${CMAKE_SOURCE_DIR}/doc/doxyindexer.1      ${PROJECT_BINARY_DIR}/
 # doc/language.doc (see tag Doxyfile:INPUT)
 add_custom_command(
         COMMAND ${PYTHON_EXECUTABLE} translator.py ${CMAKE_SOURCE_DIR}
-        DEPENDS ${PROJECT_BINARY_DIR}/doc/maintainers.txt ${PROJECT_BINARY_DIR}/doc/language.tpl ${PROJECT_BINARY_DIR}/doc/translator.py
+        DEPENDS ${CMAKE_SOURCE_DIR}/doc/maintainers.txt ${CMAKE_SOURCE_DIR}/doc/language.tpl ${PROJECT_BINARY_DIR}/doc/translator.py ${LANG_FILES}
         OUTPUT language.doc
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc
 )

--- a/doc/language.tpl
+++ b/doc/language.tpl
@@ -106,28 +106,12 @@ Just follow the following steps:
            See the HTML specification for the codes.
      </ul>
    </ul>
-<li>
-    <ul>
-      <li>On *nix systems:<br>
-    <ul>
-        <li>Rerun the `configure` script from the root (i.e. in the \c doxygen  directory) so
-        that it generates `doxygen/src/lang_cfg.h`.
-        This file should now contain a  \c \#define for your language code.<br>
-        <li>Run \c make again from the root (i.e. in the \c doxygen
-        directory) of the distribution, in order to regenerate the `Makefile`s.
-    </ul>
-      <li> On Windows:<br>
-    <ul>
-       <li>stop Visual Stdio<br>
-       <li>open a command window<br>
-       <li>goto the directory `doxygen\src`<br>
-       <li>give the command `python languages.py > ..\winbuild\Languages.rules`<br>
-       <li>close the command window<br>
-       <li>start Visual Studio again<br>
-       <li>Your language should now be selectable in the `General` part of the `Settings` of the `Properties`
-       window of `lang_cfg.py`, by default Your language will be `on`. Rebuild `doxygen` (and `doxywizard`) now.
-    </ul>
-    </ul>
+<li>Edit <code>doxygen/doc/maintainers.txt</code> and add yourself to the list of maintaners like:
+    \code
+         TranslatorYourLanguage
+         <your name>: <your dot email at your dot domain>
+    \endcode
+<li>Build the documentation by giving the appropriate build command (like: `make docs`).
 <li>Now you can use <code>OUTPUT_LANGUAGE = your_language_name</code>
     in the config file to generate output in your language.
 <li>Send <code>translator_xx.h</code> to me so I can add it to doxygen.

--- a/doc/translator.py
+++ b/doc/translator.py
@@ -1231,10 +1231,14 @@ class TrManager:
         self.src_path = os.path.join(self.doxy_path, 'src')
         #  Normally the original sources aren't in the current directory
         # (as we are in the build directory) so we have to specify the
-        # original source directory.
+        # original source /documentation / ... directory.
         self.org_src_path = self.src_path
+        self.org_doc_path = self.doc_path
+        self.org_doxy_path = self.doxy_path
         if (len(sys.argv) > 1 and os.path.isdir(os.path.join(sys.argv[1], 'src'))):
             self.org_src_path = os.path.join(sys.argv[1], 'src')
+            self.org_doc_path = os.path.join(sys.argv[1], 'doc')
+            self.org_doxy_path = sys.argv[1]
             # Get the explicit arguments of the script.
             self.script_argLst = sys.argv[2:]
         else:
@@ -1290,7 +1294,7 @@ class TrManager:
         # The translator.h must exist (the Transl object will check it),
         # create the object for it and let it build the dictionary of
         # required methods.
-        tr = Transl(os.path.join(self.src_path, 'translator.h'), self)
+        tr = Transl(os.path.join(self.org_src_path, 'translator.h'), self)
         self.requiredMethodsDic = tr.collectPureVirtualPrototypes()
         tim = tr.getmtime()
         if tim > self.lastModificationTime:
@@ -1298,7 +1302,7 @@ class TrManager:
 
         # The translator_adapter.h must exist (the Transl object will check it),
         # create the object for it and store the reference in the dictionary.
-        tr = Transl(os.path.join(self.src_path, 'translator_adapter.h'), self)
+        tr = Transl(os.path.join(self.org_src_path, 'translator_adapter.h'), self)
         self.adaptMethodsDic = tr.collectAdapterPrototypes()
         tim = tr.getmtime()
         if tim > self.lastModificationTime:
@@ -1310,11 +1314,11 @@ class TrManager:
         if self.script_argLst:
             lst = ['translator_' + x + '.h' for x in self.script_argLst]
             for fname in lst:
-                if not os.path.isfile(os.path.join(self.src_path, fname)):
+                if not os.path.isfile(os.path.join(self.org_src_path, fname)):
                     sys.stderr.write("\a\nFile '%s' not found!\n" % fname)
                     sys.exit(1)
         else:
-            lst = os.listdir(self.src_path)
+            lst = os.listdir(self.org_src_path)
             lst = [x for x in lst if x[:11] == 'translator_'
                                    and x[-2:] == '.h'
                                    and x != 'translator_adapter.h']
@@ -1323,7 +1327,7 @@ class TrManager:
         # content of the file. Then insert the object to the dictionary
         # accessed via classId.
         for fname in lst:
-            fullname = os.path.join(self.src_path, fname)
+            fullname = os.path.join(self.org_src_path, fname)
             tr = Transl(fullname, self)
             tr.processing()
             assert(tr.classId != 'Translator')
@@ -1402,7 +1406,7 @@ class TrManager:
                     self.numLang -= 1    # the couple will be counted as one
 
         # Extract the version of Doxygen.
-        f = xopen(os.path.join(self.doxy_path, 'VERSION'))
+        f = xopen(os.path.join(self.org_doxy_path, 'VERSION'))
         self.doxVersion = f.readline().strip()
         f.close()
 
@@ -1557,7 +1561,7 @@ class TrManager:
         # The e-mail addresses of the maintainers will be collected to
         # the auxiliary file in the order of translator classes listed
         # in the translator report.
-        fmail = xopen('mailto.txt', 'w')
+        fmail = xopen(os.path.join(self.doc_path, 'mailto.txt'), 'w')
 
         # Write the list of "up-to-date" translator classes.
         if self.upToDateIdLst:
@@ -1720,7 +1724,7 @@ class TrManager:
 
         Fills the dictionary classId -> [(name, e-mail), ...]."""
 
-        fname = os.path.join(self.doc_path, self.maintainersFileName)
+        fname = os.path.join(self.org_doc_path, self.maintainersFileName)
 
         # Include the maintainers file to the group of files checked with
         # respect to the modification time.
@@ -1775,7 +1779,7 @@ class TrManager:
         # Check the last modification time of the template file. It is the
         # last file from the group that decide whether the documentation
         # should or should not be generated.
-        fTplName = os.path.join(self.doc_path, self.languageTplFileName)
+        fTplName = os.path.join(self.org_doc_path, self.languageTplFileName)
         tim = os.path.getmtime(fTplName)
         if tim > self.lastModificationTime:
             self.lastModificationTime = tim


### PR DESCRIPTION
- make `GLOB` for language files consistent with `GLOB` usage in e.g. `src`
- make building of `language.doc ` depending on the language files as well
- don't copy translator and other input files and handle this also in translator.py
- update documentation

(Found after Swedish language was updated and tried to build documentation on a non new directory)