### PR TITLE
Format for size_t (in e.g. warnings)

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9237,7 +9237,7 @@ static void parseFilesMultiThreading(const std::shared_ptr<Entry> &root)
 #endif
   {
     std::size_t numThreads = std::thread::hardware_concurrency();
-    msg("Processing input using %lu threads.\n",numThreads);
+    msg("Processing input using %zu threads.\n",numThreads);
     ThreadPool threadPool(numThreads);
     using FutureType = std::shared_ptr<Entry>;
     std::vector< std::future< FutureType > > results;


### PR DESCRIPTION
From the C standard paragraph 7.21.6.1 The fprintf function
```
z

Specifies that a following d, i, o, u, x, or X conversion specifier applies to a size_t or the
corresponding signed integer type argument; or that a following n conversion specifier
applies to a pointer to a signed integer type corresponding to size_t argument.
```