### PR TITLE
bug_647654 Special command \fn fails when first argument of PHP function is call-by-reference

### DIFF
--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -149,6 +149,7 @@ ID	"$"?([a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*)|(@[0-9]+)
   				  addType(yyscanner);
   				}
 <Start>{B}*"("({ID}"::")*{B}*[&*]({B}*("const"|"volatile"){B}+)?	{
+                                  if (yyextra->insidePHP) REJECT;
   				  addType(yyscanner);
 				  QCString text=yytext;
 				  yyextra->type+=text.stripWhiteSpace();

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6505,10 +6505,17 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					  BEGIN( ReadFuncArgType ) ;
   					}
 <Prototype>"("({ID}"::")*({B}*[&*])+	{
-  					  yyextra->current->type+=yyextra->current->name+yytext;
-					  yyextra->current->name.resize(0);
-  					  BEGIN( PrototypePtr );
-  					}
+					  if (yyextra->insidePHP) // reference parameter
+					  {
+					    REJECT;
+					  }
+					  else
+					  {
+					    yyextra->current->type+=yyextra->current->name+yytext;
+					    yyextra->current->name.resize(0);
+					    BEGIN( PrototypePtr );
+					  }
+					}
 <PrototypePtr>{SCOPENAME}		{
   					  yyextra->current->name+=yytext;
   					}


### PR DESCRIPTION
The handling of `(&$var` for php was not included at all places.
It was handled with the rules (in scanner.l):
```
<FindMembers>"("/{BN}*"::"*{BN}*({TSCOPE}{BN}*"::")*{TSCOPE}{BN}*")"{BN}*"(" | /* typedef void (A<int>::func_t)(args...) */$
<FindMembers>("("({BN}*"::"*{BN}*{TSCOPE}{BN}*"::")*({BN}*[*&\^]{BN}*)+)+ {   /* typedef void (A::*ptr_t)(args...) or int (*fun     c(int))[], the ^ is for Obj-C blocks */$
```