### PR TITLE
issue #7982 invalid latex output of table having data fields with rowspan and colspan

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1144,7 +1144,7 @@ void LatexDocVisitor::visitPost(DocHtmlRow *row)
         if (span->colSpan>1) // row span is also part of a column span
         {
           m_t << "\\multicolumn{" << span->colSpan << "}{";
-          m_t <<  "}|}{}";
+          m_t <<  "c|}{}";
         }
         else // solitary row span
         {


### PR DESCRIPTION
The problem was introduced with fix #751, where an incorrect count was made of the number of `}`