### PR TITLE
Clarify that PostScript output is not supported when USE_PDFLATEX is set to YES.

### DIFF
--- a/doc/output.doc
+++ b/doc/output.doc
@@ -54,6 +54,7 @@ The following output formats are \e indirectly supported by doxygen:
 <dd>Generated from the \LaTeX output by 
     running <code>make ps</code> in the output directory.
     For the best results \ref cfg_pdf_hyperlinks "PDF_HYPERLINKS" should be set to \c NO.
+    PostScript output is not supported if \ref cfg_use_pdflatex "USE_PDFLATEX" is set to \c YES.
 <dt><b>PDF</b>\htmlonly &nbsp;&nbsp;&nbsp;\endhtmlonly
 <dd>Generated from the \LaTeX output by
     running <code>make pdf</code> in the output directory.

--- a/src/config.xml
+++ b/src/config.xml
@@ -2787,6 +2787,7 @@ or
  as specified with \ref cfg_latex_cmd_name "LATEX_CMD_NAME"
  to generate the PDF file directly from the \f$\mbox{\LaTeX}\f$
  files.  Set this option to \c YES, to get a higher quality PDF documentation.
+ Other output formats, such as PostScript, are not supported if this tag is set to YES.
 <br>
  See also section \ref cfg_latex_cmd_name "LATEX_CMD_NAME" for selecting the engine.
 ]]>


### PR DESCRIPTION
In this case doxygen may generate LaTeX source that is not readable by tex(1).

In particular, if collaboration graphs are created, the generated files will
have the extension .pdf, which will not be recognized by tex(1).