### PR TITLE
Respect value of CMAKE_INSTALL_PREFIX when packaging

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -10,6 +10,7 @@
 # - http://archive.ubuntu.com/ubuntu/pool/main/d/doxygen (http://old-releases.ubuntu.com/ubuntu/pool/main/d/doxygen)
 # - http://rpmfind.net/linux/rpm2html/search.php?query=doxygen
 
+set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 set(CPACK_STRIP_FILES      ON)
 set(CPACK_PACKAGE_NAME     ${PROJECT_NAME} )
 set(CPACK_PACKAGE_VERSION  ${VERSION})


### PR DESCRIPTION
Before this commit the value of `CMAKE_INSTALL_PREFIX` was ignored when creating a package with *CMake*/*CPack*. As a result the generated package would always install *Doxygen* to the default location (`/usr/bin` on Linux). `make install` on the other hand would install *Doxygen* to the location specified in variable `CMAKE_INSTALL_PREFIX`.

With this change the value of the variable `CMAKE_INSTALL_PREFIX` will be used when creating the package, too.