### PR TITLE
Wrong protection for C# with multiple definitions on line

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3155,6 +3155,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
   					}
 <FindMembers>[;,]			{ 
   					  QCString oldType = yyextra->current->type;
+  					  Protection oldProtection = yyextra->current->protection;
 					  if (yyextra->current->bodyLine==-1)
 					  {
 					    yyextra->current->bodyLine = yyextra->yyLineNr;
@@ -3197,6 +3198,7 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 					    int i=oldType.length(); 
 					    while (i>0 && (oldType[i-1]=='*' || oldType[i-1]=='&' || oldType[i-1]==' ')) i--;
 					    yyextra->current->type = oldType.left(i);
+					    yyextra->current->protection = oldProtection;
 					  }
 					  else
 					  {


### PR DESCRIPTION
When having  a definition like:
```
/** docu of the namespace */
namespace DoxyGenBugRepro
{
     /** docu of the public class */
     class MultiValueDictionary
     {
        /** docu of the public static member */
        public int CsInt3, CsInt4, CsInt5;
     };
}
```
The variable `CsInt3` is seen as a public attribute, but `CsInt4` and `CsInt5` are seen as private attributes.
Not only the type should be "saved" but also the protection.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5156308/example.tar.gz)
