### PR TITLE
issue #7995 Doxygen doesn't handle very simple example in the .md file

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1272,6 +1272,17 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
   					}
 <*>^{BS}"type"{BS}"="                   { g_code->codify(yytext); }
 
+<*>[\x80-\xFF]*                         { // keep utf8 characters together...
+                                          if (g_isFixedForm && yy_my_start > fixedCommentAfter)
+                                          {
+                                            startFontClass("comment");
+                                            codifyLines(yytext);
+                                          }
+                                          else
+                                          {
+                                            g_code->codify(yytext);
+                                          }
+                                        }
 <*>.                                    {
                                           if (g_isFixedForm && yy_my_start > fixedCommentAfter)
                                           {

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -190,6 +190,9 @@ commentclose    "\*/"
                         codifyLines(yytext,yyscanner);
                     }
 
+[\x80-\xFF]*        { // keep utf8 characters together...
+                        codifyLines(yytext,yyscanner);
+                    }
 .                   {
                         codifyLines(yytext,yyscanner);
                     }

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1497,6 +1497,9 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
 			   BEGIN(Bases);
                          }
 
+<*>[\x80-\xFF]*          { // keep utf8 characters together...
+                           g_code->codify(vhdlcodeYYtext);
+                         }
 <*>.                     {
                            g_code->codify(vhdlcodeYYtext);
                          }


### PR DESCRIPTION
Besides "keep utf8 characters together..." as done for the C-type parser  in code.l (commit d3d9dd8540ec159de080859c8f34a2581c4147f0) this also has to be done for the Fortran, SQL and VHDL code lexers. The code lexers for python and xml already didn't give errors as they already handled these cases for the example.

Example with other languages: [example.tar.gz](https://github.com/doxygen/doxygen/files/5161372/example.tar.gz)
