### PR TITLE
issue #7996 \ref commands broken in markdown tables

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1986,7 +1986,7 @@ int Markdown::writeTableBlock(const char *data,int size)
       }
       // need at least one space on either side of the cell text in
       // order for doxygen to do other formatting
-      m_out.addStr("> " + cellText + "\\ilinebr </" + cellTag + ">");
+      m_out.addStr("> " + cellText + " \\ilinebr </" + cellTag + ">");
     }
     cellTag = "td";
     cellClass = "class=\"markdownTableBody";


### PR DESCRIPTION
the `\ilinebr` (internal line break) should be properly be separated from previous text.