### PR TITLE
Fortran comments with C comments inside

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1205,7 +1205,7 @@ void convertCppComments(BufStr *inBuf,BufStr *outBuf,const char *fileName)
     warn(yyextra->fileName,ctx->lineNr,"Conditional section%sdoes not have "
 	"a corresponding \\endcond command within this file.",sectionInfo.data());
   }
-  if (yyextra->nestingCount>0 && yyextra->lang!=SrcLangExt_Markdown)
+  if (yyextra->nestingCount>0 && yyextra->lang!=SrcLangExt_Markdown && yyextra->lang!=SrcLangExt_Fortran)
   {
     QCString tmp= "(probable line reference: ";
     bool first = TRUE;


### PR DESCRIPTION
When having a (stripped down) example like:
```
!
!!/*T
!T*/
```
we get a warning like:
```
.../ex11f.F90:4: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (probable line reference: 2, 2)
```
even though Fortran has no nested comments, and certainly doesn't have `/*` as comment signs. So message can be ignored.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5162420/example.tar.gz)


(Found by Fossies in petsc project)