### PR TITLE
Command \ilinebr remained

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1043,6 +1043,12 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 <ClassDocArg1,CategoryDocArg1>.         { // ignore other stuff
                                         }
 
+<ClassDocArg2>{DOCNL}                   {
+                                          //addOutput(yyscanner,'\n');
+                                          //if (*yytext=='\n') yyextra->lineNr++;
+                                          unput('\n');
+                                          BEGIN( Comment );
+                                        }
 <ClassDocArg2>{FILE}|"<>"               { // second argument; include file
                                           yyextra->current->includeFile = yytext;
                                           BEGIN( ClassDocArg3 );
@@ -1050,12 +1056,6 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 <ClassDocArg2>{LC}                      { // line continuation
                                           yyextra->lineNr++;
                                           addOutput(yyscanner,'\n');
-                                        }
-<ClassDocArg2>{DOCNL}                   {
-                                          //addOutput(yyscanner,'\n');
-                                          //if (*yytext=='\n') yyextra->lineNr++;
-                                          unput('\n');
-                                          BEGIN( Comment );
                                         }
 <ClassDocArg2>.                         { // ignore other stuff
                                         }


### PR DESCRIPTION
When having the alias:
```
ALIASES += sbl_add_package_main_class{4}="\addtogroup \1-ref-manual ^^ @{ ^^ \class \2 ^^ \brief \3  \4 ^^ @}"
```
for the comment block:
```
/**
     \sbl_add_package_main_class{Molecular_potential_energy, T_Phi_psi_dihedral_angles_visitor,
      Defines iterator over all successive pairs of dihedrals.,
     \details Defines iterator over all successive pairs of dihedrals.
     \tparam CovalentStructure The type of the input covalent structure
     }
  */
```
we get the warning:
```
warning: the name '\ilinebr' supplied as the argument of the \class, \struct, \union, or \include command is not an input file
```

The problem was that the rule:
```
<ClassDocArg2>{FILE}|"<>"               { // second argument; include file
```
took the `\ilinebr`, the rule:
```
<ClassDocArg2>{DOCNL}                   {
```
should have been checked before.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5167511/example.tar.gz)


(reported as: https://stackoverflow.com/questions/63710433/doxygen-alias-with-arguments-the-classical-linebr-problem)