### PR TITLE
Warning about end of list in brief description after alias `^^` replacement

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -613,6 +613,8 @@ void DefinitionImpl::_setBriefDescription(const char *b,const char *briefFile,in
                          outputLanguage!="Korean";
   QCString brief = b;
   brief = brief.stripWhiteSpace();
+  brief = stripLeadingAndTrailingEmptyLines(brief,briefLine);
+  brief = brief.stripWhiteSpace();
   if (brief.isEmpty()) return;
   uint bl = brief.length();
   if (bl>0 && needsDot) // add punctuation if needed


### PR DESCRIPTION
With the alias:
```
ALIASES += "sbl_add_package_main_class{2}=\brief \1 ^^ \2"
```
and the comment:
```
\sbl_add_package_main_class{Defines, \details dihedrals}
```
we will get the replacement:
```
\brief Defines \ilinebr \details dihedrals
```
but this leads to a number of warnings like:
```
warning: End of list marker found without any preceding list items
```

As the end of the brief description is here `\ilinebr` this is replaced in the definition by `\ilinebr.` (so with a `.`). We first have to strip the artificial newlines at (the beginning and) the end end of the brief description before adding the `.`.

(Found as side effect of https://stackexchange.com/filters/57710/doxygen).

Example: [example.tar,.gz](https://github.com/doxygen/doxygen/files/5168000/example.tar.gz)
