### PR TITLE
Consistency in documentation of used Python versions

### DIFF
--- a/doc/install.doc
+++ b/doc/install.doc
@@ -178,7 +178,7 @@ The next step is to install modern versions of \c bison and \c flex
 (see https://sourceforge.net/projects/winflexbison/. After installation and adding them to
 your `path` rename `win_flex.exe` to `flex.exe` and `win_bison.exe` to `bison.exe`)
 \addindex python
-Furthermore you have to install \c python (version 2.6 or higher, see https://www.python.org).
+Furthermore you have to install \c python (version 2.7 or higher, see https://www.python.org).
 These packages are needed during the compilation process.
 
 Download doxygen's source tarball and put it somewhere (e.g. use <code>c:\\tools</code>)

--- a/doc/translator.py
+++ b/doc/translator.py
@@ -2002,11 +2002,11 @@ class TrManager:
 
 if __name__ == '__main__':
 
-    # The Python 2.6+ or 3.3+ is required.
+    # The Python 2.7+ or 3.3+ is required.
     major = sys.version_info[0]
     minor = sys.version_info[1]
-    if (major == 2 and minor < 6) or (major == 3 and minor < 0):
-        print('Python 2.6+ or Python 3.0+ are required for the script')
+    if (major == 2 and minor < 7) or (major == 3 and minor < 0):
+        print('Python 2.7+ or Python 3.0+ are required for the script')
         sys.exit(1)
 
     # The translator manager builds the Transl objects, parses the related


### PR DESCRIPTION
At some places Python version 2.6 was still mentioned, made uniform to 2.7 everywhere.

(Is already a bit  dubious as of January 1st, 2020 Python 2.7 will reached the end of its life., but still a lot will have Python 2.7 by default).