### PR TITLE
Not always linking in map as maps use name instead of id

### DIFF
--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -460,7 +460,7 @@ bool DotFilePatcher::run() const
         convertMapFile(tt,map->mapFile,map->relPath,map->urlOnly,map->context);
         if (!result.isEmpty())
         {
-          t << "<map name=\"" << map->label << "\" id=\"" << correctId(map->label) << "\">" << endl;
+          t << "<map name=\"" << correctId(map->label) << "\" id=\"" << correctId(map->label) << "\">" << endl;
           t << result;
           t << "</map>" << endl;
         }


### PR DESCRIPTION
The map construct runs apparently not through `id` but through `name` and thus breaking here the possibility to link
Also have `name=` use the `correctId`.

This is a regression on #7840