### PR TITLE
Double "->" in warning in case of trailing return type

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2263,7 +2263,7 @@ QCString argListToString(const ArgumentList &al,bool useCanonicalType,bool showD
   if (al.volatileSpecifier()) result+=" volatile";
   if (al.refQualifier()==RefQualifierLValue) result+=" &";
   else if (al.refQualifier()==RefQualifierRValue) result+=" &&";
-  if (!al.trailingReturnType().isEmpty()) result+=" -> "+al.trailingReturnType();
+  if (!al.trailingReturnType().isEmpty()) result+=al.trailingReturnType();
   if (al.pureSpecifier()) result+=" =0";
   return removeRedundantWhiteSpace(result);
 }


### PR DESCRIPTION
When having the input
```
/*!
 * \brief Performs some side effect
 * \param i1 first                                                                                                                   */
auto side_effect_after(int  i1, int i2) -> void;
```
we get the warning
```
warning: The following parameter of side_effect_after(int i1, int i2) -> -> void is not documented:
```
so a double "->".
The "->" has already been added in scanner.l and defargs.l so shouldn't be added here.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5182197/example.tar.gz)


(also the return type gives a warning, but this is another issue #6442).