### PR TITLE
issue #6442 C++: Trailing return type syntax + void

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4050,7 +4050,7 @@ void MemberDefImpl::warnIfUndocumented() const
     warnIfUndocumentedParams();
   }
 }
-static QCString stripTrailngReturn(const QCString trailRet)
+static QCString stripTrailingReturn(const QCString trailRet)
 {
   QCString ret = trailRet;
 
@@ -4077,7 +4077,7 @@ void MemberDefImpl::detectUndocumentedParams(bool hasParamCommand,bool hasReturn
     const ArgumentList &defArgList=isDocsForDefinition() ?  argumentList() : declArgumentList();
     if (!defArgList.trailingReturnType().isEmpty())
     {
-      QCString strippedTrailingReturn = stripTrailngReturn(defArgList.trailingReturnType());
+      QCString strippedTrailingReturn = stripTrailingReturn(defArgList.trailingReturnType());
       isVoidReturn = (strippedTrailingReturn=="void") || (strippedTrailingReturn.right(5)==" void");
     }
   }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4050,6 +4050,18 @@ void MemberDefImpl::warnIfUndocumented() const
     warnIfUndocumentedParams();
   }
 }
+static QCString stripTrailngReturn(const QCString trailRet)
+{
+  QCString ret = trailRet;
+
+  ret = ret.stripWhiteSpace();
+  if (ret.startsWith("->"))
+  {
+    ret = ret.mid(2).stripWhiteSpace();
+    return ret;
+  }
+  return trailRet;
+}
 
 void MemberDefImpl::detectUndocumentedParams(bool hasParamCommand,bool hasReturnCommand) const
 {
@@ -4058,7 +4070,17 @@ void MemberDefImpl::detectUndocumentedParams(bool hasParamCommand,bool hasReturn
   bool isPython = getLanguage()==SrcLangExt_Python;
   bool isFortran = getLanguage()==SrcLangExt_Fortran;
   bool isFortranSubroutine = isFortran && returnType.find("subroutine")!=-1;
+
   bool isVoidReturn = (returnType=="void") || (returnType.right(5)==" void");
+  if (!isVoidReturn && returnType == "auto")
+  {
+    const ArgumentList &defArgList=isDocsForDefinition() ?  argumentList() : declArgumentList();
+    if (!defArgList.trailingReturnType().isEmpty())
+    {
+      QCString strippedTrailingReturn = stripTrailngReturn(defArgList.trailingReturnType());
+      isVoidReturn = (strippedTrailingReturn=="void") || (strippedTrailingReturn.right(5)==" void");
+    }
+  }
 
   if (!m_impl->hasDocumentedParams && hasParamCommand)
   {


### PR DESCRIPTION
When having:
```
/*!
 * \brief Performs some side effect
 */
auto side_effect_after() -> void {}
```

We get the warning:
```
warning: return type of member side_effect_after is not documented
```
as the trailing return type was not taken into consideration.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5182527/example.tar.gz)
