### PR TITLE
Make testsqlite3.py python script running with python 3

### DIFF
--- a/testing/testsqlite3.py
+++ b/testing/testsqlite3.py
@@ -13,7 +13,7 @@ g_conn=None
 val=[]
 def print_unprocessed_attributes(node):
     for key in node.attrib:
-        print "WARNING: '%s' has unprocessed attr '%s'" % (node.tag,key)
+        print("WARNING: '%s' has unprocessed attr '%s'" % (node.tag,key))
 
 def extract_attribute(node,attribute,pnl):
     if not attribute in node.attrib:
@@ -69,7 +69,7 @@ def process_memberdef(node):
             extract_element(node,chld,q)
 
     for chld in node.getchildren():
-        print "WARNING: '%s' has unprocessed child elem '%s'" % (node.tag,chld.tag)
+        print("WARNING: '%s' has unprocessed child elem '%s'" % (node.tag,chld.tag))
 
     extract_attribute(node,"kind",q)
     extract_attribute(node,"prot",q)
@@ -90,12 +90,12 @@ def process_memberdef(node):
     r=[]
     try:
         r = g_conn.execute(query,val).fetchall()
-    except sqlite3.OperationalError,e:
-        print "SQL_ERROR:%s"%e
+    except(sqlite3.OperationalError,e):
+        print("SQL_ERROR:%s"%e)
 
     del val[:]
     if not len(r) > 0:
-        print "TEST_ERROR: Member not found in SQL DB"
+        print("TEST_ERROR: Member not found in SQL DB")
 
 
 def load_xml(name):
@@ -104,7 +104,7 @@ def load_xml(name):
     for event, elem in context:
         if event == "end" and elem.tag == "memberdef":
             process_memberdef(elem)
-    print "\n== Unprocessed XML =="
+    print("\n== Unprocessed XML ==")
 #    ET.dump(root)
 
 


### PR DESCRIPTION
The testsqlite3.py didn't run under python 3 (found by means of pylint).
Making it runnable under python 2 and python 3.