### PR TITLE
Force first word in table cell to hyphenate

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1307,7 +1307,11 @@ void LatexDocVisitor::visitPost(DocHtmlCell *c)
     setInColSpan(FALSE);
     m_t << "}";
   }
-  if (!c->isLast()) m_t << "&";
+  if (!c->isLast()) {
+    m_t << "&";
+    if (!c->isHeading()) m_t << "\\hspace{0pt}";
+  }
+
 }
 
 void LatexDocVisitor::visitPre(DocInternal *)


### PR DESCRIPTION
Added invisible space before first word in every table cell to allow wraps.
http://sigstp.blogspot.com/2010/09/latex-hyphenate-single-long-words-in.html