### PR TITLE
Incorrect duplicate code for Fortran fixed/free recognition

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1108,45 +1108,6 @@ static void replaceComment(yyscan_t yyscanner,int offset)
   }
 }
 
-// simplified way to know if this is fixed form
-// duplicate in fortrancode.l
-static bool recognizeFixedForm(const char* contents)
-{
-  int column=0;
-  bool skipLine=FALSE;
-
-  for(int i=0;;i++) {
-    column++;
-
-    switch(contents[i]) {
-      case '\n':
-        column=0;
-        skipLine=FALSE;
-        break;
-      case ' ':
-        break;
-      case '\000':
-        return FALSE;
-      case 'C':
-      case 'c':
-      case '*':
-        if(column==1) return TRUE;
-        if(skipLine) break;
-        return FALSE;
-      case '!':
-        if(column>1 && column<7) return FALSE;
-        skipLine=TRUE;
-        break;
-      default:
-        if(skipLine) break;
-        if(column==7) return TRUE;
-        return FALSE;
-    }
-  }
-  return FALSE;
-}
-
-
 /*! This function does three things:
  *  -# It converts multi-line C++ style comment blocks (that are aligned)
  *     to C style comment blocks (if MULTILINE_CPP_IS_BRIEF is set to NO).
@@ -1183,7 +1144,8 @@ void convertCppComments(BufStr *inBuf,BufStr *outBuf,const char *fileName)
   yyextra->isFixedForm = FALSE;
   if (yyextra->lang==SrcLangExt_Fortran)
   {
-    yyextra->isFixedForm = recognizeFixedForm(inBuf->data());
+    FortranFormat fmt = convertFileNameFortranParserCode(fileName);
+    yyextra->isFixedForm = recognizeFixedForm(inBuf->data(),fmt);
   }
 
   if (yyextra->lang==SrcLangExt_Markdown)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10838,14 +10838,14 @@ void parseInput()
       if (!dir.mkdir(outputDirectory))
       {
         err("tag OUTPUT_DIRECTORY: Output directory '%s' does not "
-	    "exist and cannot be created\n",outputDirectory.data());
+            "exist and cannot be created\n",outputDirectory.data());
         cleanUpDoxygen();
         exit(1);
       }
       else
       {
-	msg("Notice: Output directory '%s' does not exist. "
-	    "I have created it for you.\n", outputDirectory.data());
+        msg("Notice: Output directory '%s' does not exist. "
+            "I have created it for you.\n", outputDirectory.data());
       }
       dir.cd(outputDirectory);
     }

--- a/src/fortranscanner.h
+++ b/src/fortranscanner.h
@@ -53,9 +53,6 @@ class FortranOutlineParserFixed : public FortranOutlineParser
     FortranOutlineParserFixed() : FortranOutlineParser(FortranFormat_Fixed) { }
 };
 
-bool recognizeFixedForm(const char* contents, FortranFormat format);
-
 const char* prepassFixedForm(const char* contents, int *hasContLine);
-
 
 #endif

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1498,49 +1498,6 @@ void truncatePrepass(yyscan_t yyscanner,int index)
   yyextra->inputStringPrepass.truncate(index);
 }
 
-// simplified way to know if this is fixed form
-bool recognizeFixedForm(const char* contents, FortranFormat format)
-{
-  int column=0;
-  bool skipLine=FALSE;
-
-  if (format == FortranFormat_Fixed) return TRUE;
-  if (format == FortranFormat_Free)  return FALSE;
-
-  for(int i=0;;i++) {
-    column++;
-
-    switch(contents[i]) {
-      case '\n':
-        column=0;
-        skipLine=FALSE;
-        break;
-      case ' ':
-        break;
-      case '\000':
-        return FALSE;
-      case '#':
-        skipLine=TRUE;
-        break;
-      case 'C':
-      case 'c':
-      case '*':
-        if (column==1) return TRUE;
-        if (skipLine) break;
-        return FALSE;
-      case '!':
-        if (column>1 && column<7) return FALSE;
-        skipLine=TRUE;
-        break;
-      default:
-        if (skipLine) break;
-        if (column>=7) return TRUE;
-        return FALSE;
-    }
-  }
-  return FALSE;
-}
-
 /* This function assumes that contents has at least size=length+1 */
 static void insertCharacter(char *contents, int length, int pos, char c)
 {

--- a/src/parserintf.h
+++ b/src/parserintf.h
@@ -149,18 +149,19 @@ class ParserManager
 
     struct ParserPair
     {
-      ParserPair(OutlineParserFactory opf, std::unique_ptr<CodeParserInterface> cpi)
-        : outlineParserFactory(opf), codeParserInterface(std::move(cpi))
+      ParserPair(OutlineParserFactory opf, std::unique_ptr<CodeParserInterface> cpi, const QCString pn)
+        : outlineParserFactory(opf), codeParserInterface(std::move(cpi)), parserName(pn)
       {
       }
 
       OutlineParserFactory outlineParserFactory;
       std::unique_ptr<CodeParserInterface> codeParserInterface;
+      QCString parserName;
     };
 
     ParserManager(OutlineParserFactory outlineParserFactory,
                   std::unique_ptr<CodeParserInterface> codeParserInterface)
-      : m_defaultParsers(outlineParserFactory,std::move(codeParserInterface))
+      : m_defaultParsers(outlineParserFactory,std::move(codeParserInterface), "")
     {
     }
 
@@ -176,7 +177,7 @@ class ParserManager
                                          std::unique_ptr<CodeParserInterface> codeParserInterface)
     {
       m_parsers.emplace(std::string(name),
-                        ParserPair(outlineParserFactory,std::move(codeParserInterface)));
+                        ParserPair(outlineParserFactory,std::move(codeParserInterface),name));
     }
 
     /** Registers a file \a extension with a parser with name \a parserName.
@@ -214,6 +215,15 @@ class ParserManager
     CodeParserInterface &getCodeParser(const char *extension)
     {
       return *getParsers(extension).codeParserInterface;
+    }
+
+    /** Gets the name of the parser associated with given \a extension.
+     *  If there is no parser explicitly registered for the supplied extension,
+     *  te empty string  will be reurned.
+     */
+    QCString getParserName(const char *extension)
+    {
+      return getParsers(extension).parserName;
     }
 
   private:

--- a/src/util.h
+++ b/src/util.h
@@ -502,4 +502,7 @@ int usedTableLevels();
 void incUsedTableLevels();
 void decUsedTableLevels();
 
+bool recognizeFixedForm(const char* contents, FortranFormat format);
+FortranFormat convertFileNameFortranParserCode(QCString fn);
+
 #endif


### PR DESCRIPTION
There were 2 routines to recognize whether Fortran code was Fixed of Free format code, though the version in `commentcnv.l` didn't take the settings of `EXTENSION_MAPPING` into account which might lead to incorrect recognition of the format, this has been corrected.

The problem can be observed in the (constructed) example ff.missed as here the 2 spaces before the `!` kicked in, giving the wrong format.
example:
```
  !> this is fixed format code, with a mean comment
      program fixed3
      write(*,*)
     1   "the text"
c this is fixed format comment and not corect anymore in the converted free format code
      end program
```
Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5224275/example.tar.gz)

 