### PR TITLE
Added Verbatim code listings usings LaTeX packages: listings & tcolorbox

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2411,7 +2411,7 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
     <option type='string' id='FORMULA_MACROFILE' format='file' defval=''>
       <docs>
 <![CDATA[
- The \c FORMULA_MACROFILE can contain \f$\mbox{\LaTeX}\f$ `\newcommand` and 
+ The \c FORMULA_MACROFILE can contain \f$\mbox{\LaTeX}\f$ `\newcommand` and
  `\renewcommand` commands to create new \f$\mbox{\LaTeX}\f$ commands to be used
  in formulas as building blocks.
  See the section \ref formulas for details.
@@ -2758,6 +2758,13 @@ or
 ]]>
       </docs>
     </option>
+    <option type='bool' id='LATEX_VERBATIM_LISTINGS' defval='0'>
+      <docs>
+<![CDATA[
+ If the \c LATEX_VERBATIM_LISTINGS tag is set to \c YES then doxygen will use verbatim \f$\mbox{\LaTeX}\f$ environment for source code listings. You can redefine it in the \f$\mbox{\LaTeX}\f$ header file (\ref cfg_latex_header "LATEX_HEADER") or in the \ref \f$\mbox{\LaTeX}\f$ stylesheet ( \ref cfg_latex_extra_stylesheet "LATEX_EXTRA_STYLESHEET"). The environment is named \c DoxyVerbatimCode.
+]]>
+      </docs>
+    </option>
     <option type='list' id='LATEX_EXTRA_FILES' format='file' depends='GENERATE_LATEX'>
       <docs>
 <![CDATA[
@@ -2845,7 +2852,7 @@ or
     <option type='string' id='LATEX_EMOJI_DIRECTORY' format='dir' defval='' depends='GENERATE_LATEX'>
       <docs>
 <![CDATA[
- The \c LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute) 
+ The \c LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
  path from which the emoji images will be read.
  If a relative path is entered, it will be relative to the \ref cfg_latex_output "LATEX_OUTPUT"
  directory. If left blank the \ref cfg_latex_output "LATEX_OUTPUT" directory will be used.

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -351,13 +351,22 @@ void LatexDocVisitor::visit(DocVerbatim *s)
   {
     case DocVerbatim::Code:
       {
-        m_t << "\n\\begin{DoxyCode}{" << usedTableLevels() << "}\n";
-	LatexCodeGenerator::setDoxyCodeOpen(TRUE);
-        Doxygen::parserManager->getCodeParser(lang)
-                               .parseCode(m_ci,s->context(),s->text(),langExt,
-                                          s->isExample(),s->exampleFile());
-	LatexCodeGenerator::setDoxyCodeOpen(FALSE);
-        m_t << "\\end{DoxyCode}\n";
+        static bool verbatimListings = Config_getBool(LATEX_VERBATIM_LISTINGS);
+
+        if (verbatimListings) {
+          m_t << "\n\\begin{DoxyVerbatimCode}";
+          m_t << "{" << usedTableLevels() << "}{" << lang << "}\n";
+          m_t << s->text() << "\n";
+          m_t << "\\end{DoxyVerbatimCode}\n";
+        } else {
+          m_t << "\n\\begin{DoxyCode}{" << usedTableLevels() << "}\n";
+          LatexCodeGenerator::setDoxyCodeOpen(TRUE);
+                Doxygen::parserManager->getCodeParser(lang)
+                                      .parseCode(m_ci,s->context(),s->text(),langExt,
+                                                  s->isExample(),s->exampleFile());
+          LatexCodeGenerator::setDoxyCodeOpen(FALSE);
+          m_t << "\\end{DoxyCode}\n";
+        }
       }
       break;
     case DocVerbatim::Verbatim:
@@ -1957,4 +1966,3 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, DocVerbatim *s
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());
 }
-

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -571,6 +571,10 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   {
     t << font;
   }
+
+  // Use better font for listings
+  t << "\\renewcommand{\\ttdefault}{PTMono-TLF}\n";
+
   t << "\\usepackage{amssymb}\n"
        "\\usepackage{sectsty}\n"
        "\\allsectionsfont{%\n"
@@ -2378,5 +2382,3 @@ void LatexGenerator::writeLabel(const char *l,bool isLast)
 void LatexGenerator::endLabels()
 {
 }
-
-

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -20,8 +20,22 @@
 \RequirePackage{amssymb}
 \RequirePackage{stackengine}
 \RequirePackage[normalem]{ulem} % for strikeout, but don't modify emphasis
+\RequirePackage{tcolorbox} % for verbatim listings with line numbers and border
+\RequirePackage[space=true]{accsupp} % non copyable line numbers
+\RequirePackage{fancybox} % For return symbol
+\tcbuselibrary{skins,breakable,listings}
 
 %---------- Internal commands used in this style file ----------------
+
+% Do not copy line numbers in listings
+\newcommand{\noncopynumber}[1]{%
+    \BeginAccSupp{method=escape,ActualText={}}%
+    #1%
+    \EndAccSupp{}%
+}
+
+% Return symbol in verbatim listings
+\newcommand{\return}{\mbox{\scriptsize$\hookleftarrow$}}
 
 \newcommand{\ensurespace}[1]{%
   \begingroup%
@@ -132,6 +146,71 @@
   \settowidth{\CodeWidthChar}{?}%
   \settoheight{\CodeHeightChar}{?}%
 }
+
+% Verbatim listings
+
+\newtcblisting{DoxyVerbatimCode}[2]
+{
+    boxrule=0.4pt,%
+    colback=black!2!white,%
+    enhanced,breakable,%
+    listing only,%
+    top=0mm,%
+    boxsep=0mm,%
+    left=1mm,%
+    listing options={%
+      xleftmargin=0.1cm,%
+      language=,%
+      inputencoding=utf8,%
+      extendedchars=true,%
+      basicstyle=\ttfamily\normalsize,%
+      frame=none,%
+      showspaces=false, showstringspaces=false,%
+      tabsize=1, aboveskip=2mm, belowskip=0mm,%
+      lineskip=2pt, numbers=left, stepnumber=1, numbersep=4mm,%
+      numberstyle=\tiny\noncopynumber,%
+      numberblanklines=false,%
+      breaklines=true, breakatwhitespace=true,prebreak=\return,breakindent=0pt,%
+      texcl=true,%
+      columns=fullflexible,%
+      upquote=true,%
+      keepspaces=true,%
+      literate={></}{}{0\discretionary{>\return}{</}{></}}
+               {","}{}{0\discretionary{",\return}{"}{","}}
+               {','}{}{0\discretionary{',\return}{"}{','}}
+               {//}{}{0\discretionary{//\return}{}{//}}
+               {/>}{}{0\discretionary{/>\return}{}{/>}}
+               {\&}{}{0\discretionary{\&\return}{}{\&}}
+               {;}{}{0\discretionary{;\return}{}{;}}
+               {,}{}{0\discretionary{,\return}{}{,}}
+               {]}{}{0\discretionary{]\return}{}{]}}
+               {/}{}{0\discretionary{/\return}{}{/}}
+               {=}{}{0\discretionary{=\return}{}{=}}
+               {+}{}{0\discretionary{+\return}{}{+}}
+               {)}{}{0\discretionary{)\return}{}{)}}
+               {\}}{}{0\discretionary{\}\return}{}{\}}}
+               {:}{}{0\discretionary{:\return}{}{:}}
+          {*}{{\char42}}1
+          {-}{{\char45}}1
+          {\_}{{\char95}}1
+          {\$}{{\char36}}1
+          {\\}{{\char92}}1
+          {.}{{\char46}}1
+          {\{}{{\char123}}1
+          {\|}{{\char124}}1
+          {\}}{{\char125}}1
+          {/}{/}1
+        {Ö}{{\"O}}1
+        {Ä}{{\"A}}1
+        {Ü}{{\"U}}1
+        {ß}{{\ss}}1
+        {ü}{{\"u}}1
+        {ä}{{\"a}}1
+        {ö}{{\"o}}1
+        {~}{{\selectfont\textasciitilde}}1
+    }
+}
+
 
 % Redefining not defined characters, i.e. "Replacement Character" in tex output.
 \def\ucr{\adjustbox{width=\CodeWidthChar,height=\CodeHeightChar}{\stackinset{c}{}{c}{-.2pt}{%
@@ -372,7 +451,7 @@
 
 % Used for parameters within a detailed function description
 \newenvironment{DoxyParamCaption}{%
-  \renewcommand{\item}[2][]{\\ \hspace*{2.0cm} ##1 {\em ##2}}% 
+  \renewcommand{\item}[2][]{\\ \hspace*{2.0cm} ##1 {\em ##2}}%
 }{%
 }
 


### PR DESCRIPTION
Provided default settings with:

- line numbers
- border around listings
- nice UTF-8 compatible default font (important for Cyrillic and other languages)
- automatic line breaks, possibly in right places, keep readability!

Todo:

- keyword colouring or syntax highlighting (which is easy if we can provide source code language: C, javascript etc)
- copy & paste from PDF should not copy line breaks made by LaTeX.

