### PR TITLE
Line count mismatch for Python

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3234,7 +3234,7 @@ bool CommentScanner::parseCommentBlock(/* in */     OutlineParserInterface *pars
   yyextra->guards = std::stack<GuardedSection>();
   yyextra->langParser     = parser;
   yyextra->current        = curEntry;
-  yyextra->current->docLine = (lineNr > 1 ? lineNr-1: 1);
+  yyextra->current->docLine = (lineNr > 1 ? lineNr : 1);
   if (comment.isEmpty()) return FALSE; // avoid empty strings
   yyextra->inputString    = comment;
   yyextra->inputString.append(" ");

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1323,7 +1323,6 @@ STARTDOCSYMS      "##"
     \n/{B}"#"		{ // continuation of the comment on the next line
       			  yyextra->docBlock+='\n';
 			  yyextra->docBrief = FALSE;
-                          startCommentBlock(yyscanner,FALSE);
 			  incLineNr(yyscanner);
       			}
     [^#\n]+             { // any other stuff
@@ -1627,7 +1626,7 @@ static void handleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief
   }
 
   int position = 0;
-  bool needsEntry;
+  bool needsEntry = false;
   int lineNr = brief ? yyextra->current->briefLine : yyextra->current->docLine;
   Markdown markdown(yyextra->yyFileName,lineNr);
   QCString processedDoc = Config_getBool(MARKDOWN_SUPPORT) ? markdown.process(doc,lineNr) : doc;
@@ -1712,7 +1711,7 @@ static void initSpecialBlock(yyscan_t yyscanner)
   yyextra->docBrief = TRUE;
   yyextra->docBlock.resize(0);
   yyextra->commentIndent = yyextra->curIndent;
-  startCommentBlock(yyscanner,TRUE);
+  startCommentBlock(yyscanner,FALSE);
 }
 
 static void searchFoundDef(yyscan_t yyscanner)


### PR DESCRIPTION
When having an example like:
```
## General \PYgen0 docu
#
#
#
#
# General detail \PYgen1 text
# and more
STYLE_TEMPLATE = r'''
\makeatletter
'''

## General \PYgen2 docu
#
#
#
#
#
# General detail \PYgen3 text
# and more
STYLE_TEMPLATE1 = r'''
\makeatletter
'''
```
with
```
EXTRACT_ALL            = YES
QUIET                  = YES
```
we get the  warnings (removed doubles and sorted):
```
bb.py:1: warning: Found unknown command '\PYgen0'
bb.py:10: warning: Found unknown command '\PYgen1'
bb.py:12: warning: Found unknown command '\PYgen2'
bb.py:23: warning: Found unknown command '\PYgen3'
```
we see here (especially with `PYgen3` a wrong line number.

After fixing the line count in `pyscanner.l` there was for the second block an offset of 1. This was caused by `commentscan.l` introduced with #7960 after correcting this this offset was also gone.
Revisiting the original example of #7960 showed that here here was also an offset of 1 (probably due to a misinterpretation of where the `<tr>` warning should be mentioned), here it is now also correct..

(The original mismatch was shown of Fossies for the Pygments package)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5246961/example.tar.gz)
