### PR TITLE
Miscounting of lines in case of fenced code block

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2264,7 +2264,7 @@ void Markdown::writeFencedCodeBlock(const char *data,const char *lng,
   }
   addStrEscapeUtf8Nbsp(data+blockStart,blockEnd-blockStart);
   m_out.addStr("\n");
-  m_out.addStr("@endcode\n");
+  m_out.addStr("@endcode");
 }
 
 QCString Markdown::processQuotations(const QCString &s,int refIndent)


### PR DESCRIPTION
When we have an example like:
~~~
Page
=======

test text
test text \error1

```
make
```

```
make
```

test text \error2
~~~
we get the warnings:
```
aa.md:5: warning: Found unknown command '\error1'
aa.md:17: warning: Found unknown command '\error2'
```
instead of
```
aa.md:5: warning: Found unknown command '\error1'
aa.md:15: warning: Found unknown command '\error2'
```
this is due to the fact that there are 2 returns in case of a fenced code block, one with the ``endcode` but with the detection of the fenced code block (`isFencedCodeBlock`) it is not "removed".

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5251646/example.tar.gz)
