### PR TITLE
Mismatch documentation and build system

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -209,12 +209,12 @@ if (!-e "../src/${file}.l")
   exit 1;
 }
 system("touch ../src/${file}.l");
-unless (rename "src/CMakeFiles/_doxygen.dir/build.make","src/CMakeFiles/_doxygen.dir/build.make.old") {
-  print STDERR "Error: cannot rename src/CMakeFiles/_doxygen.dir/build.make!\n";
+unless (rename "src/CMakeFiles/doxymain.dir/build.make","src/CMakeFiles/doxymain.dir/build.make.old") {
+  print STDERR "Error: cannot rename src/CMakeFiles/doxymain.dir/build.make!\n";
   exit 1;
 }
-if (open(F,"<src/CMakeFiles/_doxygen.dir/build.make.old")) {
-  unless (open(G,">src/CMakeFiles/_doxygen.dir/build.make")) {
+if (open(F,"<src/CMakeFiles/doxymain.dir/build.make.old")) {
+  unless (open(G,">src/CMakeFiles/doxymain.dir/build.make")) {
     print STDERR "Error: opening file build.make for writing\n";
     exit 1;
   }
@@ -229,10 +229,10 @@ if (open(F,"<src/CMakeFiles/_doxygen.dir/build.make.old")) {
     print G "$_";
   }
   close F;
-  unlink "src/CMakeFiles/_doxygen.dir/build.make.old";
+  unlink "src/CMakeFiles/doxymain.dir/build.make.old";
 }
 else {
-  print STDERR "Warning file src/CMakeFiles/_doxygen.dir/build.make does not exist!\n";
+  print STDERR "Warning file src/CMakeFiles/doxymain.dir/build.make does not exist!\n";
 }
 
 # touch the file


### PR DESCRIPTION
Looks like the documentation update after
> Commit: 10787eed95266bb1a13c892fe4cf5a695dac1559 [10787ee]
> Date: Friday, May 15, 2020 11:28:16 AM
> Refactoring

has not been done.