### PR TITLE
issue #8053 error: Attribute target redefined in SVG

### DIFF
--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -174,6 +174,7 @@ static QCString replaceRef(const QCString &buf,const QCString relPath,
         if (!ref.isEmpty())
         {
           result = externalLinkTarget(true);
+          if (!result.isEmpty())targetAlreadySet=true;
         }
         result+= href+"=\"";
         result+=externalRef(relPath,ref,TRUE);


### PR DESCRIPTION
regression on #7706 (although it has nothing to do with double runs in my opinion as indicated in the title of that issue: " Md5 hash does not match for two different runs") looks like this statement should be present.