### PR TITLE
added support for mingw PRETTY_FUNC

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -59,9 +59,7 @@
 #ifdef ENABLE_TRACING
 #define IOSTREAM      stdout
 #define DATA_BUFSIZE  20
-#ifdef __MINGW32__
-#define PRETTY_FUNC __PRETTY_FUNCTION__
-#elif defined(_WIN32) && !defined(CYGWIN)
+#ifdef defined(_WIN32) && !defined(CYGWIN) && !defined(__MINGW32__)
 #define PRETTY_FUNC __FUNCSIG__
 #else
 #define PRETTY_FUNC __PRETTY_FUNCTION__

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -59,7 +59,7 @@
 #ifdef ENABLE_TRACING
 #define IOSTREAM      stdout
 #define DATA_BUFSIZE  20
-#ifdef defined(_WIN32) && !defined(CYGWIN) && !defined(__MINGW32__)
+#if defined(_WIN32) && !defined(CYGWIN) && !defined(__MINGW32__)
 #define PRETTY_FUNC __FUNCSIG__
 #else
 #define PRETTY_FUNC __PRETTY_FUNCTION__

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -59,7 +59,9 @@
 #ifdef ENABLE_TRACING
 #define IOSTREAM      stdout
 #define DATA_BUFSIZE  20
-#if defined(_WIN32) && !defined(CYGWIN)
+#ifdef __MINGW32__
+#define PRETTY_FUNC __PRETTY_FUNCTION__
+#elif defined(_WIN32) && !defined(CYGWIN)
 #define PRETTY_FUNC __FUNCSIG__
 #else
 #define PRETTY_FUNC __PRETTY_FUNCTION__


### PR DESCRIPTION
Hello
I add an error building using mingw64 as __FUNCSIG__ was not defined and we enter the case to define it. gnu is using __PRETTY_FUNC__ and adding the Preprocessing case solved my problem (not sure it is the most elegant solution though) 
Don't hesitate to make any remark critic 
Thank you 