### PR TITLE
No warning for unbalanced brackets in markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2729,6 +2729,7 @@ void MarkdownOutlineParser::parseInput(const char *fileName,
   }
   int lineNr=1;
 
+  p->commentScanner.enterFile(fileName,lineNr);
   Protection prot=Public;
   bool needsEntry = FALSE;
   int position=0;
@@ -2760,6 +2761,7 @@ void MarkdownOutlineParser::parseInput(const char *fileName,
   {
     root->moveToSubEntryAndKeep(current);
   }
+  p->commentScanner.leaveFile(fileName,lineNr);
 }
 
 void MarkdownOutlineParser::parsePrototype(const char *text)


### PR DESCRIPTION
When we have the input files qq.md.
```
@page xxx0 yyy0
@}
Start of text

@page xxx1 yyy1
@{
Start of text
```
and qqh.h:
```
/**

@page xxxh0 yyyh0
@}
Start of texth

*/
/**

@page xxxh1 yyyh1
@{
Start of texth

*/
```
we get the warnings:
```
qq.md:3: warning: unbalanced grouping commands
qqh.h:4: warning: unbalanced grouping commands
qqh.h:15: warning: end of file with unbalanced grouping commands
```
so we are missing
```
qq.md:9: warning: end of file with unbalanced grouping commands
```
due to the fact that the closing routine was not called (also the open routine was not called, always good to call it the set variables to their proper values.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5284124/example.tar.gz)

Based on the question: https://stackoverflow.com/q/64052923/1657886

Note: for `@page` the `@{` etc. don't make a lot of sense but the problem will also occur with commands where `@{` makes sense.
