### PR TITLE
Incorrect sorting of reflist items

### DIFF
--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -60,7 +60,7 @@ void RefList::generatePage()
 
   std::sort(m_entries.begin(),m_entries.end(),
             [](std::unique_ptr<RefItem> &left,std::unique_ptr<RefItem> &right)
-            { return qstricmp(left->title(),left->title()); });
+            { return qstricmp(left->title(),right->title()) < 0; });
   //RefItem *item;
   QCString doc;
   int cnt = 0;


### PR DESCRIPTION
When having an example like:
```
/// \file

/** \xrefitem my_errors "err2" "ERR1" ERROR 101*/
#define MY_ERR_CANNOT_OPEN_FILE 101

/** \xrefitem my_errors "err2" "ERR2" ERROR 102*/
#define MY_ERR_CANNOT_CLOSE_FILE 102

/** \xrefitem my_errors "err2" "ERR1a" ERROR 101a*/
#define MY_ERR_CANNOT_OPEN_FILE3 103

/** \xrefitem my_errors "err2" "ERR2a" ERROR 102a*/
#define MY_ERR_CANNOT_CLOSE_FILE4 104
```
the sorting should be done on the part `MY_ERR_CANNOT_...` but no sorting is done (since 1.8.18) as:
- call to `qstricmp` contains twice the same value
- a boolean value should be the result of the compare but in fact an integer value was returned

This problem is most likely a regression due to
```
Commit: aca13723a9373a1080ca7f108e7be0905b9ae793 [aca1372]
Date: Thursday, February 27, 2020 10:38:22 PM
Restructure the way RefLists are handled
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5298482/example.tar.gz)
