### PR TITLE
Warning in internal documentation

### DIFF
--- a/src/clangparser.h
+++ b/src/clangparser.h
@@ -30,7 +30,7 @@ class ClangTUParser
     void parse();
 
     /** Switches to another file within the translation unit started with start().
-     *  @param[in] fileName The name of the file to switch to.
+     *  @param[in] fd The file definition with the name of the file to switch to.
      */
     void switchToFile(FileDef *fd);
 


### PR DESCRIPTION
The internal documentation gives warning:
```
.../src/clangparser.h:33: warning: argument 'fileName' of command @param is not found in the argument list of ClangTUParser::switchToFile(FileDef *fd)
.../src/clangparser.h:35: warning: The following parameter of ClangTUParser::switchToFile(FileDef *fd) is not documented:
  parameter 'fd'
```
this is corrected.

(Note: warning regarding TokenManager is an javaCC upstream problem and corrected in their master).