### PR TITLE
Warning about possible loss of data

### DIFF
--- a/src/template.cpp
+++ b/src/template.cpp
@@ -338,7 +338,7 @@ int TemplateList::release()
 
 uint TemplateList::count() const
 {
-  return p->elems.size();
+  return static_cast<uint>(p->elems.size());
 }
 
 void TemplateList::append(const TemplateVariant &v)


### PR DESCRIPTION
Om 64-bit windows platform we get the warning:
```
src\template.cpp(341): warning C4267: 'return': conversion from 'size_t' to 'uint', possible loss of data
```

Explicit setting conversion..