### PR TITLE
Flush warnings file

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11587,7 +11587,7 @@ void generateOutput()
   generateExampleDocs();
   g_s.end();
 
-  warn_flush(void);
+  warn_flush();
 
   g_s.begin("Generating file sources...\n");
   generateFileSources();

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11587,6 +11587,8 @@ void generateOutput()
   generateExampleDocs();
   g_s.end();
 
+  warn_flush(void);
+
   g_s.begin("Generating file sources...\n");
   generateFileSources();
   g_s.end();
@@ -11691,6 +11693,8 @@ void generateOutput()
 
   if (g_useOutputTemplate) generateOutputViaTemplate();
 
+  warn_flush();
+
   if (generateRtf)
   {
     g_s.begin("Combining RTF output...\n");
@@ -11701,9 +11705,13 @@ void generateOutput()
     g_s.end();
   }
 
+  warn_flush();
+
   g_s.begin("Running plantuml with JAVA...\n");
   PlantumlManager::instance()->run();
   g_s.end();
+
+  warn_flush();
 
   if (Config_getBool(HAVE_DOT))
   {
@@ -11752,6 +11760,9 @@ void generateOutput()
     QDir::setCurrent(oldDir);
     g_s.end();
   }
+
+  warn_flush();
+
   if ( generateHtml &&
        Config_getBool(GENERATE_QHP) &&
       !Config_getString(QHG_LOCATION).isEmpty())

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -279,6 +279,12 @@ void term(const char *fmt, ...)
   exit(1);
 }
 
+void warn_flush(void)
+{
+  fflush(warnFile);
+}
+
+
 void printlex(int dbg, bool enter, const char *lexName, const char *fileName)
 {
   const char *enter_txt = "entering";

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -279,7 +279,7 @@ void term(const char *fmt, ...)
   exit(1);
 }
 
-void warn_flush(void)
+void warn_flush()
 {
   fflush(warnFile);
 }

--- a/src/message.h
+++ b/src/message.h
@@ -35,6 +35,7 @@ extern void err(const char *fmt, ...) PRINTFLIKE(1, 2);
 extern void err_full(const char *file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void term(const char *fmt, ...) PRINTFLIKE(1, 2);
 void initWarningFormat();
+void warn_flush(void);
 
 extern void printlex(int dbg, bool enter, const char *lexName, const char *fileName);
 

--- a/src/message.h
+++ b/src/message.h
@@ -35,7 +35,7 @@ extern void err(const char *fmt, ...) PRINTFLIKE(1, 2);
 extern void err_full(const char *file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void term(const char *fmt, ...) PRINTFLIKE(1, 2);
 void initWarningFormat();
-void warn_flush(void);
+void warn_flush();
 
 extern void printlex(int dbg, bool enter, const char *lexName, const char *fileName);
 


### PR DESCRIPTION
When having a large project the warnings file is buffered but when a long time there are no warnings emitted the last warnings are not yet written.
During testing this is most obvious when the `dot` process starts and one needs the `.dot` files but not the converted files at hat moment one wants to kill the doxygen process but the result is an incomplete warnings file of the warnings that should already be written.

Created a flush function for the warnings file and placed it at a few strategic points.