### PR TITLE
Using f() instead f(void) in C++ , consistency

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -161,7 +161,7 @@ static void format_warn(const char *file,int line,const char *text)
   }
 }
 
-static void handle_warn_as_error(void)
+static void handle_warn_as_error()
 {
   static bool warnAsError = Config_getBool(WARN_AS_ERROR);
   if (warnAsError)

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -196,7 +196,7 @@ int Portable::system(const char *command,const char *args,bool commandHasConsole
 
 }
 
-unsigned int Portable::pid(void)
+unsigned int Portable::pid()
 {
   unsigned int pid;
 #if !defined(_WIN32) || defined(__CYGWIN__)
@@ -322,7 +322,7 @@ FILE *Portable::fopen(const char *fileName,const char *mode)
 #endif
 }
 
-char  Portable::pathSeparator(void)
+char  Portable::pathSeparator()
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   return '\\';
@@ -331,7 +331,7 @@ char  Portable::pathSeparator(void)
 #endif
 }
 
-char  Portable::pathListSeparator(void)
+char  Portable::pathListSeparator()
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   return ';';
@@ -386,7 +386,7 @@ bool Portable::checkForExecutable(const char *fileName)
 #endif
 }
 
-const char *Portable::ghostScriptCommand(void)
+const char *Portable::ghostScriptCommand()
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
     static char *gsexe = NULL;
@@ -410,7 +410,7 @@ const char *Portable::ghostScriptCommand(void)
 #endif
 }
 
-const char *Portable::commandExtension(void)
+const char *Portable::commandExtension()
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
     return ".exe";
@@ -419,7 +419,7 @@ const char *Portable::commandExtension(void)
 #endif
 }
 
-bool Portable::fileSystemIsCaseSensitive(void)
+bool Portable::fileSystemIsCaseSensitive()
 {
 #if defined(_WIN32) || defined(macintosh) || defined(__MACOSX__) || defined(__APPLE__) || defined(__CYGWIN__)
   return FALSE;
@@ -446,17 +446,17 @@ int Portable::pclose(FILE *stream)
   #endif
 }
 
-void Portable::sysTimerStart(void)
+void Portable::sysTimerStart()
 {
   g_time.start();
 }
 
-void Portable::sysTimerStop(void)
+void Portable::sysTimerStop()
 {
   g_sysElapsedTime+=((double)g_time.elapsed())/1000.0;
 }
 
-double Portable::getSysElapsedTime(void)
+double Portable::getSysElapsedTime()
 {
   return g_sysElapsedTime;
 }
@@ -492,7 +492,7 @@ bool Portable::isAbsolutePath(const char *fileName)
  *
  * This routine was inspired by the cause for bug 766059 was that in the Windows path there were forward slashes.
  */
-void Portable::correct_path(void)
+void Portable::correct_path()
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   const char *p = Portable::getenv("PATH");
@@ -511,7 +511,7 @@ void Portable::unlink(const char *fileName)
 #endif
 }
 
-void Portable::setShortDir(void)
+void Portable::setShortDir()
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
   long     length = 0;

--- a/src/portable.h
+++ b/src/portable.h
@@ -20,7 +20,7 @@ typedef off_t portable_off_t;
 namespace Portable
 {
   int            system(const char *command,const char *args,bool commandHasConsole=true);
-  unsigned int   pid(void);
+  unsigned int   pid();
   const char *   getenv(const char *variable);
   void           setenv(const char *variable,const char *value);
   void           unsetenv(const char *variable);
@@ -28,20 +28,20 @@ namespace Portable
   portable_off_t ftell(FILE *f);
   FILE *         fopen(const char *fileName,const char *mode);
   void           unlink(const char *fileName);
-  char           pathSeparator(void);
-  char           pathListSeparator(void);
-  const char *   ghostScriptCommand(void);
-  const char *   commandExtension(void);
+  char           pathSeparator();
+  char           pathListSeparator();
+  const char *   ghostScriptCommand();
+  const char *   commandExtension();
   bool           fileSystemIsCaseSensitive();
   FILE *         popen(const char *name,const char *type);
   int            pclose(FILE *stream);
-  void           sysTimerStart(void);
-  void           sysTimerStop(void);
-  double         getSysElapsedTime(void);
+  void           sysTimerStart();
+  void           sysTimerStop();
+  double         getSysElapsedTime();
   void           sleep(int ms);
   bool           isAbsolutePath(const char *fileName);
-  void           correct_path(void);
-  void           setShortDir(void);
+  void           correct_path();
+  void           setShortDir();
   const char *   strnstr(const char *haystack, const char *needle, size_t haystack_len);
   const char *   devNull();
   bool           checkForExecutable(const char *fileName);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8376,7 +8376,7 @@ bool mainPageHasTitle()
   return Doxygen::mainPage!=0 && Doxygen::mainPage->hasTitle();
 }
 
-QCString getDotImageExtension(void)
+QCString getDotImageExtension()
 {
   QCString imgExt = Config_getEnum(DOT_IMAGE_FORMAT);
   int i= imgExt.find(':'); // strip renderer part when using e.g. 'png:cairo:gd' as format

--- a/src/util.h
+++ b/src/util.h
@@ -475,7 +475,7 @@ bool protectionLevelVisible(Protection prot);
 QCString stripIndentation(const QCString &s);
 void stripIndentation(QCString &doc,const int indentationLevel);
 
-QCString getDotImageExtension(void);
+QCString getDotImageExtension();
 
 bool fileVisibleInIndex(const FileDef *fd,bool &genSourceFile);
 


### PR DESCRIPTION
Seen the discussion in the pull request #8069, for consistency change occurrences of f(void) into f().