### PR TITLE
Give warnings even when EXTRACT_ALL is set

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1299,7 +1299,7 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
 <![CDATA[
  If the \c WARN_IF_UNDOCUMENTED tag is set to \c YES then doxygen will generate warnings
  for undocumented members. If \ref cfg_extract_all "EXTRACT_ALL" is set to \c YES then this flag will
- automatically be disabled.
+ automatically be disabled unless the \ref cfg_warn_extract_all "WARN_EXTRACT_ALL" is also set to \c YES.
 ]]>
       </docs>
     </option>
@@ -1322,7 +1322,8 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
  wrong or incomplete parameter documentation, but not about the absence of
  documentation.
  If \ref cfg_extract_all "EXTRACT_ALL" is set to \c YES then this flag will
- automatically be disabled.
+ automatically be disabled unless the \ref cfg_warn_extract_all "WARN_EXTRACT_ALL"
+ is also set to \c YES.
 ]]>
       </docs>
     </option>
@@ -1354,6 +1355,14 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
  The \c WARN_LOGFILE tag can be used to specify a file to which warning
  and error messages should be written. If left blank the output is written
  to standard error (`stderr`).
+]]>
+      </docs>
+    </option>
+    <option type='bool' id='WARN_EXTRACT_ALL' defval='0' depends='EXTRACT_ALL'>
+      <docs>
+<![CDATA[
+ If the \c WARN_EXTRACT_ALL tag is set to \c YES then doxygen will generate warnings
+ for undocumented members even when \ref cfg_extract_all "EXTRACT_ALL" is set to \c YES.
 ]]>
       </docs>
     </option>

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -6113,7 +6113,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
         {
           if (paramName.isEmpty())
           {
-            if (Config_getBool(WARN_NO_PARAMDOC))
+            if (Config_getBool(WARN_NO_PARAMDOC) || (Config_getBool(EXTRACT_ALL) && Config_getBool(WARN_EXTRACT_ALL)))
             {
               warn_doc_error(g_fileName,doctokenizerYYlineno,"empty 'name' attribute for <param%s> tag.",tagId==XML_PARAM?"":"type");
             }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2683,7 +2683,6 @@ bool MemberDefImpl::isDetailedSectionLinkable() const
          // has user comments
          Doxygen::userComments
          ;
-
   // this is not a global static or global statics should be extracted
   bool staticFilter = getClassDef()!=0 || !isStatic() || extractStatic;
 
@@ -4033,11 +4032,12 @@ void MemberDefImpl::warnIfUndocumented() const
   else
     t="file", d=fd;
   static bool extractAll = Config_getBool(EXTRACT_ALL);
+  static bool warnExtractAll = Config_getBool(WARN_EXTRACT_ALL);
 
   //printf("%s:warnIfUndoc: hasUserDocs=%d isFriendClass=%d protection=%d isRef=%d isDel=%d\n",
   //    name().data(),
   //    hasUserDocumentation(),isFriendClass(),protectionLevelVisible(m_impl->prot),isReference(),isDeleted());
-  if ((!hasUserDocumentation() && !extractAll) &&
+  if ((!hasUserDocumentation() && (!extractAll || warnExtractAll)) &&
       !isFriendClass() &&
       name().find('@')==-1 && d && d->name().find('@')==-1 &&
       protectionLevelVisible(m_impl->prot) &&
@@ -4168,7 +4168,7 @@ void MemberDefImpl::detectUndocumentedParams(bool hasParamCommand,bool hasReturn
 
 void MemberDefImpl::warnIfUndocumentedParams() const
 {
-  if (!Config_getBool(EXTRACT_ALL) &&
+  if ((!Config_getBool(EXTRACT_ALL) || Config_getBool(WARN_EXTRACT_ALL)) &&
       Config_getBool(WARN_IF_UNDOCUMENTED) &&
       Config_getBool(WARN_NO_PARAMDOC) &&
       isFunction() &&

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -222,9 +222,12 @@ void warn_simple(const char *file,int line,const char *text)
 
 void warn_undoc(const char *file,int line,const char *fmt, ...)
 {
+  static bool warnIfUndocumented = Config_getBool(WARN_IF_UNDOCUMENTED);
+  static bool extractAll = Config_getBool(EXTRACT_ALL);
+  static bool warnExtractAll = Config_getBool(WARN_EXTRACT_ALL);
   va_list args;
   va_start(args, fmt);
-  do_warn(Config_getBool(WARN_IF_UNDOCUMENTED), file, line, warning_str, fmt, args);
+  do_warn(warnIfUndocumented || (extractAll && warnExtractAll), file, line, warning_str, fmt, args);
   va_end(args);
 }
 


### PR DESCRIPTION
When `EXTRACT_ALL` is set a number of warnings is suppressed, sometimes  there is a request to see them as well.
To be able to see warnings in case `EXTRACT_ALL` is set the setting `WARN_EXTRACT_ALL` is introduced.

(See e.g. https://stackoverflow.com/questions/64156269/force-doxygen-to-pop-warnings-if-uncommented-c-methods)