### PR TITLE
Incorrect recognition as RCS tag

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -439,6 +439,7 @@ REFWORD4_NOCV  (({SCOPEPRE}*"operator"{OPMASKOP2})|(("::"|"#"){SCOPEPRE}*"operat
 REFWORD4       {REFWORD4_NOCV}{CVSPEC}?
 REFWORD        {FILEMASK}|{LABELID}|{REFWORD2}|{REFWORD3}|{REFWORD4}
 REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
+RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revision"|"Source"|"State")":"[^:\n$][^\n$]*"$"
 
 %option noyywrap
 %option yylineno
@@ -681,7 +682,7 @@ REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
                          g_token->name=yytext;
                          return TK_WORD;
                        }
-<St_Para>"$"{ID}":"[^:\n$][^\n$]*"$" { /* RCS tag */
+<St_Para>{RCSID} { /* RCS tag */
                          QCString tagName(yytext+1);
                          int index=tagName.find(':');
                          g_token->name = tagName.left(index);


### PR DESCRIPTION
When we have a, stripped down, example like:
```
\mainpage the page

<tt>$PATH:</tt>$x86$<tt>bin</tt>
```
we get the warning like:
```
aa.md:4: warning: end of comment block while expecting command </tt>
```
this is due to the fact that `$PATH:</tt>$` is seen as a RCS tag although `PATH` is not a RCS keyword.

Limiting the number of allowed keywords to the real RCS tags (for CVS the list is the same).

See also:
- https://www.gnu.org/software/trans-coord/manual/cvs/cvs.html#Keyword-substitution
- https://www.gnu.org/software/rcs/manual/rcs.html#Keywords

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5322984/example.tar.gz)
