### PR TITLE
Create possibility to show in doxywizard "condensed" settings

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -107,9 +107,11 @@ MainWindow::MainWindow()
   m_saveLog = new QPushButton(tr("Save log..."));
   m_saveLog->setEnabled(false);
   QPushButton *showSettings = new QPushButton(tr("Show configuration"));
+  QPushButton *showCondensedSettings = new QPushButton(tr("Show condensed configuration"));
   runLayout->addWidget(m_run);
   runLayout->addWidget(m_runStatus);
   runLayout->addStretch(1);
+  runLayout->addWidget(showCondensedSettings);
   runLayout->addWidget(showSettings);
   runLayout->addWidget(m_saveLog);
 
@@ -162,6 +164,7 @@ MainWindow::MainWindow()
   connect(m_run,SIGNAL(clicked()),SLOT(runDoxygen()));
   connect(m_launchHtml,SIGNAL(clicked()),SLOT(showHtmlOutput()));
   connect(m_saveLog,SIGNAL(clicked()),SLOT(saveLog()));
+  connect(showCondensedSettings,SIGNAL(clicked()),SLOT(showCondensedSettings()));
   connect(showSettings,SIGNAL(clicked()),SLOT(showSettings()));
   connect(m_expert,SIGNAL(changed()),SLOT(configChanged()));
   connect(m_wizard,SIGNAL(done()),SLOT(selectRunTab()));
@@ -288,7 +291,7 @@ void MainWindow::saveConfig(const QString &fileName)
     return;
   }
   QTextStream t(&f);
-  m_expert->writeConfig(t,false);
+  m_expert->writeConfig(t,false,false);
   updateConfigFileName(fileName);
   m_modified = false;
   updateTitle();
@@ -511,7 +514,7 @@ void MainWindow::runDoxygen()
       return;
     }
     QTextStream t(m_runProcess);
-    m_expert->writeConfig(t,false);
+    m_expert->writeConfig(t,false,false);
     m_runProcess->closeWriteChannel();
 
     if (m_runProcess->state() == QProcess::NotRunning)
@@ -625,7 +628,18 @@ void MainWindow::showSettings()
 {
   QString text;
   QTextStream t(&text);
-  m_expert->writeConfig(t,true);
+  m_expert->writeConfig(t,true,false);
+  m_outputLog->clear();
+  m_outputLog->append(APPQT(text));
+  m_outputLog->ensureCursorVisible();
+  m_saveLog->setEnabled(true);
+}
+
+void MainWindow::showCondensedSettings()
+{
+  QString text;
+  QTextStream t(&text);
+  m_expert->writeConfig(t,true,true);
   m_outputLog->clear();
   m_outputLog->append(APPQT(text));
   m_outputLog->ensureCursorVisible();

--- a/addon/doxywizard/doxywizard.h
+++ b/addon/doxywizard/doxywizard.h
@@ -61,6 +61,7 @@ class MainWindow : public QMainWindow
     void runComplete();
     void showHtmlOutput();
     void saveLog();
+    void showCondensedSettings();
     void showSettings();
     void configChanged();
     void clearRecent();

--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -752,15 +752,18 @@ void Expert::loadConfig(const QString &fileName)
 }
 
 void Expert::saveTopic(QTextStream &t,QDomElement &elem,QTextCodec *codec,
-                       bool brief)
+                       bool brief,bool condensed)
 {
   if (!brief)
   {
     t << endl;
   }
-  t << "#---------------------------------------------------------------------------" << endl;
-  t << "# " << elem.attribute(SA("docs")) << endl;
-  t << "#---------------------------------------------------------------------------" << endl;
+  if (!condensed)
+  {
+    t << "#---------------------------------------------------------------------------" << endl;
+    t << "# " << elem.attribute(SA("docs")) << endl;
+    t << "#---------------------------------------------------------------------------" << endl;
+  }
   // write options...
   QDomElement childElem = elem.firstChildElement();
   while (!childElem.isNull())
@@ -780,24 +783,29 @@ void Expert::saveTopic(QTextStream &t,QDomElement &elem,QTextCodec *codec,
           t << convertToComment(option->templateDocs());
           t << endl;
         }
-        t << name.leftJustified(MAX_OPTION_LENGTH) << "=";
-        if (option && !option->isEmpty())
+        bool toPrint = true;
+        if (option && condensed) toPrint = !option->isDefault();
+        if (toPrint)
         {
-          t << " ";
-          option->writeValue(t,codec);
+          t << name.leftJustified(MAX_OPTION_LENGTH) << "=";
+          if (option && !option->isEmpty())
+          {
+            t << " ";
+            option->writeValue(t,codec);
+          }
+          t << endl;
         }
-        t << endl;
       }
     }
     childElem = childElem.nextSiblingElement();
   }
 }
 
-bool Expert::writeConfig(QTextStream &t,bool brief)
+bool Expert::writeConfig(QTextStream &t,bool brief, bool condensed)
 {
   // write global header
   t << "# Doxyfile " << getDoxygenVersion() << endl << endl;
-  if (!brief)
+  if (!brief && !condensed)
   {
     t << convertToComment(m_header);
   }
@@ -817,7 +825,7 @@ bool Expert::writeConfig(QTextStream &t,bool brief)
   {
     if (childElem.tagName()==SA("group"))
     {
-      saveTopic(t,childElem,codec,brief);
+      saveTopic(t,childElem,codec,brief,condensed);
     }
     childElem = childElem.nextSiblingElement();
   }

--- a/addon/doxywizard/expert.h
+++ b/addon/doxywizard/expert.h
@@ -38,7 +38,7 @@ class Expert : public QSplitter, public DocIntf
     void loadSettings(QSettings *);
     void saveSettings(QSettings *);
     void loadConfig(const QString &fileName);
-    bool writeConfig(QTextStream &t,bool brief);
+    bool writeConfig(QTextStream &t,bool brief,bool condensed);
     QByteArray saveInnerState () const;
     bool restoreInnerState ( const QByteArray & state );
     const QHash<QString,Input*> &modelData() const { return m_options; }
@@ -67,7 +67,7 @@ class Expert : public QSplitter, public DocIntf
 
   private:
     void createTopics(const QDomElement &);
-    void saveTopic(QTextStream &t,QDomElement &elem,QTextCodec *codec,bool brief);
+    void saveTopic(QTextStream &t,QDomElement &elem,QTextCodec *codec,bool brief,bool dondensed);
 
     QSplitter               *m_splitter;
     QTextBrowser            *m_helper;

--- a/addon/doxywizard/input.h
+++ b/addon/doxywizard/input.h
@@ -40,6 +40,7 @@ class Input
     virtual void setEnabled(bool) = 0;
     virtual void updateDependencies() = 0;
     virtual void reset() = 0;
+    virtual bool isDefault() = 0;
     virtual void writeValue(QTextStream &t,QTextCodec *codec) = 0;
     virtual void setTemplateDocs(const QString &docs) = 0;
     virtual bool isEmpty() { return false; };

--- a/addon/doxywizard/inputbool.cpp
+++ b/addon/doxywizard/inputbool.cpp
@@ -112,3 +112,8 @@ void InputBool::writeValue(QTextStream &t,QTextCodec *codec)
     t << codec->fromUnicode(QString::fromLatin1("NO"));
 }
 
+bool InputBool::isDefault()
+{
+  return m_state == m_default;
+}
+

--- a/addon/doxywizard/inputbool.h
+++ b/addon/doxywizard/inputbool.h
@@ -38,6 +38,7 @@ class InputBool : public QObject, public Input
     void addDependency(Input *option) { m_dependencies+=option; }
     void setEnabled(bool);
     void updateDependencies();
+    bool isDefault();
     void writeValue(QTextStream &t,QTextCodec *codec);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
 

--- a/addon/doxywizard/inputint.cpp
+++ b/addon/doxywizard/inputint.cpp
@@ -112,3 +112,8 @@ void InputInt::writeValue(QTextStream &t,QTextCodec *)
   t << m_val;
 }
 
+
+bool InputInt::isDefault()
+{
+  return m_val == m_default;
+}

--- a/addon/doxywizard/inputint.h
+++ b/addon/doxywizard/inputint.h
@@ -41,6 +41,7 @@ class InputInt : public QObject, public Input
     void addDependency(Input *) { Q_ASSERT(false); }
     void setEnabled(bool);
     void updateDependencies() {}
+    bool isDefault();
     void writeValue(QTextStream &t,QTextCodec *codec);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
 

--- a/addon/doxywizard/inputstring.cpp
+++ b/addon/doxywizard/inputstring.cpp
@@ -253,6 +253,11 @@ void InputString::writeValue(QTextStream &t,QTextCodec *codec)
   writeStringValue(t,codec,m_str);
 }
 
+bool InputString::isDefault()
+{
+  return m_str == m_default;
+}
+
 QString InputString::checkEnumVal(const QString &value)
 {
   QString val = value.trimmed().toLower();

--- a/addon/doxywizard/inputstring.h
+++ b/addon/doxywizard/inputstring.h
@@ -57,6 +57,7 @@ class InputString : public QObject, public Input
     void addDependency(Input *) { Q_ASSERT(false); }
     void setEnabled(bool);
     void updateDependencies() {}
+    bool isDefault();
     void writeValue(QTextStream &t,QTextCodec *codec);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     bool isEmpty() { return m_str.isEmpty(); }

--- a/addon/doxywizard/inputstrlist.cpp
+++ b/addon/doxywizard/inputstrlist.cpp
@@ -258,6 +258,11 @@ void InputStrList::writeValue(QTextStream &t,QTextCodec *codec)
   }
 }
 
+bool InputStrList::isDefault()
+{
+  return m_strList==m_default;
+}
+
 bool InputStrList::isEmpty()
 {
   foreach (QString s, m_strList)

--- a/addon/doxywizard/inputstrlist.h
+++ b/addon/doxywizard/inputstrlist.h
@@ -51,6 +51,7 @@ class InputStrList : public QObject, public Input
     void addDependency(Input *) { Q_ASSERT(false); }
     void setEnabled(bool);
     void updateDependencies() {}
+    bool isDefault();
     void writeValue(QTextStream &t,QTextCodec *codec);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     bool isEmpty();


### PR DESCRIPTION
Doxygen has the possibility to show "condensed" (i.e. only show differences from the doxygen default)settings by means of `doxygen -x`.

Creating in the doxygen wizard a button that also can show the "condensed" settings, it is already possible to show all settings.