### PR TITLE
Doxywizard expert page item without settings

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -139,10 +139,14 @@ void Expert::createTopics(const QDomElement &rootElem)
     {
       // Remove _ from a group name like: Source_Browser
       QString name = childElem.attribute(SA("name")).replace(SA("_"),SA(" "));
-      items.append(new QTreeWidgetItem((QTreeWidget*)0,QStringList(name)));
-      QWidget *widget = createTopicWidget(childElem);
-      m_topics[name] = widget;
-      m_topicStack->addWidget(widget);
+      QString setting = childElem.attribute(SA("setting"));
+      if (setting.isEmpty() || IS_SUPPORTED(setting.toLatin1()))
+      {
+        items.append(new QTreeWidgetItem((QTreeWidget*)0,QStringList(name)));
+        QWidget *widget = createTopicWidget(childElem);
+        m_topics[name] = widget;
+        m_topicStack->addWidget(widget);
+      }
     }
     childElem = childElem.nextSiblingElement();
   }


### PR DESCRIPTION
In case of not compiling with Sqlite3 the page in the doxywizard regarding Sqlite3 remains empty. This is a bit strange as there is a setting possible (and is present) to make the group also aware of the compilation settings.