### PR TITLE
issue #8078 Warning and extra text when using Markdown as mainpage

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2661,7 +2661,7 @@ QCString markdownFileNameToId(const QCString &fileName)
   QCString baseFn  = stripFromPath(QFileInfo(fileName).absFilePath().utf8());
   int i = baseFn.findRev('.');
   if (i!=-1) baseFn = baseFn.left(i);
-  QCString baseName = substitute(substitute(substitute(baseFn," ","_"),"/","_"),":","_");
+  QCString baseName = substitute(substitute(substitute(substitute(baseFn," ","_"),"/","_"),":","_"),"@","_");
   //printf("markdownFileNameToId(%s)=md_%s\n",qPrint(fileName),qPrint(baseName));
   return "md_"+baseName;
 }


### PR DESCRIPTION
Also replace the `@` in a label.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5335166/example.tar.gz)
