### PR TITLE
Warnings during compilation of doctokinizer

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -84,7 +84,7 @@ static QStack<DocLexerContext> g_lexerStack;
 
 static int g_yyLineNr = 0;
 
-#define lineCount(s,len) do { for(int i=0;i<len;i++) if (s[i]=='\n') g_yyLineNr++; } while(0)
+#define lineCount(s,len) do { for(int i=0;i<(int)len;i++) if (s[i]=='\n') g_yyLineNr++; } while(0)
 
 
 #if USE_STATE2STRING


### PR DESCRIPTION
With the doctokinizer.l we get the warnings like:
```
doctokenizer.l(502): warning C4018: '<': signed/unsigned mismatch
```

The casting of `(int)` is also used on other places in this file like in `handleHtmlTag`.