### PR TITLE
Adding possibility to add command line options when running doxygen from doxygen wizard

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -108,6 +108,12 @@ MainWindow::MainWindow()
   m_saveLog->setEnabled(false);
   QPushButton *showSettings = new QPushButton(tr("Show configuration"));
   QPushButton *showCondensedSettings = new QPushButton(tr("Show condensed configuration"));
+  // select extra run options
+  m_runOptions = new QLineEdit;
+
+  runTabLayout->addWidget(new QLabel(tr("Step 3: Specify (optional) options for running doxygen")));
+  runTabLayout->addWidget(m_runOptions);
+
   runLayout->addWidget(m_run);
   runLayout->addWidget(m_runStatus);
   runLayout->addStretch(1);
@@ -501,6 +507,9 @@ void MainWindow::runDoxygen()
     m_runProcess->setEnvironment(env);
 
     QStringList args;
+    QStringList runOptions = m_runOptions->text().split(QLatin1Char(' '),Qt::SkipEmptyParts);
+
+    args << runOptions;
     args << QString::fromLatin1("-b"); // make stdout unbuffered
     args << QString::fromLatin1("-");  // read config from stdin
 

--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -507,7 +507,7 @@ void MainWindow::runDoxygen()
     m_runProcess->setEnvironment(env);
 
     QStringList args;
-    QStringList runOptions = m_runOptions->text().split(QLatin1Char(' '),Qt::SkipEmptyParts);
+    QStringList runOptions = m_runOptions->text().split(QLatin1Char(' '),QString::SkipEmptyParts);
 
     args << runOptions;
     args << QString::fromLatin1("-b"); // make stdout unbuffered

--- a/addon/doxywizard/doxywizard.h
+++ b/addon/doxywizard/doxywizard.h
@@ -79,6 +79,7 @@ class MainWindow : public QMainWindow
     bool discardUnsavedChanges(bool saveOption=true);
 
     QLineEdit *m_workingDir;
+    QLineEdit *m_runOptions;
     QPushButton *m_selWorkingDir;
     QPushButton *m_run;
     QPushButton *m_saveLog;


### PR DESCRIPTION
For debugging support questions it is necessary / very useful to be able to give (extra) command line options to the invoked doxygen version.