### PR TITLE
Incorrect counting of markdown verbatim block

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2130,6 +2130,7 @@ int Markdown::writeCodeBlock(const char *data,int size,int refIndent)
   TRACE(data);
   int i=0,end;
   //printf("writeCodeBlock: data={%s}\n",QCString(data).left(size).data());
+  // no need for \ilinebr here as the prvious like was empty and was skipped
   m_out.addStr("@verbatim\n");
   int emptyLines=0;
   while (i<size)
@@ -2164,7 +2165,7 @@ int Markdown::writeCodeBlock(const char *data,int size,int refIndent)
       break;
     }
   }
-  m_out.addStr("@endverbatim\n");
+  m_out.addStr("@endverbatim\\ilinebr ");
   while (emptyLines>0) // write skipped empty lines
   {
     // add empty line


### PR DESCRIPTION
When we have a file aa.md like:
```
Initial text 1

    verbatim text?

Some text \aa5
```
and a file bb.md like
```
Initial text 1

    verbatim text?
Some text \aa4
```
we get the warnings like (with current master, with 1.8.20 it is even further off):
```
aa.md:6: warning: Found unknown command '\aa5'
bb.md:5: warning: Found unknown command '\aa4'
```
instead of
```
aa.md:5: warning: Found unknown command '\aa5'
bb.md:4: warning: Found unknown command '\aa4'
```

This has been corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5348016/example.tar.gz)
