### PR TITLE
Consistency for use class graphs / class diagrams

### DIFF
--- a/addon/doxywizard/wizard.cpp
+++ b/addon/doxywizard/wizard.cpp
@@ -1127,7 +1127,7 @@ Step4::Step4(Wizard *wizard,const QHash<QString,Input*> &modelData)
 
   m_dotGroup = new QGroupBox(tr("Dot graphs to generate"));
     QVBoxLayout *vbox = new QVBoxLayout;
-    m_dotClass=new QCheckBox(tr("Class diagrams"));
+    m_dotClass=new QCheckBox(tr("Class graphs"));
     // CLASS_GRAPH
     m_dotCollaboration=new QCheckBox(tr("Collaboration diagrams"));
     // COLLABORATION_GRAPH


### PR DESCRIPTION
In the GUI the term "Class diagrams" is used although this is linked to the setting `CLASS_GRAPH` and not to the setting `CLASS_DIAGRAMS`.
Changed text in this case for consistency.