### PR TITLE
Miscounting of lines in respect to page command (ATX header)

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2529,6 +2529,7 @@ QCString Markdown::extractPageTitle(QCString &docs,QCString &id, int &prepend)
   }
   if (i<end1 && isAtxHeader(data+i,end1-i,title,id,FALSE)>0)
   {
+    docs+="\n";
     docs+=docs_org.mid(end1);
   }
   else


### PR DESCRIPTION
In case of an ATX header for a page at the beginning of a file (i.e. `#...`) there  is a line miscounting.
Analogous as done for lines type:
```
The page
====
```
in pull request #8056 we have to add an extra newline.

The example shows the differences in the files `aa.md`, `dd.md` and `ff.md`.
Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5359429/example.tar.gz)
