### PR TITLE
Translation function  trCompoundListDescription no entry for SLICE

### DIFF
--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -267,6 +267,10 @@ class TranslatorBrazilian : public TranslatorAdapter_1_8_19
       {
         return "Aqui estão as estruturas de dados, uniões e suas respectivas descrições:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Aqui estão as classes e suas respectivas descrições:";
+      }
       else
       {
         return "Aqui estão as classes, estruturas, uniões e interfaces e suas respectivas descrições:";

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -251,6 +251,10 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
       {
         return "Aquestes són les estructures de dades acompanyades amb breus descripcions:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Aquestes són les classes acompanyades amb breus descripcions:";
+      }
       else
       {
         return "Aquestes són les classes, estructures, "

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -348,13 +348,17 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-    return "Hier folgt die Aufzählung aller Datenstrukturen "
-           "mit einer Kurzbeschreibung:";
+        return "Hier folgt die Aufzählung aller Datenstrukturen "
+               "mit einer Kurzbeschreibung:";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Hier folgt die Aufzählung aller Klassen mit einer Kurzbeschreibung:";
       }
       else
       {
-    return "Hier folgt die Aufzählung aller Klassen, Strukturen, "
-           "Varianten und Schnittstellen mit einer Kurzbeschreibung:";
+        return "Hier folgt die Aufzählung aller Klassen, Strukturen, "
+               "Varianten und Schnittstellen mit einer Kurzbeschreibung:";
       }
     }
 

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -284,6 +284,8 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
 
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C)) {
         return "Her er datastrukturerne med korte beskrivelser:";
+      } else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE)) {
+        return "Her er klasserne med korte beskrivelser:";
       } else {
         return "Her er klasserne, datastrukturerne, "
                "unionerne og grænsefladerne med korte beskrivelser:";

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -252,6 +252,10 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
       {
         return "Jen datumstrukturoj kun mallongaj priskriboj:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Jen la klasoj kun mallongaj priskriboj:";
+      }
       else
       {
         return "Jen la klasoj, strukturoj, kunigoj kaj interfacoj "

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -243,6 +243,10 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
       {
         return "Lista de estructuras con una breve descripción:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Lista de las clases con una breve descripción:";
+      }
       else
       {
        return "Lista de las clases, estructuras, "

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -311,6 +311,11 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
       {
         return "Tässä ovat tietueet lyhyen selitteen kanssa:"; // "Here are the data structures with brief descriptions:"
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Tässä ovat luokat " // "Here are the classes
+             "lyhyen selitteen kanssa:"; // "with brief descriptions:"
+      }
       else
       {
         return "Tässä ovat luokat, tietueet ja " // "Here are the classes, structs and "

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -247,6 +247,10 @@ class TranslatorGreek : public TranslatorAdapter_1_8_15
       {
         return "Ακολουθούν οι δομές δεδομένων με σύντομες περιγραφές:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Ακολουθούν οι κλάσεις με σύντομες περιγραφές:";
+      }
       else
       {
         return "Ακολουθούν οι κλάσεις, οι δομές, "

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -276,6 +276,10 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
       {
         return "Az összes adatszerkezet listája rövid leírásokkal:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Az összes osztály listája rövid leírásokkal:";
+      }
       else
       {
         return "Az összes osztály, struktúra, unió és interfész "

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -234,6 +234,10 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
       {
         return "Berikut ini daftar struktur data, dengan penjelasan singkat:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Berikut ini daftar kelas, dengan penjelasan singkat:";
+      }
       else
       {
         return "Berikut ini daftar kelas, struct, union, dan interface, dengan penjelasan singkat:";

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -291,6 +291,10 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
       {
         return "Queste sono le strutture dati con una loro breve descrizione:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Queste sono le classi con una loro breve descrizione:";
+      }
       else
       {
         return "Queste sono le classi, le struct, le union e le interfacce con una loro breve descrizione:";

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -241,6 +241,10 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
       {
         return "Duomenų struktūros su trumpais aprašymais:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Klasės su trumpais aprašymais:";
+      }
       else
       {
         return "Klasės, struktūros, "

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -256,6 +256,10 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
       {
         return "Šeit ir visas datu struktūras ar īsu aprakstu:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Šeit ir visas klases ar īsu aprakstu:";
+      }
       else
       {
         return "Šeit ir visas klases, struktūras, "

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -236,6 +236,10 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
       {
         return "Список на структури со кратки описи:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Список на класи со кратки описи:";
+      }
       else
       {
         return "Список на класи, структури, унии и интерфејси "

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -111,8 +111,22 @@ class TranslatorDutch : public Translator
       return result;
     }
     QCString trCompoundListDescription()
-    { return "Hieronder volgen de klassen, structs en "
-             "unions met voor elk een korte beschrijving:";
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Hieronder volgen de structs "
+               "met voor elk een korte beschrijving:";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Hieronder volgen de klassen "
+               "met voor elk een korte beschrijving:";
+      }
+      else
+      {
+        return "Hieronder volgen de klassen, structs en "
+               "unions met voor elk een korte beschrijving:";
+      }
     }
     QCString trCompoundMembersDescription(bool extractAll)
     {

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -255,6 +255,10 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
       {
 	return "Her er datastrukturene med korte beskrivelser:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+	return "Her er klasser med korte beskrivelser:";
+      }
       else
       {
 	return "Her er klasser, struct'er, "

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -234,6 +234,10 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
       {
         return "Tutaj znajdują się struktury danych wraz z ich krótkimi opisami:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Tutaj znajdują się klasy wraz z ich krótkimi opisami:";
+      }
       else
       {
         return "Tutaj znajdują się klasy, struktury, "

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -267,6 +267,10 @@ class TranslatorPortuguese : public TranslatorAdapter_1_8_19
       {
         return "Lista das estruturas de dados com uma breve descrição:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Lista de classes com uma breve descrição:";
+      }
       else
       {
         return "Lista de classes, estruturas, uniões e interfaces com uma breve descrição:";

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -254,6 +254,10 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
       {
         return "Lista structurilor de date, cu scurte descrieri:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Lista claselor, cu scurte descrieri:";
+      }
       else
       {
         return "Lista claselor, structurilor, uniunilor şi interfeţelor"

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -212,6 +212,10 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
       {
         return "Структуры данных с их кратким описанием.";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Классы с их кратким описанием.";
+      }
       else
       {
         return "Классы с их кратким описанием.";

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -254,6 +254,10 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
       {
         return "Овде су структуре са кратким описима:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Овде су класе са кратким описима:";
+      }
       else
       {
         return "Овде су класе, структуре, "

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -235,6 +235,10 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
       {
         return "Spisak struktura sa kratkim opisima:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Spisak klasa sa kratkim opisima:";
+      }
       else
       {
         return "Spisak klasa, struktura, unija i interfejsa sa kratkim opisima:";

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -353,6 +353,10 @@ class TranslatorSwedish : public Translator
       {
         return "Här följer datastrukturerna med korta beskrivningar:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Här följer klasserna med korta beskrivningar:";
+      }
       else
       {
         return "Här följer klasserna, strukterna, unionerna och "

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -208,6 +208,10 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
       {
         return  "Структури даних з коротким описом." ;
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return  "Класи з коротким описом." ;
+      }
       else
       {
         return  "Класи, структури, об'єднання та інтерфейси  з коротким описом." ;

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -270,6 +270,10 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
       {
         return "Đây là cấu trúc cơ sở dữ liệu với mô tả tóm tắt:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Đây là các classes với các mô tả tóm tắt:";
+      }
       else
       {
         return "Đây là các classes, structs, "

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -235,6 +235,10 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
       {
         return " Data strukture met kort beskrywings:";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Klasse met kort beskrywings:";
+      }
       else
       {
         return "Klasse, structs, "


### PR DESCRIPTION
A number of languages have no translation in the function `trCompoundListDescription()` in case the `OPTIMIZATION_OUTPUT_SLICE` is set.
Translated as many as possible based on the available strings.