### PR TITLE
Compilation warnings in doxyparse

### DIFF
--- a/addon/doxyparse/doxyparse.cpp
+++ b/addon/doxyparse/doxyparse.cpp
@@ -163,8 +163,8 @@ static void printPrototypeYes() {
 static void printNumberOfLines(int lines) {
   printf("          lines_of_code: %d\n", lines);
 }
-static void printNumberOfArguments(int arguments) {
-  printf("          parameters: %d\n", arguments);
+static void printNumberOfArguments(size_t arguments) {
+  printf("          parameters: %zu\n", arguments);
 }
 static void printUses() {
   printf("          uses:\n");


### PR DESCRIPTION
In doxyparse.cpp we got some compilation warnings (Windows 64-bit compiler) like:
```
doxyparse.cpp(299): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
```
these have been eliminated.