### PR TITLE
issue #8093 Some URLs in fresh/updated Doxyfile are split over two lines

### DIFF
--- a/src/configgen.py
+++ b/src/configgen.py
@@ -62,7 +62,7 @@ def transformDocs(doc):
 	# fallback for not handled
 	doc = re.sub('\\\\ref', '', doc)
 	#<a href="address">description</a> -> description (see: address)
-	doc = re.sub('<a +href="([^"]*)" *>([^<]*)</a>', '\\2 (see: \\1)', doc)
+	doc = re.sub('<a +href="([^"]*)" *>([^<]*)</a>', '\\2 (see: \n\\1)', doc)
 	# LaTeX name as formula -> LaTeX
 	doc = doc.replace("\\f$\\mbox{\\LaTeX}\\f$", "LaTeX")
 	# Other formula's (now just 2) so explicitly mentioned.


### PR DESCRIPTION
Created an explicit split of the line before the http address so the URL will start on a new line in the doxygen configuration file and won't be split anymore (unless the total length of the  URL will be longer than 78 characters but this is in the doxygen settings not the case).
(The other formats: HTML, LaTeX and the help in the doxywizard give still the same output results).