### PR TITLE
Warning about duplicate figure numbers in LaTeX

### DIFF
--- a/doc/manual.sty
+++ b/doc/manual.sty
@@ -40,10 +40,3 @@
 \usepackage{xpatch}
 \xpatchcmd{\part}{plain}{empty}{}{}
 
-% Define caption that is also suitable in a table
-\makeatletter
-\def\doxyfigcaption{%
-\refstepcounter{figure}%
-\@dblarg{\@caption{figure}}}
-\makeatother
-

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -571,6 +571,6 @@
 % Define caption that is also suitable in a table
 \makeatletter
 \def\doxyfigcaption{%
-\refstepcounter{figure}%
+\H@refstepcounter{figure}%
 \@dblarg{\@caption{figure}}}
 \makeatother


### PR DESCRIPTION
In the log file of the generated doxygen manual we see warnings like:
```
pdfTeX warning (ext4): destination with the same identifier (name{figure.22.1})
 has been already used, duplicate ignored

\AtBegShi@Output ...ipout \box \AtBeginShipoutBox
                                                  \fi \fi

```
(this pull request was also triggered by: https://stackoverflow.com/questions/64328597/pdftex-warning-saying-about-duplicate-figures)

The solution is found by means of: https://tex.stackexchange.com/questions/566677/multiple-use-of-figure-number-ext4-warning/  in short:
> The hyperref package patches \caption so \H@refstepcounter is used instead of \refstepcounter.

The definition isn't necessary in `manual.sty` as the `doxygen_manual.tex` includes `doxygen.sty`