### PR TITLE
Space around images in LaTeX output is sometimes a bit large

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -122,6 +122,7 @@
 \usepackage{etoc}
 \etocsettocstyle{\doxytocparskip}{\doxynormalparskip}
 \begin{document}
+\raggedbottom
 \pagenumbering{alph}
 \begin{titlepage}
 \includegraphics[width=\textwidth]{doxygen_logo}

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -774,7 +774,8 @@ static void writeDefaultHeaderPart1(FTextStream &t)
   // End of preamble, now comes the document contents
   t << "%===== C O N T E N T S =====\n"
        "\n"
-       "\\begin{document}\n";
+       "\\begin{document}\n"
+       "\\raggedbottom\n";
   QCString documentPre = theTranslator->latexDocumentPre();
   if (!documentPre.isEmpty())
   {

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -186,9 +186,8 @@
 % (only if caption is specified)
 \newenvironment{DoxyImage}{%
   \begin{figure}[H]%
-    \begin{center}%
+    \centering%
 }{%
-    \end{center}%
   \end{figure}%
 }
 


### PR DESCRIPTION
When we look at images in documents we see for a number of images a big amount of white space around the image.
This is e.g. the case in the doxygen manual at page 99 of the 1.8.20 version.

- using `\raggedbottom` sees to it that the space inside the page is removed (there might be some white space when the next image doesn't fit anymore. (See https://tex.stackexchange.com/questions/566779/placing-figures-on-a-fixed-place-without-lot-of-space-around-it)
- use `\centering` instead of `\begin{center}` as the center environment adds some extra white space (see a comment with the question, on a different subject though: https://stackoverflow.com/questions/64328597/pdftex-warning-saying-about-duplicate-figures#comment113772445_64328597)