### PR TITLE
Incorrect label / name in case regeneration of HTML without regeneration of dot files

### DIFF
--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -239,7 +239,7 @@ void DotGraph::generateCode(FTextStream &t)
       t << "<img src=\"" << relImgName() << "\" border=\"0\" usemap=\"#" << correctId(getMapLabel()) << "\" alt=\"" << getImgAltText() << "\"/>";
       if (!m_noDivTag) t << "</div>";
       t << endl;
-      if (m_regenerate || !insertMapFile(t, absMapName(), m_relPath, getMapLabel()))
+      if (m_regenerate || !insertMapFile(t, absMapName(), m_relPath, correctId(getMapLabel())))
       {
         int mapId = DotManager::instance()->
           createFilePatcher(m_fileName.data())->


### PR DESCRIPTION
This is a further regression on #7840.
In case we regenerate the HTML files but not the image files based on dot we get incorrect labels for the id / name in the HTML output.

Example case: [example.tar.gz](https://github.com/doxygen/doxygen/files/5384336/example.tar.gz)

(found by @doxygen while working on #8091)