### PR TITLE
Miscounting in respect to lists in markdown

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -568,7 +568,6 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
                          }
                        }
 <St_Para>{BLANK}*(\n|"\\ilinebr"){OLISTITEM}     { /* list item on next line */
-                         lineCount(yytext,yyleng);
                          if (!g_markdownSupport || g_insidePre)
                          {
                            REJECT;


### PR DESCRIPTION
When having examples like:
```
Steps
1. \aa2
2. \aa3
3. \aa4
\aa5
```
and
```
Steps
- \bb2
- \bb3
- \bb4
\aa5
```
we get warnings like:
```
.../aa_list.md:3: warning: Found unknown command '\aa2'
.../aa_list.md:4: warning: Found unknown command '\aa3'
.../aa_list.md:5: warning: Found unknown command '\aa4'
.../aa_list.md:6: warning: Found unknown command '\aa5'
.../bb_list.md:3: warning: Found unknown command '\bb2'
.../bb_list.md:4: warning: Found unknown command '\bb3'
.../bb_list.md:5: warning: Found unknown command '\bb4'
.../bb_list.md:6: warning: Found unknown command '\aa5'
```
instead off:
```
.../aa_list.md:2: warning: Found unknown command '\aa2'
.../aa_list.md:3: warning: Found unknown command '\aa3'
.../aa_list.md:4: warning: Found unknown command '\aa4'
.../aa_list.md:5: warning: Found unknown command '\aa5'
.../bb_list.md:2: warning: Found unknown command '\bb2'
.../bb_list.md:3: warning: Found unknown command '\bb3'
.../bb_list.md:4: warning: Found unknown command '\bb4'
.../bb_list.md:5: warning: Found unknown command '\aa5'
```
this is due to the fact that there is a line le counting. In case of REJECT no lineCount should be performed and otherwise just once.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5391075/example.tar.gz)
