### PR TITLE
issue #8105 How do add (multiple files without extension) directory in INPUT field of doxygen configuration file

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -660,7 +660,8 @@ Go to the <a href="commands.html">next</a> section or return to the
 
  <br>Note: For files without extension you can use `no_extension` as a placeholder.
  <br>Note that for custom extensions you also need to set \ref cfg_file_patterns "FILE_PATTERNS" otherwise the
- files are not read by doxygen.
+ files are not read by doxygen. When specifying `no_extension` you should add `*`
+ to the \ref cfg_file_patterns "FILE_PATTERNS".
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
Small explanation added as it is not clear what to use in case of `no_extension` in `FILE_PATTERNS`