### PR TITLE
Miscounting in case of markdown links

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -808,6 +808,7 @@ int Markdown::processLink(const char *data,int,int size)
   }
   contentStart=i;
   int level=1;
+  int nlTotal=0;
   int nl=0;
   // find the matching ]
   while (i<size)
@@ -831,6 +832,8 @@ int Markdown::processLink(const char *data,int,int size)
     }
     i++;
   }
+  nlTotal += nl;
+  nl = 0;
   if (i>=size) return 0; // premature end of comment -> no link
   contentEnd=i;
   convertStringFragment(content,data+contentStart,contentEnd-contentStart);
@@ -843,9 +846,12 @@ int Markdown::processLink(const char *data,int,int size)
   if (i<size && data[i]=='\n') // one newline allowed here
   {
     i++;
+    nl++;
     // skip more whitespace
     while (i<size && data[i]==' ') i++;
   }
+  nlTotal += nl;
+  nl = 0;
 
   bool explicitTitle=FALSE;
   if (i<size && data[i]=='(') // inline link
@@ -854,7 +860,6 @@ int Markdown::processLink(const char *data,int,int size)
     while (i<size && data[i]==' ') i++;
     if (i<size && data[i]=='<') i++;
     linkStart=i;
-    nl=0;
     int braceCount=1;
     while (i<size && data[i]!='\'' && data[i]!='"' && braceCount>0)
     {
@@ -876,6 +881,8 @@ int Markdown::processLink(const char *data,int,int size)
         i++;
       }
     }
+    nlTotal += nl;
+    nl = 0;
     if (i>=size || data[i]=='\n') return 0;
     convertStringFragment(link,data+linkStart,i-linkStart);
     link = link.stripWhiteSpace();
@@ -985,6 +992,8 @@ int Markdown::processLink(const char *data,int,int size)
   {
     return 0;
   }
+  nlTotal += nl;
+  nl = 0;
   if (isToc) // special case for [TOC]
   {
     int toc_level = Config_getInt(TOC_INCLUDE_HEADINGS);
@@ -1066,6 +1075,7 @@ int Markdown::processLink(const char *data,int,int size)
       m_out.addStr("<a href=\"");
       m_out.addStr(link);
       m_out.addStr("\"");
+      for (int i = 0; i < nlTotal; i++) m_out.addStr("\n");
       if (!title.isEmpty())
       {
         m_out.addStr(" title=\"");


### PR DESCRIPTION
When we have simple input files like:
```
Chrome's trace viewer (Catapult) following the
[instructions](
https://chromium.googlesource.com/catapult/+/refs/heads/master/tracing/docs/embedding-trace-viewer.md). This directory contains
the helper files to embed Chrome's trace viewer.

The current resources were generated/copied from
[`Catapult@9508452e18f130c98499cb4c4f1e1efaedee8962`
](
https://chromium.googlesource.com/catapult/+/9508452e18f130c98499cb4c4f1e1efaedee8962).

\aa11
```
or
```
  Add new exported module Text.Pandoc.Writers.AnnotatedTable [API change]
  (#6655, Christian Despres).  This module (which should generally

  \bb3
```
one gets (in the current master version, a5ac10888f6c0b0fc00678f67aa49036b33aa4cf):
```
.../aa.md:8: warning: Found unknown command '\aa11'
.../bb.md:3: warning: Found unknown command '\bb4'
```
instead of
```
.../aa.md:11: warning: Found unknown command '\aa11'
.../bb.md:4: warning: Found unknown command '\bb4'
```
this is due to the fact that the newlines inside the links are not taken into consideration during the conversion.
We can add the extra newlines but have to do this inside the `<...>` as than they are handled correctly later on:
- when adding them before the `<` doxygen sees a newline and will start a new paragraph starting with the link instead of keeping it in its place.
- when adding them after the `>` we can get a warning about `warning: End of list marker found without any preceding list items` when after the closing `)` of the link there is directly a `.`

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5392090/example.tar.gz)
