### PR TITLE
Confusing message for extension mapping for extension with starting dot.

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10533,7 +10533,7 @@ void adjustConfiguration()
       }
       else
       {
-        msg("Adding custom extension mapping: .%s will be treated as language %s\n",
+        msg("Adding custom extension mapping: '%s' will be treated as language '%s'\n",
             ext.data(),language.data());
       }
     }


### PR DESCRIPTION
When having the settings:
```
EXTENSION_MAPPING      = .h=C++ \
                         .inl=C++
```
we get the, confusing, message with 2 dots:

```
Adding custom extension mapping: ..h will be treated as language c++
Adding custom extension mapping: ..inl will be treated as language c++
```
instead of
```
Adding custom extension mapping: '.h' will be treated as language 'c++'
Adding custom extension mapping: '.inl' will be treated as language 'c++'
```
this has been corrected and made inline with the error in case of a non-supported language.