### PR TITLE
Miscounting in case of markdown wanted newline due to spaces at end of line

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2068,7 +2068,7 @@ void Markdown::writeOneLineHeaderOrRuler(const char *data,int size)
       m_out.addStr("</"+hTag+">\n");
     }
   }
-  else // nothing interesting -> just output the line
+  else if (size>0) // nothing interesting -> just output the line
   {
     int tmpSize = size;
     if (data[size-1] == '\n') tmpSize--;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2070,11 +2070,15 @@ void Markdown::writeOneLineHeaderOrRuler(const char *data,int size)
   }
   else // nothing interesting -> just output the line
   {
-    m_out.addStr(data,size);
+    int tmpSize = size;
+    if (data[size-1] == '\n') tmpSize--;
+    m_out.addStr(data,tmpSize);
+    
     if (hasLineBreak(data,size))
     {
-      m_out.addStr("<br>\n");
+      m_out.addStr("<br>");
     }
+    if (tmpSize != size) m_out.addChar('\n');
   }
 }
 


### PR DESCRIPTION
When we have some simple markdown files like with extra spaces (after `\aa2`, `\bb2` and `\ccs2` to give in markdown a newline):

```
First test: 2 extra spaces after first line with error no extra empty lines
\aa2
\aa3
```
and
```
First test: 2 extra spaces after first line with error one extra empty line
\bb2

\bb4
```
and
```
First test: 2 extra spaces after first line with error two extra empty lines
\cc2

\cc5
```
we get warnings like:
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:4: warning: Found unknown command '\aa3'
.../bb.md:2: warning: Found unknown command '\bb2'
.../bb.md:5: warning: Found unknown command '\bb4'
.../cc.md:2: warning: Found unknown command '\cc2'
.../cc.md:6: warning: Found unknown command '\cc5'
```
whilst this should be:
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:3: warning: Found unknown command '\aa3'
.../bb.md:2: warning: Found unknown command '\bb2'
.../bb.md:4: warning: Found unknown command '\bb4'
.../cc.md:2: warning: Found unknown command '\cc2'
.../cc.md:5: warning: Found unknown command '\cc5'
```
This has been corrected by placing the `<br>` straight after the extra spaces and by not adding an extra newline.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5397631/example.tar.gz)
