### PR TITLE
Miscounting in markdown in case of a horizontal ruler.

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2033,7 +2033,7 @@ void Markdown::writeOneLineHeaderOrRuler(const char *data,int size)
   QCString id;
   if (isHRuler(data,size))
   {
-    m_out.addStr("\n<hr>\n");
+    m_out.addStr("<hr>\n");
   }
   else if ((level=isAtxHeader(data,size,header,id,TRUE)))
   {


### PR DESCRIPTION
When having code like:
```
A horizonal ruler by means of underscores
\aa2
____
\aa4

A horizonal ruler by means of hyphens
\bb7
- ---
\bb9

A horizonal ruler by means of asterisks
\cc12
****
\cc14
```
we get wanungs like:
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:5: warning: Found unknown command '\aa4'
.../aa.md:8: warning: Found unknown command '\bb7'
.../aa.md:11: warning: Found unknown command '\bb9'
.../aa.md:14: warning: Found unknown command '\cc12'
.../aa.md:17: warning: Found unknown command '\cc14'
```
instead of
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:4: warning: Found unknown command '\aa4'
.../aa.md:7: warning: Found unknown command '\bb7'
.../aa.md:9: warning: Found unknown command '\bb9'
.../aa.md:12: warning: Found unknown command '\cc12'
.../aa.md:14: warning: Found unknown command '\cc14'
```

This has been fixed.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5397844/example.tar.gz)
