### PR TITLE
Incomplete  documentation in respect to hyphens for horizontal rulers

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -155,7 +155,10 @@ Examples:
     ______
 
 Note that using asterisks in comment blocks does not work. See 
-\ref mddox_stars for details.
+\ref mddox_stars for details.<br>
+Note that when using hyphens and the previous line is not empty you have to
+use at least one whitespace in the sequence of hyphens otherwise it might be
+seen as a level 2 header (see \ref md_headers).
 
 \subsection md_emphasis Emphasis
 


### PR DESCRIPTION
In case of a sequence of hyphens the documentation was incomplete.
(found during implementation of "Miscounting in markdown in case of a horizontal ruler", #8115)