### PR TITLE
Miscounting of line in case of markdown `\ref` image

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -784,7 +784,7 @@ void Markdown::writeMarkdownImage(const char *fmt, bool explicitTitle,
     m_out.addStr(title);
     m_out.addStr("\"");
   }
-  m_out.addStr("\n");
+  m_out.addStr("\\ilinebr");
 }
 
 int Markdown::processLink(const char *data,int,int size)


### PR DESCRIPTION
In case we have:
```
The page
\aa2 Doxygen's Doxygen Documentation: <a href="https://codedocs.xyz/doxygen/doxygen/"><img src="https://codedocs.xyz/doxygen/doxygen.svg"/></a>\aa2
\aa3
\aa4 ![Caption text](@ref https://codedocs.xyz/doxygen/doxygen.svg) \aa4
\aa5

![Caption text](@ref https://codedocs.xyz/doxygen/doxygen.svg)

\aa9
```
we get the warnings:
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:3: warning: Found unknown command '\aa3'
.../aa.md:4: warning: Found unknown command '\aa4'
.../aa.md:8: warning: Found unknown command '\aa4'
.../aa.md:9: warning: Found unknown command '\aa5'
.../aa.md:17: warning: Found unknown command '\aa9'
```
instead of the expected
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:3: warning: Found unknown command '\aa3'
.../aa.md:4: warning: Found unknown command '\aa4'
.../aa.md:4: warning: Found unknown command '\aa4'
.../aa.md:5: warning: Found unknown command '\aa5'
.../aa.md:9: warning: Found unknown command '\aa9'
```
this is due to the fact that the markdown convertor adds some extra line wit `\n` instead of an internal line break `\ilinebr`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5401716/example.tar.gz)
