### PR TITLE
Remove warnings from lexers

### DIFF
--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -77,7 +77,7 @@ static const char *stateToString(int state);
 #undef	YY_INPUT
 #define	YY_INPUT(buf,result,max_size) result=yyread(buf,max_size);
 
-static int yyread(char *buf,int maxSize)
+static yy_size_t yyread(char *buf,int maxSize)
 {
     // no file included
     if (g_includeStack.isEmpty()) 

--- a/src/code.l
+++ b/src/code.l
@@ -101,7 +101,7 @@ struct codeYY_state
   yy_size_t     inputPosition = 0;   //!< read offset during parsing
   int           inputLines = 0;      //!< number of line in the code fragment
   int           yyLineNr = 0;        //!< current line number
-  int           yyColNr = 0;         //!< current column number
+  yy_size_t     yyColNr = 0;         //!< current column number
   bool          needsTermination = FALSE;
 
   bool          exampleBlock = FALSE;

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -141,7 +141,7 @@ struct fortrancodeYY_state
   CodeOutputInterface * code = 0;
 
   const char *  inputString = 0;     //!< the code fragment as text
-  int           inputPosition = 0;   //!< read offset during parsing
+  yy_size_t     inputPosition = 0;   //!< read offset during parsing
   int           inputLines = 0;      //!< number of line in the code fragment
   int           yyLineNr = 0;        //!< current line number
   int           contLineNr = 0;      //!< current, local, line number for continuation determination

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -72,7 +72,7 @@ struct pycodeYY_state
 
   CodeOutputInterface * code = 0;
   const char *  inputString = 0;     //!< the code fragment as text
-  int           inputPosition = 0;   //!< read offset during parsing
+  yy_size_t     inputPosition = 0;   //!< read offset during parsing
   const char *  currentFontClass = 0;
   bool          needsTermination = FALSE;
   const Definition *searchCtx = 0;

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -50,7 +50,7 @@ struct sqlcodeYY_state
 {
      CodeOutputInterface * code;
      const char   *inputString;     //!< the code fragment as text
-     int           inputPosition;   //!< read offset during parsing
+     yy_size_t     inputPosition;   //!< read offset during parsing
      int           inputLines;      //!< number of line in the code fragment
      int           yyLineNr;        //!< current line number
      bool          needsTermination;

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -89,7 +89,7 @@ struct vhdlcodeYY_state
 
   CodeOutputInterface * code = 0;
   const char *  inputString = 0;     //!< the code fragment as text
-  int           inputPosition = 0;   //!< read offset during parsing
+  yy_size_t     inputPosition = 0;   //!< read offset during parsing
   int           inputLines = 0;      //!< number of line in the code fragment
   int           yyLineNr = 0;        //!< current line number
   bool          needsTermination = false;
@@ -136,7 +136,7 @@ static void appStringLower(QCString& qcs,const char* text);
 static void codifyMapLines(yyscan_t yyscanner,const char *text);
 static void writeFuncProto(yyscan_t yyscanner);
 static void writeProcessProto(yyscan_t yyscanner);
-static int  yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 #if USE_STATE2STRING
 static const char *stateToString(int state);
@@ -921,7 +921,7 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
 /*@ ----------------------------------------------------------------------------
  */
 
-static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -56,7 +56,7 @@ struct xmlcodeYY_state
   QCString      parmType;
   QCString      parmName;
   const char *  inputString = 0;     //!< the code fragment as text
-  int           inputPosition = 0;   //!< read offset during parsing
+  yy_size_t     inputPosition = 0;   //!< read offset during parsing
   int           inputLines = 0;      //!< number of line in the code fragment
   int           yyLineNr = 0;        //!< current line number
   bool          needsTermination = false;


### PR DESCRIPTION
Remove warnings (Windows 64 bit compilation) like:
```
warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
```
from the different lexers by making use of more consistent data types.