### PR TITLE
Miscounting lines with markdown backtick section

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2278,7 +2278,7 @@ void Markdown::writeFencedCodeBlock(const char *data,const char *lng,
     m_out.addStr("{"+lang+"}");
   }
   addStrEscapeUtf8Nbsp(data+blockStart,blockEnd-blockStart);
-  m_out.addStr("\n");
+  m_out.addStr(" ");
   m_out.addStr("@endcode");
 }
 


### PR DESCRIPTION
When we have a program like:
```
# test
  ~~~
  npm
  ~~~
  \aa5
  ~~~
  npm ~~~
  \aa8
```
we get the warnings like:
```
.../aa.md:6: warning: Found unknown command '\aa5'
.../aa.md:10: warning: Found unknown command '\aa8'
```
instead of:
```
.../aa.md:5: warning: Found unknown command '\aa5'
.../aa.md:8: warning: Found unknown command '\aa8'
```

This has been corrected.

Note: in the example tildes are used so the backticks show up in the github issue as well.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5421923/example.tar.gz)
