### PR TITLE
Miscounting lines with markdown table

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1933,16 +1933,16 @@ int Markdown::writeTableBlock(const char *data,int size)
     {
       if (row % 2)
       {
-        m_out.addStr("<tr class=\"markdownTableRowOdd\">");
+        m_out.addStr("\n<tr class=\"markdownTableRowOdd\">");
       }
       else
       {
-        m_out.addStr("<tr class=\"markdownTableRowEven\">");
+        m_out.addStr("\n<tr class=\"markdownTableRowEven\">");
       }
     }
     else
     {
-      m_out.addStr("  <tr class=\"markdownTableHead\">");
+      m_out.addStr("\n  <tr class=\"markdownTableHead\">");
     }
     for (int c = 0; c < columns; c++)
     {
@@ -2000,7 +2000,7 @@ int Markdown::writeTableBlock(const char *data,int size)
     }
     cellTag = "td";
     cellClass = "class=\"markdownTableBody";
-    m_out.addStr("  </tr>\n");
+    m_out.addStr("  </tr>");
   }
   m_out.addStr("</table>\n");
 


### PR DESCRIPTION
When we have a program like:
```
# Test1

 | \aa3 |
 | ---- |
 | \aa5 |
\aa6
```
we get the warnings like:
```
.../cc.md:3: warning: Found unknown command '\aa3'
.../cc.md:4: warning: Found unknown command '\aa5'
.../cc.md:6: warning: Found unknown command '\aa6'
```
instead of:
```
.../cc.md:4: warning: Found unknown command '\aa3'
.../cc.md:5: warning: Found unknown command '\aa5'
.../cc.md:6: warning: Found unknown command '\aa6'
```
The external counting was correct, not the internal counting.
This has been corrected.

Example:  [example.tar.gz](https://github.com/doxygen/doxygen/files/5422074/example.tar.gz)
