### PR TITLE
Miscounting lines with markdown blockquote

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2114,14 +2114,14 @@ int Markdown::writeBlockQuote(const char *data,int size)
     {
       for (l=curLevel;l<level;l++)
       {
-        m_out.addStr("<blockquote>\n");
+        m_out.addStr("<blockquote>");
       }
     }
     else if (level<curLevel) // quote level decreased => add end markers
     {
       for (l=level;l<curLevel;l++)
       {
-        m_out.addStr("</blockquote>\n");
+        m_out.addStr("</blockquote>");
       }
     }
     curLevel=level;
@@ -2134,7 +2134,7 @@ int Markdown::writeBlockQuote(const char *data,int size)
   // end of comment within blockquote => add end markers
   for (l=0;l<curLevel;l++)
   {
-    m_out.addStr("</blockquote>\n");
+    m_out.addStr("</blockquote>");
   }
   return i;
 }


### PR DESCRIPTION
When we have a program like:
```
# test
\aa2
  > \aa3
\aa4
```
we get the warnings like:
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:4: warning: Found unknown command '\aa3'
.../aa.md:6: warning: Found unknown command '\aa4'
```
instead of:
```
.../aa.md:2: warning: Found unknown command '\aa2'
.../aa.md:3: warning: Found unknown command '\aa3'
.../aa.md:4: warning: Found unknown command '\aa4'
```
This has been corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5422303/example.tar.gz)
