### PR TITLE
issue #8132 Markdown inclusion of images broken after 39db9f48

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -784,6 +784,10 @@ void Markdown::writeMarkdownImage(const char *fmt, bool explicitTitle,
     m_out.addStr(title);
     m_out.addStr("\"");
   }
+  else
+  {
+    m_out.addStr(" ");// so the line break will not be part of the image name
+  }
   m_out.addStr("\\ilinebr");
 }
 


### PR DESCRIPTION
see to it that the `\ilinebr` cannot be seen as part of the file name (backslashes can be present as path especially in case of windows).