### PR TITLE
issue #8137 Whitespace/Separator required to recognize custom command argument

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6981,7 +6981,7 @@ static QCString replaceAliasArguments(StringUnorderedSet &aliasesProcessed,
         //printf("found marker at %d with len %d and number %d\n",
         //    markerStart-1,markerLen+1,atoi(aliasValue.mid(markerStart,markerLen)));
       }
-      markerStart=0; // outside marker
+      markerStart=(aliasValue.at(i)=='\\' ? i+1 : 0);
       markerEnd=0;
     }
   }


### PR DESCRIPTION
In case the character directly following the number of a substitution marker is a backslash search directly a new substitution pattern