### PR TITLE
issue #8144 Problem with `\\` at end of an ALIASES in the configuration file

### DIFF
--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -396,6 +396,9 @@ static void readIncludeFile(const QString &incName)
 					  }
 					  BEGIN(g_lastState);
   					}
+<GetQuotedString>("\\\\"|"@\\"|"\\@"|"@@") {
+  					  g_tmpString+=yytext;
+  					}
 <GetQuotedString>"\\\""			{
   					  g_tmpString+='"';
   					}

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -922,6 +922,9 @@ static void readIncludeFile(const char *incName)
 					  }
 					  BEGIN(g_lastState);
   					}
+<GetQuotedString>("\\\\"|"@\\"|"\\@"|"@@") {
+  					  g_tmpString+=yytext;
+  					}
 <GetQuotedString>"\\\""			{
   					  g_tmpString+='"';
   					}


### PR DESCRIPTION
In principle a configuration file should not know anything about the doxygen commands, but the handling of the escaped `\` and `@` are an exception of this rule (especially in `ALIASES`).
The mentioned escaped characters were not handled properly.