### PR TITLE
Handling of "Cancel" during "Quit" in doxywizard

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -223,6 +223,10 @@ void MainWindow::quit()
   {
     saveSettings();
   }
+  else
+  {
+    return;
+  }
   QApplication::exit(0);
 }
 


### PR DESCRIPTION
When one hasn't saved ones changes to the settings file and when selection "Quit" in the file menu one gets a message that unsaved changes will  be lost and one has 3 possibilities: "Save", "Discard" and "Cancel". The "Save" and "Discard" work as expected but when selecting "Cancel" the application is also terminated (though one would expect to return to the "GUI"). When using (on Windows) the "X-button"  one gets the same question with possibilities but here one returns to the "GUI" when selecting "Cancel".
This patch sees to it that  when selecting "Cancel" in this case one returns again to the "GUI"