### PR TITLE
Documentation correction for CASE_SENSE_NAMES

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -981,17 +981,20 @@ Go to the <a href="commands.html">next</a> section or return to the
     <option type='bool' id='CASE_SENSE_NAMES' defval='0' altdefval='Portable::fileSystemIsCaseSensitive()'>
       <docs>
 <![CDATA[
- With \c CASE_SENSE_NAMES doxygen will be better able to match the
- capabilities of the underlying file system.
- In case the files system supports files whose name only differs in the
- case used, the option must be set to \c YES to properly deal with such input files
- if they appear in the input, whereas for file systems that are not case
- sensitive the option should be be set to \c NO to properly deal with output files
- for symbols that only differ in case, like two classes one named \c CLASS
- and the other named \c Class and to support references to files without
- having to specify the correct case.
+ With the correct setting of option \c CASE_SENSE_NAMES doxygen will better be able to match the
+ capabilities of the underlying filesystem. 
 
- On Windows (including Cygwin) and Mac users are advised to set this option to \c NO.
+ In case the filesystem is case sensitive (i.e. it supports files in the same directory 
+ whose names only differ in casing), the option must be set to \c YES to properly deal with such files
+ in case they appear in the input. 
+ 
+ For filesystems that are not case sensitive the option should be be set to \c NO to properly 
+ deal with output files written for symbols that only differ in casing, such as for two classes, 
+ one named \c CLASS and the other named \c Class, and to also support references to files without
+ having to specify the exact matching casing.
+
+ On Windows (including Cygwin) and MacOS, users should typically set this option to \c NO,
+ whereas on Linux or other Unix flavors it should typically set to \c YES.
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -994,7 +994,7 @@ Go to the <a href="commands.html">next</a> section or return to the
  having to specify the exact matching casing.
 
  On Windows (including Cygwin) and MacOS, users should typically set this option to \c NO,
- whereas on Linux or other Unix flavors it should typically set to \c YES.
+ whereas on Linux or other Unix flavors it should typically be set to \c YES.
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -981,12 +981,17 @@ Go to the <a href="commands.html">next</a> section or return to the
     <option type='bool' id='CASE_SENSE_NAMES' defval='0' altdefval='Portable::fileSystemIsCaseSensitive()'>
       <docs>
 <![CDATA[
- If the \c CASE_SENSE_NAMES tag is set to \c NO then doxygen
- will only generate file names in lower-case letters. If set to
- \c YES, upper-case letters are also allowed. This is useful if you have
- classes or files whose names only differ in case and if your file system
- supports case sensitive file names. Windows (including Cygwin) and
- Mac users are advised to set this option to \c NO.
+ With \c CASE_SENSE_NAMES doxygen will be better able to match the
+ capabilities of the underlying file system.
+ In case the files system supports files whose name only differs in the
+ case used, the option must be set to \c YES to properly deal with such input files
+ if they appear in the input, whereas for file systems that are not case
+ sensitive the option should be be set to \c NO to properly deal with output files
+ for symbols that only differ in case, like two classes one named \c CLASS
+ and the other named \c Class and to support references to files without
+ having to specify the correct case.
+
+ On Windows (including Cygwin) and Mac users are advised to set this option to \c NO.
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
In issue #8129 the problem of using different case of filenames was addressed, though in the documentation it was not clear what this meant for input files.
This has been corrected (the underlying problem has been handled with different other commits a.o. 2b5a4541fb6f806c02a1f6e65a1ff2610f29751f ).