### PR TITLE
Incorrect checking between default and used values for strList in doxywizard

### DIFF
--- a/addon/doxywizard/inputstrlist.cpp
+++ b/addon/doxywizard/inputstrlist.cpp
@@ -3,8 +3,8 @@
  * Copyright (C) 1997-2019 by Dimitri van Heesch.
  *
  * Permission to use, copy, modify, and distribute this software and its
- * documentation under the terms of the GNU General Public License is hereby 
- * granted. No representations are made about the suitability of this software 
+ * documentation under the terms of the GNU General Public License is hereby
+ * granted. No representations are made about the suitability of this software
  * for any purpose. It is provided "as is" without express or implied warranty.
  * See the GNU General Public License for more details.
  *
@@ -25,7 +25,7 @@
 #include <QTextCodec>
 
 InputStrList::InputStrList( QGridLayout *layout,int &row,
-                            const QString & id, 
+                            const QString & id,
                             const QStringList &sl, ListMode lm,
                             const QString & docs)
   : m_default(sl), m_strList(sl), m_docs(docs), m_id(id)
@@ -50,7 +50,7 @@ InputStrList::InputStrList( QGridLayout *layout,int &row,
   m_lb  = new QListWidget;
   //m_lb->setMinimumSize(400,100);
   foreach (QString s, m_strList) m_lb->addItem(s);
-  
+
   m_brFile=0;
   m_brDir=0;
   if (lm!=ListString)
@@ -60,7 +60,7 @@ InputStrList::InputStrList( QGridLayout *layout,int &row,
       m_brFile = toolBar->addAction(QIcon(QString::fromLatin1(":/images/file.png")),QString(),
                                     this,SLOT(browseFiles()));
       m_brFile->setToolTip(tr("Browse to a file"));
-    } 
+    }
     if (lm&ListDir)
     {
       m_brDir = toolBar->addAction(QIcon(QString::fromLatin1(":/images/folder.png")),QString(),
@@ -78,9 +78,9 @@ InputStrList::InputStrList( QGridLayout *layout,int &row,
 
   m_value = m_strList;
 
-  connect(m_le,   SIGNAL(returnPressed()), 
+  connect(m_le,   SIGNAL(returnPressed()),
           this, SLOT(addString()) );
-  connect(m_lb,   SIGNAL(currentTextChanged(const QString &)), 
+  connect(m_lb,   SIGNAL(currentTextChanged(const QString &)),
           this, SLOT(selectText(const QString &)));
   connect( m_lab, SIGNAL(enter()), SLOT(help()) );
   connect( m_lab, SIGNAL(reset()), SLOT(reset()) );
@@ -154,7 +154,7 @@ void InputStrList::browseFiles()
   QString path = QFileInfo(MainWindow::instance().configFileName()).path();
   QStringList fileNames = QFileDialog::getOpenFileNames();	
 
-  if (!fileNames.isEmpty()) 
+  if (!fileNames.isEmpty())
   {
     QStringList::Iterator it;
     for ( it= fileNames.begin(); it != fileNames.end(); ++it )
@@ -184,7 +184,7 @@ void InputStrList::browseDir()
   QString path = QFileInfo(MainWindow::instance().configFileName()).path();
   QString dirName = QFileDialog::getExistingDirectory();	
 
-  if (!dirName.isNull()) 
+  if (!dirName.isNull())
   {
     QDir dir(path);
     if (!MainWindow::instance().configFileName().isEmpty() && dir.exists())
@@ -228,7 +228,7 @@ void InputStrList::update()
 
 void InputStrList::updateDefault()
 {
-  if (m_strList==m_default || !m_lab->isEnabled())
+  if (isDefault() || !m_lab->isEnabled())
   {
     m_lab->setText(QString::fromLatin1("<qt>")+m_id+QString::fromLatin1("</qt"));
   }
@@ -246,9 +246,9 @@ void InputStrList::reset()
 void InputStrList::writeValue(QTextStream &t,QTextCodec *codec)
 {
   bool first=true;
-  foreach (QString s, m_strList) 
+  foreach (QString s, m_strList)
   {
-    if (!first) 
+    if (!first)
     {
       t << " \\" << endl;
       t << "                         ";
@@ -258,9 +258,48 @@ void InputStrList::writeValue(QTextStream &t,QTextCodec *codec)
   }
 }
 
+#include <QMessageBox>
 bool InputStrList::isDefault()
 {
-  return m_strList==m_default;
+  bool isEq = m_strList==m_default;
+
+  if (!isEq)
+  {
+    isEq = true;
+
+    auto it1 = m_strList.begin();
+    auto it2 = m_default.begin();
+    while (it1!=m_strList.end() && it2!=m_default.end())
+    {
+      // skip over empty values
+      while (it1!=m_strList.end() && (*it1).isEmpty())
+      {
+      ++it1;
+      }
+      while (it2!=m_default.end() && (*it2).isEmpty())
+      {
+        ++it2;
+      }
+      if ((it1!=m_strList.end()) && (it2!=m_default.end()))
+      {
+        if ((*it1).trimmed()!= (*it2).trimmed()) // difference so not the default
+        {
+          isEq=false;
+          break;
+        }
+        ++it1;
+        ++it2;
+      }
+      else if ((it1!=m_strList.end()) || (it2!=m_default.end()))
+      {
+        // one list empty so cannot be the default
+        isEq=false;
+        break;
+      }
+    }
+  }
+
+  return isEq;
 }
 
 bool InputStrList::isEmpty()


### PR DESCRIPTION
In case we use a default doxygen configuration file `doxygen -g` and use this as `doxywizard Doxyfile` we would expect not to see any differences between the used values and the default values, though we see in expert tab that `ABBREVIATE_BRIEF`, `STRIP_FROM_PATH` and `INPUT` don't have the default values  (item is "red"). This can also be observed in the run tab when selecting "Condensed" "Show configuration".
In the `isDefault()` not only the `strList` itself should be tested but also its values.