### PR TITLE
Doxygen crashes on Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -774,6 +774,7 @@ private                                 {
                                              yyterminate();
                                            }
                                            yyextra->subrCurrent.pop_back();
+                                           yyextra->vtype = V_IGNORE;
                                            yy_pop_state(yyscanner) ;
                                         }
 <BlockData>{


### PR DESCRIPTION
When having a Fortran file like:
```
!>  module docu
MODULE test_mod
  INTERFACE
    !> @brief iets
    SUBROUTINE subr_i(this)
      INTEGER this
    END SUBROUTINE subr_i
  END INTERFACE

  !< @brief type brief
  TYPE, PUBLIC :: test_type
    !> docu
    integer i
  END TYPE test_type
END MODULE test_mod
```
this is due to the fact that a incorrect start of comment `!<` is used for the `TYPE` and that initiated because the last `SUBROUTINE` argument does not have any documentation.
The actual cause is that at the end of a subroutine the `vtype` is not properly reset.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5512323/example.tar.gz)
