### PR TITLE
Typo in namespacedef.h

### DIFF
--- a/src/namespacedef.h
+++ b/src/namespacedef.h
@@ -84,7 +84,7 @@ class NamespaceDef : virtual public Definition
     virtual QCString title() const = 0;
     virtual QCString compoundTypeString() const = 0;
 
-    // --- visited administation
+    // --- visited administration
     virtual void setVisited(bool v) = 0;
     virtual bool isVisited() const = 0;
 };


### PR DESCRIPTION
Typo in namespacedef.h as found by Fossies