### PR TITLE
issue #8169 "\emoji heavy_check_mark" produces ✓ instead of ✔️

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -338,7 +338,7 @@ void HtmlDocVisitor::visit(DocEmoji *s)
   const char *res = EmojiEntityMapper::instance()->unicode(s->index());
   if (res)
   {
-    m_t << res;
+    m_t << "<div class=\"emoji\">"<<res<<"</div>";
   }
   else
   {

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1426,6 +1426,12 @@ div.toc li.level4 {
         margin-left: 45px;
 }
 
+div.emoji {
+        /* font family used at the site: https://unicode.org/emoji/charts/full-emoji-list.html
+         * font-family: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", Times, Symbola, Aegyptus, Code2000, Code2001, Code2002, Musica, serif, LastResort;
+         */
+}
+
 .PageDocRTL-title div.toc li.level1 {
   margin-left: 0 !important;
   margin-right: 0;


### PR DESCRIPTION
Create the possibility to change the used font for an emoji (the default is unchanged, but an example is given of how it is used at the site: https://unicode.org/emoji/charts/full-emoji-list.html).