### PR TITLE
XHTML: div tag not possible as part of a p tag.

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -338,7 +338,7 @@ void HtmlDocVisitor::visit(DocEmoji *s)
   const char *res = EmojiEntityMapper::instance()->unicode(s->index());
   if (res)
   {
-    m_t << "<div class=\"emoji\">"<<res<<"</div>";
+    m_t << "<span class=\"emoji\">"<<res<<"</span>";
   }
   else
   {

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1426,7 +1426,7 @@ div.toc li.level4 {
         margin-left: 45px;
 }
 
-div.emoji {
+span.emoji {
         /* font family used at the site: https://unicode.org/emoji/charts/full-emoji-list.html
          * font-family: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", Times, Symbola, Aegyptus, Code2000, Code2001, Code2002, Musica, serif, LastResort;
          */


### PR DESCRIPTION
With test 76 we get a number of messages like:
```
element p: validity error : Element div is not declared in p list of possible children
```

this is a regression on issue #8169 / pull request #8170.
The `<div>` tag is not allowed as child of a `<p>` tag and furthermore in the output when a number of items should be on one line this is not the case anymore.
This all can be corrected by means of using the `<span>` tag instead of the `<div>` tag.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5546672/example.tar.gz)
