### PR TITLE
Missing commands in list of commands documentation

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -144,6 +144,7 @@ documentation:
 \refitem cmdn \\n
 \refitem cmdname \\name
 \refitem cmdnamespace \\namespace
+\refitem cmdnoop \\noop
 \refitem cmdnosubgrouping \\nosubgrouping
 \refitem cmdnote \\note
 \refitem cmdoverload \\overload
@@ -193,6 +194,7 @@ documentation:
 \refitem cmdsnippet \\snippet
 \refitem cmdsnippetdoc \\snippetdoc
 \refitem cmdsnippetlineno \\snippetlineno
+\refitem cmdstatic \\static
 \refitem cmdstartuml \\startuml
 \refitem cmdstruct \\struct
 \refitem cmdsubpage \\subpage


### PR DESCRIPTION
At the top of the chapter describing the commands there is a list with described commands, here the commands:
```
\noop
\static
```
were missing.