### PR TITLE
Silently ignoring unexpected characters in configuration

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -974,7 +974,7 @@ static void readIncludeFile(const char *incName)
 <SkipComment>\\[ \r\t]*\n		{ g_yyLineNr++; BEGIN(Start); }
 <SkipComment,SkipInvalid>.
 <*>\\[ \r\t]*\n				{ g_yyLineNr++; }
-<*>[ \t]
+<*>[ \t\r]
 <*>.                                    { config_warn("ignoring unknown character '%c' at line %d, file %s\n",yytext[0],g_yyLineNr,g_yyFileName.data()); }
 <*>\n					{ g_yyLineNr++ ; }
 

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -972,8 +972,10 @@ static void readIncludeFile(const char *incName)
   					}
 <SkipComment>\n				{ g_yyLineNr++; BEGIN(Start); }
 <SkipComment>\\[ \r\t]*\n		{ g_yyLineNr++; BEGIN(Start); }
+<SkipComment,SkipInvalid>.
 <*>\\[ \r\t]*\n				{ g_yyLineNr++; }
-<*>.
+<*>[ \t]
+<*>.                                    { config_warn("ignoring unknown character '%c' at line %d, file %s\n",yytext[0],g_yyLineNr,g_yyFileName.data()); }
 <*>\n					{ g_yyLineNr++ ; }
 
 %%


### PR DESCRIPTION
When having a doxygen configuration file like:
```
QUIET=YES
@INPUT = file
@UNKNOWN =
@UNKNOWN1
@UNKNOWN 1
@UNK # test
```
we get the warnings (with `doxygen -x`):
```
warning: ignoring unsupported tag 'UNKNOWN' at line 3, file Doxyfile
warning: ignoring unknown tag 'UNKNOWN1' at line 4, file Doxyfile
warning: ignoring unknown tag 'UNKNOWN' at line 5, file Doxyfile
warning: ignoring unknown tag '1' at line 5, file Doxyfile
warning: ignoring unknown tag 'UNK' at line 6, file Doxyfile
# Difference with default Doxyfile 1.9.0 (fa65bb38f81457d00f9c900bb57eb68bea59b1b4)
QUIET                  = YES
INPUT                  = file
```
especially the missing of a warning about the `@` in `@INPUT` can be a bit misleading (it might be that the user wanted to use `@INCLUDE` and and specified `@INPUT`

It would be better to have a warning about a not handled character instead of just ignoring it.

Example: 
[example.tar.gz](https://github.com/doxygen/doxygen/files/5560712/example.tar.gz)
