### PR TITLE
Incorrect line count in case of an error in  msc input

### DIFF
--- a/libmscgen/mscgen_language.y
+++ b/libmscgen/mscgen_language.y
@@ -209,6 +209,7 @@ Msc MscParse(FILE *in)
 
     yyin = in;
 
+    lex_resetparser();
     /* Parse, and check that no errors are found */
     if(yyparse((void *)&m) != 0)
     {

--- a/libmscgen/mscgen_lexer.h
+++ b/libmscgen/mscgen_lexer.h
@@ -56,6 +56,7 @@ Boolean        lex_getutf8(void);
 unsigned long  lex_getlinenum(void);
 char          *lex_getline(void);
 void           lex_destroy(void);
+void           lex_resetparser(void);
 
 #endif /* MSCGEN_LEXER_H */
 

--- a/libmscgen/mscgen_lexer.l
+++ b/libmscgen/mscgen_lexer.l
@@ -234,5 +234,12 @@ Boolean lex_getutf8(void)
     return lex_utf8;
 }
 
+void lex_resetparser()
+{
+  lex_linenum = 1;
+  lex_line = NULL;
+  lex_utf8 = FALSE;
+}
+
 #include "mscgen_lexer.l.h"
 /* END OF FILE */


### PR DESCRIPTION
The variables to store line number etc. are static variables and should be reset on each invocation of the lex msc parser.

Based on the comment https://github.com/doxygen/doxygen/pull/642#issuecomment-731133017 in #642.