### PR TITLE
Better warning in case of error in dot / msc / dia image

### DIFF
--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -26,7 +26,8 @@
 static const int maxCmdLine = 40960;
 
 void writeDiaGraphFromFile(const char *inFile,const char *outDir,
-                           const char *outFile,DiaOutputFormat format)
+                           const char *outFile,DiaOutputFormat format,
+                           const char *srcFile, int srcLine)
 {
   QCString absOutFile = outDir;
   absOutFile+=Portable::pathSeparator();
@@ -65,8 +66,16 @@ void writeDiaGraphFromFile(const char *inFile,const char *outDir,
   Portable::sysTimerStart();
   if ((exitCode=Portable::system(diaExe,diaArgs,FALSE))!=0)
   {
-    err("Problems running %s. Check your installation or look typos in you dia file %s\n",
+    if (srcLine == -1)
+    {
+      err("Problems running %s. Check your installation or look typos in your dia file %s\n",
         diaExe.data(),inFile);
+    }
+    else
+    {
+      err_full(srcFile,srcLine,"Problems running %s. Check your installation or look typos in your dia file %s\n",
+        diaExe.data(),inFile);
+    }
     Portable::sysTimerStop();
     goto error;
   }

--- a/src/dia.h
+++ b/src/dia.h
@@ -24,7 +24,8 @@ class FTextStream;
 enum DiaOutputFormat { DIA_BITMAP , DIA_EPS };
 
 void writeDiaGraphFromFile(const char *inFile,const char *outDir,
-                           const char *outFile,DiaOutputFormat format);
+                           const char *outFile,DiaOutputFormat format,
+                           const char *srcFile, const int srcLine);
 
 #endif
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1255,7 +1255,7 @@ void DocbookDocVisitor::visitPre(DocDotFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  startDotFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
+  startDotFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
 }
 
 void DocbookDocVisitor::visitPost(DocDotFile *df)
@@ -1269,7 +1269,7 @@ void DocbookDocVisitor::visitPre(DocMscFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  startMscFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
+  startMscFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
 }
 
 void DocbookDocVisitor::visitPost(DocMscFile *df)
@@ -1282,7 +1282,7 @@ void DocbookDocVisitor::visitPre(DocDiaFile *df)
 {
 DB_VIS_C
   if (m_hide) return;
-  startDiaFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children());
+  startDiaFile(df->file(),df->width(),df->height(),df->hasCaption(),df->children(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
 }
 
 void DocbookDocVisitor::visitPost(DocDiaFile *df)
@@ -1637,7 +1637,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_BITMAP);
+  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_BITMAP,s->getSrcReferenceFile(),s->getSrcReferenceLine());
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + ".png", s->width(), s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1663,7 +1663,9 @@ void DocbookDocVisitor::startMscFile(const QCString &fileName,
     const QCString &width,
     const QCString &height,
     bool hasCaption,
-    const QList<DocNode> &children
+    const QList<DocNode> &children,
+    const char *s,
+    const int l
     )
 {
 DB_VIS_C
@@ -1679,7 +1681,7 @@ DB_VIS_C
   }
   baseName.prepend("msc_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,s,l);
   m_t << "<para>" << endl;
   visitPreStart(m_t, children, hasCaption, baseName + ".png",  width,  height);
 }
@@ -1702,7 +1704,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DIA_BITMAP);
+  writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DIA_BITMAP,s->getSrcReferenceFile(),s->getSrcReferenceLine());
   visitPreStart(m_t, s->children(), s->hasCaption(), shortName, s->width(),s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1712,7 +1714,9 @@ void DocbookDocVisitor::startDiaFile(const QCString &fileName,
     const QCString &width,
     const QCString &height,
     bool hasCaption,
-    const QList<DocNode> &children
+    const QList<DocNode> &children,
+    const char *s,
+    const int l
     )
 {
 DB_VIS_C
@@ -1728,7 +1732,7 @@ DB_VIS_C
   }
   baseName.prepend("dia_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP);
+  writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP,s,l);
   m_t << "<para>" << endl;
   visitPreStart(m_t, children, hasCaption, baseName + ".png",  width,  height);
 }
@@ -1751,7 +1755,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP);
+  writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP,s->getSrcReferenceFile().data(),s->getSrcReferenceLine());
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + "." + getDotImageExtension(), s->width(),s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1761,7 +1765,9 @@ void DocbookDocVisitor::startDotFile(const QCString &fileName,
     const QCString &width,
     const QCString &height,
     bool hasCaption,
-    const QList<DocNode> &children
+    const QList<DocNode> &children,
+    const char *s,
+    const int l
     )
 {
 DB_VIS_C
@@ -1778,7 +1784,7 @@ DB_VIS_C
   baseName.prepend("dot_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   QCString imgExt = getDotImageExtension();
-  writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP);
+  writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP,s,l);
   m_t << "<para>" << endl;
   visitPreStart(m_t, children, hasCaption, baseName + "." + imgExt,  width,  height);
 }

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -146,15 +146,18 @@ class DocbookDocVisitor : public DocVisitor
     void pushEnabled();
     void popEnabled();
     void startMscFile(const QCString &fileName,const QCString &width,
-    const QCString &height, bool hasCaption,const QList<DocNode> &children);
+                      const QCString &height, bool hasCaption,const QList<DocNode> &children,
+                      const char *s, const int l);
     void endMscFile(bool hasCaption);
     void writeMscFile(const QCString &fileName, DocVerbatim *s);
     void startDiaFile(const QCString &fileName,const QCString &width,
-                      const QCString &height, bool hasCaption,const QList<DocNode> &children);
+                      const QCString &height, bool hasCaption,const QList<DocNode> &children,
+                      const char *s, const int l);
     void endDiaFile(bool hasCaption);
     void writeDiaFile(const QCString &fileName, DocVerbatim *s);
     void startDotFile(const QCString &fileName,const QCString &width,
-    const QCString &height, bool hasCaption,const QList<DocNode> &children);
+                      const QCString &height, bool hasCaption,const QList<DocNode> &children,
+                      const char *s, const int l);
     void endDotFile(bool hasCaption);
     void writeDotFile(const QCString &fileName, DocVerbatim *s);
     void writePlantUMLFile(const QCString &fileName, DocVerbatim *s);

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2736,8 +2736,8 @@ endlink:
 
 //---------------------------------------------------------------------------
 
-DocDotFile::DocDotFile(DocNode *parent,const QCString &name,const QCString &context) :
-      m_name(name), m_relPath(g_relPath), m_context(context)
+DocDotFile::DocDotFile(DocNode *parent,const QCString &name,const QCString &context,const QCString s, const int l) :
+      m_name(name), m_relPath(g_relPath), m_context(context), m_srcFile(s), m_srcLine(l)
 {
   m_parent = parent;
 }
@@ -2773,10 +2773,10 @@ bool DocDotFile::parse()
   return ok;
 }
 
-DocMscFile::DocMscFile(DocNode *parent,const QCString &name,const QCString &context) :
-      m_name(name), m_relPath(g_relPath), m_context(context)
+DocMscFile::DocMscFile(DocNode *parent,const QCString &name,const QCString &context,const QCString s, const int l) :
+      m_name(name), m_relPath(g_relPath), m_context(context), m_srcFile(s), m_srcLine(l)
 {
-  m_parent = parent;
+   m_parent = parent;
 }
 
 bool DocMscFile::parse()
@@ -2812,8 +2812,8 @@ bool DocMscFile::parse()
 
 //---------------------------------------------------------------------------
 
-DocDiaFile::DocDiaFile(DocNode *parent,const QCString &name,const QCString &context) :
-      m_name(name), m_relPath(g_relPath), m_context(context)
+DocDiaFile::DocDiaFile(DocNode *parent,const QCString &name,const QCString &context,const QCString s, const int l) :
+      m_name(name), m_relPath(g_relPath), m_context(context), m_srcFile(s), m_srcLine(l)
 {
   m_parent = parent;
 }
@@ -5095,7 +5095,7 @@ void DocPara::handleFile(const QCString &cmdName)
     return;
   }
   QCString name = g_token->name;
-  T *df = new T(this,name,g_context);
+  T *df = new T(this,name,g_context,g_fileName,getDoctokinizerLineNr());
   if (df->parse())
   {
     m_children.append(df);
@@ -5612,6 +5612,7 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
     case CMD_DOT:
       {
         DocVerbatim *dv = new DocVerbatim(this,g_context,g_token->verb,DocVerbatim::Dot,g_isExample,g_exampleName);
+        dv -> setSrcReference(g_fileName,getDoctokinizerLineNr());
         doctokenizerYYsetStatePara();
         QCString width,height;
         defaultHandleTitleAndSize(CMD_DOT,dv,dv->children(),width,height);
@@ -5628,6 +5629,7 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
     case CMD_MSC:
       {
         DocVerbatim *dv = new DocVerbatim(this,g_context,g_token->verb,DocVerbatim::Msc,g_isExample,g_exampleName);
+        dv -> setSrcReference(g_fileName,getDoctokinizerLineNr());
         doctokenizerYYsetStatePara();
         QCString width,height;
         defaultHandleTitleAndSize(CMD_MSC,dv,dv->children(),width,height);

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -563,6 +563,10 @@ class DocVerbatim : public DocNode
     void setText(const QCString &t)   { m_text=t;   }
     void setWidth(const QCString &w)  { m_width=w;  }
     void setHeight(const QCString &h) { m_height=h; }
+    /* functions to original start of command */
+    void setSrcReference(QCString s, int l) { m_srcFile=s; m_srcLine=l; }
+    QCString getSrcReferenceFile()  { return m_srcFile; }
+    int getSrcReferenceLine()       { return m_srcLine; }
 
   private:
     QCString  m_context;
@@ -576,6 +580,8 @@ class DocVerbatim : public DocNode
     QCString  m_width;
     QCString  m_height;
     QList<DocNode> m_children;
+    QCString  m_srcFile;
+    int       m_srcLine = -1;
 };
 
 
@@ -818,7 +824,7 @@ class DocImage : public CompAccept<DocImage>
 class DocDotFile : public CompAccept<DocDotFile>
 {
   public:
-    DocDotFile(DocNode *parent,const QCString &name,const QCString &context);
+    DocDotFile(DocNode *parent,const QCString &name,const QCString &context,const QCString s, const int l);
     bool parse();
     Kind kind() const          { return Kind_DotFile; }
     QCString name() const       { return m_name; }
@@ -828,6 +834,9 @@ class DocDotFile : public CompAccept<DocDotFile>
     QCString width() const      { return m_width; }
     QCString height() const     { return m_height; }
     QCString context() const    { return m_context; }
+    /* functions to original start of command */
+    QCString getSrcReferenceFile()  { return m_srcFile; }
+    int getSrcReferenceLine()       { return m_srcLine; }
   private:
     QCString  m_name;
     QCString  m_file;
@@ -835,13 +844,15 @@ class DocDotFile : public CompAccept<DocDotFile>
     QCString  m_width;
     QCString  m_height;
     QCString  m_context;
+    QCString  m_srcFile;
+    int       m_srcLine = -1;
 };
 
 /** Node representing a msc file */
 class DocMscFile : public CompAccept<DocMscFile>
 {
   public:
-    DocMscFile(DocNode *parent,const QCString &name,const QCString &context);
+    DocMscFile(DocNode *parent,const QCString &name,const QCString &context,const QCString s, const int l);
     bool parse();
     Kind kind() const          { return Kind_MscFile; }
     QCString name() const      { return m_name; }
@@ -851,6 +862,9 @@ class DocMscFile : public CompAccept<DocMscFile>
     QCString width() const     { return m_width; }
     QCString height() const    { return m_height; }
     QCString context() const   { return m_context; }
+    /* functions to original start of command */
+    QCString getSrcReferenceFile()  { return m_srcFile; }
+    int getSrcReferenceLine()       { return m_srcLine; }
   private:
     QCString  m_name;
     QCString  m_file;
@@ -858,13 +872,15 @@ class DocMscFile : public CompAccept<DocMscFile>
     QCString  m_width;
     QCString  m_height;
     QCString  m_context;
+    QCString  m_srcFile;
+    int       m_srcLine = -1;
 };
 
 /** Node representing a dia file */
 class DocDiaFile : public CompAccept<DocDiaFile>
 {
   public:
-    DocDiaFile(DocNode *parent,const QCString &name,const QCString &context);
+    DocDiaFile(DocNode *parent,const QCString &name,const QCString &context,const QCString s, const int l);
     bool parse();
     Kind kind() const          { return Kind_DiaFile; }
     QCString name() const      { return m_name; }
@@ -874,6 +890,9 @@ class DocDiaFile : public CompAccept<DocDiaFile>
     QCString width() const     { return m_width; }
     QCString height() const    { return m_height; }
     QCString context() const   { return m_context; }
+    /* functions to original start of command */
+    QCString getSrcReferenceFile()  { return m_srcFile; }
+    int getSrcReferenceLine()       { return m_srcLine; }
   private:
     QCString  m_name;
     QCString  m_file;
@@ -881,6 +900,8 @@ class DocDiaFile : public CompAccept<DocDiaFile>
     QCString  m_width;
     QCString  m_height;
     QCString  m_context;
+    QCString  m_srcFile;
+    int       m_srcLine = -1;
 };
 
 /** Node representing a VHDL flow chart */

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -271,7 +271,7 @@ bool DotManager::run() const
 //--------------------------------------------------------------------
 
 void writeDotGraphFromFile(const char *inFile,const char *outDir,
-                           const char *outFile,GraphOutputFormat format)
+                           const char *outFile,GraphOutputFormat format,const char *s, const int l)
 {
   QDir d(outDir);
   if (!d.exists())
@@ -287,17 +287,17 @@ void writeDotGraphFromFile(const char *inFile,const char *outDir,
   DotRunner dotRun(inFile);
   if (format==GOF_BITMAP)
   {
-    dotRun.addJob(Config_getEnum(DOT_IMAGE_FORMAT),absImgName);
+    dotRun.addJob(Config_getEnum(DOT_IMAGE_FORMAT),absImgName,s,l);
   }
   else // format==GOF_EPS
   {
     if (Config_getBool(USE_PDFLATEX))
     {
-      dotRun.addJob("pdf",absOutFile+".pdf");
+      dotRun.addJob("pdf",absOutFile+".pdf",s,l);
     }
     else
     {
-      dotRun.addJob("ps",absOutFile+".eps");
+      dotRun.addJob("ps",absOutFile+".eps",s,l);
     }
   }
 
@@ -323,7 +323,7 @@ void writeDotGraphFromFile(const char *inFile,const char *outDir,
 void writeDotImageMapFromFile(FTextStream &t,
                             const QCString &inFile, const QCString &outDir,
                             const QCString &relPath, const QCString &baseName,
-                            const QCString &context,int graphId)
+                            const QCString &context, const char *s, const int l, int graphId)
 {
 
   QDir d(outDir);
@@ -338,7 +338,7 @@ void writeDotImageMapFromFile(FTextStream &t,
   QCString absOutFile = d.absPath().utf8()+"/"+mapName;
 
   DotRunner dotRun(inFile.data());
-  dotRun.addJob(MAP_CMD,absOutFile);
+  dotRun.addJob(MAP_CMD,absOutFile,s,l);
   dotRun.preventCleanUp();
   if (!dotRun.run())
   {

--- a/src/dot.h
+++ b/src/dot.h
@@ -51,10 +51,10 @@ class DotManager
 };
 
 void writeDotGraphFromFile(const char *inFile,const char *outDir,
-                           const char *outFile,GraphOutputFormat format);
+                           const char *outFile,GraphOutputFormat format,const char *s, const int l);
 void writeDotImageMapFromFile(FTextStream &t,
                               const QCString& inFile, const QCString& outDir,
                               const QCString& relPath,const QCString& baseName,
-                              const QCString& context,int graphId=-1);
+                              const QCString& context,const char *s, const int l,int graphId=-1);
 
 #endif

--- a/src/dotrunner.h
+++ b/src/dotrunner.h
@@ -29,11 +29,13 @@ class DotRunner
 {
     struct DotJob
     {
-      DotJob(std::string f, std::string o, std::string a)
-        : format(f), output(o), args(a) {}
+      DotJob(std::string f, std::string o, std::string a, std::string s, int l)
+        : format(f), output(o), args(a), srcFile(s), srcLine(l) {}
       std::string format;
       std::string output;
       std::string args;
+      std::string srcFile;
+      int srcLine = -1;
     };
 
   public:
@@ -43,7 +45,7 @@ class DotRunner
     /** Adds an additional job to the run.
      *  Performing multiple jobs one file can be faster.
      */
-    void addJob(const char *format,const char *output);
+    void addJob(const char *format,const char *output, const char *s = "", const int l = -1);
 
     /** Prevent cleanup of the dot file (for user provided dot files) */
     void preventCleanUp() { m_cleanUp = false; }

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -584,7 +584,7 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
           file.close();
 
           m_t << "<div class=\"dotgraph\">" << endl;
-          writeDotFile(fileName,s->relPath(),s->context());
+          writeDotFile(fileName,s->relPath(),s->context(),s->getSrcReferenceFile().data(),s->getSrcReferenceLine());
           visitPreCaption(m_t, s);
           visitCaption(this, s->children());
           visitPostCaption(m_t, s);
@@ -621,7 +621,7 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
           file.close();
 
           m_t << "<div class=\"mscgraph\">" << endl;
-          writeMscFile(baseName+".msc",s->relPath(),s->context());
+          writeMscFile(baseName+".msc",s->relPath(),s->context(),s->getSrcReferenceFile().data(),s->getSrcReferenceLine());
           visitPreCaption(m_t, s);
           visitCaption(this, s->children());
           visitPostCaption(m_t, s);
@@ -1823,7 +1823,7 @@ void HtmlDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
   m_t << "<div class=\"dotgraph\">" << endl;
-  writeDotFile(df->file(),df->relPath(),df->context());
+  writeDotFile(df->file(),df->relPath(),df->context(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
   if (df->hasCaption())
   {
     m_t << "<div class=\"caption\">" << endl;
@@ -1844,7 +1844,7 @@ void HtmlDocVisitor::visitPre(DocMscFile *df)
 {
   if (m_hide) return;
   m_t << "<div class=\"mscgraph\">" << endl;
-  writeMscFile(df->file(),df->relPath(),df->context());
+  writeMscFile(df->file(),df->relPath(),df->context(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
   if (df->hasCaption())
   {
     m_t << "<div class=\"caption\">" << endl;
@@ -1864,7 +1864,7 @@ void HtmlDocVisitor::visitPre(DocDiaFile *df)
 {
   if (m_hide) return;
   m_t << "<div class=\"diagraph\">" << endl;
-  writeDiaFile(df->file(),df->relPath(),df->context());
+  writeDiaFile(df->file(),df->relPath(),df->context(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
   if (df->hasCaption())
   {
     m_t << "<div class=\"caption\">" << endl;
@@ -2298,7 +2298,9 @@ void HtmlDocVisitor::popEnabled()
 }
 
 void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
-                                  const QCString &context)
+                                  const QCString &context,
+                                  const char *s,
+                                  const int l)
 {
   QCString baseName=fn;
   int i;
@@ -2312,13 +2314,14 @@ void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
   }
   baseName.prepend("dot_");
   QCString outDir = Config_getString(HTML_OUTPUT);
-  writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP);
-  writeDotImageMapFromFile(m_t,fn,outDir,relPath,baseName,context);
+  writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP,s,l);
+  writeDotImageMapFromFile(m_t,fn,outDir,relPath,baseName,context,s,l);
 }
 
 void HtmlDocVisitor::writeMscFile(const QCString &fileName,
                                   const QCString &relPath,
-                                  const QCString &context)
+                                  const QCString &context,
+                                  const char *srcFile, const int srcLine)
 {
   QCString baseName=fileName;
   int i;
@@ -2336,13 +2339,15 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,
   MscOutputFormat mscFormat = MSC_BITMAP;
   if ("svg" == imgExt)
     mscFormat = MSC_SVG;
-  writeMscGraphFromFile(fileName,outDir,baseName,mscFormat);
-  writeMscImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,mscFormat);
+  writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,srcFile,srcLine);
+  writeMscImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,mscFormat,srcFile,srcLine);
 }
 
 void HtmlDocVisitor::writeDiaFile(const QCString &fileName,
                                   const QCString &relPath,
-                                  const QCString &)
+                                  const QCString &,
+                                  const char *s,
+                                  const int l)
 {
   QCString baseName=fileName;
   int i;
@@ -2356,7 +2361,7 @@ void HtmlDocVisitor::writeDiaFile(const QCString &fileName,
   }
   baseName.prepend("dia_");
   QCString outDir = Config_getString(HTML_OUTPUT);
-  writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP);
+  writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP,s,l);
 
   m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />" << endl;
 }

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -149,9 +149,9 @@ class HtmlDocVisitor : public DocVisitor
                    const QCString &relPath,const QCString &anchor,
                    const QCString &tooltip = "");
     void endLink();
-    void writeDotFile(const QCString &fileName,const QCString &relPath,const QCString &context);
-    void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context);
-    void writeDiaFile(const QCString &fileName,const QCString &relPath,const QCString &context);
+    void writeDotFile(const QCString &fileName,const QCString &relPath,const QCString &context, const char *srcFile, int srcLine);
+    void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context, const char *srcFile, int srcLine);
+    void writeDiaFile(const QCString &fileName,const QCString &relPath,const QCString &context, const char *srcFile, int srcLine);
     void writePlantUMLFile(const QCString &fileName,const QCString &relPath,const QCString &context);
 
     void pushEnabled();

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -392,7 +392,7 @@ void LatexDocVisitor::visit(DocVerbatim *s)
           file.writeBlock( s->text(), s->text().length() );
           file.close();
 
-          startDotFile(fileName,s->width(),s->height(),s->hasCaption());
+          startDotFile(fileName,s->width(),s->height(),s->hasCaption(),s->getSrcReferenceFile().data(),s->getSrcReferenceLine());
           visitCaption(this, s->children());
           endDotFile(s->hasCaption());
 
@@ -1373,7 +1373,7 @@ void LatexDocVisitor::visitPost(DocImage *img)
 void LatexDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
-  startDotFile(df->file(),df->width(),df->height(),df->hasCaption());
+  startDotFile(df->file(),df->width(),df->height(),df->hasCaption(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
 }
 
 void LatexDocVisitor::visitPost(DocDotFile *df)
@@ -1384,7 +1384,7 @@ void LatexDocVisitor::visitPost(DocDotFile *df)
 void LatexDocVisitor::visitPre(DocMscFile *df)
 {
   if (m_hide) return;
-  startMscFile(df->file(),df->width(),df->height(),df->hasCaption());
+  startMscFile(df->file(),df->width(),df->height(),df->hasCaption(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
 }
 
 void LatexDocVisitor::visitPost(DocMscFile *df)
@@ -1396,7 +1396,7 @@ void LatexDocVisitor::visitPost(DocMscFile *df)
 void LatexDocVisitor::visitPre(DocDiaFile *df)
 {
   if (m_hide) return;
-  startDiaFile(df->file(),df->width(),df->height(),df->hasCaption());
+  startDiaFile(df->file(),df->width(),df->height(),df->hasCaption(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
 }
 
 void LatexDocVisitor::visitPost(DocDiaFile *df)
@@ -1816,7 +1816,9 @@ void LatexDocVisitor::popEnabled()
 void LatexDocVisitor::startDotFile(const QCString &fileName,
                                    const QCString &width,
                                    const QCString &height,
-                                   bool hasCaption
+                                   bool hasCaption,
+                                   const char *s,
+                                   const int l
                                   )
 {
   QCString baseName=fileName;
@@ -1832,7 +1834,7 @@ void LatexDocVisitor::startDotFile(const QCString &fileName,
   baseName.prepend("dot_");
   QCString outDir = Config_getString(LATEX_OUTPUT);
   QCString name = fileName;
-  writeDotGraphFromFile(name,outDir,baseName,GOF_EPS);
+  writeDotGraphFromFile(name,outDir,baseName,GOF_EPS,s,l);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1845,7 +1847,9 @@ void LatexDocVisitor::endDotFile(bool hasCaption)
 void LatexDocVisitor::startMscFile(const QCString &fileName,
                                    const QCString &width,
                                    const QCString &height,
-                                   bool hasCaption
+                                   bool hasCaption,
+                                   const char *s,
+                                   const int l
                                   )
 {
   QCString baseName=fileName;
@@ -1861,7 +1865,7 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
   baseName.prepend("msc_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_EPS);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_EPS,s,l);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1881,7 +1885,7 @@ void LatexDocVisitor::writeMscFile(const QCString &baseName, DocVerbatim *s)
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS);
+  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS,s->getSrcReferenceFile().data(),s->getSrcReferenceLine());
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(),s->height());
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1891,7 +1895,9 @@ void LatexDocVisitor::writeMscFile(const QCString &baseName, DocVerbatim *s)
 void LatexDocVisitor::startDiaFile(const QCString &fileName,
                                    const QCString &width,
                                    const QCString &height,
-                                   bool hasCaption
+                                   bool hasCaption,
+                                   const char *s,
+                                   const int l
                                   )
 {
   QCString baseName=fileName;
@@ -1907,7 +1913,7 @@ void LatexDocVisitor::startDiaFile(const QCString &fileName,
   baseName.prepend("dia_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeDiaGraphFromFile(fileName,outDir,baseName,DIA_EPS);
+  writeDiaGraphFromFile(fileName,outDir,baseName,DIA_EPS,s,l);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1927,7 +1933,7 @@ void LatexDocVisitor::writeDiaFile(const QCString &baseName, DocVerbatim *s)
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DIA_EPS);
+  writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DIA_EPS,s->getSrcReferenceFile().data(),s->getSrcReferenceLine());
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(), s->height());
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -162,16 +162,16 @@ class LatexDocVisitor : public DocVisitor
                  const QCString &anchor,bool refToTable=FALSE);
     QCString escapeMakeIndexChars(const char *s);
     void startDotFile(const QCString &fileName,const QCString &width,
-                      const QCString &height, bool hasCaption);
+                      const QCString &height, bool hasCaption,const char *s,const int l);
     void endDotFile(bool hasCaption);
 
     void startMscFile(const QCString &fileName,const QCString &width,
-                      const QCString &height, bool hasCaption);
+                      const QCString &height, bool hasCaption,const char *s,const int l);
     void endMscFile(bool hasCaption);
     void writeMscFile(const QCString &fileName, DocVerbatim *s);
 
     void startDiaFile(const QCString &fileName,const QCString &width,
-                      const QCString &height, bool hasCaption);
+                      const QCString &height, bool hasCaption,const char *s,const int l);
     void endDiaFile(bool hasCaption);
     void writeDiaFile(const QCString &fileName, DocVerbatim *s);
     void writePlantUMLFile(const QCString &fileName, DocVerbatim *s);

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -92,7 +92,8 @@ static bool convertMapFile(FTextStream &t,const char *mapName,const QCString rel
 }
 
 void writeMscGraphFromFile(const char *inFile,const char *outDir,
-                           const char *outFile,MscOutputFormat format)
+                           const char *outFile,MscOutputFormat format,
+                           const char *srcFile, int srcLine)
 {
   QCString absOutFile = outDir;
   absOutFile+=Portable::pathSeparator();
@@ -120,8 +121,16 @@ void writeMscGraphFromFile(const char *inFile,const char *outDir,
   int code;
   if ((code=mscgen_generate(inFile,imgName,msc_format))!=0)
   {
-    err("Problems generating msc output (error=%s). Look for typos in you msc file %s\n",
+    if (srcLine == -1)
+    {
+      err("Problems generating msc output (error=%s). Look for typos in your msc file %s\n",
         mscgen_error2str(code),inFile);
+    }
+    else
+    {
+      err_full(srcFile,srcLine,"Problems generating msc output (error=%s). Look for typos in your msc file %s\n",
+        mscgen_error2str(code),inFile);
+    }
     return;
   }
 
@@ -144,7 +153,7 @@ void writeMscGraphFromFile(const char *inFile,const char *outDir,
 
 static QCString getMscImageMapFromFile(const QCString& inFile, const QCString& outDir,
                                 const QCString& relPath,const QCString& context,
-                                bool writeSVGMap)
+                                bool writeSVGMap,const char *srcFile,const int srcLine)
 {
   QCString outFile = inFile + ".map";
 
@@ -152,8 +161,16 @@ static QCString getMscImageMapFromFile(const QCString& inFile, const QCString& o
   if ((code=mscgen_generate(inFile,outFile,
                             writeSVGMap ? mscgen_format_svgmap : mscgen_format_pngmap))!=0)
   {
-    err("Problems generating msc output (error=%s). Look for typos in you msc file %s\n",
+    if (srcLine == -1)
+    {
+      err("Problems generating msc output (error=%s). Look for typos in your msc file %s\n",
         mscgen_error2str(code),inFile.data());
+    }
+    else
+    {
+      err_full(srcFile,srcLine,"Problems generating msc output (error=%s). Look for typos in your msc file %s\n",
+        mscgen_error2str(code),inFile);
+    }
     return "";
   }
 
@@ -170,7 +187,8 @@ void writeMscImageMapFromFile(FTextStream &t,const QCString &inFile,
                               const QCString &relPath,
                               const QCString &baseName,
                               const QCString &context,
-			      MscOutputFormat format
+			      MscOutputFormat format,
+                              const char *srcFile, const int srcLine
  			    )
 {
   QCString mapName = baseName+".map";
@@ -189,7 +207,7 @@ void writeMscImageMapFromFile(FTextStream &t,const QCString &inFile,
     default:
       t << "unknown";
   }
-  QCString imap = getMscImageMapFromFile(inFile,outDir,relPath,context,format==MSC_SVG);
+  QCString imap = getMscImageMapFromFile(inFile,outDir,relPath,context,format==MSC_SVG,srcFile,srcLine);
   if (!imap.isEmpty())
   {
     t << "\" alt=\""

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -169,7 +169,7 @@ static QCString getMscImageMapFromFile(const QCString& inFile, const QCString& o
     else
     {
       err_full(srcFile,srcLine,"Problems generating msc output (error=%s). Look for typos in your msc file %s\n",
-        mscgen_error2str(code),inFile);
+        mscgen_error2str(code),inFile.data());
     }
     return "";
   }

--- a/src/msc.h
+++ b/src/msc.h
@@ -24,15 +24,18 @@ class FTextStream;
 enum MscOutputFormat { MSC_BITMAP , MSC_EPS, MSC_SVG };
 
 void writeMscGraphFromFile(const char *inFile,const char *outDir,
-                           const char *outFile,MscOutputFormat format);
+                           const char *outFile,MscOutputFormat format,
+                           const char *srcFile, const int srcLine);
 
 QCString getMscImageMapFromFile(const QCString& inFile, const QCString& outDir,
-                                const QCString& relPath,const QCString& context);
+                                const QCString& relPath,const QCString& context,
+                                const char *srcFile, const int srcLine);
 
 void writeMscImageMapFromFile(FTextStream &t,const QCString &inFile,
                               const QCString &outDir, const QCString &relPath,
                               const QCString &baseName, const QCString &context,
-			      MscOutputFormat format
+			      MscOutputFormat format,
+                              const char *srcFile, const int srcLine
  			    );
 
 #endif

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -347,7 +347,7 @@ void RTFDocVisitor::visit(DocVerbatim *s)
         file.writeBlock( s->text(), s->text().length() );
         file.close();
 
-        writeDotFile(fileName, s->hasCaption());
+        writeDotFile(fileName, s->hasCaption(),s->getSrcReferenceFile().data(),s->getSrcReferenceLine());
         visitCaption(this, s->children());
         includePicturePostRTF(true, s->hasCaption());
 
@@ -375,7 +375,7 @@ void RTFDocVisitor::visit(DocVerbatim *s)
         file.writeBlock( text, text.length() );
         file.close();
 
-        writeMscFile(baseName, s->hasCaption());
+        writeMscFile(baseName, s->hasCaption(),s->getSrcReferenceFile().data(), s->getSrcReferenceLine()); 
         visitCaption(this, s->children());
         includePicturePostRTF(true, s->hasCaption());
 
@@ -1843,9 +1843,9 @@ void RTFDocVisitor::popEnabled()
 
 void RTFDocVisitor::writeDotFile(DocDotFile *df)
 {
-  writeDotFile(df->file(), df->hasCaption());
+  writeDotFile(df->file(), df->hasCaption(),df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
 }
-void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption)
+void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption,const char *s,const int l)
 {
   QCString baseName=filename;
   int i;
@@ -1854,16 +1854,16 @@ void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption)
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeDotGraphFromFile(filename,outDir,baseName,GOF_BITMAP);
+  writeDotGraphFromFile(filename,outDir,baseName,GOF_BITMAP,s,l);
   QCString imgExt = getDotImageExtension();
   includePicturePreRTF(baseName + "." + imgExt, true, hasCaption);
 }
 
 void RTFDocVisitor::writeMscFile(DocMscFile *df)
 {
-  writeMscFile(df->file(), df->hasCaption());
+  writeMscFile(df->file(), df->hasCaption(), df->getSrcReferenceFile().data(), df->getSrcReferenceLine());
 }
-void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption)
+void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption, const char *s, const int l)
 {
   QCString baseName=fileName;
   int i;
@@ -1872,7 +1872,7 @@ void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption)
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,s,l);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
@@ -1885,7 +1885,7 @@ void RTFDocVisitor::writeDiaFile(DocDiaFile *df)
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeDiaGraphFromFile(df->file(),outDir,baseName,DIA_BITMAP);
+  writeDiaGraphFromFile(df->file(),outDir,baseName,DIA_BITMAP,df->getSrcReferenceFile().data(),df->getSrcReferenceLine());
   includePicturePreRTF(baseName + ".png", true, df->hasCaption());
 }
 

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -153,9 +153,9 @@ class RTFDocVisitor : public DocVisitor
     void popEnabled();
     void includePicturePreRTF(const QCString name, bool isTypeRTF, bool hasCaption, bool inlineImage = FALSE);
     void includePicturePostRTF(bool isTypeRTF, bool hasCaption, bool inlineImage = FALSE);
-    void writeDotFile(const QCString &fileName, bool hasCaption);
+    void writeDotFile(const QCString &fileName, bool hasCaption, const char *s, const int l);
     void writeDotFile(DocDotFile *);
-    void writeMscFile(const QCString &fileName, bool hasCaption);
+    void writeMscFile(const QCString &fileName, bool hasCaption, const char *s, const int l);
     void writeMscFile(DocMscFile *);
     void writeDiaFile(DocDiaFile *);
     void writePlantUMLFile(const QCString &fileName, bool hasCaption);


### PR DESCRIPTION
The warning messages regarding dot / msc / dia are a bit cryptic and it is hard to find where the file is invoked.
The current messages look like:
```
Error detected at line 5: Unknown source entity 'fail1'.
Input format error for '.../html/inline_mscgraph_1.msc'
error: Problems generating msc output (error=INPUT FORMAT ERROR). Look for typos in you msc file .../html/inline_mscgraph_1.msc

Error detected at line 5: Unknown source entity 'fail1'.
Input format error for '.../aa.msc'
error: Problems generating msc output (error=INPUT FORMAT ERROR). Look for typos in you msc file .../aa.msc

error: Problems running dot: exit code=1, command='dot', arguments='".../html/inline_dotgraph_1.dot" -Tpng -o ".../html/inline_dotgraph_1.dot.png"'
error: Problems running dot: exit code=1, command='dot', arguments='".../aa.dot" -Tpng -o ".../html/aa.dot.png"'

error: Problems running D:\Programs\dia\0.97.2\bin\dia.exe. Check your installation or look typos in you dia file .../aa.dia
```

Better it is to have the source file and line in front of it, like most warnings / errors, so it might be easier to locate the problem.

Based on the comment https://github.com/doxygen/doxygen/pull/642#issuecomment-731133017 in #642.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5578122/example.tar.gz)
