### PR TITLE
Doxygen warnings are not seen as errors during running tests

### DIFF
--- a/testing/057/namespacelibrary.xml
+++ b/testing/057/namespacelibrary.xml
@@ -7,24 +7,26 @@
     <innernamespace refid="namespacelibrary_1_1v2" inline="yes">library::v2</innernamespace>
     <innernamespace refid="namespacelibrary_1_1v2_1_1_n_s">library::v2::NS</innernamespace>
     <sectiondef kind="func">
-      <memberdef kind="function" id="057__inlinenamespace_8cpp_1aba9375172f5b36e1f4fda9b1dec39d90" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+      <memberdef kind="function" id="namespacelibrary_1_1v2_1aba9375172f5b36e1f4fda9b1dec39d90" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>
         <definition>void library::v2::func</definition>
         <argsstring>()</argsstring>
         <name>func</name>
         <briefdescription>
+          <para>a method </para>
         </briefdescription>
         <detaileddescription>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="057_inlinenamespace.cpp" line="16" column="14" declfile="057_inlinenamespace.cpp" declline="16" declcolumn="14"/>
+        <location file="057_inlinenamespace.cpp" line="33" column="14" declfile="057_inlinenamespace.cpp" declline="33" declcolumn="14"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
+      <para>the main namespace </para>
     </briefdescription>
     <detaileddescription>
     </detaileddescription>
-    <location file="057_inlinenamespace.cpp" line="5" column="1"/>
+    <location file="057_inlinenamespace.cpp" line="7" column="1"/>
   </compounddef>
 </doxygen>

--- a/testing/057/namespacelibrary_1_1v1.xml
+++ b/testing/057/namespacelibrary_1_1v1.xml
@@ -5,24 +5,26 @@
     <innerclass refid="classlibrary_1_1v1_1_1foo" prot="public">library::v1::foo</innerclass>
     <innernamespace refid="namespacelibrary_1_1v1_1_1_n_s">library::v1::NS</innernamespace>
     <sectiondef kind="func">
-      <memberdef kind="function" id="057__inlinenamespace_8cpp_1a2257981298fec15f79c54c28880ac15c" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+      <memberdef kind="function" id="namespacelibrary_1_1v1_1a2257981298fec15f79c54c28880ac15c" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>
         <definition>void library::v1::func</definition>
         <argsstring>()</argsstring>
         <name>func</name>
         <briefdescription>
+          <para>a method </para>
         </briefdescription>
         <detaileddescription>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="057_inlinenamespace.cpp" line="10" column="14" declfile="057_inlinenamespace.cpp" declline="10" declcolumn="14"/>
+        <location file="057_inlinenamespace.cpp" line="19" column="14" declfile="057_inlinenamespace.cpp" declline="19" declcolumn="14"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
+      <para>the first namespace </para>
     </briefdescription>
     <detaileddescription>
     </detaileddescription>
-    <location file="057_inlinenamespace.cpp" line="7" column="5"/>
+    <location file="057_inlinenamespace.cpp" line="10" column="5"/>
   </compounddef>
 </doxygen>

--- a/testing/057/namespacelibrary_1_1v2.xml
+++ b/testing/057/namespacelibrary_1_1v2.xml
@@ -4,10 +4,27 @@
     <compoundname>library::v2</compoundname>
     <innerclass refid="classlibrary_1_1v2_1_1foo" prot="public">library::v2::foo</innerclass>
     <innernamespace refid="namespacelibrary_1_1v2_1_1_n_s">library::v2::NS</innernamespace>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="namespacelibrary_1_1v2_1aba9375172f5b36e1f4fda9b1dec39d90" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void library::v2::func</definition>
+        <argsstring>()</argsstring>
+        <name>func</name>
+        <briefdescription>
+          <para>a method </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="057_inlinenamespace.cpp" line="33" column="14" declfile="057_inlinenamespace.cpp" declline="33" declcolumn="14"/>
+      </memberdef>
+    </sectiondef>
     <briefdescription>
+      <para>the inline namespace </para>
     </briefdescription>
     <detaileddescription>
     </detaileddescription>
-    <location file="057_inlinenamespace.cpp" line="13" column="12"/>
+    <location file="057_inlinenamespace.cpp" line="24" column="12"/>
   </compounddef>
 </doxygen>

--- a/testing/057_inlinenamespace.cpp
+++ b/testing/057_inlinenamespace.cpp
@@ -2,18 +2,36 @@
 // check: namespacelibrary.xml
 // check: namespacelibrary_1_1v1.xml
 // check: namespacelibrary_1_1v2.xml
+
+/// the main namespace
 namespace library
 {
+    /// the first namespace
     namespace v1
     {
-        class foo { public: void member(); };
+        /// the class
+        class foo {
+          public:
+            /// member of the class
+            void member();
+        };
+        /// a method
         void func();
+        /// a namespace
         namespace NS {}
     }
+    /// the inline namespace
     inline namespace v2
     {
-        class foo { public: void member(); };
+        /// the class
+        class foo {
+          public:
+            /// member of the class
+            void member();
+        };
+        /// a method
         void func();
+        /// a namespace
         namespace NS {}
     }
 }

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -118,6 +118,7 @@ class Tester:
 			print('INPUT=%s/%s' % (self.args.inputdir,self.test), file=f)
 			print('STRIP_FROM_PATH=%s' % self.args.inputdir, file=f)
 			print('EXAMPLE_PATH=%s' % self.args.inputdir, file=f)
+			print('WARN_LOGFILE=%s/warnings.log' % self.test_out, file=f)
 			if 'config' in self.config:
 				for option in self.config['config']:
 					print(option, file=f)
@@ -162,7 +163,7 @@ class Tester:
 
 		# run doxygen
 		if (sys.platform == 'win32'):
-			redir=' > nul:'
+			redir=' > nul: 2>&1'
 		else:
 			redir=' 2> /dev/null > /dev/null'
 
@@ -400,7 +401,12 @@ class Tester:
 			elif not self.args.keep:
 				shutil.rmtree(latex_output,ignore_errors=True)
 
-		if failed_xml or failed_html or failed_latex or failed_docbook or failed_rtf or failed_xmlxsd:
+		warnings = xopen(self.test_out + "/warnings.log",'r',encoding='ISO-8859-1').read()
+		failed_warn =  len(warnings)!=0
+		if failed_warn:
+			msg += (warnings,)
+
+		if failed_warn or failed_xml or failed_html or failed_latex or failed_docbook or failed_rtf or failed_xmlxsd:
 			testmgr.ok(False,self.test_name,msg)
 			return False
 


### PR DESCRIPTION
Doxygen warnings were on *nix suppressed but shown on Windows though the tests were nevertheless shown as OK
- correct redirection under windows
- catch doxygen warnings and make the corresponding test fail