### PR TITLE
Exclude markdown mapped documentation files from Files list

### DIFF
--- a/doc/docblocks.doc
+++ b/doc/docblocks.doc
@@ -431,7 +431,9 @@ using structural commands:
  a case where the \\fn command is redundant and will only lead to problems.
 
  When you place a comment block in a file with one of the following extensions
- `.dox`, `.txt`, or `.doc` then doxygen will hide this file from the file list.
+ `.dox`, `.txt`, `.doc`, `.md` or `.markdown` or when the extension maps to
+ `md` by means of the \ref cfg_extension_mapping "EXTENSION_MAPPING" 
+ then doxygen will hide this file from the file list.
 
  If you have a file that doxygen cannot parse but still would like to document it,
  you can show it as-is using \ref cmdverbinclude "\\verbinclude", e.g.

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1918,7 +1918,8 @@ bool FileDefImpl::isDocumentationFile() const
          name().right(4)==".txt" ||
          name().right(4)==".dox" ||
          name().right(3)==".md"  ||
-         name().right(9)==".markdown";
+         name().right(9)==".markdown" ||
+         getLanguageFromFileName(getFileNameExtension(name())) == SrcLangExt_Markdown;
 }
 
 void FileDefImpl::acquireFileVersion()


### PR DESCRIPTION
The files with an obvious documentation extension are excluded from the "Files list" (e.g in top blue bar).
Files that are mapped through `EXTENSION_MAPPING` to markdown files are also documentation files and should also be excluded.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5582519/example.tar.gz)
