### PR TITLE
issue #8023 Add option to exit with non-zero exit code on warnings even if WARN_AS_ERROR is OFF

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1335,13 +1335,19 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
 ]]>
       </docs>
     </option>
-    <option type='bool' id='WARN_AS_ERROR' defval='0'>
+    <option type='enum' id='WARN_AS_ERROR' defval='NO'>
       <docs>
 <![CDATA[
  If the \c WARN_AS_ERROR tag is set to \c YES then doxygen will immediately stop
  when a warning is encountered.
+ If the \c WARN_AS_ERROR tag is set to \c FAIL_ON_WARNINGS then doxygen will continue
+ running as if \c WARN_AS_ERROR tag is set to \c NO, but at the end of the doxygen
+ process doxygen will return with a non-zero status.
 ]]>
       </docs>
+      <value name="NO"/>
+      <value name="YES" />
+      <value name="FAIL_ON_WARNINGS" />
     </option>
     <option type='string' id='WARN_FORMAT' format='string' defval='$file:$line: $text'>
       <docs>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11912,6 +11912,7 @@ void generateOutput()
   QDir thisDir;
   thisDir.remove(Doxygen::objDBFileName);
   thisDir.remove(Doxygen::filterDBFileName);
+  finishWarnExit();
   Config::deinit();
   QTextCodec::deleteAllCodecs();
   delete Doxygen::clangUsrMap;

--- a/src/message.h
+++ b/src/message.h
@@ -36,6 +36,7 @@ extern void err_full(const char *file,int line,const char *fmt, ...) PRINTFLIKE(
 extern void term(const char *fmt, ...) PRINTFLIKE(1, 2);
 void initWarningFormat();
 void warn_flush();
+extern void finishWarnExit();
 
 extern void printlex(int dbg, bool enter, const char *lexName, const char *fileName);
 


### PR DESCRIPTION
In case we want for a Continuous integration system a non-zero exit status at the end of a doxygen we can now set `WARN_AS_ERRORS=FAIL_ON_WARNINGS`.
The behavior for `NO` and `YES` remains as it was.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5583561/example.tar.gz)
