### PR TITLE
Making the use of DOT_CLEANUP more transparent

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2800,6 +2800,10 @@ only copy the detailed documentation, not the brief description.
   The nodes of a graph can be made clickable by using the URL attribute.
   By using the command \ref cmdref "\\ref" inside the URL value you can conveniently
   link to an item inside doxygen. Here is an example:
+
+  \note doxygen creates a temporary file that is automatically removed unless
+  the \ref cfg_dot_cleanup "DOT_CLEANUP" tag is set to `NO`.
+
 \code
 /*! class B */
 class B {};
@@ -2863,6 +2867,8 @@ See also the \ref emojisup "emoji support page" for details.
   within the <code>msc {...}</code> block (this is different from
   \ref cmdmscfile "\\mscfile").
   \note mscgen is now built in into doxygen
+  \note doxygen creates a temporary file that is automatically removed unless
+  the \ref cfg_dot_cleanup "DOT_CLEANUP" tag is set to `NO`.
 
 Here is an example of the use of the \c \\msc command.
 \code
@@ -2932,6 +2938,9 @@ class Receiver
   For a description of the possibilities see the paragraph
   \ref image_sizeindicator "Size indication" with the
   \ref cmdimage "\\image" command.
+
+  \note doxygen creates a temporary file that is automatically removed unless
+  the \ref cfg_dot_cleanup "DOT_CLEANUP" tag is set to `NO`.
 
 Here is an example of the use of the \c \\startuml command.
 \code

--- a/src/config.xml
+++ b/src/config.xml
@@ -3690,11 +3690,14 @@ add type and arguments for attributes and methods in the UML graphs.
 ]]>
       </docs>
     </option>
-    <option type='bool' id='DOT_CLEANUP' defval='1' depends='HAVE_DOT'>
+    <option type='bool' id='DOT_CLEANUP' defval='1'>
       <docs>
 <![CDATA[
 If the \c DOT_CLEANUP tag is set to \c YES, doxygen will
-remove the intermediate dot files that are used to generate the various graphs.
+remove the intermediate files that are used to generate the various graphs.
+ <br>Note:
+This setting is not only used for dot files but also for msc and plantuml
+temporary files.
 ]]>
       </docs>
     </option>

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -356,12 +356,13 @@ DB_VIS_C
         QFile file(baseName+".dot");
         if (!file.open(IO_WriteOnly))
         {
-          err("Could not open file %s.msc for writing\n",baseName.data());
+          err("Could not open file %s.dot for writing\n",baseName.data());
         }
         file.writeBlock( stext, stext.length() );
         file.close();
         writeDotFile(baseName, s);
         m_t << "</para>" << endl;
+        if (Config_getBool(DOT_CLEANUP)) file.remove();
       }
       break;
     case DocVerbatim::Msc:
@@ -388,6 +389,7 @@ DB_VIS_C
         file.close();
         writeMscFile(baseName,s);
         m_t << "</para>" << endl;
+        if (Config_getBool(DOT_CLEANUP)) file.remove();
       }
       break;
     case DocVerbatim::PlantUML:


### PR DESCRIPTION
- The setting `DOT_CLEANUP` is not only used for `dot` files but also for temporary `msc` and `plantuml` files, though this was not clear from the documentation.
- For the docbook output format the removal of the `dot` and `msc` files was not don like in the output formats html / LatTeX / rtf.