### PR TITLE
issue #8184 Bad parsing of CMakeLists.txt

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -427,7 +427,7 @@ static QString getDocsForNode(const QDomElement &child)
   regexp.setPattern(SA("`([^`]+)`"));
   docs.replace(regexp,SA("<code>\\1</code>"));
   // \ref key "desc" -> <code>desc</code>
-  regexp.setPattern(SA("\\\\ref[ ]+[^ ]+[ ]+\"([^ ]+)\""));
+  regexp.setPattern(SA("\\\\ref[ ]+[^ ]+[ ]+\"([^\"]+)\""));
   docs.replace(regexp,SA("<code>\\1</code> "));
   //\ref specials
   // \ref <key> -> description

--- a/doc/starting.doc
+++ b/doc/starting.doc
@@ -103,6 +103,7 @@ To omit all \c test directories from a source tree for instance, one could use:
 \verbatim EXCLUDE_PATTERNS = */test/* 
 \endverbatim
 
+\anchor default_file_extension_mapping
 Doxygen looks at the file's extension to determine how to parse a file,
 using the following table:
 
@@ -130,8 +131,11 @@ Extension | Language | Extension | Language     | Extension | Language
 .mm       |C / C++   | | | | |
 .txt      |C / C++   | | | | |
 
-Any other extension is not parsed unless it is added to
-\ref cfg_file_patterns "FILE_PATTERNS" and the appropriate
+Please note that the above list might contain more items than that by default set
+in the \ref cfg_file_patterns "FILE_PATTERNS".
+
+Any extension that is not parsed can be set by adding it to
+\ref cfg_file_patterns "FILE_PATTERNS" and when the appropriate
 \ref cfg_extension_mapping "EXTENSION_MAPPING" is set.
 
 \anchor extract_all

--- a/src/config.xml
+++ b/src/config.xml
@@ -662,6 +662,7 @@ Go to the <a href="commands.html">next</a> section or return to the
  <br>Note that for custom extensions you also need to set \ref cfg_file_patterns "FILE_PATTERNS" otherwise the
  files are not read by doxygen. When specifying `no_extension` you should add `*`
  to the \ref cfg_file_patterns "FILE_PATTERNS".
+ <br>Note see also the list of \ref default_file_extension_mapping "default file extension mappings".
 ]]>
       </docs>
     </option>
@@ -1404,6 +1405,8 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
  Note that for custom extensions or not directly supported extensions you also
  need to set \ref cfg_extension_mapping "EXTENSION_MAPPING" for the extension
  otherwise the files are not read by doxygen.<br>
+ Note the list of default checked file patterns might differ from the list of
+ \ref default_file_extension_mapping "default file extension mappings".<br>
  If left blank the following patterns are tested:
 ]]>
       </docs>
@@ -1438,8 +1441,6 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
       <value name='*.md'/>
       <value name='*.mm'/>
       <value name='*.dox' desc='(to be provided as doxygen C comment)'/>
-      <value name='*.doc' desc='(to be provided as doxygen C comment)'/>
-      <value name='*.txt' desc='(to be provided as doxygen C comment)'/>
       <value name='*.py'/>
       <value name='*.pyw'/>
       <value name='*.f90'/>


### PR DESCRIPTION
- Removing the `txt` and `doc` extension from the default list of `FILE_PATTERNS`
- Updating documentation
- Incorrect parsing for the doxywizard of some \ref items (i.e. when the description contains a space, made compatible again with that happens in configgen.py).