### PR TITLE
Default doxygen search mechanism doesn't work when using with XHTML output

### DIFF
--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -923,7 +923,8 @@ void writeJavaScriptSearchIndex()
 
           t << "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""
             " \"https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" << endl;
-          t << "<html><head><title></title>" << endl;
+          t << "<html xmlns=\"http://www.w3.org/1999/xhtml\">" << endl;
+          t << "<head><title></title>" << endl;
           t << "<meta http-equiv=\"Content-Type\" content=\"text/xhtml;charset=UTF-8\"/>" << endl;
           t << "<meta name=\"generator\" content=\"Doxygen " << getDoxygenVersion() << "\"/>" << endl;
           t << "<link rel=\"stylesheet\" type=\"text/css\" href=\"search.css\"/>" << endl;
@@ -934,18 +935,18 @@ void writeJavaScriptSearchIndex()
           t << "<div id=\"SRIndex\">" << endl;
           t << "<div class=\"SRStatus\" id=\"Loading\">" << theTranslator->trLoading() << "</div>" << endl;
           t << "<div id=\"SRResults\"></div>" << endl; // here the results will be inserted
-          t << "<script type=\"text/javascript\"><!--" << endl;
-					t << "/* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&amp;dn=gpl-2.0.txt GPL-v2 */\n";
+          t << "<script type=\"text/javascript\">" << endl;
+          t << "/* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&amp;dn=gpl-2.0.txt GPL-v2 */\n";
           t << "createResults();" << endl; // this function will insert the results
-					t << "/* @license-end */\n";
-          t << "--></script>" << endl;
+          t << "/* @license-end */\n";
+          t << "</script>" << endl;
           t << "<div class=\"SRStatus\" id=\"Searching\">"
             << theTranslator->trSearching() << "</div>" << endl;
           t << "<div class=\"SRStatus\" id=\"NoMatches\">"
             << theTranslator->trNoMatches() << "</div>" << endl;
 
-          t << "<script type=\"text/javascript\"><!--" << endl;
-					t << "/* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&amp;dn=gpl-2.0.txt GPL-v2 */\n";
+          t << "<script type=\"text/javascript\">" << endl;
+          t << "/* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&amp;dn=gpl-2.0.txt GPL-v2 */\n";
           t << "document.getElementById(\"Loading\").style.display=\"none\";" << endl;
           t << "document.getElementById(\"NoMatches\").style.display=\"none\";" << endl;
           t << "var searchResults = new SearchResults(\"searchResults\");" << endl;
@@ -956,8 +957,8 @@ void writeJavaScriptSearchIndex()
           t << "    if (elem) elem.focus();" << endl;
           t << "  }" << endl;
           t << "});" << endl;
-					t << "/* @license-end */\n";
-          t << "--></script>" << endl;
+          t << "/* @license-end */\n";
+          t << "</script>" << endl;
           t << "</div>" << endl; // SRIndex
           t << "</body>" << endl;
           t << "</html>" << endl;
@@ -1229,7 +1230,8 @@ void writeJavaScriptSearchIndex()
       FTextStream t(&f);
       t << "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" "
            "\"https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" << endl;
-      t << "<html><head><title></title>" << endl;
+      t << "<html xmlns=\"http://www.w3.org/1999/xhtml\">" << endl;
+      t << "<head><title></title>" << endl;
       t << "<meta http-equiv=\"Content-Type\" content=\"text/xhtml;charset=UTF-8\"/>" << endl;
       t << "<link rel=\"stylesheet\" type=\"text/css\" href=\"search.css\"/>" << endl;
       t << "<script type=\"text/javascript\" src=\"search.js\"></script>" << endl;

--- a/templates/html/htmlsearchresult.tpl
+++ b/templates/html/htmlsearchresult.tpl
@@ -11,14 +11,14 @@
 <div id="SRIndex">
 <div class="SRStatus" id="Loading">{{ tr.loading }}</div>
 <div id="SRResults"></div>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 /* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&dn=gpl-2.0.txt GPL-v2 */
 createResults();
 /* @license-end */
---></script>
+</script>
 <div class="SRStatus" id="Searching">{{ tr.searching }}</div>
 <div class="SRStatus" id="NoMatches">{{ tr.noMatches }}</div>
-<script type="text/javascript"><!--
+<script type="text/javascript">
 /* @license magnet:?xt=urn:btih:cf05388f2679ee054f2beb29a391d25f4e673ac3&dn=gpl-2.0.txt GPL-v2 */
 document.getElementById("Loading").style.display="none";
 document.getElementById("NoMatches").style.display="none";
@@ -31,7 +31,7 @@ window.addEventListener("message", function(event) {
   }
 });
 /* @license-end */
---></script>
+</script>
 </div>
 </body>
 </html>

--- a/templates/html/search.js
+++ b/templates/html/search.js
@@ -355,7 +355,7 @@ function SearchBox(name, resultsPath, inFrame, label, extension)
     }
     else // nothing available for this search term
     {
-       resultsPage = this.resultsPath + '/nomatches.html';
+       resultsPage = this.resultsPath + '/nomatches' + this.extension;
        resultsPageWithSearch = resultsPage;
        hasResultsPage = false;
     }


### PR DESCRIPTION
The problem has been tested with the doxygen test 021. With the output format html all works OK.
- When giving a `t` in the search window a window appears with the message "This XML file does not appear to have any style information associated with it. The document tree is shown below."
  - the `<html> statement has to replaced by `<html xmlns="http://www.w3.org/1999/xhtml">` in searchindex.cpp (is normally also present in the non search xhtml files).
    - this results in a window with just the words:
      Loading....
      Searching...
      No Matches
      - this is due to the extra `<!--` / `-->` in the htmlsearchresults.tpl (strange enough html output has no problem with it).
- When giving a `a` in the search windows we get a "File not found" message as the file nomatches.html cannot be found
  - the extension for "nomatches" has to be set properly as well (search.js), for the other files this is done a few lines upward.

Issue is due to #8029 / #7898