### PR TITLE
Incorrect XHTML results

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -133,7 +133,6 @@ class ClangTUParser::Private
     CXToken *tokens = 0;
     uint numTokens = 0;
     StringVector filesInSameTU;
-    TooltipManager tooltipManager;
 
     // state while parsing sources
     MemberDef  *currentMemberDef=0;
@@ -573,7 +572,7 @@ void ClangTUParser::writeMultiLineCodeLink(CodeOutputInterface &ol,
                   const char *text)
 {
   static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
-  p->tooltipManager.addTooltip(d);
+  TooltipManager::instance()->addTooltip(d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();
   QCString anchor = d->anchor();

--- a/src/code.l
+++ b/src/code.l
@@ -175,7 +175,6 @@ struct codeYY_state
 
   VariableContext theVarContext;
   CallContext     theCallContext;
-  TooltipManager  tooltipManager;
   SymbolResolver  symbolResolver;
 };
 
@@ -2469,7 +2468,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
-  yyextra->tooltipManager.addTooltip(d);
+  TooltipManager::instance()->addTooltip(d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();
   QCString anchor = d->anchor();
@@ -3885,8 +3884,6 @@ void CCodeParser::parseCode(CodeOutputInterface &od,const char *className,const 
     delete yyextra->sourceFileDef;
     yyextra->sourceFileDef=0;
   }
-  // write the tooltips
-  yyextra->tooltipManager.writeTooltips(od);
 
   printlex(yy_flex_debug, FALSE, __FILE__, fd ? fd->fileName().data(): NULL);
   return;

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -172,7 +172,6 @@ struct fortrancodeYY_state
   int           inTypeDecl = 0;
 
   bool          endComment = false;
-  TooltipManager tooltipManager;
 };
 
 #if USE_STATE2STRING
@@ -1017,7 +1016,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
-  yyextra->tooltipManager.addTooltip(d);
+  TooltipManager::instance()->addTooltip(d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();
   QCString anchor = d->anchor();
@@ -1519,9 +1518,6 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   }
   if (yyextra->hasContLine) free(yyextra->hasContLine);
   yyextra->hasContLine = NULL;
-
-  // write the tooltips
-  yyextra->tooltipManager.writeTooltips(codeOutIntf);
 
   printlex(yy_flex_debug, FALSE, __FILE__, fileDef ? fileDef->fileName().data(): NULL);
 }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1231,6 +1231,8 @@ void HtmlGenerator::writePageFooter(FTextStream &t,const QCString &lastTitle,
 
 void HtmlGenerator::writeFooter(const char *navPath)
 {
+  // Currently only tooltips in HTML
+  TooltipManager::instance()->writeTooltips(m_codeGen);
   writePageFooter(t,m_lastTitle,m_relPath,navPath);
 }
 

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -107,7 +107,6 @@ struct pycodeYY_state
   bool          endComment = FALSE;
   VariableContext theVarContext;
   CallContext theCallContext;
-  TooltipManager tooltipManager;
   SymbolResolver symbolResolver;
 };
 
@@ -1097,7 +1096,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
-  yyextra->tooltipManager.addTooltip(d);
+  TooltipManager::instance()->addTooltip(d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();
   QCString anchor = d->anchor();
@@ -1626,8 +1625,6 @@ void PythonCodeParser::parseCode(CodeOutputInterface &codeOutIntf,
     delete yyextra->sourceFileDef;
     yyextra->sourceFileDef=0;
   }
-  // write the tooltips
-  yyextra->tooltipManager.writeTooltips(codeOutIntf);
   printlex(yy_flex_debug, FALSE, __FILE__, fileDef ? fileDef->fileName().data(): NULL);
 }
 

--- a/src/tooltip.h
+++ b/src/tooltip.h
@@ -24,8 +24,7 @@ class CodeOutputInterface;
 class TooltipManager
 {
   public:
-    TooltipManager();
-   ~TooltipManager();
+    static TooltipManager *instance();
 
     /** add a tooltip for a given symbol definition */
     void addTooltip(const Definition *d);
@@ -34,8 +33,12 @@ class TooltipManager
     void writeTooltips(CodeOutputInterface &ol);
 
   private:
+    TooltipManager();
+   ~TooltipManager();
+
     class Private;
     std::unique_ptr<Private> p;
+    static TooltipManager *s_theInstance;
 };
 
 #endif

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -109,7 +109,6 @@ struct vhdlcodeYY_state
 
   bool          lexInit = false;
   int           braceCount = 0;
-  TooltipManager tooltipManager;
 };
 
 
@@ -1230,7 +1229,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
-  yyextra->tooltipManager.addTooltip(d);
+  TooltipManager::instance()->addTooltip(d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();
   QCString anchor = d->anchor();
@@ -1657,9 +1656,6 @@ void VHDLCodeParser::parseCode(CodeOutputInterface &od,
     yyextra->sourceFileDef=0;
   }
   yyextra->startCode=false;
-
-  // write the tooltips
-  yyextra->tooltipManager.writeTooltips(od);
 
   printlex(yy_flex_debug, false, __FILE__, fd ? fd->fileName().data(): NULL);
 }


### PR DESCRIPTION
Since commit d03e8d9411ab3e983fc3413c147fba1a5e5c9dad  stating
```
Refactoring: modernize TooltipManager class and source reference lists

- Tooltips are now collected per file instead of globally
```

We get for tests 021 and 085 XHTML warnings like:
```
test_output_021/html/index.xhtml:73: element div: validity error : ID aclass_test_xhtml already defined
<div class="ttc" id="aclass_test_xhtml"><div class="ttname"><a href="class_test.
```
when running
```
doxygen tests TEST_FLAGS=--xhtml
```
The tooltips should not be collected per input file type (or block of input file type), but should be collected for each output file and this requiring a global instance to collect the tooptip data  and writing the tooltip data at the end of the file.