### PR TITLE
Enable UML diagrams without member fields

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3444,22 +3444,22 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
-    <option type='bool' id='DOT_UML_DETAILS' defval='0' depends='UML_LOOK'>
+    <option type='enum' id='DOT_UML_DETAILS' defval='NO' depends='UML_LOOK'>
       <docs>
 <![CDATA[
+If the \c DOT_UML_DETAILS tag is set to \c NO, doxygen will
+show attributes and methods without types and arguments in the UML graphs.
 If the \c DOT_UML_DETAILS tag is set to \c YES, doxygen will
 add type and arguments for attributes and methods in the UML graphs.
+If the \c DOT_UML_DETAILS tag is set to \c NONE, doxygen will not generate
+fields with class member information in the UML graphs.
+The class diagrams will look similar to the default class diagrams but using
+UML notation for the relationships.
 ]]>
       </docs>
-    </option>
-    <option type='bool' id='DOT_UML_SHOW_MEMBER' defval='1' depends='UML_LOOK'>
-      <docs>
-<![CDATA[
- If the \c DOT_UML_SHOW_MEMBER tag is set to \c NO, doxygen will not generate fields with
- class member information inside the class nodes. The class diagrams will look similar to
- the default class diagrams but using UML notation for the relationships. 
-]]>
-      </docs>
+      <value name="NO" />
+      <value name="YES" />
+      <value name="NONE" />
     </option>
     <option type='int' id='DOT_WRAP_THRESHOLD' defval='17' minval='0' maxval='1000' depends='HAVE_DOT'>
       <docs>

--- a/src/config.xml
+++ b/src/config.xml
@@ -3452,6 +3452,15 @@ add type and arguments for attributes and methods in the UML graphs.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='DOT_UML_SHOW_MEMBER' defval='1' depends='UML_LOOK'>
+      <docs>
+<![CDATA[
+ If the \c DOT_UML_SHOW_MEMBER tag is set to \c NO, doxygen will not generate fields with
+ class member information inside the class nodes. The class diagrams will look similar to
+ the default class diagrams but using UML notation for the relationships. 
+]]>
+      </docs>
+    </option>
     <option type='int' id='DOT_WRAP_THRESHOLD' defval='17' minval='0' maxval='1000' depends='HAVE_DOT'>
       <docs>
 <![CDATA[

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -428,45 +428,48 @@ void DotNode::writeBox(FTextStream &t,
     }
 
     //printf("DotNode::writeBox for %s\n",m_classDef->name().data());
-    t << "{" << convertLabel(m_label);
-    t << "\\n|";
-    writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubAttribs),m_classDef,FALSE,&arrowNames);
-    writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubStaticAttribs),m_classDef,TRUE,&arrowNames);
-    writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_properties),m_classDef,FALSE,&arrowNames);
-    writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacAttribs),m_classDef,FALSE,&arrowNames);
-    writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacStaticAttribs),m_classDef,TRUE,&arrowNames);
-    writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proAttribs),m_classDef,FALSE,&arrowNames);
-    writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proStaticAttribs),m_classDef,TRUE,&arrowNames);
-    if (Config_getBool(EXTRACT_PRIVATE))
+    t << "{" << convertLabel(m_label) << "\\n";
+    if (Config_getBool(DOT_UML_SHOW_MEMBER))
     {
-      writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priAttribs),m_classDef,FALSE,&arrowNames);
-      writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priStaticAttribs),m_classDef,TRUE,&arrowNames);
-    }
-    t << "|";
-    writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubMethods),m_classDef);
-    writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubStaticMethods),m_classDef,TRUE);
-    writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubSlots),m_classDef);
-    writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacMethods),m_classDef);
-    writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacStaticMethods),m_classDef,TRUE);
-    writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proMethods),m_classDef);
-    writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proStaticMethods),m_classDef,TRUE);
-    writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proSlots),m_classDef);
-    if (Config_getBool(EXTRACT_PRIVATE))
-    {
-      writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priMethods),m_classDef);
-      writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priStaticMethods),m_classDef,TRUE);
-      writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priSlots),m_classDef);
-    }
-    if (m_classDef->getLanguage()!=SrcLangExt_Fortran &&
-      m_classDef->getMemberGroupSDict())
-    {
-      MemberGroupSDict::Iterator mgdi(*m_classDef->getMemberGroupSDict());
-      MemberGroup *mg;
-      for (mgdi.toFirst();(mg=mgdi.current());++mgdi)
+      t << "|";
+      writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubAttribs),m_classDef,FALSE,&arrowNames);
+      writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubStaticAttribs),m_classDef,TRUE,&arrowNames);
+      writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_properties),m_classDef,FALSE,&arrowNames);
+      writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacAttribs),m_classDef,FALSE,&arrowNames);
+      writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacStaticAttribs),m_classDef,TRUE,&arrowNames);
+      writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proAttribs),m_classDef,FALSE,&arrowNames);
+      writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proStaticAttribs),m_classDef,TRUE,&arrowNames);
+      if (Config_getBool(EXTRACT_PRIVATE))
       {
-        if (mg->members())
+        writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priAttribs),m_classDef,FALSE,&arrowNames);
+        writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priStaticAttribs),m_classDef,TRUE,&arrowNames);
+      }
+      t << "|";
+      writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubMethods),m_classDef);
+      writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubStaticMethods),m_classDef,TRUE);
+      writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubSlots),m_classDef);
+      writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacMethods),m_classDef);
+      writeBoxMemberList(t,'~',m_classDef->getMemberList(MemberListType_pacStaticMethods),m_classDef,TRUE);
+      writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proMethods),m_classDef);
+      writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proStaticMethods),m_classDef,TRUE);
+      writeBoxMemberList(t,'#',m_classDef->getMemberList(MemberListType_proSlots),m_classDef);
+      if (Config_getBool(EXTRACT_PRIVATE))
+      {
+        writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priMethods),m_classDef);
+        writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priStaticMethods),m_classDef,TRUE);
+        writeBoxMemberList(t,'-',m_classDef->getMemberList(MemberListType_priSlots),m_classDef);
+      }
+      if (m_classDef->getLanguage()!=SrcLangExt_Fortran &&
+        m_classDef->getMemberGroupSDict())
+      {
+        MemberGroupSDict::Iterator mgdi(*m_classDef->getMemberGroupSDict());
+        MemberGroup *mg;
+        for (mgdi.toFirst();(mg=mgdi.current());++mgdi)
         {
-          writeBoxMemberList(t,'*',mg->members(),m_classDef,FALSE,&arrowNames);
+          if (mg->members())
+          {
+            writeBoxMemberList(t,'*',mg->members(),m_classDef,FALSE,&arrowNames);
+          }
         }
       }
     }

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -97,6 +97,30 @@ static EdgeProperties umlEdgeProps =
   umlEdgeColorMap, umlArrowStyleMap, umlEdgeStyleMap
 };
 
+// Extracted from config setting "DOT_UML_DETAILS"
+enum class UmlDetailLevel
+{
+  Default, // == NO, the default setting
+  Full,    // == YES, include type and arguments
+  None     // == NONE, don't include compartments for attributes and methods
+};
+
+// Local helper function for extracting the configured detail level
+static UmlDetailLevel getUmlDetailLevelFromConfig()
+{
+  UmlDetailLevel result = UmlDetailLevel::Default;
+  QCString umlDetailsStr = Config_getEnum(DOT_UML_DETAILS).upper();
+  if (umlDetailsStr == "YES")
+  {
+    result=UmlDetailLevel::Full;
+  }
+  else if (umlDetailsStr == "NONE")
+  {
+    result=UmlDetailLevel::None;
+  }
+  return result;
+} 
+
 static QCString escapeTooltip(const QCString &tooltip)
 {
   QCString result;
@@ -149,7 +173,7 @@ static void writeBoxMemberList(FTextStream &t,
         {
           t << prot << " ";
           QCString label;
-          if(Config_getBool(DOT_UML_DETAILS))
+          if(getUmlDetailLevelFromConfig()==UmlDetailLevel::Full)
           {
             label+=mma->typeString();
             label+=" ";
@@ -157,7 +181,7 @@ static void writeBoxMemberList(FTextStream &t,
           label+=mma->name();
           if (!mma->isObjCMethod() && (mma->isFunction() || mma->isSlot() || mma->isSignal()))
           {
-            if(Config_getBool(DOT_UML_DETAILS))
+            if(getUmlDetailLevelFromConfig()==UmlDetailLevel::Full)
             {
               label+=mma->argsString();
             }
@@ -429,7 +453,7 @@ void DotNode::writeBox(FTextStream &t,
 
     //printf("DotNode::writeBox for %s\n",m_classDef->name().data());
     t << "{" << convertLabel(m_label) << "\\n";
-    if (Config_getBool(DOT_UML_SHOW_MEMBER))
+    if (getUmlDetailLevelFromConfig()!=UmlDetailLevel::None)
     {
       t << "|";
       writeBoxMemberList(t,'+',m_classDef->getMemberList(MemberListType_pubAttribs),m_classDef,FALSE,&arrowNames);


### PR DESCRIPTION
The compartment for class attributes and the compartment for the
operations are optional.

By providing a new option "DOT_UML_SHOW_MEMBER" an user can
configure to use the UML_LOOK but without the additional
information regarding the content of the class.

#6204 