### PR TITLE
Line miscount in case of Html type Comment

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -887,7 +887,11 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 
 <HtmlComment>"--"[!]?">"{B}*            { BEGIN( Comment ); }
 <HtmlComment>{DOCNL}                    {
-                                          if (*yytext=='\n') yyextra->lineNr++;
+                                          if (*yytext=='\n')
+                                          {
+                                            addOutput(yyscanner,*yytext);
+                                            yyextra->lineNr++;
+                                          }
                                         }
 <HtmlComment>[^\\\n\-]+                 { // ignore unimportant characters
                                         }


### PR DESCRIPTION
When having an example like:
```
/*! \file
    <table>
    <tr><th> Command</th> <th> Function</th></tr>
<!-- this is a multiline comment
     end of comment -->
    <tr><td> ? \xx6 </td><td> Dummy</td></tr>
    </table>
*/
```
we get the warning:
```
.../aa.c:5: warning: Found unknown command '\xx6'
```
instead of
```
.../aa.c:6: warning: Found unknown command '\xx6'
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5610610/example.tar.gz)
