### PR TITLE
Warning about shadowed variable

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6520,7 +6520,6 @@ QCString replaceColorMarkers(const char *str)
   QCString s=str;
   if (s.isEmpty()) return result;
   static QRegExp re("##[0-9A-Fa-f][0-9A-Fa-f]");
-  static const char hex[] = "0123456789ABCDEF";
   static int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
   static int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
   static int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);


### PR DESCRIPTION
In util.cpp the variable `hex` is double declared.
```
/cygdrive/d/Programs/Doxygen/Doxygen-.git/doxygen/src/util.cpp: In function ‘QCString replaceColorMarkers(const char*)’:
/cygdrive/d/Programs/Doxygen/Doxygen-.git/doxygen/src/util.cpp:6523:25: warning: declaration of ‘hex’ shadows a global declaration  -Wshadow]
 6523 |   static const char hex[] = "0123456789ABCDEF";
      |                         ^
/cygdrive/d/Programs/Doxygen/Doxygen-.git/doxygen/src/util.cpp:99:20: note: shadowed declaration is here
   99 | static const char *hex = "0123456789ABCDEF";
      |                    ^~~
```