### PR TITLE
fix: adding meta description and lang attribute, Closes #8214

### DIFF
--- a/templates/html/header.html
+++ b/templates/html/header.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="Description" content="$projectbrief">
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Three points:

1.  The `<!DOCTYPE html` attribute should really come first in the document.  Perhaps the autogenerated doxygen version line comment could come at the end?  or second line?
2. Perhaps lang attribute could be in the doxyfile, along with some other SEO attributes
3. The meta description tag needs to be in the `<head>` - so isn't wrapped in the PROJECT_BRIEF markers.  I believe that without PROJECT_BRIEF the attribute will be empty, which is harmless (no worse than without it)

See issue #8214 for before / after SEO results