### PR TITLE
Extend tests with some other default tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ script:
     - cmake -G "Unix Makefiles" -Dbuild_doc=ON -Dbuild_wizard=ON ..
     - make
     - if [ ! "${TRAVIS_OS_NAME}" == "osx" ] && [ ! "${TRAVIS_COMPILER}" == "clang" ]; then
-        make tests docs;
+        make tests TEST_FLAGS="--xml --xmlxsd --xhtml --docbook --rtf" docs;
       fi;
     - if [ ! "${TRAVIS_OS_NAME}" == "osx" ] && [ "${TRAVIS_COMPILER}" == "clang" ]; then
         make docs;


### PR DESCRIPTION
Extend tests with generating xhtml, docbook, rtf to see if the files can be generated and build.
Check also the generated xsd files in xml mode.

Note for the new checks no comparison is done with previous versions.