### PR TITLE
\name gives warnings regarding multiple defined labels

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1122,7 +1122,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           yyextra->current->type = yyextra->current->type.stripWhiteSpace();
                                         }
 <GroupDocArg2>{DOCNL}                   {
-                                          if ( yyextra->current->groupDocType==Entry::GROUPDOC_NORMAL &&
+                                          if ( yyextra->current->groupDocType==GroupType::GROUPDOC_NORMAL &&
                                                yyextra->current->type.isEmpty()
                                              ) // defgroup requires second argument
                                           {
@@ -1936,7 +1936,7 @@ static bool handleDefGroup(yyscan_t yyscanner,const QCString &, const QCStringLi
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool stop=makeStructuralIndicator(yyscanner,Entry::GROUPDOC_SEC);
-  yyextra->current->groupDocType = Entry::GROUPDOC_NORMAL;
+  yyextra->current->groupDocType = GroupType::GROUPDOC_NORMAL;
   BEGIN( GroupDocArg1 );
   return stop;
 }
@@ -1945,7 +1945,7 @@ static bool handleAddToGroup(yyscan_t yyscanner,const QCString &, const QCString
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool stop=makeStructuralIndicator(yyscanner,Entry::GROUPDOC_SEC);
-  yyextra->current->groupDocType = Entry::GROUPDOC_ADD;
+  yyextra->current->groupDocType = GroupType::GROUPDOC_ADD;
   BEGIN( GroupDocArg1 );
   return stop;
 }
@@ -1954,7 +1954,7 @@ static bool handleWeakGroup(yyscan_t yyscanner,const QCString &, const QCStringL
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool stop=makeStructuralIndicator(yyscanner,Entry::GROUPDOC_SEC);
-  yyextra->current->groupDocType = Entry::GROUPDOC_WEAK;
+  yyextra->current->groupDocType = GroupType::GROUPDOC_WEAK;
   BEGIN( GroupDocArg1 );
   return stop;
 }
@@ -2152,6 +2152,7 @@ static bool handleName(yyscan_t yyscanner,const QCString &, const QCStringList &
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool stop=makeStructuralIndicator(yyscanner,Entry::MEMBERGRP_SEC);
+  yyextra->current->groupDocType = GroupType::GROUPDOC_NAME;
   if (!stop)
   {
     yyextra->docGroup.clearHeader();

--- a/src/docgroup.cpp
+++ b/src/docgroup.cpp
@@ -122,6 +122,7 @@ void DocGroup::open(Entry *e,const char *,int, bool implicit)
       MemberGroupInfo *info = new MemberGroupInfo;
       info->header = m_memberGroupHeader.stripWhiteSpace();
       info->compoundName = m_compoundName;
+      info->groupDocType = e->groupDocType;
       m_memberGroupId = findExistingGroup(info);
       //printf("    use membergroup %d\n",m_memberGroupId);
       Doxygen::memGrpInfoDict.insert(m_memberGroupId,info);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -372,8 +372,10 @@ static void buildGroupListFiltered(const Entry *root,bool additional, bool inclu
          ( includeExternal && root->tagInfo()!=0))
      )
   {
-    if ((root->groupDocType==Entry::GROUPDOC_NORMAL && !additional) ||
-        (root->groupDocType!=Entry::GROUPDOC_NORMAL &&  additional))
+    if ((root->groupDocType==GroupType::GROUPDOC_NORMAL && !additional) ||
+        (root->groupDocType==GroupType::GROUPDOC_NAME   && !additional) ||
+        (root->groupDocType!=GroupType::GROUPDOC_NORMAL &&  additional) ||
+        (root->groupDocType!=GroupType::GROUPDOC_NAME   &&  additional))
     {
       GroupDef *gd = Doxygen::groupSDict->find(root->name);
       //printf("Processing group '%s':'%s' add=%d ext=%d gd=%p\n",
@@ -467,8 +469,10 @@ static void organizeSubGroupsFiltered(const Entry *root,bool additional)
 {
   if (root->section==Entry::GROUPDOC_SEC && !root->name.isEmpty())
   {
-    if ((root->groupDocType==Entry::GROUPDOC_NORMAL && !additional) ||
-        (root->groupDocType!=Entry::GROUPDOC_NORMAL && additional))
+    if ((root->groupDocType==GroupType::GROUPDOC_NORMAL && !additional) ||
+        (root->groupDocType==GroupType::GROUPDOC_NAME   && !additional) ||
+        (root->groupDocType!=GroupType::GROUPDOC_NORMAL && additional)  ||
+        (root->groupDocType!=GroupType::GROUPDOC_NAME   && additional))
     {
       GroupDef *gd;
       if ((gd=Doxygen::groupSDict->find(root->name)))

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -40,7 +40,7 @@ Entry::Entry()
   hasTagInfo = FALSE;
   relatesType = Simple;
   hidden = FALSE;
-  groupDocType = GROUPDOC_NORMAL;
+  groupDocType = GroupType::GROUPDOC_UNKNOWN;
   reset();
 }
 
@@ -230,7 +230,7 @@ void Entry::reset()
   artificial = FALSE;
   subGrouping = TRUE;
   protection = Public;
-  groupDocType = GROUPDOC_NORMAL;
+  groupDocType = GroupType::GROUPDOC_UNKNOWN;
   id.resize(0);
   metaData.resize(0);
   m_sublist.clear();

--- a/src/entry.h
+++ b/src/entry.h
@@ -183,13 +183,6 @@ class Entry
     static const uint64 MaybeAmbiguous  = (1ULL<<62); // on UNO IDL property
     static const uint64 Published       = (1ULL<<63); // UNO IDL keyword
 
-    enum GroupDocType
-    {
-      GROUPDOC_NORMAL,        //!< defgroup
-      GROUPDOC_ADD,           //!< addtogroup
-      GROUPDOC_WEAK           //!< weakgroup
-    };                        //!< kind of group
-
     Entry();
     Entry(const Entry &);
    ~Entry();
@@ -292,7 +285,7 @@ class Entry
     SrcLangExt  lang;         //!< programming language in which this entry was found
     bool        hidden;       //!< does this represent an entity that is hidden from the output
     bool        artificial;   //!< Artificially introduced item
-    GroupDocType groupDocType;
+    GroupType::GroupDocType groupDocType;
     QCString    id;           //!< libclang id
     LocalToc    localToc;
     QCString    metaData;     //!< Slice metadata
@@ -302,9 +295,10 @@ class Entry
     {
       switch( groupDocType )
       {
-        case GROUPDOC_NORMAL: return "\\defgroup";
-        case GROUPDOC_ADD: return "\\addtogroup";
-        case GROUPDOC_WEAK: return "\\weakgroup";
+        case GroupType::GROUPDOC_NORMAL: return "\\defgroup";
+        case GroupType::GROUPDOC_ADD: return "\\addtogroup";
+        case GroupType::GROUPDOC_WEAK: return "\\weakgroup";
+        case GroupType::GROUPDOC_NAME: return "\\name";
         default: return "unknown group command";
       }
     }
@@ -316,9 +310,10 @@ class Entry
       }
       switch( groupDocType )
       {
-        case GROUPDOC_NORMAL: return Grouping::GROUPING_AUTO_DEF;
-        case GROUPDOC_ADD:    return Grouping::GROUPING_AUTO_ADD;
-        case GROUPDOC_WEAK:   return Grouping::GROUPING_AUTO_WEAK;
+        case GroupType::GROUPDOC_NORMAL: return Grouping::GROUPING_AUTO_DEF;
+        case GroupType::GROUPDOC_ADD:    return Grouping::GROUPING_AUTO_ADD;
+        case GroupType::GROUPDOC_WEAK:   return Grouping::GROUPING_AUTO_WEAK;
+        case GroupType::GROUPDOC_NAME:   return Grouping::GROUPING_AUTO_DEF;
         default: return Grouping::GROUPING_LOWEST;
       }
     }

--- a/src/membergroup.cpp
+++ b/src/membergroup.cpp
@@ -29,8 +29,8 @@
 #include "entry.h"
 #include "md5.h"
 
-MemberGroup::MemberGroup(const Definition *container,int id,const char *hdr,const char *d,const char *docFile,int docLine)
-  : m_container(container), grpId(id), grpHeader(hdr), doc(d), m_docFile(docFile), m_docLine(docLine)
+MemberGroup::MemberGroup(const Definition *container,int id,const char *hdr,const char *d,const char *docFile,int docLine,GroupType::GroupDocType groupDocType)
+  : m_container(container), grpId(id), grpHeader(hdr), doc(d), m_docFile(docFile), m_docLine(docLine), m_groupDocType(groupDocType)
 {
   static bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
 
@@ -93,9 +93,8 @@ void MemberGroup::writeDeclarations(OutputList &ol,
                const ClassDef *cd,const NamespaceDef *nd,const FileDef *fd,const GroupDef *gd,
                bool showInline) const
 {
-  //printf("MemberGroup::writeDeclarations() %s\n",grpHeader.data());
   QCString ldoc = doc;
-  if (!ldoc.isEmpty()) ldoc.prepend("<a name=\""+anchor()+"\" id=\""+anchor()+"\"></a>");
+  if (m_groupDocType!=GroupType::GROUPDOC_NAME && !ldoc.isEmpty() && !grpHeader.isEmpty()) ldoc.prepend("<a name=\""+anchor()+"\" id=\""+anchor()+"\"></a>");
   memberList->writeDeclarations(ol,cd,nd,fd,gd,grpHeader,ldoc,FALSE,showInline);
 }
 

--- a/src/membergroup.h
+++ b/src/membergroup.h
@@ -45,7 +45,7 @@ class MemberGroup
   public:
     //MemberGroup();
     MemberGroup(const Definition *container,int id,const char *header,
-                const char *docs,const char *docFile,int docLine);
+                const char *docs,const char *docFile,int docLine,GroupType::GroupDocType groupDocType);
    ~MemberGroup();
     QCString header() const { return grpHeader; }
     int groupId() const { return grpId; }
@@ -101,8 +101,9 @@ class MemberGroup
     QCString doc;
     bool inSameSection = true;
     QCString m_docFile;
-    int m_docLine;
+    int m_docLine = -1;
     RefItemVector m_xrefListItems;
+    GroupType::GroupDocType m_groupDocType = GroupType::GROUPDOC_UNKNOWN;
 };
 
 /** A list of MemberGroup objects. */
@@ -140,6 +141,7 @@ struct MemberGroupInfo
   QCString docFile;
   int docLine = -1;
   QCString compoundName;
+  GroupType::GroupDocType groupDocType;
   RefItemVector m_sli;
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -96,6 +96,19 @@ struct Grouping
   GroupPri_t pri;       //!< priority of this definition
 
 };
+/** Grouping type */
+struct GroupType
+{
+  
+  enum GroupDocType
+  {
+    GROUPDOC_UNKNOWN = -1,  //!< unknown group
+    GROUPDOC_NORMAL,        //!< defgroup
+    GROUPDOC_ADD,           //!< addtogroup
+    GROUPDOC_WEAK,          //!< weakgroup
+    GROUPDOC_NAME           //!< name
+  };                        //!< kind of group
+};
 
 enum MemberListType
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4422,7 +4422,8 @@ void addMembersToMemberGroup(MemberList *ml,
                     info->header,
                     info->doc,
                     info->docFile,
-                    info->docLine
+                    info->docLine,
+                    info->groupDocType
                     );
                 (*ppMemberGroupSDict)->append(groupId,mg);
               }
@@ -4455,7 +4456,8 @@ void addMembersToMemberGroup(MemberList *ml,
               info->header,
               info->doc,
               info->docFile,
-              info->docLine
+              info->docLine,
+              info->groupDocType
               );
           (*ppMemberGroupSDict)->append(groupId,mg);
         }


### PR DESCRIPTION
When having multiple statement like `\name` (without description) in one file or a statement like `\name Types` in multiple file an automatic label is created, but when xmllint checking in html we get messages like:
```
 element a: validity error : ID amgrp01747264fe7bf50731df0522c351974e already defined
```
or when building teh pdf from LaTeX:
```
LaTeX Warning: Label `_amgrp01747264fe7bf50731df0522c351974e' multiply defined.
```

A `\name` has no "anchor" so no need for a label either.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5631235/example.tar.gz)

(Problem found through CGAL code)