### PR TITLE
Creating link to not defined label in case of groups

### DIFF
--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -890,9 +890,7 @@ void GroupDefImpl::writeBriefDescription(OutputList &ol)
       ol.writeString(" \n");
       ol.enable(OutputGenerator::RTF);
 
-      if (Config_getBool(REPEAT_BRIEF) ||
-          !documentation().isEmpty()
-         )
+      if (hasDetailedDescription())
       {
         ol.disableAllBut(OutputGenerator::Html);
         ol.startTextLink(0,"details");
@@ -1783,8 +1781,8 @@ void GroupDefImpl::updateLanguage(const Definition *d)
 bool GroupDefImpl::hasDetailedDescription() const
 {
   static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
-  return ((!briefDescription().isEmpty() && repeatBrief) ||
-          !documentation().isEmpty());
+  return ((!briefDescription().isEmpty() && repeatBrief) || !documentation().isEmpty() || !inbodyDocumentation().isEmpty()) &&
+         (m_pageDict->count()!=(uint)numDocMembers());
 }
 
 // --- Cast functions

--- a/src/groupdef.h
+++ b/src/groupdef.h
@@ -23,6 +23,7 @@
 #include "sortdict.h"
 #include "definition.h"
 #include "dirdef.h"
+#include "layout.h"
 
 class MemberList;
 class FileList;


### PR DESCRIPTION
In the doxygen group example there is for group 5 a "More" link but this points to nowhere as there is no detailed section. Using a link checker this gives:
```
Processing      file:///.../html/group__group5.html

List of broken links and other issues:
file:///.../html/group__group5.html
  Line: 47
  Code: 200 (no message)
 To do: Some of the links to this resource point to broken URI fragments
        (such as index.html#fragment).
The following fragments need to be fixed:
        details                         Line: 47
```

By applying the same logic for creating the "More" link as for for the real writing and using the appropriate function (with correction) for it