### PR TITLE
Warning building test 45 i.e. incorrect links specified

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1331,19 +1331,22 @@ DB_VIS_C
   if (!ref->file().isEmpty()) endLink();
 }
 
-void DocbookDocVisitor::visitPre(DocSecRefItem *)
+void DocbookDocVisitor::visitPre(DocSecRefItem *ref)
 {
 DB_VIS_C
   if (m_hide) return;
-  //m_t << "<tocentry xml:idref=\"_" <<  stripPath(ref->file()) << "_1" << ref->anchor() << "\">";
-  m_t << "<tocentry>";
+  m_t << "<tocdiv>";
+  m_t << "<link linkend=\"_" << stripPath(ref->file());
+  if (!ref->anchor().isEmpty()) m_t << "_1" << ref->anchor();
+  m_t << "\">";
 }
 
 void DocbookDocVisitor::visitPost(DocSecRefItem *)
 {
 DB_VIS_C
   if (m_hide) return;
-  m_t << "</tocentry>" << endl;
+  m_t << "</link>";
+  m_t << "</tocdiv>" << endl;
 }
 
 void DocbookDocVisitor::visitPre(DocSecRefList *)

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2283,7 +2283,8 @@ void DocSecRefItem::parse()
     if (sec)
     {
       m_file   = sec->fileName();
-      m_anchor = sec->label();
+      m_anchor = "";
+      if (sec->type() != SectionType::Page) m_anchor = sec->label();
     }
     else
     {

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1915,7 +1915,9 @@ void HtmlDocVisitor::visitPre(DocSecRefItem *ref)
 {
   if (m_hide) return;
   QCString refName=addHtmlExtensionIfMissing(ref->file());
-  m_t << "<li><a href=\"" << refName << "#" << ref->anchor() << "\">";
+  m_t << "<li><a href=\"" << refName;
+  if (!ref->anchor().isEmpty()) m_t << "#" << ref->anchor();
+  m_t << "\">";
 
 }
 

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1452,7 +1452,9 @@ void LatexDocVisitor::visitPre(DocSecRefItem *ref)
   static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (pdfHyperlinks)
   {
-    m_t << "\\mbox{\\hyperlink{" << ref->file() << "_" << ref->anchor() << "}{" ;
+    m_t << "\\mbox{\\hyperlink{" << ref->file();
+    if (!ref->anchor().isEmpty()) m_t << "_" << ref->anchor();
+    m_t << "}{" ;
   }
 }
 
@@ -1464,7 +1466,9 @@ void LatexDocVisitor::visitPost(DocSecRefItem *ref)
   {
     m_t << "}}";
   }
-  m_t << "}{\\ref{" << ref->file() << "_" << ref->anchor() << "}}{}" << endl;
+  m_t << "}{\\ref{" << ref->file();
+  if (!ref->anchor().isEmpty()) m_t << "_" << ref->anchor();
+  m_t << "}}{}" << endl;
 }
 
 void LatexDocVisitor::visitPre(DocSecRefList *)

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1224,10 +1224,12 @@ void PerlModDocVisitor::visitPost(DocRef *)
   closeItem();
 }
 
-void PerlModDocVisitor::visitPre(DocSecRefItem *)
+void PerlModDocVisitor::visitPre(DocSecRefItem *ref)
 {
 #if 0
-  m_output.add("<tocitem id=\""); m_output.add(ref->file()); m_output.add("_1"); m_output.add(ref->anchor()); m_output.add("\">");
+  m_output.add("<tocitem id=\""); m_output.add(ref->file());
+  if (!ref->anchor().isEmpty()) m_output.add("_1"); m_output.add(ref->anchor());
+  m_output.add("\">");
 #endif
 }
 

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -1004,7 +1004,9 @@ void XmlDocVisitor::visitPost(DocRef *ref)
 void XmlDocVisitor::visitPre(DocSecRefItem *ref)
 {
   if (m_hide) return;
-  m_t << "<tocitem id=\"" << ref->file() << "_1" << ref->anchor() << "\">";
+  m_t << "<tocitem id=\"" << ref->file();
+  if (!ref->anchor().isEmpty()) m_t << "_1" << ref->anchor();
+  m_t << "\">";
 }
 
 void XmlDocVisitor::visitPost(DocSecRefItem *)

--- a/testing/045/indexpage.xml
+++ b/testing/045/indexpage.xml
@@ -9,7 +9,7 @@
       <para>
         <toclist>
           <tocitem id="index_1item1">First Item</tocitem>
-          <tocitem id="item2_1item2">Second Item</tocitem>
+          <tocitem id="item2">Second Item</tocitem>
           <tocitem id="item2_1item3">Third Item</tocitem>
         </toclist>
       </para>


### PR DESCRIPTION
When running test 45 for HTML and LaTeX  and doing link checks / build pdf we get the warnings:
```
List of broken links and other issues:
file:///.../html/item2.html
 Lines: 71, 76
  Code: 200 (no message)
 To do: Some of the links to this resource point to broken URI fragments
        (such as index.html#fragment).
The following fragments need to be fixed:
        item2                           Line: 71

```
and
```
LaTeX Warning: Reference `item2_item2' on page 1 undefined on input line 5.
```

In case a refitem references to a page it should not add an anchor behind it.