### PR TITLE
Incorrect link from summary links for namespaces

### DIFF
--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -893,10 +893,19 @@ void NamespaceDefImpl::writeSummaryLinks(OutputList &ol) const
     }
     else if (lde->kind()==LayoutDocEntry::NamespaceNestedNamespaces && namespaceSDict && namespaceSDict->declVisible())
     {
-      LayoutDocEntrySection *ls = (LayoutDocEntrySection*)lde;
-      QCString label = "namespaces";
-      ol.writeSummaryLink(0,label,ls->title(lang),first);
-      first=FALSE;
+      SDict<NamespaceDef>::Iterator ni(*namespaceSDict);
+      NamespaceDef *nd;
+      for (ni.toFirst();(nd=ni.current());++ni)
+      {
+        if (nd->isLinkable() && nd->hasDocumentation())
+        {
+          LayoutDocEntrySection *ls = (LayoutDocEntrySection*)lde;
+          QCString label = "namespaces";
+          ol.writeSummaryLink(0,label,ls->title(lang),first);
+          first=FALSE;
+          break;
+        }
+      }
     }
     else if (lde->kind()== LayoutDocEntry::MemberDecl)
     {


### PR DESCRIPTION
When running a link checker on the CGAL BGL package we get the warning:
```
List of broken links and other issues:
file:///.../doc_output/BGL/namespaceCGAL.html
 Lines: 164, 172, 1143, 1153
  Code: 200 (no message)
 To do: Some of the links to this resource point to broken URI fragments
        (such as index.html#fragment).
The following fragments need to be fixed:
        namespaces                      Line: 164
```
This is due to the fact that on the mentioned page no "section" namespaces is but in the summary links (top right) there is still "Namespaces".
Before writing the summary link it should be checked whether or not there are really namespaces shown (se also `NamespaceSDict::writeDeclaration`).