### PR TITLE
Problem with reproducibility of MSC graph in HTML

### DIFF
--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -54,14 +54,20 @@ static bool convertMapFile(FTextStream &t,const char *mapName,const QCString rel
     //printf("ReadLine '%s'\n",buf);
     if (qstrncmp(buf,"rect",4)==0)
     {
-      // obtain the url and the coordinates in the order used by graphviz-1.5
-      sscanf(buf,"rect %s %d,%d %d,%d",url,&x1,&y1,&x2,&y2);
-
-      if (qstrcmp(url,"\\ref")==0 || qstrcmp(url,"@ref")==0)
+      sscanf(buf,"rect %s",ref); // lets get the first word after 'rect'
+      if (qstrcmp(ref,"\\ref")==0 || qstrcmp(ref,"@ref")==0)
       {
         isRef = TRUE;
-        sscanf(buf,"rect %s %s %d,%d %d,%d",ref,url,&x1,&y1,&x2,&y2);
+        int j = sscanf(buf,"rect %s %s %d,%d %d,%d",ref,url,&x1,&y1,&x2,&y2);
+        if (j!=6) continue;
       }
+      else
+      {
+        // obtain the url and the coordinates in the order used by graphviz-1.5
+        int i = sscanf(buf,"rect %s %d,%d %d,%d",url,&x1,&y1,&x2,&y2);
+        if (i!=5) continue;
+      }
+
 
       // sanity checks
       if (y2<y1) { int temp=y2; y2=y1; y1=temp; }

--- a/testing/037/037__msc_8cpp.xml
+++ b/testing/037/037__msc_8cpp.xml
@@ -12,13 +12,13 @@ Sender_1,Receiver_1,Sender1_1,
 Sender,Receiver,Sender1,
 Sender_2,Receiver_2,Sender1_2;
 
-Sender_1-&gt;Receiver_1 [label="Command()", URL="nref Receiver::Command()"],
-Sender1_1&lt;-Receiver_1 [label="Ack()", URL="nref Ack()", ID="1"];
+Sender_1-&gt;Receiver_1 [label="Command()", URL="\ref Receiver::Command()"],
+Sender1_1&lt;-Receiver_1 [label="Ack()", URL="\ref Sender::Ack()", ID="1"];
 
-Sender-&gt;Receiver [label="Command()", URL="nref Receiver::Command()"];
-Sender1&lt;-Receiver [label="Ack()", URL="nref Ack()", ID="1"];
-Sender_2-&gt;Receiver_2 [label="Command()", URL="nref Receiver::Command()"],
-Sender1_2&lt;-Receiver_2 [label="Ack()", URL="nref Ack()", ID="1"];
+Sender-&gt;Receiver [label="Command()", URL="\ref Receiver::Command()"];
+Sender1&lt;-Receiver [label="Ack()", URL="\ref Sender::Ack()", ID="1"];
+Sender_2-&gt;Receiver_2 [label="Command()", URL="\ref Receiver::Command()"],
+Sender1_2&lt;-Receiver_2 [label="Ack()", URL="\ref Sender::Ack()", ID="1"];
 </msc>
  </para>
     </detaileddescription>

--- a/testing/037_msc.cpp
+++ b/testing/037_msc.cpp
@@ -10,13 +10,13 @@
  * Sender,Receiver,Sender1,
  * Sender_2,Receiver_2,Sender1_2;
  * 
- * Sender_1->Receiver_1 [label="Command()", URL="nref Receiver::Command()"],
- * Sender1_1<-Receiver_1 [label="Ack()", URL="nref Ack()", ID="1"];
+ * Sender_1->Receiver_1 [label="Command()", URL="\ref Receiver::Command()"],
+ * Sender1_1<-Receiver_1 [label="Ack()", URL="\ref Sender::Ack()", ID="1"];
  * 
- * Sender->Receiver [label="Command()", URL="nref Receiver::Command()"];
- * Sender1<-Receiver [label="Ack()", URL="nref Ack()", ID="1"];
- * Sender_2->Receiver_2 [label="Command()", URL="nref Receiver::Command()"],
- * Sender1_2<-Receiver_2 [label="Ack()", URL="nref Ack()", ID="1"];
+ * Sender->Receiver [label="Command()", URL="\ref Receiver::Command()"];
+ * Sender1<-Receiver [label="Ack()", URL="\ref Sender::Ack()", ID="1"];
+ * Sender_2->Receiver_2 [label="Command()", URL="\ref Receiver::Command()"],
+ * Sender1_2<-Receiver_2 [label="Ack()", URL="\ref Sender::Ack()", ID="1"];
  * \endmsc
  */
 


### PR DESCRIPTION
The main problem was that the example / test didn't contain correct "code" i.e. it used `nref` instead of `\ref` (or `@ref`) (and also the definition of `Ack` was not correct).
- example made correct
- the reading and interpretation of the map file made more robust.

The problem showed with test 37.