### PR TITLE
Incorrect link from summary links for classes

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2120,6 +2120,7 @@ void ClassDefImpl::writeAuthorSection(OutputList &ol) const
 
 void ClassDefImpl::writeSummaryLinks(OutputList &ol) const
 {
+  static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
   ol.pushGeneratorState();
   ol.disableAllBut(OutputGenerator::Html);
   QListIterator<LayoutDocEntry> eli(
@@ -2137,9 +2138,22 @@ void ClassDefImpl::writeSummaryLinks(OutputList &ol) const
           m_impl->innerClasses->declVisible()
          )
       {
-        LayoutDocEntrySection *ls = (LayoutDocEntrySection*)lde;
-        ol.writeSummaryLink(0,"nested-classes",ls->title(lang),first);
-        first=FALSE;
+        ClassSDict::Iterator sdi(*(m_impl->innerClasses));
+        ClassDef *cd=0;
+        for (sdi.toFirst();(cd=sdi.current());++sdi)
+        {
+          if (!cd->isAnonymous() &&
+              !cd->isExtension() &&
+              (cd->protection()!=Private || extractPrivate) &&
+              cd->visibleInParentsDeclList()
+             )
+          {
+            LayoutDocEntrySection *ls = (LayoutDocEntrySection*)lde;
+            ol.writeSummaryLink(0,"nested-classes",ls->title(lang),first);
+            first=FALSE;
+            break;
+          }
+        }
       }
       else if (lde->kind()==LayoutDocEntry::ClassAllMembersLink &&
                !m_impl->allMemberNameInfoLinkedMap.empty() &&


### PR DESCRIPTION
When running a link checker on the CGAL Classification or Point_set_processing_3 package we get the warning:
```
List of broken links and other issues:
file:///.../doc_output/Classification/classCGAL_1_1Classification_1_1Point__set__feature__generator.html
  Code: 200 (no message)
 To do: Some of the links to this resource point to broken URI fragments
        (such as index.html#fragment).
The following fragments need to be fixed:
        nested-classes
```
This is due to the fact that on the mentioned page no "section" classes is but in the summary links (top right) there is still "Classes".