### PR TITLE
Multiple anchors with member-group

### DIFF
--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -1094,7 +1094,7 @@ QCString MemberList::listTypeAsString(MemberListType type)
     case MemberListType_decFriendMembers: return "friend-members";
     case MemberListType_decPropMembers: return "prop-members";
     case MemberListType_enumFields: return "enum-fields";
-    case MemberListType_memberGroup: return "member-group";
+    case MemberListType_memberGroup: break;
     default: break;
   }
   return "";


### PR DESCRIPTION
When running a link checker on the CGAL (e.g. AABB_tree package) we get a lot of warnings like:
```
Processing      file:///.../doc_output/AABB_tree/classCGAL_1_1AABB__tree.html

List of duplicate and empty anchors
        member-group    Lines: 191, 229, 258, 297, 316, 335, 347
```

The member-group anchor is shown like:
```
<a name="member-group"></a>
```
and create each time the `\name` command is used. the `\name` command can be used multiple times on a page.
There is (no way to) reference the anchor (like `<a href="#member-group">...`)  found in the doxygen code.

Setting the name to the empty string prevents the anchor from being created.