### PR TITLE
\name gives warnings regarding multiple defined labels

### DIFF
--- a/src/membergroup.cpp
+++ b/src/membergroup.cpp
@@ -325,7 +325,7 @@ QCString MemberGroup::anchor() const
   if (locHeader.isEmpty()) locHeader="[NOHEADER]";
   MD5Buffer((const unsigned char *)locHeader.data(),locHeader.length(),md5_sig);
   MD5SigToString(md5_sig,sigStr.rawData(),33);
-  return "amgrp"+sigStr;
+  return "amgrp"+QCString().setNum(grpId)+sigStr;
 }
 
 void MemberGroup::addListReferences(Definition *def)


### PR DESCRIPTION
When having multiple statement like `\name` (without description) in one file or a statement like `\name Types` in multiple file an automatic label is created, but when xmllint checking in html we get messages like:
```
 element a: validity error : ID amgrp01747264fe7bf50731df0522c351974e already defined
```
or when building teh pdf from LaTeX:
```
LaTeX Warning: Label `_amgrp01747264fe7bf50731df0522c351974e' multiply defined.
```

A `\name` has no "anchor" so no need for a label either, though we see that in combination with an `xrefitem` command the "anchor" is referenced thus the solution in #8220 is not correct (no anchor generated at all).
Creating now an unique label based on the available information.

The problem was seen in the CGAL package Periodic_2_triangulation_2 in the files:
```
doc_output/Periodic_2_triangulation_2/models.html
doc_output/Periodic_2_triangulation_2/classCGAL_1_1Periodic__2__triangulation__2.html#amgrp103faca12f60c9c4bed5bcd83ebeee0412
```