### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,8 @@ endif()
 
 if (WIN32)
     if ((NOT CMAKE_GENERATOR MATCHES "MinGW Makefiles") AND 
-        (NOT CMAKE_GENERATOR MATCHES "MSYS Makefiles"))
+        (NOT CMAKE_GENERATOR MATCHES "MSYS Makefiles") AND
+        (NOT CMAKE_GENERATOR MATCHES "Unix Makefiles"))
         if (NOT ICONV_DIR)
           set(ICONV_DIR "${PROJECT_SOURCE_DIR}/winbuild")
         endif()


### PR DESCRIPTION
Update CMakeLists.txt to allow cross compiling on Linux for Windows.

Pass -DCMAKE_CXX_FLAGS="$(CXXFLAGS) -DCYGWIN=1" to cmake so right PRETTY_FUNC is used in markdown.cpp when -DWIN32 is set somewhere else.
Pass -DCMAKE_EXE_LINKER_FLAGS="$(LDFLAGS)  -Wl,--whole-archive -liconv -Wl,--no-whole-archive" (and make sure win-iconv is in library search path. https://github.com/win-iconv/win-iconv)