### PR TITLE
Incorrect specification of irc as URL protocol

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -386,7 +386,7 @@ ATTRNAME  [a-z_A-Z\x80-\xFF][:a-z_A-Z0-9\x80-\xFF\-]*
 ATTRIB    {ATTRNAME}{WS}*("="{WS}*(("\""[^\"]*"\"")|("'"[^\']*"'")|[^ \t\r\n'"><]+))?
 URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=]
 URLMASK   ({URLCHAR}+([({]{URLCHAR}*[)}])?)+
-URLPROTOCOL ("http:"|"https:"|"ftp:"|"file:"|"news:"|"irc")
+URLPROTOCOL ("http:"|"https:"|"ftp:"|"ftps:"|"sftp:"|"file:"|"news:"|"irc:"|"ircs:")
 FILESCHAR [a-z_A-Z0-9\\:\\\/\-\+&#@]
 FILEECHAR [a-z_A-Z0-9\-\+&#@]
 HFILEMASK ("."{FILESCHAR}*{FILEECHAR}+)+

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6686,7 +6686,8 @@ bool isURL(const QCString &url)
 {
   QCString loc_url = url.stripWhiteSpace();
   return loc_url.left(5)=="http:" || loc_url.left(6)=="https:" ||
-         loc_url.left(4)=="ftp:"  || loc_url.left(5)=="file:";
+         loc_url.left(4)=="ftp:"  || loc_url.left(5)=="ftps:"  || loc_url.left(5)=="sftp:"  ||
+         loc_url.left(5)=="file:";
 }
 /** Corrects URL \a url according to the relative path \a relPath.
  *  Returns the corrected URL. For absolute URLs no correction will be done.


### PR DESCRIPTION
- missing colon (`:`) at irc
- adding irc, sftp and ftps