### PR TITLE
issue #8142 UTF-8 in URL in source generates truncated URL in HTML

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -384,7 +384,7 @@ OLISTITEM {BLANK}*[1-9][0-9]*"."{BLANK}
 ENDLIST   {BLANK}*"."{BLANK}*\n
 ATTRNAME  [a-z_A-Z\x80-\xFF][:a-z_A-Z0-9\x80-\xFF\-]*
 ATTRIB    {ATTRNAME}{WS}*("="{WS}*(("\""[^\"]*"\"")|("'"[^\']*"'")|[^ \t\r\n'"><]+))?
-URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=]
+URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=\x80-\xFF]
 URLMASK   ({URLCHAR}+([({]{URLCHAR}*[)}])?)+
 URLPROTOCOL ("http:"|"https:"|"ftp:"|"file:"|"news:"|"irc")
 FILESCHAR [a-z_A-Z0-9\\:\\\/\-\+&#@]


### PR DESCRIPTION
Specifying the URL in a similar way as other IDs