### PR TITLE
issue #8231 The use of \code results in skipping the commentary block

### DIFF
--- a/src/vhdljjparser.h
+++ b/src/vhdljjparser.h
@@ -69,7 +69,6 @@ class VHDLOutlineParser : public OutlineParserInterface
     bool checkMultiComment(QCString& qcs,int line);
     void insertEntryAtLine(std::shared_ptr<Entry> ce,int line);
     QString getNameID();
-    int checkInlineCode(QCString & doc);
   private:
     struct Private;
     std::unique_ptr<Private> p;


### PR DESCRIPTION
The handling of a code block was done in a non-doxygen conform way. It should be left to the doxygen commentScanner.parseCommentBlock i.e. a complete comment block has to be handed to the comment block parser.