### PR TITLE
issue #8247 declaration different in cpp and h file of qstrncmp

### DIFF
--- a/qtools/qcstring.h
+++ b/qtools/qcstring.h
@@ -58,7 +58,7 @@ inline char *cstrcpy( char *dst, const char *src )
 inline char *qstrcpy( char *dst, const char *src )
 { return src ? strcpy(dst, src) : 0; }
 
-char * qstrncpy(char *src,const char *dst, uint len);
+char * qstrncpy(char *dst,const char *src, uint len);
 
 inline int cstrcmp( const char *str1, const char *str2 )
 { return strcmp(str1,str2); }


### PR DESCRIPTION
argument names of source and destination were in h file switched compared to the cpp file, no harm done it are just names in the prototype but it is confusing.