### PR TITLE
issue #8246 The prefix &#х202А; for files is displayed incorrectly in the file names.

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -743,7 +743,7 @@ static void writeDirTreeNode(OutputList &ol, DirDef *dd, int level, FTVHelp* ftv
         else if (src)
         {
           Doxygen::indexList->addContentsItem(
-               FALSE, convertToHtml(fd->name(),TRUE), 0,
+               FALSE, fd->name(), 0,
                fd->getSourceFileBase(), 0, FALSE, TRUE, fd);
         }
       }
@@ -813,7 +813,7 @@ static void writeDirHierarchy(OutputList &ol, FTVHelp* ftv,bool addToIndex)
             else if (src)
             {
               Doxygen::indexList->addContentsItem(
-                  FALSE, convertToHtml(fd->name(),TRUE), 0,
+                  FALSE, fd->name(), 0,
                   fd->getSourceFileBase(), 0, FALSE, TRUE, fd.get());
             }
           }
@@ -4131,7 +4131,7 @@ static void writeGroupTreeNode(OutputList &ol, GroupDef *gd, int level, FTVHelp*
           bool hasSections = pd->hasSections();
           Doxygen::indexList->addContentsItem(
               hasSubPages || hasSections,
-              convertToHtml(pd->title(),TRUE),
+              pd->title(),
               gd->getReference(),
               gd->getOutputFileBase(),
               si ? si->label().data() : 0,


### PR DESCRIPTION
Each index generator should handle its Left-To-Right / Right-To-Left handling on its own as otherwise we get for e.g.
treeview in the js file:
```
[ "\u202A&#x202A;afx3.h", "a00002_source.html", null ]
```
instead of:
```
[ "\u202A;afx3.h", "a00002_source.html", null ]
```
resulting in the problems from this issue.

in the htmlhelp (index.hhc):
```
... value="&#x202A;&#x202A;afx3.h" ...
```
i.e. a double `&#x202A;` which is not nice.

In "XML" type formats (not the doxygen xml output!), here qhp index.qhp:
```
... title="&amp;#x202A;afx3.h" ...
```
where the LTR sequence is escaped.

Example for the small test: [example.tar.gz](https://github.com/doxygen/doxygen/files/5688650/example.tar.gz)
