### PR TITLE
Recent file list of doxywizard not cleared properly

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -388,7 +388,7 @@ void MainWindow::clearRecent()
     m_recentFiles.clear();
     for (int i=0;i<MAX_RECENT_FILES;i++)
     {
-      m_settings.setValue(QString::fromLatin1("recent/config%1").arg(i++),QString::fromLatin1(""));
+      m_settings.setValue(QString::fromLatin1("recent/config%1").arg(i),QString::fromLatin1(""));
     }
     m_clearRecent->setEnabled(false);
     m_recentMenu->setEnabled(false);


### PR DESCRIPTION
Only half of the items in the list of recently loaded configuration files were removed,
(One notices this e.g. after clearing the list, leave the wizard, start wizard and look in the recent loaded files list)