### PR TITLE
Extend tests with some other default tests

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -10,54 +10,54 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-            name: "Ubuntu Latest GCC Release",
-            os: ubuntu-latest,
-            build_type: "Release", cc: "gcc", cxx: "g++",
-            build_gen: "Unix Makefiles"
-          }
-        - {
-            name: "Ubuntu Latest GCC Debug",
-            os: ubuntu-latest,
-            build_type: "Debug", cc: "gcc", cxx: "g++",
-            build_gen: "Unix Makefiles"
-          }
-        - {
-            name: "Ubuntu Latest Clang Release",
-            os: ubuntu-latest,
-            build_type: "Release", cc: "clang", cxx: "clang++",
-            build_gen: "Unix Makefiles"
-          }
-        - {
-            name: "Ubuntu Latest Clang Debug",
-            os: ubuntu-latest,
-            build_type: "Debug", cc: "clang", cxx: "clang++",
-            build_gen: "Unix Makefiles"
-          }
-        - {
-            name: "macOS Latest Release",
-            os: macos-latest,
-            build_type: "Release", cc: "clang", cxx: "clang++",
-            build_gen: "Unix Makefiles"
-          }
-        - {
-            name: "macOS Latest Debug",
-            os: macos-latest,
-            build_type: "Debug", cc: "clang", cxx: "clang++",
-            build_gen: "Unix Makefiles"
-          }
+#        - {
+#            name: "Ubuntu Latest GCC Release",
+#            os: ubuntu-latest,
+#            build_type: "Release", cc: "gcc", cxx: "g++",
+#            build_gen: "Unix Makefiles"
+#          }
+#        - {
+#            name: "Ubuntu Latest GCC Debug",
+#            os: ubuntu-latest,
+#            build_type: "Debug", cc: "gcc", cxx: "g++",
+#            build_gen: "Unix Makefiles"
+#          }
+#        - {
+#            name: "Ubuntu Latest Clang Release",
+#            os: ubuntu-latest,
+#            build_type: "Release", cc: "clang", cxx: "clang++",
+#            build_gen: "Unix Makefiles"
+#          }
+#        - {
+#            name: "Ubuntu Latest Clang Debug",
+#            os: ubuntu-latest,
+#            build_type: "Debug", cc: "clang", cxx: "clang++",
+#            build_gen: "Unix Makefiles"
+#          }
+#        - {
+#            name: "macOS Latest Release",
+#            os: macos-latest,
+#            build_type: "Release", cc: "clang", cxx: "clang++",
+#            build_gen: "Unix Makefiles"
+#          }
+#        - {
+#            name: "macOS Latest Debug",
+#            os: macos-latest,
+#            build_type: "Debug", cc: "clang", cxx: "clang++",
+#            build_gen: "Unix Makefiles"
+#          }
         - {
             name: "Windows Latest MSVC Debug", 
             os: windows-latest,
             build_type: "Debug", cc: "cl", cxx: "cl",
             build_gen: "NMake Makefiles"
           }
-        - {
-            name: "Windows Latest MSVC Release", 
-            os: windows-latest,
-            build_type: "Release", cc: "cl", cxx: "cl",
-            build_gen: "NMake Makefiles"
-          }
+#        - {
+#            name: "Windows Latest MSVC Release", 
+#            os: windows-latest,
+#            build_type: "Release", cc: "cl", cxx: "cl",
+#            build_gen: "NMake Makefiles"
+#          }
     steps:
     - uses: actions/checkout@v1
       
@@ -137,6 +137,11 @@ jobs:
         choco install ghostscript
       if: matrix.config.os == 'windows-latest'
       
+    - name: Ghostscript Results (Windows)
+      run:
+        more C:\ProgramData\chocolatey\logs\chocolatey.log
+      if: matrix.config.os == 'windows-latest'
+      
     - name: Install xmllint (Linux)
       run: sudo apt-get install libxml2-utils
       if: matrix.config.os == 'ubuntu-latest'
@@ -169,10 +174,10 @@ jobs:
         choco install graphviz
       if: matrix.config.os == 'windows-latest'
 
-#    - name: Install Perl (Windows)
-#      run:
-#        choco install activeperl
-#      if: matrix.config.os == 'windows-latest'
+##    - name: Install Perl (Windows)
+##      run:
+##        choco install activeperl
+##      if: matrix.config.os == 'windows-latest'
 
     - name: Setup VS Environment (Windows)
       uses: seanmiddleditch/gha-setup-vsdevenv@master
@@ -226,74 +231,78 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
+        echo "=== PF x86 ===";
+        dir /s / b "C:\Program Files (x86)"
+        echo "=== PF ===";
+        dir /s / b "C:\Program Files"
         gswin32c --version;
       if: matrix.config.os == 'windows-latest'
 
-    - name: Configure
-      shell: cmake -P {0}
-      run: |
-        set(ENV{CC} ${{ matrix.config.cc }})
-        set(ENV{CXX} ${{ matrix.config.cxx }})
-
-        execute_process(
-          COMMAND cmake
-            -S .
-            -B build
-            -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
-            -G "${{ matrix.config.build_gen }}"
-            -Dbuild_doc=YES
-            -Dbuild_app=YES
-            -Dbuild_parse=YES
-            -Dbuild_xmlparser=YES            
-          RESULT_VARIABLE result
-        )
-        if (NOT result EQUAL 0)
-          message(FATAL_ERROR "Bad exit status")
-        endif()
-
-    - name: Build
-      shell: cmake -P {0}
-      run: |
-        include(ProcessorCount)
-        ProcessorCount(N)
-        execute_process(
-          COMMAND cmake --build build --parallel ${N} 
-          RESULT_VARIABLE result
-          OUTPUT_VARIABLE output
-          ERROR_VARIABLE output
-          ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
-        )
-        if (NOT result EQUAL 0)
-          string(REGEX MATCH "FAILED:.*$" error_message "${output}")
-          string(REPLACE "\n" "%0A" error_message "${error_message}")
-          message("::error::${error_message}")
-          message(FATAL_ERROR "Build failed")
-        endif()
-
-    - name: Run tests
-      shell: cmake -P {0}
-      run: |
-        include(ProcessorCount)
-        ProcessorCount(N)
-
-        set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
-
-        execute_process(
-          COMMAND cmake --build build --target tests TEST_FLAGS="--keep --xml --xmlxsd --xhtml --docbook --rtf"
-          RESULT_VARIABLE result
-        )
-        if (NOT result EQUAL 0)
-          message(FATAL_ERROR "Running tests failed!")
-        endif()
-
-    - name: Generate documentation
-      shell: cmake -P {0}
-      run: |
-        execute_process(
-          COMMAND cmake --build build --target docs
-          RESULT_VARIABLE result
-        )
-        if (NOT result EQUAL 0)
-          message(FATAL_ERROR "Building documentation failed")
-        endif()
-      if: matrix.config.os != 'windows-latest'
+#    - name: Configure
+#      shell: cmake -P {0}
+#      run: |
+#        set(ENV{CC} ${{ matrix.config.cc }})
+#        set(ENV{CXX} ${{ matrix.config.cxx }})
+#
+#        execute_process(
+#          COMMAND cmake
+#            -S .
+#            -B build
+#            -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+#            -G "${{ matrix.config.build_gen }}"
+#            -Dbuild_doc=YES
+#            -Dbuild_app=YES
+#            -Dbuild_parse=YES
+#            -Dbuild_xmlparser=YES            
+#          RESULT_VARIABLE result
+#        )
+#        if (NOT result EQUAL 0)
+#          message(FATAL_ERROR "Bad exit status")
+#        endif()
+#
+#    - name: Build
+#      shell: cmake -P {0}
+#      run: |
+#        include(ProcessorCount)
+#        ProcessorCount(N)
+#        execute_process(
+#          COMMAND cmake --build build --parallel ${N} 
+#          RESULT_VARIABLE result
+#          OUTPUT_VARIABLE output
+#          ERROR_VARIABLE output
+#          ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
+#        )
+#        if (NOT result EQUAL 0)
+#          string(REGEX MATCH "FAILED:.*$" error_message "${output}")
+#          string(REPLACE "\n" "%0A" error_message "${error_message}")
+#          message("::error::${error_message}")
+#          message(FATAL_ERROR "Build failed")
+#        endif()
+#
+#    - name: Run tests
+#      shell: cmake -P {0}
+#      run: |
+#        include(ProcessorCount)
+#        ProcessorCount(N)
+#
+#        set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
+#
+#        execute_process(
+#          COMMAND cmake --build build --target tests TEST_FLAGS="--keep --xml --xmlxsd --xhtml --docbook --rtf"
+#          RESULT_VARIABLE result
+#        )
+#        if (NOT result EQUAL 0)
+#          message(FATAL_ERROR "Running tests failed!")
+#        endif()
+#
+#    - name: Generate documentation
+#      shell: cmake -P {0}
+#      run: |
+#        execute_process(
+#          COMMAND cmake --build build --target docs
+#          RESULT_VARIABLE result
+#        )
+#        if (NOT result EQUAL 0)
+#          message(FATAL_ERROR "Building documentation failed")
+#        endif()
+#      if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -81,11 +81,6 @@ jobs:
         choco install ghostscript
       if: matrix.config.os == 'windows-latest'
       
-    - name: Ghostscript Results (Windows)
-      run:
-        more C:\ProgramData\chocolatey\logs\chocolatey.log
-      if: matrix.config.os == 'windows-latest'
-      
     - name: Install bison/flex (Windows)
       run:
         choco install winflexbison
@@ -127,9 +122,9 @@ jobs:
         dot -V;
         echo "=== ghostscript ===";
         echo "=== PF x86 ===";
-        dir /s / b "C:\Program Files (x86)"
+        dir /s / b "C:\Program Files (x86)\gs*exe"
         echo "=== PF ===";
-        dir /s / b "C:\Program Files"
+        dir /s / b "C:\Program Files\gs*exe"
         gswin32c --version;
       if: matrix.config.os == 'windows-latest'
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -101,16 +101,6 @@ jobs:
         refreshenv
       if: matrix.config.os == 'windows-latest'
     
-    - name: Results ghostscript (Windows)
-      shell: pwsh
-      run: |
-        echo "=== ghostscript ===";
-        echo "=== PF x86 ===";
-        dir /s /b "C:\Program Files (x86)\gs*exe"
-        echo "=== PF ===";
-        dir /s /b "C:\Program Files\gs*exe"
-      if: matrix.config.os == 'windows-latest'
-
     - name: Check tool versions (Windows)
       shell: bash
       run: |
@@ -131,6 +121,6 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
-        gswin32c --version;
+        gs --version;
       if: matrix.config.os == 'windows-latest'
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -84,10 +84,10 @@ jobs:
     - name: Setting Ghostscript paths (Windows)
       shell: bash
       run: |
-        echo "C:/Program Files (x86)/gs/gs9.53/bin/" >> $GITHUB_PATH
-        echo "C:/Program Files/gs/gs9.53/bin/" >> $GITHUB_PATH
-        export PATH="/c/Program Files (x86)/gs/gs9.53/bin/:$PATH"
-        export PATH="/c/Program Files/gs/gs9.53/bin/:$PATH"
+        echo "C:/Program Files (x86)/gs/gs9.53/bin/" >> $GITHUB_PATH;
+        echo "C:/Program Files/gs/gs9.53/bin/" >> $GITHUB_PATH;
+        export PATH="/c/Program Files (x86)/gs/gs9.53/bin/:$PATH";
+        export PATH="/c/Program Files/gs/gs9.53/bin/:$PATH";
       if: matrix.config.os == 'windows-latest'
         
     - name: Install bison/flex (Windows)
@@ -130,9 +130,9 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
-        echo "=== ghostscript 32 bit ===";
-        gswin32c --version;
         echo "=== ghostscript 64 bit ===";
         gswin64c --version;
+        echo "=== ghostscript 32 bit ===";
+        gswin32c --version;
       if: matrix.config.os == 'windows-latest'
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -127,6 +127,8 @@ jobs:
         latex --version;
         echo "=== bibtex ===";
         bibtex --version
+        echo "=== dvips ===";
+        dvips --version
         echo "=== bison ===";
         win_bison --version;
         echo "=== flex ===";

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -80,7 +80,7 @@ jobs:
       run:
         choco install ghostscript
       if: matrix.config.os == 'windows-latest'
-      
+
     - name: Setting Ghostscript paths (Windows)
       shell: bash
       run: |
@@ -89,7 +89,7 @@ jobs:
         export PATH="/c/Program Files (x86)/gs/gs9.53.3/bin/:$PATH"
         export PATH="/c/Program Files/gs/gs9.53.3/bin/:$PATH"
       if: matrix.config.os == 'windows-latest'
-        
+
     - name: Install bison/flex (Windows)
       run:
         choco install winflexbison
@@ -100,6 +100,10 @@ jobs:
         choco install graphviz
       if: matrix.config.os == 'windows-latest'
 
+#    - name: Install Perl (Windows)
+#      run:
+#        choco install activeperl
+#      if: matrix.config.os == 'windows-latest'
 
     - name: Setup VS Environment (Windows)
       uses: seanmiddleditch/gha-setup-vsdevenv@master
@@ -130,7 +134,62 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
-        echo "=== ghostscript 64 bit ===";
         gswin64c --version;
       if: matrix.config.os == 'windows-latest'
 
+    - name: Configure
+      shell: cmake -P {0}
+      run: |
+        set(ENV{CC} ${{ matrix.config.cc }})
+        set(ENV{CXX} ${{ matrix.config.cxx }})
+
+        execute_process(
+          COMMAND cmake
+            -S .
+            -B build
+            -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+            -G "${{ matrix.config.build_gen }}"
+            -Dbuild_doc=YES
+            -Dbuild_app=YES
+            -Dbuild_parse=YES
+            -Dbuild_xmlparser=YES            
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Bad exit status")
+        endif()
+
+    - name: Build
+      shell: cmake -P {0}
+      run: |
+        include(ProcessorCount)
+        ProcessorCount(N)
+        execute_process(
+          COMMAND cmake --build build --parallel ${N} 
+          RESULT_VARIABLE result
+          OUTPUT_VARIABLE output
+          ERROR_VARIABLE output
+          ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
+        )
+        if (NOT result EQUAL 0)
+          string(REGEX MATCH "FAILED:.*$" error_message "${output}")
+          string(REPLACE "\n" "%0A" error_message "${error_message}")
+          message("::error::${error_message}")
+          message(FATAL_ERROR "Build failed")
+        endif()
+
+    - name: Run tests
+      shell: cmake -P {0}
+      run: |
+        include(ProcessorCount)
+        ProcessorCount(N)
+
+        set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
+
+        execute_process(
+          COMMAND cmake --build build --target tests TEST_FLAGS="--keep --xml --xmlxsd --xhtml --docbook --rtf"
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Running tests failed!")
+        endif()

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -10,54 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-#        - {
-#            name: "Ubuntu Latest GCC Release",
-#            os: ubuntu-latest,
-#            build_type: "Release", cc: "gcc", cxx: "g++",
-#            build_gen: "Unix Makefiles"
-#          }
-#        - {
-#            name: "Ubuntu Latest GCC Debug",
-#            os: ubuntu-latest,
-#            build_type: "Debug", cc: "gcc", cxx: "g++",
-#            build_gen: "Unix Makefiles"
-#          }
-#        - {
-#            name: "Ubuntu Latest Clang Release",
-#            os: ubuntu-latest,
-#            build_type: "Release", cc: "clang", cxx: "clang++",
-#            build_gen: "Unix Makefiles"
-#          }
-#        - {
-#            name: "Ubuntu Latest Clang Debug",
-#            os: ubuntu-latest,
-#            build_type: "Debug", cc: "clang", cxx: "clang++",
-#            build_gen: "Unix Makefiles"
-#          }
-#        - {
-#            name: "macOS Latest Release",
-#            os: macos-latest,
-#            build_type: "Release", cc: "clang", cxx: "clang++",
-#            build_gen: "Unix Makefiles"
-#          }
-#        - {
-#            name: "macOS Latest Debug",
-#            os: macos-latest,
-#            build_type: "Debug", cc: "clang", cxx: "clang++",
-#            build_gen: "Unix Makefiles"
-#          }
         - {
             name: "Windows Latest MSVC Debug", 
             os: windows-latest,
             build_type: "Debug", cc: "cl", cxx: "cl",
             build_gen: "NMake Makefiles"
           }
-#        - {
-#            name: "Windows Latest MSVC Release", 
-#            os: windows-latest,
-#            build_type: "Release", cc: "cl", cxx: "cl",
-#            build_gen: "NMake Makefiles"
-#          }
     steps:
     - uses: actions/checkout@v1
       
@@ -83,16 +41,6 @@ jobs:
         target: .  
       if: matrix.config.os == 'windows-latest'
 
-    - name: Install LaTeX (Linux)
-      run: sudo apt-get install texlive texlive-generic-recommended texlive-extra-utils texlive-latex-extra texlive-font-utils
-      if: matrix.config.os == 'ubuntu-latest'
-
-    - name: Install LaTeX (MacOS)
-      run: |
-        brew install --cask mactex;
-        echo "/Library/TeX/texbin/" >> $GITHUB_PATH
-      if: matrix.config.os == 'macos-latest'
-    
     - name: Extract MikTex zip (Windows)
       shell: bash
       run: |
@@ -128,10 +76,6 @@ jobs:
         initexmf --admin --verbose --set-config-value='[MPM]AutoInstall=1'
       if: matrix.config.os == 'windows-latest'
 
-    - name: Install Ghostscript (Linux)
-      run: sudo apt-get install ghostscript
-      if: matrix.config.os == 'ubuntu-latest'
-    
     - name: Install Ghostscript (Windows)
       run:
         choco install ghostscript
@@ -142,42 +86,16 @@ jobs:
         more C:\ProgramData\chocolatey\logs\chocolatey.log
       if: matrix.config.os == 'windows-latest'
       
-    - name: Install xmllint (Linux)
-      run: sudo apt-get install libxml2-utils
-      if: matrix.config.os == 'ubuntu-latest'
-
-    - name: Install xmllint (MacOS)
-      run: brew install libxml2
-      if: matrix.config.os == 'macos-latest'
-
-    - name: Install bison (MacOS)
-      run: |
-        brew install bison;
-        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
-      if: matrix.config.os == 'macos-latest'
-    
     - name: Install bison/flex (Windows)
       run:
         choco install winflexbison
       if: matrix.config.os == 'windows-latest'
-
-    - name: Install Graphviz (Linux)
-      run: sudo apt-get install graphviz
-      if: matrix.config.os == 'ubuntu-latest'
-
-    - name: Install Graphviz (MacOS)
-      run: brew install graphviz
-      if: matrix.config.os == 'macos-latest'
 
     - name: Install Graphviz (Windows)
       run:
         choco install graphviz
       if: matrix.config.os == 'windows-latest'
 
-##    - name: Install Perl (Windows)
-##      run:
-##        choco install activeperl
-##      if: matrix.config.os == 'windows-latest'
 
     - name: Setup VS Environment (Windows)
       uses: seanmiddleditch/gha-setup-vsdevenv@master
@@ -188,29 +106,6 @@ jobs:
         refreshenv
       if: matrix.config.os == 'windows-latest'
     
-    - name: Check tool versions (Linux / MacOS)
-      shell: bash
-      run: |
-        echo "=== perl ===";
-        perl --version;
-        echo "=== python ===";
-        python --version;
-        echo "=== cmake ===";
-        cmake --version;
-        echo "=== latex ===";
-        latex --version;
-        echo "=== bibtex ===";
-        bibtex --version
-        echo "=== bison ===";
-        bison --version;
-        echo "=== flex ===";
-        flex --version;
-        echo "=== dot ===";
-        dot -V;
-        echo "=== ghostscript ===";
-        gs --version;
-      if: matrix.config.os != 'windows-latest'
-
     - name: Check tool versions (Windows)
       shell: bash
       run: |
@@ -238,71 +133,3 @@ jobs:
         gswin32c --version;
       if: matrix.config.os == 'windows-latest'
 
-#    - name: Configure
-#      shell: cmake -P {0}
-#      run: |
-#        set(ENV{CC} ${{ matrix.config.cc }})
-#        set(ENV{CXX} ${{ matrix.config.cxx }})
-#
-#        execute_process(
-#          COMMAND cmake
-#            -S .
-#            -B build
-#            -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
-#            -G "${{ matrix.config.build_gen }}"
-#            -Dbuild_doc=YES
-#            -Dbuild_app=YES
-#            -Dbuild_parse=YES
-#            -Dbuild_xmlparser=YES            
-#          RESULT_VARIABLE result
-#        )
-#        if (NOT result EQUAL 0)
-#          message(FATAL_ERROR "Bad exit status")
-#        endif()
-#
-#    - name: Build
-#      shell: cmake -P {0}
-#      run: |
-#        include(ProcessorCount)
-#        ProcessorCount(N)
-#        execute_process(
-#          COMMAND cmake --build build --parallel ${N} 
-#          RESULT_VARIABLE result
-#          OUTPUT_VARIABLE output
-#          ERROR_VARIABLE output
-#          ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
-#        )
-#        if (NOT result EQUAL 0)
-#          string(REGEX MATCH "FAILED:.*$" error_message "${output}")
-#          string(REPLACE "\n" "%0A" error_message "${error_message}")
-#          message("::error::${error_message}")
-#          message(FATAL_ERROR "Build failed")
-#        endif()
-#
-#    - name: Run tests
-#      shell: cmake -P {0}
-#      run: |
-#        include(ProcessorCount)
-#        ProcessorCount(N)
-#
-#        set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
-#
-#        execute_process(
-#          COMMAND cmake --build build --target tests TEST_FLAGS="--keep --xml --xmlxsd --xhtml --docbook --rtf"
-#          RESULT_VARIABLE result
-#        )
-#        if (NOT result EQUAL 0)
-#          message(FATAL_ERROR "Running tests failed!")
-#        endif()
-#
-#    - name: Generate documentation
-#      shell: cmake -P {0}
-#      run: |
-#        execute_process(
-#          COMMAND cmake --build build --target docs
-#          RESULT_VARIABLE result
-#        )
-#        if (NOT result EQUAL 0)
-#          message(FATAL_ERROR "Building documentation failed")
-#        endif()
-#      if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -106,9 +106,9 @@ jobs:
       run: |
         echo "=== ghostscript ===";
         echo "=== PF x86 ===";
-        dir /s / b "C:\Program Files (x86)\gs*exe"
+        dir /s /b "C:\Program Files (x86)\gs*exe"
         echo "=== PF ===";
-        dir /s / b "C:\Program Files\gs*exe"
+        dir /s /b "C:\Program Files\gs*exe"
       if: matrix.config.os == 'windows-latest'
 
     - name: Check tool versions (Windows)

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -132,9 +132,10 @@ jobs:
       run: sudo apt-get install ghostscript
       if: matrix.config.os == 'ubuntu-latest'
     
-#    - name: Install Ghostscript (Windows)
-#      run: choco install ghostscript
-#      if: matrix.config.os == 'windows-latest'
+    - name: Install Ghostscript (Windows)
+      run:
+        choco install ghostscript
+      if: matrix.config.os == 'windows-latest'
       
     - name: Install xmllint (Linux)
       run: sudo apt-get install libxml2-utils
@@ -201,6 +202,8 @@ jobs:
         flex --version;
         echo "=== dot ===";
         dot -V;
+        echo "=== ghostscript ===";
+        gs --version;
       if: matrix.config.os != 'windows-latest'
 
     - name: Check tool versions (Windows)
@@ -222,6 +225,8 @@ jobs:
         win_flex --version;
         echo "=== dot ===";
         dot -V;
+        echo "=== ghostscript ===";
+        gswin32c --version;
       if: matrix.config.os == 'windows-latest'
 
     - name: Configure

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -11,9 +11,51 @@ jobs:
       matrix:
         config:
         - {
+            name: "Ubuntu Latest GCC Release",
+            os: ubuntu-latest,
+            build_type: "Release", cc: "gcc", cxx: "g++",
+            build_gen: "Unix Makefiles"
+          }
+        - {
+            name: "Ubuntu Latest GCC Debug",
+            os: ubuntu-latest,
+            build_type: "Debug", cc: "gcc", cxx: "g++",
+            build_gen: "Unix Makefiles"
+          }
+        - {
+            name: "Ubuntu Latest Clang Release",
+            os: ubuntu-latest,
+            build_type: "Release", cc: "clang", cxx: "clang++",
+            build_gen: "Unix Makefiles"
+          }
+        - {
+            name: "Ubuntu Latest Clang Debug",
+            os: ubuntu-latest,
+            build_type: "Debug", cc: "clang", cxx: "clang++",
+            build_gen: "Unix Makefiles"
+          }
+        - {
+            name: "macOS Latest Release",
+            os: macos-latest,
+            build_type: "Release", cc: "clang", cxx: "clang++",
+            build_gen: "Unix Makefiles"
+          }
+        - {
+            name: "macOS Latest Debug",
+            os: macos-latest,
+            build_type: "Debug", cc: "clang", cxx: "clang++",
+            build_gen: "Unix Makefiles"
+          }
+        - {
             name: "Windows Latest MSVC Debug", 
             os: windows-latest,
             build_type: "Debug", cc: "cl", cxx: "cl",
+            build_gen: "NMake Makefiles"
+          }
+        - {
+            name: "Windows Latest MSVC Release", 
+            os: windows-latest,
+            build_type: "Release", cc: "cl", cxx: "cl",
             build_gen: "NMake Makefiles"
           }
     steps:
@@ -41,6 +83,16 @@ jobs:
         target: .  
       if: matrix.config.os == 'windows-latest'
 
+    - name: Install LaTeX (Linux)
+      run: sudo apt-get install texlive texlive-generic-recommended texlive-extra-utils texlive-latex-extra texlive-font-utils
+      if: matrix.config.os == 'ubuntu-latest'
+
+    - name: Install LaTeX (MacOS)
+      run: |
+        brew install --cask mactex;
+        echo "/Library/TeX/texbin/" >> $GITHUB_PATH
+      if: matrix.config.os == 'macos-latest'
+    
     - name: Extract MikTex zip (Windows)
       shell: bash
       run: |
@@ -76,6 +128,10 @@ jobs:
         initexmf --admin --verbose --set-config-value='[MPM]AutoInstall=1'
       if: matrix.config.os == 'windows-latest'
 
+    - name: Install Ghostscript (Linux)
+      run: sudo apt-get install ghostscript
+      if: matrix.config.os == 'ubuntu-latest'
+    
     - name: Install Ghostscript (Windows)
       run:
         choco install ghostscript
@@ -89,11 +145,33 @@ jobs:
         export PATH="/c/Program Files (x86)/gs/gs9.53.3/bin/:$PATH"
         export PATH="/c/Program Files/gs/gs9.53.3/bin/:$PATH"
       if: matrix.config.os == 'windows-latest'
+      
+    - name: Install xmllint (Linux)
+      run: sudo apt-get install libxml2-utils
+      if: matrix.config.os == 'ubuntu-latest'
 
+    - name: Install xmllint (MacOS)
+      run: brew install libxml2
+      if: matrix.config.os == 'macos-latest'
+
+    - name: Install bison (MacOS)
+      run: |
+        brew install bison;
+        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+      if: matrix.config.os == 'macos-latest'
+    
     - name: Install bison/flex (Windows)
       run:
         choco install winflexbison
       if: matrix.config.os == 'windows-latest'
+
+    - name: Install Graphviz (Linux)
+      run: sudo apt-get install graphviz
+      if: matrix.config.os == 'ubuntu-latest'
+
+    - name: Install Graphviz (MacOS)
+      run: brew install graphviz
+      if: matrix.config.os == 'macos-latest'
 
     - name: Install Graphviz (Windows)
       run:
@@ -114,6 +192,31 @@ jobs:
         refreshenv
       if: matrix.config.os == 'windows-latest'
     
+    - name: Check tool versions (Linux / MacOS)
+      shell: bash
+      run: |
+        echo "=== perl ===";
+        perl --version;
+        echo "=== python ===";
+        python --version;
+        echo "=== cmake ===";
+        cmake --version;
+        echo "=== latex ===";
+        latex --version;
+        echo "=== bibtex ===";
+        bibtex --version
+        echo "=== dvips ===";
+        dvips --version
+        echo "=== bison ===";
+        bison --version;
+        echo "=== flex ===";
+        flex --version;
+        echo "=== dot ===";
+        dot -V;
+        echo "=== ghostscript ===";
+        gs --version;
+      if: matrix.config.os != 'windows-latest'
+
     - name: Check tool versions (Windows)
       shell: bash
       run: |
@@ -195,3 +298,15 @@ jobs:
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Running tests failed!")
         endif()
+
+    - name: Generate documentation
+      shell: cmake -P {0}
+      run: |
+        execute_process(
+          COMMAND cmake --build build --target docs
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Building documentation failed")
+        endif()
+      if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -84,10 +84,10 @@ jobs:
     - name: Setting Ghostscript paths (Windows)
       shell: bash
       run: |
-        echo "C:/Program Files (x86)/gs/gs9.53/bin/" >> $GITHUB_PATH;
-        echo "C:/Program Files/gs/gs9.53/bin/" >> $GITHUB_PATH;
-        export PATH="/c/Program Files (x86)/gs/gs9.53/bin/:$PATH";
-        export PATH="/c/Program Files/gs/gs9.53/bin/:$PATH";
+        echo "C:/Program Files (x86)/gs/gs9.53.3/bin/" >> $GITHUB_PATH
+        echo "C:/Program Files/gs/gs9.53.3/bin/" >> $GITHUB_PATH
+        export PATH="/c/Program Files (x86)/gs/gs9.53.3/bin/:$PATH"
+        export PATH="/c/Program Files/gs/gs9.53.3/bin/:$PATH"
       if: matrix.config.os == 'windows-latest'
         
     - name: Install bison/flex (Windows)
@@ -130,9 +130,9 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
-        echo "=== ghostscript 64 bit ===";
-        gswin64c --version;
         echo "=== ghostscript 32 bit ===";
         gswin32c --version;
+        echo "=== ghostscript 64 bit ===";
+        gswin64c --version;
       if: matrix.config.os == 'windows-latest'
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -81,6 +81,15 @@ jobs:
         choco install ghostscript
       if: matrix.config.os == 'windows-latest'
       
+    - name: Setting Ghostscript paths (Windows)
+      shell: bash
+      run: |
+        echo "C:/Program Files (x86)/gs/gs9.53/bin/" >> $GITHUB_PATH
+        echo "C:/Program Files/gs/gs9.53/bin/" >> $GITHUB_PATH
+        export PATH="/c/Program Files (x86)/gs/gs9.53/bin/:$PATH"
+        export PATH="/c/Program Files/gs/gs9.53/bin/:$PATH"
+      if: matrix.config.os == 'windows-latest'
+        
     - name: Install bison/flex (Windows)
       run:
         choco install winflexbison
@@ -121,6 +130,9 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
-        gs --version;
+        echo "=== ghostscript 32 bit ===";
+        gswin32c --version;
+        echo "=== ghostscript 64 bit ===";
+        gswin64c --version;
       if: matrix.config.os == 'windows-latest'
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -277,14 +277,6 @@ jobs:
           COMMAND cmake --build build --target tests TEST_FLAGS="--keep --xml --xmlxsd --xhtml --docbook --rtf"
           RESULT_VARIABLE result
         )
-        execute_process(
-          COMMAND ls -lsR build/testing
-          RESULT_VARIABLE resultls
-        )
-        execute_process(
-          COMMAND more build/testing/test_output_001/out/temp
-          RESULT_VARIABLE resultmore
-        )
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Running tests failed!")
         endif()

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -155,6 +155,19 @@ jobs:
         choco install winflexbison
       if: matrix.config.os == 'windows-latest'
 
+    - name: Install Grapviz (Linux)
+      run: sudo apt-get install grapviz
+      if: matrix.config.os == 'ubuntu-latest'
+
+    - name: Install Grapviz (MacOS)
+      run: brew install grapviz
+      if: matrix.config.os == 'macos-latest'
+
+    - name: Install Grapviz (Windows)
+      run:
+        choco install grapviz
+      if: matrix.config.os == 'windows-latest'
+
 #    - name: Install Perl (Windows)
 #      run:
 #        choco install activeperl
@@ -186,6 +199,8 @@ jobs:
         win_bison --version;
         echo "=== flex ===";
         win_flex --version;
+        echo "=== dot ===";
+        dot -V;
       if: matrix.config.os == 'windows-latest'
 
     - name: Configure

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Install Graphviz (Windows)
       run:
-        choco install graphviz
+        choco install graphviz.portable
       if: matrix.config.os == 'windows-latest'
 
 #    - name: Install Perl (Windows)

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -238,7 +238,7 @@ jobs:
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
 
         execute_process(
-          COMMAND cmake --build build --target tests
+          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd --xhtml --docbook --rtf"
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)
@@ -253,6 +253,6 @@ jobs:
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)
-          message(FATAL_ERROR "Bad exit status")
+          message(FATAL_ERROR "Building documentation failed")
         endif()
       if: matrix.config.os != 'windows-latest'

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -130,8 +130,6 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
-        echo "=== ghostscript 32 bit ===";
-        gswin32c --version;
         echo "=== ghostscript 64 bit ===";
         gswin64c --version;
       if: matrix.config.os == 'windows-latest'

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -101,6 +101,16 @@ jobs:
         refreshenv
       if: matrix.config.os == 'windows-latest'
     
+    - name: Results ghostscript (Windows)
+      shell: pwsh
+      run: |
+        echo "=== ghostscript ===";
+        echo "=== PF x86 ===";
+        dir /s / b "C:\Program Files (x86)\gs*exe"
+        echo "=== PF ===";
+        dir /s / b "C:\Program Files\gs*exe"
+      if: matrix.config.os == 'windows-latest'
+
     - name: Check tool versions (Windows)
       shell: bash
       run: |
@@ -121,10 +131,6 @@ jobs:
         echo "=== dot ===";
         dot -V;
         echo "=== ghostscript ===";
-        echo "=== PF x86 ===";
-        dir /s / b "C:\Program Files (x86)\gs*exe"
-        echo "=== PF ===";
-        dir /s / b "C:\Program Files\gs*exe"
         gswin32c --version;
       if: matrix.config.os == 'windows-latest'
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -182,7 +182,28 @@ jobs:
         refreshenv
       if: matrix.config.os == 'windows-latest'
     
-    - name: Check tool versions
+    - name: Check tool versions (Linux / MacOS)
+      shell: bash
+      run: |
+        echo "=== perl ===";
+        perl --version;
+        echo "=== python ===";
+        python --version;
+        echo "=== cmake ===";
+        cmake --version;
+        echo "=== latex ===";
+        latex --version;
+        echo "=== bibtex ===";
+        bibtex --version
+        echo "=== bison ===";
+        bison --version;
+        echo "=== flex ===";
+        flex --version;
+        echo "=== dot ===";
+        dot -V;
+      if: matrix.config.os != 'windows-latest'
+
+    - name: Check tool versions (Windows)
       shell: bash
       run: |
         echo "=== perl ===";
@@ -253,8 +274,16 @@ jobs:
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
 
         execute_process(
-          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd --xhtml --docbook --rtf"
+          COMMAND cmake --build build --target tests TEST_FLAGS="--keep --xml --xmlxsd --xhtml --docbook --rtf"
           RESULT_VARIABLE result
+        )
+        execute_process(
+          COMMAND ls -lsR build/testing
+          RESULT_VARIABLE resultls
+        )
+        execute_process(
+          COMMAND more build/testing/test_output_001/out/temp
+          RESULT_VARIABLE resultmore
         )
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Running tests failed!")

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -283,7 +283,7 @@ jobs:
           message(FATAL_ERROR "Build failed")
         endif()
 
-    - name: Run tests
+    - name: Run tests (Linux / MacOS)
       shell: cmake -P {0}
       run: |
         include(ProcessorCount)
@@ -292,12 +292,30 @@ jobs:
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
 
         execute_process(
-          COMMAND cmake --build build --target tests TEST_FLAGS="--keep --xml --xmlxsd --xhtml --docbook --rtf"
+          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd --xhtml --docbook --rtf"
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Running tests failed!")
         endif()
+      if: matrix.config.os != 'windows-latest'
+
+    - name: Run tests (Linux / MacOS)
+      shell: cmake -P {0}
+      run: |
+        include(ProcessorCount)
+        ProcessorCount(N)
+
+        set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
+
+        execute_process(
+          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd"
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Running tests failed!")
+        endif()
+      if: matrix.config.os == 'windows-latest'
 
     - name: Generate documentation
       shell: cmake -P {0}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -155,17 +155,17 @@ jobs:
         choco install winflexbison
       if: matrix.config.os == 'windows-latest'
 
-    - name: Install Grapviz (Linux)
-      run: sudo apt-get install grapviz
+    - name: Install Graphviz (Linux)
+      run: sudo apt-get install graphviz
       if: matrix.config.os == 'ubuntu-latest'
 
-    - name: Install Grapviz (MacOS)
-      run: brew install grapviz
+    - name: Install Graphviz (MacOS)
+      run: brew install graphviz
       if: matrix.config.os == 'macos-latest'
 
-    - name: Install Grapviz (Windows)
+    - name: Install Graphviz (Windows)
       run:
-        choco install grapviz
+        choco install graphviz
       if: matrix.config.os == 'windows-latest'
 
 #    - name: Install Perl (Windows)

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -208,11 +208,14 @@ void FormulaManager::generateImages(const char *path,Format format,HighDPI hd) c
     QCString latexCmd = "latex";
     Portable::sysTimerStart();
     char args[4096];
-    sprintf(args,"-interaction=batchmode _formulas.tex >%s",Portable::devNull());
+    //sprintf(args,"-interaction=batchmode _formulas.tex >%s",Portable::devNull());
+    sprintf(args,"-interaction=batchmode _formulas.tex");
     if (Portable::system(latexCmd,args)!=0)
     {
       err("Problems running latex. Check your installation or look "
           "for typos in _formulas.tex and check _formulas.log!\n");
+    Portable::system("more","_formulas.tex");
+    Portable::system("more","_formulas.log");
       Portable::sysTimerStop();
       QDir::setCurrent(oldDir);
       return;

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -208,14 +208,11 @@ void FormulaManager::generateImages(const char *path,Format format,HighDPI hd) c
     QCString latexCmd = "latex";
     Portable::sysTimerStart();
     char args[4096];
-    //sprintf(args,"-interaction=batchmode _formulas.tex >%s",Portable::devNull());
-    sprintf(args,"-interaction=batchmode _formulas.tex");
+    sprintf(args,"-interaction=batchmode _formulas.tex >%s",Portable::devNull());
     if (Portable::system(latexCmd,args)!=0)
     {
       err("Problems running latex. Check your installation or look "
           "for typos in _formulas.tex and check _formulas.log!\n");
-    Portable::system("more","_formulas.tex");
-    Portable::system("more","_formulas.log");
       Portable::sysTimerStop();
       QDir::setCurrent(oldDir);
       return;

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -35,6 +35,26 @@ def xpopen(cmd, cmd1="",encoding='utf-8-sig', getStderr=False):
 			proc = subprocess.Popen(shlex.split(cmd),stdout=subprocess.PIPE,stderr=subprocess.PIPE,encoding=encoding) # Python 3 with encoding
 			return proc.stdout.read()
 
+def clean_header(errmsg):
+	# messages (due to the usage of more) have a contents like:
+	# ::::::::::::
+	# <file name>
+	# ::::::::::::
+	# we want to skip these
+	msg = errmsg.split('\n')
+	rtnmsg = ""
+	cnt = -1
+	for o in msg:
+		if (o):
+			if (cnt == -1):
+				if o.startswith(":::::::"):
+					cnt = 3
+			if (cnt > 0):
+				cnt-=1
+			else:
+				rtnmsg+=0
+	return rtnmsg
+ 
 class Tester:
 	def __init__(self,args,test):
 		self.args      = args
@@ -280,6 +300,8 @@ class Tester:
 					msg += ('Failed to run %s with schema %s for files: %s' % (self.args.xmllint,index_xsd,index_xml),)
 					failed_xmlxsd=True
 				if xmllint_out:
+					xmllint_out  = clean_header(xmllint_out)
+				if xmllint_out:
 					msg += (xmllint_out,)
 					failed_xmlxsd=True
 				#
@@ -305,6 +327,8 @@ class Tester:
 				else:
 					msg += ('Failed to run %s with schema %s for files: %s' % (self.args.xmllint,compound_xsd,compound_xml),)
 					failed_xmlxsd=True
+				if xmllint_out:
+					xmllint_out  = clean_header(xmllint_out)
 				if xmllint_out:
 					msg += (xmllint_out,)
 					failed_xmlxsd=True
@@ -338,6 +362,8 @@ class Tester:
 			xmllint_out = xpopen(exe_string,exe_string1,getStderr=True)
 			xmllint_out = self.cleanup_xmllint_docbook(xmllint_out)
 			if xmllint_out:
+				xmllint_out  = clean_header(xmllint_out)
+			if xmllint_out:
 				msg += (xmllint_out,)
 				failed_docbook=True
 			elif not self.args.keep:
@@ -360,6 +386,8 @@ class Tester:
 			failed_html=False
 			xmllint_out = xpopen(exe_string,exe_string1,getStderr=True)
 			xmllint_out = self.cleanup_xmllint(xmllint_out)
+			if xmllint_out:
+				xmllint_out  = clean_header(xmllint_out)
 			if xmllint_out:
 				msg += (xmllint_out,)
 				failed_html=True

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -190,7 +190,7 @@ class Tester:
 		if (self.args.noredir):
 			redir=''
 
-		if os.system('%s -d extcmd %s/Doxyfile %s' % (self.args.doxygen,self.test_out,redir))!=0:
+		if os.system('%s %s/Doxyfile %s' % (self.args.doxygen,self.test_out,redir))!=0:
 			print('Error: failed to run %s on %s/Doxyfile' % (self.args.doxygen,self.test_out))
 			sys.exit(1)
 

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -190,7 +190,7 @@ class Tester:
 		if (self.args.noredir):
 			redir=''
 
-		if os.system('%s %s/Doxyfile %s' % (self.args.doxygen,self.test_out,redir))!=0:
+		if os.system('%s -d extcmd %s/Doxyfile %s' % (self.args.doxygen,self.test_out,redir))!=0:
 			print('Error: failed to run %s on %s/Doxyfile' % (self.args.doxygen,self.test_out))
 			sys.exit(1)
 

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -481,6 +481,7 @@ class TestManager:
 			shutil.copytree(self.args.inputdir+"/dtd", "dtd")
 
 def split_and_keep(s,sep):
+    s = s.replace('"','')             # add token separator
     s = s.replace(sep,'\0'+sep)             # add token separator
     s = s.split('\0')                       # split by null delimiter
     s = [x.strip() for x in filter(None,s)] # strip and remove empty elements
@@ -540,11 +541,8 @@ def main():
 		'(the option may be specified multiple times')
 
 	test_flags = split_and_keep(os.getenv('TEST_FLAGS', default=''), '--')
-	print(test_flags)
-	print(sys.argv[1:])
 
 	args = parser.parse_args(test_flags + sys.argv[1:])
-	print(args)
 
 	# sanity check
 	if (not args.xml) and (not args.pdf) and (not args.xhtml) and (not args.docbook and (not args.rtf) and (not args.xmlxsd)):

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -540,8 +540,11 @@ def main():
 		'(the option may be specified multiple times')
 
 	test_flags = split_and_keep(os.getenv('TEST_FLAGS', default=''), '--')
+	print(test_flags)
+	print(sys.argv[1:])
 
 	args = parser.parse_args(test_flags + sys.argv[1:])
+	print(args)
 
 	# sanity check
 	if (not args.xml) and (not args.pdf) and (not args.xhtml) and (not args.docbook and (not args.rtf) and (not args.xmlxsd)):


### PR DESCRIPTION
During the change to GitHub Actions the extra  tests as added in #8217 were lost:

Extend tests with generating xhtml, docbook, rtf to see if the files can be generated and build.
Check also the generated xsd files in xml mode.

Note for the new checks no comparison is done with previous versions.