### PR TITLE
Add param validation to typedef function pointers

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2351,7 +2351,7 @@ static MemberDef *addVariableToFile(
       type,name,args,0,
       root->protection, Normal,root->stat,Member,
       mtype,!root->tArgLists.empty() ? root->tArgLists.back() : ArgumentList(),
-      ArgumentList(), root->metaData) };
+      root->argList, root->metaData) };
   md->setTagInfo(root->tagInfo());
   md->setMemberSpecifiers(root->spec);
   md->setDocumentation(root->doc,root->docFile,root->docLine);

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -845,7 +845,7 @@ static bool writeDefArgumentList(OutputList &ol,const Definition *scope,const Me
   const ArgumentList &defArgList=(md->isDocsForDefinition()) ?
                              md->argumentList() : md->declArgumentList();
   //printf("writeDefArgumentList '%s' isDocsForDefinition()=%d\n",md->name().data(),md->isDocsForDefinition());
-  if (!defArgList.hasParameters() || md->isProperty())
+  if (!defArgList.hasParameters() || md->isProperty() || md->isTypedef())
   {
     return FALSE; // member has no function like argument list
   }


### PR DESCRIPTION
Currently typedef'd function pointers, typically used as callbacks, don't have their `@param` documentation properly validated. This commit adds a proper check by initializing their memberdef with the parsed args. To avoid duplicating the params in the output, since typedef's already have the params in their definition, an extra check was added.