### PR TITLE
Extend tests with some other default tests

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -132,9 +132,19 @@ jobs:
       run: sudo apt-get install ghostscript
       if: matrix.config.os == 'ubuntu-latest'
     
-#    - name: Install Ghostscript (Windows)
-#      run: choco install ghostscript
-#      if: matrix.config.os == 'windows-latest'
+    - name: Install Ghostscript (Windows)
+      run:
+        choco install ghostscript
+      if: matrix.config.os == 'windows-latest'
+
+    - name: Setting Ghostscript paths (Windows)
+      shell: bash
+      run: |
+        echo "C:/Program Files (x86)/gs/gs9.53.3/bin/" >> $GITHUB_PATH
+        echo "C:/Program Files/gs/gs9.53.3/bin/" >> $GITHUB_PATH
+        export PATH="/c/Program Files (x86)/gs/gs9.53.3/bin/:$PATH"
+        export PATH="/c/Program Files/gs/gs9.53.3/bin/:$PATH"
+      if: matrix.config.os == 'windows-latest'
       
     - name: Install xmllint (Linux)
       run: sudo apt-get install libxml2-utils
@@ -155,6 +165,19 @@ jobs:
         choco install winflexbison
       if: matrix.config.os == 'windows-latest'
 
+    - name: Install Graphviz (Linux)
+      run: sudo apt-get install graphviz
+      if: matrix.config.os == 'ubuntu-latest'
+
+    - name: Install Graphviz (MacOS)
+      run: brew install graphviz
+      if: matrix.config.os == 'macos-latest'
+
+    - name: Install Graphviz (Windows)
+      run:
+        choco install graphviz.portable
+      if: matrix.config.os == 'windows-latest'
+
 #    - name: Install Perl (Windows)
 #      run:
 #        choco install activeperl
@@ -169,7 +192,7 @@ jobs:
         refreshenv
       if: matrix.config.os == 'windows-latest'
     
-    - name: Check tool versions
+    - name: Check tool versions (Linux / MacOS)
       shell: bash
       run: |
         echo "=== perl ===";
@@ -182,10 +205,41 @@ jobs:
         latex --version;
         echo "=== bibtex ===";
         bibtex --version
+        echo "=== dvips ===";
+        dvips --version
+        echo "=== bison ===";
+        bison --version;
+        echo "=== flex ===";
+        flex --version;
+        echo "=== dot ===";
+        dot -V;
+        echo "=== ghostscript ===";
+        gs --version;
+      if: matrix.config.os != 'windows-latest'
+
+    - name: Check tool versions (Windows)
+      shell: bash
+      run: |
+        echo "=== perl ===";
+        perl --version;
+        echo "=== python ===";
+        python --version;
+        echo "=== cmake ===";
+        cmake --version;
+        echo "=== latex ===";
+        latex --version;
+        echo "=== bibtex ===";
+        bibtex --version
+        echo "=== dvips ===";
+        dvips --version
         echo "=== bison ===";
         win_bison --version;
         echo "=== flex ===";
         win_flex --version;
+        echo "=== dot ===";
+        dot -V;
+        echo "=== ghostscript ===";
+        gswin64c --version;
       if: matrix.config.os == 'windows-latest'
 
     - name: Configure
@@ -229,7 +283,7 @@ jobs:
           message(FATAL_ERROR "Build failed")
         endif()
 
-    - name: Run tests
+    - name: Run tests (Linux / MacOS)
       shell: cmake -P {0}
       run: |
         include(ProcessorCount)
@@ -238,12 +292,30 @@ jobs:
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
 
         execute_process(
-          COMMAND cmake --build build --target tests
+          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd --xhtml --docbook --rtf"
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Running tests failed!")
         endif()
+      if: matrix.config.os != 'windows-latest'
+
+    - name: Run tests (Windows)
+      shell: cmake -P {0}
+      run: |
+        include(ProcessorCount)
+        ProcessorCount(N)
+
+        set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
+
+        execute_process(
+          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd"
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Running tests failed!")
+        endif()
+      if: matrix.config.os == 'windows-latest'
 
     - name: Generate documentation
       shell: cmake -P {0}
@@ -253,6 +325,6 @@ jobs:
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)
-          message(FATAL_ERROR "Bad exit status")
+          message(FATAL_ERROR "Building documentation failed")
         endif()
       if: matrix.config.os != 'windows-latest'

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -35,6 +35,26 @@ def xpopen(cmd, cmd1="",encoding='utf-8-sig', getStderr=False):
 			proc = subprocess.Popen(shlex.split(cmd),stdout=subprocess.PIPE,stderr=subprocess.PIPE,encoding=encoding) # Python 3 with encoding
 			return proc.stdout.read()
 
+def clean_header(errmsg):
+	# messages (due to the usage of more) have a contents like:
+	# ::::::::::::
+	# <file name>
+	# ::::::::::::
+	# we want to skip these
+	msg = errmsg.split('\n')
+	rtnmsg = ""
+	cnt = -1
+	for o in msg:
+		if (o):
+			if (cnt == -1):
+				if o.startswith(":::::::"):
+					cnt = 3
+			if (cnt > 0):
+				cnt-=1
+			else:
+				rtnmsg+=0
+	return rtnmsg
+ 
 class Tester:
 	def __init__(self,args,test):
 		self.args      = args
@@ -280,6 +300,8 @@ class Tester:
 					msg += ('Failed to run %s with schema %s for files: %s' % (self.args.xmllint,index_xsd,index_xml),)
 					failed_xmlxsd=True
 				if xmllint_out:
+					xmllint_out  = clean_header(xmllint_out)
+				if xmllint_out:
 					msg += (xmllint_out,)
 					failed_xmlxsd=True
 				#
@@ -305,6 +327,8 @@ class Tester:
 				else:
 					msg += ('Failed to run %s with schema %s for files: %s' % (self.args.xmllint,compound_xsd,compound_xml),)
 					failed_xmlxsd=True
+				if xmllint_out:
+					xmllint_out  = clean_header(xmllint_out)
 				if xmllint_out:
 					msg += (xmllint_out,)
 					failed_xmlxsd=True
@@ -338,6 +362,8 @@ class Tester:
 			xmllint_out = xpopen(exe_string,exe_string1,getStderr=True)
 			xmllint_out = self.cleanup_xmllint_docbook(xmllint_out)
 			if xmllint_out:
+				xmllint_out  = clean_header(xmllint_out)
+			if xmllint_out:
 				msg += (xmllint_out,)
 				failed_docbook=True
 			elif not self.args.keep:
@@ -360,6 +386,8 @@ class Tester:
 			failed_html=False
 			xmllint_out = xpopen(exe_string,exe_string1,getStderr=True)
 			xmllint_out = self.cleanup_xmllint(xmllint_out)
+			if xmllint_out:
+				xmllint_out  = clean_header(xmllint_out)
 			if xmllint_out:
 				msg += (xmllint_out,)
 				failed_html=True
@@ -481,6 +509,7 @@ class TestManager:
 			shutil.copytree(self.args.inputdir+"/dtd", "dtd")
 
 def split_and_keep(s,sep):
+    s = s.replace('"','')             # add token separator
     s = s.replace(sep,'\0'+sep)             # add token separator
     s = s.split('\0')                       # split by null delimiter
     s = [x.strip() for x in filter(None,s)] # strip and remove empty elements


### PR DESCRIPTION
During the change to GitHub Actions the extra tests as added in #8217 were lost:

Extend tests with generating xhtml, docbook, rtf to see if the files can be generated and build, not for Windows as it loos like that the "latex" command cannot always be run (problems with test 28).
Check also the generated xsd files in xml mode.

Note for the new checks no comparison is done with previous versions.