### PR TITLE
Doxygen's own documentation doesn't build with recent LaTeX version

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -177,79 +177,79 @@ Written by Dimitri van Heesch\\[2ex]
 \appendix
 %mean that subinputfrom requires a / at the end of the path
 \chapter{Autolink Example}\label{autolink_example}\hypertarget{autolink_example}{}
-\subinputfrom{../html/examples/autolink/latex/}{refman_doc}
+\subinputfrom{examples/autolink/latex/}{refman_doc}
 \chapter{Resolving Typedef Example}\label{restypedef_example}\hypertarget{restypedef_example}{}
-\subinputfrom{../html/examples/restypedef/latex/}{refman_doc}
+\subinputfrom{examples/restypedef/latex/}{refman_doc}
 
-\IfFileExists{../html/examples/diagrams/latex/refman_doc.tex}
+\IfFileExists{examples/diagrams/latex/refman_doc.tex}
 {
   \chapter{Diagrams Example}\label{diagrams_example}\hypertarget{diagrams_example}{}
-  \subinputfrom{../html/examples/diagrams/latex/}{refman_doc}
+  \subinputfrom{examples/diagrams/latex/}{refman_doc}
 }{}
 
 \chapter{Modules Example}\label{modules_example}\hypertarget{modules_example}{}
-\subinputfrom{../html/examples/group/latex/}{refman_doc}
+\subinputfrom{examples/group/latex/}{refman_doc}
 \chapter{Member Groups Example}\label{memgrp_example}\hypertarget{memgrp_example}{}
-\subinputfrom{../html/examples/memgrp/latex/}{refman_doc}
+\subinputfrom{examples/memgrp/latex/}{refman_doc}
 \chapter{Style Examples}
   \doxysection{After Block Example}\label{afterdoc_example}\hypertarget{afterdoc_example}{}
   \begin{DoxygenSubAppendix}
-    \subinputfrom{../html/examples/afterdoc/latex/}{refman_doc}
+    \subinputfrom{examples/afterdoc/latex/}{refman_doc}
   \end{DoxygenSubAppendix}
   \doxysection{QT Style Example}\label{qtstyle_example}\hypertarget{qtstyle_example}{}
   \begin{DoxygenSubAppendix}
-    \subinputfrom{../html/examples/qtstyle/latex/}{refman_doc}
+    \subinputfrom{examples/qtstyle/latex/}{refman_doc}
   \end{DoxygenSubAppendix}
   \doxysection{Javadoc Style Example}\label{jdstyle_example}\hypertarget{jdstyle_example}{}
   \begin{DoxygenSubAppendix}
-    \subinputfrom{../html/examples/jdstyle/latex/}{refman_doc}
+    \subinputfrom{examples/jdstyle/latex/}{refman_doc}
   \end{DoxygenSubAppendix}
   \doxysection{Javadoc Banner Example}\label{javadoc_banner_example}\hypertarget{javadoc_banner_example}{}
   \begin{DoxygenSubAppendix}
-    \subinputfrom{../html/examples/javadoc-banner/latex/}{refman_doc}
+    \subinputfrom{examples/javadoc-banner/latex/}{refman_doc}
   \end{DoxygenSubAppendix}
 \chapter{Structural Commands Example}\label{structcmd_example}\hypertarget{structcmd_example}{}
-\subinputfrom{../html/examples/structcmd/latex/}{refman_doc}
+\subinputfrom{examples/structcmd/latex/}{refman_doc}
 \chapter{Language Examples}
   \doxysection{Python Docstring Example}\label{python_example}\hypertarget{python_example}{}
   \begin{DoxygenSubAppendix}
-    \subinputfrom{../html/examples/docstring/latex/}{refman_doc}
+    \subinputfrom{examples/docstring/latex/}{refman_doc}
   \end{DoxygenSubAppendix}
   \doxysection{Python Example}\label{py_example}\hypertarget{py_example}{}
   \begin{DoxygenSubAppendix}
-    \subinputfrom{../html/examples/pyexample/latex/}{refman_doc}
+    \subinputfrom{examples/pyexample/latex/}{refman_doc}
   \end{DoxygenSubAppendix}
   \doxysection{VHDL Example}\label{vhdl_example}\hypertarget{vhdl_example}{}
   \begin{DoxygenSubAppendix}
-    \subinputfrom{../html/examples/mux/latex/}{refman_doc}
+    \subinputfrom{examples/mux/latex/}{refman_doc}
   \end{DoxygenSubAppendix}
 
 \chapter{Class Example}\label{class_example}\hypertarget{class_example}{}
-\subinputfrom{../html/examples/class/latex/}{refman_doc}
+\subinputfrom{examples/class/latex/}{refman_doc}
 \chapter{Define Example}\label{define_example}\hypertarget{define_example}{}
-\subinputfrom{../html/examples/define/latex/}{refman_doc}
+\subinputfrom{examples/define/latex/}{refman_doc}
 \chapter{Enum Example}\label{enum_example}\hypertarget{enum_example}{}
-\subinputfrom{../html/examples/enum/latex/}{refman_doc}
+\subinputfrom{examples/enum/latex/}{refman_doc}
 \chapter{Example Example}\label{example_example}\hypertarget{example_example}{}
-\subinputfrom{../html/examples/example/latex/}{refman_doc}
+\subinputfrom{examples/example/latex/}{refman_doc}
 \chapter{Extends/Implements Example}\label{extends_example}\hypertarget{extends_example}{}
-\subinputfrom{../html/examples/manual/latex/}{refman_doc}
+\subinputfrom{examples/manual/latex/}{refman_doc}
 \chapter{File Example}\label{file_example}\hypertarget{file_example}{}
-\subinputfrom{../html/examples/file/latex/}{refman_doc}
+\subinputfrom{examples/file/latex/}{refman_doc}
 \chapter{Fn Example}\label{fn_example}\hypertarget{fn_example}{}
-\subinputfrom{../html/examples/func/latex/}{refman_doc}
+\subinputfrom{examples/func/latex/}{refman_doc}
 \chapter{Overload Example}\label{overload_example}\hypertarget{overload_example}{}
-\subinputfrom{../html/examples/overload/latex/}{refman_doc}
+\subinputfrom{examples/overload/latex/}{refman_doc}
 \chapter{Page Example}\label{page_example}\hypertarget{page_example}{}
-\subinputfrom{../html/examples/page/latex/}{refman_doc}
+\subinputfrom{examples/page/latex/}{refman_doc}
 \chapter{Relates Example}\label{relates_example}\hypertarget{relates_example}{}
-\subinputfrom{../html/examples/relates/latex/}{refman_doc}
+\subinputfrom{examples/relates/latex/}{refman_doc}
 \chapter{Author Example}\label{author_example}\hypertarget{author_example}{}
-\subinputfrom{../html/examples/author/latex/}{refman_doc}
+\subinputfrom{examples/author/latex/}{refman_doc}
 \chapter{Par Example}\label{par_example}\hypertarget{par_example}{}
-\subinputfrom{../html/examples/par/latex/}{refman_doc}
+\subinputfrom{examples/par/latex/}{refman_doc}
 \chapter{Include Example}\label{include_example}\hypertarget{include_example}{}
-\subinputfrom{../html/examples/include/latex/}{refman_doc}
+\subinputfrom{examples/include/latex/}{refman_doc}
 
 
 \printindex

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/examples
-                    ${PROJECT_BINARY_DIR}/html/examples)
+                    ${PROJECT_BINARY_DIR}/html/examples
+                    ${PROJECT_BINARY_DIR}/latex/examples)
 file(GLOB EXAMPLE_FILES RELATIVE ${PROJECT_SOURCE_DIR}/examples "*")
 
 if (DOT)
@@ -50,10 +51,12 @@ foreach (f_inp  ${BASIC_EXAMPLES})
         string(REGEX REPLACE ".*:" "" f_ext ${f_inp})
         string(REGEX REPLACE ":.*" "" f ${f_inp})
     add_custom_command(
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/html/examples/${f}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/latex/examples/${f}
 	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen ${f}.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/${f}/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/${f}/latex/refman_doc.tex
+        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/latex/examples/${f}/latex/refman.tex > ${PROJECT_BINARY_DIR}/latex/examples/${f}/latex/refman_doc.tex
 	DEPENDS doxygen ${f}.${f_ext} ${f}.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/${f}/html/index.html ${PROJECT_BINARY_DIR}/html/examples/${f}/latex/refman_doc.tex
+	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/${f}/html/index.html ${PROJECT_BINARY_DIR}/latex/examples/${f}/latex/refman_doc.tex
     )
     set(EXAMPLES_RES ${EXAMPLES_RES} "" ${PROJECT_BINARY_DIR}/html/examples/${f}/html/index.html)
 endforeach()
@@ -67,9 +70,11 @@ add_custom_target(examples
 
 if (DOT)
   add_custom_command(
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/html/examples/diagrams
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/latex/examples/diagrams
 	COMMAND ${EXECUTABLE_OUTPUT_PATH}/doxygen diagrams.cfg
-        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/html/examples/diagrams/latex/refman.tex > ${PROJECT_BINARY_DIR}/html/examples/diagrams/latex/refman_doc.tex
+        COMMAND ${PYTHON_EXECUTABLE}  ${TOP}/examples/strip_example.py  < ${PROJECT_BINARY_DIR}/latex/examples/diagrams/latex/refman.tex > ${PROJECT_BINARY_DIR}/latex/examples/diagrams/latex/refman_doc.tex
 	DEPENDS doxygen diagrams_a.h diagrams_b.h diagrams_c.h diagrams_d.h diagrams_e.h diagrams.cfg ${TOP}/examples/strip_example.py
-	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/diagrams/html/index.html ${PROJECT_BINARY_DIR}/html/examples/diagrams/latex/refman_doc.tex
+	OUTPUT ${PROJECT_BINARY_DIR}/html/examples/diagrams/html/index.html ${PROJECT_BINARY_DIR}/latex/examples/diagrams/latex/refman_doc.tex
   )
 endif(DOT)

--- a/examples/afterdoc.cfg
+++ b/examples/afterdoc.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME      = "AfterDocs"
-OUTPUT_DIRECTORY  = ../html/examples/afterdoc
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/afterdoc/html
+LATEX_OUTPUT     = latex/examples/afterdoc/latex
 GENERATE_LATEX    = YES
 GENERATE_MAN      = NO
 GENERATE_RTF      = NO

--- a/examples/author.cfg
+++ b/examples/author.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Author Command"
-OUTPUT_DIRECTORY = ../html/examples/author
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/author/html
+LATEX_OUTPUT     = latex/examples/author/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/autolink.cfg
+++ b/examples/autolink.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Automatic link generation"
-OUTPUT_DIRECTORY = ../html/examples/autolink
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/autolink/html
+LATEX_OUTPUT     = latex/examples/autolink/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/class.cfg
+++ b/examples/class.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Class Command"
-OUTPUT_DIRECTORY = ../html/examples/class
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/class/html
+LATEX_OUTPUT     = latex/examples/class/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/define.cfg
+++ b/examples/define.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Define Command"
-OUTPUT_DIRECTORY = ../html/examples/define
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/define/html
+LATEX_OUTPUT     = latex/examples/define/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/diagrams.cfg
+++ b/examples/diagrams.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME       = "Diagrams"
-OUTPUT_DIRECTORY   = ../html/examples/diagrams
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/diagrams/html
+LATEX_OUTPUT     = latex/examples/diagrams/latex
 HAVE_DOT           = YES
 EXTRACT_ALL        = YES
 GENERATE_LATEX     = YES

--- a/examples/docstring.cfg
+++ b/examples/docstring.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Python"
-OUTPUT_DIRECTORY = ../html/examples/docstring
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/docstring/html
+LATEX_OUTPUT     = latex/examples/docstring/latex
 EXTRACT_ALL      = YES
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO

--- a/examples/enum.cfg
+++ b/examples/enum.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Enum Command"
-OUTPUT_DIRECTORY = ../html/examples/enum
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/enum/html
+LATEX_OUTPUT     = latex/examples/enum/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/example.cfg
+++ b/examples/example.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME      = "Example Command"
-OUTPUT_DIRECTORY  = ../html/examples/example
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/example/html
+LATEX_OUTPUT     = latex/examples/example/latex
 GENERATE_TAGFILE  = example.tag
 GENERATE_LATEX    = YES
 GENERATE_MAN      = NO

--- a/examples/file.cfg
+++ b/examples/file.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "File Command"
-OUTPUT_DIRECTORY = ../html/examples/file
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/file/html
+LATEX_OUTPUT     = latex/examples/file/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/func.cfg
+++ b/examples/func.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Fn Command"
-OUTPUT_DIRECTORY = ../html/examples/func
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/func/html
+LATEX_OUTPUT     = latex/examples/func/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/group.cfg
+++ b/examples/group.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Grouping"
-OUTPUT_DIRECTORY = ../html/examples/group
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/group/html
+LATEX_OUTPUT     = latex/examples/group/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/include.cfg
+++ b/examples/include.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Include Command"
-OUTPUT_DIRECTORY = ../html/examples/include
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/include/html
+LATEX_OUTPUT     = latex/examples/include/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/javadoc-banner.cfg
+++ b/examples/javadoc-banner.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Javadoc Banner"
-OUTPUT_DIRECTORY = ../html/examples/javadoc-banner
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/javadoc-banner/html
+LATEX_OUTPUT     = latex/examples/javadoc-banner/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/jdstyle.cfg
+++ b/examples/jdstyle.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME      = "Javadoc Style"
-OUTPUT_DIRECTORY  = ../html/examples/jdstyle
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/jdstyle/html
+LATEX_OUTPUT     = latex/examples/jdstyle/latex
 GENERATE_LATEX    = YES
 GENERATE_MAN      = NO
 GENERATE_RTF      = NO

--- a/examples/manual.cfg
+++ b/examples/manual.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME           = "Manual inheritance and membership"
-OUTPUT_DIRECTORY       = ../html/examples/manual
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/manual/html
+LATEX_OUTPUT     = latex/examples/manual/latex
 GENERATE_LATEX         = YES
 GENERATE_MAN           = NO
 GENERATE_RTF           = NO

--- a/examples/memgrp.cfg
+++ b/examples/memgrp.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME         = "Member Grouping"
-OUTPUT_DIRECTORY     = ../html/examples/memgrp
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/memgrp/html
+LATEX_OUTPUT     = latex/examples/memgrp/latex
 GENERATE_LATEX       = YES
 GENERATE_MAN         = NO
 GENERATE_RTF         = NO

--- a/examples/mux.cfg
+++ b/examples/mux.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME         = Mux
-OUTPUT_DIRECTORY     = ../html/examples/mux
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/mux/html
+LATEX_OUTPUT     = latex/examples/mux/latex
 GENERATE_LATEX       = YES
 GENERATE_MAN         = NO
 GENERATE_RTF         = NO

--- a/examples/overload.cfg
+++ b/examples/overload.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Overloaded Command"
-OUTPUT_DIRECTORY = ../html/examples/overload
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/overload/html
+LATEX_OUTPUT     = latex/examples/overload/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/page.cfg
+++ b/examples/page.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Page Command"
-OUTPUT_DIRECTORY = ../html/examples/page
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/page/html
+LATEX_OUTPUT     = latex/examples/page/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/par.cfg
+++ b/examples/par.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Par Command"
-OUTPUT_DIRECTORY = ../html/examples/par
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/par/html
+LATEX_OUTPUT     = latex/examples/par/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/pyexample.cfg
+++ b/examples/pyexample.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Python"
-OUTPUT_DIRECTORY = ../html/examples/pyexample
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/pyexample/html
+LATEX_OUTPUT     = latex/examples/pyexample/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/qtstyle.cfg
+++ b/examples/qtstyle.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Qt Style"
-OUTPUT_DIRECTORY = ../html/examples/qtstyle
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/qtstyle/html
+LATEX_OUTPUT     = latex/examples/qtstyle/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/relates.cfg
+++ b/examples/relates.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Relates Command"
-OUTPUT_DIRECTORY = ../html/examples/relates
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/relates/html
+LATEX_OUTPUT     = latex/examples/relates/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/restypedef.cfg
+++ b/examples/restypedef.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Resolving Typedefs"
-OUTPUT_DIRECTORY = ../html/examples/restypedef
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/restypedef/html
+LATEX_OUTPUT     = latex/examples/restypedef/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/structcmd.cfg
+++ b/examples/structcmd.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Structural commands"
-OUTPUT_DIRECTORY = ../html/examples/structcmd
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/structcmd/html
+LATEX_OUTPUT     = latex/examples/structcmd/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/tag.cfg
+++ b/examples/tag.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Tag Files"
-OUTPUT_DIRECTORY = ../html/examples/tag
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/tag/html
+LATEX_OUTPUT     = latex/examples/tag/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO

--- a/examples/templ.cfg
+++ b/examples/templ.cfg
@@ -1,5 +1,7 @@
 PROJECT_NAME     = "Template Test"
-OUTPUT_DIRECTORY = ../html/examples/templ
+OUTPUT_DIRECTORY = ..
+HTML_OUTPUT      = html/examples/templ/html
+LATEX_OUTPUT     = latex/examples/templ/latex
 GENERATE_LATEX   = YES
 GENERATE_MAN     = NO
 GENERATE_RTF     = NO


### PR DESCRIPTION
Due to a recent change in the new distribution of LaTeX in the handling of the "input" commands we get the error like:
```
Appendix D.
(../html/examples/group/latex/refman_doc.tex (../html/examples/group/latex//gro
up__group1.tex) [243]
! I can't write on file `../html/examples/group/latex//group__group2.aux'.
\@include ...mmediate \openout \@partaux "#1.aux"
                                                  \immediate \write \@partau...
l.3 \include{group__group2}

Please type another output file name
! Emergency stop.
\@include ...mmediate \openout \@partaux "#1.aux"
                                                  \immediate \write \@partau...
l.3 \include{group__group2}

*** (job aborted, file error in nonstop mode)
```

The problem is that now an intermediate file is written to `../html/examples/group/latex//group__group2.aux` that was written in the older distributions as `./group__group2.aux`, so in the current directory.
Writing to sub directories of the current directory is possible but it is not allowed (unless special, dangerous, options are used) to write to directories outside tgese directories.
(see also: https://tex.stackexchange.com/questions/575120/problem-writing-aux-file)

This fix writes the examples in subdirectories in the latex directory and not under the, parallel, html directory. This means also that there is a cleaner and clearer distinction between the html and latex output.