### PR TITLE
Remove some build warnings

### DIFF
--- a/qtools/qdatastream.cpp
+++ b/qtools/qdatastream.cpp
@@ -799,7 +799,7 @@ QDataStream &QDataStream::operator<<( Q_INT64 i )
     } else {					// swap bytes
 	uchar *p = (uchar *)(&i);
 	char b[sizeof(Q_INT64)];
-	if ( sizeof(Q_INT64) == 8 ) {
+	if ( sizeof(b) == 8 ) {
 	    b[7] = *p++;
 	    b[6] = *p++;
 	    b[5] = *p++;

--- a/qtools/qdatastream.cpp
+++ b/qtools/qdatastream.cpp
@@ -799,7 +799,7 @@ QDataStream &QDataStream::operator<<( Q_INT64 i )
     } else {					// swap bytes
 	uchar *p = (uchar *)(&i);
 	char b[sizeof(Q_INT64)];
-	if ( sizeof(b) == 8 ) {
+	if ( sizeof(Q_INT64) == 8 ) {
 	    b[7] = *p++;
 	    b[6] = *p++;
 	    b[5] = *p++;

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -76,7 +76,7 @@ class GroupDefImpl : public DefinitionMixin<GroupDef>
     virtual void writeMemberPages(OutputList &ol);
     virtual void writeQuickMemberLinks(OutputList &ol,const MemberDef *currentMd) const;
     virtual void writeTagFile(FTextStream &);
-    virtual int  numDocMembers() const;
+    virtual size_t numDocMembers() const;
     virtual bool isLinkableInProject() const;
     virtual bool isLinkable() const;
     virtual bool isASubGroup() const;
@@ -617,7 +617,7 @@ void GroupDefImpl::countMembers()
   }
 }
 
-int GroupDefImpl::numDocMembers() const
+size_t GroupDefImpl::numDocMembers() const
 {
   return m_fileList->count()+
          m_classes.size()+
@@ -775,7 +775,7 @@ void GroupDefImpl::writeDetailedDescription(OutputList &ol,const QCString &title
      )
   {
     ol.pushGeneratorState();
-    if (m_pageDict->count()!=(uint)numDocMembers()) // not only pages -> classical layout
+    if (m_pageDict->count()!=numDocMembers()) // not only pages -> classical layout
     {
       ol.pushGeneratorState();
         ol.disable(OutputGenerator::Html);
@@ -1817,7 +1817,7 @@ bool GroupDefImpl::hasDetailedDescription() const
 {
   static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   return ((!briefDescription().isEmpty() && repeatBrief) || !documentation().isEmpty() || !inbodyDocumentation().isEmpty()) &&
-         (m_pageDict->count()!=(uint)numDocMembers());
+         (m_pageDict->count()!=numDocMembers());
 }
 
 // --- Cast functions

--- a/src/groupdef.h
+++ b/src/groupdef.h
@@ -70,7 +70,7 @@ class GroupDef : public DefinitionMutable, public Definition
     virtual void writeMemberPages(OutputList &ol) = 0;
     virtual void writeQuickMemberLinks(OutputList &ol,const MemberDef *currentMd) const = 0;
     virtual void writeTagFile(FTextStream &) = 0;
-    virtual int  numDocMembers() const = 0;
+    virtual size_t numDocMembers() const = 0;
     virtual bool isLinkableInProject() const = 0;
     virtual bool isLinkable() const = 0;
     virtual bool isASubGroup() const = 0;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3934,7 +3934,7 @@ static void writeGroupTreeNode(OutputList &ol, GroupDef *gd, int level, FTVHelp*
     // write group info
     bool hasSubGroups = gd->getSubGroups()->count()>0;
     bool hasSubPages = gd->getPages()->count()>0;
-    int numSubItems = 0;
+    size_t numSubItems = 0;
     if (1 /*Config_getBool(TOC_EXPAND)*/)
     {
       QListIterator<MemberList> mli(gd->getMemberLists());
@@ -3949,7 +3949,7 @@ static void writeGroupTreeNode(OutputList &ol, GroupDef *gd, int level, FTVHelp*
       numSubItems += gd->getNamespaces()->count();
       numSubItems += gd->getClasses().size();
       numSubItems += gd->getFiles()->count();
-      numSubItems += static_cast<int>(gd->getDirs().size());
+      numSubItems += gd->getDirs().size();
       numSubItems += gd->getPages()->count();
     }
 


### PR DESCRIPTION
Removing some build warnings like:
```
D:\a\doxygen\doxygen\src\groupdef.cpp(628): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data
D:\a\doxygen\doxygen\src\index.cpp(3950): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
```