### PR TITLE
Remove warnings from util.cpp

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3588,9 +3588,9 @@ int getUtf8Char(const char *input,char ids[MAX_UTF8_CHAR_SIZE],CaseModifier modi
     {
       switch (modifier)
       {
-        case CaseModifier::None:    ids[0]=*input;          break;
-        case CaseModifier::ToUpper: ids[0]=toupper(*input); break;
-        case CaseModifier::ToLower: ids[0]=tolower(*input); break;
+        case CaseModifier::None:    ids[0]=*input;                break;
+        case CaseModifier::ToUpper: ids[0]=(char)toupper(*input); break;
+        case CaseModifier::ToLower: ids[0]=(char)tolower(*input); break;
       }
       l=1; // 0xxx.xxxx => normal single byte ascii character
     }


### PR DESCRIPTION
Remove warnings from util.cpp (as done on other places as well):
```
...\src\util.cpp(3592): warning C4242: '=': conversion from 'int' to 'char', possible loss of data
...\src\util.cpp(3593): warning C4242: '=': conversion from 'int' to 'char', possible loss of data
```