### PR TITLE
Miscounting of lines in case of inserting an anchor for a "H." tag

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2073,7 +2073,7 @@ void Markdown::writeOneLineHeaderOrRuler(const char *data,int size)
     {
       if (!id.isEmpty())
       {
-        m_out.addStr("\\anchor "+id+"\n");
+        m_out.addStr("\\anchor "+id+"\\ilinebr ");
       }
       hTag.sprintf("h%d",level);
       m_out.addStr("<"+hTag+">");


### PR DESCRIPTION
When having a simple file like:
```
# The page

# a section

##### a h5 section

\error7
```
we get as warning:
```
.../aa.md:8: warning: Found unknown command '\error7'
```
instead of
```
.../aa.md:7: warning: Found unknown command '\error7'
```
This is due to the fact  that the
```
##### a h5 section
```
is translated into:
```
\anchor autotoc_md2
<h5>a h5 section</h5>
```
instead of
```
\anchor autotoc_md2\ilinebr <h5>a h5 section</h5>
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5731217/example.tar.gz)
