### PR TITLE
issue #8269 Make failed when building layout.cpp

### DIFF
--- a/src/to_c_cmd.py
+++ b/src/to_c_cmd.py
@@ -5,4 +5,4 @@
 # place an escaped \n and " at the end of each line
 import sys
 for line in sys.stdin:
-    sys.stdout.write('"' + line.replace('\\','\\\\').replace('"','\\"').replace('\n','') + '\\n"\n')
+    sys.stdout.write('"' + line.replace('\\','\\\\').replace('"','\\"').replace('\n','').replace('\r','') + '\\n"\n')


### PR DESCRIPTION
When a `\r` is present of the line ending of the file `layout_default.xml` this leads to unexpected results (the `\r` should not be present at all).
By means of removing the `\r` this problem can be solved.