### PR TITLE
Concatenation of \param text and \details text

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -810,7 +810,7 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
                          }
                          lineCount(yytext,yyleng);
                        }
-<St_Para>({BLANK}*\n)+{BLANK}*\n{BLANK}* {
+<St_Para>({BLANK}*(\n|"\\ilinebr"))+{BLANK}*(\n|"\\ilinebr"){BLANK}* {
                          lineCount(yytext,yyleng);
                          if (g_insidePre)
                          {


### PR DESCRIPTION
When having a simple file like:
```
/// \file

/// @brief Different xxxxxxxxxxxxxxxxxxxxx
/// @param[in]   var = zzzzzz
/// @details Different yyyyyyyy
void fie(int var);
```
we see in the version 1.8.18 that the text is displayed as:
```
Parameters
    [in] var = zzzzzz

Different yyyyyyyy
```
but in the newer versions this is like:
```
Parameters
    [in] var = zzzzzz Different yyyyyyyy
```
the inserted intermediate `\ilinebr` are not handled as newlines

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5736487/example.tar.gz)
