### PR TITLE
Miscounting lines in case a fenced code block

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1649,7 +1649,7 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
   {
     if (data[i]==tildaChar)
     {
-      end=i-1;
+      end=i;
       int endTildes=0;
       while (i<size && data[i]==tildaChar) endTildes++,i++;
       while (i<size && data[i]==' ') i++;
@@ -2291,7 +2291,6 @@ void Markdown::writeFencedCodeBlock(const char *data,const char *lng,
     m_out.addStr("{"+lang+"}");
   }
   addStrEscapeUtf8Nbsp(data+blockStart,blockEnd-blockStart);
-  m_out.addStr(" ");
   m_out.addStr("@endcode");
 }
 


### PR DESCRIPTION
When having the following code:
```
# The page

~~~
ABC
  ~~~

~~~
DEF
~~~

~~~
GHI ~~~

~~~
JKL~~~

\line17
```
we get the warnings:
```
.../aa.md:16: warning: Found unknown command '\line17'
```
instead of
```
.../aa.md:17: warning: Found unknown command '\line17'
```

The last character of the fenced code block is not handled in the code block.
This problem has been solved (and also checked against the previous examples of #8045 and #8123).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5743458/example.tar.gz)
