### PR TITLE
archive build artefacts in GitHub Actions

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -60,6 +60,11 @@ jobs:
           }
     steps:
     - uses: actions/checkout@v1
+    
+    - name: print env
+      run: |
+        pwd
+        find
       
     - name: Download MikTex (Windows)
       run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -283,6 +283,12 @@ jobs:
           message(FATAL_ERROR "Build failed")
         endif()
 
+    - name: Archive build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: "${{ matrix.config.name }} build artifacts"
+        path: bin
+
     - name: Run tests (Linux / MacOS)
       shell: cmake -P {0}
       run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -60,11 +60,6 @@ jobs:
           }
     steps:
     - uses: actions/checkout@v1
-    
-    - name: print env
-      run: |
-        pwd
-        find
       
     - name: Download MikTex (Windows)
       run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -287,7 +287,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: "${{ matrix.config.name }} build artifacts"
-        path: bin
+        path: build/bin/
 
     - name: Run tests (Linux / MacOS)
       shell: cmake -P {0}


### PR DESCRIPTION
Adds an action which archives the build artefacts in `build/bin/` for each build configuration. This provides the binaries for all supported operating systems for every workflow run available.

This facilitates to have development builds available for all operating systems.

Preview
----------

![Screenshot from 2020-12-27 11-23-55](https://user-images.githubusercontent.com/1594340/103168741-21f3ed00-4836-11eb-91a4-ecda80621ffc.png)
