### PR TITLE
Layout in doxywizard documentation

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -951,6 +951,26 @@ void LatexDocVisitor::visitPost(DocHtmlListItem *)
 //  m_t << "\\end{alltt}\\normalsize " << endl;
 //}
 
+static bool listIsNested(const DocNode *n)
+{
+  bool isNested=false;
+  if (n)
+  {
+    if (n->kind()==DocNode::Kind_HtmlDescList && ((DocHtmlDescList *)n)->attribs().find("class") == "reflist") return false;
+    n  = n->parent();
+  }
+  while (n && !isNested)
+  {
+    if (n->kind()==DocNode::Kind_HtmlDescList)
+    {
+      QCString val = ((DocHtmlDescList *)n)->attribs().find("class");
+      isNested = (val!="reflist");
+    }
+    n  = n->parent();
+  }
+  return isNested;
+}
+
 void LatexDocVisitor::visitPre(DocHtmlDescList *dl)
 {
   if (m_hide) return;
@@ -961,6 +981,7 @@ void LatexDocVisitor::visitPre(DocHtmlDescList *dl)
   }
   else
   {
+    if (listIsNested(dl)) m_t << "\n\\hfill";
     m_t << "\n\\begin{DoxyDescription}";
   }
 }


### PR DESCRIPTION
When looking at page 100 of the doxygen 1.9.0 manual (i.e. chapter Doxywizard usage, bold part "Configure doxygen using the Wizard and/or Expert tab..Configure doxygen using the Wizard and/or Expert tab...") we see that the word "Wizard tab" in comparison to "Expert tab" are a bit on a strange place. In the HTML documentation this looks OK
The problem is caused by the fact that we have her nested description (`<dl>` lists), a new paragraph should be started / the line should be properly filled and this can be done by means of the `\hfill`.