### PR TITLE
issue #8286 Incorrect processing of VHDL strings

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -541,7 +541,7 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
 <SkipString>\\.                    { /* escaped character in string */
-                                     if (yyextra->lang==SrcLangExt_Fortran)
+                                     if (yyextra->lang==SrcLangExt_Fortran || yyextra->lang==SrcLangExt_VHDL)
                                      {
                                        unput(yytext[1]);
                                        copyToOutput(yyscanner,yytext,1);
@@ -562,7 +562,7 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
 <SkipChar>\\.		           { /* escaped character */
-                                     if (yyextra->lang==SrcLangExt_Fortran)
+                                     if (yyextra->lang==SrcLangExt_Fortran || yyextra->lang==SrcLangExt_VHDL)
                                      {
                                        unput(yytext[1]);
                                        copyToOutput(yyscanner,yytext,1);


### PR DESCRIPTION
See a `\` in comment in VHDL also as a normal character in a string.