### PR TITLE
issue #8286 Incorrect processing of VHDL strings (comment part)

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -348,6 +348,16 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                        yyextra->commentStack.push(new CommentCtx(yyextra->lineNr));
 				     }
   				   }
+<Scan>"--"[^!][^\n]*		   {
+                                     if (yyextra->lang!=SrcLangExt_VHDL)
+				     {
+				       REJECT;
+				     }
+				     else
+				     {
+                                       copyToOutput(yyscanner,yytext,(int)yyleng); 
+				     }
+  				   }
 <Scan>"--!"		           {
                                      if (yyextra->lang!=SrcLangExt_VHDL)
 				     {


### PR DESCRIPTION
Just copying normal vhdl comment, don't interpret it.

Different problem from the problem solved in #8287