### PR TITLE
Add a CLANG_INCLUDE_INPUT_PATHS option

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -163,6 +163,7 @@ void ClangTUParser::parse()
   //printf("ClangTUParser::ClangTUParser(fileName=%s,#filesInSameTU=%d)\n",
   //    qPrint(fileName),(int)p->filesInSameTU.size());
   bool clangAssistedParsing = Config_getBool(CLANG_ASSISTED_PARSING);
+  bool clangIncludeInputPaths = Config_getBool(CLANG_INCLUDE_INPUT_PATHS);
   bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
   const StringVector &includePath = Config_getList(INCLUDE_PATH);
   const StringVector &clangOptions = Config_getList(CLANG_OPTIONS);
@@ -211,11 +212,14 @@ void ClangTUParser::parse()
   else
   {
     // add include paths for input files
-    for (const std::string &path : Doxygen::inputPaths)
+    if (clangIncludeInputPaths)
     {
-      QCString inc = QCString("-I")+path.data();
-      argv[argc++]=qstrdup(inc.data());
-      //printf("argv[%d]=%s\n",argc,argv[argc]);
+      for (const std::string &path : Doxygen::inputPaths)
+      {
+        QCString inc = QCString("-I")+path.data();
+        argv[argc++]=qstrdup(inc.data());
+        //printf("argv[%d]=%s\n",argc,argv[argc]);
+      }
     }
     // add external include paths
     for (size_t i=0;i<includePath.size();i++)

--- a/src/config.xml
+++ b/src/config.xml
@@ -982,14 +982,14 @@ Go to the <a href="commands.html">next</a> section or return to the
       <docs>
 <![CDATA[
  With the correct setting of option \c CASE_SENSE_NAMES doxygen will better be able to match the
- capabilities of the underlying filesystem. 
+ capabilities of the underlying filesystem.
 
- In case the filesystem is case sensitive (i.e. it supports files in the same directory 
+ In case the filesystem is case sensitive (i.e. it supports files in the same directory
  whose names only differ in casing), the option must be set to \c YES to properly deal with such files
- in case they appear in the input. 
- 
- For filesystems that are not case sensitive the option should be be set to \c NO to properly 
- deal with output files written for symbols that only differ in casing, such as for two classes, 
+ in case they appear in the input.
+
+ For filesystems that are not case sensitive the option should be be set to \c NO to properly
+ deal with output files written for symbols that only differ in casing, such as for two classes,
  one named \c CLASS and the other named \c Class, and to also support references to files without
  having to specify the exact matching casing.
 
@@ -1740,6 +1740,15 @@ to disable this feature.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='CLANG_INCLUDE_INPUT_PATHS' setting='USE_LIBCLANG' defval='1'>
+      <docs>
+<![CDATA[
+  If clang assisted parsing is enabled and the \c CLANG_INCLUDE_INPUT_PATHS tag
+  is set to \c YES then doxygen will add the directory of each input to the
+  include path.
+]]>
+      </docs>
+    </option>
     <option type='list' id='CLANG_OPTIONS' format='string' setting='USE_LIBCLANG' depends='CLANG_ASSISTED_PARSING'>
       <docs>
 <![CDATA[
@@ -2429,7 +2438,7 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
     <option type='string' id='FORMULA_MACROFILE' format='file' defval=''>
       <docs>
 <![CDATA[
- The \c FORMULA_MACROFILE can contain \f$\mbox{\LaTeX}\f$ `\newcommand` and 
+ The \c FORMULA_MACROFILE can contain \f$\mbox{\LaTeX}\f$ `\newcommand` and
  `\renewcommand` commands to create new \f$\mbox{\LaTeX}\f$ commands to be used
  in formulas as building blocks.
  See the section \ref formulas for details.
@@ -2863,7 +2872,7 @@ or
     <option type='string' id='LATEX_EMOJI_DIRECTORY' format='dir' defval='' depends='GENERATE_LATEX'>
       <docs>
 <![CDATA[
- The \c LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute) 
+ The \c LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
  path from which the emoji images will be read.
  If a relative path is entered, it will be relative to the \ref cfg_latex_output "LATEX_OUTPUT"
  directory. If left blank the \ref cfg_latex_output "LATEX_OUTPUT" directory will be used.


### PR DESCRIPTION
This PR adds a new option, `CLANG_INCLUDE_INPUT_PATHS`, which is on by default. If this option is on, then the directory of each input file is added to the include path when using Clang parsing. This behavior is the current status quo, but some projects need to be able to disable it.

Adding the directory of every input file to the include path is problematic for a number of projects. We ran into problems with it in [Thrust](https://github.com/NVIDIA/thrust).

For example, imagine a project that has this structure:

```
include/myproject/version.h
include/myproject/component0/coolstuff.h
include/myproject/component1/coolstuff.h
include/myproject/component1/widget.h
```

And those files are intended to be included by users as:

```
#include <myproject/version.h>
#include <myproject/component0/coolstuff.h>
#include <myproject/component1/coolstuff.h>
#include <myproject/component1/widget.h>
```

But within `include/myproject/component1/widget.h`, you might have:

```
#include "coolstuff.h" // Should resolve to `include/myproject/component1/coolstuff.h`.
```

If you have `INPUT = include`, then the directories of all headers found in `include` will be added as includes by Doxygen:

```
-Iinclude/myproject -Iinclude/myproject/component0 -Iinclude/myproject/component1
```

This is problematic, because now `include/myproject/component1/widget.h` will include `include/myproject/component0/coolstuff.h` instead of `include/myproject/component1/coolstuff.h`.

Alternatively, consider the case we ran into in Thrust, where our project structure looks like:

```
thrust/version.h
...
thrust/system/detail/errno.h
...
```

With `INPUT = thrust`, Doxygen will add the following as includes:

```
"-Ithrust ... -Ithrust/system/detail"
```

This is problematic because `errno.h` is also the name of a system header, and will now be found instead of the system header.




