### PR TITLE
Change container type of UsedDir from QDict to STL container

### DIFF
--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -20,6 +20,7 @@
 #include "definition.h"
 
 #include <vector>
+#include <map>
 #include <qglobal.h>
 #include <qcstring.h>
 
@@ -43,6 +44,8 @@ class DirDef : public DefinitionMutable, public Definition
   public:
     virtual ~DirDef() {}
 
+    using UsedDirsContainer = std::map<QCString, UsedDir * >;
+
     // accessors
     virtual DefType definitionType() const = 0;
     virtual QCString getOutputFileBase() const = 0;
@@ -59,7 +62,7 @@ class DirDef : public DefinitionMutable, public Definition
     virtual int level() const = 0;
     virtual DirDef *parent() const = 0;
     virtual int dirCount() const = 0;
-    virtual const QDict<UsedDir> *usedDirs() const = 0;
+    virtual const UsedDirsContainer* usedDirs() const = 0;
     virtual bool isParentOf(const DirDef *dir) const = 0;
     virtual bool depGraphIsTrivial() const = 0;
     virtual QCString shortTitle() const = 0;

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -89,13 +89,11 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
 
   // add nodes for other used directories
   {
-    QDictIterator<UsedDir> udi(*dd->usedDirs());
-    UsedDir *udir;
     //printf("*** For dir %s\n",shortName().data());
-    for (udi.toFirst();(udir=udi.current());++udi) 
+    for (const auto &usedDirectoryEntry : *dd->usedDirs())
       // for each used dir (=directly used or a parent of a directly used dir)
     {
-      const DirDef *usedDir=udir->dir();
+      const DirDef *usedDir = usedDirectoryEntry.second->dir();
       const DirDef *dir=dd;
       while (dir)
       {
@@ -135,10 +133,9 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
   QDictIterator<DirDef> di(dirsInGraph);
   for (;(dir=di.current());++di) // foreach dir in the graph
   {
-    QDictIterator<UsedDir> udi(*dir->usedDirs());
-    UsedDir *udir;
-    for (udi.toFirst();(udir=udi.current());++udi) // foreach used dir
+    for (const auto &usedDirectoryEntry : *dir->usedDirs())
     {
+      UsedDir *const udir = usedDirectoryEntry.second;
       const DirDef *usedDir=udir->dir();
       if ((dir!=dd || !udir->inherited()) &&     // only show direct dependencies for this dir
         (usedDir!=dd || !udir->inherited()) && // only show direct dependencies for this dir


### PR DESCRIPTION
Effort to reduce (outdated) Qt dependencies (similar to #7651) in order to simplify modern C++ coding. This allows to use range based for loops.