### PR TITLE
Draw sibling dependee directories within same parent direcoty in directory dependency graph.

### DIFF
--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -23,9 +23,9 @@
 /**
  * Puts DOT code for drawing directory to stream and adds it to the list.
  * @param outStream[in,out] stream to which the DOT code is written to
- * @param directory
- * @param fillBackground
- * @param directoriesInGraph[in,out]
+ * @param directory[in] will be mapped to a node in DOT code
+ * @param fillBackground[in] if the node shall be explicitly filled
+ * @param directoriesInGraph[in,out] lists the directories which have been written to the output stream
  */
 static void drawDirectory(FTextStream &outStream, const DirDef *const directory, const bool fillBackground,
     QDict<DirDef> &directoriesInGraph)

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -61,10 +61,10 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
 
   dirsInGraph.insert(dd->getOutputFileBase(),dd);
 
-  std::vector<const DirDef *> usedDirsToBeDrawn;
+  std::vector<const DirDef *> usedDirsNotDrawn;
   for(const auto& usedDir : dd->usedDirs())
   {
-    usedDirsToBeDrawn.push_back(usedDir->dir());
+    usedDirsNotDrawn.push_back(usedDir->dir());
   }
 
   const auto parent = dd->parent();
@@ -79,9 +79,9 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
 
     {
       // draw all directories which have `dd->parent()` as parent and `dd` as dependent
-      const auto newEnd = std::remove_if(usedDirsToBeDrawn.begin(), usedDirsToBeDrawn.end(), [&](const DirDef *const usedDir)
+      const auto newEnd = std::remove_if(usedDirsNotDrawn.begin(), usedDirsNotDrawn.end(), [&](const DirDef *const usedDir)
       {
-        if (usedDir->parent() == parent)
+        if (dd!=usedDir && dd->parent()==usedDir->parent() && !usedDir->isParentOf(dd))
         {
           drawDirectory(t, usedDir, usedDir->isCluster() && !Config_getBool(DOT_TRANSPARENT), dirsInGraph);
           return true;
@@ -89,7 +89,7 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
         return false;
       }
       );
-      usedDirsToBeDrawn.erase(newEnd, usedDirsToBeDrawn.end());
+      usedDirsNotDrawn.erase(newEnd, usedDirsNotDrawn.end());
     }
   }
   if (dd->isCluster())
@@ -123,7 +123,7 @@ void writeDotDirDepGraph(FTextStream &t,const DirDef *dd,bool linkRelations)
   // add nodes for other used directories
   {
     //printf("*** For dir %s\n",shortName().data());
-    for (const auto &usedDir : usedDirsToBeDrawn)
+    for (const auto &usedDir : usedDirsNotDrawn)
       // for each used dir (=directly used or a parent of a directly used dir)
     {
       const DirDef *dir=dd;


### PR DESCRIPTION
Summary of changes
================

- move code to generate DOT code for a directory to dedicated function as this is now used 3 times
- collect dependee directories in list
- while parent directory is drawn (cluster subgraph), draw dependees which have the same parent directory
- finally only draw the remaining directories

Fixes #8293.

Effect by example
==============

See for example the following directory structure (truncated):

```
src/
├── a
│   ├── aa
│   └── depends_on_b.h
├── b
│   ├── bb
│   ├── dependent.h
│   └── depends_on_cc.h
├── c
│   ├── cc
│   └── dependent.h
└── d
    └── dd
```

Previous behaviour
--------------------------

In directory dependency graph for `a`, `b` was drawn outside of `src`.

![dir_85293cd6fb67eb83825626cd83b71cea_dep_MASTER](https://user-images.githubusercontent.com/1594340/103443176-ccb44300-4c5c-11eb-97a3-bee30ad732ac.png)

The directory dependency graph is on the Directory Reference page for directory `a`: File --> select directory `a`.

To Reproduce
-------------------

[move-parent-directory-example.zip](https://github.com/doxygen/doxygen/files/5759190/move-parent-directory-example.zip)

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux 10 (buster)
Release:        10
Codename:       buster
```

changed behavior
------------------------

For example in the directory dependency graph for `a` the graph is now drawn such as `a` and its dependee `b` are inside of `src`.

![dir_85293cd6fb67eb83825626cd83b71cea_dep](https://user-images.githubusercontent.com/1594340/103443196-f40b1000-4c5c-11eb-82bc-c4ce44dd0113.png)