### PR TITLE
issue #8297 fails to parse list of INPUT files

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -873,7 +873,7 @@ static void readIncludeFile(const char *incName)
                                            g_config->appendUserComment(yytext);
                                            g_yyLineNr++;
                                          }
-<Start>"#"[^#].*"\n"                     { /* normal comment */
+<Start>"#".*"\n"                         { /* normal comment */
                                            g_yyLineNr++;
                                          }
 


### PR DESCRIPTION
The rule also caught a `\n` at the second position.