### PR TITLE
Compilation warning in groupdef

### DIFF
--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1046,7 +1046,7 @@ void GroupDefImpl::writeSummaryLinks(OutputList &ol) const
     if ((lde->kind()==LayoutDocEntry::GroupClasses && m_classes.declVisible()) ||
         (lde->kind()==LayoutDocEntry::GroupNamespaces && m_namespaces.declVisible()) ||
         (lde->kind()==LayoutDocEntry::GroupFiles && m_fileList->count()>0) ||
-        (lde->kind()==LayoutDocEntry::GroupNestedGroups && !m_groups.empty()>0) ||
+        (lde->kind()==LayoutDocEntry::GroupNestedGroups && !m_groups.empty()) ||
         (lde->kind()==LayoutDocEntry::GroupDirs && !m_dirList.empty())
        )
     {


### PR DESCRIPTION
When compiling groupdef.cpp we get (on Windows) the warning:
```
groupdef.cpp(1049): warning C4804: '>': unsafe use of type 'bool' in operation
```