### PR TITLE
Compilation warning in util.cpp

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1072,7 +1072,7 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
 
 void writeExamples(OutputList &ol,const ExampleList &list)
 {
-  QCString exampleLine=theTranslator->trWriteList(list.size());
+  QCString exampleLine=theTranslator->trWriteList((int)list.size());
 
   //bool latexEnabled = ol.isEnabled(OutputGenerator::Latex);
   //bool manEnabled   = ol.isEnabled(OutputGenerator::Man);


### PR DESCRIPTION
When compiling util.cpp we get (on Windows 64-bit) the warning:

```
util.cpp(1075): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
```
making it conform other calls.