### PR TITLE
Incorrect entries on treeview

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2734,8 +2734,8 @@ void MarkdownOutlineParser::parseInput(const char *fileName,
   if (id.startsWith("autotoc_md")) id = "";
   int indentLevel=title.isEmpty() ? 0 : -1;
   markdown.setIndentLevel(indentLevel);
-  QCString titleFn = QFileInfo(fileName).baseName().utf8();
   QCString fn      = QFileInfo(fileName).fileName().utf8();
+  QCString titleFn = stripExtensionGeneral(fn,getFileNameExtension(fn));
   QCString mdfileAsMainPage = Config_getString(USE_MDFILE_AS_MAINPAGE);
   bool wasEmpty = id.isEmpty();
   if (wasEmpty) id = markdownFileNameToId(fileName);


### PR DESCRIPTION
When having e.g. markdown files like:
```
0.3.1.md
0.3.2.md
```
we get in the treeview twice the item "0" instead of the, more, expected "0.3.1" and "0.3.2".
This is due to the fact that the filename is seen as `0` and the extension `.3.1.md` and `.3.2.md` instead of
filename `0.3.1` and `0.3.2` and extension in both cases `.md`.

The problem was found by Fossies in the Buildbot project.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5769847/example.tar.gz)
