### PR TITLE
issue #8311 Markdown table: double-quote ruins the output

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -755,6 +755,8 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
 <St_Para,St_Text>[\-+0-9] |
 <St_Para,St_Text>{WORD1} |
 <St_Para,St_Text>{WORD2} { /* function call */
+                         QCString tmp = yytext;
+                         if (tmp.contains("\\ilinebr")>0) REJECT;
                          lineCount(yytext,yyleng);
                          if (yytext[0]=='%') // strip % if present
                            g_token->name = &yytext[1];
@@ -1042,6 +1044,8 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
 <St_TitleN>[\-+0-9]    |
 <St_TitleN>{WORD1}     |
 <St_TitleN>{WORD2}     { /* word */
+                         QCString tmp = yytext;
+                         if (tmp.contains("\\ilinebr")>0) REJECT;
                          lineCount(yytext,yyleng);
                          if (yytext[0]=='%') // strip % if present
                            g_token->name = &yytext[1];


### PR DESCRIPTION
In case of an artificial line break and the string starting with a `"` reject the rule, so lonely `"` are handled properly.