### PR TITLE
Typeerror when running tests

### DIFF
--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -52,7 +52,7 @@ def clean_header(errmsg):
 			if (cnt > 0):
 				cnt-=1
 			else:
-				rtnmsg+=0
+				rtnmsg+=o
 	return rtnmsg
  
 class Tester:


### PR DESCRIPTION
Some tests get (#8313):
```
  File "/home/runner/work/doxygen/doxygen/testing/runtests.py", line 55, in clean_header
    rtnmsg+=0
TypeError: can only concatenate str (not "int") to str
```
most likely caused by the fact that `more` has error lines and that here not `0` (zero) but  `o` should be used for the concatenation.