### PR TITLE
Incorrect type for enum struct

### DIFF
--- a/src/entry.h
+++ b/src/entry.h
@@ -137,6 +137,7 @@ class Entry
     static const uint64 Local           = (1ULL<<16); // for Slice types
 
     // member specifiers (add new items to the beginning)
+    static const uint64 EnumStruct      = (1ULL<<18);
     static const uint64 ConstExpr       = (1ULL<<19); // C++11 constexpr
     static const uint64 PrivateGettable     = (1ULL<<20); // C# private getter
     static const uint64 ProtectedGettable   = (1ULL<<21); // C# protected getter

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -138,6 +138,7 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual bool isRetain() const;
     virtual bool isWeak() const;
     virtual bool isStrong() const;
+    virtual bool isEnumStruct() const;
     virtual bool isUnretained() const;
     virtual bool isNew() const;
     virtual bool isSealed() const;
@@ -543,6 +544,8 @@ class MemberDefAliasImpl : public DefinitionAliasMixin<MemberDef>
     { return getMdAlias()->isWeak(); }
     virtual bool isStrong() const
     { return getMdAlias()->isStrong(); }
+    virtual bool isEnumStruct() const
+    { return getMdAlias()->isEnumStruct(); }
     virtual bool isUnretained() const
     { return getMdAlias()->isUnretained(); }
     virtual bool isNew() const
@@ -3244,6 +3247,8 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
     }
     else
     {
+      if (isEnumStruct()) ldef.prepend("struct ");
+      else if (isStrong()) ldef.prepend("class ");
       ldef.prepend("enum ");
       if (isSliceLocal())
       {
@@ -5148,6 +5153,11 @@ bool MemberDefImpl::isWeak() const
 bool MemberDefImpl::isStrong() const
 {
   return (m_impl->memSpec&Entry::Strong)!=0;
+}
+
+bool MemberDefImpl::isEnumStruct() const
+{
+  return (m_impl->memSpec&Entry::EnumStruct)!=0;
 }
 
 bool MemberDefImpl::isStrongEnumValue() const

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -149,6 +149,7 @@ class MemberDef : public Definition
     virtual bool isRetain() const = 0;
     virtual bool isWeak() const = 0;
     virtual bool isStrong() const = 0;
+    virtual bool isEnumStruct() const = 0;
     virtual bool isUnretained() const = 0;
     virtual bool isNew() const = 0;
     virtual bool isSealed() const = 0;

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -487,7 +487,14 @@ void MemberList::writePlainDeclarations(OutputList &ol,
               ol.writeString("enum ");
               if (md->isStrong())
               {
-                ol.writeString("class ");
+                if (md->isEnumStruct())
+                {
+                  ol.writeString("struct ");
+                }
+                else
+                {
+                  ol.writeString("class ");
+                }
               }
               ol.insertMemberAlign();
               md->writeEnumDeclaration(ol,cd,nd,fd,gd);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1574,7 +1574,8 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 <FindMembers>{B}*{TYPEDEFPREFIX}{IDLATTR}?"enum"({BN}+("class"|"struct"))?{BN}+ { // for IDL: typedef [something] enum
                                           QCString text=yytext;
                                           yyextra->isTypedef    = text.find("typedef")!=-1;
-                                          bool isStrongEnum = text.find("struct")!=-1 || text.find("class")!=-1 || yyextra->insideCS;
+                                          bool isStrongEnum =  text.find("class")!=-1 || yyextra->insideCS;
+                                          bool isEnumSytruct = text.find("struct")!=-1;
                                           if (yyextra->insideJava)
                                           {
                                             yyextra->current->section = Entry::CLASS_SEC;
@@ -1589,6 +1590,11 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
                                           if (isStrongEnum)
                                           {
                                             yyextra->current->spec |= Entry::Strong;
+                                          }
+                                          if (isEnumSytruct)
+                                          {
+                                            yyextra->current->spec |= Entry::Strong;
+                                            yyextra->current->spec |= Entry::EnumStruct;
                                           }
                                           yyextra->current->fileName  = yyextra->yyFileName;
                                           yyextra->current->startLine = yyextra->yyLineNr;


### PR DESCRIPTION
In case we have the simple file:
```
/// \file

/// docu with nothing
        enum MyEnum_not { v1_0, v2_0 };
/// docu with class
        enum class MyEnum_cls { v1_2, v2_2 };
/// docu with struct
        enum struct MyEnum_str { v1_3, v2_3 };
```
with settings:
```
QUIET=YES
ALWAYS_DETAILED_SEC=YES
```
the `enum struct` is shown as `enum class` in the brief description and in the detailed description just as `enum` (the later also is the case for the `enum class`).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5802540/example.tar.gz)
