### PR TITLE
issue #8329 Force line buffering

### DIFF
--- a/doc/faq.doc
+++ b/doc/faq.doc
@@ -306,6 +306,14 @@ Doc++ but that just wasn't good enough (it didn't support signals and
 slots and did not have the Qt look and feel I had grown to like),
 so I started to write my own tool...
 
+\section faq_bin How to prevent interleaved output
+
+When redirecting all the console output of doxygen, i.e. messages and warnings, this can be interleaved or
+in a non-expected order.
+The, technical, reason for this is that the `stdout` can be buffered.
+It is possible to overcome this by means of the `-b` of doxygen, like e.g `doxygen -b > out.txt 2>&1`.
+Note this might cost a little more time though.
+
 \htmlonly
 Go to the <a href="trouble.html">next</a> section or return to the
  <a href="index.html">index</a>.

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -145,7 +145,6 @@ bool                  Doxygen::parseSourcesNeeded = FALSE;
 SearchIndexIntf      *Doxygen::searchIndex=0;
 SymbolMap<Definition> Doxygen::symbolMap;
 ClangUsrMap          *Doxygen::clangUsrMap = 0;
-bool                  Doxygen::outputToWizard=FALSE;
 Cache<std::string,LookupInfo> *Doxygen::lookupCache;
 DirLinkedMap         *Doxygen::dirLinkedMap;
 DirRelationLinkedMap  Doxygen::dirRelations;
@@ -10076,7 +10075,7 @@ static void devUsage()
 {
   msg("Developer parameters:\n");
   msg("  -m          dump symbol map\n");
-  msg("  -b          output to wizard\n");
+  msg("  -b          making messages output unbuffered\n");
   msg("  -T          activates output generation via Django like template\n");
   msg("  -d <level>  enable a debug level, such as (multiple invocations of -d are possible):\n");
   Debug::printFlags();
@@ -10550,7 +10549,6 @@ void readConfiguration(int argc, char **argv)
         break;
       case 'b':
         setvbuf(stdout,NULL,_IONBF,0);
-        Doxygen::outputToWizard=TRUE;
         break;
       case 'T':
         msg("Warning: this option activates output generation via Django like template files. "

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -121,7 +121,6 @@ class Doxygen
     static SearchIndexIntf          *searchIndex;
     static SymbolMap<Definition>     symbolMap;
     static ClangUsrMap              *clangUsrMap;
-    static bool                      outputToWizard;
     static Cache<std::string,LookupInfo> *lookupCache;
     static DirLinkedMap             *dirLinkedMap;
     static DirRelationLinkedMap      dirRelations;


### PR DESCRIPTION
By default stdout is buffered when redirecting, the `-b` option of doxygen prevents this.

Removing non used variable `outputToWizard`.