### PR TITLE
issue #8338 \until and \skipline don't hide doxygen comments like \skip does

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2016,20 +2016,15 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                             BEGIN(SkipComment);
                                           }
                                         }
-<*>^{B}*"//"[!/][^\n]*\n                { // remove special one-line comment
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
-                                          {
-                                            yyextra->yyLineNr++;
-                                            //nextCodeLine(yyscanner);
-                                          }
-                                          else
+<*>^{B}*"//"[!/][^\n]*                  { // remove special one-line comment
+                                          if (!Config_getBool(STRIP_CODE_COMMENTS))
                                           {
                                             startFontClass(yyscanner,"comment");
                                             codifyLines(yyscanner,yytext);
                                             endFontClass(yyscanner);
                                           }
                                         }
-<*>"//"[!/][^\n]*/\n                    { // strip special one-line comment
+<*>"//"[!/][^\n]*                       { // strip special one-line comment
                                           if (YY_START==SkipComment || YY_START==SkipString) REJECT;
                                           if (!Config_getBool(STRIP_CODE_COMMENTS))
                                           {


### PR DESCRIPTION
The last line doesn't necessary contain the newline character, but the rule required it. The newline character will be handled, correctly, separately.