### PR TITLE
issue #8343 doxygen-1.9.1 crashes when parsing config file (part 2)

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1175,8 +1175,7 @@ static void substEnvVarsInStrList(StringVector &sl)
   for (const auto &s : sl)
   {
     QCString result = s.c_str();
-    // an argument with quotes will have an extra space at the end, so wasQuoted will be TRUE.
-    bool wasQuoted = (result.find(' ')!=-1) || (result.find('\t')!=-1);
+    bool wasQuoted = (result.find(' ')!=-1) || (result.find('\t')!=-1) || (result.find('"')!=-1);
     // here we strip the quote again
     substEnvVarsInString(result);
 
@@ -1229,7 +1228,7 @@ static void substEnvVarsInStrList(StringVector &sl)
       }
       if (p!=l) // add the leftover as a string
       {
-        results.push_back(result.right(l-p).data());
+        results.push_back(result.right(l-p).str());
       }
     }
     else // just goto the next element in the list


### PR DESCRIPTION
- In the past in case of a quoted string there was a space at the end of the string (as also indicated in the comment), now this space is gone so the `wasQuoted` would not kick in. A string with an escaped double quote should be / has to be escaped so it should also be included in the `wasQuoted`
- missing one `data()` -> `str()` (should not give a problem due to the guard, but better for consistency).

Extra tests run (for using  with `doxygen -x`):
```
PREDEFINED             = "LIBSBML_EXTERN:=\"" \
                         "LIBSBML_EXTERN:=\"" \
                         "LIBSBML_EXTERN:=\"a\"" \
                         "LIBSBML_EXTERN:=\"a\"" \
                         "LIBSBML_EXTERN:=\" \"" \
                         LIBSBML_EXTERN:=A \
                         LIBSBML_EXTERN:=A \
                         "LIBSBML_EXTERN:=\"\"" \
                         "LIBSBML_EXTERN:=\"\""
```