### PR TITLE
Non default value not shown properly in doxywizard

### DIFF
--- a/addon/doxywizard/inputstrlist.cpp
+++ b/addon/doxywizard/inputstrlist.cpp
@@ -276,8 +276,8 @@ bool InputStrList::isDefault()
   if (it1==m_strList.end() && it2==m_default.end()) return true;
 
   // one list is empty but the other is not
-  if (it1==m_default.end()) return false;
-  if (it2==m_strList.end()) return false;
+  if (it1==m_strList.end()) return false;
+  if (it2==m_default.end()) return false;
 
   it1 = m_strList.begin();
   it2 = m_default.begin();


### PR DESCRIPTION
In case of a string list with no default values the changed item was not shown with a red color when the list to be used had elements.
The test was done against the wrong list.