### PR TITLE
Add possibility to preserve relevant comments when using -x option

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -261,8 +261,10 @@ Studio projects), e.g. `setenv TEST_FLAGS "--id 5 --id 7"` and `make tests`.
 In case one has to communicate through e.g. a forum the configuration settings that
 are different from the standard doxygen configuration file settings one can run the
 doxygen command: with the `-x` option and the name of the configuration file (default
-is `Doxyfile`). The output will be a list of the not default settings (in `Doxyfile`
+is `Doxyfile`). The output will be a list of the non default settings (in `Doxyfile`
 format).
+To have also the standard comments of the non default items and all the user comments
+use `-xl` instead of `-x`.
 
 \htmlonly
 Return to the <a href="index.html">index</a>.

--- a/src/config.h
+++ b/src/config.h
@@ -59,7 +59,7 @@ namespace Config
   /*! Writes a the differences between the current configuration and the
    *  template configuration to stream \a t.
    */
-  void compareDoxyfile(FTextStream &t);
+  void compareDoxyfile(FTextStream &t, const bool longList);
 
   /*! Parses a configuration file with name \a fn.
    *  \returns TRUE if successful, FALSE if the file could not be

--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -74,7 +74,7 @@ class ConfigOption
 
   protected:
     virtual void writeTemplate(FTextStream &t,bool sl,bool upd) = 0;
-    virtual void compareDoxyfile(FTextStream &t) = 0;
+    virtual void compareDoxyfile(FTextStream &t, const bool longList) = 0;
     virtual void convertStrToVal() {}
     virtual void emptyValueToDefault() {}
     virtual void substEnvVars() = 0;
@@ -106,7 +106,7 @@ class ConfigInfo : public ConfigOption
       m_doc = doc;
     }
     void writeTemplate(FTextStream &t, bool sl,bool);
-    void compareDoxyfile(FTextStream &){};
+    void compareDoxyfile(FTextStream &, const bool longList){};
     void substEnvVars() {}
 };
 
@@ -129,7 +129,7 @@ class ConfigList : public ConfigOption
     StringVector *valueRef() { return &m_value; }
     StringVector getDefault() { return m_defaultValue; }
     void writeTemplate(FTextStream &t,bool sl,bool);
-    void compareDoxyfile(FTextStream &t);
+    void compareDoxyfile(FTextStream &t, const bool longList);
     void substEnvVars();
     void init() { m_value = m_defaultValue; }
   private:
@@ -160,7 +160,7 @@ class ConfigEnum : public ConfigOption
     void substEnvVars();
     void writeTemplate(FTextStream &t,bool sl,bool);
     void convertStrToVal();
-    void compareDoxyfile(FTextStream &t);
+    void compareDoxyfile(FTextStream &t, const bool longList);
     void init() { m_value = m_defValue.copy(); }
 
   private:
@@ -190,7 +190,7 @@ class ConfigString : public ConfigOption
     void setDefaultValue(const char *v) { m_defValue = v; }
     QCString *valueRef() { return &m_value; }
     void writeTemplate(FTextStream &t,bool sl,bool);
-    void compareDoxyfile(FTextStream &t);
+    void compareDoxyfile(FTextStream &t, const bool longList);
     void substEnvVars();
     void init() { m_value = m_defValue.copy(); }
     void emptyValueToDefault() { if(m_value.isEmpty()) m_value=m_defValue; };
@@ -223,7 +223,7 @@ class ConfigInt : public ConfigOption
     void convertStrToVal();
     void substEnvVars();
     void writeTemplate(FTextStream &t,bool sl,bool upd);
-    void compareDoxyfile(FTextStream &t);
+    void compareDoxyfile(FTextStream &t, const bool longList);
     void init() { m_value = m_defValue; }
   private:
     int m_value;
@@ -252,7 +252,7 @@ class ConfigBool : public ConfigOption
     void substEnvVars();
     void setValueString(const QCString &v) { m_valueString = v; }
     void writeTemplate(FTextStream &t,bool sl,bool upd);
-    void compareDoxyfile(FTextStream &t);
+    void compareDoxyfile(FTextStream &t, const bool longList);
     void init() { m_value = m_defValue; }
   private:
     bool m_value;
@@ -268,7 +268,7 @@ class ConfigObsolete : public ConfigOption
     ConfigObsolete(const char *name) : ConfigOption(O_Obsolete)
     { m_name = name; }
     void writeTemplate(FTextStream &,bool,bool);
-    void compareDoxyfile(FTextStream &) {}
+    void compareDoxyfile(FTextStream &, const bool longList) {}
     void substEnvVars() {}
 };
 
@@ -280,7 +280,7 @@ class ConfigDisabled : public ConfigOption
     ConfigDisabled(const char *name) : ConfigOption(O_Disabled)
     { m_name = name; }
     void writeTemplate(FTextStream &,bool,bool);
-    void compareDoxyfile(FTextStream &) {}
+    void compareDoxyfile(FTextStream &, const bool longList) {}
     void substEnvVars() {}
 };
 
@@ -483,7 +483,7 @@ class ConfigImpl
     /*! Writes a the differences between the current configuration and the
      *  template configuration to stream \a t.
      */
-    void compareDoxyfile(FTextStream &t);
+    void compareDoxyfile(FTextStream &t, const bool longList);
 
     void setHeader(const char *header) { m_header = header; }
 

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -338,24 +338,29 @@ void ConfigInfo::writeTemplate(FTextStream &t, bool sl,bool)
   t << "#---------------------------------------------------------------------------\n";
 }
 
+static void writeUserComment(FTextStream &t,bool sl, QCString userComment, QCString doc, const bool compare = false)
+{
+  if (!sl && !compare)
+  {
+    t << endl;
+    t << convertToComment(doc, userComment);
+    t << endl;
+  }
+  else if (!userComment.isEmpty())
+  {
+    t << convertToComment("", userComment);
+  }
+}
+
 void ConfigList::writeTemplate(FTextStream &t,bool sl,bool)
 {
-  if (!sl)
-  {
-    t << endl;
-    t << convertToComment(m_doc, m_userComment);
-    t << endl;
-  }
-  else if (!m_userComment.isEmpty())
-  {
-    t << convertToComment("", m_userComment);
-  }
+  writeUserComment(t, sl, m_userComment, m_doc);
   t << m_name << m_spaces.left(MAX_OPTION_LENGTH-m_name.length()) << "=";
   writeStringList(t,m_value);
   t << "\n";
 }
 
-void ConfigList::compareDoxyfile(FTextStream &t)
+void ConfigList::compareDoxyfile(FTextStream &t, const bool longList)
 {
   auto get_stripped = [](std::string s)             { return QCString(s.c_str()).stripWhiteSpace(); };
   auto is_not_empty = [get_stripped](std::string s) { return !get_stripped(s).isEmpty();            };
@@ -363,9 +368,10 @@ void ConfigList::compareDoxyfile(FTextStream &t)
   int valCnt = std::count_if(m_defaultValue.begin(),m_defaultValue.end(),is_not_empty);
   if ( valCnt != defCnt)
   {
-    writeTemplate(t,TRUE,TRUE);
+    writeTemplate(t,!longList,TRUE);
     return;
   }
+  else writeUserComment(t, !longList, m_userComment, m_doc, true);
   auto it1 = m_value.begin();
   auto it2 = m_defaultValue.begin();
   while (it1!=m_value.end() && it2!=m_defaultValue.end())
@@ -379,9 +385,10 @@ void ConfigList::compareDoxyfile(FTextStream &t)
     {
       if (get_stripped(*it1) != get_stripped(*it2)) // not the default, write as difference
       {
-        writeTemplate(t,TRUE,TRUE);
+        writeTemplate(t,!longList,TRUE);
         return;
       }
+      else writeUserComment(t, !longList, m_userComment, m_doc, true);
       ++it1;
       ++it2;
     }
@@ -390,60 +397,35 @@ void ConfigList::compareDoxyfile(FTextStream &t)
 
 void ConfigEnum::writeTemplate(FTextStream &t,bool sl,bool)
 {
-  if (!sl)
-  {
-    t << endl;
-    t << convertToComment(m_doc, m_userComment);
-    t << endl;
-  }
-  else if (!m_userComment.isEmpty())
-  {
-    t << convertToComment("", m_userComment);
-  }
+  writeUserComment(t, sl, m_userComment, m_doc);
   t << m_name << m_spaces.left(MAX_OPTION_LENGTH-m_name.length()) << "=";
   writeStringValue(t,m_value);
   t << "\n";
 }
 
-void ConfigEnum::compareDoxyfile(FTextStream &t)
+void ConfigEnum::compareDoxyfile(FTextStream &t, const bool longList)
 {
-  if (m_value != m_defValue) writeTemplate(t,TRUE,TRUE);
+  if (m_value != m_defValue) writeTemplate(t,!longList,TRUE);
+  else writeUserComment(t, !longList, m_userComment, m_doc, true);
 }
 
 void ConfigString::writeTemplate(FTextStream &t,bool sl,bool)
 {
-  if (!sl)
-  {
-    t << endl;
-    t << convertToComment(m_doc, m_userComment);
-    t << endl;
-  }
-  else if (!m_userComment.isEmpty())
-  {
-    t << convertToComment("", m_userComment);
-  }
+  writeUserComment(t, sl, m_userComment, m_doc);
   t << m_name << m_spaces.left(MAX_OPTION_LENGTH-m_name.length()) << "=";
   writeStringValue(t,m_value);
   t << "\n";
 }
 
-void ConfigString::compareDoxyfile(FTextStream &t)
+void ConfigString::compareDoxyfile(FTextStream &t, const bool longList)
 {
-  if (m_value.stripWhiteSpace() != m_defValue.stripWhiteSpace()) writeTemplate(t,TRUE,TRUE);
+  if (m_value.stripWhiteSpace() != m_defValue.stripWhiteSpace()) writeTemplate(t,!longList,TRUE);
+  else writeUserComment(t, !longList, m_userComment, m_doc, true);
 }
 
 void ConfigInt::writeTemplate(FTextStream &t,bool sl,bool upd)
 {
-  if (!sl)
-  {
-    t << endl;
-    t << convertToComment(m_doc, m_userComment);
-    t << endl;
-  }
-  else if (!m_userComment.isEmpty())
-  {
-    t << convertToComment("", m_userComment);
-  }
+  writeUserComment(t, sl, m_userComment, m_doc);
   t << m_name << m_spaces.left(MAX_OPTION_LENGTH-m_name.length()) << "=";
   if (upd && !m_valueString.isEmpty())
   {
@@ -456,23 +438,15 @@ void ConfigInt::writeTemplate(FTextStream &t,bool sl,bool upd)
   t << "\n";
 }
 
-void ConfigInt::compareDoxyfile(FTextStream &t)
+void ConfigInt::compareDoxyfile(FTextStream &t, const bool longList)
 {
-  if (m_value != m_defValue) writeTemplate(t,TRUE,TRUE);
+  if (m_value != m_defValue) writeTemplate(t,!longList,TRUE);
+  else writeUserComment(t, !longList, m_userComment, m_doc, true);
 }
 
 void ConfigBool::writeTemplate(FTextStream &t,bool sl,bool upd)
 {
-  if (!sl)
-  {
-    t << endl;
-    t << convertToComment(m_doc, m_userComment);
-    t << endl;
-  }
-  else if (!m_userComment.isEmpty())
-  {
-    t << convertToComment("", m_userComment);
-  }
+  writeUserComment(t, sl, m_userComment, m_doc);
   t << m_name << m_spaces.left(MAX_OPTION_LENGTH-m_name.length()) << "=";
   if (upd && !m_valueString.isEmpty())
   {
@@ -485,9 +459,10 @@ void ConfigBool::writeTemplate(FTextStream &t,bool sl,bool upd)
   t << "\n";
 }
 
-void ConfigBool::compareDoxyfile(FTextStream &t)
+void ConfigBool::compareDoxyfile(FTextStream &t, const bool longList)
 {
-  if (m_value != m_defValue) writeTemplate(t,TRUE,TRUE);
+  if (m_value != m_defValue) writeTemplate(t,!longList,TRUE);
+  else writeUserComment(t, !longList, m_userComment, m_doc, true);
 }
 
 void ConfigObsolete::writeTemplate(FTextStream &,bool,bool) {}
@@ -1116,7 +1091,7 @@ void ConfigImpl::writeTemplate(FTextStream &t,bool sl,bool upd)
   }
 }
 
-void ConfigImpl::compareDoxyfile(FTextStream &t)
+void ConfigImpl::compareDoxyfile(FTextStream &t, const bool longList)
 {
   t << "# Difference with default Doxyfile " << getFullVersion();
   t << endl;
@@ -1124,8 +1099,13 @@ void ConfigImpl::compareDoxyfile(FTextStream &t)
   ConfigOption *option;
   for (;(option=it.current());++it)
   {
-    option->m_userComment = "";
-    option->compareDoxyfile(t);
+    if (!longList) option->m_userComment = "";
+    option->compareDoxyfile(t, longList);
+  }
+  if (longList && m_userComment)
+  {
+    t << "\n";
+    t << takeUserComment();
   }
 }
 
@@ -2108,10 +2088,10 @@ void Config::writeTemplate(FTextStream &t,bool shortList,bool update)
   ConfigImpl::instance()->writeTemplate(t,shortList,update);
 }
 
-void Config::compareDoxyfile(FTextStream &t)
+void Config::compareDoxyfile(FTextStream &t, const bool longList)
 {
   postProcess(FALSE, TRUE);
-  ConfigImpl::instance()->compareDoxyfile(t);
+  ConfigImpl::instance()->compareDoxyfile(t,longList);
 }
 
 bool Config::parse(const char *fileName,bool update)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9124,7 +9124,7 @@ static void generateConfigFile(const char *configFile,bool shortList,
     term("Cannot open file %s for writing\n",configFile);
   }
 }
-static void compareDoxyfile()
+static void compareDoxyfile(const bool longList)
 {
   QFile f;
   char configFile[2];
@@ -9134,7 +9134,7 @@ static void compareDoxyfile()
   if (fileOpened)
   {
     FTextStream t(&f);
-    Config::compareDoxyfile(t);
+    Config::compareDoxyfile(t,longList);
   }
   else
   {
@@ -10108,6 +10108,8 @@ static void usage(const char *name,const char *versionString)
   msg("    If - is used for extensionsFile doxygen will write to standard output.\n\n");
   msg("7) Use doxygen to compare the used configuration file with the template configuration file\n");
   msg("    %s -x [configFile]\n\n",name);
+  msg("   to get also the comments in the results use\n");
+  msg("    %s -xl [configFile]\n\n",name);
   msg("8) Use doxygen to show a list of built-in emojis.\n");
   msg("    %s -f emoji outputFileName\n\n",name);
   msg("    If - is used for outputFileName doxygen will write to standard output.\n\n");
@@ -10286,6 +10288,7 @@ void readConfiguration(int argc, char **argv)
   const char *listName;
   bool genConfig=FALSE;
   bool shortList=FALSE;
+  bool longList=FALSE;
   bool diffList=FALSE;
   bool updateConfig=FALSE;
   int retVal;
@@ -10330,6 +10333,8 @@ void readConfiguration(int argc, char **argv)
         }
         break;
       case 'x':
+        longList=FALSE;
+        if (argv[optind][2]=='l') longList=TRUE;
         diffList=TRUE;
         break;
       case 's':
@@ -10634,7 +10639,7 @@ void readConfiguration(int argc, char **argv)
 
   if (diffList)
   {
-    compareDoxyfile();
+    compareDoxyfile(longList);
     cleanUpDoxygen();
     exit(0);
   }


### PR DESCRIPTION
In case of using the `-x` with doxygen we get a short list with the differences compared to the default doxygen settings.

Sometimes it is useful to see also the comments of the non default items and save the user comments (`##`) of the Doxyfile.
To be able to do this the "new"  option `-xl` is introduced.
(explicitly not introducing a new single letter option as `-l` already exists and also a new option would complicate the option handling).