### PR TITLE
Incorrect line count for normal comment in define

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1351,6 +1351,7 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
   					  yyextra->yyLineNr++;
 					  yyextra->defLitText+=yytext;
 					  yyextra->defText+=' ';
+  					  outputChar(yyscanner,'\n');
   					}
 <RemoveCComment>"*/"{B}*"#"	        { // see bug 594021 for a usecase for this rule
                                           if (yyextra->lastCContext==SkipCPPBlock)


### PR DESCRIPTION
When having the program:
```
/// \file

#define A_DEF 2 /* A line
                 * A line */

/**
 * the wrong line \line7
 */
void fie(void)
{}
```
we get the message:
```
aa.c:6: warning: Found unknown command '\line7'
```
instead of
```
aa.c:7: warning: Found unknown command '\line7'
```
Also in the source code and the reference to it we see a wrong line number for the function `fie`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5844313/example.tar.gz)
