### PR TITLE
Wrong place in comment scanner of end summary tag

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -592,12 +592,10 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"</summary>"                   { // start of a .NET XML style detailed description
-                                          setOutput(yyscanner,OutputBrief);
                                           addOutput(yyscanner,yytext);
                                           setOutput(yyscanner,OutputDoc);
                                         }
 <Comment>"</remarks>"                   { // end of a brief or detailed description
-
                                           setOutput(yyscanner,OutputDoc);
                                           addOutput(yyscanner,yytext);
                                         }


### PR DESCRIPTION
When having:
```
/// \file

/// The namespace docu
namespace Demo
{
    /// <summary>
    /// The base class
    /// </summary>
    public class Base
    {
        /// <summary>
        /// The foo function
        /// </summary>
        /// <remarks>
        /// <param name="value">The foo parameter</param>
        /// <returns>foo Something</returns>
        /// </remarks>
        public virtual int foo(int value);
    }
}
```
and we run this with `doxygen -d commentscan` we see that the `</summary>` is in the detailed part and not in the brief part:
```
CommentScanner: .../Class1.cs:6
input=[
<summary>
The base class
</summary>
 ]
-----------
CommentScanner: .../Class1.cs:6
output=[
brief=[line=6
<summary>
The base class
]
docs=[line=6
</summary> ]
inbody=[line=-1
]
]
```
this happened between the versions 1.8.14(OK) and 1.8.15(wrong), most likely through an improvement in case there are multiple brief section.
In case `</summary>` we should be already in the brief section so no need to switch again as the second switch would have no effect and we would land in the details.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5855722/example.tar.gz)
