### PR TITLE
Incorrect code coloring of typedef

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1102,6 +1102,7 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                           yyextra->name+=yytext;
                                         }
 <Body>{SCOPENAME}/{BN}*[:;,)\]]         { // "int var;" or "var, var2" or "debug(f) macro" , or int var : 5;
+                                          if (QCString(yytext).startsWith("typedef")) REJECT;
                                           addType(yyscanner);
                                           // changed this to generateFunctionLink, see bug 624514
                                           //generateClassOrGlobalLink(yyscanner,*yyextra->code,yytext,FALSE,TRUE);
@@ -1109,6 +1110,7 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                           yyextra->name+=yytext;
                                         }
 <Body>{SCOPENAME}/{B}*                  { // p->func()
+                                          if (QCString(yytext).startsWith("typedef")) REJECT;
                                           addType(yyscanner);
                                           generateClassOrGlobalLink(yyscanner,*yyextra->code,yytext);
                                           yyextra->name+=yytext;


### PR DESCRIPTION
In case we have `typedef ::my_type T2;` the code coloring should be:
- typedef : keyword
- ::my_type : link
- T2 : link

though we see:
- typedef ::my_type : link
- T2 : link

this has been corrected.
Found by means of issue #8350
Note there might be other cases with the same problem as well.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5856314/example.tar.gz)
