### PR TITLE
issue #8357 XML output does not include cross-references in code-fragments

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -610,11 +610,11 @@ DB_GEN_C
   }
 }
 
-void DocbookGenerator::writeDoc(DocNode *n,const Definition *,const MemberDef *,int)
+void DocbookGenerator::writeDoc(DocNode *n,const Definition *ctx,const MemberDef *,int)
 {
 DB_GEN_C
   DocbookDocVisitor *visitor =
-    new DocbookDocVisitor(t,*this);
+    new DocbookDocVisitor(t,*this,ctx?ctx->getDefFileExtension():QCString(""));
   n->accept(visitor);
   delete visitor;
 }

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -150,8 +150,8 @@ void DocbookDocVisitor::visitPostEnd(FTextStream &t, bool hasCaption, bool inlin
   }
 }
 
-DocbookDocVisitor::DocbookDocVisitor(FTextStream &t,CodeOutputInterface &ci)
-  : DocVisitor(DocVisitor_Docbook), m_t(t), m_ci(ci)
+DocbookDocVisitor::DocbookDocVisitor(FTextStream &t,CodeOutputInterface &ci,const char *langExt)
+  : DocVisitor(DocVisitor_Docbook), m_t(t), m_ci(ci),m_langExt(langExt)
 {
 DB_VIS_C
   // m_t << "<section>" << endl;

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -29,7 +29,7 @@ class QCString;
 class DocbookDocVisitor : public DocVisitor
 {
     public:
-    DocbookDocVisitor(FTextStream &t,CodeOutputInterface &ci);
+    DocbookDocVisitor(FTextStream &t,CodeOutputInterface &ci,const char *langExt);
     ~DocbookDocVisitor();
     //--------------------------------------
     // visitor functions for leaf nodes

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -88,8 +88,9 @@ static void visitPostEnd(FTextStream &t, const char *cmd)
   t << "</" << cmd << ">" << endl;
 }
 
-XmlDocVisitor::XmlDocVisitor(FTextStream &t,CodeOutputInterface &ci)
-  : DocVisitor(DocVisitor_XML), m_t(t), m_ci(ci), m_insidePre(FALSE), m_hide(FALSE)
+XmlDocVisitor::XmlDocVisitor(FTextStream &t,CodeOutputInterface &ci,const char *langExt)
+  : DocVisitor(DocVisitor_XML), m_t(t), m_ci(ci), m_insidePre(FALSE), m_hide(FALSE),
+    m_langExt(langExt)
 {
 }
 

--- a/src/xmldocvisitor.h
+++ b/src/xmldocvisitor.h
@@ -30,7 +30,7 @@ class QCString;
 class XmlDocVisitor : public DocVisitor
 {
   public:
-    XmlDocVisitor(FTextStream &t,CodeOutputInterface &ci);
+    XmlDocVisitor(FTextStream &t,CodeOutputInterface &ci,const char *langExt);
 
     //--------------------------------------
     // visitor functions for leaf nodes

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -419,7 +419,7 @@ static void writeXMLDocBlock(FTextStream &t,
   // create a code generator
   XMLCodeGenerator *xmlCodeGen = new XMLCodeGenerator(t);
   // create a parse tree visitor for XML
-  XmlDocVisitor *visitor = new XmlDocVisitor(t,*xmlCodeGen);
+  XmlDocVisitor *visitor = new XmlDocVisitor(t,*xmlCodeGen,scope?scope->getDefFileExtension():QCString(""));
   // visit all nodes
   root->accept(visitor);
   // clean up

--- a/testing/014/indexpage.xml
+++ b/testing/014/indexpage.xml
@@ -42,7 +42,7 @@
       <para>
         <programlisting>
           <codeline>
-            <highlight class="normal">//<sp/>implicit<sp/>code<sp/>language</highlight>
+            <highlight class="comment">//<sp/>implicit<sp/>code<sp/>language</highlight>
           </codeline>
         </programlisting>
       </para>


### PR DESCRIPTION
In case of explicit code samples the language was not specified for the code and the code was parsed verbatim.
Same was valid for code in the Docbook output.

The LaTeX version has been taken as reference for the implementation.