### PR TITLE
Extension during mapping not correctly replaced.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5508,7 +5508,7 @@ bool updateLanguageMapping(const QCString &extension,const QCString &language)
   QCString extName = extension.lower();
   if (extName.isEmpty()) return FALSE;
   if (extName.at(0)!='.') extName.prepend(".");
-  auto it = g_extLookup.find(extension.str());
+  auto it = g_extLookup.find(extName.str());
   if (it!=g_extLookup.end())
   {
     g_extLookup.erase(it); // language was already register for this ext


### PR DESCRIPTION
When searching whether the extension is already in the list of mapped extensions the input extension is used but when inserting the eventually corrected extension (extName) is used.
In all cases the inserted extension contains a dot (`.`) , but for the input extension this is not necessarily the case. This can cause problems when searching for an extension as the search will always search wit a dot and thus find the first (is old) value.