### PR TITLE
Parser for verbatim including a (text) file.

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10058,6 +10058,8 @@ void initDoxygen()
                                                          make_parser_factory<SQLCodeParser>());
   Doxygen::parserManager->registerParser("md",           make_parser_factory<MarkdownOutlineParser>(),
                                                          make_parser_factory<FileCodeParser>());
+  Doxygen::parserManager->registerParser("unparsed",     make_parser_factory<FileOutlineParser>(),
+                                                         make_parser_factory<FileCodeParser>());
 
   // register any additional parsers here...
 

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1524,12 +1524,13 @@ void FileDefImpl::combineUsingRelations()
 
 bool FileDefImpl::isDocumentationFile() const
 {
-  return name().right(4)==".doc" ||
+  return getLanguageFromFileName(getFileNameExtension(name())) != SrcLangExt_Unparsed &&
+        (name().right(4)==".doc" ||
          name().right(4)==".txt" ||
          name().right(4)==".dox" ||
          name().right(3)==".md"  ||
          name().right(9)==".markdown" ||
-         getLanguageFromFileName(getFileNameExtension(name())) == SrcLangExt_Markdown;
+         getLanguageFromFileName(getFileNameExtension(name())) == SrcLangExt_Markdown);
 }
 
 void FileDefImpl::acquireFileVersion()

--- a/src/fileparser.cpp
+++ b/src/fileparser.cpp
@@ -15,6 +15,41 @@
 
 #include "fileparser.h"
 #include "outputgen.h"
+#include "filedef.h"
+#include "entry.h"
+#include "commentscan.h"
+
+void FileOutlineParser::parseInput(const char *fileName, const char *fileBuf,const std::shared_ptr<Entry> &root, ClangTUParser*)
+{
+  CommentScanner commentScanner;
+  std::shared_ptr<Entry> current = std::make_shared<Entry>();
+  current->lang = SrcLangExt_Unparsed;
+  current->fileName = fileName;
+  current->docFile  = fileName;
+  current->docLine  = 1;
+  int lineNr=1;
+  Protection prot=Public;
+  bool needsEntry = FALSE;
+  int position=0;
+  QCString processedDocs = QCString("\\file \n\\verbinclude ") + fileName;
+
+  commentScanner.enterFile(fileName,lineNr);
+  commentScanner.parseCommentBlock(
+        this,
+        current.get(),
+        processedDocs,
+        fileName,
+        lineNr,
+        FALSE,     // isBrief
+        FALSE,     // javadoc autobrief
+        FALSE,     // inBodyDocs
+        prot,      // protection
+        position,
+        needsEntry,
+        true);
+  root->moveToSubEntryAndKeep(current);
+  commentScanner.leaveFile(fileName,lineNr);
+}
 
 void FileCodeParser::parseCode(CodeOutputInterface &codeOutIntf,
                const char *,     // scopeName

--- a/src/fileparser.h
+++ b/src/fileparser.h
@@ -18,6 +18,14 @@
 
 #include "parserintf.h"
 
+class FileOutlineParser : public OutlineParserInterface
+{
+  public:
+    void parseInput(const char *, const char *,const std::shared_ptr<Entry> &, ClangTUParser*);
+    bool needsPreprocessing(const QCString &) const { return FALSE; }
+    void parsePrototype(const char *) {}
+};
+
 /** @brief Generic code parser */
 class FileCodeParser : public CodeParserInterface
 {

--- a/src/types.h
+++ b/src/types.h
@@ -57,7 +57,8 @@ enum SrcLangExt
   //SrcLangExt_Tcl      = 0x08000, // no longer supported
   SrcLangExt_Markdown = 0x10000,
   SrcLangExt_SQL      = 0x20000,
-  SrcLangExt_Slice    = 0x40000
+  SrcLangExt_Slice    = 0x40000,
+  SrcLangExt_Unparsed = 0x80000
 };
 
 /** Grouping info */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5489,6 +5489,7 @@ g_lang2extMap[] =
   { "xml",         "xml",           SrcLangExt_XML      },
   { "sql",         "sql",           SrcLangExt_SQL      },
   { "md",          "md",            SrcLangExt_Markdown },
+  { "unparsed",    "unparsed",      SrcLangExt_Unparsed },
   { 0,             0,              (SrcLangExt)0        }
 };
 


### PR DESCRIPTION
In older projects it is quite common to have files like `README.txt` that don't contain code or markdown markup, but that would be nice to have verbatim into the documentation.
The same is true for other types of files like configuration files or sh / zsh / bat files that should not be processed in ant way.

For this the "language" `unparsed` is created.