### PR TITLE
Extended doxygen version information

### DIFF
--- a/doc/trouble.doc
+++ b/doc/trouble.doc
@@ -106,7 +106,8 @@ helpful and it will cost me much more time to figure out what you mean.
 In the worst-case your bug report may even be completely ignored by me, so
 always try to include the following information in your bug report: 
 - The version of doxygen you are using (for instance 1.5.3, use 
-  `doxygen --version` if you are not sure).
+  `doxygen --version` if you are not sure or `doxygen --Version` for a bit
+  more information).
 - The name and version number of your operating system (for instance 
   Ubuntu Linux 18.04 LTS)
 - It is usually a good idea to send along the configuration file as well, 


### PR DESCRIPTION
Create possibility for extended version  information with included extra possibilities (clang / sqlite3 / ...) by means of the options `-V` / `--Version` / `--VERSION`.