### PR TITLE
Support vertical alignment in a multi-row HTML cell to LaTex

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -3408,6 +3408,8 @@ DocHtmlCell::Valignment DocHtmlCell::valignment() const
         return Top;
       else if (attr.value.lower()=="bottom")
         return Bottom;
+      else if (attr.value.lower()=="middle")
+        return Middle;
       else return Middle;
     }
   }

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -3398,6 +3398,21 @@ DocHtmlCell::Alignment DocHtmlCell::alignment() const
   return Left;
 }
 
+DocHtmlCell::Valignment DocHtmlCell::valignment() const
+{
+  for (const auto &attr : attribs())
+  {
+    if (attr.name.lower()=="valign")
+    {
+      if (attr.value.lower()=="top")
+        return Top;
+      else if (attr.value.lower()=="bottom")
+        return Bottom;
+      else return Middle;
+    }
+  }
+  return Middle;
+}
 
 //---------------------------------------------------------------------------
 

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -1338,6 +1338,7 @@ class DocHtmlCell : public CompAccept<DocHtmlCell>
     friend class DocHtmlTable;
   public:
     enum Alignment { Left, Right, Center };
+    enum Valignment {Top, Middle, Bottom};
     DocHtmlCell(DocNode *parent,const HtmlAttribList &attribs,bool isHeading) :
        m_isHeading(isHeading), m_attribs(attribs) { m_parent = parent; }
     bool isHeading() const      { return m_isHeading; }
@@ -1354,6 +1355,7 @@ class DocHtmlCell : public CompAccept<DocHtmlCell>
     uint rowSpan() const;
     uint colSpan() const;
     Alignment alignment() const;
+    Valignment valignment() const;
 
   private:
     void setRowIndex(uint idx)    { m_rowIdx = idx; }

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1283,6 +1283,8 @@ void LatexDocVisitor::visitPre(DocHtmlCell *c)
       case DocHtmlCell::Bottom:
         m_t << "[b]";
         break;
+      case DocHtmlCell::Middle:
+        break; // No alignment option needed
       default:
         break;
     }

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1270,14 +1270,27 @@ void LatexDocVisitor::visitPre(DocHtmlCell *c)
     }
   }
   int rs = c->rowSpan();
+  int va = c->valignment();
   if (rs>0)
   {
     setInRowSpan(TRUE);
+    m_t << "\\multirow";
+    switch(va)
+    {
+      case DocHtmlCell::Top:
+        m_t << "[t]";
+        break;
+      case DocHtmlCell::Bottom:
+        m_t << "[b]";
+        break;
+      default:
+        break;
+    }
     //printf("adding row span: cell={r=%d c=%d rs=%d cs=%d} curCol=%d\n",
     //                       c->rowIndex(),c->columnIndex(),c->rowSpan(),c->colSpan(),
     //                       currentColumn());
     addRowSpan(ActiveRowSpan(c,rs,cs,currentColumn()));
-    m_t << "\\multirow{" << rs << "}{*}{";
+    m_t << "{" << rs << "}{*}{";
   }
   if (a==DocHtmlCell::Center)
   {


### PR DESCRIPTION
There is an issue of pdflatex where a rowspan cell value stay out of page margin (see the picture below)

![doxygen_table_before](https://user-images.githubusercontent.com/40583705/106477566-e0acc800-64da-11eb-8b89-ee956a72d443.PNG)

I created this request to support vertical alignment when using multi-row HTML cell as a solution.

User need to add "valign=..." attribute to \<td\> tag for vertical alignment. Supported values are "top", "bottom", otherwise the cell is middle aligned as default.

This can be combined with horizontal alignment ("align" attribute).

_Example_:

```html
<td rowspan=2 align=left valign=top>Cell value</td>
```

The result is looking better:

![doxygen_table_after](https://user-images.githubusercontent.com/40583705/106477575-e1ddf500-64da-11eb-9e35-15422a699c24.PNG)

This supports only HTML to LaTeX table. Markdown seems not have the same feature.