### PR TITLE
Correction Doxyfile for documentation of doxygen code

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -141,7 +141,6 @@ VERBATIM_HEADERS       = YES
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = YES
-COLS_IN_ALPHA_INDEX    = 5
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
@@ -328,5 +327,5 @@ DOT_TRANSPARENT        = NO
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = NO
-DOT_MAX_FOLD           = 17
+DOT_WRAP_THRESHOLD     = 17
 DOT_UML_DETAILS        = NO


### PR DESCRIPTION
When runing doxygen on itself we get the warnings:
```
warning: Tag 'COLS_IN_ALPHA_INDEX' at line 144 of file 'Doxyfile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: ignoring unsupported tag 'DOT_MAX_FOLD' at line 331, file Doxyfile
```
- COLS_IN_ALPHA_INDEX has been removed
- DOT_MAX_FOLD has been renamed to DOT_WRAP_THRESHOLD (during "Some tweaks & fixes", onOctober 20 202 i.e. commit 0006f830184ea30abdd9eb13e79ca2587004a63d ).