### PR TITLE
add config option WARN_IF_INCOMPLETE_DOC

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1342,7 +1342,7 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
  documentation.
  If \ref cfg_extract_all "EXTRACT_ALL" is set to \c YES then this flag will
  automatically be disabled.
- See also \ref cfg_warn_if_incomplete_paramdoc "WARN_IF_INCOMPLETE_PARAMDOC"
+ See also \ref cfg_warn_if_incomplete_doc "WARN_IF_INCOMPLETE_DOC"
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -1316,9 +1316,19 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
       <docs>
 <![CDATA[
  If the \c WARN_IF_DOC_ERROR tag is set to \c YES, doxygen will generate warnings for
- potential errors in the documentation, such as not documenting some
- parameters in a documented function, or documenting parameters that
+ potential errors in the documentation, such as documenting some
+ parameters in a documented function twice, or documenting parameters that
  don't exist or using markup commands wrongly.
+]]>
+      </docs>
+    </option>
+    <option type='bool' id='WARN_IF_INCOMPLETE_DOC' defval='1'>
+      <docs>
+<![CDATA[
+ If \c WARN_IF_INCOMPLETE_DOC is set to \c YES, doxygen will warn about
+ incomplete function parameter documentation.
+ If set to \c NO, doxygen will accept that some parameters have no
+ documentation without warning.
 ]]>
       </docs>
     </option>
@@ -1328,10 +1338,11 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
  This \c WARN_NO_PARAMDOC option can be enabled to get warnings for
  functions that are documented, but have no documentation for their parameters
  or return value. If set to \c NO, doxygen will only warn about
- wrong or incomplete parameter documentation, but not about the absence of
+ wrong parameter documentation, but not about the absence of
  documentation.
  If \ref cfg_extract_all "EXTRACT_ALL" is set to \c YES then this flag will
  automatically be disabled.
+ See also \ref cfg_warn_if_incomplete_paramdoc "WARN_IF_INCOMPLETE_PARAMDOC"
 ]]>
       </docs>
     </option>

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -512,7 +512,7 @@ static void checkRetvalName(const QCString &name)
  */
 static void checkUnOrMultipleDocumentedParams()
 {
-  if (g_memberDef && g_hasParamCommand && Config_getBool(WARN_IF_DOC_ERROR))
+  if (g_memberDef && g_hasParamCommand)
   {
     const ArgumentList &al=g_memberDef->isDocsForDefinition() ?
       g_memberDef->argumentList() :
@@ -544,7 +544,7 @@ static void checkUnOrMultipleDocumentedParams()
             if (argName == par) count++;
           }
         }
-        if (count > 1)
+        if ((count > 1) &&  Config_getBool(WARN_IF_DOC_ERROR))
         {
           warn_doc_error(g_memberDef->getDefFileName(),
                          g_memberDef->getDefLine(),
@@ -555,7 +555,7 @@ static void checkUnOrMultipleDocumentedParams()
                          " has multiple @param documentation sections").data());
         }
       }
-      if (notArgCnt>0)
+      if ((notArgCnt>0) && Config_getBool(WARN_IF_INCOMPLETE_DOC))
       {
         bool first=TRUE;
         QCString errMsg=
@@ -587,10 +587,10 @@ static void checkUnOrMultipleDocumentedParams()
             errMsg+="  parameter '"+argName+"'";
           }
         }
-        warn_doc_error(g_memberDef->getDefFileName(),
-                       g_memberDef->getDefLine(),
-                       "%s",
-                       substitute(errMsg,"%","%%").data());
+        warn_incomplete_doc(g_memberDef->getDefFileName(),
+                            g_memberDef->getDefLine(),
+                            "%s",
+                            substitute(errMsg,"%","%%").data());
       }
     }
   }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -240,6 +240,14 @@ void warn_undoc(const char *file,int line,const char *fmt, ...)
   va_end(args);
 }
 
+void warn_incomplete_doc(const char *file,int line,const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  do_warn(Config_getBool(WARN_IF_INCOMPLETE_DOC), file, line, warning_str, fmt, args);
+  va_end(args);
+}
+
 void warn_doc_error(const char *file,int line,const char *fmt, ...)
 {
   va_list args;

--- a/src/message.h
+++ b/src/message.h
@@ -29,6 +29,7 @@ extern void warn(const char *file,int line,const char *fmt, ...) PRINTFLIKE(3, 4
 extern void va_warn(const char* file, int line, const char* fmt, va_list args);
 extern void warn_simple(const char *file,int line,const char *text);
 extern void warn_undoc(const char *file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void warn_incomplete_doc(const char *file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void warn_doc_error(const char *file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void warn_uncond(const char *fmt, ...) PRINTFLIKE(1, 2);
 extern void err(const char *fmt, ...) PRINTFLIKE(1, 2);


### PR DESCRIPTION
Add a new warning class, "INCOMPLETE_DOC", and warning option
"WARN_IF_INCOMPLETE_DOC", to control whether you get a warning
for only documenting some of your function parameters.

All users who want to retain the current behavior set
WARN_IF_INCOMPLETE_DOC to the value of WARN_IF_DOC_ERROR.


User story
----------

As a developer who follows clean code principles, 

I strive for self-explanatory function parameters (using specialized and constrained
data types, and using meaningful names). Some of my parameters need additional documentation, 
but not all.

I want to trigger a warning in my continuous integration system when a pull requests
leads to new Doxygen warnings, but I want to avoid boilerplate `@param` commands without content.

Problem
-------

Currently, Doxygen can only be configured to either issue no warnings about documentation errors
at all (WARN_IF_DOC_ERROR). I can tune Doxygen to not warn about completetly missing param docs
(WARN_NO_PARAMDOC=NO), but if I then *add* documentation for some parameters I get a warning.
This feels kinda weird.

Tests
-----

The problematic warning looks like this:

```
Generating docs for compound kdtree::KDTree...
kdtree/kdtree.h:89: warning: The following parameter of kdtree::KDTree::findNearestNeighbor(const PointT &query, SquaredDistanceFuncT squared_distance_function) const is not documented:
  parameter 'query'
```

With the new config option enabled, those warnings disappear. Ran it on 2 of my projects.
I did not find a warning-related automated test case in doxygen, so that's all I could do here.
