### PR TITLE
Get preprocessor output without line numbers

### DIFF
--- a/doc/preprocessing.doc
+++ b/doc/preprocessing.doc
@@ -259,6 +259,10 @@ you can run doxygen as follows:
 \verbatim
   doxygen -d Preprocessor
 \endverbatim
+or without line numbers:
+\verbatim
+  doxygen -d PreprocessorNolineno
+\endverbatim
 This will instruct doxygen to dump the input sources to standard output after
 preprocessing has been done (Hint: set <code>QUIET = YES</code> and 
 <code>WARNINGS = NO</code> in the configuration file to disable any other 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -31,6 +31,7 @@ static std::map< std::string, Debug::DebugMask > s_labels =
   { "functions",         Debug::Functions         },
   { "variables",         Debug::Variables         },
   { "preprocessor",      Debug::Preprocessor      },
+  { "preprocessornolineno",Debug::PreprocessorNolineno},
   { "classes",           Debug::Classes           },
   { "commentcnv",        Debug::CommentCnv        },
   { "commentscan",       Debug::CommentScan       },
@@ -79,13 +80,18 @@ static int labelToEnumValue(const char *l)
 int Debug::setFlag(const char *lab)
 {
   int retVal = labelToEnumValue(lab);
-  curMask = (DebugMask)(curMask | labelToEnumValue(lab));
+  curMask = (DebugMask)(curMask | retVal);
   return retVal;
 }
 
 void Debug::clearFlag(const char *lab)
 {
   curMask = (DebugMask)(curMask & ~labelToEnumValue(lab));
+}
+
+void Debug::clearFlag(const DebugMask mask)
+{
+  curMask = (DebugMask)(curMask & ~(int)(mask));
 }
 
 void Debug::setPriority(int p)

--- a/src/debug.h
+++ b/src/debug.h
@@ -37,12 +37,14 @@ class Debug
                      Lex          = 0x00002000,
                      Plantuml     = 0x00004000,
                      FortranFixed2Free = 0x00008000,
-                     Cite         = 0x00010000
+                     Cite         = 0x00010000,
+                     PreprocessorNolineno = 0x00020000
                    };
     static void print(DebugMask mask,int prio,const char *fmt,...);
 
     static int  setFlag(const char *label);
     static void clearFlag(const char *label);
+    static void clearFlag(const DebugMask mask);
     static bool isFlagSet(DebugMask mask);
     static void printFlags();
     static void setPriority(int p);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10206,6 +10206,20 @@ void readConfiguration(int argc, char **argv)
           cleanUpDoxygen();
           exit(1);
         }
+        else
+        {
+          switch (retVal)
+          {
+            case Debug::Preprocessor:
+              Debug::clearFlag(Debug::PreprocessorNolineno);
+              break;
+            case Debug::PreprocessorNolineno:
+              Debug::clearFlag(Debug::Preprocessor);
+              break;
+            default:
+              break;
+          }
+        }
         break;
       case 'x':
         diffList=TRUE;

--- a/src/pre.l
+++ b/src/pre.l
@@ -304,6 +304,10 @@ struct preYY_state
   DefineMap                                localDefines;   // macros defined in this file
   DefineList                               macroDefinitions;
   LinkedMap<PreIncludeInfo>                includeRelations;
+
+  bool                                     debugEnabled = false;
+  bool                                     debugLineno = false;
+  Debug::DebugMask                         optionSet = Debug::Quiet; 
 };
 
 // stateless functions
@@ -1563,9 +1567,9 @@ CHARLIT   (("'"\\[0-7]{1,3}"'")|("'"\\."'")|("'"[^'\\\n]{1,4}"'"))
                                               }
                                               else
                                               {
-                                                if (Debug::isFlagSet(Debug::Preprocessor))
+                                                if (yyextra->debugEnabled)
                                                 {
-                                                  Debug::print(Debug::Preprocessor,0,"#include %s: was already processed by another thread! not storing data...\n",qPrint(toFileName));
+                                                  Debug::print(yyextra->optionSet,0,"#include %s: was already processed by another thread! not storing data...\n",qPrint(toFileName));
                                                 }
                                               }
                                             }
@@ -2844,6 +2848,7 @@ static QCString determineAbsoluteIncludeName(const QCString &curFile,const QCStr
 
 static void readIncludeFile(yyscan_t yyscanner,const QCString &inc)
 {
+  struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
   YY_EXTRA_TYPE state = preYYget_extra(yyscanner);
   uint i=0;
 
@@ -2890,13 +2895,13 @@ static void readIncludeFile(yyscan_t yyscanner,const QCString &inc)
       }
 
       //printf("Found include file!\n");
-      if (Debug::isFlagSet(Debug::Preprocessor))
+      if (yyextra->debugEnabled)
       {
         for (i=0;i<state->includeStack.size();i++) 
         {
-          Debug::print(Debug::Preprocessor,0,"  ");
+          Debug::print(yyextra->optionSet,0,"  ");
         }
-        Debug::print(Debug::Preprocessor,0,"#include %s: parsing...\n",incFileName.data());
+        Debug::print(yyextra->optionSet,0,"#include %s: parsing...\n",incFileName.data());
       }
 
       if (state->includeStack.empty() && oldFileDef)
@@ -2966,19 +2971,19 @@ static void readIncludeFile(yyscan_t yyscanner,const QCString &inc)
         }
       }
 
-      if (Debug::isFlagSet(Debug::Preprocessor))
+      if (yyextra->debugEnabled)
       {
         for (i=0;i<state->includeStack.size();i++) 
         {
-          Debug::print(Debug::Preprocessor,0,"  ");
+          Debug::print(yyextra->optionSet,0,"  ");
         }
 	if (alreadyProcessed)
 	{
-          Debug::print(Debug::Preprocessor,0,"#include %s: already processed! skipping...\n",qPrint(incFileName));
+          Debug::print(yyextra->optionSet,0,"#include %s: already processed! skipping...\n",qPrint(incFileName));
 	}
 	else
 	{
-          Debug::print(Debug::Preprocessor,0,"#include %s: not found! skipping...\n",qPrint(incFileName));
+          Debug::print(yyextra->optionSet,0,"#include %s: not found! skipping...\n",qPrint(incFileName));
 	}
         //printf("error: include file %s not found\n",yytext);
       }
@@ -3333,6 +3338,11 @@ void Preprocessor::processFile(const char *fileName,BufStr &input,BufStr &output
   preYYset_debug(1,yyscanner);
 #endif
 
+  yyextra->debugEnabled = Debug::isFlagSet(Debug::Preprocessor) || Debug::isFlagSet(Debug::PreprocessorNolineno);
+  yyextra->debugLineno  = !Debug::isFlagSet(Debug::PreprocessorNolineno);
+  if (Debug::isFlagSet(Debug::Preprocessor)) yyextra->optionSet = Debug::Preprocessor;
+  else if (Debug::isFlagSet(Debug::PreprocessorNolineno)) yyextra->optionSet = Debug::PreprocessorNolineno;
+
   printlex(yy_flex_debug, TRUE, __FILE__, fileName);
   uint orgOffset=output.curPos();
   //printf("##########################\n%s\n####################\n",
@@ -3383,12 +3393,12 @@ void Preprocessor::processFile(const char *fileName,BufStr &input,BufStr &output
   // make sure we don't extend a \cond with missing \endcond over multiple files (see bug 624829)
   forceEndCondSection(yyscanner);
 
-  if (Debug::isFlagSet(Debug::Preprocessor))
+  if (yyextra->debugEnabled)
   {
     std::lock_guard<std::mutex> lock(g_debugMutex);
     char *orgPos=output.data()+orgOffset;
     char *newPos=output.data()+output.curPos();
-    Debug::print(Debug::Preprocessor,0,"Preprocessor output of %s (size: %d bytes):\n",fileName,newPos-orgPos);
+    Debug::print(yyextra->optionSet,0,"Preprocessor output of %s (size: %d bytes):\n",fileName,newPos-orgPos);
     int line=1;
     Debug::print(Debug::Preprocessor,0,"---------\n00001 ");
     while (orgPos<newPos) 
@@ -3397,24 +3407,24 @@ void Preprocessor::processFile(const char *fileName,BufStr &input,BufStr &output
       if (*orgPos=='\n') Debug::print(Debug::Preprocessor,0,"%05d ",++line);
       orgPos++;
     }
-    Debug::print(Debug::Preprocessor,0,"\n---------\n");
+    Debug::print(yyextra->optionSet,0,"\n---------\n");
     if (yyextra->contextDefines.size()>0)
     {
-      Debug::print(Debug::Preprocessor,0,"Macros accessible in this file (%s):\n", fileName);
-      Debug::print(Debug::Preprocessor,0,"---------\n");
+      Debug::print(yyextra->optionSet,0,"Macros accessible in this file (%s):\n", fileName);
+      Debug::print(yyextra->optionSet,0,"---------\n");
       for (auto &kv : yyextra->contextDefines)
       {
-        Debug::print(Debug::Preprocessor,0,"%s ",qPrint(kv.second.name));
+        Debug::print(yyextra->optionSet,0,"%s ",qPrint(kv.second.name));
       }
       for (auto &kv : yyextra->localDefines)
       {
-        Debug::print(Debug::Preprocessor,0,"%s ",qPrint(kv.second.name));
+        Debug::print(yyextra->optionSet,0,"%s ",qPrint(kv.second.name));
       }
-      Debug::print(Debug::Preprocessor,0,"\n---------\n");
+      Debug::print(yyextra->optionSet,0,"\n---------\n");
     }
     else
     {
-      Debug::print(Debug::Preprocessor,0,"No macros accessible in this file (%s).\n", fileName);
+      Debug::print(yyextra->optionSet,0,"No macros accessible in this file (%s).\n", fileName);
     }
   }
 


### PR DESCRIPTION
For easier comparison of  the original source with doxygen preprocessed source the line numbers can be a bit of an obstacle.
To remove the line numbers the debug option  `PreprocessorNolineno` has been added.
(In case `Preprocessor` and `PreprocessorNolineno` the latest invoked one is used).