### PR TITLE
Get preprocessor output without line numbers

### DIFF
--- a/doc/preprocessing.doc
+++ b/doc/preprocessing.doc
@@ -259,7 +259,7 @@ you can run doxygen as follows:
 \verbatim
   doxygen -d Preprocessor
 \endverbatim
-when the line numbers are no required:
+or when the line numbers are not wanted:
 \verbatim
   doxygen -d Preprocessor -d NoLineno
 \endverbatim

--- a/doc/preprocessing.doc
+++ b/doc/preprocessing.doc
@@ -259,6 +259,10 @@ you can run doxygen as follows:
 \verbatim
   doxygen -d Preprocessor
 \endverbatim
+when the line numbers are no required:
+\verbatim
+  doxygen -d Preprocessor -d NoLineno
+\endverbatim
 This will instruct doxygen to dump the input sources to standard output after
 preprocessing has been done (Hint: set <code>QUIET = YES</code> and 
 <code>WARNINGS = NO</code> in the configuration file to disable any other 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -31,6 +31,7 @@ static std::map< std::string, Debug::DebugMask > s_labels =
   { "functions",         Debug::Functions         },
   { "variables",         Debug::Variables         },
   { "preprocessor",      Debug::Preprocessor      },
+  { "nolineno",          Debug::NoLineNo          },
   { "classes",           Debug::Classes           },
   { "commentcnv",        Debug::CommentCnv        },
   { "commentscan",       Debug::CommentScan       },
@@ -79,7 +80,7 @@ static int labelToEnumValue(const char *l)
 int Debug::setFlag(const char *lab)
 {
   int retVal = labelToEnumValue(lab);
-  curMask = (DebugMask)(curMask | labelToEnumValue(lab));
+  curMask = (DebugMask)(curMask | retVal);
   return retVal;
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -37,7 +37,8 @@ class Debug
                      Lex          = 0x00002000,
                      Plantuml     = 0x00004000,
                      FortranFixed2Free = 0x00008000,
-                     Cite         = 0x00010000
+                     Cite         = 0x00010000,
+                     NoLineNo     = 0x00020000
                    };
     static void print(DebugMask mask,int prio,const char *fmt,...);
 

--- a/src/pre.l
+++ b/src/pre.l
@@ -3390,11 +3390,12 @@ void Preprocessor::processFile(const char *fileName,BufStr &input,BufStr &output
     char *newPos=output.data()+output.curPos();
     Debug::print(Debug::Preprocessor,0,"Preprocessor output of %s (size: %d bytes):\n",fileName,newPos-orgPos);
     int line=1;
-    Debug::print(Debug::Preprocessor,0,"---------\n00001 ");
+    Debug::print(Debug::Preprocessor,0,"---------\n");
+    if (!Debug::isFlagSet(Debug::NoLineNo)) Debug::print(Debug::Preprocessor,0,"00001 ");
     while (orgPos<newPos) 
     {
       putchar(*orgPos);
-      if (*orgPos=='\n') Debug::print(Debug::Preprocessor,0,"%05d ",++line);
+      if (*orgPos=='\n' && !Debug::isFlagSet(Debug::NoLineNo)) Debug::print(Debug::Preprocessor,0,"%05d ",++line);
       orgPos++;
     }
     Debug::print(Debug::Preprocessor,0,"\n---------\n");


### PR DESCRIPTION
For easier comparison of  the original source with a doxygen preprocessed source the line numbers can be a bit of an obstacle.
To remove the line numbers in the preprocessor output the option  `NoLineno` has been added.
(In case `Preprocessor` is not invoked, `NoLineno` has no effect).