### PR TITLE
Strange HTML tab title in case of a page without title

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8587,6 +8587,7 @@ static void findMainPage(Entry *root)
       //printf("mainpage: docLine=%d startLine=%d\n",root->docLine,root->startLine);
       //printf("Found main page! \n======\n%s\n=======\n",root->doc.data());
       QCString title=root->args.stripWhiteSpace();
+      if (title.isEmpty()) title = Config_getString(PROJECT_NAME);
       //QCString indexName=Config_getBool(GENERATE_TREEVIEW)?"main":"index";
       QCString indexName="index";
       Doxygen::mainPage.reset(createPageDef(root->docFile,root->docLine,

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -82,7 +82,7 @@ PageDef *createPageDef(const char *f,int l,const char *n,const char *d,const cha
 
 PageDefImpl::PageDefImpl(const char *f,int l,const char *n,
                  const char *d,const char *t)
- : DefinitionMixin(f,l,1,n), m_title(t)
+ : DefinitionMixin(f,l,1,n), m_title(t?t:n)
 {
   setDocumentation(d,f,l);
   m_pageScope = 0;


### PR DESCRIPTION
In case we have an example like:
```
/// @page Bug_err
///
/// \brief Some text in cpp file
/// \details Some detailed text in cpp file
```
we will have as in the HTML tab: `Project Title: $title` as the page has an empty title.
A better title would in this case be: `Project Title: Bug_err`.

This has been implemented  by setting the name of the page in the empty title. In case of a main page the xml output sets the empty title to the PROJECT_NAME, as the new, default, setting would see to it that also the mainpage with an empty title would be set we have to see that this is done beforehand.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/5989379/example.tar.gz)
