### PR TITLE
Correct documentation redirection link

### DIFF
--- a/doc/xmlcmds.doc
+++ b/doc/xmlcmds.doc
@@ -18,7 +18,7 @@
 
 Doxygen supports most of the XML commands that are typically used in C# 
 code comments. The XML tags are defined in Appendix D of the
-<a href="http://www.ecma-international.org/publications/standards/Ecma-334.htm">ECMA-334</a> 
+<a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-334/">ECMA-334</a> 
 standard, which defines the C# language. Unfortunately, the specification is
 not very precise and a number of the examples given are of poor quality.
 


### PR DESCRIPTION
The link to the C#-standard has changed, it is redirected to the new place. The new place is now used in the documentation.