### PR TITLE
Problems generating chm documentation

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -161,7 +161,15 @@ void HtmlHelpIndex::addItem(const char *level1,const char *level2,
   {
     return;
   }
-  std::string key_anchor = key+anchor;
+  std::string key_anchor;
+  if (anchor)
+  {
+    key_anchor = key+anchor;
+  }
+  else
+  {
+    key_anchor = key;
+  }
   m_map.add(key_anchor.c_str(),key.c_str(),url,anchor,hasLink,reversed);
 }
 


### PR DESCRIPTION
Generating doxygen's own manual in chm mode crashed (`qmake doc s_chm`). The problem was introduced during:
Refactoring: replace QRegExp by std::regex in htmlhelp.cpp  (1d993b03f)

Looks like that a std::string cannot add a null pointer to a std::string