### PR TITLE
Missing build note for sqlite3

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3247,6 +3247,9 @@ front of it.
 <![CDATA[
 If the \c GENERATE_SQLITE3 tag is set to \c YES doxygen will generate a
 \c Sqlite3 database with symbols found by doxygen stored in tables.
+
+  @note The availability of this option depends on whether or not doxygen
+  was generated with the `-Duse_sqlite3=ON` option for CMake.
 ]]>
       </docs>
     </option>
@@ -3256,6 +3259,9 @@ If the \c GENERATE_SQLITE3 tag is set to \c YES doxygen will generate a
 The \c SQLITE3_OUTPUT tag is used to specify where the \c Sqlite3 database will be put.
 If a relative path is entered the value of \ref cfg_output_directory "OUTPUT_DIRECTORY" will be
 put in front of it.
+
+  @note The availability of this option depends on whether or not doxygen
+  was generated with the `-Duse_sqlite3=ON` option for CMake.
 ]]>
       </docs>
     </option>
@@ -3265,6 +3271,9 @@ put in front of it.
 The \c SQLITE3_OVERWRITE_DB tag is set to \c YES, the existing doxygen_sqlite3.db
 database file will be recreated with each doxygen run.
 If set to \c NO, doxygen will warn if an a database file is already found and not modify it.
+
+  @note The availability of this option depends on whether or not doxygen
+  was generated with the `-Duse_sqlite3=ON` option for CMake.
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
The reference, analogous to what is present for clang, regarding the need of compiling doxygen with `-Duse_sqlite3=ON` was missing