### PR TITLE
UTF-8 characters in email address

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -124,7 +124,7 @@ static void clearCommentStack(yyscan_t yyscanner);
 
 %}
 
-MAILADR   ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z_A-Z0-9\-]+
+MAILADDR   ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a-z_A-Z0-9\x80-\xff\-]+)+[a-z_A-Z0-9\x80-\xff\-]+
 
 %option noyywrap
 
@@ -401,8 +401,8 @@ SLASHopt [/]*
                                        yyextra->commentStack.push(yyextra->lineNr);
 				     }
   				   }
-<CComment,ReadLine>{MAILADR}      |
-<CComment,ReadLine>"<"{MAILADR}">" { // Mail address, to prevent seeing e.g x@code-factory.org as start of a code block
+<CComment,ReadLine>{MAILADDR}      |
+<CComment,ReadLine>"<"{MAILADDR}">" { // Mail address, to prevent seeing e.g x@code-factory.org as start of a code block
                                      copyToOutput(yyscanner,yytext,(int)yyleng);
                                    }
 <CComment>"{@code"/[ \t\n]	   {

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -486,7 +486,7 @@ CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{C
 SCOPEID   {ID}({ID}*{BN}*"::"{BN}*)*({ID}?)
 SCOPENAME "$"?(({ID}?{BN}*("::"|"."){BN}*)*)((~{BN}*)?{ID})
 TMPLSPEC  "<"{BN}*[^>]+{BN}*">"
-MAILADDR   [a-z_A-Z0-9.+\-]+"@"[a-z_A-Z0-9\-]+("."[a-z_A-Z0-9\-]+)+[a-z_A-Z0-9\-]+
+MAILADDR  ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a-z_A-Z0-9\x80-\xff\-]+)+[a-z_A-Z0-9\x80-\xff\-]+
 RCSTAG    "$"{ID}":"[^\n$]+"$"
 
   // C start comment 

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -372,8 +372,8 @@ PHPTYPE   [\\:a-z_A-Z0-9\x80-\xFF\-]+
 CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
 CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]
 CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*"\""
-MAILADDR  ("mailto:")?[a-z_A-Z0-9.+-]+"@"[a-z_A-Z0-9-]+("."[a-z_A-Z0-9\-]+)+[a-z_A-Z0-9\-]+
-MAILWS    [\t a-z_A-Z0-9+-]
+MAILADDR  ("mailto:")?[a-z_A-Z0-9\x80-\xFF.+-]+"@"[a-z_A-Z0-9\x80-\xFf-]+("."[a-z_A-Z0-9\x80-\xFf\-]+)+[a-z_A-Z0-9\x80-\xFf\-]+
+MAILWS    [\t a-z_A-Z0-9\x80-\xFF+-]
 MAILADDR2 {MAILWS}+{BLANK}+("at"|"AT"|"_at_"|"_AT_"){BLANK}+{MAILWS}+("dot"|"DOT"|"_dot_"|"_DOT_"){BLANK}+{MAILWS}+
 OPTSTARS  ("/""/"{BLANK}*)?"*"*{BLANK}*
 LISTITEM  {BLANK}*[-]("#")?{WS}

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -357,9 +357,26 @@ void HtmlDocVisitor::visit(DocURL *u)
     uint size=5,i;
     for (i=0;i<url.length();)
     {
-      filter(url.mid(i,size));
+      uint extra = 0;
+      for (uint j = 0; j < size && (i + j + extra) < url.length() ; j++)
+      {
+        unsigned char c = static_cast<unsigned char>(url.at(i + j + extra));
+        if ((c&0xE0)==0xC0)
+        {
+          extra+=1; // 110x.xxxx: >=2 byte character
+        }
+        if ((c&0xF0)==0xE0)
+        {
+          extra+=2; // 1110.xxxx: >=3 byte character
+        }
+        if ((c&0xF8)==0xF0)
+        {
+          extra+=3; // 1111.0xxx: >=4 byte character
+        }
+      }
+      filter(url.mid(i,size + extra));
       if (i<url.length()-size) m_t << "<span style=\"display: none;\">.nosp@m.</span>";
-      i+=size;
+      i+=size + extra;
       if (size==5) size=4; else size=5;
     }
     m_t << "</a>";


### PR DESCRIPTION
When having:
```
# test email adddress

 mailru: Видео@Mail.Ru

```
we get a warning like:
```
.../bb.md:3: warning: Found unknown command '@Mail'
```

According to RFC6530 it is also possible to have UTF-8 (see also https://en.wikipedia.org/wiki/Email_address#Internationalization).

- extended lexers with range `\x80-\xFF` as done for other UTF-8 searches in lexers
- adjusted no spam filter so UTF-8 characters are kept together

(Found by Fossies in youtube-dl-2021.03.03)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6096928/example.tar.gz)
