### PR TITLE
Problem with non escaped double quote in preprocessor

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -621,6 +621,9 @@ WSopt [ \t\r]*
 <CopyLine,LexCopyLine>"\\"\r?/\n	{ // strip line continuation characters
                                           if (getLanguageFromFileName(yyextra->yyFileName)==SrcLangExt_Fortran) outputChar(yyscanner,*yytext);
   					}
+<CopyLine,LexCopyLine>\\.		{
+  					  outputArray(yyscanner,yytext,(int)yyleng);
+  					}
 <CopyLine,LexCopyLine>.			{
   					  outputChar(yyscanner,*yytext);
   					}


### PR DESCRIPTION
When having the (lex) program like:
```
%%
[\"]                       {}
%%

#ifdef SHARED_OBJECT

int filter_func(FILE *in, FILE *out)
{
    /* " */
}
#else
int main(void) { }
#endif
```
we get the messages like:
```
.../htuml2txt.lex:11: warning: Found an #else without a preceding #if.
.../htuml2txt.lex:13: warning: More #endif's than #if's found.
```
due to the fact that the escaped double quote is not seen as an escaped character.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6115276/example.tar.gz)
