### PR TITLE
Usage of default lex rule with `\param`

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1198,6 +1198,10 @@ STopt  [^\n@\\]*
 <ParamArg1>","                          {
                                           addOutput(yyscanner," , ");
                                         }
+<ParamArg1>{DOCNL}                      {
+                                          if (*yytext=='\n') yyextra->lineNr++;
+                                          addOutput(yyscanner," ");
+                                        }
 <ParamArg1>{ID}                         {
                                           addOutput(yyscanner,yytext);
                                           BEGIN( Comment );
@@ -1897,6 +1901,10 @@ STopt  [^\n@\\]*
                                           addOutput(yyscanner,yytext);
                                         }
 
+ /*
+<*>.  { fprintf(stderr,"Lex scanner %s %sdefault rule for state %s: #%s#\n", __FILE__,yyextra->fileName ? ("(" + yyextra->fileName +") ").data(): "",stateToString(YY_START),yytext);}
+<*>\n  { fprintf(stderr,"Lex scanner %s %sdefault rule newline for state %s.\n", __FILE__, yyextra->fileName ? ("(" + yyextra->fileName +") ").data(): "",stateToString(YY_START));}
+  */
 
 %%
 


### PR DESCRIPTION
In case we have a file like
```
/// \file

/// the fie
/// \param
///    arg the argument
void fie(int arg);
```
we get in the console output extra empty lines, this is due to the fact that the default lex rule kicks in an the output is echoed to the console.
We have defined an explicit rule.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6130485/example.tar.gz)
