### PR TITLE
Incorrect line number from tag file

### DIFF
--- a/addon/doxysearch/doxyindexer.cpp
+++ b/addon/doxysearch/doxyindexer.cpp
@@ -175,7 +175,7 @@ class XMLContentHandler
     };
 
     /** Handler for a start tag. Called for <doc> and <field> tags */
-    void startElement(const std::string &name, const XMLHandlers::Attributes &attrib)
+    void startElement(const std::string &name, const XMLHandlers::Attributes &attrib, const int lineNr)
     {
       m_data="";
       if (name=="field")
@@ -354,7 +354,7 @@ int main(int argc,const char **argv)
     }
     XMLContentHandler contentHandler(outputDir);
     XMLHandlers handlers;
-    handlers.startElement = [&contentHandler](const std::string &name,const XMLHandlers::Attributes &attrs)  { contentHandler.startElement(name,attrs);   };
+    handlers.startElement = [&contentHandler](const std::string &name,const XMLHandlers::Attributes &attrs, const int lineNr)  { contentHandler.startElement(name,attrs,lineNr);   };
     handlers.endElement   = [&contentHandler](const std::string &name)                                       { contentHandler.endElement(name);           };
     handlers.characters   = [&contentHandler](const std::string &chars)                                      { contentHandler.characters(chars);          };
     handlers.error        = [&contentHandler](const std::string &fileName,int lineNr,const std::string &msg) { contentHandler.error(fileName,lineNr,msg); };

--- a/libxml/xml.h
+++ b/libxml/xml.h
@@ -29,7 +29,7 @@ class XMLHandlers
     using Attributes       = std::unordered_map<std::string,std::string>;
     using StartDocType     = void();
     using EndDocType       = void();
-    using StartElementType = void(const std::string &,const Attributes &);
+    using StartElementType = void(const std::string &,const Attributes &, const int);
     using EndElementType   = void(const std::string &);
     using ErrorType        = void(const std::string,int,const std::string &);
     using CharsType        = void(const std::string &);

--- a/libxml/xml.l
+++ b/libxml/xml.l
@@ -282,7 +282,7 @@ static void addElement(yyscan_t yyscanner)
     yyextra->xpath.push_back(yyextra->name);
     if (yyextra->handlers.startElement)
     {
-      yyextra->handlers.startElement(yyextra->name,yyextra->attrs);
+      yyextra->handlers.startElement(yyextra->name,yyextra->attrs,yyextra->lineNr);
     }
     if (yy_flex_debug)
     {

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -176,7 +176,7 @@ class LayoutParser
     {
       ::warn(fileName.c_str(),lineNr,"%s",msg.c_str());
     }
-    void startElement( const std::string &name, const XMLHandlers::Attributes& attrib );
+    void startElement( const std::string &name, const XMLHandlers::Attributes& attrib, const int );
     void endElement( const std::string &name );
 
     void startSimpleEntry(LayoutDocEntry::Kind k,const XMLHandlers::Attributes &attrib)
@@ -1440,7 +1440,7 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
 
 };
 
-void LayoutParser::startElement( const std::string &name, const XMLHandlers::Attributes& attrib )
+void LayoutParser::startElement( const std::string &name, const XMLHandlers::Attributes& attrib, const int )
 {
   //printf("startElement [%s]::[%s]\n",m_scope.data(),name.data());
   auto it = g_elementHandlers.find(m_scope.str()+name);
@@ -1498,7 +1498,7 @@ void LayoutDocManager::init()
 {
   LayoutParser &layoutParser = LayoutParser::instance();
   XMLHandlers handlers;
-  handlers.startElement = [&layoutParser](const std::string &name,const XMLHandlers::Attributes &attrs) { layoutParser.startElement(name,attrs); };
+  handlers.startElement = [&layoutParser](const std::string &name,const XMLHandlers::Attributes &attrs,const int lineNr) { layoutParser.startElement(name,attrs, lineNr); };
   handlers.endElement   = [&layoutParser](const std::string &name) { layoutParser.endElement(name); };
   handlers.error        = [&layoutParser](const std::string &fileName,int lineNr,const std::string &msg) { layoutParser.error(fileName,lineNr,msg); };
   XMLParser parser(handlers);
@@ -1542,7 +1542,7 @@ void LayoutDocManager::parse(const char *fileName)
 {
   LayoutParser &layoutParser = LayoutParser::instance();
   XMLHandlers handlers;
-  handlers.startElement = [&layoutParser](const std::string &name,const XMLHandlers::Attributes &attrs) { layoutParser.startElement(name,attrs); };
+  handlers.startElement = [&layoutParser](const std::string &name,const XMLHandlers::Attributes &attrs,const int lineNr) { layoutParser.startElement(name,attrs,lineNr); };
   handlers.endElement   = [&layoutParser](const std::string &name) { layoutParser.endElement(name); };
   handlers.error        = [&layoutParser](const std::string &fn,int lineNr,const std::string &msg) { layoutParser.error(fn,lineNr,msg); };
   XMLParser parser(handlers);


### PR DESCRIPTION
In the ACE TAO project we see a lot of warnings like:
```
.../ACE_TAO/ACE/html/libtao-doc/TAO.tag:1: error: Internal inconsistency: namespace in IDL not module, library or constant group
```
the line number 1 is here incorrect and should be 54613, 55152 or 55345.
The reason is that the real line number is not stored although it is available from the xml reader

(the reason for the warning is another issue and should be handled separately)