### PR TITLE
Warnings regarding Internal inconsistency: namespace in IDL

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -118,7 +118,10 @@ documentation:
 \refitem cmdhideinitializer \\hideinitializer
 \refitem cmdhtmlinclude \\htmlinclude
 \refitem cmdhtmlonly \\htmlonly
+\refitem cmdidlconstants \\idlconstants
 \refitem cmdidlexcept \\idlexcept
+\refitem cmdidllibrary \\idllibrary
+\refitem cmdidlmodule \\idlmodule
 \refitem cmdif \\if
 \refitem cmdifnot \\ifnot
 \refitem cmdimage \\image
@@ -725,6 +728,44 @@ Structural indicators
   Indicates that a comment block contains documentation for a
   IDL exception with name \<name\>.
 
+  \sa sections \ref cmdidlconstants "\\idlconstants",
+    \ref cmdidllibrary "\\idllibrary" and
+    \ref cmdidlmodule "\\idlmodule".
+
+<hr>
+\section cmdidlmodule \\idlmodule <name>
+  \addindex \\idlmodule
+
+  Indicates that a comment block contains documentation for a
+  IDL module with name \<name\>.
+
+  \sa sections \ref cmdidlconstants "\\idlconstants",
+    \ref cmdidlexcept "\\idlexcept" and
+    \ref cmdidllibrary "\\idllibrary".
+
+<hr>
+\section cmdidllibrary \\idllibrary <name>
+  \addindex \\idllibrary
+
+  Indicates that a comment block contains documentation for a
+  IDL library with name \<name\>.
+
+  \sa sections \ref cmdidlconstants "\\idlconstants",
+    \ref cmdidlexcept "\\idlexcept",
+    \ref cmdidlmodule "\\idlmodule".
+
+<hr>
+\section cmdidlconstants \\idlconstants <name>
+  \addindex \\idlconstants
+
+  Indicates that a comment block contains documentation for a
+  IDL constants group with name \<name\>.
+
+  \sa sections 
+    \ref cmdidlexcept "\\idlexcept",
+    \ref cmdidllibrary "\\idllibrary" and
+    \ref cmdidlmodule "\\idlmodule".
+
 <hr>
 \section cmdimplements \\implements <name>
 
@@ -867,6 +908,10 @@ Structural indicators
   \addindex \\namespace
   Indicates that a comment block contains documentation for a
   namespace with name \<name\>.
+
+  \sa sections \ref cmdidlconstants "\\idlconstants",
+    \ref cmdidllibrary "\\idllibrary" and
+    \ref cmdidlmodule "\\idlmodule".
 
 <hr>
 \section cmdnosubgrouping \\nosubgrouping

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -152,6 +152,15 @@ enum class CommandSpacing
   XRef       // command is a cross reference (todo, bug, test, xrefitem).
 };
 
+enum class NamespaceSpec
+{
+  None,
+  Namespace,
+  IDLModule,
+  IDLLibrary,
+  IDLConstants
+};
+
 struct DocCmdMap
 {
   DocCmdMap(DocCmdFunc h,CommandSpacing s) : handler(h), spacing(s) {}
@@ -211,6 +220,9 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "htmlinclude",     { 0,                       CommandSpacing::Inline    }},
   { "htmlonly",        { &handleFormatBlock,      CommandSpacing::Invisible }},
   { "idlexcept",       { &handleIdlException,     CommandSpacing::Invisible }},
+  { "idlmodule",       { &handleNamespace,        CommandSpacing::Invisible }},
+  { "idlconstants",    { &handleNamespace,        CommandSpacing::Invisible }},
+  { "idllibrary",      { &handleNamespace,        CommandSpacing::Invisible }},
   { "if",              { &handleIf,               CommandSpacing::Inline    }},
   { "ifnot",           { &handleIfNot,            CommandSpacing::Inline    }},
   { "image",           { 0,                       CommandSpacing::Block     }},
@@ -422,7 +434,7 @@ static SectionType sectionLevelToType(int level);
 static void stripTrailingWhiteSpace(QCString &s);
 
 static void initParser(yyscan_t yyscanner);
-static bool makeStructuralIndicator(yyscan_t yyscanner,Entry::Sections s);
+static bool makeStructuralIndicator(yyscan_t yyscanner,Entry::Sections s, NamespaceSpec spec=NamespaceSpec::None);
 static void lineCount(yyscan_t yyscanner);
 static void addXRefItem(yyscan_t yyscanner,
                         const char *listName,const char *itemTitle,
@@ -1971,10 +1983,14 @@ static bool handleWeakGroup(yyscan_t yyscanner,const QCString &, const QCStringL
   return stop;
 }
 
-static bool handleNamespace(yyscan_t yyscanner,const QCString &, const QCStringList &)
+static bool handleNamespace(yyscan_t yyscanner,const QCString &cmd, const QCStringList &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,Entry::NAMESPACEDOC_SEC);
+  NamespaceSpec spec = NamespaceSpec::Namespace;
+  if (cmd == "idlmodule")         spec = NamespaceSpec::IDLModule;
+  else if (cmd == "idllibrary")   spec = NamespaceSpec::IDLLibrary;
+  else if (cmd == "idlconstants") spec = NamespaceSpec::IDLConstants;
+  bool stop=makeStructuralIndicator(yyscanner,Entry::NAMESPACEDOC_SEC,spec);
   BEGIN( NameSpaceDocArg1 );
   return stop;
 }
@@ -2787,7 +2803,7 @@ static bool getDocSectionName(int s)
 
 //-----------------------------------------------------------------------------
 
-static bool makeStructuralIndicator(yyscan_t yyscanner,Entry::Sections s)
+static bool makeStructuralIndicator(yyscan_t yyscanner,Entry::Sections s, NamespaceSpec spec)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   //printf("yyextra->current->section=%x\n",yyextra->current->section);
@@ -2799,6 +2815,30 @@ static bool makeStructuralIndicator(yyscan_t yyscanner,Entry::Sections s)
   {
     yyextra->needNewEntry = TRUE;
     yyextra->current->section = s;
+    if (s == Entry::NAMESPACEDOC_SEC)
+    {
+      // some cases are for compatibility reasons not set
+      switch(spec)
+      {
+        case NamespaceSpec::None:
+          break;
+        case NamespaceSpec::Namespace:
+          if (yyextra->current->lang==SrcLangExt_IDL)
+          {
+            if (s == Entry::NAMESPACEDOC_SEC) yyextra->current->type = QCString("module");
+          }
+          break;
+        case NamespaceSpec::IDLModule:
+          yyextra->current->type = QCString("module");
+          break;
+        case NamespaceSpec::IDLLibrary:
+          yyextra->current->type = QCString("library");
+          break;
+        case NamespaceSpec::IDLConstants:
+          yyextra->current->type = QCString("constants");
+          break;
+      }
+    }
     yyextra->current->fileName = yyextra->fileName;
     yyextra->current->startLine = yyextra->lineNr;
     yyextra->current->docLine = yyextra->lineNr;

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -79,7 +79,7 @@ class NamespaceDefImpl : public DefinitionMixin<NamespaceDefMutable>
     virtual QCString localName() const;
     virtual void setInline(bool isInline) { m_inline = isInline; }
     virtual bool isConstantGroup() const { return CONSTANT_GROUP == m_type; }
-    virtual bool isModule()        const { return MODULE == m_type; }
+    virtual bool isModule()        const { return NAMESPACE == m_type || MODULE == m_type; }
     virtual bool isLibrary() const { return LIBRARY == m_type; }
     virtual bool isInline() const { return m_inline; }
     virtual bool isLinkableInProject() const;

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -535,7 +535,21 @@ bool NamespaceDefImpl::hasDetailedDescription() const
 
 void NamespaceDefImpl::writeTagFile(FTextStream &tagFile)
 {
-  tagFile << "  <compound kind=\"namespace\">" << endl;
+  switch (m_type)
+  {
+    case NAMESPACE:
+      tagFile << "  <compound kind=\"" << "namespace" << "\">" << endl;
+      break;
+    case MODULE:
+      tagFile << "  <compound kind=\"" << "module" << "\">" << endl;
+      break;
+    case CONSTANT_GROUP:
+      tagFile << "  <compound kind=\"" << "constants" << "\">" << endl;
+      break;
+    case LIBRARY:
+      tagFile << "  <compound kind=\"" << "library" << "\">" << endl;
+      break;
+  }
   tagFile << "    <name>" << convertToXML(name()) << "</name>" << endl;
   tagFile << "    <filename>" << convertToXML(getOutputFileBase()) << Doxygen::htmlFileExtension << "</filename>" << endl;
   QCString idStr = id();


### PR DESCRIPTION
In the ACE TAO package we find a number of warnings like:
```
.../ACE_TAO/ACE/html/libtao-doc/security/TAO_Security.tag:1: error: Internal inconsistency: namespace in IDL not module, library or constant group
.../ACE_TAO/TAO/orbsvcs/orbsvcs/CosEventChannelAdmin.idl:30: error: Internal inconsistency: namespace in IDL not module, library or constant group
```

There are a number of reasons for these warnings a.o. IDL modules not handled properly but seen as namespaces and when type is not an IDL modules a warning is given. This happens especially when the module is documented with `@namespace`, this can partly be solved by testing the file type but when in a general file (out of place documentation) this does not work.
- introducing new commands to document IDL specific "namespaces"
- introducing and handling of IDL specific "namespaces" in tag files.

(A problem remains when we have e.g. an IDL module and in a C++ file there is a namespace with the same name.)