### PR TITLE
Warnings regarding Internal inconsistency: namespace in IDL

### DIFF
--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -79,7 +79,7 @@ class NamespaceDefImpl : public DefinitionMixin<NamespaceDefMutable>
     virtual QCString localName() const;
     virtual void setInline(bool isInline) { m_inline = isInline; }
     virtual bool isConstantGroup() const { return CONSTANT_GROUP == m_type; }
-    virtual bool isModule()        const { return MODULE == m_type; }
+    virtual bool isModule()        const { return NAMESPACE == m_type || MODULE == m_type; }
     virtual bool isLibrary() const { return LIBRARY == m_type; }
     virtual bool isInline() const { return m_inline; }
     virtual bool isLinkableInProject() const;


### PR DESCRIPTION
n the ACE TAO package we find a number of warnings like:
```
.../ACE_TAO/ACE/html/libtao-doc/security/TAO_Security.tag:1: error: Internal inconsistency: namespace in IDL not module, library or constant group
.../ACE_TAO/TAO/orbsvcs/orbsvcs/CosEventChannelAdmin.idl:30: error: Internal inconsistency: namespace in IDL not module, library or constant group
```

There are a number of reasons for these warnings a.o. IDL modules not handled properly but seen as namespaces and when type is not an IDL modules a warning is given.
This happens especially when the module is documented with `@namespace` or there is a namespace definition with the same name in a C++ file (which is just a mapping between IDL and C++).

Based on the discussion in https://github.com/DOCGroup/ACE_TAO/pull/1450#issuecomment-799277574 and the results from pull request #8429
a new version has been crated with just the extra test this just removes all Internal inconsistency warnings.