### PR TITLE
issue #8434 Java: static classes not recognized as static

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -208,6 +208,7 @@ class ClassDefImpl : public DefinitionMixin<ClassDefMutable>
     virtual QCString qualifiedNameWithTemplateParameters(
         const ArgumentLists *actualParams=0,uint *actualParamIndex=0) const;
     virtual bool isAbstract() const;
+    virtual bool isStatic() const;
     virtual bool isObjectiveC() const;
     virtual bool isFortran() const;
     virtual bool isCSharp() const;
@@ -262,6 +263,7 @@ class ClassDefImpl : public DefinitionMixin<ClassDefMutable>
     virtual void setCompoundType(CompoundType t);
     virtual void setClassName(const char *name);
     virtual void setClassSpecifier(uint64 spec);
+    virtual void setClassStatic(bool stat);
     virtual void setTemplateArguments(const ArgumentList &al);
     virtual void setTemplateBaseClassNames(const TemplateNameMap &templateNames);
     virtual void setTemplateMaster(const ClassDef *tm);
@@ -464,6 +466,8 @@ class ClassDefAliasImpl : public DefinitionAliasMixin<ClassDef>
     { return makeQualifiedNameWithTemplateParameters(this,actualParams,actualParamIndex); }
     virtual bool isAbstract() const
     { return getCdAlias()->isAbstract(); }
+    virtual bool isStatic() const
+    { return getCdAlias()->isStatic(); }
     virtual bool isObjectiveC() const
     { return getCdAlias()->isObjectiveC(); }
     virtual bool isFortran() const
@@ -703,6 +707,7 @@ class ClassDefImpl::IMPL
     bool isJavaEnum = false;
 
     uint64 spec = 0;
+    bool stat = false;
 
     QCString metaData;
 };
@@ -2435,6 +2440,7 @@ void ClassDefImpl::addClassAttributes(OutputList &ol) const
   if (isFinal())    sl.append("final");
   if (isSealed())   sl.append("sealed");
   if (isAbstract()) sl.append("abstract");
+  if (isStatic())   sl.append("static");
   if (getLanguage()==SrcLangExt_IDL && isPublished()) sl.append("published");
 
   ol.pushGeneratorState();
@@ -4591,6 +4597,11 @@ bool ClassDefImpl::isAbstract() const
   return m_impl->isAbstract || (m_impl->spec&Entry::Abstract);
 }
 
+bool ClassDefImpl::isStatic() const
+{
+  return m_impl->isStatic || m_impl->stat;
+}
+
 bool ClassDefImpl::isFinal() const
 {
   return m_impl->spec&Entry::Final;
@@ -4795,6 +4806,11 @@ bool ClassDefImpl::isJavaEnum() const
 void ClassDefImpl::setClassSpecifier(uint64 spec)
 {
   m_impl->spec = spec;
+}
+
+void ClassDefImpl::setClassStatic(bool stat)
+{
+  m_impl->stat = stat;
 }
 
 bool ClassDefImpl::isExtension() const

--- a/src/classdef.h
+++ b/src/classdef.h
@@ -286,6 +286,9 @@ class ClassDef : public Definition
      */
     virtual bool isAbstract() const = 0;
 
+    /** Returns TRUE if this class is static */
+    virtual bool isStatic() const = 0;
+
     /** Returns TRUE if this class is implemented in Objective-C */
     virtual bool isObjectiveC() const = 0;
 
@@ -397,6 +400,7 @@ class ClassDefMutable : public DefinitionMutable, public ClassDef
     virtual void setCompoundType(CompoundType t) = 0;
     virtual void setClassName(const char *name) = 0;
     virtual void setClassSpecifier(uint64 spec) = 0;
+    virtual void setClassStatic(bool stat) = 0;
     virtual void setTemplateArguments(const ArgumentList &al) = 0;
     virtual void setTemplateBaseClassNames(const TemplateNameMap &templateNames) = 0;
     virtual void setTemplateMaster(const ClassDef *tm) = 0;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1074,6 +1074,7 @@ static void addClassToContext(const Entry *root)
       cd->setHidden(root->hidden);
       cd->setArtificial(root->artificial);
       cd->setClassSpecifier(root->spec);
+      cd->setClassStatic(root->stat);
       cd->setTypeConstraints(root->typeConstr);
       //printf("new ClassDef %s tempArgList=%p specScope=%s\n",fullName.data(),root->tArgList,root->scopeSpec.data());
 

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -1250,6 +1250,7 @@ static void generateXMLForClass(const ClassDef *cd,FTextStream &ti)
   if (cd->isFinal()) t << "\" final=\"yes";
   if (cd->isSealed()) t << "\" sealed=\"yes";
   if (cd->isAbstract()) t << "\" abstract=\"yes";
+  if (cd->isStatic()) t << "\" static=\"yes";
   t << "\">" << endl;
   t << "    <compoundname>";
   writeXMLString(t,cd->name());


### PR DESCRIPTION
The information of a class being static was not being processed as it was not stored with a class (contrary to e.g. abstract, but this is done through another mechanism).