### PR TITLE
Building Cygwin version of doxygen fails

### DIFF
--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -54,7 +54,7 @@
 #ifndef GHC_OS_DETECTED
 #if defined(__APPLE__) && defined(__MACH__)
 #define GHC_OS_MACOS
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__CYGWIN__)
 #define GHC_OS_LINUX
 #if defined(__ANDROID__)
 #define GHC_OS_ANDROID


### PR DESCRIPTION
The ghc filesystem does not support Cygwin, resulting in:
```
.../src/filesystem.hpp:76:2: error: #error "Operating system currently not supported!
   76 | #error "Operating system currently not supported!"
      |  ^~~~~
```

Added Cygwin in selection of supported "GHC_OS_DETECTED".