### PR TITLE
Incorrect handling of JAVA style code statement in preprocessor

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -288,6 +288,7 @@ struct preYY_state
   bool               insideFtn      = false;
   bool               isSource       = false;
 
+  int                javaBlock      = 0;
   yy_size_t          fenceSize      = 0;
   bool               ccomment       = false;
   QCString           delimiter;
@@ -1196,6 +1197,11 @@ WSopt [ \t\r]*
   					  outputArray(yyscanner,yytext,(int)yyleng);
   					  yyextra->yyLineNr+=QCString(yytext).contains('\n');
   					}
+<SkipCComment>[ \t]*"{@code"/[ \t\n]    {
+                                          outputArray(yyscanner,yytext,(int)yyleng);
+                                          yyextra->javaBlock=1;
+                                          BEGIN(SkipVerbatim);
+                                        }
 <SkipCComment>[\\@]("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"docbookonly"|"rtfonly"|"manonly"|"dot"|"code"("{"[^}]*"}")?){BN}+	{
   					  outputArray(yyscanner,yytext,(int)yyleng);
   					  yyextra->yyLineNr+=QCString(yytext).contains('\n');
@@ -1315,6 +1321,21 @@ WSopt [ \t\r]*
                                             BEGIN(yyextra->condCtx);
                                           }
   					}
+<SkipVerbatim>[ \t]*"}"                 {
+                                          if (yyextra->javaBlock==0)
+                                          {
+                                            REJECT;
+                                          }
+                                          else
+                                          {
+                                            yyextra->javaBlock--;
+                                            outputArray(yyscanner,yytext,(int)yyleng);
+                                            if (yyextra->javaBlock==0)
+                                            {
+					      BEGIN(SkipCComment);
+                                            }
+                                          }
+                                        }
 <SkipVerbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"enddot"|"endcode"|"f$"|"f]"|"f}") { /* end of verbatim block */
   					  outputArray(yyscanner,yytext,(int)yyleng);
 					  if (yytext[1]=='f' && yyextra->blockName=="f")


### PR DESCRIPTION
When we have a program like:
```
/**
 * {@code
 * uspoof_setChecks(USPOOF_ALL_CHECKS & ~USPOOF_CONFUSABLE);
 * }
 *
 */
U_CAPI void U_EXPORT2
uspoof_setChecks(USpoofChecker *sc, int32_t checks, UErrorCode *status);

/**
 * \cond
 */
U_DEFINE_LOCAL_OPEN_POINTER(LocalUSpoofCheckerPointer, USpoofChecker, uspoof_close);
/** \endcond */
```
In the console output this results in some empty lines from the commentcnv lexer.

The problem comes from the preprocessor that doesn't recognize `{@code` as a JAVA style code statement that should end at the corresponding `}` and thus we remain in a code section. and thus not handling the `\cond` statement.
In the commentcnv lexer the `{@code` is handled as a special case and this is done in the preprocessor now as well.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6172066/example.tar.gz)

(Found by Fossies in package icu4c-69)
