### PR TITLE
Regression: dead code in classdef.cpp

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2998,7 +2998,6 @@ void ClassDefImpl::writeMemberList(OutputList &ol) const
             )
             && memberWritten)
         {
-          ol.writeString("<span class=\"mlabel\">");
           StringVector sl;
           if (lang==SrcLangExt_VHDL)
           {
@@ -3040,11 +3039,15 @@ void ClassDefImpl::writeMemberList(OutputList &ol) const
             if (!firstSpan)
             {
               ol.writeString("</span><span class=\"mlabel\">");
+            }
+            else
+            {
+              ol.writeString("<span class=\"mlabel\">");
               firstSpan=false;
             }
             ol.docify(s.c_str());
           }
-          ol.writeString("</span>");
+          if (!firstSpan) ol.writeString("</span>");
         }
         if (memberWritten)
         {


### PR DESCRIPTION
According to coverity:
```
assignment: Assigning: firstSpan = true.
3037          bool firstSpan=true;
3038          for (const auto &s : sl)
3039          {
    cond_const: Condition firstSpan, taking true branch. Now the value of firstSpan is equal to 1.
    const: At condition firstSpan, the value of firstSpan must be equal to 1.
    dead_error_condition: The condition !firstSpan cannot be true.
3040            if (!firstSpan)
3041            {
    CID 315162 (#1 of 1): Logically dead code (DEADCODE)dead_error_begin: Execution cannot reach this statement: ol->writeString("</span><sp....
3042              ol.writeString("</span><span class=\"mlabel\">");
3043              firstSpan=false;
3044            }
```
this problem has been introduced in: Refactoring: Replaced QDir with Dir (Commit: 0d05e79d67b5b808918541f429b06805207e8bdb)

Reformulated loop and condition, also it is not guaranteed that the list contains a member so adjusted also for an empty list.