### PR TITLE
Regression: dead code in configimpl.l

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1313,7 +1313,6 @@ static QCString configFileToString(const char *name)
     return ret;
   };
 
-  bool fileOpened=FALSE;
   if (name[0]=='-' && name[1]==0) // read from stdin
   {
     // read contents from stdin into contents string
@@ -1324,16 +1323,11 @@ static QCString configFileToString(const char *name)
     std::ifstream f(name,std::istream::in);
     if (!f.is_open())
     {
-      config_err("file '%s' not found\n",name);
+      config_term("file '%s' not found or could not be opened\n",name);
       return "";
     }
     return stream2string(f);
   }
-  if (!fileOpened)
-  {
-    config_term("cannot open file '%s' for reading\n",name);
-  }
-  return "";
 }
 
 bool ConfigImpl::parseString(const char *fn,const char *str,bool update)


### PR DESCRIPTION
According to coverity:
```
CID 315169 (#1 of 1): Structurally dead code (UNREACHABLE)unreachable: This code cannot be reached: if (!fileOpened) {

  config....
```
this problem has been introduced in: Refactoring: replace QFile/FTextStream with fstream/stringstream (Commit: fa1897b1889f7bf74de68f1ac99cf3be343a7551)