### PR TITLE
Maintenance doxygen internal Doxyfiles

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,3 @@
-# Doxyfile 1.8.16
 
 #---------------------------------------------------------------------------
 # Project related configuration options
@@ -12,7 +11,6 @@ OUTPUT_DIRECTORY       = doxygen_docs
 CREATE_SUBDIRS         = YES
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
-OUTPUT_TEXT_DIRECTION  = None
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = YES
 ABBREVIATE_BRIEF       =
@@ -110,6 +108,7 @@ INPUT                  = src \
                          libxml
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.h \
+                         *.hpp \
                          *.cpp \
                          *.l \
                          *.md

--- a/qtools/Doxyfile
+++ b/qtools/Doxyfile
@@ -1,4 +1,3 @@
-# Doxyfile 1.8.14
 
 #---------------------------------------------------------------------------
 # Project related configuration options
@@ -136,7 +135,6 @@ VERBATIM_HEADERS       = YES
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = YES
-COLS_IN_ALPHA_INDEX    = 4
 IGNORE_PREFIX          = Q
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
@@ -283,7 +281,6 @@ EXTERNAL_PAGES         = YES
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 CLASS_DIAGRAMS         = YES
-MSCGEN_PATH            =
 DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES


### PR DESCRIPTION
The Doxyfiles for the doxygen internal doxygen documentation had some obsolete entries and was lacking a new file (filesystem.hpp)