### PR TITLE
Regression, incorrect creation of path

### DIFF
--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -218,7 +218,7 @@ std::string Dir::filePath(const std::string &path,bool acceptsAbsPath) const
   }
   else
   {
-    result = (p->path / path).string();
+    result = currentDirPath() + "/" + path;
   }
   correctPath(result);
   return result;


### PR DESCRIPTION
Running the generation of the doxygen internal documentation I noticed the message:
```
Notice: Output directory 'doxygen_docs' does not exist. I have created it for you.
```
although the directory did exist.
The result was `doxygen_docs/doxygen_docs` but should have been the absolute path.