### PR TITLE
Maintenance of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /doxygen_docs
 /doxygen.tag
 /build*
+/qtools_docs
+/warnings.log
 
 tags
 


### PR DESCRIPTION
A file and a directory, generated by the doxygen internal documentation, were not excluded from the list that should go into the repository.