### PR TITLE
Fix deadlock when using `WARN_AS_ERROR = YES`.

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -122,9 +122,11 @@ static void handle_warn_as_error()
 {
   if (warnBehavior == WARN_YES)
   {
-    std::unique_lock<std::mutex> lock(g_mutex);
-    QCString msgText = " (warning treated as error, aborting now)\n";
-    fwrite(msgText.data(),1,msgText.length(),warnFile);
+    {
+      std::unique_lock<std::mutex> lock(g_mutex);
+      QCString msgText = " (warning treated as error, aborting now)\n";
+      fwrite(msgText.data(),1,msgText.length(),warnFile);
+    }
     exit(1);
   }
   warnStat = true;


### PR DESCRIPTION
**Describe the bug**
Doxygen encounters a deadlock when using a configuration file that specifies `WARN_AS_ERROR = YES`. This can be reproduced by setting `TAGFILES = invalid.tag`. I have not tested with other warnings.

**Expected behavior**
No deadlock and doxygen exits with exit code indicating error.

**To Reproduce**
This works from any location. It does not even require a source tree or anything.
```
doxygen -s -g
sed -i -e 's/^WARN_AS_ERROR.*/WARN_AS_ERROR = YES/' -e 's/^TAGFILES.*/TAGFILES = invalid.tag/' Doxyfile
doxygen
```

Console output is
```
Doxygen version used: 1.9.2 (39d20a3660942b12f3b003d0986794568e86d984*)
Searching for include files...
Searching for example files...
Searching for images...
Searching for dot files...
Searching for msc files...
Searching for dia files...
Searching for files to exclude
Searching INPUT for files to process...
Searching for files in directory /home/kolleck/projects/doxygen
Reading and parsing tag files
error: Tag file 'invalid.tag' does not exist or is not a file. Skipping it...
 (warning treated as error, aborting now)
```
The the program hangs. It does not react to CTRL+C and needs to be killed from separate shell.

**Version**
First discovered in doxygen-1.9.1 on Gentoo Linux on both x86 and x86_64.

**Stack trace**
Built doxygen directly from git checkout:
```
cmake -DCMAKE_BUILD_TYPE=Debug
make
```
Running the example above using `bin/doxygen` directly from the source tree results in the same behaviour. Stack trace with gdb when it hangs:
```
#0  0x00007ffff7f8e62b in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007ffff7f871e3 in pthread_mutex_lock () from /lib64/libpthread.so.0
#2  0x000055555569f827 in __gthread_mutex_lock (__mutex=0x5555568d3420 <g_mutex>) at /usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/include/g++-v10/x86_64-pc-linux-gnu/bits/gthr-default.h:749
#3  0x00005555556a1768 in std::mutex::lock (this=0x5555568d3420 <g_mutex>) at /usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/include/g++-v10/bits/std_mutex.h:100
#4  0x00005555556b8143 in std::unique_lock<std::mutex>::lock (this=0x7fffffffd3c0) at /usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/include/g++-v10/bits/unique_lock.h:138
#5  0x00005555556ac6db in std::unique_lock<std::mutex>::unique_lock (this=0x7fffffffd3c0, __m=...) at /usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/include/g++-v10/bits/unique_lock.h:68
#6  0x0000555555db6e81 in msg (fmt=0x555555e620ff "Exiting...\n") at /home/mkolleck/doxygen/src/message.cpp:70
#7  0x000055555568d9ca in exitDoxygen () at /home/mkolleck/doxygen/src/doxygen.cpp:10717
#8  0x00007ffff7a3f5d3 in __run_exit_handlers () from /lib64/libc.so.6
#9  0x00007ffff7a3f78c in exit () from /lib64/libc.so.6
#10 0x0000555555db73d3 in handle_warn_as_error () at /home/mkolleck/doxygen/src/message.cpp:128
#11 0x0000555555db7d27 in err (fmt=0x555555e60cf8 "Tag file '%s' does not exist or is not a file. Skipping it...\n") at /home/mkolleck/doxygen/src/message.cpp:219
#12 0x00005555556844ca in readTagFile (root=..., tl=0x555556952000 "invalid.tag") at /home/mkolleck/doxygen/src/doxygen.cpp:9054
#13 0x000055555568fef4 in parseInput () at /home/mkolleck/doxygen/src/doxygen.cpp:11163
#14 0x000055555564b479 in main (argc=1, argv=0x7fffffffdc38) at /home/mkolleck/doxygen/src/main.cpp:37
```

The deadlock is on `g_mutex`. Calling `exit(1)` at `message.cpp:128` (frame 10) while having the mutex locked. The next message from `exitDoxygen()` (frames 6 and 7) cannot acquire the lock.