### PR TITLE
Problem with empty buffer in pyscanner.l

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1438,6 +1438,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
+  if (yyextra->inputString.isEmpty()) return 0;
   const char *p = yyextra->inputString.data() + yyextra->inputPosition;
   while ( c < max_size && *p ) { *buf++ = *p++; c++; }
   yyextra->inputPosition+=c;


### PR DESCRIPTION
After commit:
```
Commit: 9533e6d6e8e69954593da006ab00ea362980bc76
Date: Wednesday, March 24, 2021 11:44:20 PM

Regression: fix potential lockup while parsing python code
```

the package fwupd-1.5.8 crashes with:
```
Reading /cygdrive/e/Fossies/fwupd-1.5.8/contrib/firmware_packager/__init__.py...
Parsing file /cygdrive/e/Fossies/fwupd-1.5.8/contrib/firmware_packager/__init__.py...

Thread 1 "doxygen" received signal SIGSEGV, Segmentation fault.
0x000000010065ea24 in yyread (yyscanner=0x8005d6930, buf=0x6ffffff60010 "", max_size=262143)
    at .../doxygen/src/pyscanner.l:1443
1443      yyextra->inputPosition+=c;

```