### PR TITLE
Write out used settings when generating XML output

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -61,6 +61,11 @@ namespace Config
    */
   void compareDoxyfile(std::ostream &t);
 
+  /*! Writes a the used settings of the current configuartion as XML format
+   *  to stream \a t.
+   */
+  void writeXMLDoxyfile(std::ostream &t);
+
   /*! Parses a configuration file with name \a fn.
    *  \returns TRUE if successful, FALSE if the file could not be
    *  opened or read.

--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -77,14 +77,16 @@ class ConfigOption
   protected:
     virtual void writeTemplate(std::ostream &t,bool sl,bool upd) = 0;
     virtual void compareDoxyfile(std::ostream &t) = 0;
+    virtual void writeXMLDoxyfile(std::ostream &t) = 0;
     virtual void convertStrToVal() {}
     virtual void emptyValueToDefault() {}
     virtual void substEnvVars() = 0;
     virtual void init() {}
+    virtual bool isDefault() {return true;}
 
-    void writeBoolValue(std::ostream &t,bool v);
-    void writeIntValue(std::ostream &t,int i);
-    void writeStringValue(std::ostream &t,const QCString &s);
+    void writeBoolValue(std::ostream &t,bool v,bool initSpace = true);
+    void writeIntValue(std::ostream &t,int i,bool initSpace = true);
+    void writeStringValue(std::ostream &t,const QCString &s,bool initSpace = true);
     void writeStringList(std::ostream &t,const StringVector &l);
 
     QCString m_spaces;
@@ -109,6 +111,7 @@ class ConfigInfo : public ConfigOption
     }
     void writeTemplate(std::ostream &t, bool sl,bool);
     void compareDoxyfile(std::ostream &){};
+    void writeXMLDoxyfile(std::ostream &) {};
     void substEnvVars() {}
 };
 
@@ -132,8 +135,10 @@ class ConfigList : public ConfigOption
     StringVector getDefault() { return m_defaultValue; }
     void writeTemplate(std::ostream &t,bool sl,bool);
     void compareDoxyfile(std::ostream &t);
+    void writeXMLDoxyfile(std::ostream &t);
     void substEnvVars();
     void init() { m_value = m_defaultValue; }
+    bool isDefault();
   private:
     StringVector m_value;
     StringVector m_defaultValue;
@@ -160,7 +165,9 @@ class ConfigEnum : public ConfigOption
     void writeTemplate(std::ostream &t,bool sl,bool);
     void convertStrToVal();
     void compareDoxyfile(std::ostream &t);
+    void writeXMLDoxyfile(std::ostream &t);
     void init() { m_value = m_defValue.copy(); }
+    bool isDefault() { return (m_value == m_defValue); }
 
   private:
     std::vector<QCString> m_valueRange;
@@ -190,9 +197,11 @@ class ConfigString : public ConfigOption
     QCString *valueRef() { return &m_value; }
     void writeTemplate(std::ostream &t,bool sl,bool);
     void compareDoxyfile(std::ostream &t);
+    void writeXMLDoxyfile(std::ostream &t);
     void substEnvVars();
     void init() { m_value = m_defValue.copy(); }
     void emptyValueToDefault() { if(m_value.isEmpty()) m_value=m_defValue; };
+    bool isDefault() { return (m_value.stripWhiteSpace() == m_defValue.stripWhiteSpace()); }
 
   private:
     QCString m_value;
@@ -223,7 +232,9 @@ class ConfigInt : public ConfigOption
     void substEnvVars();
     void writeTemplate(std::ostream &t,bool sl,bool upd);
     void compareDoxyfile(std::ostream &t);
+    void writeXMLDoxyfile(std::ostream &t);
     void init() { m_value = m_defValue; }
+    bool isDefault() { return (m_value == m_defValue); }
   private:
     int m_value;
     int m_defValue;
@@ -252,7 +263,9 @@ class ConfigBool : public ConfigOption
     void setValueString(const QCString &v) { m_valueString = v; }
     void writeTemplate(std::ostream &t,bool sl,bool upd);
     void compareDoxyfile(std::ostream &t);
+    void writeXMLDoxyfile(std::ostream &t);
     void init() { m_value = m_defValue; }
+    bool isDefault() { return (m_value == m_defValue); }
   private:
     bool m_value;
     bool m_defValue;
@@ -268,6 +281,7 @@ class ConfigObsolete : public ConfigOption
     { m_name = name; }
     void writeTemplate(std::ostream &,bool,bool);
     void compareDoxyfile(std::ostream &) {}
+    void writeXMLDoxyfile(std::ostream &) {};
     void substEnvVars() {}
 };
 
@@ -280,6 +294,7 @@ class ConfigDisabled : public ConfigOption
     { m_name = name; }
     void writeTemplate(std::ostream &,bool,bool);
     void compareDoxyfile(std::ostream &) {}
+    void writeXMLDoxyfile(std::ostream &) {};
     void substEnvVars() {}
 };
 
@@ -479,6 +494,11 @@ class ConfigImpl
      *  template configuration to stream \a t.
      */
     void compareDoxyfile(std::ostream &t);
+
+    /*! Writes a the used settings of the current configuartion as XML format
+     *  to stream \a t.
+     */
+    void writeXMLDoxyfile(std::ostream &t);
 
     void setHeader(const char *header) { m_header = header; }
 

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -37,6 +37,7 @@
 #include "portable.h"
 #include "message.h"
 #include "lang_cfg.h"
+#include "language.h"
 #include "configoptions.h"
 #include "fileinfo.h"
 #include "dir.h"
@@ -127,18 +128,19 @@ static QCString convertToComment(const QCString &s, const QCString &u)
   return result;
 }
 
-void ConfigOption::writeBoolValue(std::ostream &t,bool v)
+void ConfigOption::writeBoolValue(std::ostream &t,bool v,bool initSpace)
 {
-  t << " ";
+  if (initSpace) t << " ";
   if (v) t << "YES"; else t << "NO";
 }
 
-void ConfigOption::writeIntValue(std::ostream &t,int i)
+void ConfigOption::writeIntValue(std::ostream &t,int i,bool initSpace)
 {
-  t << " " << i;
+  if (initSpace) t << " ";
+  t << i;
 }
 
-void ConfigOption::writeStringValue(std::ostream &t,const QCString &s)
+void ConfigOption::writeStringValue(std::ostream &t,const QCString &s,bool initSpace)
 {
   char c;
   bool needsEscaping=FALSE;
@@ -147,7 +149,7 @@ void ConfigOption::writeStringValue(std::ostream &t,const QCString &s)
   const char *p=se.data();
   if (p)
   {
-    t << " ";
+    if (initSpace) t << " ";
     while ((c=*p++)!=0 && !needsEscaping)
       needsEscaping = (c==' ' || c== ',' || c=='\n' || c=='\t' || c=='"' || c=='#');
     if (needsEscaping)
@@ -349,7 +351,7 @@ void ConfigList::writeTemplate(std::ostream &t,bool sl,bool)
   t << "\n";
 }
 
-void ConfigList::compareDoxyfile(std::ostream &t)
+bool ConfigList::isDefault()
 {
   auto get_stripped = [](std::string s)             { return QCString(s.c_str()).stripWhiteSpace(); };
   auto is_not_empty = [get_stripped](std::string s) { return !get_stripped(s).isEmpty();            };
@@ -357,8 +359,7 @@ void ConfigList::compareDoxyfile(std::ostream &t)
   int valCnt = std::count_if(m_defaultValue.begin(),m_defaultValue.end(),is_not_empty);
   if ( valCnt != defCnt)
   {
-    writeTemplate(t,TRUE,TRUE);
-    return;
+    return false;
   }
   auto it1 = m_value.begin();
   auto it2 = m_defaultValue.begin();
@@ -373,13 +374,37 @@ void ConfigList::compareDoxyfile(std::ostream &t)
     {
       if (get_stripped(*it1) != get_stripped(*it2)) // not the default, write as difference
       {
-        writeTemplate(t,TRUE,TRUE);
-        return;
+        return false;
       }
       ++it1;
       ++it2;
     }
   }
+  return true;
+}
+
+void ConfigList::compareDoxyfile(std::ostream &t)
+{
+  if (!isDefault()) writeTemplate(t,TRUE,TRUE);
+}
+
+void ConfigList::writeXMLDoxyfile(std::ostream &t)
+{
+  t << "  <option  id='" << m_name << "'";
+  t << " default='" << (isDefault() ? "yes" : "no") << "'";
+  t << " type='stringlist'";
+  t << ">";
+  t << "\n";
+  for (const auto &p : m_value)
+  {
+    QCString s=p.c_str();
+    t << "    <value>";
+    t << "<![CDATA[";
+    writeStringValue(t,s,false);
+    t << "]]>";
+    t << "</value>\n";
+  }
+  t << "  </option>\n";
 }
 
 void ConfigEnum::writeTemplate(std::ostream &t,bool sl,bool)
@@ -401,7 +426,19 @@ void ConfigEnum::writeTemplate(std::ostream &t,bool sl,bool)
 
 void ConfigEnum::compareDoxyfile(std::ostream &t)
 {
-  if (m_value != m_defValue) writeTemplate(t,TRUE,TRUE);
+  if (!isDefault()) writeTemplate(t,TRUE,TRUE);
+}
+
+void ConfigEnum::writeXMLDoxyfile(std::ostream &t)
+{
+  t << "  <option  id='" << m_name << "'";
+  t << " default='" << (isDefault() ? "yes" : "no") << "'";
+  t << " type='string'";
+  t << ">";
+  t << "<value>";
+  writeStringValue(t,m_value,false);
+  t << "</value>";
+  t << "</option>\n";
 }
 
 void ConfigString::writeTemplate(std::ostream &t,bool sl,bool)
@@ -423,7 +460,21 @@ void ConfigString::writeTemplate(std::ostream &t,bool sl,bool)
 
 void ConfigString::compareDoxyfile(std::ostream &t)
 {
-  if (m_value.stripWhiteSpace() != m_defValue.stripWhiteSpace()) writeTemplate(t,TRUE,TRUE);
+  if (!isDefault()) writeTemplate(t,TRUE,TRUE);
+}
+
+void ConfigString::writeXMLDoxyfile(std::ostream &t)
+{
+  t << "  <option  id='" << m_name << "'";
+  t << " default='" << (isDefault() ? "yes" : "no") << "'";
+  t << " type='string'";
+  t << ">";
+  t << "<value>";
+  t << "<![CDATA[";
+  writeStringValue(t,m_value,false);
+  t << "]]>";
+  t << "</value>";
+  t << "</option>\n";
 }
 
 void ConfigInt::writeTemplate(std::ostream &t,bool sl,bool upd)
@@ -452,8 +503,21 @@ void ConfigInt::writeTemplate(std::ostream &t,bool sl,bool upd)
 
 void ConfigInt::compareDoxyfile(std::ostream &t)
 {
-  if (m_value != m_defValue) writeTemplate(t,TRUE,TRUE);
+  if (!isDefault()) writeTemplate(t,TRUE,TRUE);
 }
+
+void ConfigInt::writeXMLDoxyfile(std::ostream &t)
+{
+  t << "  <option  id='" << m_name << "'";
+  t << " default='" << (isDefault() ? "yes" : "no") << "'";
+  t << " type='int'";
+  t << ">";
+  t << "<value>";
+  writeIntValue(t,m_value,false);
+  t << "</value>";
+  t << "</option>\n";
+}
+
 
 void ConfigBool::writeTemplate(std::ostream &t,bool sl,bool upd)
 {
@@ -482,8 +546,21 @@ void ConfigBool::writeTemplate(std::ostream &t,bool sl,bool upd)
 
 void ConfigBool::compareDoxyfile(std::ostream &t)
 {
-  if (m_value != m_defValue) writeTemplate(t,TRUE,TRUE);
+  if (!isDefault()) writeTemplate(t,TRUE,TRUE);
 }
+
+void ConfigBool::writeXMLDoxyfile(std::ostream &t)
+{
+  t << "  <option  id='" << m_name << "'";
+  t << " default='" << (isDefault() ? "yes" : "no") << "'";
+  t << " type='bool'";
+  t << ">";
+  t << "<value>";
+  writeBoolValue(t,m_value,false);
+  t << "</value>";
+  t << "</option>\n";
+}
+
 
 void ConfigObsolete::writeTemplate(std::ostream &,bool,bool) {}
 void ConfigDisabled::writeTemplate(std::ostream &,bool,bool) {}
@@ -1115,6 +1192,17 @@ void ConfigImpl::compareDoxyfile(std::ostream &t)
     option->m_userComment = "";
     option->compareDoxyfile(t);
   }
+}
+
+void ConfigImpl::writeXMLDoxyfile(std::ostream &t)
+{
+  t << "<?xml version='1.0' encoding='UTF-8' standalone='no'?>\n";
+  t << "<doxyfile xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"doxyfile.xsd\" version=\"" << getDoxygenVersion() << "\" xml:lang=\"" <<  theTranslator->trISOLang() << "\">\n";
+  for (const auto &option : m_options)
+  {
+    option->writeXMLDoxyfile(t);
+  }
+  t << "</doxyfile>\n";
 }
 
 void ConfigImpl::convertStrToVal()
@@ -2071,6 +2159,11 @@ void Config::compareDoxyfile(std::ostream &t)
 {
   postProcess(FALSE, TRUE);
   ConfigImpl::instance()->compareDoxyfile(t);
+}
+
+void Config::writeXMLDoxyfile(std::ostream &t)
+{
+  ConfigImpl::instance()->writeXMLDoxyfile(t);
 }
 
 bool Config::parse(const char *fileName,bool update)

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -1822,6 +1822,7 @@ void generateXML()
 
   ResourceMgr::instance().copyResource("xml.xsd",outputDirectory);
   ResourceMgr::instance().copyResource("index.xsd",outputDirectory);
+  ResourceMgr::instance().copyResource("doxyfile.xsd",outputDirectory);
 
   QCString fileName=outputDirectory+"/compound.xsd";
   std::ofstream t(fileName.str(),std::ofstream::out | std::ofstream::binary);
@@ -1857,6 +1858,19 @@ void generateXML()
     startLine=endLine;
   }
   t.close();
+
+  std::ofstream f;
+  fileName=outputDirectory+"/Doxyfile.xml";
+  bool fileOpened=openOutputFile(fileName,f);
+  if (fileOpened)
+  {
+    Config::writeXMLDoxyfile(f);
+  }
+  else
+  {
+    err("Cannot open file %s for writing\n",fileName.data());
+    return;
+  }
 
   fileName=outputDirectory+"/index.xml";
   t.open(fileName.str(),std::ofstream::out | std::ofstream::binary);

--- a/templates/xml/doxyfile.xsd
+++ b/templates/xml/doxyfile.xsd
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+
+  <xsd:element name="doxyfile" type="DoxygenFileType"/>
+
+  <xsd:complexType name="DoxygenFileType">
+    <xsd:sequence>
+      <xsd:element name="option" type="OptionType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="version" type="xsd:string" use="required"/>
+    <xsd:attribute ref="xml:lang" use="required"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="OptionType">
+    <xsd:sequence>
+      <xsd:element name="value" type="valueType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:string" use="required"/>
+    <xsd:attribute name="default" type="defaultType" use="required"/>
+    <xsd:attribute name="type" type="typeType" use="required"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="valueType">
+    <xsd:restriction base="xsd:string">
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="defaultType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="yes"/>
+      <xsd:enumeration value="no"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="typeType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="int"/>
+      <xsd:enumeration value="bool"/>
+      <xsd:enumeration value="string"/>
+      <xsd:enumeration value="stringlist"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>
+
+<!--
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxyfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="doxyfile.xsd" version="1.9.2" xml:lang="en-US">
+  <option  id='DOXYFILE_ENCODING' default='yes' type='string'><![CDATA[UTF-8]]></option>
+<value><![CDATA[d:/Programs/CGAL/cgal_fork/AABB_tree/doc/AABB_tree/]]></value>
+-->
+

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -305,12 +305,39 @@ class Tester:
 					msg += (xmllint_out,)
 					failed_xmlxsd=True
 				#
+				doxyfile_xml = []
+				doxyfile_xml.append(glob.glob('%s/Doxyfile.xml' % (xmlxsd_output)))
+				doxyfile_xml.append(glob.glob('%s/*/*/Doxyfile.xml' % (xmlxsd_output)))
+				doxyfile_xml = ' '.join(list(itertools.chain.from_iterable(doxyfile_xml))).replace(self.args.outputdir +'/','').replace('\\','/')
+				doxyfile_xsd = []
+				doxyfile_xsd.append(glob.glob('%s/doxyfile.xsd' % (xmlxsd_output)))
+				doxyfile_xsd.append(glob.glob('%s/*/*/doxyfile.xsd' % (xmlxsd_output)))
+				doxyfile_xsd = ' '.join(list(itertools.chain.from_iterable(doxyfile_xsd))).replace(self.args.outputdir +'/','').replace('\\','/')
+				exe_string = '%s --noout --schema %s %s' % (self.args.xmllint,doxyfile_xsd,doxyfile_xml)
+				exe_string1 = exe_string
+				exe_string += ' %s' % (redirx)
+				exe_string += ' %s more "%s/temp"' % (separ,xmlxsd_output)
+
+				xmllint_out = xpopen(exe_string,exe_string1,getStderr=True)
+				if xmllint_out:
+					xmllint_out = re.sub(r'.*validates','',xmllint_out).rstrip('\n')
+				else:
+					msg += ('Failed to run %s with schema %s for files: %s' % (self.args.xmllint,doxyfile_xsd,doxyfile_xml),)
+					failed_xmlxsd=True
+				if xmllint_out:
+					xmllint_out  = clean_header(xmllint_out)
+				if xmllint_out:
+					msg += (xmllint_out,)
+					failed_xmlxsd=True
+				#
 				compound_xml = []
 				compound_xml.append(glob.glob('%s/*.xml' % (xmlxsd_output)))
 				compound_xml.append(glob.glob('%s/*/*/*.xml' % (xmlxsd_output)))
 				compound_xml = ' '.join(list(itertools.chain.from_iterable(compound_xml))).replace(self.args.outputdir +'/','').replace('\\','/')
 				compound_xml = re.sub(r' [^ ]*/index.xml','',compound_xml)
 				compound_xml = re.sub(r'[^ ]*/index.xml ','',compound_xml)
+				compound_xml = re.sub(r' [^ ]*/Doxyfile.xml','',compound_xml)
+				compound_xml = re.sub(r'[^ ]*/Doxyfile.xml ','',compound_xml)
 
 				compound_xsd = []
 				compound_xsd.append(glob.glob('%s/compound.xsd' % (xmlxsd_output)))


### PR DESCRIPTION
When generating XML output is is afterwards unknown which settings have been used to generate the XML output, e.g. whether `EXTRACT_PRIVATE` was set or not as the XML output tries to write out all information contained in the sources and not to limit it.
By writing out a Doxyfile.xml with all the used settings this can be overcome.