### PR TITLE
issue #8485 The browser based search doesn't handle underscores correctly

### DIFF
--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -555,7 +555,7 @@ QCString searchId(const Definition *d)
   TextStream t;
   for (size_t i=0;i<s.length();i++)
   {
-    if (isId(s[i]))
+    if (isIdJS(s[i]))
     {
       t << s[i];
     }

--- a/src/util.h
+++ b/src/util.h
@@ -191,6 +191,10 @@ inline bool isId(int c)
 {
   return c=='_' || c>=128 || c<0 || isalnum(c);
 }
+inline bool isIdJS(int c)
+{
+  return c>=128 || c<0 || isalnum(c);
+}
 
 QCString removeRedundantWhiteSpace(const QCString &s);
 


### PR DESCRIPTION
The problem is that that "_" is seen as an Id character and not is escaped for JS search.

This is a regression on:
```
Commit: a4ecbee86766b35d25d41d1a178806e1688485df [a4ecbee]
Date: Monday, March 22, 2021 8:02:06 PM
issue #8375: Lowercase search does not find non-ASCII uppercase pages and vice versa
```
and
```
Commit: 3a365ab230cab40910366eee5352534719541598 [3a365ab]
Date: Wednesday, March 24, 2021 8:34:50 PM
issue #8375 Lowercase search does not find non-ASCII uppercase pages and vice versa (part 2)
```