### PR TITLE
Incorrect linecount in case of JAVADOC_AUTOBRIEF set

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3120,6 +3120,7 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
       if (oldContext!=yyextra->inContext)
       {
         stripTrailingWhiteSpace(yyextra->current->doc);
+        if (yyextra->current->doc.isEmpty()) yyextra->current->docLine = yyextra->lineNr;
         if (yyextra->current->docFile.isEmpty())
         {
           yyextra->current->docFile = yyextra->fileName;
@@ -3131,6 +3132,7 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
     case OutputBrief:
       if (oldContext!=yyextra->inContext)
       {
+        if (yyextra->current->brief.isEmpty()) yyextra->current->briefLine = yyextra->lineNr;
         if (yyextra->current->briefFile.isEmpty())
         {
           yyextra->current->briefFile = yyextra->fileName;


### PR DESCRIPTION
Based on the side remark in issue #8482 about incorrect line count.
The Incorrect line count is seen when `JAVADOC_AUTOBRIEF` is set and due to the fact that

Test example: 
[example.tar.gz](https://github.com/doxygen/doxygen/files/6285132/example.tar.gz)
