### PR TITLE
Incorrect warning regarding end of list

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -787,7 +787,7 @@ int Markdown::processEmphasis(const char *data,int offset,int size)
 
 void Markdown::writeMarkdownImage(const char *fmt, bool explicitTitle,
                                   const QCString &title, const QCString &content,
-                                  const QCString &link, const FileDef *fd)
+                                  const QCString &link, const FileDef *fd, const QCString &post)
 {
   m_out.addStr("@image{inline} ");
   m_out.addStr(fmt);
@@ -797,17 +797,20 @@ void Markdown::writeMarkdownImage(const char *fmt, bool explicitTitle,
   {
     m_out.addStr(" \"");
     m_out.addStr(escapeDoubleQuotes(content));
+    m_out.addStr(post);
     m_out.addStr("\"");
   }
   else if ((content.isEmpty() || explicitTitle) && !title.isEmpty())
   {
     m_out.addStr(" \"");
     m_out.addStr(escapeDoubleQuotes(title));
+    m_out.addStr(post);
     m_out.addStr("\"");
   }
   else
   {
     m_out.addStr(" ");// so the line break will not be part of the image name
+    m_out.addStr(post);
   }
   m_out.addStr("\\ilinebr");
 }
@@ -1037,10 +1040,19 @@ int Markdown::processLink(const char *data,int,int size)
         (fd=findFileDef(Doxygen::imageNameLinkedMap,link,ambig)))
         // assume doxygen symbol link or local image link
     {
-      writeMarkdownImage("html",    explicitTitle, title, content, link, fd);
-      writeMarkdownImage("latex",   explicitTitle, title, content, link, fd);
-      writeMarkdownImage("rtf",     explicitTitle, title, content, link, fd);
-      writeMarkdownImage("docbook", explicitTitle, title, content, link, fd);
+      QCString post = "";
+      static const reg::Ex r(R"(^( *\.)\n)");
+      reg::Match match;
+      if (reg::search(data + i,match,r))
+      {
+        post = match[1].str();
+        i += match[1].length();
+      }
+
+      writeMarkdownImage("html",    explicitTitle, title, content, link, fd, post);
+      writeMarkdownImage("latex",   explicitTitle, title, content, link, fd, post);
+      writeMarkdownImage("rtf",     explicitTitle, title, content, link, fd, post);
+      writeMarkdownImage("docbook", explicitTitle, title, content, link, fd, post);
     }
     else
     {

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -59,7 +59,7 @@ class Markdown
     void processInline(const char *data,int size);
     void writeMarkdownImage(const char *fmt, bool explicitTitle,
                             const QCString &title, const QCString &content,
-                            const QCString &link, const FileDef *fd);
+                            const QCString &link, const FileDef *fd, const QCString &post);
     int isHeaderline(const char *data, int size, bool allowAdjustLevel);
     int isAtxHeader(const char *data,int size,
                        QCString &header,QCString &id,bool allowAdjustLevel);


### PR DESCRIPTION
When having a simple file like:
```
Some notes on how we use git
============================

![squash and merge](squash.png) .
```
we get the warning:
```
git.md:5: warning: End of list marker found without any preceding list items
```
This is due to the fact that the image line is translated into:
```
@image{inline} html squash.png "squash and merge"\ilinebr@image{inline} latex squash.png "squash and merge"\ilinebr@image{inline} rtf squash.png "squash and merge"\ilinebr@image{inline} docbook squash.png "squash and merge"\ilinebr .
```

The ."." part has been made part of (all) the title(s).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6289846/example.tar.gz)
