### PR TITLE
Usage of HTML BR tag in HTML A tag

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -3000,6 +3000,10 @@ int DocHRef::parse()
             {
               goto endhref;
             }
+            else if (tagId==HTML_BR)
+            {
+              m_children.push_back(std::make_unique<DocLineBreak>(this,g_token->attribs));
+            }
             else
             {
               warn_doc_error(g_fileName,getDoctokinizerLineNr(),"Unexpected html tag <%s%s> found within <a href=...> context",


### PR DESCRIPTION
when having:
```
[<img src="../windows.png" width="100px;"/><br /><sub><b>an image</b></sub>](http://example.com)
```
we get the warning like:
```
warning: Unexpected html tag <br> found within <a href=...> context
```
due to the fact that the line is translated into:
```
<a href="http://example.com"><img src="../windows.png" width="100px;"/><br /><sub><b>an image</b></sub></a>
```
but there is no reason why the usage of  `<br>` inside a `A`-tag is not possible.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6289938/example.tar.gz)
