### PR TITLE
issue #7346 Incompatibility with MathJax 3.0

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2475,20 +2475,33 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
 ]]>
       </docs>
     </option>
+    <option type='enum' id='MATHJAX_VERSION' defval='MathJax_2' depends='USE_MATHJAX'>
+      <docs>
+<![CDATA[
+ With \c MATHJAX_VERSION it is possible to specify the MathJax version to be used.
+ Note that the different versions of MathJax have different requirements with regards to
+ the different settings, so it is possible that also other MathJax settings have to be changed
+ when switching between the different MathJax versions. 
+]]>
+      </docs>
+      <value name="MathJax_2"/>
+      <value name="MathJax_3"/>
+    </option>
     <option type='enum' id='MATHJAX_FORMAT' defval='HTML-CSS' depends='USE_MATHJAX'>
       <docs>
 <![CDATA[
  When MathJax is enabled you can set the default output format to be used for
  the MathJax output.
- See <a href="http://docs.mathjax.org/en/v2.7-latest/output.html">the MathJax site</a>
- for more details.
+ For more details about the output format see <a href="http://docs.mathjax.org/en/v2.7-latest/output.html">MathJax version 2</a>
+ and <a href="http://docs.mathjax.org/en/latest/web/components/output.html">MathJax version 3</a>.
 ]]>
       </docs>
-      <value name="HTML-CSS" desc="(which is slower, but has the best compatibility)"/>
-      <value name="NativeMML" desc="(i.e. MathML)"/>
+      <value name="HTML-CSS" desc="(which is slower, but has the best compatibility. This is the name for Mathjax version 2, for MathJax version 3 this will be translated into \c chtml)"/>
+      <value name="NativeMML" desc="(i.e. MathML. Only supported for NathJax 2. For MathJax version 3 \c chtml will be used instead.)"/>
+      <value name="chtml" desc="(This is the name for Mathjax version 3, for MathJax version 2 this will be translated into \c HTML-CSS)"/>
       <value name="SVG"/>
     </option>
-    <option type='string' id='MATHJAX_RELPATH' format='string' defval='https://cdn.jsdelivr.net/npm/mathjax@2' depends='USE_MATHJAX'>
+    <option type='string' id='MATHJAX_RELPATH' format='string' depends='USE_MATHJAX'>
       <docs>
 <![CDATA[
  When MathJax is enabled you need to specify the location relative to the
@@ -2499,6 +2512,10 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
  the MathJax Content Delivery Network so you can quickly see the result without
  installing MathJax.  However, it is strongly recommended to install a local
  copy of MathJax from https://www.mathjax.org before deployment.
+
+ The default value is:
+ - in case of  MathJax version 2: https://cdn.jsdelivr.net/npm/mathjax@2
+ - in case of  MathJax version 3: https://cdn.jsdelivr.net/npm/mathjax@3
 ]]>
       </docs>
     </option>
@@ -2506,9 +2523,14 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
       <docs>
 <![CDATA[
  The \c MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax extension
- names that should be enabled during MathJax rendering. For example
+ names that should be enabled during MathJax rendering. For example for MathJax version 2
+ (see https://docs.mathjax.org/en/v2.7-latest/tex.html#tex-and-latex-extensions):
 \verbatim
 MATHJAX_EXTENSIONS     = TeX/AMSmath TeX/AMSsymbols
+\endverbatim
+For example for MathJax version 3 (see http://docs.mathjax.org/en/latest/input/tex/extensions/index.html):
+\verbatim
+MATHJAX_EXTENSIONS     = ams
 \endverbatim
 ]]>
       </docs>

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1548,6 +1548,23 @@ void Config::checkAndCorrect()
   // Test to see if MathJax code file is valid
   if (Config_getBool(USE_MATHJAX))
   {
+    QCString mathJaxFormat = Config_getEnum(MATHJAX_FORMAT);
+    QCString mathjaxVersion = Config_getEnum(MATHJAX_VERSION);
+    if (!mathJaxFormat.isEmpty())
+    {
+      if (mathjaxVersion == "MathJax_2")
+      {
+        if (mathJaxFormat=="chtml") Config_updateEnum(MATHJAX_FORMAT,"HTML-CSS");
+      }
+      else
+      {
+        if (mathJaxFormat=="HTML-CSS" || mathJaxFormat=="NativeMML")
+        {
+          Config_updateEnum(MATHJAX_FORMAT,"chtml");
+        }
+      }
+    }
+
     QCString mathJaxCodefile = Config_getString(MATHJAX_CODEFILE);
     if (!mathJaxCodefile.isEmpty())
     {
@@ -1559,7 +1576,19 @@ void Config::checkAndCorrect()
       }
     }
     QCString path = Config_getString(MATHJAX_RELPATH);
-    if (!path.isEmpty() && path.at(path.length()-1)!='/')
+    if (path.isEmpty())
+    {
+      if (mathjaxVersion == "MathJax_2")
+      {
+        path = "https://cdn.jsdelivr.net/npm/mathjax@2";
+      }
+      else
+      {
+        path = "https://cdn.jsdelivr.net/npm/mathjax@3";
+      }
+    }
+
+    if (path.at(path.length()-1)!='/')
     {
       path+="/";
     }
@@ -1973,15 +2002,6 @@ void Config::checkAndCorrect()
     gamma=240;
   }
   Config_updateInt(HTML_COLORSTYLE_GAMMA,gamma);
-
-  //------------------------
-  QCString mathJaxFormat = Config_getEnum(MATHJAX_FORMAT);
-  if (!mathJaxFormat.isEmpty() && mathJaxFormat!="HTML-CSS" &&
-       mathJaxFormat!="NativeMML" && mathJaxFormat!="SVG")
-  {
-    err("Unsupported value for MATHJAX_FORMAT: Should be one of HTML-CSS, NativeMML, or SVG\n");
-    Config_updateEnum(MATHJAX_FORMAT,"HTML-CSS");
-  }
 
   //------------------------
   // add default words if needed

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -437,44 +437,109 @@ static QCString substituteHtmlKeywords(const QCString &str,
 
   if (mathJax)
   {
+    QCString mathJaxVersion = Config_getEnum(MATHJAX_VERSION);
     QCString path = Config_getString(MATHJAX_RELPATH);
     if (path.isEmpty() || path.left(2)=="..") // relative path
     {
       path.prepend(relPath);
     }
-    mathJaxJs = "<script type=\"text/x-mathjax-config\">\n"
-                "  MathJax.Hub.Config({\n"
-                "    extensions: [\"tex2jax.js\"";
-    const StringVector &mathJaxExtensions = Config_getList(MATHJAX_EXTENSIONS);
-    for (const auto &s : mathJaxExtensions)
+
+    if (mathJaxVersion == "MathJax_3")
     {
-      mathJaxJs+= ", \""+QCString(s.c_str())+".js\"";
+       mathJaxJs += "<script>\n"
+                    "  window.MathJax = {\n"
+                    "    options: {\n"
+                    "      ignoreHtmlClass: 'tex2jax_ignore',\n"
+                    "      processHtmlClass: 'tex2jax_process'\n"
+                    "    },\n";
+      const StringVector &mathJaxExtensions = Config_getList(MATHJAX_EXTENSIONS);
+      if (!mathJaxExtensions.empty() || !g_latex_macro.isEmpty())
+      {
+        mathJaxJs+= "    tex: {\n"
+                    "      packages: ['base'";
+        if (!g_latex_macro.isEmpty())
+        {
+          mathJaxJs+= ",'newcommand'";
+        }
+        for (const auto &s : mathJaxExtensions)
+        {
+          mathJaxJs+= ",'"+QCString(s.c_str())+"'";
+        }
+        mathJaxJs += "]\n"
+                      "    },\n"
+                      "    tex: {\n"
+                      "      macros: {}\n"
+                      "    }\n";
+      }
+      mathJaxJs += "  };\n";
+      mathJaxJs += "</script>\n";
+
+      if (!g_latex_macro.isEmpty())
+      {
+        mathJaxJs += "<script>\n"
+                   "  Object.assign(MathJax.tex.macros, {\n";
+        mathJaxJs += g_latex_macro;
+        mathJaxJs += "\n"
+                     "  });\n"
+                     "</script>\n";
+      }
+
+      // MATHJAX_CODEFILE
+      if (!g_mathjax_code.isEmpty())
+      {
+        mathJaxJs += "<script>\n";
+        mathJaxJs += g_mathjax_code;
+        mathJaxJs += "\n";
+        mathJaxJs += "</script>\n";
+      }
+
+
+      mathJaxJs += "<script type=\"text/javascript\" id=\"MathJax-script\" async=\"async\" src=\"" + path;
+      if (mathJaxFormat == "chtml")
+      {
+        mathJaxJs += "es5/tex-chtml.js\"></script>\n" ;
+      }
+      else if (mathJaxFormat == "SVG")
+      {
+        mathJaxJs += "es5/tex-svg.js\"></script>\n" ;
+      }
     }
-    if (mathJaxFormat.isEmpty())
+    else
     {
-      mathJaxFormat = "HTML-CSS";
+      mathJaxJs = "<script type=\"text/x-mathjax-config\">\n"
+                  "  MathJax.Hub.Config({\n"
+                  "    extensions: [\"tex2jax.js\"";
+      const StringVector &mathJaxExtensions = Config_getList(MATHJAX_EXTENSIONS);
+      for (const auto &s : mathJaxExtensions)
+      {
+        mathJaxJs+= ", \""+QCString(s.c_str())+".js\"";
+      }
+      if (mathJaxFormat.isEmpty())
+      {
+        mathJaxFormat = "HTML-CSS";
+      }
+      mathJaxJs += "],\n"
+                   "    jax: [\"input/TeX\",\"output/"+mathJaxFormat+"\"],\n"
+                   "});\n";
+      if (!g_mathjax_code.isEmpty())
+      {
+        mathJaxJs += g_mathjax_code;
+        mathJaxJs += "\n";
+      }
+      mathJaxJs += "</script>\n";
+      if (!g_latex_macro.isEmpty())
+      {
+        mathJaxJs += "<script type=\"text/x-mathjax-config\">\n"
+                     "  MathJax.Hub.Config({\n"
+  		   "   TeX: { Macros: {\n";
+        mathJaxJs += g_latex_macro;
+        mathJaxJs += "\n"
+                     "  } }\n"
+                     "});\n"
+                     "</script>\n";
+      }
+      mathJaxJs += "<script type=\"text/javascript\" async=\"async\" src=\"" + path + "MathJax.js\"></script>\n";
     }
-    mathJaxJs += "],\n"
-                 "    jax: [\"input/TeX\",\"output/"+mathJaxFormat+"\"],\n"
-                 "});\n";
-    if (!g_mathjax_code.isEmpty())
-    {
-      mathJaxJs += g_mathjax_code;
-      mathJaxJs += "\n";
-    }
-    mathJaxJs += "</script>\n";
-    if (!g_latex_macro.isEmpty())
-    {
-      mathJaxJs += "<script type=\"text/x-mathjax-config\">\n"
-                   "  MathJax.Hub.Config({\n"
-		   "   TeX: { Macros: {\n";
-      mathJaxJs += g_latex_macro;
-      mathJaxJs += "\n"
-                   "  } }\n"
-                   "});\n"
-                   "</script>\n";
-    }
-    mathJaxJs += "<script type=\"text/javascript\" async=\"async\" src=\"" + path + "MathJax.js\"></script>\n";
   }
 
   // first substitute generic keywords


### PR DESCRIPTION
Implementing the possibility to use MathJax versie 3
- Added setting MATHJAX_VERSION
- made setting for MATHJAX_RELPATH so that is suited for version Mathjax version3, i.e. selecting right default
- made setting for MATHJAX_FORMAT so that is suited for version Mathjax version3, automatic conversion between MathJax 2 and MathJax3 format setting

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6297549/example.tar.gz)
