### PR TITLE
Coverity warnings

### DIFF
--- a/src/template.cpp
+++ b/src/template.cpp
@@ -4023,6 +4023,7 @@ class TemplateNodeCycle : public TemplateNodeCreator<TemplateNodeCycle>
     void render(TextStream &ts, TemplateContext *c)
     {
       TemplateContextImpl *ci = dynamic_cast<TemplateContextImpl*>(c);
+      if (ci==0) return; // should not happen
       ci->setLocation(m_templateName,m_line);
       if (m_index<m_args.size())
       {

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -117,8 +117,6 @@ static inline uint32_t convertUTF8CharToUnicode(const char *s,size_t bytesLeft,i
         return uc;
       }
   }
-  len=0;
-  return 0;
 }
 
 std::string getUTF8CharAt(const std::string &input,size_t pos)


### PR DESCRIPTION
Correcting new coverity warnings.
- utf8.cpp is dead code.
- template.cpp, made consistent with other render functions