### PR TITLE
Warning from preprocessor regarding binary literals

### DIFF
--- a/src/constexp.l
+++ b/src/constexp.l
@@ -90,6 +90,9 @@ CONSTSUFFIX ([uU][lL]?[lL]?)|([lL][lL]?[uU]?)
 (0x|0X)[0-9a-fA-F]+{CONSTSUFFIX}?  { yyextra->strToken=yytext+2; 
                                      return TOK_HEXADECIMALINT; 
                                    }
+(0b|0B)[01]+{CONSTSUFFIX}?         { yyextra->strToken=yytext+2; 
+                                     return TOK_BINARYINT; 
+                                   }
 (([0-9]+\.[0-9]*)|([0-9]*\.[0-9]+))([eE]([\-\+])?[0-9]+)?([fFlL])? { 
                                      yyextra->strToken=yytext; return TOK_FLOAT; 
                                    }

--- a/src/constexp.y
+++ b/src/constexp.y
@@ -64,6 +64,7 @@ int constexpYYerror(yyscan_t yyscanner, const char *s)
 %token TOK_OCTALINT
 %token TOK_DECIMALINT
 %token TOK_HEXADECIMALINT
+%token TOK_BINARYINT
 %token TOK_CHARACTER
 %token TOK_FLOAT
 
@@ -275,6 +276,11 @@ constant: TOK_OCTALINT
 	  {
 	    struct constexpYY_state* yyextra = constexpYYget_extra(yyscanner);
 	    $$ = parseHexadecimal(yyextra->strToken);
+	  }
+	| TOK_BINARYINT
+	  {
+	    struct constexpYY_state* yyextra = constexpYYget_extra(yyscanner);
+	    $$ = parseBinary(yyextra->strToken);
 	  }
 	| TOK_CHARACTER
 	  {

--- a/src/cppvalue.cpp
+++ b/src/cppvalue.cpp
@@ -51,6 +51,16 @@ CPPValue parseHexadecimal(const std::string& token)
   return CPPValue(val);
 }
 
+CPPValue parseBinary(const std::string& token)
+{
+  long val = 0;
+  for (const char *p = token.c_str(); *p != 0; p++)
+  {
+    if (*p >= '0' && *p <= '1') val = val * 2 + *p - '0';
+  }
+  return CPPValue(val);
+}
+
 CPPValue parseCharacter(const std::string& token) // does not work for '\n' and the alike
 {
   if (token[1]=='\\')

--- a/src/cppvalue.h
+++ b/src/cppvalue.h
@@ -52,6 +52,7 @@ class CPPValue
 extern CPPValue parseOctal(const std::string& token);
 extern CPPValue parseDecimal(const std::string& token);
 extern CPPValue parseHexadecimal(const std::string& token);
+extern CPPValue parseBinary(const std::string& token);
 extern CPPValue parseCharacter(const std::string& token);
 extern CPPValue parseFloat(const std::string& token);
 


### PR DESCRIPTION
When having a line like:
```
#if (JITTERLISP_FIXNUM_TAG_BIN  == 0)
```
with
```
#define JITTERLISP_FIXNUM_TAG_BIN           0b0000
```
we get the warning:
```
warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' ( 0b0000   == 0)'
```

The equivalent hexadecimal / octal / decimal versions are OK, the handling for the binary was missing.

(Found by Fossies in the poke package).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6335017/example.tar.gz)
