### PR TITLE
Error messages on ASSERTS

### DIFF
--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -40,7 +40,7 @@ typedef unsigned long	ulong;
 typedef int64_t         int64;
 typedef uint64_t        uint64;
 #define ASSERT(x)  if ( !(x) )\
-	fprintf(stderr,"ASSERT: \"%s\" in %s (%d)",#x,__FILE__,__LINE__)
+	fprintf(stderr,"ASSERT: \"%s\" in %s (%d)\n",#x,__FILE__,__LINE__)
 
 
 /*****************************************************************************


### PR DESCRIPTION
Added missing `\n` in output, most likely regression due to change from the qt version of  `ASSERT`:
```
        qFatal("ASSERT: \"%s\" in %s (%d)",#x,__FILE__,__LINE__)
```
or
```
        qWarning("ASSERT: \"%s\" in %s (%d)",#x,__FILE__,__LINE__)
```

In Fossies we got that the messages were just put behind each other (they should not appear at all but that is another issue):