### PR TITLE
No warning for incorrect ALIASES

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1626,8 +1626,8 @@ void Config::checkAndCorrect()
   for (const auto &alias : aliasList)
   {
     // match aliases of the form re1='name=' and re2='name{2} ='
-    static const reg::Ex re1(R"(\a\w*\s*=)");
-    static const reg::Ex re2(R"(\a\w*{\d+}\s*=)");
+    static const reg::Ex re1(R"(^\a\w*\s*=)");
+    static const reg::Ex re2(R"(^\a\w*{\d+}\s*=)");
     if (!reg::search(alias,re1) && !reg::search(alias,re2))
     {
       err("Illegal ALIASES format '%s'. Use \"name=value\" or \"name{n}=value\", where n is the number of arguments\n",


### PR DESCRIPTION
When having the alias:
```
"\latexonly mytable=\\mytable \endlatexonly"
```
the 1.9.1. version gave a warning:
```
error: Illegal ALIASES format '\latexonly mytable=\\mytable \endlatexonly'. Use "name=value" or "name{n}=value", where n is the number of arguments
```
though the current version doesn't give a warning, probably due to the regexp replacement. Now most likely the string found starts at `mytable=`
The alias should start at the beginning of the string when searching.

Example (there is no need for input files): [example.tar.gz](https://github.com/doxygen/doxygen/files/6358243/example.tar.gz)
