### PR TITLE
Problem with Fortran, giving a warning about invalid state

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -378,6 +378,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                             if (YY_START != Prepass)
                                             {
                                               yyextra->comments.clear();
+                                              yyextra->inputStringPrepass=QCString();
                                               yy_push_state(Prepass,yyscanner);
                                             }
 


### PR DESCRIPTION
Fortran gives a warning like
```
Error in file .../mic_lib.f90 line: 15, state: 4(SubprogBody)
```
This happens after the update:
```
Commit: 592aaa4f17d73ec8c475df0f44efaea8cc4d575c [592aaa4]
Date: Sunday, April 11, 2021 9:22:59 PM
Commit Date: Thursday, April 22, 2021 7:34:13 PM
Refactoring: remove implicit conversion from QCString to const char *
```

Looks like an initialization that was previously done automatic doesn't happen anymore.
(Problem found by Fossies in openmpi, gcc, fimex).

Small example: [example2.tar.gz](https://github.com/doxygen/doxygen/files/6365718/example2.tar.gz)
