### PR TITLE
issue #8518 tag </programlisting> was inserted before </highlight> parsing python file to xml

### DIFF
--- a/src/pycode.l
+++ b/src/pycode.l
@@ -172,7 +172,7 @@ NONEMPTYEXP       [^ \t\n:]
 PARAMNONEMPTY     [^ \t\n():]
 IDENTIFIER        ({LETTER}|"_")({LETTER}|{DIGIT}|"_")*
 SCOPE             {IDENTIFIER}("."{IDENTIFIER})*
-CALLANY           "("[^)]*")"
+CALLANY           "("[^)\n]*")"
 BORDER            ([^A-Za-z0-9])
 
 POUNDCOMMENT      "##"

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -331,6 +331,7 @@ STARTDOCSYMS      "##"
        			yyextra->stat=TRUE;
       		      }
     "@"{SCOPE}{CALL}? { // decorator
+                        lineCount(yyscanner);
                       }
     {SCRIPTCOMMENT}   { // Unix type script comment
                         if (yyextra->yyLineNr != 1) REJECT;


### PR DESCRIPTION
Doxygen expects that decorators don't have a return in them, but the complicated decorator:
```
   @basetest.unittest.skipIf(
      api_implementation.Type() != 'cpp' or api_implementation.Version() != 2,
       'Errors are only available from the most recent C++ implementation.')
```
has some in them.
This leads to the mentioned problem as well as that the line counting is incorrect (we see that the last mentioned lie number in the xml file is 2964 though the file has 2966 lines). By fixing this (and also the line counting in the python scanner) the problem looks to be handled.