### PR TITLE
issue #8522 Javadoc: type attribute of ordered lists not preserved

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -932,7 +932,30 @@ void DocbookDocVisitor::visitPre(DocHtmlList *s)
 DB_VIS_C
   if (m_hide) return;
   if (s->type()==DocHtmlList::Ordered)
-    m_t << "<orderedlist>\n";
+  {
+    m_t << "<orderedlist";
+    for (const auto &opt : s->attribs())
+    {
+      if (opt.name=="type")
+      {
+        if (opt.value=="1")
+          m_t << " numeration=\"arabic\"";
+        else if (opt.value=="a")
+          m_t << " numeration=\"loweralpha\"";
+        else if (opt.value=="A")
+          m_t << " numeration=\"upperalpha\"";
+        else if (opt.value=="i")
+          m_t << " numeration=\"lowerroman\"";
+        else if (opt.value=="I")
+          m_t << " numeration=\"upperroman\"";
+      }
+      else if (opt.name=="start")
+      {
+        m_t << " startingnumber=\"" << opt.value << "\"";
+      }
+    }
+    m_t << ">\n";
+  }
   else
     m_t << "<itemizedlist>\n";
 }

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -916,7 +916,53 @@ void LatexDocVisitor::visitPre(DocHtmlList *s)
 {
   if (m_hide) return;
   if (s->type()==DocHtmlList::Ordered)
+  {
+    bool first = true;
     m_t << "\n\\begin{DoxyEnumerate}";
+    for (const auto &opt : s->attribs())
+    {
+      if (opt.name=="type")
+      {
+        if (opt.value=="1")
+        {
+          m_t << (first ?  "[": ",");
+          m_t << "label=\\arabic*";
+          first = false;
+        }
+        else if (opt.value=="a")
+        {
+          m_t << (first ?  "[": ",");
+          m_t << "label=\\enumalphalphcnt*";
+          first = false;
+        }
+        else if (opt.value=="A")
+        {
+          m_t << (first ?  "[": ",");
+          m_t << "label=\\enumAlphAlphcnt*";
+          first = false;
+        }
+        else if (opt.value=="i")
+        {
+          m_t << (first ?  "[": ",");
+          m_t << "label=\\roman*";
+          first = false;
+        }
+        else if (opt.value=="I")
+        {
+          m_t << (first ?  "[": ",");
+          m_t << "label=\\Roman*";
+          first = false;
+        }
+      }
+      else if (opt.name=="start")
+      {
+        m_t << (first ?  "[": ",");
+        m_t << "start=" << opt.value;
+        first = false;
+      }
+    }
+    if (!first) m_t << "]\n";
+  }
   else
     m_t << "\n\\begin{DoxyItemize}";
 }

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -28,6 +28,8 @@
 #include "emoji.h"
 #include "fileinfo.h"
 
+ManListItemInfo man_listItemInfo[man_maxIndentLevels];
+
 ManDocVisitor::ManDocVisitor(TextStream &t,CodeOutputInterface &ci,
                              const QCString &langExt)
   : DocVisitor(DocVisitor_Man), m_t(t), m_ci(ci), m_insidePre(FALSE), m_hide(FALSE), m_firstCol(FALSE),
@@ -643,12 +645,27 @@ void ManDocVisitor::visitPost(DocSection *)
 {
 }
 
-void ManDocVisitor::visitPre(DocHtmlList *)
+void ManDocVisitor::visitPre(DocHtmlList *l)
 {
   if (m_hide) return;
   m_indent+=2;
   if (!m_firstCol) m_t << "\n";
   m_t << ".PD 0\n";
+  man_listItemInfo[m_indent].number = 1;
+  man_listItemInfo[m_indent].type   = '1';
+  for (const auto &opt : l->attribs())
+  {
+    if (opt.name=="type")
+    {
+      man_listItemInfo[m_indent].type = opt.value[0];
+    }
+    if (opt.name=="start")
+    {
+      bool ok;
+      int val = opt.value.toInt(&ok);
+      if (ok) man_listItemInfo[m_indent].number = val;
+    }
+  }
 }
 
 void ManDocVisitor::visitPost(DocHtmlList *)
@@ -668,7 +685,29 @@ void ManDocVisitor::visitPre(DocHtmlListItem *li)
   m_t << ".IP \"" << ws;
   if (((DocHtmlList *)li->parent())->type()==DocHtmlList::Ordered)
   {
-    m_t << li->itemNumber() << ".\" " << m_indent+2;
+    switch (man_listItemInfo[m_indent].type)
+    {
+      case '1':
+        m_t << man_listItemInfo[m_indent].number;
+        break;
+      case 'a':
+        m_t << intergerToAlpha(man_listItemInfo[m_indent].number,false);
+        break;
+      case 'A':
+        m_t << intergerToAlpha(man_listItemInfo[m_indent].number);
+        break;
+      case 'i':
+        m_t << integerToRoman(man_listItemInfo[m_indent].number,false);
+        break;
+      case 'I':
+        m_t << integerToRoman(man_listItemInfo[m_indent].number);
+        break;
+      default:
+        m_t << man_listItemInfo[m_indent].number;
+        break;
+    }
+    m_t << ".\" " << m_indent+2;
+    man_listItemInfo[m_indent].number++;
   }
   else // bullet list
   {

--- a/src/mandocvisitor.h
+++ b/src/mandocvisitor.h
@@ -159,4 +159,13 @@ class ManDocVisitor : public DocVisitor
     QCString m_langExt;
 };
 
+struct ManListItemInfo
+{
+  int number;
+  char type;
+};
+
+const int man_maxIndentLevels = 13;
+
+extern ManListItemInfo man_listItemInfo[man_maxIndentLevels];
 #endif

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -930,6 +930,17 @@ void PerlModDocVisitor::visitPre(DocHtmlList *l)
 {
   openItem("list");
   m_output.addFieldQuotedString("style", (l->type() == DocHtmlList::Ordered) ? "ordered" : "itemized");
+  for (const auto &opt : l->attribs())
+  {
+    if (opt.name=="type")
+    {
+      m_output.addFieldQuotedString("list_type", qPrint(opt.value));
+    }
+    if (opt.name=="start")
+    {
+      m_output.addFieldQuotedString("start", qPrint(opt.value));
+    }
+  }
   openSubBlock("content");
 }
 

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -385,7 +385,17 @@ class PrintDocVisitor : public DocVisitor
     void visitPre(DocHtmlList *s)
     {
       indent_pre();
-      if (s->type()==DocHtmlList::Ordered) printf("<ol>\n"); else printf("<ul>\n");
+      if (s->type()==DocHtmlList::Ordered)
+      {
+        printf("<ol");
+        for (const auto &opt : s->attribs())
+        {
+          printf(" %s=\"%s\"",qPrint(opt.name),qPrint(opt.value));
+        }
+        printf(">\n");
+      }
+      else printf("<ul>\n");
+ 
     }
     void visitPost(DocHtmlList *s)
     {

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -891,6 +891,20 @@ void RTFDocVisitor::visitPre(DocHtmlList *l)
   m_t << "{\n";
   rtf_listItemInfo[m_indentLevel].isEnum = l->type()==DocHtmlList::Ordered;
   rtf_listItemInfo[m_indentLevel].number = 1;
+  rtf_listItemInfo[m_indentLevel].type   = '1';
+  for (const auto &opt : l->attribs())
+  {
+    if (opt.name=="type")
+    {
+      rtf_listItemInfo[m_indentLevel].type = opt.value[0];
+    }
+    if (opt.name=="start")
+    {
+      bool ok;
+      int val = opt.value.toInt(&ok);
+      if (ok) rtf_listItemInfo[m_indentLevel].number = val;
+    }
+  }
   m_lastIsPara=FALSE;
 }
 
@@ -911,7 +925,28 @@ void RTFDocVisitor::visitPre(DocHtmlListItem *)
   if (rtf_listItemInfo[m_indentLevel].isEnum)
   {
     m_t << getStyle("ListEnum") << "\n";
-    m_t << rtf_listItemInfo[m_indentLevel].number << ".\\tab ";
+    switch (rtf_listItemInfo[m_indentLevel].type)
+    {
+      case '1':
+        m_t << rtf_listItemInfo[m_indentLevel].number;
+        break;
+      case 'a':
+        m_t << intergerToAlpha(rtf_listItemInfo[m_indentLevel].number,false);
+        break;
+      case 'A':
+        m_t << intergerToAlpha(rtf_listItemInfo[m_indentLevel].number);
+        break;
+      case 'i':
+        m_t << integerToRoman(rtf_listItemInfo[m_indentLevel].number,false);
+        break;
+      case 'I':
+        m_t << integerToRoman(rtf_listItemInfo[m_indentLevel].number);
+        break;
+      default:
+        m_t << rtf_listItemInfo[m_indentLevel].number;
+        break;
+    }
+    m_t << ".\\tab ";
     rtf_listItemInfo[m_indentLevel].number++;
   }
   else

--- a/src/rtfstyle.h
+++ b/src/rtfstyle.h
@@ -39,6 +39,7 @@ struct RTFListItemInfo
 {
   bool isEnum;
   int number;
+  char type;
 };
 
 const int rtf_maxIndentLevels = 13;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7461,3 +7461,39 @@ std::string join(const StringVector &sv,const std::string &delimiter)
   return result;
 }
 
+std::string intergerToAlpha(const int n, const bool upper)
+{
+  std::string result = "";
+  int residual = n;
+
+  char modVal[2];
+  modVal[1] = 0;
+  while (residual > 0)
+  {
+    modVal[0] = (upper ? 'A': 'a') + (residual-1)%26;
+    result = modVal + result;
+    residual = (residual-1) / 26;
+  }
+  return result;
+}
+
+std::string integerToRoman(const int n, const bool upper)
+{
+  static std::string str_romans_upper[] = {"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
+  static std::string str_romans_lower[] = {"m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i"};
+  static int values[] = {1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
+
+  std::string result = "";
+  int residual = n;
+
+  for (int i = 0; i < 13; ++i)
+  {
+    while(residual - values[i] >= 0)
+    {
+      result += (upper ? str_romans_upper[i] : str_romans_lower[i]);
+      residual -= values[i];
+    }
+  }
+
+  return result;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -460,4 +460,6 @@ std::string join(const StringVector &s,const std::string &delimiter);
 bool recognizeFixedForm(const QCString &contents, FortranFormat format);
 FortranFormat convertFileNameFortranParserCode(QCString fn);
 
+std::string intergerToAlpha(const int n, const bool upper=true);
+std::string integerToRoman(const int n, const bool upper=true);
 #endif

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -710,7 +710,14 @@ void XmlDocVisitor::visitPre(DocHtmlList *s)
 {
   if (m_hide) return;
   if (s->type()==DocHtmlList::Ordered)
-    m_t << "<orderedlist>\n";
+  {
+    m_t << "<orderedlist";
+    for (const auto &opt : s->attribs())
+    {
+      m_t << " " << opt.name << "=\"" << opt.value << "\"";
+    }
+    m_t << ">\n";
+  }
   else
     m_t << "<itemizedlist>\n";
 }

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -20,6 +20,8 @@
 \RequirePackage{adjustbox}
 \RequirePackage{amssymb}
 \RequirePackage{stackengine}
+\RequirePackage{enumitem}
+\RequirePackage{alphalph}
 \RequirePackage[normalem]{ulem} % for strikeout, but don't modify emphasis
 
 %---------- Internal commands used in this style file ----------------
@@ -574,3 +576,13 @@
 \H@refstepcounter{figure}%
 \@dblarg{\@caption{figure}}}
 \makeatother
+
+% Define alpha enumarative names for counters > 26
+\makeatletter
+\def\enumalphalphcnt#1{\expandafter\@enumalphalphcnt\csname c@#1\endcsname}
+\def\@enumalphalphcnt#1{\alphalph{#1}}
+\def\enumAlphAlphcnt#1{\expandafter\@enumAlphAlphcnt\csname c@#1\endcsname}
+\def\@enumAlphAlphcnt#1{\AlphAlph{#1}}
+\makeatother
+\AddEnumerateCounter{\enumalphalphcnt}{\@enumalphalphcnt}{aa}
+\AddEnumerateCounter{\enumAlphAlphcnt}{\@enumAlphAlphcnt}{AA}

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -512,6 +512,8 @@
     <xsd:sequence>
       <xsd:element name="listitem" type="docListItemType" maxOccurs="unbounded" />
     </xsd:sequence>
+    <xsd:attribute name="type" type="DoxOlType" />
+    <xsd:attribute name="start" type="xsd:integer" />
   </xsd:complexType>
 
   <xsd:complexType name="docListItemType">
@@ -964,6 +966,16 @@
       <xsd:enumeration value="bottom"/>
       <xsd:enumeration value="top"/>
       <xsd:enumeration value="middle"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="DoxOlType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="1" />
+      <xsd:enumeration value="a" />
+      <xsd:enumeration value="A" />
+      <xsd:enumeration value="i" />
+      <xsd:enumeration value="I" />
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
The problem was a bit deeper, it was also valid for other output formats.
Implemented the `type` and `start` attribute for all relevant output types.

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6398345/example.tar.gz)
