### PR TITLE
Spelling corrections

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -61,7 +61,7 @@ namespace Config
    */
   void compareDoxyfile(TextStream &t);
 
-  /*! Writes a the used settings of the current configuartion as XML format
+  /*! Writes a the used settings of the current configuration as XML format
    *  to stream \a t.
    */
   void writeXMLDoxyfile(TextStream &t);

--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -496,7 +496,7 @@ class ConfigImpl
      */
     void compareDoxyfile(TextStream &t);
 
-    /*! Writes a the used settings of the current configuartion as XML format
+    /*! Writes a the used settings of the current configuration as XML format
      *  to stream \a t.
      */
     void writeXMLDoxyfile(TextStream &t);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10200,7 +10200,7 @@ static void usage(const QCString &name,const QCString &versionString)
   msg("    HTML:       %s -w html headerFile footerFile styleSheetFile [configFile]\n",qPrint(name));
   msg("    LaTeX:      %s -w latex headerFile footerFile styleSheetFile [configFile]\n\n",qPrint(name));
   msg("6) Use doxygen to generate a rtf extensions file\n");
-  msg("    RTF:   %s -e rtf extensionsFile\n\n",qPrint(name));
+  msg("    %s -e rtf extensionsFile\n\n",qPrint(name));
   msg("    If - is used for extensionsFile doxygen will write to standard output.\n\n");
   msg("7) Use doxygen to compare the used configuration file with the template configuration file\n");
   msg("    %s -x [configFile]\n\n",qPrint(name));


### PR DESCRIPTION
- small spelling corrections
- removing RTF: as this is clear from description.