### PR TITLE
issue #8495 Java: members entirely missing if generic parameter extends another generic

### DIFF
--- a/src/defargs.l
+++ b/src/defargs.l
@@ -471,6 +471,7 @@ CPPC  "/\/"
                                            {
                                              yyextra->curTypeConstraint.resize(0);
                                              yyextra->lastExtendsContext=YY_START;
+                                             assert(yyextra->argSharpCount == 0);
                                              BEGIN(ReadTypeConstraint);
                                            }
                                         }
@@ -500,9 +501,25 @@ CPPC  "/\/"
 <CopyArgRound,CopyArgRound2,CopyArgSharp,CopyArgCurly>.  {
 					  *yyextra->copyArgValue += *yytext;
 					}
-<ReadTypeConstraint>[,)>]               {
+<ReadTypeConstraint>[,)]               {
                                           unput(*yytext);
                                           BEGIN(yyextra->lastExtendsContext);
+                                       }
+<ReadTypeConstraint>">"                {
+                                          if (yyextra->argSharpCount > 0)
+                                          {
+                                            yyextra->curTypeConstraint+=yytext;
+                                            --yyextra->argSharpCount;
+                                          }
+                                          else
+                                          {
+                                            unput(*yytext);
+                                            BEGIN(yyextra->lastExtendsContext);
+                                          }
+                                        }
+<ReadTypeConstraint>"<"                 {
+                                          yyextra->curTypeConstraint+=yytext;
+                                          ++yyextra->argSharpCount;
                                         }
 <ReadTypeConstraint>.                   {
                                           yyextra->curTypeConstraint+=yytext;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1049,7 +1049,7 @@ static void addClassToContext(const Entry *root)
       }
     }
     std::unique_ptr<ArgumentList> tArgList;
-    if ((root->lang==SrcLangExt_CSharp || root->lang==SrcLangExt_Java) && (i=fullName.findRev('<'))!=-1)
+    if ((root->lang==SrcLangExt_CSharp || root->lang==SrcLangExt_Java) && (i=fullName.find('<'))!=-1)
     {
       // a Java/C# generic class looks like a C++ specialization, so we need to split the
       // name and template arguments here


### PR DESCRIPTION
Proposed fix for #8495. See discussion therein.