### PR TITLE
Missing page when followed by mainpage

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2120,7 +2120,6 @@ static bool handleMainpage(yyscan_t yyscanner,const QCString &, const StringVect
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   bool stop=makeStructuralIndicator(yyscanner,Entry::MAINPAGEDOC_SEC);
-  yyextra->current->name = "";
   if (!stop)
   {
     yyextra->current->name = "mainpage";


### PR DESCRIPTION
When we have in one file a `\page` followed by a `\mainpage` than this page is not shown / completely ignored, an example:
```
@page pg_tst_1 Test 1

the 1 page

@mainpage Test MainPage

the mainpage
```
this problem is due to the fact that `handleMainPage` is called when a `\mainpage` command is found, and this is also the case at the end of the content of `\page` resulting in the fact that the name of this page is removed (and thus actually the complete page).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6445840/example.tar.gz)
