### PR TITLE
Confusing debug output for markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2695,7 +2695,7 @@ QCString Markdown::detab(const QCString &s,int &refIndent)
 
 //---------------------------------------------------------------------------
 
-QCString Markdown::process(const QCString &input, int &startNewlines)
+QCString Markdown::process(const QCString &input, int &startNewlines, bool fromParseInput)
 {
   if (input.isEmpty()) return input;
   int refIndent;
@@ -2718,7 +2718,14 @@ QCString Markdown::process(const QCString &input, int &startNewlines)
   m_out.clear();
   processInline(s.data(),s.length());
   m_out.addChar(0);
-  Debug::print(Debug::Markdown,0,"======== Markdown =========\n---- input ------- \n%s\n---- output -----\n%s\n=========\n",qPrint(input),qPrint(m_out.get()));
+  if (fromParseInput)
+  {
+    Debug::print(Debug::Markdown,0,"---- output -----\n%s\n=========\n",qPrint(m_out.get()));
+  }
+  else
+  {
+    Debug::print(Debug::Markdown,0,"======== Markdown =========\n---- input ------- \n%s\n---- output -----\n%s\n=========\n",qPrint(input),qPrint(m_out.get()));
+  }
 
   // post processing
   QCString result = substitute(m_out.get(),g_doxy_nsbp,"&nbsp;");
@@ -2785,6 +2792,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
   current->docFile  = fileName;
   current->docLine  = 1;
   QCString docs = fileBuf;
+  Debug::print(Debug::Markdown,0,"======== Markdown =========\n---- input ------- \n%s\n",qPrint(fileBuf));
   QCString id;
   Markdown markdown(fileName,1,0);
   QCString title=markdown.extractPageTitle(docs,id,prepend).stripWhiteSpace();
@@ -2827,7 +2835,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
   Protection prot=Public;
   bool needsEntry = FALSE;
   int position=0;
-  QCString processedDocs = markdown.process(docs,lineNr);
+  QCString processedDocs = markdown.process(docs,lineNr,true);
   while (p->commentScanner.parseCommentBlock(
         this,
         current.get(),

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -33,7 +33,7 @@ class Markdown
 {
   public:
     Markdown(const QCString &fileName,int lineNr,int indentLevel=0);
-    QCString process(const QCString &input, int &startNewlines);
+    QCString process(const QCString &input, int &startNewlines, bool fromParseInput = false);
     QCString extractPageTitle(QCString &docs,QCString &id,int &prepend);
     void setIndentLevel(int level) { m_indentLevel = level; }
 


### PR DESCRIPTION
When having debug output one expects to have an overview what goes into the markdown processor and comes out of it. For markdown this happens but there can be a small step in front of it (page handling) and than the input is confusing as some processing already took place.

When having a file aa.md:
```
This is a .md file
```
we get with `doxygen -d markdown`:
```
======== Markdown =========
---- input -------
@page md_aa aa\ilinebr This is a .md file

---- output -----
@page md_aa aa\ilinebr This is a .md file

=========
```
whilst it would be less confusing when we have:
```
======== Markdown =========
---- input -------
This is a .md file

---- output -----
@page md_aa aa\ilinebr This is a .md file

=========
```
Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6457671/example.tar.gz)
