### PR TITLE
issue #8541 Javadoc: external links to classes in java.lang are not resolved

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7563,8 +7563,8 @@ static void parseMain(yyscan_t yyscanner,
   }
   else if ( yyextra->insideJava )
   {
-    QCString scope="java.lang.*";
-    yyextra->current->name=removeRedundantWhiteSpace(substitute(scope.left(scope.length()-1),".","::"));
+    QCString scope="java.lang";
+    yyextra->current->name=removeRedundantWhiteSpace(substitute(scope,".","::"));
     yyextra->current->fileName = yyextra->yyFileName;
     yyextra->current->section=Entry::USINGDIR_SEC;
     yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7561,6 +7561,16 @@ static void parseMain(yyscan_t yyscanner,
   {
     BEGIN( FindMembersPHP );
   }
+  else if ( yyextra->insideJava )
+  {
+    QCString scope="java.lang.*";
+    yyextra->current->name=removeRedundantWhiteSpace(substitute(scope.left(scope.length()-1),".","::"));
+    yyextra->current->fileName = yyextra->yyFileName;
+    yyextra->current->section=Entry::USINGDIR_SEC;
+    yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
+    initEntry(yyscanner);
+    BEGIN( FindMembers );
+  }
   else
   {
     BEGIN( FindMembers );


### PR DESCRIPTION
Adding the default packages from "java.lang"
From the standard "The Java® Language, Specification, Java SE 16 Edition" ,Chapter 7, Packages and Modules:

> Code in a compilation unit automatically has access to all classes and interfaces
> declared in its package and also automatically imports all of the public classes and
> interfaces declared in the predefined package java.lang.