### PR TITLE
Formulas with a new environment handled as inline formulas

### DIFF
--- a/src/docparser.h
+++ b/src/docparser.h
@@ -642,7 +642,11 @@ class DocFormula : public DocNode
     QCString relPath() const    { return m_relPath; }
     int id() const             { return m_id; }
     void accept(DocVisitor *v) override { v->visit(this); }
-    bool isInline()            { return m_text.length()>1 ? !(m_text.at(0)=='\\' && (m_text.at(1)=='{' || m_text.at(1)=='[')): TRUE; }
+    bool isInline()            {
+      if (m_text.length()>1 && m_text.at(0)=='\\' && m_text.at(1)=='[') return false;
+      if (m_text.length()>7 && m_text.startsWith("\\begin{")) return false;
+      return true;
+    }
 
   private:
     QCString  m_name;


### PR DESCRIPTION
As a regression of #8509 formulas that start a new environment (`\f{`) were considered as inline formulas as the inline test looked for `\{` but should look for `\begin{`.

Seen through CGAL and doxygen's own documentation.