### PR TITLE
Empty class definition.

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1266,7 +1266,12 @@ void HtmlDocVisitor::visitPre(DocPara *p)
   //printf("  needsTag=%d\n",needsTag);
   // write the paragraph tag (if needed)
   if (needsTag)
-    m_t << "<p class=\"" << contexts[t] << "\"" << htmlAttribsToString(p->attribs()) << ">";
+  {
+    if (strlen(contexts[t]))
+      m_t << "<p class=\"" << contexts[t] << "\"" << htmlAttribsToString(p->attribs()) << ">";
+    else
+      m_t << "<p " << htmlAttribsToString(p->attribs()) << ">";
+  }
 }
 
 void HtmlDocVisitor::visitPost(DocPara *p)


### PR DESCRIPTION
In e.g. the HTML output of the doxygen documentation, chapter about formulas we see:
```
  <p class="">
```
this is a regressing due to commit:
```
Commit: bb89b8136ff835c8fbd9f313d58815c8f361dff9 [bb89b81]
Date: Thursday, March 4, 2021 9:14:49 PM

Refactoring: some cleanup and removed text direction logic
```
made test now so that no empty class can occur.