### PR TITLE
Inconsistent behavior between unknown command and unknown html entity

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -6771,6 +6771,7 @@ reparsetoken:
           }
           else
           {
+            m_children.push_back(std::make_unique<DocWord>(this,g_token->name));
             warn_doc_error(g_fileName,getDoctokinizerLineNr(),"Unsupported symbol %s found",
                 qPrint(g_token->name));
           }


### PR DESCRIPTION
When having:
```
/**
 * an unknown command \unkn
 *
 * an unknown html entity &bsol;
 */
void fie();
```
we get the, correct, warnings:
```
 warning: Found unknown command '\unkn'
 warning: Unsupported symbol &bsol; found
```
but contrary to ``unkn` the text for `&bsol;` is not echoed to the output.

See also the discussion at https://github.com/doxygen/doxygen/issues/8547#issuecomment-840848411

Example; [example.tar.gz](https://github.com/doxygen/doxygen/files/6478021/example.tar.gz)