### PR TITLE
No specific way to set class attributes of a treeview link.

### DIFF
--- a/templates/html/navtree.css
+++ b/templates/html/navtree.css
@@ -65,6 +65,9 @@
   padding:0px;
 }
 
+#nav-tree .link {
+}
+
 #nav-tree {
   padding: 0px 0px;
   background-color: #FAFAFF; 

--- a/templates/html/navtree.js
+++ b/templates/html/navtree.js
@@ -205,7 +205,7 @@ function newNode(o, po, text, link, childrenData, lastNode)
     } else {
       url = node.relpath+link;
     }
-    a.className = stripPath(link.replace('#',':'));
+    a.className = stripPath(link.replace('#',':')) + " link";
     if (link.indexOf('#')!=-1) {
       var aname = '#'+link.split('#')[1];
       var srcPage = stripPath(pathName());


### PR DESCRIPTION
A link in a navtree / treeview has not a general class attached to it so its properties can only be changed by means of the global `a` tag.
There is a class attached to it but this contains the link reference so it is possible to highlight an item in the treeview when clicking in the text part of the documentation on a link.
A general class has been added to the navtree link.