### PR TITLE
issue #8552 Javadoc: strange issue with @verbatim ... @endverbatim

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1479,7 +1479,7 @@ STopt  [^\n@\\]*
 
   /* ----- handle arguments of the preformatted block commands ------- */
 
-<FormatBlock>{CMD}("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"enddot"|"endcode"|"endmsc"|"endvhdlflow")/{NW} { // possible ends
+<FormatBlock>{CMD}("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endrtfonly"|"endmanonly"|"enddot"|"endcode"|"endmsc")/{NW} { // possible ends
                                           addOutput(yyscanner,yytext);
                                           if (&yytext[4]==yyextra->blockName) // found end of the block
                                           {

--- a/src/lexcode.l
+++ b/src/lexcode.l
@@ -727,9 +727,17 @@ NONLopt [^\n]*
 <DocBlock>{CMD}("f$"|"f["|"f{"|"f(") {
                             yyextra->CCodeBuffer += yytext;
                             yyextra->docBlockName=&yytext[1];
+                            if (yyextra->docBlockName.at(1)=='[')
+                            {
+                              yyextra->docBlockName.at(1)=']';
+                            }
                             if (yyextra->docBlockName.at(1)=='{')
                             {
                               yyextra->docBlockName.at(1)='}';
+                            }
+                            if (yyextra->docBlockName.at(1)=='(')
+                            {
+                              yyextra->docBlockName.at(1)=')';
                             }
                             yyextra->fencedSize=0;
                             yyextra->nestedComment=FALSE;
@@ -742,7 +750,14 @@ NONLopt [^\n]*
                             yyextra->nestedComment=FALSE;
                             BEGIN(DocCopyBlock);
                           }
-<DocBlock>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"code")/[^a-z_A-Z0-9\-] { // verbatim command (which could contain nested comments!)
+<DocBlock>{CMD}"startuml"/[^a-z_A-Z0-9\-] { // verbatim type command (which could contain nested comments!)
+                            yyextra->CCodeBuffer += yytext;
+                            yyextra->docBlockName="uml";
+                            yyextra->fencedSize=0;
+                            yyextra->nestedComment=FALSE;
+                            BEGIN(DocCopyBlock);
+                          }
+<DocBlock>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"msc"|"code")/[^a-z_A-Z0-9\-] { // verbatim command (which could contain nested comments!)
                             yyextra->CCodeBuffer += yytext;
                             yyextra->docBlockName=&yytext[1];
                             yyextra->fencedSize=0;
@@ -796,9 +811,12 @@ NONLopt [^\n]*
                           }
 <DocCopyBlock>[\\@]("f$"|"f]"|"f}"|"f)") {
                             yyextra->CCodeBuffer += yytext;
-                            BEGIN(DocBlock);
+                            if (yyextra->docBlockName==&yytext[1])
+                            {
+                              BEGIN(DocBlock);
+                            }
                           }
-<DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
+<DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endmsc"|"enduml"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
                             yyextra->CCodeBuffer += yytext;
                             if (&yytext[4]==yyextra->docBlockName)
                             {

--- a/src/lexscanner.l
+++ b/src/lexscanner.l
@@ -732,7 +732,14 @@ NONLopt [^\n]*
                             yyextra->nestedComment=FALSE;
                             BEGIN(DocCopyBlock);
                           }
-<DocBlock>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"code")/[^a-z_A-Z0-9\-] { // verbatim command (which could contain nested comments!)
+<DocBlock>{CMD}"startuml"/[^a-z_A-Z0-9\-] { // verbatim type command (which could contain nested comments!)
+                            yyextra->cCodeBuffer += yytext;
+                            yyextra->docBlockName="uml";
+                            yyextra->fencedSize=0;
+                            yyextra->nestedComment=FALSE;
+                            BEGIN(DocCopyBlock);
+                          }
+<DocBlock>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"msc"|"code")/[^a-z_A-Z0-9\-] { // verbatim command (which could contain nested comments!)
                             yyextra->cCodeBuffer += yytext;
                             yyextra->docBlockName=&yytext[1];
                             yyextra->fencedSize=0;
@@ -790,7 +797,7 @@ NONLopt [^\n]*
                               BEGIN(DocBlock);
                             }
                           }
-<DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
+<DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endmsc"|"enduml"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
                             yyextra->cCodeBuffer += yytext;
                             if (yyextra->docBlockName==&yytext[4])
                             {

--- a/src/lexscanner.l
+++ b/src/lexscanner.l
@@ -709,9 +709,17 @@ NONLopt [^\n]*
 <DocBlock>{CMD}("f$"|"f["|"f{"|"f(") {
                             yyextra->cCodeBuffer += yytext;
                             yyextra->docBlockName=&yytext[1];
+                            if (yyextra->docBlockName.at(1)=='[')
+                            {
+                              yyextra->docBlockName.at(1)=']';
+                            }
                             if (yyextra->docBlockName.at(1)=='{')
                             {
                               yyextra->docBlockName.at(1)='}';
+                            }
+                            if (yyextra->docBlockName.at(1)=='(')
+                            {
+                              yyextra->docBlockName.at(1)=')';
                             }
                             yyextra->fencedSize=0;
                             yyextra->nestedComment=FALSE;
@@ -777,11 +785,14 @@ NONLopt [^\n]*
                           }
 <DocCopyBlock>[\\@]("f$"|"f]"|"f}"|"f)") {
                             yyextra->cCodeBuffer += yytext;
-                            BEGIN(DocBlock);
+                            if (yyextra->docBlockName==&yytext[1])
+                            {
+                              BEGIN(DocBlock);
+                            }
                           }
 <DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
                             yyextra->cCodeBuffer += yytext;
-                            if (&yytext[4]==yyextra->docBlockName)
+                            if (yyextra->docBlockName==&yytext[4])
                             {
                               BEGIN(DocBlock);
                             }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4534,7 +4534,12 @@ NONLopt [^\n]*
                                             unput(yyextra->lastCopyArgChar);
                                           BEGIN( yyextra->lastCommentInArgContext );
                                         }
-<CopyArgCommentLine>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"code")/[^a-z_A-Z0-9\-]   { // verbatim command (which could contain nested comments!)
+<CopyArgCommentLine>{CMD}"startuml"/[^a-z_A-Z0-9\-]   { // verbatim type command (which could contain nested comments!)
+                                          yyextra->docBlockName="uml";
+                                          yyextra->fullArgString+=yytext;
+                                          BEGIN(CopyArgVerbatim);
+                                        }
+<CopyArgCommentLine>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"msc"|"code")/[^a-z_A-Z0-9\-]   { // verbatim command (which could contain nested comments!)
                                           yyextra->docBlockName=&yytext[1];
                                           yyextra->fullArgString+=yytext;
                                           BEGIN(CopyArgVerbatim);
@@ -4556,7 +4561,7 @@ NONLopt [^\n]*
                                           yyextra->fullArgString+=yytext;
                                           BEGIN(CopyArgVerbatim);
                                         }
-<CopyArgVerbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endcode"|"f$"|"f]"|"f}"|"f)")/[^a-z_A-Z0-9\-] { // end of verbatim block
+<CopyArgVerbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"ebdmsc"|"enduml"|"endcode"|"f$"|"f]"|"f}"|"f)")/[^a-z_A-Z0-9\-] { // end of verbatim block
                                           yyextra->fullArgString+=yytext;
 					  if (yytext[1]=='f' && yyextra->docBlockName==&yytext[1])
                                           {
@@ -6579,7 +6584,14 @@ NONLopt [^\n]*
                                           yyextra->nestedComment=FALSE;
                                           BEGIN(DocCopyBlock);
                                         }
-<DocBlock>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"code")/[^a-z_A-Z0-9\-]     { // verbatim command (which could contain nested comments!)
+<DocBlock>{CMD}"startuml"/[^a-z_A-Z0-9\-]     { // verbatim command (which could contain nested comments!)
+                                          yyextra->docBlock << yytext;
+                                          yyextra->docBlockName="uml";
+                                          yyextra->fencedSize=0;
+                                          yyextra->nestedComment=FALSE;
+                                          BEGIN(DocCopyBlock);
+                                        }
+<DocBlock>{CMD}("verbatim"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"msc"|"code")/[^a-z_A-Z0-9\-]     { // verbatim command (which could contain nested comments!)
                                           yyextra->docBlock << yytext;
                                           yyextra->docBlockName=&yytext[1];
                                           yyextra->fencedSize=0;
@@ -6650,7 +6662,7 @@ NONLopt [^\n]*
                                             BEGIN(DocBlock);
                                           }
                                         }
-<DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
+<DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endmsc"|"enduml"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
                                           yyextra->docBlock << yytext;
                                           if (&yytext[4]==yyextra->docBlockName)
                                           {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4543,7 +4543,7 @@ NONLopt [^\n]*
                                           yyextra->docBlockName=&yytext[1];
                                           if (yyextra->docBlockName.at(1)=='[')
                                           {
-                                            yyextra->docBlockName.at(1)='}';
+                                            yyextra->docBlockName.at(1)=']';
                                           }
                                           if (yyextra->docBlockName.at(1)=='{')
                                           {
@@ -4558,7 +4558,7 @@ NONLopt [^\n]*
                                         }
 <CopyArgVerbatim>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endcode"|"f$"|"f]"|"f}"|"f)")/[^a-z_A-Z0-9\-] { // end of verbatim block
                                           yyextra->fullArgString+=yytext;
-                                          if (yytext[1]=='f') // end of formula
+					  if (yytext[1]=='f' && yyextra->docBlockName==&yytext[1])
                                           {
                                             BEGIN(CopyArgCommentLine);
                                           }
@@ -6556,9 +6556,17 @@ NONLopt [^\n]*
 <DocBlock>{CMD}("f$"|"f["|"f{"|"f(")         {
                                           yyextra->docBlock << yytext;
                                           yyextra->docBlockName=&yytext[1];
+                                          if (yyextra->docBlockName.at(1)=='[')
+                                          {
+                                            yyextra->docBlockName.at(1)=']';
+                                          }
                                           if (yyextra->docBlockName.at(1)=='{')
                                           {
                                             yyextra->docBlockName.at(1)='}';
+                                          }
+                                          if (yyextra->docBlockName.at(1)=='(')
+                                          {
+                                            yyextra->docBlockName.at(1)=')';
                                           }
                                           yyextra->fencedSize=0;
                                           yyextra->nestedComment=FALSE;
@@ -6637,7 +6645,10 @@ NONLopt [^\n]*
                                         }
 <DocCopyBlock>[\\@]("f$"|"f]"|"f}"|"f)")     {
                                           yyextra->docBlock << yytext;
-                                          BEGIN(DocBlock);
+                                          if (yyextra->docBlockName==&yytext[1])
+                                          {
+                                            BEGIN(DocBlock);
+                                          }
                                         }
 <DocCopyBlock>[\\@]("endverbatim"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
                                           yyextra->docBlock << yytext;


### PR DESCRIPTION
The end condition of a block was not detected correctly. in `scanner.l` (and thus `lexscanner.l` too) either the second part was missing or the compete test was missing.
Furthermore some conditions weren't handled correctly / incomplete.