### PR TITLE
Extra settings for MathJax V3

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -449,6 +449,7 @@ static QCString substituteHtmlKeywords(const QCString &str,
 
     if (mathJaxVersion == "MathJax_3")
     {
+       mathJaxJs += "<script src=\"https://polyfill.io/v3/polyfill.min.js?features=es6\"></script>\n"; 
        mathJaxJs += "<script>\n"
                     "  window.MathJax = {\n"
                     "    options: {\n"
@@ -459,7 +460,8 @@ static QCString substituteHtmlKeywords(const QCString &str,
       if (!mathJaxExtensions.empty() || !g_latex_macro.isEmpty())
       {
         mathJaxJs+= "    tex: {\n"
-                    "      packages: ['base'";
+                    "      macros: {},\n"
+                    "      packages: ['base','configmacros'";
         if (!g_latex_macro.isEmpty())
         {
           mathJaxJs+= ",'newcommand'";
@@ -469,9 +471,6 @@ static QCString substituteHtmlKeywords(const QCString &str,
           mathJaxJs+= ",'"+QCString(s.c_str())+"'";
         }
         mathJaxJs += "]\n"
-                      "    },\n"
-                      "    tex: {\n"
-                      "      macros: {}\n"
                       "    }\n";
       }
       mathJaxJs += "  };\n";

--- a/templates/html/header.html
+++ b/templates/html/header.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
-<meta http-equiv="X-UA-Compatible" content="IE=9"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
 <meta name="generator" content="Doxygen $doxygenversion"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->

--- a/templates/html/htmlbase.tpl
+++ b/templates/html/htmlbase.tpl
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
-<meta http-equiv="X-UA-Compatible" content="IE=9"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
 <meta name="generator" content="Doxygen {{ doxygen.version }}"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>{% if config.PROJECT_NAME %}{{ config.PROJECT_NAME }}: {% endif %}{{ page.title }}</title>


### PR DESCRIPTION
For support of the `\eqref` command (used in CGAL) in MathJax V3 a small change has to be made (for a rationale see the discussion on https://groups.google.com/g/mathjax-users/c/oS0yQLb5BMk)