### PR TITLE
Issue #8556 Removed bracket '(' in HTML an XML output

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1955,7 +1955,7 @@ NONLopt [^\n]*
                                             //printf("Found %s\n",qPrint(yyextra->current->name));
                                             BEGIN( ReadFuncArgType ) ;
                                           }
-                                          else if (yyextra->sharpCount<=0)
+                                          else
                                           {
                                              yyextra->current->name+="(";
                                              yyextra->roundCount++;


### PR DESCRIPTION
The opening bracket was "forgotten" when the sharp count > 0 (in this case 1). the closing bracket was later on added to the name so the opening bracket is also be added to the name.