### PR TITLE
Using spaces in a PREDEFINED setting

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -3258,22 +3258,16 @@ static void initPredefined(yyscan_t yyscanner,const QCString &fileName)
       size_t i=i_obrace+1;
       //printf("predefined function macro '%s'\n",ds.c_str());
       int count = 0;
-      reg::Iterator arg_it(ds,reId,i);
+      reg::Iterator arg_it(args,reId,0);
       // gather the formal arguments in a dictionary
       while (i<i_cbrace && arg_it!=end)
       {
         const auto &match = *arg_it;
-        size_t pi = match.position();
         size_t l  = match.length();
         if (l>0) // see bug375037
         {
           argMap.emplace(match.str(),count);
           count++;
-          i=pi+l;
-        }
-        else
-        {
-          i++;
         }
         ++arg_it;
       }


### PR DESCRIPTION
When having in the settings:
```
PREDEFINED += "HELP_DOT_SPACE( xs , ys , ... )=enum class xs { ys, __VA_ARGS__}"
```
we expect that the result is similar to when using a PREDEFINED setting:
```
#define LOC_SPACE( xs , ys , ... ) enum class xs { ys, __VA_ARGS__}
```
this is not the case especially due to the space after the last named argument.

We see that when we have:
```
LOC_SPACE(locSpace2, last);
```
we get
```
enum class   locSpace2 { last }
```
and when having:
```
HELP_DOT_SPACE(dotSpace2, last);
```
we get:
```
  HELP_DOT_SPACE (dotSpace2, last)
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6522682/example.tar.gz)
