### PR TITLE
#8569 Java, xml: members after certain comments with {@code} are missing

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -174,7 +174,7 @@ CCS   "/\*"
   // C end comment
 CCE   "*\/"
   // Cpp comment 
-CPPC  "/\/"
+CPPC  "//"
 
   // Optional any character
 ANYopt .*
@@ -323,13 +323,16 @@ SLASHopt [/]*
 				     yyextra->inRoseComment=TRUE;
 				     BEGIN(SComment);
   				   }
-<Scan>{CPPC}[!\/]/.*\n[ \t]*{CPPC}[|\/][ \t]*[@\\]"}" { // next line contains an end marker, see bug 752712
+<Scan>{CPPC}[!\/]/.*\n[ \t]*{CPPC}[!\/][ \t]*[@\\]"}" { // next line contains an end marker, see bug 752712
 				     yyextra->inSpecialComment=yytext[2]=='/' || yytext[2]=='!';
   				     copyToOutput(yyscanner,yytext,(int)yyleng); 
 				     yyextra->readLineCtx=YY_START;
 				     BEGIN(ReadLine);
                                    }
-<Scan>{CPPC}/.*\n	                   { /* one line C++ comment */ 
+<Scan>{CPPC}[^!/].*\n              { /* one line normal C++ comment */
+                                     copyToOutput(yyscanner,yytext,(int)yyleng);
+                                   }
+<Scan>{CPPC}/.*\n	           { /* one line doxygen C++ comment */
 				     yyextra->inSpecialComment=yytext[2]=='/' || yytext[2]=='!';
   				     copyToOutput(yyscanner,yytext,(int)yyleng); 
 				     yyextra->readLineCtx=YY_START;

--- a/src/pre.l
+++ b/src/pre.l
@@ -1631,6 +1631,18 @@ WSopt [ \t\r]*
 					    BEGIN(SkipCComment);
                                           }
   					}
+<*>{CPPC}[^/!].*\n                      {
+                                          if (YY_START==SkipVerbatim || YY_START==SkipCond || getLanguageFromFileName(yyextra->yyFileName)==SrcLangExt_Fortran)
+                                          {
+                                            REJECT;
+                                          }
+                                          else
+                                          {
+  					    yyextra->yyLineNr++;
+                                            yyextra->isSpecialComment = false;
+                                            outputArray(yyscanner,yytext,yyleng);
+                                          }
+                                        }
 <*>{CPPC}[/!]?				{
                                           if (YY_START==SkipVerbatim || YY_START==SkipCond || getLanguageFromFileName(yyextra->yyFileName)==SrcLangExt_Fortran)
                                           {


### PR DESCRIPTION
The handling of special commands in normal comment blocks (contrary to doxygen comment block starting with `///`, `//!`, `/**` and `/*!`) was done for compatibility with, the now obsolete / unmaintained / dead package Doc++.
This compatibility was already dropped for some commands / languages but will now be dropped in general.

This patch handles the situation wit non-doxygen comments `//`, the situation with `/*` will be handled separately.