### PR TITLE
Incorrect warning for \ref comand

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -385,7 +385,7 @@ ATTRIB    {ATTRNAME}{WS}*("="{WS}*(("\""[^\"]*"\"")|("'"[^\']*"'")|[^ \t\r\n'"><
 URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=\x80-\xFF]
 URLMASK   ({URLCHAR}+([({]{URLCHAR}*[)}])?)+
 URLPROTOCOL ("http:"|"https:"|"ftp:"|"ftps:"|"sftp:"|"file:"|"news:"|"irc:"|"ircs:")
-FILESCHAR [a-z_A-Z0-9\\:\\\/\-\+&#@]
+FILESCHAR [a-z_A-Z0-9\\:\\\/\-\+&#@\.]
 FILEECHAR [a-z_A-Z0-9\-\+&#@]
 HFILEMASK ("."{FILESCHAR}*{FILEECHAR}+)+
 FILEMASK  ({FILESCHAR}*{FILEECHAR}+("."{FILESCHAR}*{FILEECHAR}+)*)|{HFILEMASK}


### PR DESCRIPTION
When having references like in:
```
# Contribute & Develop

txt1 [contribution guidelines](d:/some/github/OK.md).

txt2 [contribution guidelines](d:/some/.github/wrong1.md).

txt3 [contribution guidelines](./.github/wrong2.md).

txt4 [contribution guidelines](.github/OK.md).

txt5 [contribution guidelines](.github/.github/wrong3.md).

txt6 [contribution guidelines](d:/some/git.hub/OK.md).

txt7 [contribution guidelines](./git.hub/OK.md).

txt8 [contribution guidelines](git.hub/OK.md).

txt9 [contribution guidelines](git.hub/git.hub/OK.md).
```
We get the warnings like:
```
.../aa.md:3: warning: unable to resolve reference to 'd:/some/github/OK.md' for \ref command
.../aa.md:5: warning: unable to resolve reference to 'd:/some' for \ref command
.../aa.md:7: warning: unexpected token TK_EOF as the argument of ref
.../aa.md:9: warning: unable to resolve reference to '.github/OK.md' for \ref command
.../aa.md:11: warning: unable to resolve reference to '.github' for \ref command
.../aa.md:13: warning: unable to resolve reference to 'd:/some/git.hub/OK.md' for \ref command
.../aa.md:15: warning: unable to resolve reference to './git.hub/OK.md' for \ref command
.../aa.md:17: warning: unable to resolve reference to 'git.hub/OK.md' for \ref command
.../aa.md:19: warning: unable to resolve reference to 'git.hub/git.hub/OK.md' for \ref command
```
Where we see that the warnings for the lines 5,7 and 11 are a bit strange / incorrect (in the original indicated with `wrong`.
We should similar warnings for all lines like, so for the wrong ones also:
```
.../aa.md:5: warning: unable to resolve reference to 'd:/some/.github/wrong1.md' for \ref command
.../aa.md:7: warning: unable to resolve reference to './.github/wrong2.md' for \ref command
.../aa.md:11: warning: unable to resolve reference to '.github/.github/wrong3.md' for \ref command
```

An argument as `.github` is a hidden directory is of no concern to doxygen (especially as for `.github/OK.md` we get the right warning)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6570672/example.tar.gz)
