### PR TITLE
Running tests with subdirs enabled

### DIFF
--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -257,6 +257,7 @@ class Tester:
 						else:
 							check_file = check_file[0]
 					# convert output to canonical form
+					check_file = check_file.replace('\\','/')
 					data = xpopen('%s --format --noblanks --nowarning %s' % (self.args.xmllint,check_file))
 					if data:
 						# strip version
@@ -264,6 +265,8 @@ class Tester:
 					else:
 						msg += ('Failed to run %s on the doxygen output file %s' % (self.args.xmllint,self.test_out),)
 						break
+					if self.args.subdirs:
+						data = re.sub('d[0-9a-f]/d[0-9a-f][0-9a-f]/','',data)
 					out_file='%s/%s' % (self.test_out,check)
 					with xopen(out_file,'w') as f:
 						print(data,file=f)


### PR DESCRIPTION
When running the standard doxygen tests with subdirs enabled (i.e. on windows `nmake tests TESTS_FLAGS==--subdirs`) we get the following type errors:
```
Failed to run xmllint on the doxygen output file ..../testing/test_output_008
```
this is due to the fact that the file to be checked is in a subdirectory and as directory separator a backslash is used (initially there are 2 backslashes but due to e.g. `check_file = check_file[0]` one backslash disappears. Furthermore everywhere else the backslashes are converted to forward slashes.

In the resulting files there are references to the mentioned sub directories path, but the file to compare to is without these so we have to filter them as well.