### PR TITLE
Problem with cite command (tests 12)

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1190,7 +1190,14 @@ void DocbookDocVisitor::visitPre(DocHRef *href)
 {
 DB_VIS_C
   if (m_hide) return;
-  m_t << "<link xlink:href=\"" << convertToDocBook(href->url()) << "\">";
+  if (href->url().at(0) != '#')
+  {
+    m_t << "<link xlink:href=\"" << convertToDocBook(href->url()) << "\">";
+  }
+  else
+  {
+    startLink(href->file(),filterId(href->url().mid(1)));
+  }
 }
 
 void DocbookDocVisitor::visitPost(DocHRef *)

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1016,7 +1016,9 @@ static int handleAHref(DocNode *parent,DocNodeList &children,const HtmlAttribLis
       HtmlAttribList attrList = tagHtmlAttribs;
       // and remove the href attribute
       attrList.erase(attrList.begin()+index);
-      DocHRef *href = new DocHRef(parent,attrList,opt.value,g_relPath);
+      QCString relPath;
+      if (opt.value.at(0) != '#') relPath = g_relPath;
+      DocHRef *href = new DocHRef(parent,attrList,opt.value,relPath,convertNameToFile(g_fileName,FALSE,TRUE));
       children.push_back(std::unique_ptr<DocHRef>(href));
       g_insideHtmlLink=TRUE;
       retval = href->parse();

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -915,10 +915,11 @@ class DocHRef : public CompAccept<DocHRef>
 {
   public:
     DocHRef(DocNode *parent,const HtmlAttribList &attribs,const QCString &url,
-           const QCString &relPath) :
-      m_attribs(attribs), m_url(url), m_relPath(relPath) { m_parent = parent; }
+           const QCString &relPath, const QCString &file) :
+      m_attribs(attribs), m_url(url), m_relPath(relPath), m_file(file) { m_parent = parent; }
     int parse();
     QCString url() const        { return m_url; }
+    QCString file() const       { return m_file; }
     QCString relPath() const    { return m_relPath; }
     Kind kind() const override           { return Kind_HRef; }
     const HtmlAttribList &attribs() const { return m_attribs; }
@@ -926,6 +927,7 @@ class DocHRef : public CompAccept<DocHRef>
   private:
     HtmlAttribList m_attribs;
     QCString   m_url;
+    QCString   m_file;
     QCString   m_relPath;
 };
 

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1135,12 +1135,11 @@ void RTFDocVisitor::visitPre(DocHRef *href)
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocHRef)}\n");
   if (Config_getBool(RTF_HYPERLINKS))
   {
-    if (href->url().startsWith("#CITEREF"))
+    if (href->url().startsWith("#"))
     {
-      // when starting with #CITEREF it is a doxygen generated "url"a
-      // so a local link
+      // when starting with # so a local link
       QCString cite;
-      cite = "citelist_" + href->url().right(href->url().length()-1);
+      cite = href->file() + "_" + href->url().right(href->url().length()-1);
       m_t << "{\\field "
                "{\\*\\fldinst "
                  "{ HYPERLINK \\\\l \"" << rtfFormatBmkStr(cite) << "\" "

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5179,6 +5179,12 @@ QCString rtfFormatBmkStr(const QCString &name)
   // substitute a short arbitrary string for the name
   // supplied, and keep track of the correspondence
   // between names and strings.
+  auto it = g_tagMap.find(name.str());
+  if (it!=g_tagMap.end()) // already known
+  {
+    return QCString(it->second);
+  }
+
   QCString tag = g_nextTag;
   auto result = g_tagMap.insert( std::make_pair(name.str(), g_nextTag.str()) );
 


### PR DESCRIPTION
When running a link checker over the (x)html results of the doxygen tests 12 and subdirs enabled we get the error:
```
Processing      file:///.../testing/test_output_012/html/d0/de3/citelist.xhtml

List of broken links and other issues:
file:///..../testing/test_output_012/html/
 Lines: 70, 74
  Code: 200 (no message)
 To do: Some of the links to this resource point to broken URI fragments
        (such as index.html#fragment).
The following fragments need to be fixed:
        CITEREF_LeLe12                  Lines: 70, 74
```

Also looking at the results of  rtf and docbook output we see incorrect links.
With the rtf links there is a subsequent problem of not returning the right "label" (see util.h).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6609117/example.tar.gz)
