### PR TITLE
issue #8585 INLINE_SOURCES = YES do not generate code inline from sources if there is no @return after @brief.

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1334,6 +1334,16 @@ void DefinitionImpl::writeSourceRefs(OutputList &ol,const QCString &scopeName) c
   _writeSourceRefList(ol,scopeName,theTranslator->trReferences(),m_impl->sourceRefsDict,TRUE);
 }
 
+bool DefinitionImpl::hasSourceReffedBy() const
+{
+  return !m_impl->sourceRefByDict.empty();
+}
+
+bool DefinitionImpl::hasSourceRefs() const
+{
+  return !m_impl->sourceRefsDict.empty();
+}
+
 bool DefinitionImpl::hasDocumentation() const
 {
   static bool extractAll    = Config_getBool(EXTRACT_ALL);

--- a/src/definition.h
+++ b/src/definition.h
@@ -379,6 +379,8 @@ class DefinitionMutable
     //-----------------------------------------------------------------------------------
     virtual void writeSourceDef(OutputList &ol,const QCString &scopeName) const = 0;
     virtual void writeInlineCode(OutputList &ol,const QCString &scopeName) const = 0;
+    virtual bool hasSourceRefs() const = 0;
+    virtual bool hasSourceReffedBy() const = 0;
     virtual void writeSourceRefs(OutputList &ol,const QCString &scopeName) const = 0;
     virtual void writeSourceReffedBy(OutputList &ol,const QCString &scopeName) const = 0;
     virtual void writeNavigationPath(OutputList &ol) const = 0;

--- a/src/definitionimpl.h
+++ b/src/definitionimpl.h
@@ -103,6 +103,8 @@ class DefinitionImpl
     void setLanguage(SrcLangExt lang);
     void writeSourceDef(OutputList &ol,const QCString &scopeName) const;
     void writeInlineCode(OutputList &ol,const QCString &scopeName) const;
+    bool hasSourceRefs() const;
+    bool hasSourceReffedBy() const;
     void writeSourceRefs(OutputList &ol,const QCString &scopeName) const;
     void writeSourceReffedBy(OutputList &ol,const QCString &scopeName) const;
     void makePartOfGroup(const GroupDef *gd);
@@ -245,6 +247,10 @@ class DefinitionMixin : public Base
     { m_impl.writeSourceDef(ol,scopeName); }
     virtual void writeInlineCode(OutputList &ol,const QCString &scopeName) const
     { m_impl.writeInlineCode(ol,scopeName); }
+    virtual bool hasSourceRefs() const
+    { return m_impl.hasSourceRefs(); }
+    virtual bool hasSourceReffedBy() const
+    { return m_impl.hasSourceReffedBy(); }
     virtual void writeSourceRefs(OutputList &ol,const QCString &scopeName) const
     { m_impl.writeSourceRefs(ol,scopeName); }
     virtual void writeSourceReffedBy(OutputList &ol,const QCString &scopeName) const

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -239,6 +239,9 @@ class MemberDef : public Definition
     virtual bool hasReferencesRelation() const = 0;
     virtual bool hasReferencedByRelation() const = 0;
 
+    virtual bool hasMemberSourceRefs() const = 0;
+    virtual bool hasMemberSourceReffedBy() const = 0;
+
     virtual const MemberDef *templateMaster() const = 0;
     virtual QCString getScopeString() const = 0;
     virtual ClassDef *getClassDefOfAnonymousType() const = 0;


### PR DESCRIPTION
- Extended tests for the determination whether or not detailed section is available
- Corrected links in the brief section part depending on the presence  / not present detailed documentation