### PR TITLE
issue #8591 Doxygen comment suggestion in help collides with clang-format

### DIFF
--- a/doc/docblocks.doc
+++ b/doc/docblocks.doc
@@ -113,7 +113,10 @@ documentation. For this purpose you can use the following:
  *  ... text
  ***********************************************/
 \endverbatim
-(note the 2 slashes to end the normal comment block and start a special comment block).
+Note: the 2 slashes to end the normal comment block and start a special comment block.
+
+Note: be careful when using a reformatter as a reformatter can see this type of comment
+as 2 separate comments resulting in non expected comment formatting.
 
 or
 


### PR DESCRIPTION
Added a general warning about the `/****//**` type of comment