### PR TITLE
bug_765867 Ampersand not rendered correctly in HTML Help index

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -262,7 +262,7 @@ void HtmlHelpIndex::writeFields(std::ostream &t)
         t << "  <LI><OBJECT type=\"text/sitemap\">";
         t << "<param name=\"Local\" value=\"" << field2URL(f.get(),FALSE);
         t << "\">";
-        t << "<param name=\"Name\" value=\"" << m_recoder.recode(level1) << "\">"
+        t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">"
            "</OBJECT>\n";
       }
       else
@@ -272,14 +272,14 @@ void HtmlHelpIndex::writeFields(std::ostream &t)
           t << "  <LI><OBJECT type=\"text/sitemap\">";
           t << "<param name=\"Local\" value=\"" << field2URL(f.get(),TRUE);
           t << "\">";
-          t << "<param name=\"Name\" value=\"" << m_recoder.recode(level1) << "\">"
+          t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">"
                "</OBJECT>\n";
         }
         else
         {
           t << "  <LI><OBJECT type=\"text/sitemap\">";
-          t << "<param name=\"See Also\" value=\"" << m_recoder.recode(level1) << "\">";
-          t << "<param name=\"Name\" value=\"" << m_recoder.recode(level1) << "\">"
+          t << "<param name=\"See Also\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">";
+          t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">"
                "</OBJECT>\n";
         }
       }
@@ -299,7 +299,7 @@ void HtmlHelpIndex::writeFields(std::ostream &t)
       t << "    <LI><OBJECT type=\"text/sitemap\">";
       t << "<param name=\"Local\" value=\"" << field2URL(f.get(),FALSE);
       t << "\">";
-      t << "<param name=\"Name\" value=\"" << m_recoder.recode(level2) << "\">"
+      t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level2),TRUE) << "\">"
          "</OBJECT>\n";
     }
   }


### PR DESCRIPTION
Corresponds to issue #5994

In the index the (index.hhk) the special HTML characters were not escaped (as done for the index.hhc (see HtmlHelp::addContentsItem). This is corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6630789/example.tar.gz)


Old output in chm file:
![image](https://user-images.githubusercontent.com/5223533/121514919-dbadd700-c9ec-11eb-87f6-df8392b9e4ef.png)

Corrected output:
![image](https://user-images.githubusercontent.com/5223533/121515023-fb44ff80-c9ec-11eb-92cf-46eedc5632a3.png)

