### PR TITLE
Compilation warnings regarding reordering

### DIFF
--- a/src/docparser.h
+++ b/src/docparser.h
@@ -927,8 +927,8 @@ class DocHRef : public CompAccept<DocHRef>
   private:
     HtmlAttribList m_attribs;
     QCString   m_url;
-    QCString   m_file;
     QCString   m_relPath;
+    QCString   m_file;
 };
 
 /** Node Html heading */


### PR DESCRIPTION
For a number of files we get a warning (gcc  10.2.0 and 7.5.0 and on MacOS) similar to:
```
In file included from .../src/util.h:31,
                 from .../src/xmlgen.cpp:24:
.../src/docparser.h: In constructor ‘DocHRef::DocHRef(DocNode*, const HtmlAttribList&, const QCString&, const QCString&, const QCString&)’:
.../src/docparser.h:931:16: warning: ‘DocHRef::m_relPath’ will be initialized after [-Wreorder]
  931 |     QCString   m_relPath;
      |                ^~~~~~~~~
.../src/docparser.h:930:16: warning:   ‘QCString DocHRef::m_file’ [-Wreorder]
  930 |     QCString   m_file;
      |                ^~~~~~
.../src/docparser.h:917:5: warning:   when initialized here [-Wreorder]
  917 |     DocHRef(DocNode *parent,const HtmlAttribList &attribs,const QCString &url,
      |     ^~~~~~~
```