### PR TITLE
Merged brief and detailed description in case if INLINE_SIMPLE_STRUCTS with LaTeX / RTF

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3770,6 +3770,12 @@ void MemberDefImpl::writeMemberDocSimple(OutputList &ol, const Definition *conta
   /* write detailed description */
   if (!detailed.isEmpty())
   {
+    if (!brief.isEmpty())
+    {
+      ol.disable(OutputGenerator::Html);
+      ol.lineBreak();
+      ol.enable(OutputGenerator::Html);
+    }
     ol.generateDoc(docFile(),docLine(),
                 getOuterScope()?getOuterScope():container,this,
                 detailed+"\n",FALSE,FALSE,


### PR DESCRIPTION
When we have a program like:
```
/** \file */

/** outer */
struct Outer
{
  /** foo */
  union Foo
  {
    /** Bar */
    struct FooFlags
    {
      bool cond1; /*!< \brief bar 1
                   *   \details details1 bar 1
                   */
      bool cond2; /*!< bar 2 */
    } flags; /*!< \brief foo bar
              *   \details details2 of foo bar
              */
  } myMember; /*!< public member */
private:
  void myWork(); /*!< private member function */
};
```
and a Doxyfile like
```
INLINE_SIMPLE_STRUCTS  = YES
QUIET=YES
GENERATE_RTF=YES
```
We see in HTML that brief and detailed description start on a separate line, but for LaTeX and RTF (it is not implemented in docbook) the detailed description directly follows the brief description without a line separator.

In HTML we currently see:

![image](https://user-images.githubusercontent.com/5223533/121806057-7a853e00-cc4e-11eb-970e-57acc37eab2f.png)


But in e.g. LaTeX we see:

![image](https://user-images.githubusercontent.com/5223533/121806085-a9031900-cc4e-11eb-88d1-7aa98f4816e7.png)

and with this patch:

![image](https://user-images.githubusercontent.com/5223533/121806125-f1223b80-cc4e-11eb-97b2-c2149a2e942d.png)



Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6643820/example.tar.gz)
