### PR TITLE
Implementation functions for INLINE_SIMPLE_STRUCTS for docbook output

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -856,7 +856,7 @@ void DocbookGenerator::startDoxyAnchor(const QCString &fName,const QCString &,
                                  const QCString &)
 {
 DB_GEN_C
-  if (!m_inListItem[m_levelListItem] && !m_descTable)
+  if (!m_inListItem[m_levelListItem] && !m_descTable && !m_simpleTable)
   {
     if (!m_firstMember) m_t << "    </section>";
     m_firstMember = FALSE;
@@ -1028,6 +1028,77 @@ void DocbookGenerator::addIndexItem(const QCString &prim,const QCString &sec)
 {
 DB_GEN_C
   addIndexTerm(m_t, prim, sec);
+}
+
+void DocbookGenerator::startMemberDocSimple(bool isEnum)
+{
+DB_GEN_C
+  int ncols;
+  QCString title;
+  if (isEnum)
+  {
+    ncols = 2;
+    title = theTranslator->trEnumerationValues();
+  }
+  else
+  {
+    ncols = 3;
+    title = theTranslator->trCompoundMembers();
+  }
+  m_t << "<table frame=\"all\">\n";
+  if (!title.isEmpty()) m_t << "<title>" << convertToDocBook(title) << "</title>\n";
+  m_t << "    <tgroup cols=\"" << ncols << "\" align=\"left\" colsep=\"1\" rowsep=\"1\">\n";
+  for (int i = 0; i < ncols; i++)
+  {
+    m_t << "      <colspec colname='c" << i+1 << "'/>\n";
+  }
+  m_t << "<tbody>\n";
+  m_simpleTable = true;
+}
+
+void DocbookGenerator::endMemberDocSimple(bool isEnum)
+{
+DB_GEN_C
+  m_t << "    </tbody>\n";
+  m_t << "    </tgroup>\n";
+  m_t << "</table>\n";
+  m_simpleTable = false;
+}
+
+void DocbookGenerator::startInlineMemberType()
+{
+DB_GEN_C
+  m_t << "<row><entry>";
+}
+
+void DocbookGenerator::endInlineMemberType()
+{
+DB_GEN_C
+  m_t << "</entry>";
+}
+
+void DocbookGenerator::startInlineMemberName()
+{
+DB_GEN_C
+  m_t << "<entry>";
+}
+
+void DocbookGenerator::endInlineMemberName()
+{
+DB_GEN_C
+  m_t << "</entry>";
+}
+
+void DocbookGenerator::startInlineMemberDoc()
+{
+DB_GEN_C
+  m_t << "<entry>";
+}
+
+void DocbookGenerator::endInlineMemberDoc()
+{
+DB_GEN_C
+  m_t << "</entry></row>\n";
 }
 
 void DocbookGenerator::startDescTable(const QCString &title)

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -321,14 +321,14 @@ class DocbookGenerator : public OutputGenerator
     void endConstraintDocs();
     void endConstraintList();
 
-    void startMemberDocSimple(bool){DB_GEN_NEW};
-    void endMemberDocSimple(bool){DB_GEN_NEW};
-    void startInlineMemberType(){DB_GEN_NEW};
-    void endInlineMemberType(){DB_GEN_NEW};
-    void startInlineMemberName(){DB_GEN_NEW};
-    void endInlineMemberName(){DB_GEN_NEW};
-    void startInlineMemberDoc(){DB_GEN_NEW};
-    void endInlineMemberDoc(){DB_GEN_NEW};
+    void startMemberDocSimple(bool);
+    void endMemberDocSimple(bool);
+    void startInlineMemberType();
+    void endInlineMemberType();
+    void startInlineMemberName();
+    void endInlineMemberName();
+    void startInlineMemberDoc();
+    void endInlineMemberDoc();
 
     void startLabels();
     void writeLabel(const QCString &,bool);
@@ -349,6 +349,7 @@ private:
     bool m_inListItem[20] = { false, };
     bool m_inSimpleSect[20] = { false, };
     bool m_descTable = false;
+    bool m_simpleTable = false;
     int m_inLevel = -1;
     bool m_firstMember = false;
 };


### PR DESCRIPTION
The implementation of the `INLINE_SIMPLE_STRUCTS` functions was missing for docbook.
The problem shows up when using e.g.
```
/** \file */

/** outer */
struct Outer
{
  /** foo */
  union Foo
  {
    /** Bar */
    struct FooFlags
    {
      bool cond1; /*!< \brief bar 1
                   *   \details details1 bar 1
                   */
      bool cond2; /*!< bar 2 */
    } flags; /*!< \brief foo bar
              *   \details details2 of foo bar
              */
  } myMember; /*!< public member */
private:
  void myWork(); /*!< private member function */
};
```
with
```
INLINE_SIMPLE_STRUCTS  = YES
QUIET=YES
GENERATE_DOCBOOK=YES
```

Note with the `INLINE_SIMPLE_STRUCTS` there is also a mismatch with the opening  and closing `section` tags, but that is unrelated to this implementation(in this case is is "solved" by adding a closing section tag to struct_outer.xml and removing the last closing section tag from structs_8hpp.xml

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6654130/example.tar.gz)
