### PR TITLE
EXTRACT_ALL should not trigger a link to a detailed section

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2528,7 +2528,6 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
 
 bool MemberDefImpl::isDetailedSectionLinkable() const
 {
-  static bool extractAll        = Config_getBool(EXTRACT_ALL);
   static bool alwaysDetailedSec = Config_getBool(ALWAYS_DETAILED_SEC);
   static bool repeatBrief       = Config_getBool(REPEAT_BRIEF);
   static bool briefMemberDesc   = Config_getBool(BRIEF_MEMBER_DESC);
@@ -2539,8 +2538,6 @@ bool MemberDefImpl::isDetailedSectionLinkable() const
 
   // the member has details documentation for any of the following reasons
   bool docFilter =
-         // treat everything as documented
-         extractAll ||
          // has detailed docs
          !documentation().isEmpty() ||
          // has inbody docs


### PR DESCRIPTION
A detailed section is not triggered by `EXTRACT_ALL=YES` but by other instances like having a detailed description etc.

This is a regression on issue #8585  / pull request #8592, with CGAL numerous references (More ...) appeared to non existing detailed sections.