### PR TITLE
issue #8604 `LATEX_BATCHMODE` not used for formulas anymore

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3010,8 +3010,7 @@ The following block name is set based on whether or not a feature is used in the
  If the \c LATEX_BATCHMODE tag is set to \c YES, doxygen will add the \c \\batchmode
  command to the generated \f$\mbox{\LaTeX}\f$ files. This will
  instruct \f$\mbox{\LaTeX}\f$ to keep running if errors occur, instead of
- asking the user for help. This option is also used when generating formulas
- in HTML.
+ asking the user for help.
 ]]>
       </docs>
     </option>

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -155,7 +155,6 @@ void FormulaManager::generateImages(const QCString &path,Format format,HighDPI h
   if (f.is_open())
   {
     TextStream t(&f);
-    if (Config_getBool(LATEX_BATCHMODE)) t << "\\batchmode\n";
     t << "\\documentclass{article}\n";
     t << "\\usepackage{ifthen}\n";
     t << "\\usepackage{epsfig}\n"; // for those who want to include images


### PR DESCRIPTION
The `LATEX_BATCHMODE` setting is not used anymore for formulas since:
```
Commit: 10b2b8fc694b60a17ccd2642f3a40c851e33b9da [10b2b8f]
Date: Wednesday, February 12, 2020 9:08:11 PM
Improve formula handling and rendering.
```
but there were still references in the formulas code and in the documentation.