### PR TITLE
Incorrect docbook output (section tag  mismatch)

### DIFF
--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -344,7 +344,6 @@ private:
     bool m_prettyCode = Config_getBool(DOCBOOK_PROGRAMLISTING);
     bool m_denseText = false;
     bool m_inGroup = false;
-    bool m_inDetail = false;
     int  m_levelListItem = 0;
     bool m_inListItem[20] = { false, };
     bool m_inSimpleSect[20] = { false, };
@@ -352,6 +351,7 @@ private:
     bool m_simpleTable = false;
     int m_inLevel = -1;
     bool m_firstMember = false;
+    int m_openSection = 0;
 };
 
 #endif


### PR DESCRIPTION
In case `INLINE_SIMPLE_STRUCTS` has been set the resulting opening / closing  section tags don't match.
This problem can be be seen with the doxygen tests 36, 67 and 68 and well as with the test case used for issue #8588
Instead of explicit using special flags now a general close is done (in the cases examined no problems were found with this strategy).