### PR TITLE
List item problem

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -545,7 +545,7 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
                              g_token->id         = std::stoul(match.str());
                            } catch (...) {
                              g_token->id         = -1;
-                             warn(g_fileName,g_yyLineNr,"Unexpected number for list item '%s' ",match.str());
+                             warn(g_fileName,g_yyLineNr,"Unexpected number for list item '%s' ",match.str().c_str());
                            }
                            g_token->indent     = computeIndent(yytext,markPos);
                            return TK_LISTITEM;
@@ -600,7 +600,7 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
                              g_token->id         = std::stoul(match.str());
                            } catch (...) {
                              g_token->id         = -1;
-                             warn(g_fileName,g_yyLineNr,"Unexpected number for list item '%s' ",match.str());
+                             warn(g_fileName,g_yyLineNr,"Unexpected number for list item '%s' ",match.str().c_str());
                            }
                            g_token->indent     = computeIndent(text.c_str(),markPos);
                            return TK_LISTITEM;

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -541,7 +541,12 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
                            size_t markPos = match.position();
                            assert(markPos!=std::string::npos);
                            g_token->isEnumList = true;
-                           g_token->id         = std::stoul(match.str());
+                           try {
+                             g_token->id         = std::stoul(match.str());
+                           } catch (...) {
+                             g_token->id         = -1;
+                             warn(g_fileName,g_yyLineNr,"Unexpected number for list item '%s' ",match.str());
+                           }
                            g_token->indent     = computeIndent(yytext,markPos);
                            return TK_LISTITEM;
                          }
@@ -591,7 +596,12 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
                            size_t markPos = match.position();
                            assert(markPos!=std::string::npos);
                            g_token->isEnumList = true;
-                           g_token->id         = std::stoul(match.str());
+                           try {
+                             g_token->id         = std::stoul(match.str());
+                           } catch (...) {
+                             g_token->id         = -1;
+                             warn(g_fileName,g_yyLineNr,"Unexpected number for list item '%s' ",match.str());
+                           }
                            g_token->indent     = computeIndent(text.c_str(),markPos);
                            return TK_LISTITEM;
                          }


### PR DESCRIPTION
When having:
```
111111111111111111111111111111111111111111. is this a valid bullet?
```
or

```
1. the first
111111111111111111111111111111111111111111. is this a valid bullet?
```

doxygen will stop working with no message on Windows or
```
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoul
```
on Linux

The actual calls:

111111111111111111111111111111111111111111. is this a valid bullet?

1. the first
111111111111111111111111111111111111111111. is this a valid bullet?

The problem has been solved by catching the exception thrown.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6685646/example.tar.gz)


(Found by Fossies for the cmark package)