### PR TITLE
Fix variable assignment to itself in util.cpp

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2062,7 +2062,7 @@ void mergeArguments(ArgumentList &srcAl,ArgumentList &dstAl,bool forceNameOverwr
         //printf("type: '%s':='%s'\n",qPrint(dstA.type),qPrint(srcA.type));
         //printf("name: '%s':='%s'\n",qPrint(dstA.name),qPrint(srcA.name));
         dstA.type = srcA.type;
-        dstA.name = dstA.name;
+        dstA.name = srcA.name;
       }
       else if (!srcA.name.isEmpty() && !dstA.name.isEmpty())
       {
@@ -2117,7 +2117,7 @@ void mergeArguments(ArgumentList &srcAl,ArgumentList &dstAl,bool forceNameOverwr
       //printf("type: '%s':='%s'\n",qPrint(dstA.type),qPrint(srcA.type));
       //printf("name: '%s':='%s'\n",qPrint(dstA.name),qPrint(srcA.name));
       dstA.type = srcA.type.left(i1+2)+dstA.type;
-      dstA.name = dstA.name;
+      dstA.name = srcA.name;
     }
     else if (i1==-1 && i2!=-1 && dstA.type.right(j2)==srcA.type)
     {


### PR DESCRIPTION
Issue was found by PVS-Studio static analysis tool.

Error reported:
/home/ralexe/Desktop/doxygen/src/util.cpp:2065: error: V570 The 'dstA.name' variable is assigned to itself.
/home/ralexe/Desktop/doxygen/src/util.cpp:2120: error: V570 The 'dstA.name' variable is assigned to itself.

The fix is simple, assigning srcA.name to dstA.name as it was the intention.

Thank you,
Razvan Alexe