### PR TITLE
bug_744840  <tt> blocks cause error "end of comment while expecting command </code>"

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -852,6 +852,9 @@ STopt  [^\n@\\]*
 <Comment>"...\\"[ \t]                   { // ellipsis with escaped space.
                                           addOutput(yyscanner,"... ");
                                         }
+<Comment>"..."/[^\.]                    { // ellipsis
+                                          addOutput(yyscanner,"...");
+                                        }
 <Comment>".."[\.]?/[^ \t\n]             { // internal ellipsis
                                           addOutput(yyscanner,yytext);
                                         }


### PR DESCRIPTION
The problem is cased due to setting of auto brief options, and the fact that `...` is not seen as a 'special character' but as the end of a brief comment.
(In the current master the warning is a bit better already:
```
warning: end of comment block while expecting command </tt>
```
but the root cause is still present).

Making the `....` to be seen as a 'special character'