### PR TITLE
issue #8615 Markdown **emphasis** at the beginning of the line is not rendered.

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -600,6 +600,21 @@ An emphasis or a strikethrough ends if
 
 Lastly, the span of the emphasis or strikethrough is limited to a single paragraph.
 
+Note When using emphasis by means of `*`s at the beginning of a line and a
+C-type doxygen comment block (`/&zwj;** ... *&zwj;/`) and not using an `*` as
+"lineup" doxygen will seen the sequence of `*`s at the beginning of the line as
+"lineup" and not as emphasis. So the following will not render as bold:
+\verbatim
+/**
+ **this is not bold**
+ */
+\endverbatim
+but will render as bold:
+\verbatim
+/**
+ * **this is bold**
+ */
+\endverbatim
 
 \subsection mddox_code_spans Code Spans Limits
 

--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -609,7 +609,7 @@ C-type doxygen comment block (`/&zwj;** ... *&zwj;/`) and not using an `*` as
  **this is not bold**
  */
 \endverbatim
-but will render as bold:
+but this will render as bold:
 \verbatim
 /**
  * **this is bold**

--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -600,7 +600,7 @@ An emphasis or a strikethrough ends if
 
 Lastly, the span of the emphasis or strikethrough is limited to a single paragraph.
 
-Note When using emphasis by means of `*`s at the beginning of a line and a
+Note that when using emphasis by means of `*`s at the beginning of a line and a
 C-type doxygen comment block (`/&zwj;** ... *&zwj;/`) and not using an `*` as
 "lineup" doxygen will seen the sequence of `*`s at the beginning of the line as
 "lineup" and not as emphasis. So the following will not render as bold:


### PR DESCRIPTION
The mentioned restrictions in the documentation are valid for markdown. When using C-type comment and no "lineup"  character, the start emphasis is seen as "lineup".
There is no real solution for this problem so a note in the documentation.