### PR TITLE
issue #8617 XML: Issue with $ sign in Java identifiers

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -270,7 +270,7 @@ static std::mutex g_countFlowKeywordsMutex;
 B       [ \t]
 Bopt    {B}*
 BN      [ \t\n\r]
-ID      "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+ID      "$"?[$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 SEP     ("::"|"\\")
 SCOPENAME ({SEP}{BN}*)?({ID}{BN}*{SEP}{BN}*)*("~"{BN}*)?{ID}
 TEMPLIST "<"[^\"\}\{\(\)\/\n\>]*">"

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -479,7 +479,7 @@ NW          [^a-z_A-Z0-9]
 FILESCHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+@&#]
 FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+@&#]
 FILE      ({FILESCHAR}*{FILEECHAR}+("."{FILESCHAR}*{FILEECHAR}+)*)|("\""[^\n\"]*"\"")
-ID        "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+ID        "$"?[$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
 CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
 CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]*

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -84,7 +84,7 @@ static yy_size_t yyread(char *buf,yy_size_t max_size, yyscan_t yyscanner);
 
 B       [ \t]
 Bopt    {B}*
-ID	"$"?([a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*)|(@[0-9]+)
+ID	"$"?([$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*)|(@[0-9]+)
 
 %x      Start
 %x	Template

--- a/src/defargs.l
+++ b/src/defargs.l
@@ -114,7 +114,7 @@ static bool nameIsActuallyPartOfType(QCString &name);
 
 B       [ \t]
 Bopt    {B}*
-ID	[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+ID	[$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 RAWBEGIN  (u|U|L|u8)?R\"[^ \t\(\)\\]{0,16}"("
 RAWEND    ")"[^ \t\(\)\\]{0,16}\"
 

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -366,7 +366,7 @@ WS        [ \t\r\n]
 NONWS     [^ \t\r\n]
 BLANK     [ \t\r]
 BLANKopt  {BLANK}*
-ID        "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+ID        "$"?[$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
 PHPTYPE   [\\:a-z_A-Z0-9\x80-\xFF\-]+
 CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]

--- a/src/lexcode.l
+++ b/src/lexcode.l
@@ -128,7 +128,7 @@ BN        [ \t\n\r]
 BL        [ \t\r]*"\n"
 B         [ \t]
 Bopt      {B}*
-ID        "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+ID        "$"?[$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 PRE       [pP][rR][eE]
 CODE      [cC][oO][dD][eE]
 RAWBEGIN  (u|U|L|u8)?R\"[^ \t\(\)\\]{0,16}"("

--- a/src/lexscanner.l
+++ b/src/lexscanner.l
@@ -126,7 +126,7 @@ BN        [ \t\n\r]
 BL        [ \t\r]*"\n"
 B         [ \t]
 Bopt      {B}*
-ID        "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+ID        "$"?[$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 PRE       [pP][rR][eE]
 CODE      [cC][oO][dD][eE]
 RAWBEGIN  (u|U|L|u8)?R\"[^ \t\(\)\\]{0,16}"("

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -239,7 +239,7 @@ BNopt     {BN}*
 BL        [ \t\r]*"\n"
 B         [ \t]
 Bopt      {B}*
-ID        "$"?[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+ID        "$"?[$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 SCOPENAME "$"?(({ID}?{BN}*"::"{BN}*)*)(((~|!){BN}*)?{ID})
 TSCOPE    {ID}("<"[a-z_A-Z0-9 \t\*\&,:]*">")?
 CSSCOPENAME (({ID}?{BN}*"."{BN}*)*)((~{BN}*)?{ID})

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -723,8 +723,14 @@ QCString removeRedundantWhiteSpace(const QCString &s)
         }
         *dst++=c;
         break;
-      case '@':  // '@name' -> ' @name'
       case '$':  // '$name' -> ' $name'
+                 // 'name$name' -> 'name$name'
+        if (isId(pc))
+        {
+          *dst++=c;
+          break;
+        } // fallthrough
+      case '@':  // '@name' -> ' @name'
       case '\'': // ''name' -> '' name'
         if (i>0 && i<l-1 && pc!='=' && pc!=':' && !isspace((uchar)pc) &&
             isId(nc) && osp<8) // ")id" -> ") id"

--- a/src/util.h
+++ b/src/util.h
@@ -171,7 +171,7 @@ int guessSection(const QCString &name);
 
 inline bool isId(int c)
 {
-  return c=='_' || c>=128 || c<0 || isalnum(c);
+  return c=='_' || c>=128 || c<0 || isalnum(c) || c=='$';
 }
 inline bool isIdJS(int c)
 {


### PR DESCRIPTION
- adding in the *.l files the `$` in the detection of an ID
- util.h add the `$` as allowed ID character
- util.cpp in case the previous character is an ID character don't place a space in front of it (otherwise a text line `some$method` would render as `some $method`).