### PR TITLE
bug_735146 MSC images not included in QHP index

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1773,10 +1773,10 @@ void Config::checkAndCorrect()
   }
 
   //------------------------
-  // check if GENERATE_TREEVIEW and GENERATE_HTMLHELP are both enabled
-  if (Config_getBool(GENERATE_TREEVIEW) && Config_getBool(GENERATE_HTMLHELP))
+  // check if GENERATE_TREEVIEW is not used in combination with GENERATE_HTMLHELP or GENERATE_QHP
+  if (Config_getBool(GENERATE_TREEVIEW) && (Config_getBool(GENERATE_HTMLHELP) || Config_getBool(GENERATE_QHP)))
   {
-    err("When enabling GENERATE_HTMLHELP the tree view (GENERATE_TREEVIEW) should be disabled. I'll do it for you.\n");
+    err("When enabling GENERATE_HTMLHELP or GENERATE_QHP the tree view (GENERATE_TREEVIEW) should be disabled. I'll do it for you.\n");
     Config_updateBool(GENERATE_TREEVIEW,FALSE);
   }
 
@@ -1789,10 +1789,10 @@ void Config::checkAndCorrect()
   }
 
   //------------------------
-  // check if SEARCHENGINE and GENERATE_HTMLHELP are both enabled
-  if (Config_getBool(SEARCHENGINE) && Config_getBool(GENERATE_HTMLHELP))
+  // check if SEARCHENGINE is not used in combination with GENERATE_HTMLHELP or GENERATE_QHP
+  if (Config_getBool(SEARCHENGINE) && (Config_getBool(GENERATE_HTMLHELP) || Config_getBool(GENERATE_QHP)))
   {
-    err("When enabling GENERATE_HTMLHELP the search engine (SEARCHENGINE) should be disabled. I'll do it for you.\n");
+    err("When enabling GENERATE_HTMLHELP or GENERATE_QHP the search engine (SEARCHENGINE) should be disabled. I'll do it for you.\n");
     Config_updateBool(SEARCHENGINE,FALSE);
   }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -2076,7 +2076,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
               QCString name = convertToHtml(m_classDef->displayName());
               d.writeImage(tt,g_globals.outputDir,
                            relPathAsString(),
-                           m_classDef->getOutputFileBase());
+                           m_classDef->getOutputFileBase(),ClassDiagram::DIAG_HTML);
               if (!tt.empty())
               {
                 t << "<div class=\"center\">\n";

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -1342,7 +1342,7 @@ void ClassDiagram::writeFigure(TextStream &output,const QCString &path,
 
 void ClassDiagram::writeImage(TextStream &t,const QCString &path,
                               const QCString &relPath,const QCString &fileName,
-                              bool generateMap) const
+                              DocFormat docFormat,bool generateMap) const
 {
   uint baseRows=p->base.computeRows();
   uint superRows=p->super.computeRows();
@@ -1369,6 +1369,6 @@ void ClassDiagram::writeImage(TextStream &t,const QCString &path,
 
 #define IMAGE_EXT ".png"
   image.save((QCString)path+"/"+fileName+IMAGE_EXT);
-  Doxygen::indexList->addImageFile(QCString(fileName)+IMAGE_EXT);
+  if (docFormat == DIAG_HTML) Doxygen::indexList->addImageFile(QCString(fileName)+IMAGE_EXT);
 }
 

--- a/src/diagram.h
+++ b/src/diagram.h
@@ -29,12 +29,14 @@ class TextStream;
 class ClassDiagram
 {
   public:
+    enum DocFormat { DIAG_HTML, DIAG_LATEX, DIAG_RTF, DIAG_DOCBOOK };
+
     ClassDiagram(const ClassDef *root);
    ~ClassDiagram();
     void writeFigure(TextStream &t,const QCString &path,
                      const QCString &file) const;
     void writeImage(TextStream &t,const QCString &path,const QCString &relPath,
-                     const QCString &file,bool generateMap=true) const;
+                     const QCString &file,DocFormat docFormat,bool generateMap=true) const;
   private:
     struct Private;
     std::unique_ptr<Private> p;

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -908,7 +908,7 @@ DB_GEN_C
   m_t << "                <imagedata width=\"50%\" align=\"center\" valign=\"middle\" scalefit=\"0\" fileref=\""
                          << relPath << fileName << ".png\">" << "</imagedata>\n";
   m_t << "            </imageobject>\n";
-  d.writeImage(m_t,dir(),relPath,fileName,FALSE);
+  d.writeImage(m_t,dir(),relPath,fileName,ClassDiagram::DIAG_DOCBOOK,FALSE);
   m_t << "        </mediaobject>\n";
   m_t << "    </informalfigure>\n";
   m_t << "</para>\n";

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1641,7 +1641,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_BITMAP,s->srcFile(),s->srcLine());
+  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_BITMAP,MSC_DOCBOOK,s->srcFile(),s->srcLine());
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + ".png", s->width(), s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1657,7 +1657,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
+  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP,PlantumlManager::PUML_DOCBOOK);
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + ".png", s->width(),s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1685,7 +1685,7 @@ DB_VIS_C
   }
   baseName.prepend("msc_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,MSC_DOCBOOK,srcFile,srcLine);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, baseName + ".png",  width,  height);
 }
@@ -1759,7 +1759,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP,s->srcFile(),s->srcLine());
+  writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP,EOF_DocBook,s->srcFile(),s->srcLine());
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + "." + getDotImageExtension(), s->width(),s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1788,7 +1788,7 @@ DB_VIS_C
   baseName.prepend("dot_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   QCString imgExt = getDotImageExtension();
-  writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP,srcFile,srcLine);
+  writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP,EOF_DocBook,srcFile,srcLine);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, baseName + "." + imgExt,  width,  height);
 }

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -271,6 +271,7 @@ bool DotManager::run() const
 
 void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,GraphOutputFormat format,
+                           EmbeddedOutputFormat docFormat,
                            const QCString &srcFile,int srcLine)
 {
   Dir d(outDir.str());
@@ -307,7 +308,7 @@ void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
      return;
   }
 
-  Doxygen::indexList->addImageFile(imgName);
+  if (docFormat == EOF_Html) Doxygen::indexList->addImageFile(imgName);
 
 }
 

--- a/src/dot.h
+++ b/src/dot.h
@@ -50,6 +50,7 @@ class DotManager
 
 void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,GraphOutputFormat format,
+                           EmbeddedOutputFormat docFormat,
                            const QCString &srcFile,int srcLine);
 void writeDotImageMapFromFile(TextStream &t,
                               const QCString &inFile, const QCString& outDir,

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -133,7 +133,7 @@ QCString DotGraph::writeGraph(
 
   m_regenerate = prepareDotFile();
 
-  if (!m_doNotAddImageToIndex) Doxygen::indexList->addImageFile(imgName());
+  if (!m_doNotAddImageToIndex && ef == EOF_Html) Doxygen::indexList->addImageFile(imgName());
 
   generateCode(t);
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9362,7 +9362,7 @@ static void copyStyleSheet()
   }
 }
 
-static void copyLogo(const QCString &outputOption)
+static void copyLogo(const QCString &outputOption, const QCString docFormat)
 {
   QCString projectLogo = Config_getString(PROJECT_LOGO);
   if (!projectLogo.isEmpty())
@@ -9377,12 +9377,12 @@ static void copyLogo(const QCString &outputOption)
     {
       QCString destFileName = outputOption+"/"+fi.fileName();
       copyFile(projectLogo,destFileName);
-      Doxygen::indexList->addImageFile(fi.fileName().c_str());
+      if (docFormat == "HTML") Doxygen::indexList->addImageFile(fi.fileName().c_str());
     }
   }
 }
 
-static void copyExtraFiles(const StringVector &files,const QCString &filesOption,const QCString &outputOption)
+static void copyExtraFiles(const StringVector &files,const QCString &filesOption,const QCString &outputOption, const QCString docFormat)
 {
   for (const auto &fileName : files)
   {
@@ -9396,7 +9396,7 @@ static void copyExtraFiles(const StringVector &files,const QCString &filesOption
       else
       {
         QCString destFileName = outputOption+"/"+fi.fileName();
-        Doxygen::indexList->addImageFile(fi.fileName().c_str());
+        if (docFormat == "HTML") Doxygen::indexList->addImageFile(fi.fileName().c_str());
         copyFile(QCString(fileName), destFileName);
       }
     }
@@ -11934,20 +11934,23 @@ void generateOutput()
   {
     g_s.begin("Generating images for formulas in HTML...\n");
     fm.generateImages(Config_getString(HTML_OUTPUT), Config_getEnum(HTML_FORMULA_FORMAT)=="svg" ?
-        FormulaManager::Format::Vector : FormulaManager::Format::Bitmap, FormulaManager::HighDPI::On);
+        FormulaManager::Format::Vector : FormulaManager::Format::Bitmap, FormulaManager::DocFormat::FORM_HTML,
+        FormulaManager::HighDPI::On);
     g_s.end();
   }
   if (fm.hasFormulas() && generateRtf)
   {
     g_s.begin("Generating images for formulas in RTF...\n");
-    fm.generateImages(Config_getString(RTF_OUTPUT),FormulaManager::Format::Bitmap);
+    fm.generateImages(Config_getString(RTF_OUTPUT),FormulaManager::Format::Bitmap,
+        FormulaManager::FormulaManager::DocFormat::FORM_RTF);
     g_s.end();
   }
 
   if (fm.hasFormulas() && generateDocbook)
   {
     g_s.begin("Generating images for formulas in Docbook...\n");
-    fm.generateImages(Config_getString(DOCBOOK_OUTPUT),FormulaManager::Format::Bitmap);
+    fm.generateImages(Config_getString(DOCBOOK_OUTPUT),FormulaManager::Format::Bitmap,
+        FormulaManager::DocFormat::FORM_DOCBOOK);
     g_s.end();
   }
 
@@ -12097,22 +12100,22 @@ void generateOutput()
   {
     FTVHelp::generateTreeViewImages();
     copyStyleSheet();
-    copyLogo(Config_getString(HTML_OUTPUT));
-    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT));
+    copyLogo(Config_getString(HTML_OUTPUT),"HTML");
+    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT),"HTML");
   }
   if (generateLatex)
   {
     copyLatexStyleSheet();
-    copyLogo(Config_getString(LATEX_OUTPUT));
-    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT));
+    copyLogo(Config_getString(LATEX_OUTPUT),"LATEX");
+    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT),"LATEX");
   }
   if (generateDocbook)
   {
-    copyLogo(Config_getString(DOCBOOK_OUTPUT));
+    copyLogo(Config_getString(DOCBOOK_OUTPUT),"DOCBOOK");
   }
   if (generateRtf)
   {
-    copyLogo(Config_getString(RTF_OUTPUT));
+    copyLogo(Config_getString(RTF_OUTPUT),"RTF");
   }
 
   if (generateHtml &&

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -127,7 +127,7 @@ void FormulaManager::readFormulas(const QCString &dir,bool doCompare)
   }
 }
 
-void FormulaManager::generateImages(const QCString &path,Format format,HighDPI hd) const
+void FormulaManager::generateImages(const QCString &path,Format format,DocFormat docFormat,HighDPI hd) const
 {
   Dir d(path.str());
   // store the original directory
@@ -181,7 +181,7 @@ void FormulaManager::generateImages(const QCString &path,Format format,HighDPI h
         t << p->formulas[i].c_str() << "\n\\pagebreak\n\n";
         formulasToGenerate.push_back(i);
       }
-      Doxygen::indexList->addImageFile(resultName);
+      if (docFormat == DocFormat::FORM_HTML) Doxygen::indexList->addImageFile(resultName);
     }
     t << "\\end{document}\n";
     t.flush();

--- a/src/formula.h
+++ b/src/formula.h
@@ -34,12 +34,13 @@ class FormulaManager
       int height;
     };
     enum class Format { Bitmap, Vector };
+    enum class DocFormat { FORM_HTML, FORM_LATEX, FORM_RTF, FORM_DOCBOOK };
     enum class HighDPI { On, Off };
     static FormulaManager &instance();
     void readFormulas(const QCString &dir,bool doCompare=false);
     void clear();
     int addFormula(const std::string &formulaText);
-    void generateImages(const QCString &outputDir,Format format,HighDPI hd = HighDPI::Off) const;
+    void generateImages(const QCString &outputDir,Format format,DocFormat docFormat,HighDPI hd = HighDPI::Off) const;
     std::string findFormula(int formulaId) const;
     bool hasFormulas() const;
     DisplaySize displaySize(int formulaId) const;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2261,7 +2261,7 @@ void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
   }
   baseName.prepend("dot_");
   QCString outDir = Config_getString(HTML_OUTPUT);
-  writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP,srcFile,srcLine);
+  writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP,EOF_Html,srcFile,srcLine);
   writeDotImageMapFromFile(m_t,fn,outDir,relPath,baseName,context,-1,srcFile,srcLine);
 }
 
@@ -2284,7 +2284,7 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPa
   MscOutputFormat mscFormat = MSC_BITMAP;
   if ("svg" == imgExt)
     mscFormat = MSC_SVG;
-  writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,MSC_HTML,srcFile,srcLine);
   writeMscImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,mscFormat,srcFile,srcLine);
 }
 
@@ -2325,7 +2325,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")
   {
-    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG);
+    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG,PlantumlManager::PUML_HTML);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />\n";
     //m_t << "<p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p>";
     //m_t << "</iframe>\n";
@@ -2333,7 +2333,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   }
   else
   {
-    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
+    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP,PlantumlManager::PUML_HTML);
     m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
   }
 }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1013,6 +1013,7 @@ void HtmlGenerator::writeTabData()
   mgr.copyResource("nav_f.lum",dname);
   mgr.copyResource("bc_s.luma",dname);
   mgr.copyResource("doxygen.svg",dname);
+  Doxygen::indexList->addImageFile("doxygen.svg");
   mgr.copyResource("closed.luma",dname);
   mgr.copyResource("open.luma",dname);
   mgr.copyResource("bdwn.luma",dname);
@@ -1617,7 +1618,7 @@ void HtmlGenerator::endClassDiagram(const ClassDiagram &d,
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
   TextStream tt;
-  d.writeImage(tt,dir(),m_relPath,fileName);
+  d.writeImage(tt,dir(),m_relPath,fileName,ClassDiagram::DIAG_HTML);
   if (!tt.empty())
   {
     m_t << " <div class=\"center\">\n";

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -32,7 +32,6 @@
 #include "util.h"
 #include "linkedmap.h"
 #include "regex.h"
-#include "fileinfo.h"
 
 //----------------------------------------------------------------------------
 
@@ -553,7 +552,7 @@ void HtmlHelp::Private::createProjectFile()
     }
     for (auto &s : imageFiles)
     {
-      t << FileInfo(s).fileName() << "\n";
+      t << s << "\n";
     }
     t.close();
   }

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1905,7 +1905,7 @@ void LatexDocVisitor::startDotFile(const QCString &fileName,
   baseName.prepend("dot_");
   QCString outDir = Config_getString(LATEX_OUTPUT);
   QCString name = fileName;
-  writeDotGraphFromFile(name,outDir,baseName,GOF_EPS,srcFile,srcLine);
+  writeDotGraphFromFile(name,outDir,baseName,GOF_EPS,EOF_LaTeX,srcFile,srcLine);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1936,7 +1936,7 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
   baseName.prepend("msc_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_EPS,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_EPS,MSC_LATEX,srcFile,srcLine);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1956,7 +1956,7 @@ void LatexDocVisitor::writeMscFile(const QCString &baseName, DocVerbatim *s)
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS,s->srcFile(),s->srcLine());
+  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS,MSC_LATEX,s->srcFile(),s->srcLine());
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(),s->height());
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -2019,7 +2019,7 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, DocVerbatim *s
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_EPS);
+  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_EPS,PlantumlManager::PUML_LATEX);
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(), s->height());
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -90,6 +90,7 @@ static bool convertMapFile(TextStream &t,const QCString &mapName,const QCString 
 
 void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,MscOutputFormat format,
+                           MscDocOutputFormat docFormat,
                            const QCString &srcFile,int srcLine
                           )
 {
@@ -99,18 +100,22 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
 
   mscgen_format_t msc_format;
   QCString imgName = absOutFile;
+  QCString outFileName = outFile;
   switch (format)
   {
     case MSC_BITMAP:
       msc_format = mscgen_format_png;
+      outFileName+=".png";
       imgName+=".png";
       break;
     case MSC_EPS:
       msc_format = mscgen_format_eps;
+      outFileName+=".eps";
       imgName+=".eps";
       break;
     case MSC_SVG:
       msc_format = mscgen_format_svg;
+      outFileName+=".svg";
       imgName+=".svg";
       break;
     default:
@@ -138,7 +143,7 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
     Portable::sysTimerStop();
   }
 
-  Doxygen::indexList->addImageFile(imgName);
+   if (docFormat == MSC_HTML) Doxygen::indexList->addImageFile(outFileName);
 
 }
 

--- a/src/msc.h
+++ b/src/msc.h
@@ -20,9 +20,11 @@ class QCString;
 class TextStream;
 
 enum MscOutputFormat { MSC_BITMAP , MSC_EPS, MSC_SVG };
+enum MscDocOutputFormat { MSC_HTML, MSC_LATEX, MSC_RTF, MSC_DOCBOOK };
 
 void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,MscOutputFormat format,
+                           MscDocOutputFormat docFormat,
                            const QCString &srcFile,int srcLine);
 
 QCString getMscImageMapFromFile(const QCString &inFile, const QCString &outDir,

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -88,7 +88,8 @@ QCString PlantumlManager::writePlantUMLSource(const QCString &outDirArg,const QC
   return baseName;
 }
 
-void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format)
+void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,
+                                             OutputFormat format,PumlDocOutputFormat docFormat)
 {
   QCString plantumlJarPath = Config_getString(PLANTUML_JAR_PATH);
   QCString plantumlConfigFile = Config_getString(PLANTUML_CFG_FILE);
@@ -115,7 +116,7 @@ void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCSt
       break;
   }
 
-  Doxygen::indexList->addImageFile(imgName);
+  if (docFormat == PUML_HTML) Doxygen::indexList->addImageFile(imgName);
 }
 
 //--------------------------------------------------------------------

--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -43,6 +43,7 @@ class PlantumlManager
   public:
     /** Plant UML output image formats */
     enum OutputFormat { PUML_BITMAP, PUML_EPS, PUML_SVG };
+    enum PumlDocOutputFormat { PUML_HTML, PUML_LATEX, PUML_RTF, PUML_DOCBOOK };
 
     static PlantumlManager &instance();
 
@@ -69,7 +70,7 @@ class PlantumlManager
      *  @param[in] outDir   the directory to write the resulting image into.
      *  @param[in] format   the image format to generate.
      */
-    void generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format);
+    void generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format,PumlDocOutputFormat docFormat);
 
     using FilesMap   = std::map< std::string, StringVector    >;
     using ContentMap = std::map< std::string, PlantumlContent >;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1848,7 +1848,7 @@ void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption,
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeDotGraphFromFile(filename,outDir,baseName,GOF_BITMAP,srcFile,srcLine);
+  writeDotGraphFromFile(filename,outDir,baseName,GOF_BITMAP,EOF_Rtf,srcFile,srcLine);
   QCString imgExt = getDotImageExtension();
   includePicturePreRTF(baseName + "." + imgExt, true, hasCaption);
 }
@@ -1867,7 +1867,7 @@ void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption,
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,MSC_RTF,srcFile,srcLine);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
@@ -1893,6 +1893,6 @@ void RTFDocVisitor::writePlantUMLFile(const QCString &fileName, bool hasCaption)
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
+  PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP,PlantumlManager::PUML_RTF);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1889,7 +1889,7 @@ void RTFGenerator::endClassDiagram(const ClassDiagram &d,
   newParagraph();
 
   // create a png file
-  d.writeImage(m_t,dir(),m_relPath,fileName,FALSE);
+  d.writeImage(m_t,dir(),m_relPath,fileName,ClassDiagram::DIAG_RTF,FALSE);
 
   // display the file
   m_t << "{\n";

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3342,7 +3342,7 @@ void  FlowChart::printUmlTree()
 
   QCString n=convertNameToFileName();
   n=PlantumlManager::instance().writePlantUMLSource(htmlOutDir,n,qcs,PlantumlManager::PUML_SVG,"uml",n,1);
-  PlantumlManager::instance().generatePlantUMLOutput(n,htmlOutDir,PlantumlManager::PUML_SVG);
+  PlantumlManager::instance().generatePlantUMLOutput(n,htmlOutDir,PlantumlManager::PUML_SVG,PlantumlManager::PUML_HTML);
 }
 
 QCString FlowChart::convertNameToFileName()


### PR DESCRIPTION
The problem mentioned in this issue, missing MSC file in index.qhp, was not present anymore, but a few other problems showed:
- QHP should also not use `GENERATE_TREEVIEW` and `SEARCHENGINE`
- quite a few file names were placed into the `index.qhp` and `index.hhp` although not relevant for these "HTML type " output as they came from other output formats, resulting in:
  - double entries
  - non existing files as the files are not present on the `HTML_OUTPUT` directory
- some paths were shown with (full-) path due to a wrong used name (see msc.cpp: imgName -> outFileName).
- in case of `CREATE_SUBDIRS` the path was stripped (for "dot" files) due to the usage of `fileName()` (see htmlhelp.cpp)

A bit a more extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6721439/example.tar.gz)
