### PR TITLE
Allow overwriting scope of an object from comment block (via new command)

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -94,6 +94,7 @@ static bool handleXRefItem(yyscan_t yyscanner,const QCString &, const StringVect
 static bool handleRelated(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleRelatedAlso(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleMemberOf(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleBelongsTo(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleRefItem(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleSection(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleAnchor(yyscan_t yyscanner,const QCString &, const StringVector &);
@@ -169,6 +170,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "attention",       { 0,                       CommandSpacing::Block     }},
   { "author",          { 0,                       CommandSpacing::Block     }},
   { "authors",         { 0,                       CommandSpacing::Block     }},
+  { "belongsto",       { &handleBelongsTo,        CommandSpacing::Invisible }},
   { "brief",           { &handleBrief,            CommandSpacing::Invisible }},
   { "bug",             { &handleBug,              CommandSpacing::XRef      }},
   { "callergraph",     { &handleCallergraph,      CommandSpacing::Invisible }},
@@ -509,6 +511,7 @@ STopt  [^\n@\\]*
 %x      PageDocArg1
 %x      PageDocArg2
 %x      RelatesParam1
+%x      BelongsParam
 %x      ClassDocArg1
 %x      ClassDocArg2
 %x      ClassDocArg3
@@ -1354,6 +1357,16 @@ STopt  [^\n@\\]*
 <RelatesParam1>.                        { // ignore other stuff
                                         }
 
+  /* ----- handle arguments of the belongsto commands ----- */
+
+<BelongsParam>{SCOPENAME}               { 
+                                          StringVector scopeList;
+                                          scopeList = split(yyextra->current->name.str(),"::");
+                                          QCString classname = QCString(scopeList[scopeList.size()-1]);
+                                          yyextra->current->name = substitute(removeRedundantWhiteSpace(QCString(yytext) 
+                                            + QCString("::") + classname),".","::");
+                                          BEGIN( Comment );
+                                        }
 
   /* ----- handle arguments of the relates(also)/addindex commands ----- */
 
@@ -2324,6 +2337,15 @@ static bool handleRelatedAlso(yyscan_t yyscanner,const QCString &cmd, const Stri
   yyextra->current->relatesType = Duplicate;
   yyextra->currentCmd = cmd;
   BEGIN(RelatesParam1);
+  return FALSE;
+}
+
+static bool handleBelongsTo(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
+{   
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->relatesType = BelongsTo;
+  yyextra->currentCmd = cmd;
+  BEGIN(BelongsParam);
   return FALSE;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -32,7 +32,7 @@ enum Specifier    { Normal, Virtual, Pure } ;
 enum MethodTypes  { Method, Signal, Slot, DCOP, Property, Event };
 
 /** Type of member relation */
-enum RelatesType  { Simple, Duplicate, MemberOf };
+enum RelatesType  { Simple, Duplicate, MemberOf, BelongsTo };
 
 /** Kind of member relationship */
 enum Relationship { Member, Related, Foreign };


### PR DESCRIPTION
Right now, in my opinion, documenting C++/Python mixed code has some shortcomings, one of which being the limited namespace controls for python.

In my example, i wanted to add all my python classes in a namespace called Python::Module, while keeping C++ code the same.

I've implemented a small comment command, `\belongsto {SCOPENAME}`

This allows overwriting the scope of an object from the related comment block (from class docstrings)

Consider the following example:

```py
#example_py.py
##
# @namespace Python::Example
# @brief Python portion of a mixed-code project

class ExampleClass:
    """!
         @belongsto Python::Module::example_py
         @brief A python class
    """
```

```cpp
//example_cpp.cpp

namespace ExampleCPP{
    class ExampleClass{};
};
```

Without belongsto command, this will generate the following hierarchy:

```
/
├─ ExampleCPP
│  ├─ ExampleClass
├─ example_py
   ├─ ExampleClass
```

As far as i know, it is not possible to change the scope/namespace of a Python class in Doxygen without changing the filenames.

This command allows moving the class out of example_py namespace created from the filename.
```

/
├─ ExampleCPP
│  ├─ ExampleClass
├─ Python
   ├─ Module
      ├─ example_py
          ├─ ExampleClass
```

Please let me know if there was another way of doing this without implementing the new command.
I've been going over the documentation and pretty much trying anything with package, relates, memberof commands but nothing worked.







