### PR TITLE
Self recursive Fortran functions did not show a self arrow in the callgraph

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1231,7 +1231,7 @@ static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // dictionary with 
     if (d && d->isLinkable())
     {
       if (yyextra->currentDefinition && yyextra->currentMemberDef &&
-          md!=yyextra->currentMemberDef && yyextra->insideBody && yyextra->collectXRefs)
+          yyextra->insideBody && yyextra->collectXRefs)
       {
         std::lock_guard<std::mutex> lock(g_docCrossReferenceMutex);
         addDocCrossReference(toMemberDefMutable(yyextra->currentMemberDef),toMemberDefMutable(md));


### PR DESCRIPTION
In commit ce032dd509862a2af10c389c0609a5736540ef61 the problem for a self arrow in a recursive function was handled for C-type and Python function.
Here the problem is handled for Fortran subroutines

Extended example: [example_2.tar.gz](https://github.com/doxygen/doxygen/files/6739099/example_2.tar.gz)
