### PR TITLE
Warning with a newline in a conditional expression in a \if command

### DIFF
--- a/src/condparser.cpp
+++ b/src/condparser.cpp
@@ -113,7 +113,7 @@ void CondParser::getToken()
   //printf("\tgetToken e:{%c}, ascii=%i, col=%i\n", *e, *e, e-expr);
 
   // skip over whitespaces
-  while (*m_e == ' ' || *m_e == '\t')     // space or tab
+  while (*m_e == ' ' || *m_e == '\t' || *m_e == '\n')     // space or tab or newline
   {
     m_e++;
   }


### PR DESCRIPTION
When having a problem like:
```
/// \file

/**
 * ggg
 */
typedef enum {
  /** hhh
   * \line_
   * @if (INTERNAL ||
   *     NO_INTERNAL)
   * \line_
   * @endif
   * \line_
   */
         BS3
} bse_type_enum;
```
we get a warning like:
```
.../b.h:10: warning: problem evaluating expression '(INTERNAL ||
     NO_INTERNAL)': Parenthesis ) missing
```
due to the fact that a newline is not seen as "white-space" character during the evaluation of the conditional expression.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6740149/example.tar.gz)
