### PR TITLE
Incorrect line number in warnings in case of if command

### DIFF
--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -150,6 +150,7 @@ CommandMap cmdMap[] =
   { "docbookinclude",CMD_DOCBOOKINCLUDE },
   { "maninclude",    CMD_MANINCLUDE },
   { "xmlinclude",    CMD_XMLINCLUDE },
+  { "iline",         CMD_ILINE },
   { 0,               0 },
 };
 

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -141,7 +141,8 @@ enum CommandType
   CMD_RTFINCLUDE   = 112,
   CMD_DOCBOOKINCLUDE= 113,
   CMD_MANINCLUDE   = 114,
-  CMD_XMLINCLUDE   = 115
+  CMD_XMLINCLUDE   = 115,
+  CMD_ILINE        = 116,
 };
 
 enum HtmlTagType

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1538,6 +1538,7 @@ STopt  [^\n@\\]*
                                         }
 <GuardExpr>[^()]*                       {
                                           yyextra->guardExpr+=yytext;
+                                          lineCount(yyscanner);
                                         }
 <GuardExpr>"("                          {
                                           yyextra->guardExpr+=yytext;
@@ -1564,6 +1565,9 @@ STopt  [^\n@\\]*
                                           if (*yytext=='\n') yyextra->lineNr++;
                                           //next line is commented out due to bug620924
                                           //addOutput(yyscanner,'\n');
+                                          char tmp[20];
+                                          sprintf(tmp,"\\iline %d ",yyextra->lineNr);
+                                          addOutput(yyscanner, tmp);
                                           BEGIN( Comment );
                                         }
 <GuardParam>{LC}                        { // line continuation
@@ -1576,6 +1580,9 @@ STopt  [^\n@\\]*
 <GuardParamEnd>{B}*{DOCNL}              {
                                           lineCount(yyscanner);
                                           yyextra->spaceBeforeIf.resize(0);
+                                          char tmp[20];
+                                          sprintf(tmp,"\\iline %d ",yyextra->lineNr);
+                                          addOutput(yyscanner, tmp);
                                           BEGIN(Comment);
                                         }
 <GuardParamEnd>{B}*                     {
@@ -1584,10 +1591,16 @@ STopt  [^\n@\\]*
                                             addOutput(yyscanner,yyextra->spaceBeforeIf);
                                           }
                                           yyextra->spaceBeforeIf.resize(0);
+                                          char tmp[20];
+                                          sprintf(tmp,"\\iline %d ",yyextra->lineNr);
+                                          addOutput(yyscanner, tmp);
                                           BEGIN(Comment);
                                         }
 <GuardParamEnd>.                        {
                                           unput(*yytext);
+                                          char tmp[20];
+                                          sprintf(tmp,"\\iline %d ",yyextra->lineNr);
+                                          addOutput(yyscanner, tmp);
                                           BEGIN(Comment);
                                         }
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -4843,6 +4843,13 @@ int DocPara::handleXRefItem()
   return retval;
 }
 
+void DocPara::handleIline()
+{
+  doctokenizerYYsetStateIline();
+  int retval=doctokenizerYYlex();
+  doctokenizerYYsetStatePara();
+}
+
 void DocPara::handleIncludeOperator(const QCString &cmdName,DocIncOperator::Type t)
 {
   QCString saveCmdName = cmdName;
@@ -5844,6 +5851,9 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       break;
     case CMD_INHERITDOC:
       handleInheritDoc();
+      break;
+    case CMD_ILINE:
+      handleIline();
       break;
     default:
       // we should not get here!

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -1178,6 +1178,7 @@ class DocPara : public CompAccept<DocPara>
     void handleSection(const QCString &cmdName);
     void handleInheritDoc();
     void handleVhdlFlow();
+    void handleIline();
     int handleStartCode();
     int handleHtmlHeader(const HtmlAttribList &tagHtmlAttribs,int level);
 

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -167,5 +167,6 @@ void doctokenizerYYsetStatePlantUMLOpt();
 void doctokenizerYYsetStateOptions();
 void doctokenizerYYsetStateBlock();
 void doctokenizerYYsetStateEmoji();
+void doctokenizerYYsetStateIline();
 
 #endif

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -444,6 +444,7 @@ REFWORD4       {REFWORD4_NOCV}{CVSPEC}?
 REFWORD        {FILEMASK}|{LABELID}|{REFWORD2}|{REFWORD3}|{REFWORD4}
 REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revision"|"Source"|"State")":"[^:\n$][^\n$]*"$"
+LINENR {BLANK}*[1-9][0-9]*{BLANK}
 
 %option noyywrap
 
@@ -488,6 +489,7 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
 %x St_Options
 %x St_Block
 %x St_Emoji
+%x St_Iline
 
 %x St_Sections
 %s St_SecLabel1
@@ -1299,6 +1301,17 @@ RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revisio
 <St_Emoji>.            {
                          return 0;
                        }
+<St_Iline>{LINENR}     {
+                         try {
+                           g_yyLineNr = std::stoul(yytext);
+                         } catch (...) {
+                           warn(g_fileName,g_yyLineNr,"Unexpected line number '%s' ",yytext);
+                         }
+                         return TK_WORD;
+                       }
+<St_Iline>.            {
+                         return 0;
+                       }
 <St_File>{FILEMASK}    {
                          g_token->name = yytext;
                          return TK_WORD;
@@ -1715,6 +1728,11 @@ void doctokenizerYYsetStateEmoji()
 {
   g_token->name="";
   BEGIN(St_Emoji);
+}
+
+void doctokenizerYYsetStateIline()
+{
+  BEGIN(St_Iline);
 }
 
 void doctokenizerYYcleanup()


### PR DESCRIPTION
When having a problem like:
```
/// \file

/**
 * aaa
 */
typedef enum {
  /** bbb
   * \line_9
   * @if INTERNAL
   * \line_11
   * @endif
   * \line_13
   */
         BS
} bsb_type_enum;
```
with Doxyfile:
```
JAVADOC_AUTOBRIEF      = NO
ENABLED_SECTIONS       = INTERNAL
GENERATE_LATEX         = NO
INPUT=b.h
QUIET                  = YES
```
we get the warnings:
.../b.h:9: warning: Found unknown command '\line_9'
.../b.h:10: warning: Found unknown command '\line_11'
.../b.h:11: warning: Found unknown command '\line_13'
```
so the line number in the warning is incorrect for the lines after the `if` and `endif` command.
Looking at the output of the commentscanner we see:
```
CommentScanner: .../b.h:8
output=[
brief=[line=-1
]
docs=[line=8
bbb
 \line_9
 \line_11
  \line_13]
inbody=[line=-1
]
]
```
in other words a number of lines "disappear".

As the `if` command is an inline command it is not possible to just replace e.g. the `if` line wit an empty line (as this would be seen as a paragraph break).

With this patch a new internal command `iline` is defined with which it is possible to overrule in the documentation tokenizer the line counter.

Example: [example_2.tar.gz](https://github.com/doxygen/doxygen/files/6741505/example_2.tar.gz)
