### PR TITLE
bug_640740 mistakenly detecting command in email addresses

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -625,7 +625,7 @@ SLASHopt [/]*
 <CComment,CNComment>[^ `~<\\!@*\n{\"\/]*     { /* anything that is not a '*' or command */ 
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
-<CComment,CNComment>"*"+[^*\/\\@\n{\"]*      { /* stars without slashes */
+<CComment,CNComment>"*"+[^*\/\\@\n{\"a-zA-Z0_9_]*      { /* stars without slashes */
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
 <CComment>"\"\"\""                 { /* end of Python docstring */


### PR DESCRIPTION
Also known as #4115

See to it that other "special" commands can be handled properly as well

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6754481/example.tar.gz)
