### PR TITLE
Issue #8640: replaced spaces in front of lines in python examples with css margin

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -716,7 +716,6 @@ void HtmlCodeGenerator::writeLineNumber(const QCString &ref,const QCString &file
     codify(lineNumber);
   }
   m_t << "</span>";
-  m_t << "&#160;";
   m_col=0;
 }
 

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -313,6 +313,7 @@ div.line.glow {
 
 span.lineno {
 	padding-right: 4px;
+        margin-right: 9px;
 	text-align: right;
 	border-right: 2px solid #0F0;
 	background-color: #E8E8E8;


### PR DESCRIPTION
Replaced character `&#160;` with css margin.