### PR TITLE
issue #8642 invalid argument for command iline

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -4766,7 +4766,7 @@ void DocPara::handleIline()
   int tok = doctokenizerYYlex();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(g_parserContext.fileName,getDoctokinizerLineNr(),"invalid argument for command iline\n");
+    warn_doc_error(g_parserContext.fileName,getDoctokinizerLineNr(),"invalid argument for command '\\iline'\n");
     return;
   }
   doctokenizerYYsetStatePara();

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -444,7 +444,7 @@ REFWORD4       {REFWORD4_NOCV}{CVSPEC}?
 REFWORD        {FILEMASK}|{LABELID}|{REFWORD2}|{REFWORD3}|{REFWORD4}
 REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revision"|"Source"|"State")":"[^:\n$][^\n$]*"$"
-LINENR {BLANK}*[1-9][0-9]*{BLANK}
+LINENR {BLANK}*[1-9][0-9]*
 
 %option noyywrap
 
@@ -1301,7 +1301,11 @@ LINENR {BLANK}*[1-9][0-9]*{BLANK}
 <St_Emoji>.            {
                          return 0;
                        }
-<St_Iline>{LINENR}     {
+<St_Iline>{LINENR}/[\n\.]     {
+                         g_yyLineNr = QCString(yytext).toInt();
+                         return TK_WORD;
+                       }
+<St_Iline>{LINENR}{BLANK}     {
                          g_yyLineNr = QCString(yytext).toInt();
                          return TK_WORD;
                        }


### PR DESCRIPTION
From the string presented to the tokenizer the end spaces are stripped so it is not necessary that a space is present at the end.
Due to the brief command it is also possible that a `.` is present at the end.
These cases are handled now.

Furthermore small improvement on warning message.