### PR TITLE
Warning message in case of preprocesssor macro substitution

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -340,6 +340,7 @@ static Define *      isDefined(yyscan_t yyscanner,const QCString &name);
 %}
 
 ID	[a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF]*
+IDSTART	[a-z_A-Z\x80-\xFF]
 B       [ \t]
 Bopt    {B}*
 BN	[ \t\r\n]
@@ -1417,7 +1418,7 @@ WSopt [ \t\r]*
 <RemoveCPPComment>{CPPC}
 <RemoveCPPComment>[^\x06\n]+
 <RemoveCPPComment>.
-<DefineText>"#"				{
+<DefineText>"#"/{IDSTART}		{
   					  yyextra->quoteArg=TRUE;
 					  yyextra->defLitText+=yytext;
   					}
@@ -1464,6 +1465,25 @@ WSopt [ \t\r]*
 					}
 <DefineText>\n				{
 					  QCString comment=extractTrailingComment(yyextra->defLitText);
+                                          yyextra->defText = yyextra->defText.stripWhiteSpace();
+                                          if (yyextra->defText.startsWith("##"))
+                                          {
+                                            warn(yyextra->yyFileName,yyextra->yyLineNr,
+                                                 "'##' cannot occur at the beginning of a macro definition '%s': '%s'",
+                                                 qPrint(yyextra->defName),qPrint(yyextra->defLitText.stripWhiteSpace()));
+                                          }
+                                          else if (yyextra->defText.endsWith("##"))
+                                          {
+                                            warn(yyextra->yyFileName,yyextra->yyLineNr,
+                                                 "'##' cannot occur at the end of a macro definition '%s': '%s'",
+                                                 qPrint(yyextra->defName),qPrint(yyextra->defLitText.stripWhiteSpace()));
+                                          }
+                                          else if (yyextra->defText.endsWith("#"))
+                                          {
+                                            warn(yyextra->yyFileName,yyextra->yyLineNr,
+                                                 "expected macro formal parameter in macro definition '%s': '%s'",
+                                                 qPrint(yyextra->defName),qPrint(yyextra->defLitText.stripWhiteSpace()));
+                                          }
 					  yyextra->defLitText+=yytext;
 					  if (!comment.isEmpty())
 					  {


### PR DESCRIPTION
In the macro preprocessor it is not allowed to have `##` at the beginning of a definition nor at the end.
Furthermore a single `#` should be followed by an ID (now enforced by means of the ID-start  character).

Normally in case we have something like (derived from berkeley_upc-2021.4.0 package):
```
#define GASNET_ALIGNED_SEGMENTS   ###

#if !defined(GASNET_ALIGNED_SEGMENTS) || \
    (defined(GASNET_ALIGNED_SEGMENTS) && GASNET_ALIGNED_SEGMENTS != 0 && GASNET_ALIGNED_SEGMENTS != 1)
  #error GASNet core failed to define GASNET_ALIGNED_SEGMENTS to 0 or 1
#endif
```
we get as warning:
```
...:4: warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' ! 1L  ||      ( 1L  && #  != 0 && #  != 1)'
```
but nothing about the real problem (i.e. incorrect define) and now we also get:
```
...:1: warning: '##' cannot occur at the beginning of a macro definition 'GASNET_ALIGNED_SEGMENTS': '###'
```
so it is a bit easier to find the problem.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6758292/example.tar.gz)
