### PR TITLE
issue #8648 positioning at line anchors is disturbed by the navigation bar

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -907,7 +907,7 @@ void HtmlDocVisitor::visit(DocIndexEntry *e)
   {
     anchor.prepend(e->member()->anchor()+"_");
   }
-  m_t << "<a name=\"" << anchor << "\"></a>";
+  m_t << "<a id=\"" << anchor << "\" name=\"" << anchor << "\"></a>";
   //printf("*** DocIndexEntry: word='%s' scope='%s' member='%s'\n",
   //       qPrint(e->entry()),
   //       e->scope()  ? qPrint(e->scope()->name())  : "<null>",

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -706,7 +706,7 @@ void HtmlCodeGenerator::writeLineNumber(const QCString &ref,const QCString &file
     m_lineOpen = TRUE;
   }
 
-  m_t << "<a id=\"" << lineAnchor << "\"></a><span class=\"lineno\">";
+  m_t << "<a id=\"" << lineAnchor << "\" name=\"" << lineAnchor << "\"></a><span class=\"lineno\">";
   if (!filename.isEmpty())
   {
     _writeCodeLink("line",ref,filename,anchor,lineNumber,QCString());
@@ -871,7 +871,7 @@ void HtmlCodeGenerator::endFontClass()
 
 void HtmlCodeGenerator::writeCodeAnchor(const QCString &anchor)
 {
-  m_t << "<a name=\"" << anchor << "\"></a>";
+  m_t << "<a id=\"" << anchor << "\" name=\"" << anchor << "\"></a>";
 }
 
 void HtmlCodeGenerator::startCodeFragment(const QCString &)
@@ -1286,7 +1286,7 @@ void HtmlGenerator::startDoxyAnchor(const QCString &,const QCString &,
                                     const QCString &anchor, const QCString &,
                                     const QCString &)
 {
-  m_t << "<a id=\"" << anchor << "\"></a>";
+  m_t << "<a id=\"" << anchor << "\" name=\"" << anchor << "\"></a>";
 }
 
 void HtmlGenerator::endDoxyAnchor(const QCString &,const QCString &)
@@ -1466,7 +1466,7 @@ void HtmlGenerator::startSection(const QCString &lab,const QCString &,SectionTyp
     case SectionType::Paragraph:     m_t << "\n\n<h5>"; break;
     default: ASSERT(0); break;
   }
-  m_t << "<a id=\"" << lab << "\"></a>";
+  m_t << "<a id=\"" << lab << "\" name=\"" << lab << "\"></a>";
 }
 
 void HtmlGenerator::endSection(const QCString &,SectionType type)
@@ -1780,7 +1780,7 @@ void HtmlGenerator::startMemberHeader(const QCString &anchor, int typ)
   m_t << "<tr class=\"heading\"><td colspan=\"" << typ << "\"><h2 class=\"groupheader\">";
   if (!anchor.isEmpty())
   {
-    m_t << "<a name=\"" << anchor << "\"></a>\n";
+    m_t << "<a id=\"" << anchor << "\" name=\"" << anchor << "\"></a>\n";
   }
 }
 

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -706,7 +706,7 @@ void HtmlCodeGenerator::writeLineNumber(const QCString &ref,const QCString &file
     m_lineOpen = TRUE;
   }
 
-  m_t << "<a name=\"" << lineAnchor << "\"></a><span class=\"lineno\">";
+  m_t << "<a id=\"" << lineAnchor << "\"></a><span class=\"lineno\">";
   if (!filename.isEmpty())
   {
     _writeCodeLink("line",ref,filename,anchor,lineNumber,QCString());


### PR DESCRIPTION
It looks like the line numbering uses as anchor:
```
< name=...
```
instead of
```
<a id=...
```

See also:
https://www.w3schools.com/tags/tag_a.asp and https://www.w3schools.com/tags/ref_standardattributes.asp
>  id  Specifies a unique id for an element

and the `name` is not mentioned as attribute.