### PR TITLE
bug_464993 Todo-entries should be listed with file+location

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -370,6 +370,8 @@ struct commentscanYY_state
   QCString         blockName;                // preformatted block name (e.g. verbatim, latexonly,...)
   XRefKind         xrefKind    = XRef_Item;  // kind of cross-reference command
   XRefKind         newXRefKind = XRef_Item;  //
+  QCString         currentXrefFileName;
+  int              currentXrefLineNr;
   GuardType        guardType = Guard_If;     // kind of guards for conditional section
   bool             enabledSectionFound = FALSE;
   QCString         functionProto;          // function prototype
@@ -2230,11 +2232,19 @@ static bool handleName(yyscan_t yyscanner,const QCString &, const StringVector &
   return stop;
 }
 
+static void setXrefPosition(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->currentXrefFileName = yyextra->fileName;
+  yyextra->currentXrefLineNr = yyextra->lineNr;
+}
+
 static bool handleTodo(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->newXRefKind = XRef_Todo;
   setOutput(yyscanner,OutputXRef);
+  setXrefPosition(yyscanner);
   yyextra->xrefKind = XRef_Todo;
   return FALSE;
 }
@@ -2244,6 +2254,7 @@ static bool handleTest(yyscan_t yyscanner,const QCString &, const StringVector &
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->newXRefKind = XRef_Test;
   setOutput(yyscanner,OutputXRef);
+  setXrefPosition(yyscanner);
   yyextra->xrefKind = XRef_Test;
   return FALSE;
 }
@@ -2253,6 +2264,7 @@ static bool handleBug(yyscan_t yyscanner,const QCString &, const StringVector &)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->newXRefKind = XRef_Bug;
   setOutput(yyscanner,OutputXRef);
+  setXrefPosition(yyscanner);
   yyextra->xrefKind = XRef_Bug;
   return FALSE;
 }
@@ -2924,6 +2936,7 @@ static void addXRefItem(yyscan_t yyscanner,
     anchorLabel.sprintf("_%s%06d",listName.data(),item->id());
     item->setText(yyextra->outputXRef);
     item->setAnchor(anchorLabel);
+    item->setPosition(yyextra->currentXrefFileName,yyextra->currentXrefLineNr);
     yyextra->current->sli.push_back(item);
     QCString cmdString;
     cmdString.sprintf(" \\xrefitem %s %d.",qPrint(listName),item->id());

--- a/src/config.xml
+++ b/src/config.xml
@@ -1108,42 +1108,62 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
-    <option type='bool' id='GENERATE_TODOLIST' defval='1'>
+    <option type='enum' id='GENERATE_TODOLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_TODOLIST tag can be used to enable (\c YES) or
- disable (\c NO) the todo list. This list is created by
+ disable (\c NO) the todo list. When using the value \c POSITION
+ the todo list is enabled and also the place of the item in the source
+ is given. This list is created by
  putting \ref cmdtodo "\\todo" commands in the documentation.
 ]]>
       </docs>
+      <value name="NO"/>
+      <value name="YES" />
+      <value name="POSITION" />
     </option>
-    <option type='bool' id='GENERATE_TESTLIST' defval='1'>
+    <option type='enum' id='GENERATE_TESTLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_TESTLIST tag can be used to enable (\c YES) or
- disable (\c NO) the test list. This list is created by
+ disable (\c NO) the test list. When using the value \c POSITION
+ the test list is enabled and also the place of the item in the source
+ is given. This list is created by
  putting \ref cmdtest "\\test" commands in the documentation.
 ]]>
       </docs>
+      <value name="NO"/>
+      <value name="YES" />
+      <value name="POSITION" />
     </option>
-    <option type='bool' id='GENERATE_BUGLIST' defval='1'>
+    <option type='enum' id='GENERATE_BUGLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_BUGLIST tag can be used to enable (\c YES) or
- disable (\c NO) the bug list. This list is created by
+ disable (\c NO) the bug list. When using the value \c POSITION
+ the todo bug is enabled and also the place of the item in the source
+ is given. This list is created by
  putting \ref cmdbug "\\bug" commands in the documentation.
 ]]>
       </docs>
+      <value name="NO"/>
+      <value name="YES" />
+      <value name="POSITION" />
     </option>
-    <option type='bool' id='GENERATE_DEPRECATEDLIST' defval='1'>
+    <option type='enum' id='GENERATE_DEPRECATEDLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_DEPRECATEDLIST tag can be used to enable (\c YES) or
- disable (\c NO) the deprecated list. This list is created by
+ disable (\c NO) the deprecated list. When using the value \c POSITION
+ the deprecated list is enabled and also the place of the item in the source
+ is given. This list is created by
  putting \ref cmddeprecated "\\deprecated"
  commands in the documentation.
 ]]>
       </docs>
+      <value name="NO"/>
+      <value name="YES" />
+      <value name="POSITION" />
     </option>
     <option type='list' id='ENABLED_SECTIONS' format='string'>
       <docs>

--- a/src/reflist.h
+++ b/src/reflist.h
@@ -40,6 +40,7 @@ class RefItem
     void setArgs  (const QCString &args)   { m_args   = args;   }
     void setGroup (const QCString &group)  { m_group  = group;  }
     void setScope (const Definition *scope) { m_scope  = scope;  }
+    void setPosition (const QCString fileName, const int lineNr) { m_fileName = fileName; m_lineNr = lineNr;}
 
     QCString text()     const { return m_text;   }
     QCString anchor()   const { return m_anchor; }
@@ -51,6 +52,8 @@ class RefItem
     int id()            const { return m_id;     }
     RefList *list()     const { return m_list;   }
     const Definition *scope() const { return m_scope;  }
+    QCString fileName() const { return m_fileName;}
+    int lineNr()        const { return m_lineNr; }
 
   private:
     int m_id = 0;              //!< unique identifier for this item within its list
@@ -62,6 +65,8 @@ class RefItem
     QCString m_title;          //!< display name of the entity
     QCString m_args;           //!< optional arguments for the entity (if function)
     QCString m_group;          //!< group id used to combine item under a single header
+    QCString m_fileName;       //!< file name of first occurrence of this ref
+    int m_lineNr = -1;         //!< line number of first occurrence of this ref
     const Definition *m_scope = 0;   //!< scope to use for references.
 };
 
@@ -84,7 +89,7 @@ class RefList
      *  @param secTitle String representing the title of the section.
      */
     RefList(const QCString &listName, const QCString &pageTitle, const QCString &secTitle);
-    bool isEnabled() const;
+    bool isEnabled();
 
     /*! Adds a new item to the list.
      *  @returns A unique id for this item.
@@ -105,7 +110,10 @@ class RefList
     void generatePage();
 
   private:
+    QCString createDefLine(QCString fileName, int lineNr);
+
     int m_id = 0;
+    bool m_position = false; //!< signal whether or not the POSITION setting is used
     QCString m_listName;
     QCString m_fileName;
     QCString m_pageTitle;


### PR DESCRIPTION
Also known as #2574

Add for the standard reference lists (todo, test, bug, deprecated) the possibility to add the place in the original file where the corresponding command was given.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6776036/example.tar.gz)
