### PR TITLE
QUIET=YES doesn't work anymore

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1516,7 +1516,7 @@ void Config::checkAndCorrect(bool quiet)
 {
   ConfigValues::instance().init();
 
-  Config_updateBool(QUIET,quiet);
+  Config_updateBool(QUIET,quiet || Config_getBool(QUIET));
   //------------------------
   // check WARN_FORMAT
   QCString warnFormat = Config_getString(WARN_FORMAT);


### PR DESCRIPTION
Regression
Due to the fix in #8651 (bug_464997 Commandline-parameter for quiet operation) the `QUIET=YES` didn't work anymore i.e. when `QUIET=YES` and `-q` was not used we still got the full output