### PR TITLE
Feature: IGNORE_CPP_ALIGNMENT

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -40,7 +40,8 @@
 
 #include <assert.h>
 
-#define YY_NO_INPUT 1
+// yyinput used to assign afterMarker
+//#define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
 #define ADDCHAR(c)    yyextra->outBuf->addChar(c)
@@ -83,6 +84,7 @@ struct commentcnvYY_state
   int      lastCommentContext = 0;
   bool     inSpecialComment = FALSE;
   bool     inRoseComment= FALSE;
+  bool     afterMarker = FALSE;
   int      stringContext = 0;
   int      charContext = 0;
   int      javaBlock = 0;
@@ -311,6 +313,12 @@ SLASHopt [/]*
 				       yyextra->inSpecialComment=TRUE;
 				       //BEGIN(SComment); 
 				       yyextra->readLineCtx=SComment;
+
+				       // remember the after-mark, compare later on replaceComment()
+				       int nextChar = yyinput(yyscanner);
+				       yyextra->afterMarker = nextChar == '<';
+				       unput(nextChar);
+
 				       BEGIN(ReadLine);
 				     }
                                    }
@@ -1140,7 +1148,15 @@ static void replaceComment(yyscan_t yyscanner,int offset)
   {
     //printf("replaceComment(%s)\n",yytext);
     int i=computeIndent(&yytext[offset]);
-    if (i==yyextra->blockHeadCol)
+
+    // ignore C++ comment alignment
+    // plus extra check for the '<' after-marker (do not pair ///< with plain ///)
+
+    bool afterMarker = yytext[yyleng-1] == '<';
+    bool ignoreCppAlignment = Config_getBool(IGNORE_CPP_ALIGNMENT)
+                              && afterMarker == yyextra->afterMarker;
+
+    if (ignoreCppAlignment || i==yyextra->blockHeadCol)
     {
       replaceCommentMarker(yyscanner,yytext,(int)yyleng);
     }

--- a/src/config.xml
+++ b/src/config.xml
@@ -499,6 +499,16 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='bool' id='IGNORE_CPP_ALIGNMENT' defval='0'>
+      <docs>
+<![CDATA[
+  When the \c IGNORE_CPP_ALIGNMENT tag is set to \c YES, doxygen will
+  build multi-line C++ special comment blocks regardless of the indentation
+  of the comments. If set to \c NO, doxygen would only group multi-line C++
+  comments if they align vertically.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='PYTHON_DOCSTRING' defval='1'>
       <docs>
 <![CDATA[

--- a/src/doxygen.md
+++ b/src/doxygen.md
@@ -149,6 +149,7 @@ easy ways to get debug information.
     following:
      - It converts multi-line C++ style comment blocks (that are aligned)
        to C style comment blocks (if `MULTILINE_CPP_IS_BRIEF` is set to `NO`).
+       (`IGNORE_CPP_ALIGNMENT` loosens the alignment criterion.)
      - It replaces aliases with their definition (see `ALIASES`)
      - It handles conditional sections (<tt>\\cond ... \\endcond</tt> blocks)
   - commentscan<br>


### PR DESCRIPTION
This feature is a workaround for the following problem (although it can conceivable be used on its own).

## PROBLEM DESCRIPTION:
**Incorrect brief/detailed blocks in ///< comments on macros**

Doxygen (on default config settings) is presently interpreting two-line comments like this:

```
#define SOME_MACRO 42  ///< This is the documentation for SOME_MACRO
                       ///< where this second line appears as brief description
```

taking the first line as "detailed" description, and the second as "brief" description.
(It you were to show "brief first, detailed after", the two lines would be in reverse order.)

This is especially a problem for people who use the XML output.

**Related issue:**
  https://github.com/doxygen/doxygen/issues/5266

## CAUSE AND WORKAROUND:

The reason for this behavior is in the `pre.l` pass, where
the body of the macro ("42" plus blanks in this example)
is removed from the input text, and as a result the vertical
alignment of the comments is broken.

A proper solution would have involved preserving the vertical alignment
of C++ comments in `pre.l`. Since I had no time for it, I am submitting
a workaround: make vertical alignment optional via a configuration keyword,
"IGNORE_CPP_ALIGNMENT".

Note that Doxygen doesn't seem to mind if ///< and /// are intermixed, as long
as they are vertically aligned (is this another bug?), so our workaround explicitly
avoids mixing ///< and /// in the same block when IGNORE_CPP_ALIGNMENT is YES.
