### PR TITLE
Incorrect enduml warning message

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1512,8 +1512,10 @@ STopt  [^\n@\\]*
                                             yyextra->commentCount--;
                                             if (yyextra->commentCount<0)
                                             {
+                                              QCString endTag = "end"+yyextra->blockName;
+                                              if (yyextra->blockName=="startuml") endTag="enduml";
                                               warn(yyextra->fileName,yyextra->lineNr,
-                                                 "found */ without matching /* while inside a \\%s block! Perhaps a missing \\end%s?\n",qPrint(yyextra->blockName),qPrint(yyextra->blockName));
+                                                 "found */ without matching /* while inside a \\%s block! Perhaps a missing \\%s?\n",qPrint(yyextra->blockName),qPrint(endTag));
                                             }
                                           }
                                         }


### PR DESCRIPTION
In case we have a simple uml script:
```
# error message

@startuml
* some '*/' some text
* some text
@enduml
```
we get the wwarning:
```
aa.md:4: warning: found */ without matching /* while inside a \startuml block! Perhaps a missing \endstartuml?
```
note the: `\endstartuml` instead of `\enduml`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6795376/example.tar.gz)
