### PR TITLE
Handling escaped own end block command in special command block

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -186,6 +186,7 @@ RLopt [^\\@\n\*\/]*
   // Optional slash
 SLASHopt [/]*
 
+CMD          ("\\"|"@")
 %%
 
 <Scan>{NUMBER}			    { //Note similar code in code.l
@@ -576,6 +577,9 @@ SLASHopt [/]*
 				       REJECT;
 				     }
   				   }
+<Verbatim,VerbatimCode>{CMD}{CMD}  {
+                                     copyToOutput(yyscanner,yytext,(int)yyleng); 
+                                   }
 <Verbatim,VerbatimCode>.	   { /* any other character */
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1517,6 +1517,9 @@ STopt  [^\n@\\]*
                                             }
                                           }
                                         }
+<FormatBlock>{CMD}{CMD}                 {
+                                          addOutput(yyscanner,yytext);
+                                        }
 <FormatBlock>.                          {
                                           addOutput(yyscanner,*yytext);
                                         }

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -885,6 +885,9 @@ LINENR {BLANK}*[1-9][0-9]*
                          lineCount(yytext,yyleng);
                          g_token->verb+=yytext;
                        }
+<St_Code>{CMD}{CMD}    {
+                         g_token->verb+=yytext;
+                       }
 <St_HtmlOnlyOption>" [block]" { // the space is added in commentscan.l
                          g_token->name="block";
                          BEGIN(St_HtmlOnly);
@@ -906,6 +909,9 @@ LINENR {BLANK}*[1-9][0-9]*
                          lineCount(yytext,yyleng);
                          g_token->verb+=yytext;
                        }
+<St_HtmlOnly>{CMD}{CMD} {
+                         g_token->verb+=yytext;
+                       }
 <St_ManOnly>{CMD}"endmanonly" {
                          return RetVal_OK;
                        }
@@ -913,6 +919,9 @@ LINENR {BLANK}*[1-9][0-9]*
 <St_ManOnly>\n            |
 <St_ManOnly>.             {
                          lineCount(yytext,yyleng);
+                         g_token->verb+=yytext;
+                       }
+<St_ManOnly>{CMD}{CMD} {
                          g_token->verb+=yytext;
                        }
 <St_RtfOnly>{CMD}"endrtfonly" {
@@ -924,6 +933,9 @@ LINENR {BLANK}*[1-9][0-9]*
                          lineCount(yytext,yyleng);
                          g_token->verb+=yytext;
                        }
+<St_RtfOnly>{CMD}{CMD} {
+                         g_token->verb+=yytext;
+                       }
 <St_LatexOnly>{CMD}"endlatexonly" {
                          return RetVal_OK;
                        }
@@ -931,6 +943,9 @@ LINENR {BLANK}*[1-9][0-9]*
 <St_LatexOnly>\n            |
 <St_LatexOnly>.             {
                          lineCount(yytext,yyleng);
+                         g_token->verb+=yytext;
+                       }
+<St_LatexOnly>{CMD}{CMD} {
                          g_token->verb+=yytext;
                        }
 <St_XmlOnly>{CMD}"endxmlonly" {
@@ -942,6 +957,9 @@ LINENR {BLANK}*[1-9][0-9]*
                          lineCount(yytext,yyleng);
                          g_token->verb+=yytext;
                        }
+<St_XmlOnly>{CMD}{CMD} {
+                         g_token->verb+=yytext;
+                       }
 <St_DbOnly>{CMD}"enddocbookonly" {
                          return RetVal_OK;
                        }
@@ -949,6 +967,9 @@ LINENR {BLANK}*[1-9][0-9]*
 <St_DbOnly>\n         |
 <St_DbOnly>.          {
                          lineCount(yytext,yyleng);
+                         g_token->verb+=yytext;
+                       }
+<St_DbOnly>{CMD}{CMD} {
                          g_token->verb+=yytext;
                        }
 <St_Verbatim>{CMD}"endverbatim" {
@@ -961,6 +982,9 @@ LINENR {BLANK}*[1-9][0-9]*
                          lineCount(yytext,yyleng);
                          g_token->verb+=yytext;
                        }
+<St_Verbatim>{CMD}{CMD} {
+                         g_token->verb+=yytext;
+                       }
 <St_Dot>{CMD}"enddot"  {
                          return RetVal_OK;
                        }
@@ -970,6 +994,9 @@ LINENR {BLANK}*[1-9][0-9]*
                          lineCount(yytext,yyleng);
                          g_token->verb+=yytext;
                        }
+<St_Dot>{CMD}{CMD} {
+                         g_token->verb+=yytext;
+                       }
 <St_Msc>{CMD}("endmsc")  {
                          return RetVal_OK;
                        }
@@ -977,6 +1004,9 @@ LINENR {BLANK}*[1-9][0-9]*
 <St_Msc>\n             |
 <St_Msc>.              { /* msc text */
                          lineCount(yytext,yyleng);
+                         g_token->verb+=yytext;
+                       }
+<St_Msc>{CMD}{CMD} {
                          g_token->verb+=yytext;
                        }
 <St_PlantUMLOpt>{BLANK}*"{"[a-zA-Z_,:0-9\. ]*"}" { // case 1: options present
@@ -1013,6 +1043,9 @@ LINENR {BLANK}*[1-9][0-9]*
 <St_PlantUML>\n        |
 <St_PlantUML>.         { /* plantuml text */
                          lineCount(yytext,yyleng);
+                         g_token->verb+=yytext;
+                       }
+<St_PlantUML>{CMD}{CMD} {
                          g_token->verb+=yytext;
                        }
 <St_Title>"\""         { // quoted title

--- a/src/lexscanner.l
+++ b/src/lexscanner.l
@@ -889,6 +889,9 @@ NONLopt [^\n]*
 <DocCopyBlock>\n          { // newline
                             yyextra->cCodeBuffer += yytext;
                           }
+<DocCopyBlock>{CMD}{CMD}  {
+                            yyextra->cCodeBuffer += yytext;
+                          }
 <DocCopyBlock>.           { // any other character
                             yyextra->cCodeBuffer += yytext;
                           }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6763,6 +6763,9 @@ NONLopt [^\n]*
                                           yyextra->docBlock << *yytext;
                                           lineCount(yyscanner);
                                         }
+<DocCopyBlock>{CMD}{CMD}                {
+                                          yyextra->docBlock << yytext;
+                                        }
 <DocCopyBlock>.                         { // any other character
                                           yyextra->docBlock << *yytext;
                                         }


### PR DESCRIPTION
When having an example like:
```
# doxygen

@htmlonly
* finding \\endhtmlonly when
* \code
@endhtmlonly

@code
* finding \\endcode when
* \verbatim
@endcode
```

we get warnings like:
```
.../aa.md:13: warning: reached end of comment while inside a \verbatim block; check for missing \endverbatim tag!
.../aa.md:12: warning: verbatim section ended without end marker
```
this due to the fact that inside the special blocks the `\` is eaten separately and afterwards the parser sees the own special block end command and interpret this.
By handling the escaped command character (so `\\` etc.) separately we can overcome this problem.
(a workaround might be that the user uses e.g. `\&zwj;\`)

Example: [example.tar,gz](https://github.com/doxygen/doxygen/files/6795445/example.tar.gz)
