### PR TITLE
issue #8657 Plantuml ditaa diagram is not visible in refman.pdf

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2966,13 +2966,15 @@ class Receiver
   \note You need to install Java and the PlantUML's jar file,
   if you want to use this command. When using PlantUML in \LaTeX you have to download
   some more `jar` files, for details see the PlantUML documentation.
-  The location of the jar file should be specified using
-  \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH".
+  This also is valid for the `<engine>`s `latex` and `math`.
+  The location of the PlantUML file should be specified using
+  \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH". The other jar files should also reside
+  in this directory.
 
   Not all diagrams can be created with the PlantUML `@startuml` command but need another
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
-  the following `<engine>`'s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
-  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`a, `board` and `git`.s
+  the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
+  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board` and `git`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5567,8 +5567,30 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
         defaultHandleTitleAndSize(CMD_STARTUML,dv,dv->children(),width,height);
         doctokenizerYYsetStatePlantUML();
         retval = doctokenizerYYlex();
-        int line=0;
-        dv->setText(stripLeadingAndTrailingEmptyLines(g_parserContext.token->verb,line));
+        int line = 0;
+        QCString trimmedVerb = stripLeadingAndTrailingEmptyLines(g_parserContext.token->verb,line);
+        if (engine == "ditaa")
+        {
+          dv->setUseBitmap(true);
+        }
+        else if (engine == "uml")
+        {
+           // check on ditaa in first line
+           if (!trimmedVerb.isEmpty())
+           {
+             const char *p = trimmedVerb.data();
+             int i=0;
+             while (*p)
+             {
+               if (*p=='\n') break;
+               i++;
+               p++;
+             }
+             QCString firstLine = trimmedVerb.left(i);
+             if (firstLine.stripWhiteSpace() == "ditaa") dv->setUseBitmap(true);
+           }
+        }
+        dv->setText(trimmedVerb);
         dv->setWidth(width);
         dv->setHeight(height);
         dv->setLocation(g_parserContext.fileName,getDoctokinizerLineNr());

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5575,20 +5575,13 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
         }
         else if (engine == "uml")
         {
-           // check on ditaa in first line
-           if (!trimmedVerb.isEmpty())
-           {
-             const char *p = trimmedVerb.data();
-             int i=0;
-             while (*p)
-             {
-               if (*p=='\n') break;
-               i++;
-               p++;
-             }
-             QCString firstLine = trimmedVerb.left(i);
-             if (firstLine.stripWhiteSpace() == "ditaa") dv->setUseBitmap(true);
-           }
+          int i = trimmedVerb.find('\n');
+          QCString firstLine;
+          if (i == -1)
+            firstLine = trimmedVerb;
+          else
+            firstLine = trimmedVerb.left(i);
+          if (firstLine.stripWhiteSpace() == "ditaa") dv->setUseBitmap(true);
         }
         dv->setText(trimmedVerb);
         dv->setWidth(width);

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -508,6 +508,7 @@ class DocVerbatim : public DocNode
     QCString width() const       { return m_width; }
     QCString height() const      { return m_height; }
     QCString engine() const      { return m_engine; }
+    bool useBitmap() const       { return m_useBitmap; }
     const DocNodeList &children() const { return m_children; }
     DocNodeList &children()      { return m_children; }
     QCString srcFile() const     { return m_srcFile; }
@@ -516,6 +517,7 @@ class DocVerbatim : public DocNode
     void setWidth(const QCString &w)  { m_width=w;  }
     void setHeight(const QCString &h) { m_height=h; }
     void setEngine(const QCString &e) { m_engine=e; }
+    void setUseBitmap(const bool &u)  { m_useBitmap=u; }
     void setLocation(const QCString &file,int line) { m_srcFile=file; m_srcLine=line; }
 
   private:
@@ -530,6 +532,7 @@ class DocVerbatim : public DocNode
     QCString  m_width;
     QCString  m_height;
     QCString  m_engine;
+    bool      m_useBitmap=false; // some PlantUML engines cannot output data in EPS format so bitmap format is required
     DocNodeList m_children;
     QCString  m_srcFile;
     int       m_srcLine = -1;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -434,7 +434,8 @@ void LatexDocVisitor::visit(DocVerbatim *s)
         QCString latexOutput = Config_getString(LATEX_OUTPUT);
         QCString baseName = PlantumlManager::instance().writePlantUMLSource(
                               latexOutput,s->exampleFile(),s->text(),
-                              PlantumlManager::PUML_EPS,s->engine(),s->srcFile(),s->srcLine());
+                              s->useBitmap() ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS,
+                              s->engine(),s->srcFile(),s->srcLine());
 
         writePlantUMLFile(baseName, s);
       }
@@ -2018,8 +2019,13 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, DocVerbatim *s
   {
     shortName=shortName.right(shortName.length()-i-1);
   }
+  if (s->useBitmap())
+  {
+    if (shortName.find('.')==-1) shortName += ".png";
+  }
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_EPS);
+  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,
+                              s->useBitmap() ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS);
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(), s->height());
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());


### PR DESCRIPTION
The current version of plantuml does not support EPS as output format for `ditaa` (Diagram through ASCII art), so we have to revert to PNG in this case.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6796798/example.tar.gz)
