### PR TITLE
issue #7273 dot called even when HAVE_DOT is NO

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2850,6 +2850,8 @@ only copy the detailed documentation, not the brief description.
   By using the command \ref cmdref "\\ref" inside the URL value you can conveniently
   link to an item inside doxygen. Here is an example:
 
+  \note usage of this command requires that \ref cfg_have_dot "HAVE_DOT" is set to \c YES
+
   \note doxygen creates a temporary file that is automatically removed unless
   the \ref cfg_dot_cleanup "DOT_CLEANUP" tag is set to `NO`.
 
@@ -3057,6 +3059,8 @@ class Receiver
   For a description of the possibilities see the paragraph
   \ref image_sizeindicator "Size indication" with the
   \ref cmdimage "\\image" command.
+
+  \note usage of this command requires that \ref cfg_have_dot "HAVE_DOT" is set to \c YES
 
   \sa section \ref cmddot "\\dot".
 

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -1169,7 +1169,7 @@ class DocPara : public CompAccept<DocPara>
                            int direction);
     void handleIncludeOperator(const QCString &cmdName,DocIncOperator::Type t);
     void handleImage(const QCString &cmdName);
-    template<class T> void handleFile(const QCString &cmdName);
+    template<class T> void handleFile(const QCString &cmdName, const char *warnTxt = NULL);
     void handleInclude(const QCString &cmdName,DocInclude::Type t);
     void handleLink(const QCString &cmdName,bool isJavaLink);
     void handleCite();


### PR DESCRIPTION
Guarded the `\dot` and `\dotfile` against  `HAVE_DOT` not set.

(PlantUML was already guarded by means of `PLANTUML_JAR_PATH`)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6796871/example.tar.gz)
