### PR TITLE
issue #7195 reserved identifier violation

### DIFF
--- a/addon/doxywizard/inputbool.h
+++ b/addon/doxywizard/inputbool.h
@@ -10,8 +10,8 @@
  *
  */
 
-#ifndef _INPUTBOOL_H
-#define _INPUTBOOL_H
+#ifndef INPUTBOOL_H
+#define INPUTBOOL_H
 
 #include "input.h"
 #include <QObject>

--- a/addon/doxywizard/inputint.h
+++ b/addon/doxywizard/inputint.h
@@ -10,8 +10,8 @@
  *
  */
 
-#ifndef _INPUTINT_H
-#define _INPUTINT_H
+#ifndef INPUTINT_H
+#define INPUTINT_H
 
 #include "input.h"
 #include <QObject>

--- a/addon/doxywizard/inputstring.h
+++ b/addon/doxywizard/inputstring.h
@@ -10,8 +10,8 @@
  *
  */
 
-#ifndef _INPUTSTRING_H
-#define _INPUTSTRING_H
+#ifndef INPUTSTRING_H
+#define INPUTSTRING_H
 
 #include "input.h"
 

--- a/addon/doxywizard/inputstrlist.h
+++ b/addon/doxywizard/inputstrlist.h
@@ -10,8 +10,8 @@
  *
  */
 
-#ifndef _INPUTSTRLIST_H
-#define _INPUTSTRLIST_H
+#ifndef INPUTSTRLIST_H
+#define INPUTSTRLIST_H
 
 #include "input.h"
 

--- a/examples/diagrams_a.h
+++ b/examples/diagrams_a.h
@@ -1,4 +1,4 @@
-#ifndef _DIAGRAMS_A_H
-#define _DIAGRAMS_A_H
+#ifndef DIAGRAMS_A_H
+#define DIAGRAMS_A_H
 class A { public: A *m_self; };
 #endif

--- a/examples/diagrams_b.h
+++ b/examples/diagrams_b.h
@@ -1,5 +1,5 @@
-#ifndef _DIAGRAMS_B_H
-#define _DIAGRAMS_B_H
+#ifndef DIAGRAMS_B_H
+#define DIAGRAMS_B_H
 class A;
 class B { public: A *m_a; };
 #endif

--- a/examples/diagrams_c.h
+++ b/examples/diagrams_c.h
@@ -1,5 +1,5 @@
-#ifndef _DIAGRAMS_C_H
-#define _DIAGRAMS_C_H
+#ifndef DIAGRAMS_C_H
+#define DIAGRAMS_C_H
 #include "diagrams_c.h"
 class D;
 class C : public A { public: D *m_d; };

--- a/examples/diagrams_d.h
+++ b/examples/diagrams_d.h
@@ -1,5 +1,5 @@
-#ifndef _DIAGRAM_D_H
-#define _DIAGRAM_D_H
+#ifndef DIAGRAM_D_H
+#define DIAGRAM_D_H
 #include "diagrams_a.h"
 #include "diagrams_b.h"
 class C;

--- a/examples/diagrams_e.h
+++ b/examples/diagrams_e.h
@@ -1,5 +1,5 @@
-#ifndef _DIAGRAM_E_H
-#define _DIAGRAM_E_H
+#ifndef DIAGRAM_E_H
+#define DIAGRAM_E_H
 #include "diagrams_d.h"
 class E : public D {};
 #endif

--- a/libmd5/md5_loc.h
+++ b/libmd5/md5_loc.h
@@ -1,5 +1,5 @@
-#ifndef _MD5LOC_H
-#define _MD5LOC_H
+#ifndef MD5LOC_H
+#define MD5LOC_H
 
 # define UWORD32 unsigned int
 

--- a/libmscgen/gdfonts.h
+++ b/libmscgen/gdfonts.h
@@ -1,5 +1,5 @@
-#ifndef _GDFONTS_H_
-#define _GDFONTS_H_ 1
+#ifndef GDFONTS_H
+#define GDFONTS_H 1
 
 #ifdef __cplusplus
 extern "C"

--- a/libmscgen/gdfontt.h
+++ b/libmscgen/gdfontt.h
@@ -1,5 +1,5 @@
-#ifndef _GDFONTT_H_
-#define _GDFONTT_H_ 1
+#ifndef GDFONTT_H
+#define GDFONTT_H 1
 
 #ifdef __cplusplus
 extern "C"

--- a/src/bufstr.h
+++ b/src/bufstr.h
@@ -15,8 +15,8 @@
  * input used in their production; they are not affected by this license.
  *
  */
-#ifndef _BUFSTR_H
-#define _BUFSTR_H
+#ifndef BUFSTR_H
+#define BUFSTR_H
 
 #include <cstdlib>
 #include "qcstring.h"

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _CMDMAPPER_H
-#define _CMDMAPPER_H
+#ifndef CMDMAPPER_H
+#define CMDMAPPER_H
 
 #include <map>
 #include <string>

--- a/src/commentcnv.h
+++ b/src/commentcnv.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef _COMMENTCNV_H
-#define _COMMENTCNV_H
+#ifndef COMMENTCNV_H
+#define COMMENTCNV_H
 
 class BufStr;
 class QCString;

--- a/src/constexp.h
+++ b/src/constexp.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _CONSTEXP_H
-#define _CONSTEXP_H
+#ifndef CONSTEXP_H
+#define CONSTEXP_H
 
 #include <string>
 

--- a/src/constexp_p.h
+++ b/src/constexp_p.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _CONSTEXP_P_H
-#define _CONSTEXP_P_H
+#ifndef CONSTEXP_P_H
+#define CONSTEXP_P_H
 
 #include <string>
 

--- a/src/cppvalue.h
+++ b/src/cppvalue.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _CPPVALUE_H
-#define _CPPVALUE_H
+#ifndef CPPVALUE_H
+#define CPPVALUE_H
 
 #include <cstdio>
 #include <string>

--- a/src/debug.h
+++ b/src/debug.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _DEBUG_H
-#define _DEBUG_H
+#ifndef DEBUG_H
+#define DEBUG_H
 
 class QCString;
 

--- a/src/dia.h
+++ b/src/dia.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef _DIA_H
-#define _DIA_H
+#ifndef DIA_H
+#define DIA_H
 
 class QCString;
 

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -13,8 +13,8 @@
 *
 */
 
-#ifndef _DOCBOOKDOCVISITOR_H
-#define _DOCBOOKDOCVISITOR_H
+#ifndef DOCBOOKDOCVISITOR_H
+#define DOCBOOKDOCVISITOR_H
 
 #include <iostream>
 

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _DOCPARSER_H
-#define _DOCPARSER_H
+#ifndef DOCPARSER_H
+#define DOCPARSER_H
 
 #include <stdio.h>
 #include <vector>

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _DOCTOKENIZER_H
-#define _DOCTOKENIZER_H
+#ifndef DOCTOKENIZER_H
+#define DOCTOKENIZER_H
 
 #include <stdio.h>
 

--- a/src/docvisitor.h
+++ b/src/docvisitor.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _DOCVISITOR_H
-#define _DOCVISITOR_H
+#ifndef DOCVISITOR_H
+#define DOCVISITOR_H
 
 #include <memory>
 

--- a/src/htmlattrib.h
+++ b/src/htmlattrib.h
@@ -12,8 +12,8 @@
  *
  */
 
-#ifndef _HTMLATTRIB_H
-#define _HTMLATTRIB_H
+#ifndef HTMLATTRIB_H
+#define HTMLATTRIB_H
 
 #include <vector>
 

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _HTMLDOCVISITOR_H
-#define _HTMLDOCVISITOR_H
+#ifndef HTMLDOCVISITOR_H
+#define HTMLDOCVISITOR_H
 
 #include "docvisitor.h"
 #include "qcstring.h"

--- a/src/image.h
+++ b/src/image.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _IMAGE_H
-#define _IMAGE_H
+#ifndef IMAGE_H
+#define IMAGE_H
 
 #include "types.h"
 #include "qcstring.h"

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _LATEXDOCVISITOR_H
-#define _LATEXDOCVISITOR_H
+#ifndef LATEXDOCVISITOR_H
+#define LATEXDOCVISITOR_H
 
 #include <stack>
 

--- a/src/mandocvisitor.h
+++ b/src/mandocvisitor.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _MANDOCVISITOR_H
-#define _MANDOCVISITOR_H
+#ifndef MANDOCVISITOR_H
+#define MANDOCVISITOR_H
 
 #include <iostream>
 

--- a/src/msc.h
+++ b/src/msc.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _MSC_H
-#define _MSC_H
+#ifndef MSC_H
+#define MSC_H
 
 class QCString;
 class TextStream;

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _PRINTDOCVISITOR_H
-#define _PRINTDOCVISITOR_H
+#ifndef PRINTDOCVISITOR_H
+#define PRINTDOCVISITOR_H
 
 #include "docvisitor.h"
 #include "htmlentity.h"

--- a/src/reflist.h
+++ b/src/reflist.h
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef _REFLIST_H
-#define _REFLIST_H
+#ifndef REFLIST_H
+#define REFLIST_H
 
 #include <vector>
 #include <unordered_map>

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _RTFDOCVISITOR_H
-#define _RTFDOCVISITOR_H
+#ifndef RTFDOCVISITOR_H
+#define RTFDOCVISITOR_H
 
 #include <iostream>
 

--- a/src/textdocvisitor.h
+++ b/src/textdocvisitor.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _TEXTDOCVISITOR_H
-#define _TEXTDOCVISITOR_H
+#ifndef TEXTDOCVISITOR_H
+#define TEXTDOCVISITOR_H
 
 #include "qcstring.h"
 #include "docvisitor.h"

--- a/src/xmldocvisitor.h
+++ b/src/xmldocvisitor.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _XMLDOCVISITOR_H
-#define _XMLDOCVISITOR_H
+#ifndef XMLDOCVISITOR_H
+#define XMLDOCVISITOR_H
 
 #include <iostream>
 


### PR DESCRIPTION
Based in the example in the issue there are a few more files to be handled (also to have all guards consistent).
The file winbuild/iconv.h is explicitly not changed as this is an external file.

The change is based on:
- https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL51-CPP.+Do+not+declare+or+define+a+reserved+identifier#DCL51-CPP.Donotdeclareordefineareservedidentifier-NoncompliantCodeExample%28HeaderGuard%29
- https://en.wikipedia.org/wiki/Include_guard#Discussion