### PR TITLE
Add config option SHOW_HEADERFILE

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -714,7 +714,7 @@ Structural indicators
   \ref cfg_force_local_includes "FORCE_LOCAL_INCLUDES" to \c YES.
 
   To disable the include information altogether set
-  \ref cfg_show_include_files "SHOW_INCLUDE_FILES" to \c NO.
+  \ref cfg_show_headerfile "SHOW_HEADERFILE" to \c NO.
 
 <hr>
 \section cmdhideinitializer \\hideinitializer

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1889,7 +1889,7 @@ void ClassDefImpl::writeIncludeFilesForSlice(OutputList &ol) const
 
 void ClassDefImpl::writeIncludeFiles(OutputList &ol) const
 {
-  if (m_impl->incInfo /*&& Config_getBool(SHOW_INCLUDE_FILES)*/)
+  if (m_impl->incInfo /*&& Config_getBool(SHOW_HEADERFILE)*/)
   {
     SrcLangExt lang = getLanguage();
     QCString nm=m_impl->incInfo->includeName.isEmpty() ?

--- a/src/config.xml
+++ b/src/config.xml
@@ -1003,6 +1003,14 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='bool' id='SHOW_HEADERFILE' defval='1'>
+      <docs>
+<![CDATA[
+ If the \c SHOW_HEADERFILE tag is set to \c YES then the documentation
+ for a class will show which file needs to be included to use the class.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='SHOW_INCLUDE_FILES' defval='1'>
       <docs>
 <![CDATA[

--- a/templates/general/layout_default.xml
+++ b/templates/general/layout_default.xml
@@ -41,7 +41,7 @@
   <!-- Layout definition for a class page -->
   <class>
     <briefdescription visible="yes"/>
-    <includes visible="$SHOW_INCLUDE_FILES"/>
+    <includes visible="$SHOW_HEADERFILE"/>
     <inheritancegraph visible="$CLASS_GRAPH"/>
     <collaborationgraph visible="$COLLABORATION_GRAPH"/>
     <memberdecl>
@@ -132,7 +132,7 @@
   <!-- Layout definition for a concept page -->
   <concept>
     <briefdescription visible="yes"/>
-    <includes visible="$SHOW_INCLUDE_FILES"/>
+    <includes visible="$SHOW_HEADERFILE"/>
     <definition visible="yes" title=""/>
     <detaileddescription title=""/>
     <authorsection visible="yes"/>


### PR DESCRIPTION
This adds a new configuration option that controls whether to show the
file specified by \headerfile (or the header-file argument of \class) in
the documentation for a class or concept.

Previously that was controlled by SHOW_INCLUDE_FILES, but that should be
used for showing the include list for \file documentation. With this
change, there are two separate options to control the two separate
behaviours.

Fixes #8639