### PR TITLE
bug_172256 Todo stops at first sentence.

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -690,7 +690,7 @@ STopt  [^\n@\\]*
                                             int i=0;
                                             while (yytext[i]==' ' || yytext[i]=='\t') i++;
                                             yyextra->spaceBeforeCmd = QCString(yytext).left(i);
-                                            if (it->second.spacing==CommandSpacing::Block && !(yyextra->inContext==OutputXRef && cmdName=="parblock"))
+                                            if ((it->second.spacing==CommandSpacing::Block || it->second.spacing==CommandSpacing::XRef) && !(yyextra->inContext==OutputXRef && cmdName=="parblock"))
                                             {
                                               yyextra->briefEndsAtDot=FALSE;
                                               // this command forces the end of brief description


### PR DESCRIPTION
Based on the example give we see that the first to do of
```
/// @todo Item1. More text.
/// @todo Item2. More text 2.
class aa
{
}
```
is split over 2 lines and this should not be the case (second line is even outside the `\todo` part).

The problem has also been checked against bug_754184 as its fix:
```
commit 13e2b18c93df1351c4e91d13a7fe224b4841fa73
Date:   Tue Oct 20 22:01:55 2015 +0200

    Bug 754184 - \bug paragraph doesn't end with a new sectioning command
```
caused the problem as indicated in the 2nd part of the issue.
Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6817447/example.tar.gz)
