### PR TITLE
Missing rule in defargs.l

### DIFF
--- a/src/defargs.l
+++ b/src/defargs.l
@@ -269,6 +269,10 @@ CPPC  "/\/"
 					  if (yyextra->argRoundCount>0) yyextra->argRoundCount--;
 					  else BEGIN( yyextra->readArgContext );
                                         }
+<CopyArgSquare>"["                      {
+                                           yyextra->argSquareCount++;
+                                           *yyextra->copyArgValue += *yytext;
+                                        }
 <CopyArgSquare>"]"({B}*{ID})* {
 					  *yyextra->copyArgValue += yytext;
 					  if (yyextra->argSquareCount>0) 


### PR DESCRIPTION
The fix in defargs.l regarding the "undeclared start condition CCopyArgSquare" should not have removed the complete rule but just the first `C` of `CCopyArgSquare`