### PR TITLE
Warning message in case of preprocesssor macro substitution

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1441,7 +1441,7 @@ WSopt [ \t\r]*
 <RemoveCPPComment>{CPPC}
 <RemoveCPPComment>[^\x06\n]+
 <RemoveCPPComment>.
-<DefineText>"#"                         {
+<DefineText>"#"/{IDSTART}               {
                                           outputChar(yyscanner,' ');
                                           yyextra->quoteArg=TRUE;
                                           yyextra->defLitText+=yytext;


### PR DESCRIPTION
During the manual merge of issue #8645 the change of a rule has been missed resulting in incorrect and missing warnings:

missing:
```
aa.cpp:9: warning: expected formal parameter after # in macro definition 'def7': 'a#'
aa.h:7: warning: expected formal parameter after # in macro definition 'def7': 'a#'
gasnetex.h:16: warning: expected formal parameter after # in macro definition 'Z1': '#'
```

Less correct warnings, due to incorrect rule we get:
```
gasnetex.h:3: warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' ( != 1)'
gasnetex.h:17: warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' (   != 1)'
gg.h:4: warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' ! 1L  ||      ( 1L  &&  != 0 &&  != 1)'
```

instead of:
```
gasnetex.h:3: warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' (#  != 1)'
gasnetex.h:17: warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' ( #  != 1)'
gg.h:4: warning: preprocessing issue while doing constant expression evaluation: syntax error: input=' ! 1L  ||      ( 1L  && #  != 0 && #  != 1)'
```