### PR TITLE
issue #8633 Line break in C++ nested-name confuses doxygen

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -226,6 +226,7 @@ static void addKnRArgInfo(yyscan_t yyscanner,const QCString &type,const QCString
                           const QCString &brief,const QCString &docs);
 static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
+static QCString removeWhiteSpace(const QCString &s);
 
 /* ----------------------------------------------------------------- */
 #undef  YY_INPUT
@@ -2345,6 +2346,7 @@ NONLopt [^\n]*
                                               BEGIN(FindMembers);
                                             }
                                           }
+                                          yyextra->current->name = removeWhiteSpace(yyextra->current->name);
                                         }
 <StaticAssert>"("                       {
                                           yyextra->lastSkipRoundContext = FindMembers;
@@ -7068,7 +7070,7 @@ static void addType(yyscan_t yyscanner)
   {
     yyextra->current->type += ' ' ;
   }
-  yyextra->current->type += yyextra->current->name ;
+  yyextra->current->type += yyextra->current->name;
   yyextra->current->name.resize(0) ;
   tl=yyextra->current->type.length();
   if( tl>0 && !yyextra->current->args.isEmpty() && yyextra->current->type.at(tl-1)!='.')
@@ -7702,6 +7704,19 @@ static void parsePrototype(yyscan_t yyscanner,const QCString &text)
 
 
   //printf("**** parsePrototype end\n");
+}
+
+// removeRedundantWhiteSpace does not work as it will leave e.g. "foo:: bar"
+static QCString removeWhiteSpace(const QCString &s)
+{
+  QCString res;
+  uint l=s.length();
+  const char *src=s.data();
+  for (uint i = 0;i<l;i++)
+  {
+    if (!isspace((uchar)src[i])) res += src[i];
+  }
+  return res;
 }
 
 //static void handleGroupStartCommand(const char *header)


### PR DESCRIPTION
The white space was detected by doxygen in the name of a variable / scope name but handled with removeRedundantWhiteSpace and this left a space after the `::`, using a dedicated method solves this issue.