### PR TITLE
Source code requires in a number of cases `EXTRACT_ALL`

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -377,6 +377,8 @@ DB_GEN_C
 void DocbookGenerator::startIndexSection(IndexSections is)
 {
 DB_GEN_C2("IndexSections " << is)
+  bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
+
   switch (is)
   {
     case isTitlePageStart:
@@ -571,29 +573,20 @@ DB_GEN_C2("IndexSections " << is)
     case isFileDocumentation:
       {
         m_t << "</title>\n";
-        bool isFirst=TRUE;
         for (const auto &fn : *Doxygen::inputNameLinkedMap)
         {
           for (const auto &fd : *fn)
           {
-            if (fd->isLinkableInProject())
+            if ((fd->isLinkableInProject()) ||
+                (sourceBrowser && m_prettyCode && fd->generateSourceFile()))
             {
-              if (isFirst)
+              if (fd->isLinkableInProject())
               {
                 m_t << "    <xi:include href=\"" << fd->getOutputFileBase() << ".xml\" xmlns:xi=\"http://www.w3.org/2001/XInclude\"/>\n";
-                if (sourceBrowser && m_prettyCode && fd->generateSourceFile())
-                {
-                  m_t << "    <xi:include href=\"" << fd->getSourceFileBase() << ".xml\" xmlns:xi=\"http://www.w3.org/2001/XInclude\"/>\n";
-                }
-                isFirst=FALSE;
               }
-              else
+              if (sourceBrowser && m_prettyCode && fd->generateSourceFile())
               {
-                m_t << "    <xi:include href=\"" << fd->getOutputFileBase() << ".xml\" xmlns:xi=\"http://www.w3.org/2001/XInclude\"/>\n";
-                if (sourceBrowser && m_prettyCode && fd->generateSourceFile())
-                {
-                  m_t << "    <xi:include href=\"" << fd->getSourceFileBase() << ".xml\" xmlns:xi=\"http://www.w3.org/2001/XInclude\"/>\n";
-                }
+                m_t << "    <xi:include href=\"" << fd->getSourceFileBase() << ".xml\" xmlns:xi=\"http://www.w3.org/2001/XInclude\"/>\n";
               }
             }
           }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5233,7 +5233,7 @@ QCString rtfFormatBmkStr(const QCString &name)
     }
   }
 
-  //printf("Name = %s RTF_tag = %s\n",name,qPrint(*tag)));
+  //printf("Name = %s RTF_tag = %s\n",qPrint(name),qPrint(tag));
   return tag;
 }
 


### PR DESCRIPTION
Looking at issue #8679 we detected that the source code was not always shown when `EXTRACT_ALL` was not set. This happened with LaTeX, RTF and Docbook.
To be able to really address the problem of #8679 it is necessary that the source code is correctly included when it is required, otherwise there will be a lot of undefined references.
In this pull request the handling of the source code for the mentioned output formats has been corrected. Due to the extra flag to show the source code in the output for these format some code duplication was necessary.

Further improvements:
- debug statement in util.cpp
- creation of anchor in LaTeX