### PR TITLE
LaTeX warning in test 26

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -223,11 +223,11 @@ void LatexDocVisitor::visit(DocSymbol *s)
   {
     if (((s->symbol() == DocSymbol::Sym_lt) || (s->symbol() == DocSymbol::Sym_Less))&& (!m_insidePre))
     {
-      m_t << "$<$";
+      m_t << "\\texorpdfstring{$<$}{<}";
     }
     else if (((s->symbol() == DocSymbol::Sym_gt) || (s->symbol() == DocSymbol::Sym_Greater)) && (!m_insidePre))
     {
-      m_t << "$>$";
+      m_t << "\\texorpdfstring{$>$}{>}";
     }
     else
     {


### PR DESCRIPTION
In test 26 we getre a number of warnings like:
```
Package hyperref Warning: Token not allowed in a PDF string (Unicode):
(hyperref)                removing `math shift' on input line 1.
```
this is due to the usage of the math mode for `<` and `>` in the section title, i.e.:
```
\doxysection{Test$<$ T $>$ Class Template Reference}
```

This has been corrected
(see also discussion at: https://tex.stackexchange.com/questions/606043/size-of-and-in-sectops-in-relation-to-hyper-references)