### PR TITLE
issue #8680 Markdown links going via tag files instead of local resolution

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2946,7 +2946,15 @@ static void addXRefItem(yyscan_t yyscanner,
       const SectionInfo *si = sm.find(anchorLabel);
       if (si)
       {
-        if (si->lineNr() != -1)
+        if (!si->ref().isEmpty()) // we are from a tag file
+        {
+          sm.del(anchorLabel);
+          si = sm.add(anchorLabel,listName,yyextra->lineNr,
+              yyextra->sectionTitle,SectionType::Anchor,
+              yyextra->sectionLevel);
+          yyextra->current->anchors.push_back(si);
+        }
+        else if (si->lineNr() != -1)
         {
           warn(listName,yyextra->lineNr,"multiple use of section label '%s', (first occurrence: %s, line %d)",qPrint(anchorLabel),qPrint(si->fileName()),si->lineNr());
         }
@@ -3001,7 +3009,20 @@ static void addSection(yyscan_t yyscanner)
   const SectionInfo *si = sm.find(yyextra->sectionLabel);
   if (si)
   {
-    if (si->lineNr() != -1)
+    if (!si->ref().isEmpty()) // we are from a tag file
+    {
+      sm.del(yyextra->sectionLabel);
+      // create a new section element
+      yyextra->sectionTitle+=yytext;
+      yyextra->sectionTitle=yyextra->sectionTitle.stripWhiteSpace();
+      si = sm.add(yyextra->sectionLabel,yyextra->fileName,yyextra->lineNr,
+                  yyextra->sectionTitle,sectionLevelToType(yyextra->sectionLevel),
+                  yyextra->sectionLevel);
+
+      // add section to this entry
+      yyextra->current->anchors.push_back(si);
+    }
+    else if (si->lineNr() != -1)
     {
       warn(yyextra->fileName,yyextra->lineNr,"multiple use of section label '%s' while adding section, (first occurrence: %s, line %d)",qPrint(yyextra->sectionLabel),qPrint(si->fileName()),si->lineNr());
     }
@@ -3202,7 +3223,13 @@ static void addAnchor(yyscan_t yyscanner,const QCString &anchor)
   const SectionInfo *si = sm.find(anchor);
   if (si)
   {
-    if (si->lineNr() != -1)
+    if (!si->ref().isEmpty()) // we are from a tag file
+    {
+      sm.del(anchor);
+      si = sm.add(anchor,yyextra->fileName,yyextra->lineNr,QCString(),SectionType::Anchor,0);
+      yyextra->current->anchors.push_back(si);
+    }
+    else if (si->lineNr() != -1)
     {
       warn(yyextra->fileName,yyextra->lineNr,
           "multiple use of section label '%s' while adding anchor, (first occurrence: %s, line %d)",

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8817,7 +8817,19 @@ static void findMainPage(Entry *root)
       const SectionInfo *si = SectionManager::instance().find(Doxygen::mainPage->name());
       if (si)
       {
-        if (si->lineNr() != -1)
+        if (!si->ref().isEmpty()) // we are from a tag file
+        {
+          SectionManager::instance().del(Doxygen::mainPage->name());
+          // a page name is a label as well! but should no be double either
+          SectionManager::instance().add(
+            Doxygen::mainPage->name(),
+            indexName,
+            root->startLine,
+            Doxygen::mainPage->title(),
+            SectionType::Page,
+            0); // level 0
+        }
+        else if (si->lineNr() != -1)
         {
           warn(root->fileName,root->startLine,"multiple use of section label '%s' for main page, (first occurrence: %s, line %d)",
                qPrint(Doxygen::mainPage->name()),qPrint(si->fileName()),si->lineNr());

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4758,9 +4758,10 @@ PageDef *addRelatedPage(const QCString &name,const QCString &ptitle,
     )
 {
   PageDef *pd=0;
-  //printf("addRelatedPage(name=%s gd=%p)\n",name,gd);
+  //printf("addRelatedPage(name=%s gd=%p)\n",qPrint(name),gd);
   QCString title=ptitle.stripWhiteSpace();
-  if ((pd=Doxygen::pageLinkedMap->find(name)) && !tagInfo)
+  bool newPage = true;
+  if ((pd=Doxygen::pageLinkedMap->find(name)) && !pd->isReference())
   {
     if (!xref && !title.isEmpty() && pd->title()!=title)
     {
@@ -4772,8 +4773,14 @@ PageDef *addRelatedPage(const QCString &name,const QCString &ptitle,
     //printf("Adding page docs '%s' pi=%p name=%s\n",qPrint(doc),pd,name);
     // append (x)refitems to the page.
     pd->setRefItems(sli);
+    newPage = false;
   }
-  else // new page
+  else if (pd) // we are from a tag file
+  {
+    Doxygen::pageLinkedMap->del(name);
+  }
+
+  if (newPage) // new page
   {
     QCString baseName=name;
     if (baseName.right(4)==".tex")
@@ -4821,7 +4828,13 @@ PageDef *addRelatedPage(const QCString &name,const QCString &ptitle,
       const SectionInfo *si = SectionManager::instance().find(pd->name());
       if (si)
       {
-        if (si->lineNr() != -1)
+        if (!si->ref().isEmpty()) // we are from a tag file
+        {
+          SectionManager::instance().del(pd->name());
+          SectionManager::instance().add(pd->name(),
+              file,-1,pd->title(),SectionType::Page,0,pd->getReference());
+        }
+        else if (si->lineNr() != -1)
         {
           warn(orgFile,line,"multiple use of section label '%s', (first occurrence: %s, line %d)",qPrint(pd->name()),qPrint(si->fileName()),si->lineNr());
         }


### PR DESCRIPTION
Prefer local page and section references above references to pages and sections from other projects (i.e. just ignore them).
When a local reference should be added an already an external reference is found ignore the external reference, remove it from the list and add the local reference.