### PR TITLE
issue #7434 Error in LaTeX output of doxygen documentation of VHDL

### DIFF
--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -808,6 +808,7 @@ class TranslatorBrazilian : public TranslatorAdapter_1_9_2
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"A documentação para ";
       if (compType == ClassDef::Protocol)
       {
@@ -819,7 +820,7 @@ class TranslatorBrazilian : public TranslatorAdapter_1_9_2
       }
       switch(compType)
       {
-        case ClassDef::Class:      result+="classe "; break;
+        case ClassDef::Class:      result+=vhdlOpt?"Unidade de Design ":"classe "; break;
         case ClassDef::Struct:     result+="estrutura "; break;
         case ClassDef::Union:      result+="união "; break;
         case ClassDef::Interface:  result+="interface "; break;

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -864,10 +864,11 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
         bool single)
     { // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"Die Dokumentation für diese";
       switch(compType)
       {
-        case ClassDef::Class:      result+=" Klasse"; break;
+        case ClassDef::Class:      result+=vhdlOpt?"Entwurfseinheiten":"Klasse"; break;
         case ClassDef::Struct:     result+=" Struktur"; break;
         case ClassDef::Union:      result+=" Variante"; break;
         case ClassDef::Interface:  result+=" Schnittstelle"; break;

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -766,10 +766,11 @@ class TranslatorEnglish : public Translator
     virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
         bool single)
     { // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"The documentation for this ";
       switch(compType)
       {
-        case ClassDef::Class:      result+="class"; break;
+        case ClassDef::Class:      result+=vhdlOpt?"design unit":"class"; break;
         case ClassDef::Struct:     result+="struct"; break;
         case ClassDef::Union:      result+="union"; break;
         case ClassDef::Interface:  result+="interface"; break;

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -756,10 +756,11 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"La documentación para est";
       switch(compType)
       {
-        case ClassDef::Class:      result+="a clase"; break;
+        case ClassDef::Class:      result+=vhdlOpt? "a unidades de diseño":"a clase"; break;
         case ClassDef::Struct:     result+="a estructura"; break;
         case ClassDef::Union:      result+="a unión"; break;
         case ClassDef::Interface:  result+="e interfaz"; break;

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -822,11 +822,12 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       bool feminine = true;
       QCString result=(QCString)"La documentation de ";
       switch(compType)
       {
-        case ClassDef::Class:      result+="cette classe"; break;
+        case ClassDef::Class:      result+=vhdlOpt? "cette unités de conception":"cette classe"; break;
         case ClassDef::Struct:     result+="cette structure"; break;
         case ClassDef::Union:      result+="cette union"; break;
         case ClassDef::Interface:  result+="cette interface"; break;

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -414,10 +414,11 @@ class TranslatorDutch : public Translator
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"De documentatie voor ";
       switch(compType)
       {
-        case ClassDef::Class:      result+="deze klasse"; break;
+        case ClassDef::Class:      result+=vhdlOpt?"deze ontwerp eenheid":"deze klasse"; break;
         case ClassDef::Struct:     result+="deze struct"; break;
         case ClassDef::Union:      result+="deze union"; break;
         case ClassDef::Interface:  result+="dit interface"; break;

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -770,10 +770,11 @@ class TranslatorPortuguese : public TranslatorAdapter_1_9_2
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"A documentação para ";
       switch(compType)
       {
-        case ClassDef::Class:      result+="esta classe"; break;
+        case ClassDef::Class:      result+=vhdlOpt?"esta Unidade de Design":"esta classe"; break;
         case ClassDef::Struct:     result+="esta estrutura"; break;
         case ClassDef::Union:      result+="esta união"; break;
         case ClassDef::Interface:  result+="este interface"; break;

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -866,10 +866,11 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_2
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
+      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"Dokumentationen för ";
       switch(compType)
       {
-        case ClassDef::Class:      result+="denna klass"; break;
+        case ClassDef::Class:      result+=vhdlOpt? "denna designenhets":"denna klass"; break;
         case ClassDef::Struct:     result+="denna strukt"; break;
         case ClassDef::Union:      result+="denna union"; break;
         case ClassDef::Interface:  result+="detta gränssnitt"; break;


### PR DESCRIPTION
In this issue there are 2 texts to be replaced: Class and Namespace.

Most Class texts are already corrected, though, at least, the sentence "The documentation for this class was generated from the following file:" was not corrected.
Based on the output languages where the word "design unit" was translated the relevant function was, best guess, corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6872345/example.tar.gz)
