### PR TITLE
bug_796673 doxygen markdown engine disallow parentheses in image title

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1002,12 +1002,21 @@ int Markdown::processLink(const char *data,int,int size)
       i++;
       titleStart=i;
       nl=0;
-      while (i<size && data[i]!=')')
+      while (i<size)
       {
         if (data[i]=='\n')
         {
           if (nl>1) { TRACE_RESULT(0); return 0; }
           nl++;
+        }
+        else if (data[i]=='\\') // escaped char in string
+        {
+          i++; 
+        }
+        else if (data[i]==c)
+        {
+          i++; 
+          break;
         }
         i++;
       }
@@ -1023,6 +1032,16 @@ int Markdown::processLink(const char *data,int,int size)
       {
         convertStringFragment(title,data+titleStart,titleEnd-titleStart);
         //printf("processLink: title={%s}\n",qPrint(title));
+        while (i<size)
+        {
+          if (data[i]==' ')i++; // remove space after the closing quote and the closing bracket
+          else if (data[i] == ')') break; // the end bracket
+          else // illegal
+          {
+            TRACE_RESULT(0);
+            return 0;
+          }
+        }
       }
       else
       {


### PR DESCRIPTION
(Also known as: #6380).
Ignore brackets inside a title, so it is not terminating the title detection.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6873652/example.tar.gz)
