### PR TITLE
Equation reference  for formulas missing for HTML / Docbook / RTF

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -195,7 +195,7 @@ void FormulaManager::generateImages(const QCString &path,Format format,HighDPI h
     Portable::sysTimerStart();
     char args[4096];
     sprintf(args,"-interaction=batchmode _formulas.tex >%s",Portable::devNull());
-    if (Portable::system(latexCmd,args)!=0)
+    if ((Portable::system(latexCmd,args)!=0) || (Portable::system(latexCmd,args)!=0))
     {
       err("Problems running latex. Check your installation or look "
           "for typos in _formulas.tex and check _formulas.log!\n");


### PR DESCRIPTION
When having a simple example:
```
# Math references

\f{equation}{
\alpha = \beta * \gamma
  \label{eq:my_system}
\f}

The reference: \f$\eqref{eq:my_system}\f$
```
and
```
EXTRA_PACKAGES = amsmath amssymb
```

The reference will be `??` instead of `1` due to the fact that that `latex` command is only run once.
Note: When using MathJax with (but this is not a solution for e.g RTF):
```
USE_MATHJAX = YES
EXTRA_PACKAGES = amsmath amssymb
MATHJAX_EXTENSIONS     = amssymb amsmath
MATHJAX_CODEFILE       = mycode.js
```
and `mycode.js` like
```
MathJax.Hub.Config({
  TeX: { equationNumbers: { autoNumber: "AMS" } }
});
```
the reference is shown again.

Old result:

![image](https://user-images.githubusercontent.com/5223533/126980682-a5d471c8-bcdd-4aa8-b57a-199ac0e092a0.png)


New result:
![image](https://user-images.githubusercontent.com/5223533/126980618-e7336d9d-c68c-4a30-80ec-ac55da1e626e.png)


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6877705/example.tar.gz)

The problem was found based on: https://stackoverflow.com/questions/68521882/autonumbering-equations-in-doxygen/
