### PR TITLE
Add option for an anchor to the image command

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3330,7 +3330,7 @@ class Receiver
               \ref cmdhtmlinclude "\\htmlinclude".
 
 <hr>
-\section cmdimage \\image['{'option'}'] <format> <file> ["caption"] [<sizeindication>=<size>]
+\section cmdimage \\image['{'option[,option]'}'] <format> <file> ["caption"] [<sizeindication>=<size>]
 
   \addindex \\image
   Inserts an image into the documentation. This command is format
@@ -3362,9 +3362,10 @@ class Receiver
   The size specifier in \LaTeX (for example `10cm` or
   `4in` or a symbolic width like `\textwidth`).
 
-  Currently only the option `inline` is supported. In case the option `inline` is
+  Currently only the options `inline` and `anchor` are supported. In case the option `inline` is
   specified the image is placed "in the line", when a caption s present it is shown
-  in HTML as tooltip (ignored for the other formats).
+  in HTML as tooltip (ignored for the other formats). For the `anchor` option the syntax is:
+  `anchor:<anchorId>`.
 
   Here is example of a comment block:
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -97,6 +97,7 @@ static bool handleMemberOf(yyscan_t yyscanner,const QCString &, const StringVect
 static bool handleRefItem(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleSection(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleAnchor(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleImage(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleCite(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleFormatBlock(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleAddIndex(yyscan_t yyscanner,const QCString &, const StringVector &);
@@ -213,7 +214,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "idlexcept",       { &handleIdlException,     CommandSpacing::Invisible }},
   { "if",              { &handleIf,               CommandSpacing::Inline    }},
   { "ifnot",           { &handleIfNot,            CommandSpacing::Inline    }},
-  { "image",           { 0,                       CommandSpacing::Block     }},
+  { "image",           { &handleImage,            CommandSpacing::Block     }},
   { "implements",      { &handleExtends,          CommandSpacing::Invisible }},
   { "include",         { 0,                       CommandSpacing::Block     }},
   { "includelineno",   { 0,                       CommandSpacing::Block     }},
@@ -2394,6 +2395,31 @@ static bool handleAnchor(yyscan_t yyscanner,const QCString &s, const StringVecto
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   addOutput(yyscanner,"@"+s+" ");
   BEGIN(AnchorLabel);
+  return FALSE;
+}
+
+static bool handleImage(yyscan_t yyscanner,const QCString &s, const StringVector &optList)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  for (const auto &opt : optList)
+  {
+    QCString locOpt(opt);
+    locOpt = locOpt.stripWhiteSpace();
+    if (locOpt.lower().startsWith("anchor:"))
+    {
+      addAnchor(yyscanner,locOpt.mid(7));
+      break; // real option handling will be done later on
+    }
+  }
+  if (optList.empty())
+  {
+    addOutput(yyscanner,"@"+s+" ");
+  }
+  else
+  {
+    addOutput(yyscanner,"@"+s+"{"+QCString(join(optList,","))+"} ");
+  }
+  BEGIN(Comment);
   return FALSE;
 }
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -4868,7 +4868,8 @@ void DocPara::handleIncludeOperator(const QCString &cmdName,DocIncOperator::Type
 void DocPara::handleImage(const QCString &cmdName)
 {
   QCString saveCmdName = cmdName;
-  bool inlineImage = FALSE;
+  bool inlineImage = false;
+  QCString anchorStr;
 
   int tok=m_parser.tokenizer.lex();
   if (tok!=TK_WHITESPACE)
@@ -4877,31 +4878,46 @@ void DocPara::handleImage(const QCString &cmdName)
     {
       if (m_parser.context.token->name == "{")
       {
-        while ((tok=m_parser.tokenizer.lex())==TK_WHITESPACE);
-        if (m_parser.context.token->name != "}") // non-empty option string
-	{
-          if (m_parser.context.token->name.lower() != "inline")
+        m_parser.tokenizer.setStateOptions();
+        tok=m_parser.tokenizer.lex();
+        m_parser.tokenizer.setStatePara();
+        StringVector optList=split(m_parser.context.token->name.str(),",");
+        for (const auto &opt : optList)
+        {
+          if (opt.empty()) continue;
+          QCString locOpt(opt);
+          QCString locOptLow;
+          locOpt = locOpt.stripWhiteSpace();
+          locOptLow = locOpt.lower();
+          if (locOptLow == "inline")
           {
-            warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"currently only 'inline' supported as option of %s command",
-              qPrint(saveCmdName));
+            inlineImage = true;
+          }
+          else if (locOptLow.startsWith("anchor:"))
+          {
+            if (!anchorStr.isEmpty())
+            {
+               warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),
+                  "multiple use of option 'anchor' for '%s' command, ignoring: '%s'",
+                  qPrint(saveCmdName),qPrint(locOpt.mid(7)));
+            }
+            else
+            {
+               anchorStr = locOpt.mid(7);
+            }
           }
           else
           {
-            inlineImage = TRUE;
+            warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),
+                  "unknown option '%s' for '%s' command specified",
+                  qPrint(locOpt), qPrint(saveCmdName));
           }
-          while ((tok=m_parser.tokenizer.lex())==TK_WHITESPACE);
-	}
-        if (!((tok==TK_WORD) && (m_parser.context.token->name == "}")))
-        {
-          warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"expected closing '}' at option of %s command",
-            qPrint(saveCmdName));
-          return;
         }
         tok=m_parser.tokenizer.lex();
         if (tok!=TK_WHITESPACE)
         {
-          warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"expected whitespace after \\%s command with option",
-            qPrint(saveCmdName));
+          warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"expected whitespace after \\%s command",
+              qPrint(saveCmdName));
           return;
         }
       }
@@ -4948,6 +4964,11 @@ void DocPara::handleImage(const QCString &cmdName)
     warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"unexpected token %s as the argument of %s",
         DocTokenizer::tokToString(tok),qPrint(saveCmdName));
     return;
+  }
+  if (!anchorStr.isEmpty())
+  {
+    DocAnchor *anchor = new DocAnchor(m_parser,this,anchorStr,true);
+    m_children.push_back(std::unique_ptr<DocAnchor>(anchor));
   }
   HtmlAttribList attrList;
   DocImage *img = new DocImage(m_parser,this,attrList,

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1151,7 +1151,11 @@ LINENR {BLANK}*[1-9][0-9]*
 <St_Options>{ID}       {
                          yyextra->token->name+=yytext;
                        }
-<St_Options>{WS}*","{WS}*
+<St_Options>{WS}*":"{WS}* {
+                         lineCount(yytext,yyleng);
+                         yyextra->token->name+=":";
+                       }
+<St_Options>{WS}*","{WS}* |
 <St_Options>{WS}       { /* option separator */
                          lineCount(yytext,yyleng);
                          yyextra->token->name+=",";


### PR DESCRIPTION
Currently the image command has no possibility to specify an anchor with it making it necessary to add an extra command and based on the comment with the stack overflow question: https://stackoverflow.com/questions/55522057/display-image-inline-using-doxygen/55522855?noredirect=1#comment121096947_55522855 this has now been implemented