### PR TITLE
Incorrect line count on warning for \snippet and missing warning for \snippet{doc}

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5149,6 +5149,12 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
      m_parser.readTextFileByName(fileName,inc_text);
      if (t==DocInclude::SnippetDoc)
      {
+       int count;
+       if (!blockId.isEmpty() && (count=inc_text.contains(blockId.data()))!=2)
+       {
+          warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"block marked with %s for \\snippet should appear twice in file %s, found it %d times\n",
+            qPrint(blockId),qPrint(fileName),count);
+       }
        inc_line = lineBlock(inc_text, blockId);
        inc_text = extractBlock(inc_text, blockId);
      }

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1374,7 +1374,7 @@ LINENR {BLANK}*[1-9][0-9]*
                          yyextra->token->name += yytext;
                        }
 <St_Snippet>(\n|"\\ilinebr")  {
-                         lineCount(yytext,yyleng);
+                         unput_string(yytext,yyleng);
                          yyextra->token->name = yyextra->token->name.stripWhiteSpace();
                          return TK_WORD;
                        }


### PR DESCRIPTION
When having the following code:
```
/** \file */

/**
  [handle_blank]
  between first and second blank
  [handle_blank]
  between second and third blank
  [handle_blank]
  <br>The docu<br>
  The blank snippet:<br>
  \snippet this handle_blank

  Some more text
  <hr>
*/
void fie();
/**
  [handle_doc]
  between first and second doc
  [handle_doc]
  between second and third doc
  [handle_doc]
  <br>The docu<br>
  <hr>
  The doc snippet:<br>
  \snippet{doc} this handle_doc

  Some more text
  <hr>
*/
void fie1();
```
we only get the warning:
```
aa.h:12: warning: block marked with [handle_blank] for \snippet should appear twice in file D:/speeltuin/tsts_snip_doc/aa.h, found it 3 times
```
i.e.
- no warning for the `snippet{doc}`
- wrong line number at the warning (the actual line is line 11).

In the output for the `\snippet{doc}` we also see:
```
between first and second doc Some more text
```
instead if the expected:
```
between first and second doc

Some more text
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/6893464/example.tar.gz)
