### PR TITLE
Incorrect debug statements in docbookgen

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -59,9 +59,9 @@
 //#define Docbook_DB(x) QCString __t;__t.sprintf x;m_t << __t
 
 #if 0
-#define DB_GEN_C DB_GEN_C1(t)
+#define DB_GEN_C DB_GEN_C1(m_t)
 #define DB_GEN_C1(x) x << "<!-- DB_GEN_C " << __LINE__ << " -->\n";
-#define DB_GEN_C2(y) DB_GEN_C2a(t,y)
+#define DB_GEN_C2(y) DB_GEN_C2a(m_t,y)
 #define DB_GEN_C2a(x,y) x << "<!-- DB_GEN_C " << __LINE__ << " " << y << " -->\n";
 #else
 #define DB_GEN_C

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -68,16 +68,16 @@ class DocbookCodeGenerator : public CodeOutputInterface
 
 #if 0
 // define for cases that have been implemented with an empty body
-#define DB_GEN_EMPTY  t << "<!-- DBG_GEN_head_check " << __LINE__ << " -->\n";
+#define DB_GEN_EMPTY  m_t << "<!-- DBG_GEN_head_check " << __LINE__ << " -->\n";
 #else
 #define DB_GEN_EMPTY
 #endif
 
 #if 0
 // Generic debug statements
-#define DB_GEN_H DB_GEN_H1(t)
+#define DB_GEN_H DB_GEN_H1(m_t)
 #define DB_GEN_H1(x) x << "<!-- DBG_GEN_head " << __LINE__ << " -->\n";
-#define DB_GEN_H2(y) DB_GEN_H2a(t,y)
+#define DB_GEN_H2(y) DB_GEN_H2a(m_t,y)
 #define DB_GEN_H2a(x,y) x << "<!-- DBG_GEN_head " << __LINE__ << " " << y << " -->\n";
 // define for cases that have NOT yet been implemented / considered
 #define DB_GEN_NEW fprintf(stderr,"DBG_GEN_head %d\n",__LINE__); DB_GEN_H


### PR DESCRIPTION
The stream `t` does not exist anymore and is replaced by `m_t` but this was not done in the DBG settings