### PR TITLE
Warnings running doxygen on its own internal documentation

### DIFF
--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -334,6 +334,10 @@ bool DotFilePatcher::run() const
   bool foundSize=FALSE;
   int lineNr=1;
   std::string lineStr;
+  static const reg::Ex reSVG(R"([\[<]!-- SVG [0-9]+)");
+  static const reg::Ex reMAP(R"(<!-- MAP [0-9]+)");
+  static const reg::Ex reFIG(R"(% FIG [0-9]+)");
+
   while (getline(fi,lineStr))
   {
     QCString line = lineStr+'\n';
@@ -381,7 +385,7 @@ bool DotFilePatcher::run() const
         t << replaceRef(line,map.relPath,map.urlOnly,map.context,"_top");
       }
     }
-    else if ((i=line.find("<!-- SVG"))!=-1 || (i=line.find("[!-- SVG"))!=-1)
+    else if ((i=findIndex(line.str(),reSVG))!=-1)
     {
       //printf("Found marker at %d\n",i);
       int mapId=-1;
@@ -405,7 +409,7 @@ bool DotFilePatcher::run() const
         t << line.mid(i);
       }
     }
-    else if ((i=line.find("<!-- MAP"))!=-1)
+    else if ((i=findIndex(line.str(),reMAP))!=-1)
     {
       int mapId=-1;
       t << line.left(i);
@@ -430,7 +434,7 @@ bool DotFilePatcher::run() const
         t << line.mid(i);
       }
     }
-    else if ((i=line.find("% FIG"))!=-1)
+    else if ((i=findIndex(line.str(),reFIG))!=-1)
     {
       int mapId=-1;
       int n = sscanf(line.data()+i+2,"FIG %d",&mapId);


### PR DESCRIPTION
When we run doxygen on its own sources we te errors:
```
error: Found invalid bounding FIG -1 in file .../doxygen_docs/html/d0/d32/class_dot_graph.html!
error: Found invalid SVG id in file .../doxygen_docs/html/db/daa/class_dot_file_patcher.html!
error: Found invalid bounding FIG -1 in file .../doxygen_docs/html/db/daa/class_dot_file_patcher.html!
```
tis is due to the fact that the INLINE_SOURCES`  is set and we have the doxygen sources in the HTML files. For the dot file patcher in these files there is a search for strings to be patched with the correct image commands (files that are generated by dot).
Due to the simplicity of the test also the search / replace text was found with the test., the test has been extended a bit so that a better search is performed.