### PR TITLE
issue #8713 external markdown links do not respect EXT_LINKS_IN_WINDOW

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1196,6 +1196,8 @@ int Markdown::processLink(const char *data,int,int size)
         m_out.addStr(substitute(title.simplifyWhiteSpace(),"\"","&quot;"));
         m_out.addStr("\"");
       }
+      m_out.addStr(" ");
+      m_out.addStr(externalLinkTarget());
       m_out.addStr(">");
       content = content.simplifyWhiteSpace();
       processInline(content.data(),content.length());


### PR DESCRIPTION
The setting of EXT_LINKS_IN_WINDOW was not taken into consideration when transforming a markdown type link into a HTML link that is understood by doxygen.