### PR TITLE
representation of inheritance relations in relation to HAVE_DOT setting

### DIFF
--- a/addon/doxywizard/wizard.cpp
+++ b/addon/doxywizard/wizard.cpp
@@ -64,7 +64,6 @@
 #define STR_PDF_HYPERLINKS        QString::fromLatin1("PDF_HYPERLINKS")
 #define STR_SEARCHENGINE          QString::fromLatin1("SEARCHENGINE")
 #define STR_HAVE_DOT              QString::fromLatin1("HAVE_DOT")
-#define STR_CLASS_DIAGRAMS        QString::fromLatin1("CLASS_DIAGRAMS")
 #define STR_CLASS_GRAPH           QString::fromLatin1("CLASS_GRAPH")
 #define STR_COLLABORATION_GRAPH   QString::fromLatin1("COLLABORATION_GRAPH")
 #define STR_GRAPHICAL_HIERARCHY   QString::fromLatin1("GRAPHICAL_HIERARCHY")
@@ -1132,19 +1131,21 @@ Step4::Step4(Wizard *wizard,const QHash<QString,Input*> &modelData)
   QGridLayout *gbox = new QGridLayout( this );
   gbox->addWidget(new QLabel(tr("Diagrams to generate")),0,0);
 
+  // CLASS_GRAPH = NO, HAVE_DOT = NO
   QRadioButton *rb = new QRadioButton(tr("No diagrams"));
   m_diagramModeGroup->addButton(rb, 0);
   gbox->addWidget(rb,1,0);
-  // CLASS_DIAGRAMS = NO, HAVE_DOT = NO
   rb->setChecked(true);
+
+  // CLASS_GRAPH = YES, HAVE_DOT = NO
   rb = new QRadioButton(tr("Use built-in class diagram generator"));
   m_diagramModeGroup->addButton(rb, 1);
-  // CLASS_DIAGRAMS = YES, HAVE_DOT = NO
   gbox->addWidget(rb,2,0);
+
+  // CLASS_GRAPH = YES, HAVE_DOT = YES
   rb = new QRadioButton(tr("Use dot tool from the GraphViz package"));
   m_diagramModeGroup->addButton(rb, 2);
   gbox->addWidget(rb,3,0);
-  // CLASS_DIAGRAMS = NO, HAVE_DOT = YES
 
   m_dotGroup = new QGroupBox(tr("Dot graphs to generate"));
     QVBoxLayout *vbox = new QVBoxLayout;
@@ -1202,24 +1203,24 @@ void Step4::diagramModeChanged(int id)
   if (id==0) // no diagrams
   {
     updateBoolOption(m_modelData,STR_HAVE_DOT,false);
-    updateBoolOption(m_modelData,STR_CLASS_DIAGRAMS,false);
+    updateStringOption(m_modelData,STR_CLASS_GRAPH, QString::fromLatin1("NO"));
   }
   else if (id==1) // builtin diagrams
   {
     updateBoolOption(m_modelData,STR_HAVE_DOT,false);
-    updateBoolOption(m_modelData,STR_CLASS_DIAGRAMS,true);
+    updateStringOption(m_modelData,STR_CLASS_GRAPH, QString::fromLatin1("YES"));
   }
   else if (id==2) // dot diagrams
   {
     updateBoolOption(m_modelData,STR_HAVE_DOT,true);
-    updateBoolOption(m_modelData,STR_CLASS_DIAGRAMS,false);
+    updateStringOption(m_modelData,STR_CLASS_GRAPH, QString::fromLatin1("YES"));
   }
   m_dotGroup->setEnabled(id==2);
 }
 
 void Step4::setClassGraphEnabled(int state)
 {
-  updateBoolOption(m_modelData,STR_CLASS_GRAPH,state==Qt::Checked);
+  updateStringOption(m_modelData,STR_CLASS_GRAPH,state==Qt::Checked ? QString::fromLatin1("YES") : QString::fromLatin1("NO"));
 }
 
 void Step4::setCollaborationGraphEnabled(int state)
@@ -1257,13 +1258,17 @@ void Step4::init()
   int id = 0;
   if (getBoolOption(m_modelData,STR_HAVE_DOT))
   {
-    m_diagramModeGroup->button(2)->setChecked(true); // Dot
-    id = 2;
-  }
-  else if (getBoolOption(m_modelData,STR_CLASS_DIAGRAMS))
-  {
-    m_diagramModeGroup->button(1)->setChecked(true); // Builtin diagrams
-    id = 1;
+    QString class_graph = getStringOption(m_modelData,STR_CLASS_GRAPH).toLower();
+    if ((class_graph == QString::fromLatin1("yes")) || (class_graph == QString::fromLatin1("graph")))
+    {
+      m_diagramModeGroup->button(1)->setChecked(true); // Dot
+      id = 2;
+    }
+    else 
+    {
+      m_diagramModeGroup->button(1)->setChecked(true); // Builtin diagrams
+      id = 1;
+    }
   }
   else
   {

--- a/doc/customize.doc
+++ b/doc/customize.doc
@@ -336,7 +336,7 @@ The class page has the following specific elements:
       this class.
 <dt>\c inheritancegraph
   <dd>Represents the inheritance relations for a class.
-      Note that the CLASS_DIAGRAM option determines
+      Note that the \ref cfg_class_graph "CLASS_GRAPH" option determines
       if the inheritance relation is a list of base and derived classes or
       a graph.
 <dt>\c collaborationgraph

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1605,12 +1605,15 @@ int ClassDefImpl::countInheritanceNodes() const
 
 void ClassDefImpl::writeInheritanceGraph(OutputList &ol) const
 {
+  static bool haveDot        = Config_getBool(HAVE_DOT);
+  static QCString classGraph = Config_getEnum(CLASS_GRAPH).upper();
+
+  if (classGraph == "NO") return;
   // count direct inheritance relations
   const int count=countInheritanceNodes();
 
   bool renderDiagram = FALSE;
-  if (Config_getBool(HAVE_DOT) &&
-      (Config_getBool(CLASS_DIAGRAMS) || Config_getBool(CLASS_GRAPH)))
+  if (haveDot && (classGraph == "YES" || classGraph =="GRAPH"))
     // write class diagram using dot
   {
     DotClassGraph inheritanceGraph(this,Inheritance);
@@ -1630,7 +1633,7 @@ void ClassDefImpl::writeInheritanceGraph(OutputList &ol) const
       renderDiagram = TRUE;
     }
   }
-  else if (Config_getBool(CLASS_DIAGRAMS) && count>0)
+  else if ((classGraph == "YES" || classGraph =="GRAPH") && count>0)
     // write class diagram using built-in generator
   {
     ClassDiagram diagram(this); // create a diagram of this class.

--- a/src/config.xml
+++ b/src/config.xml
@@ -3489,17 +3489,6 @@ where `loc1` and `loc2` can be relative or absolute paths or URLs.
     </option>
   </group>
   <group name='Dot' docs='Configuration options related to the dot tool'>
-    <option type='bool' id='CLASS_DIAGRAMS' defval='1'>
-      <docs>
-<![CDATA[
- If the \c CLASS_DIAGRAMS tag is set to \c YES, doxygen will
- generate a class diagram (in HTML and \f$\mbox{\LaTeX}\f$) for classes with base or
- super classes. Setting the tag to \c NO turns the diagrams off. Note that
- this option also works with \ref cfg_have_dot "HAVE_DOT" disabled, but it is recommended to
- install and use \c dot, since it yields more powerful graphs.
-]]>
-      </docs>
-    </option>
     <option type='string' id='DIA_PATH' format='dir' defval=''>
       <docs>
 <![CDATA[
@@ -3570,15 +3559,21 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
-    <option type='bool' id='CLASS_GRAPH' defval='1' depends='HAVE_DOT'>
+    <option type='enum' id='CLASS_GRAPH' defval='YES'>
       <docs>
 <![CDATA[
- If the \c CLASS_GRAPH tag is set to \c YES then doxygen
+ If the \c CLASS_GRAPH tag is set to \c YES (or \c GRAPH) then doxygen
  will generate a graph for each documented class showing the direct and
- indirect inheritance relations. Setting this tag to \c YES will force
- the \ref cfg_class_diagrams "CLASS_DIAGRAMS" tag to \c NO.
+ indirect inheritance relations. In case \ref cfg_have_dot "HAVE_DOT" is set as well
+ `dot` will be used to draw the graph, otherwise the built-in generator will be used.
+ If the \c CLASS_GRAPH tag is set to \c TEXT the direct and indirect inheritance relations
+ will be shown as texts / links.
 ]]>
       </docs>
+      <value name="NO" />
+      <value name="YES" />
+      <value name="TEXT" />
+      <value name="GRAPH" />
     </option>
     <option type='bool' id='COLLABORATION_GRAPH' defval='1' depends='HAVE_DOT'>
       <docs>
@@ -3914,5 +3909,6 @@ This setting is not only used for dot files but also for msc temporary files.
     <option type='obsolete' id='DOCBOOK_PROGRAMLISTING'/>
     <option type='obsolete' id='RTF_SOURCE_CODE'/>
     <option type='obsolete' id='LATEX_SOURCE_CODE'/>
+    <option type='obsolete' id='CLASS_DIAGRAM'/>
   </group>
 </doxygenconfig>

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1995,15 +1995,15 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
     TemplateVariant hasInheritanceDiagram() const
     {
       bool result=FALSE;
-      static bool haveDot       = Config_getBool(HAVE_DOT);
-      static bool classDiagrams = Config_getBool(CLASS_DIAGRAMS);
-      static bool classGraph    = Config_getBool(CLASS_GRAPH);
-      if (haveDot && (classDiagrams || classGraph))
+      static bool haveDot        = Config_getBool(HAVE_DOT);
+      static QCString classGraph = Config_getEnum(CLASS_GRAPH).upper();
+
+      if (haveDot && (classGraph == "YES" || classGraph =="GRAPH"))
       {
         DotClassGraph *cg = getClassGraph();
         result = !cg->isTrivial() && !cg->isTooBig();
       }
-      else if (classDiagrams)
+      else if (classGraph == "YES" || classGraph =="GRAPH")
       {
         result = numInheritanceNodes()>0;
       }
@@ -2012,10 +2012,10 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
     TemplateVariant inheritanceDiagram() const
     {
       TextStream t;
-      static bool haveDot       = Config_getBool(HAVE_DOT);
-      static bool classDiagrams = Config_getBool(CLASS_DIAGRAMS);
-      static bool classGraph    = Config_getBool(CLASS_GRAPH);
-      if (haveDot && (classDiagrams || classGraph))
+      static bool haveDot        = Config_getBool(HAVE_DOT);
+      static QCString classGraph = Config_getEnum(CLASS_GRAPH).upper();
+
+      if (haveDot && (classGraph == "YES" || classGraph =="GRAPH"))
       {
         DotClassGraph *cg = getClassGraph();
         switch (g_globals.outputFormat)
@@ -2045,7 +2045,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
         }
         g_globals.dynSectionId++;
       }
-      else if (classDiagrams)
+      else if (classGraph == "YES" || classGraph =="GRAPH")
       {
         ClassDiagram d(m_classDef);
         switch (g_globals.outputFormat)

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -89,6 +89,10 @@ static bool elemIsVisible(const XMLHandlers::Attributes &attrib,bool defVal=TRUE
     {
       return ConfigValues::instance().*(opt->value.b);
     }
+    else if (opt && opt->type==ConfigValues::Info::String)
+    {
+      return ConfigValues::instance().*(opt->value.s) != "NO";
+    }
     else if (!opt)
     {
       err("found unsupported value %s for visible attribute in layout file\n",


### PR DESCRIPTION
Since  the issue #7273  and pull request #8663 the setting `HAVE_DOT` was required when one wants to incorporate a "dot" type of graph, though this interferes with the Inheritance usage, especially when one wants to have a textual" list.
There were a number of settings etc. involved:
- `CLASS_GRAPH`
- `CLASS_DIAGRAMS`
- `HAVE_DOT`

and the layout setting
- `<inheritancegraph visible="$CLASS_GRAPH"/>`

With this patch the following scheme has been implemented:
```
HAVE_DOT, CLASS_GRAPH,   class diagram output
================================================================
NO,       NO             nothing shown (expected)
NO,       YES            built-in diagram
NO,       TEXT           text link
NO,       GRAPH          built-in diagram (same as YES)
YES,      NO             nothing shown (expected, HAVE_DOT can be used for other diagrams and \dot)
YES,      YES            dot generated diagram
YES,      TEXT           text link
YES,      GRAPH          dot generated diagram (same as YES)
```
The setting `CLASS_DIAGRAMS` is not necessary and has been declared obsolete.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7022836/example.tar.gz)
