### PR TITLE
bug_568636 provide an @INCLUDE_IF_PRESENT tag to allow local customizations

### DIFF
--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -329,7 +329,7 @@ static FILE *findFile(const QString &fileName)
   return tryPath(QString::fromLatin1("."),fileName);
 }
 
-static void readIncludeFile(const QString &incName)
+static void readIncludeFile(const QString &incName, const bool mandatory)
 {
   if (g_includeDepth==MAX_INCLUDE_DEPTH)
   {
@@ -371,7 +371,7 @@ static void readIncludeFile(const QString &incName)
   }
   else
   {
-    config_err("@INCLUDE = %s: not found!\n",qPrintable(inc));
+    if (mandatory) config_err("@INCLUDE = %s: not found!\n",qPrintable(inc));
   }
 }
 
@@ -385,10 +385,9 @@ static void readIncludeFile(const QString &incName)
 %x      Start
 %x      SkipInvalid
 %x      GetString
-%x      GetEnum
 %x      GetStrList
-%x      GetQuotedString
 %x      Include
+%x      IncludeIfPresent
 
 %%
 
@@ -512,7 +511,12 @@ static void readIncludeFile(const QString &incName)
   /* include a config file */
 <Start>"@INCLUDE"[ \t]*"="     		{ BEGIN(Include);}
 <Include>([^ \"\t\r\n]+)|("\""[^\n\"]+"\"") {
-  					  readIncludeFile(g_codec->toUnicode(yytext));
+  					  readIncludeFile(g_codec->toUnicode(yytext),true);
+  					  BEGIN(Start);
+					}
+<Start>"@INCLUDE_IF_PRESENT"[ \t]*"="   { BEGIN(IncludeIfPresent);}
+<IncludeIfPresent>([^ \"\t\r\n]+)|("\""[^\n\"]+"\"") {
+  					  readIncludeFile(g_codec->toUnicode(yytext),false);
   					  BEGIN(Start);
 					}
 <<EOF>>					{

--- a/src/config.xml
+++ b/src/config.xml
@@ -60,6 +60,11 @@ with these paths before the <code>\@INCLUDE</code> tag, e.g.:
 \verbatim
 @INCLUDE_PATH = my_config_dir
 \endverbatim
+\note with the <code>\@INCLUDE</code> tag the file to be included has to exist
+otherwise doxygen is terminated.
+When local changes should be allowed the tag <code>\@INCLUDE_IF_PRESENT</code>
+can be used that works identical when the file is present and ignores the 
+setting when the file is not present.
 
 The configuration options can be divided into several categories.
 Below is an alphabetical index of the tags that are recognized

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -891,7 +891,7 @@ static FILE *findFile(const QCString &fileName)
   return tryPath(".",fileName);
 }
 
-static void readIncludeFile(const QCString &incName)
+static void readIncludeFile(const QCString &incName,const bool mandatory)
 {
   if (g_includeStack.size()==MAX_INCLUDE_DEPTH) {
     config_term("maximum include depth (%d) reached, %s is not included. Aborting...\n",
@@ -932,7 +932,7 @@ static void readIncludeFile(const QCString &incName)
   }
   else
   {
-    config_term("@INCLUDE = %s: not found!\n",qPrint(inc));
+    if (mandatory) config_term("@INCLUDE = %s: not found!\n",qPrint(inc));
   }
 }
 
@@ -947,6 +947,7 @@ static void readIncludeFile(const QCString &incName)
 %x      GetString
 %x      GetStrList
 %x      Include
+%x      IncludeIfPresent
 
 %%
 
@@ -1115,7 +1116,12 @@ static void readIncludeFile(const QCString &incName)
   /* include a g_config file */
 <Start>"@INCLUDE"[ \t]*"="              { BEGIN(Include);}
 <Include>([^ \"\t\r\n]+)|("\""[^\n\"]+"\"") {
-                                          readIncludeFile(configStringRecode(yytext,g_encoding,"UTF-8"));
+                                          readIncludeFile(configStringRecode(yytext,g_encoding,"UTF-8"),true);
+                                          BEGIN(Start);
+                                        }
+<Start>"@INCLUDE_IF_PRESENT"[ \t]*"="   { BEGIN(IncludeIfPresent);}
+<IncludeIfPresent>([^ \"\t\r\n]+)|("\""[^\n\"]+"\"") {
+                                          readIncludeFile(configStringRecode(yytext,g_encoding,"UTF-8"),false);
                                           BEGIN(Start);
                                         }
 <<EOF>>                                 {


### PR DESCRIPTION
With the `@INCLUDE` tag the file to be included has to exist
otherwise doxygen is terminated.
When local changes should be allowed the tag `@INCLUDE_IF_PRESENT`
can be used that works identical when the file is present and ignores the
setting when the file is not present.

Example to test some settings (changing the Doxyfile): [example.tar.gz](https://github.com/doxygen/doxygen/files/7066402/example.tar.gz)
