### PR TITLE
Correction of some small documentation problems

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -51,8 +51,8 @@ USE_PDFLATEX      = YES
 STRIP_CODE_COMMENTS = NO
 HTML_STYLESHEET   = doxygen_manual.css
 HTML_EXTRA_FILES  = doxygen_logo.svg
-ALIASES           = LaTeX="\f(\LaTeX\f)"
-ALIASES          += TeX="\f(\TeX\f)"
+ALIASES           = LaTeX="\f({\LaTeX}\f)"
+ALIASES          += TeX="\f({\TeX}\f)"
 ALIASES          += forceNewPage="\latexonly \newpage \endlatexonly"
 LATEX_BATCHMODE   = YES
 LATEX_EXTRA_STYLESHEET = manual.sty

--- a/doc/perlmod.doc
+++ b/doc/perlmod.doc
@@ -79,7 +79,7 @@ to automate the use of these files are also added to
 <ul>
 
 <li>`doxylatex.pl`: This Perl script uses `DoxyDocs.pm` and 
-DoxyModel.pm to generate `doxydocs.tex`, a \TeX file containing 
+`DoxyModel.pm` to generate `doxydocs.tex`, a \TeX file containing 
 the documentation in a format that can be accessed by \LaTeX code. This 
 file is not directly LaTeXable.
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -2869,7 +2869,7 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
            as set by \ref cfg_latex_bib_style "LATEX_BIB_STYLE", in case nothing is set the bib style
            `plain` is used.
            This setting is typically used in combination with the block name `CITATIONS_PRESENT`.
- <dt><code>$latexbibfiles</code><dd>will be replaced by the comma separated list of `bib. files
+ <dt><code>$latexbibfiles</code><dd>will be replaced by the comma separated list of `bib`. files
            as set by \ref cfg_cite_bib_files "CITE_BIB_FILES" (when necessary a missing `.bib` is
            automatically added).
            This setting is typically used in combination with the block name `CITATIONS_PRESENT`.


### PR DESCRIPTION
- Doxyfile, in the LaTeX documentation the word word Latex and the following word were directly joined
- prelmod.doc the filename was not set in code format like other file names
- config.xml missing closing back tick