### PR TITLE
issue #8747 Improve output with WARN_AS_ERROR = FAIL_ON_WARNINGS

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -43,7 +43,7 @@ void initWarningFormat()
     g_warnFile = stderr;
   }
   g_warnBehavior = Config_getEnum(WARN_AS_ERROR);
-  if (g_warnBehavior == WARN_AS_ERROR_t::YES)
+  if (g_warnBehavior != WARN_AS_ERROR_t::NO)
   {
     g_warningStr = g_errorStr;
   }


### PR DESCRIPTION
Setting text indication for a warning to error for `WARN_AS_ERROR = FAIL_ON_WARNINGS` like it is already done for `WARN_AS_ERROR = YES`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7083412/example.tar.gz)
