### PR TITLE
bug 679192 Missing images from generated qhp file

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -12249,6 +12249,29 @@ void generateOutput()
   }
   g_s.end();
 
+  // copy static stuff
+  if (generateHtml)
+  {
+    FTVHelp::generateTreeViewImages();
+    copyStyleSheet();
+    copyLogo(Config_getString(HTML_OUTPUT));
+    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT));
+  }
+  if (generateLatex)
+  {
+    copyLatexStyleSheet();
+    copyLogo(Config_getString(LATEX_OUTPUT));
+    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT));
+  }
+  if (generateDocbook)
+  {
+    copyLogo(Config_getString(DOCBOOK_OUTPUT));
+  }
+  if (generateRtf)
+  {
+    copyLogo(Config_getString(RTF_OUTPUT));
+  }
+
   const FormulaManager &fm = FormulaManager::instance();
   if (fm.hasFormulas() && generateHtml
       && !Config_getBool(USE_MATHJAX))
@@ -12411,29 +12434,6 @@ void generateOutput()
     g_s.begin("Running dot...\n");
     DotManager::instance()->run();
     g_s.end();
-  }
-
-  // copy static stuff
-  if (generateHtml)
-  {
-    FTVHelp::generateTreeViewImages();
-    copyStyleSheet();
-    copyLogo(Config_getString(HTML_OUTPUT));
-    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT));
-  }
-  if (generateLatex)
-  {
-    copyLatexStyleSheet();
-    copyLogo(Config_getString(LATEX_OUTPUT));
-    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT));
-  }
-  if (generateDocbook)
-  {
-    copyLogo(Config_getString(DOCBOOK_OUTPUT));
-  }
-  if (generateRtf)
-  {
-    copyLogo(Config_getString(RTF_OUTPUT));
   }
 
   if (generateHtml &&

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1023,6 +1023,7 @@ void HtmlGenerator::writeTabData()
   mgr.copyResource("nav_f.lum",dname);
   mgr.copyResource("bc_s.luma",dname);
   mgr.copyResource("doxygen.svg",dname);
+  Doxygen::indexList->addImageFile("doxygen.svg");
   mgr.copyResource("closed.luma",dname);
   mgr.copyResource("open.luma",dname);
   mgr.copyResource("bdwn.luma",dname);
@@ -1036,6 +1037,7 @@ void HtmlGenerator::writeTabData()
   //  img.save(dname+"/nav_g.png");
   //}
   mgr.copyResource("nav_g.png",dname);
+  Doxygen::indexList->addImageFile("nav_g.png");
 }
 
 void HtmlGenerator::writeSearchData(const QCString &dname)


### PR DESCRIPTION
- the file doxygen.svg has to be added with addImageFile as wee (and also nav_g.png)
- the adding the static parts for the different output formats has to be done earlier otherwise e.g.. the copied resources (logo) won't land in the "overview files" (like index.qhp).