### PR TITLE
Warning with python file starting and ending with __ as file name

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1284,7 +1284,14 @@ STARTDOCSYMS      "##"
 			          actualDoc.append("\\endverbatim ");
 			        }
 			      }
-			      actualDoc.prepend("\\namespace "+yyextra->moduleScope+" ");
+                              if (yyextra->moduleScope.startsWith("__") &&  yyextra->moduleScope.endsWith("__"))
+                              {
+			        actualDoc.prepend("\\namespace \\"+yyextra->moduleScope+" ");
+                              }
+                              else
+                              {
+			        actualDoc.prepend("\\namespace "+yyextra->moduleScope+" ");
+                              }
 			      handleCommentBlock(yyscanner, actualDoc, FALSE);
 			    }
 			    if ((yyextra->docBlockContext==ClassBody /*&& !yyextra->hideClassDocs*/) ||


### PR DESCRIPTION
When we have a file in python with a file name starting and ending with `__` other than `__init__.py` we get a message like:
```
warning: found </strong> tag without matching <strong>
```
this is due to the fact that the file name is translated to a namespace with name like the file name and this is translated  to e.g. `<strong>future</strong>`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7107395/example.tar.gz)

(Found by Fossies for Python-3.9.7)
