### PR TITLE
Warnings when generating diagrams with LaTeX and HTMLHelp / QHP enabled

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1971,7 +1971,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                              g_globals.outputDir,
                              g_globals.outputDir+Portable::pathSeparator()+m_classDef->getOutputFileBase()+Doxygen::htmlFileExtension,
-                             relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
+                             relPathAsString(),true,TRUE,TRUE,g_globals.dynSectionId
                             );
             }
             break;
@@ -1980,7 +1980,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                              g_globals.outputDir,
                              g_globals.outputDir+Portable::pathSeparator()+m_classDef->getOutputFileBase()+".tex",
-                             relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
+                             relPathAsString(),false,TRUE,TRUE,g_globals.dynSectionId
                             );
             }
             break;
@@ -2003,7 +2003,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
               QCString name = convertToHtml(m_classDef->displayName());
               d.writeImage(tt,g_globals.outputDir,
                            relPathAsString(),
-                           m_classDef->getOutputFileBase());
+                           m_classDef->getOutputFileBase(),true);
               if (!tt.empty())
               {
                 t << "<div class=\"center\">\n";
@@ -2062,7 +2062,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                              g_globals.outputDir,
                              g_globals.outputDir+Portable::pathSeparator()+m_classDef->getOutputFileBase()+Doxygen::htmlFileExtension,
-                             relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
+                             relPathAsString(),true,TRUE,TRUE,g_globals.dynSectionId
                             );
             }
             break;
@@ -2071,7 +2071,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                              g_globals.outputDir,
                              g_globals.outputDir+Portable::pathSeparator()+m_classDef->getOutputFileBase()+".tex",
-                             relPathAsString(),TRUE,TRUE,g_globals.dynSectionId
+                             relPathAsString(),false,TRUE,TRUE,g_globals.dynSectionId
                             );
             }
             break;
@@ -2924,7 +2924,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_fileDef->getOutputFileBase()+Doxygen::htmlFileExtension,
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),true,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -2933,7 +2933,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_fileDef->getOutputFileBase()+".tex",
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),false,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -2966,7 +2966,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_fileDef->getOutputFileBase()+Doxygen::htmlFileExtension,
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),true,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -2975,7 +2975,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_fileDef->getOutputFileBase()+".tex",
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),false,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -3269,6 +3269,7 @@ class DirContext::Private : public DefinitionContext<DirContext::Private>
                                 g_globals.outputDir,
                                 g_globals.outputDir+Portable::pathSeparator()+m_dirDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                                 relPathAsString(),
+                                true,
                                 TRUE,
                                 g_globals.dynSectionId,
                                 FALSE);
@@ -3281,6 +3282,7 @@ class DirContext::Private : public DefinitionContext<DirContext::Private>
                                 g_globals.outputDir,
                                 g_globals.outputDir+Portable::pathSeparator()+m_dirDef->getOutputFileBase()+".tex",
                                 relPathAsString(),
+                                false,
                                 TRUE,
                                 g_globals.dynSectionId,
                                 FALSE);
@@ -3982,7 +3984,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_memberDef->getOutputFileBase()+Doxygen::htmlFileExtension,
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),true,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -3991,7 +3993,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_memberDef->getOutputFileBase()+".tex",
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),false,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -4040,7 +4042,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
               cg->writeGraph(t,GOF_BITMAP,EOF_Html,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_memberDef->getOutputFileBase()+Doxygen::htmlFileExtension,
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),true,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -4049,7 +4051,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
               cg->writeGraph(t,GOF_EPS,EOF_LaTeX,
                   g_globals.outputDir,
                   g_globals.outputDir+Portable::pathSeparator()+m_memberDef->getOutputFileBase()+".tex",
-                  relPathAsString(),TRUE,g_globals.dynSectionId
+                  relPathAsString(),false,TRUE,g_globals.dynSectionId
                   );
             }
             break;
@@ -4780,6 +4782,7 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
                                 g_globals.outputDir,
                                 g_globals.outputDir+Portable::pathSeparator()+m_groupDef->getOutputFileBase()+Doxygen::htmlFileExtension,
                                 relPathAsString(),
+                                true,
                                 TRUE,
                                 g_globals.dynSectionId);
             }
@@ -4791,6 +4794,7 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
                                 g_globals.outputDir,
                                 g_globals.outputDir+Portable::pathSeparator()+m_groupDef->getOutputFileBase()+".tex",
                                 relPathAsString(),
+                                false,
                                 TRUE,
                                 g_globals.dynSectionId);
             }

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -1342,7 +1342,7 @@ void ClassDiagram::writeFigure(TextStream &output,const QCString &path,
 
 void ClassDiagram::writeImage(TextStream &t,const QCString &path,
                               const QCString &relPath,const QCString &fileName,
-                              bool generateMap) const
+                              const bool toIndex, bool generateMap) const
 {
   uint baseRows=p->base.computeRows();
   uint superRows=p->super.computeRows();
@@ -1369,6 +1369,6 @@ void ClassDiagram::writeImage(TextStream &t,const QCString &path,
 
 #define IMAGE_EXT ".png"
   image.save((QCString)path+"/"+fileName+IMAGE_EXT);
-  Doxygen::indexList->addImageFile(QCString(fileName)+IMAGE_EXT);
+  if (toIndex) Doxygen::indexList->addImageFile(QCString(fileName)+IMAGE_EXT);
 }
 

--- a/src/diagram.h
+++ b/src/diagram.h
@@ -34,7 +34,7 @@ class ClassDiagram
     void writeFigure(TextStream &t,const QCString &path,
                      const QCString &file) const;
     void writeImage(TextStream &t,const QCString &path,const QCString &relPath,
-                     const QCString &file,bool generateMap=true) const;
+                     const QCString &file,const bool toIndex,bool generateMap=true) const;
   private:
     struct Private;
     std::unique_ptr<Private> p;

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -898,7 +898,7 @@ DB_GEN_C
   m_t << "                <imagedata width=\"50%\" align=\"center\" valign=\"middle\" scalefit=\"0\" fileref=\""
                          << relPath << fileName << ".png\">" << "</imagedata>\n";
   m_t << "            </imageobject>\n";
-  d.writeImage(m_t,dir(),relPath,fileName,FALSE);
+  d.writeImage(m_t,dir(),relPath,fileName,false,FALSE);
   m_t << "        </mediaobject>\n";
   m_t << "    </informalfigure>\n";
   m_t << "</para>\n";
@@ -1151,7 +1151,7 @@ DB_GEN_C
 void DocbookGenerator::endGroupCollaboration(DotGroupCollaboration &g)
 {
 DB_GEN_C
-  g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,FALSE);
+  g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,false,FALSE);
 }
 void DocbookGenerator::startDotGraph()
 {
@@ -1160,7 +1160,7 @@ DB_GEN_C
 void DocbookGenerator::endDotGraph(DotClassGraph &g)
 {
 DB_GEN_C
-  g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,TRUE,FALSE);
+  g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,false,TRUE,FALSE);
 }
 void DocbookGenerator::startInclDepGraph()
 {
@@ -1169,7 +1169,7 @@ DB_GEN_C
 void DocbookGenerator::endInclDepGraph(DotInclDepGraph &g)
 {
 DB_GEN_C
-  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,FALSE);
+  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,false,FALSE);
 }
 void DocbookGenerator::startCallGraph()
 {
@@ -1178,7 +1178,7 @@ DB_GEN_C
 void DocbookGenerator::endCallGraph(DotCallGraph &g)
 {
 DB_GEN_C
-  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,FALSE);
+  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,false,FALSE);
 }
 void DocbookGenerator::startDirDepGraph()
 {
@@ -1187,7 +1187,7 @@ DB_GEN_C
 void DocbookGenerator::endDirDepGraph(DotDirDeps &g)
 {
 DB_GEN_C
-  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,FALSE);
+  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_DocBook,dir(),fileName(),relPath,false,FALSE);
 }
 void DocbookGenerator::startMemberDocList()
 {

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1641,7 +1641,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_BITMAP,s->srcFile(),s->srcLine());
+  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_BITMAP,s->srcFile(),s->srcLine(),false);
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + ".png", s->width(), s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1657,7 +1657,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
+  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP,false);
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + ".png", s->width(),s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1685,7 +1685,7 @@ DB_VIS_C
   }
   baseName.prepend("msc_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,srcFile,srcLine,false);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, baseName + ".png",  width,  height);
 }
@@ -1759,7 +1759,7 @@ DB_VIS_C
     shortName=shortName.right((int)shortName.length()-i-1);
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP,s->srcFile(),s->srcLine());
+  writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP,s->srcFile(),s->srcLine(),false);
   visitPreStart(m_t, s->children(), s->hasCaption(), s->relPath() + shortName + "." + getDotImageExtension(), s->width(),s->height());
   visitCaption(s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -1788,7 +1788,7 @@ DB_VIS_C
   baseName.prepend("dot_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   QCString imgExt = getDotImageExtension();
-  writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP,srcFile,srcLine);
+  writeDotGraphFromFile(fileName,outDir,baseName,GOF_BITMAP,srcFile,srcLine,false);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, baseName + "." + imgExt,  width,  height);
 }

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -271,7 +271,7 @@ bool DotManager::run() const
 
 void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,GraphOutputFormat format,
-                           const QCString &srcFile,int srcLine)
+                           const QCString &srcFile,int srcLine,const bool toIndex)
 {
   Dir d(outDir.str());
   if (!d.exists())
@@ -307,7 +307,7 @@ void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
      return;
   }
 
-  Doxygen::indexList->addImageFile(imgName);
+  if (toIndex) Doxygen::indexList->addImageFile(imgName);
 
 }
 

--- a/src/dot.h
+++ b/src/dot.h
@@ -50,7 +50,7 @@ class DotManager
 
 void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,GraphOutputFormat format,
-                           const QCString &srcFile,int srcLine);
+                           const QCString &srcFile,int srcLine,const bool toIndex);
 void writeDotImageMapFromFile(TextStream &t,
                               const QCString &inFile, const QCString& outDir,
                               const QCString &relPath,const QCString& baseName,

--- a/src/dotcallgraph.cpp
+++ b/src/dotcallgraph.cpp
@@ -186,10 +186,10 @@ QCString DotCallGraph::writeGraph(
         EmbeddedOutputFormat textFormat,
         const QCString &path,
         const QCString &fileName,
-        const QCString &relPath,bool generateImageMap,
+        const QCString &relPath,const bool toIndex,bool generateImageMap,
         int graphId)
 {
-  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
+  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, toIndex, generateImageMap, graphId);
 }
 
 bool DotCallGraph::isTrivial() const

--- a/src/dotcallgraph.h
+++ b/src/dotcallgraph.h
@@ -33,7 +33,7 @@ class DotCallGraph : public DotGraph
     int numNodes() const;
     QCString writeGraph(TextStream &t, GraphOutputFormat gf, EmbeddedOutputFormat ef,
                         const QCString &path,const QCString &fileName,
-                        const QCString &relPath,bool writeImageMap=TRUE,
+                        const QCString &relPath,const bool toIndex,bool writeImageMap=TRUE,
                         int graphId=-1);
     static bool isTrivial(const MemberDef *md,bool inverse);
 

--- a/src/dotclassgraph.cpp
+++ b/src/dotclassgraph.cpp
@@ -450,11 +450,12 @@ QCString DotClassGraph::writeGraph(TextStream &out,
   const QCString &path,
   const QCString &fileName,
   const QCString &relPath,
+  const bool toIndex,
   bool /*isTBRank*/,
   bool generateImageMap,
   int graphId)
 {
-  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
+  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, toIndex, generateImageMap, graphId);
 }
 
 //--------------------------------------------------------------------

--- a/src/dotclassgraph.h
+++ b/src/dotclassgraph.h
@@ -35,6 +35,7 @@ public:
   int numNodes() const;
   QCString writeGraph(TextStream &t,GraphOutputFormat gf,EmbeddedOutputFormat ef,
     const QCString &path, const QCString &fileName, const QCString &relPath,
+    const bool toIndex,
     bool TBRank=TRUE,bool imageMap=TRUE,int graphId=-1);
 
   void writeXML(TextStream &t);

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -220,13 +220,14 @@ QCString DotDirDeps::writeGraph(TextStream &out,
   const QCString &path,
   const QCString &fileName,
   const QCString &relPath,
+  const bool toIndex,
   bool generateImageMap,
   int graphId,
   bool linkRelations)
 {
   m_linkRelations = linkRelations;
   m_urlOnly = TRUE;
-  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
+  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, toIndex, generateImageMap, graphId);
 }
 
 bool DotDirDeps::isTrivial() const

--- a/src/dotdirdeps.h
+++ b/src/dotdirdeps.h
@@ -34,6 +34,7 @@ class DotDirDeps : public DotGraph
                         const QCString &path,
                         const QCString &fileName,
                         const QCString &relPath,
+                        const bool toIndex,
                         bool writeImageMap=TRUE,
                         int graphId=-1,
                         bool linkRelations=TRUE);

--- a/src/dotgfxhierarchytable.cpp
+++ b/src/dotgfxhierarchytable.cpp
@@ -69,7 +69,7 @@ void DotGfxHierarchyTable::createGraph(DotNode *n,TextStream &out,
   m_graphId = id;
   m_noDivTag = TRUE;
   m_zoomable = FALSE;
-  DotGraph::writeGraph(out, GOF_BITMAP, EOF_Html, path, fileName, "", TRUE, 0);
+  DotGraph::writeGraph(out, GOF_BITMAP, EOF_Html, path, fileName, "", true, TRUE, 0);
 }
 
 void DotGfxHierarchyTable::writeGraph(TextStream &out,

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -115,6 +115,7 @@ QCString DotGraph::writeGraph(
         const QCString &path,     // output folder
         const QCString &fileName, // name of the code file (for code patcher)
         const QCString &relPath,  // output folder relative to code file
+        const bool toIndex,       // Do we need to add the file to the indexList
         bool generateImageMap,    // in case of bitmap, shall there be code generated?
         int graphId)              // number of this graph in the current code, used in svg code
 {
@@ -133,7 +134,7 @@ QCString DotGraph::writeGraph(
 
   m_regenerate = prepareDotFile();
 
-  if (!m_doNotAddImageToIndex) Doxygen::indexList->addImageFile(imgName());
+  if (toIndex) Doxygen::indexList->addImageFile(imgName());
 
   generateCode(t);
 

--- a/src/dotgraph.h
+++ b/src/dotgraph.h
@@ -46,6 +46,7 @@ class DotGraph
                         const QCString &path,
                         const QCString &fileName,
                         const QCString &relPath,
+                        const bool toIndex,
                         bool writeImageMap=TRUE,
                         int graphId=-1
                        );

--- a/src/dotgroupcollaboration.cpp
+++ b/src/dotgroupcollaboration.cpp
@@ -242,11 +242,10 @@ QCString DotGroupCollaboration::getMapLabel() const
 QCString DotGroupCollaboration::writeGraph( TextStream &t,
   GraphOutputFormat graphFormat, EmbeddedOutputFormat textFormat,
   const QCString &path, const QCString &fileName, const QCString &relPath,
-  bool generateImageMap,int graphId)
+  const bool toIndex,bool generateImageMap,int graphId)
 {
-  m_doNotAddImageToIndex = TRUE;
-
-  return DotGraph::writeGraph(t, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
+  m_doNotAddImageToIndex = !toIndex;
+  return DotGraph::writeGraph(t, graphFormat, textFormat, path, fileName, relPath, toIndex, generateImageMap, graphId);
 }
 
 void DotGroupCollaboration::Edge::write( TextStream &t ) const

--- a/src/dotgroupcollaboration.h
+++ b/src/dotgroupcollaboration.h
@@ -32,7 +32,7 @@ class DotGroupCollaboration : public DotGraph
    ~DotGroupCollaboration();
     QCString writeGraph(TextStream &t, GraphOutputFormat gf,EmbeddedOutputFormat ef,
                         const QCString &path,const QCString &fileName,const QCString &relPath,
-                        bool writeImageMap=TRUE,int graphId=-1);
+                        const bool toIndex,bool writeImageMap=TRUE,int graphId=-1);
     bool isTrivial() const;
 
   protected:

--- a/src/dotincldepgraph.cpp
+++ b/src/dotincldepgraph.cpp
@@ -187,10 +187,11 @@ QCString DotInclDepGraph::writeGraph(TextStream &out,
                                      const QCString &path,
                                      const QCString &fileName,
                                      const QCString &relPath,
+                                     const bool toIndex,
                                      bool generateImageMap,
                                      int graphId)
 {
-  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
+  return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, toIndex, generateImageMap, graphId);
 }
 
 bool DotInclDepGraph::isTrivial() const

--- a/src/dotincldepgraph.h
+++ b/src/dotincldepgraph.h
@@ -34,6 +34,7 @@ class DotInclDepGraph : public DotGraph
     ~DotInclDepGraph();
     QCString writeGraph(TextStream &t, GraphOutputFormat gf, EmbeddedOutputFormat ef,
                         const QCString &path,const QCString &fileName,const QCString &relPath,
+                        const bool toIndex,
                         bool writeImageMap=TRUE,int graphId=-1);
     bool isTrivial() const;
     bool isTooBig() const;

--- a/src/dotlegendgraph.cpp
+++ b/src/dotlegendgraph.cpp
@@ -26,7 +26,7 @@
 void DotLegendGraph::writeGraph(const QCString &path)
 {
   TextStream ts;
-  DotGraph::writeGraph(ts, GOF_BITMAP, EOF_Html, path, "", "", FALSE, 0);
+  DotGraph::writeGraph(ts, GOF_BITMAP, EOF_Html, path, "", "", true, FALSE, 0);
 
   if (getDotImageExtension()=="svg")
   {

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9683,7 +9683,7 @@ static void copyStyleSheet()
   }
 }
 
-static void copyLogo(const QCString &outputOption)
+static void copyLogo(const QCString &outputOption, const bool toIndex)
 {
   QCString projectLogo = Config_getString(PROJECT_LOGO);
   if (!projectLogo.isEmpty())
@@ -9698,12 +9698,12 @@ static void copyLogo(const QCString &outputOption)
     {
       QCString destFileName = outputOption+"/"+fi.fileName();
       copyFile(projectLogo,destFileName);
-      Doxygen::indexList->addImageFile(fi.fileName().c_str());
+      if (toIndex) Doxygen::indexList->addImageFile(fi.fileName().c_str());
     }
   }
 }
 
-static void copyExtraFiles(const StringVector &files,const QCString &filesOption,const QCString &outputOption)
+static void copyExtraFiles(const StringVector &files,const QCString &filesOption,const QCString &outputOption, const bool toIndex)
 {
   for (const auto &fileName : files)
   {
@@ -9717,7 +9717,7 @@ static void copyExtraFiles(const StringVector &files,const QCString &filesOption
       else
       {
         QCString destFileName = outputOption+"/"+fi.fileName();
-        Doxygen::indexList->addImageFile(fi.fileName().c_str());
+        if (toIndex) Doxygen::indexList->addImageFile(fi.fileName().c_str());
         copyFile(QCString(fileName), destFileName);
       }
     }
@@ -12259,22 +12259,22 @@ void generateOutput()
   {
     FTVHelp::generateTreeViewImages();
     copyStyleSheet();
-    copyLogo(Config_getString(HTML_OUTPUT));
-    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT));
+    copyLogo(Config_getString(HTML_OUTPUT),true);
+    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT),true);
   }
   if (generateLatex)
   {
     copyLatexStyleSheet();
-    copyLogo(Config_getString(LATEX_OUTPUT));
-    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT));
+    copyLogo(Config_getString(LATEX_OUTPUT),false);
+    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT),false);
   }
   if (generateDocbook)
   {
-    copyLogo(Config_getString(DOCBOOK_OUTPUT));
+    copyLogo(Config_getString(DOCBOOK_OUTPUT),false);
   }
   if (generateRtf)
   {
-    copyLogo(Config_getString(RTF_OUTPUT));
+    copyLogo(Config_getString(RTF_OUTPUT),false);
   }
 
   const FormulaManager &fm = FormulaManager::instance();
@@ -12283,20 +12283,20 @@ void generateOutput()
   {
     g_s.begin("Generating images for formulas in HTML...\n");
     fm.generateImages(Config_getString(HTML_OUTPUT), Config_getEnum(HTML_FORMULA_FORMAT)==HTML_FORMULA_FORMAT_t::svg ?
-        FormulaManager::Format::Vector : FormulaManager::Format::Bitmap, FormulaManager::HighDPI::On);
+        FormulaManager::Format::Vector : FormulaManager::Format::Bitmap, true, FormulaManager::HighDPI::On);
     g_s.end();
   }
   if (fm.hasFormulas() && generateRtf)
   {
     g_s.begin("Generating images for formulas in RTF...\n");
-    fm.generateImages(Config_getString(RTF_OUTPUT),FormulaManager::Format::Bitmap);
+    fm.generateImages(Config_getString(RTF_OUTPUT),FormulaManager::Format::Bitmap,false);
     g_s.end();
   }
 
   if (fm.hasFormulas() && generateDocbook)
   {
     g_s.begin("Generating images for formulas in Docbook...\n");
-    fm.generateImages(Config_getString(DOCBOOK_OUTPUT),FormulaManager::Format::Bitmap);
+    fm.generateImages(Config_getString(DOCBOOK_OUTPUT),FormulaManager::Format::Bitmap,false);
     g_s.end();
   }
 

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -127,7 +127,7 @@ void FormulaManager::readFormulas(const QCString &dir,bool doCompare)
   }
 }
 
-void FormulaManager::generateImages(const QCString &path,Format format,HighDPI hd) const
+void FormulaManager::generateImages(const QCString &path,Format format,const bool toIndex,HighDPI hd) const
 {
   Dir d(path.str());
   // store the original directory
@@ -180,7 +180,7 @@ void FormulaManager::generateImages(const QCString &path,Format format,HighDPI h
         t << p->formulas[i].c_str() << "\n\\pagebreak\n\n";
         formulasToGenerate.push_back(i);
       }
-      Doxygen::indexList->addImageFile(resultName);
+      if (toIndex) Doxygen::indexList->addImageFile(resultName);
     }
     t << "\\end{document}\n";
     t.flush();

--- a/src/formula.h
+++ b/src/formula.h
@@ -39,7 +39,7 @@ class FormulaManager
     void readFormulas(const QCString &dir,bool doCompare=false);
     void clear();
     int addFormula(const std::string &formulaText);
-    void generateImages(const QCString &outputDir,Format format,HighDPI hd = HighDPI::Off) const;
+    void generateImages(const QCString &outputDir,Format format,const bool toIndex,HighDPI hd = HighDPI::Off) const;
     std::string findFormula(int formulaId) const;
     bool hasFormulas() const;
     DisplaySize displaySize(int formulaId) const;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2267,7 +2267,7 @@ void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
   }
   baseName.prepend("dot_");
   QCString outDir = Config_getString(HTML_OUTPUT);
-  writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP,srcFile,srcLine);
+  writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP,srcFile,srcLine,true);
   writeDotImageMapFromFile(m_t,fn,outDir,relPath,baseName,context,-1,srcFile,srcLine);
 }
 
@@ -2290,7 +2290,7 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPa
   MscOutputFormat mscFormat = MSC_BITMAP;
   if ("svg" == imgExt)
     mscFormat = MSC_SVG;
-  writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,srcFile,srcLine,true);
   writeMscImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,mscFormat,srcFile,srcLine);
 }
 
@@ -2331,7 +2331,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")
   {
-    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG);
+    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG,true);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />\n";
     //m_t << "<p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p>";
     //m_t << "</iframe>\n";
@@ -2339,7 +2339,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   }
   else
   {
-    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
+    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP,true);
     m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
   }
 }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1629,7 +1629,7 @@ void HtmlGenerator::endClassDiagram(const ClassDiagram &d,
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
   TextStream tt;
-  d.writeImage(tt,dir(),m_relPath,fileName);
+  d.writeImage(tt,dir(),m_relPath,fileName,true);
   if (!tt.empty())
   {
     m_t << " <div class=\"center\">\n";
@@ -2017,7 +2017,7 @@ void HtmlGenerator::endDotGraph(DotClassGraph &g)
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
 
-  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,TRUE,TRUE,m_sectionCount);
+  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,true,TRUE,TRUE,m_sectionCount);
   if (generateLegend && !umlLook)
   {
     m_t << "<center><span class=\"legend\">[";
@@ -2043,7 +2043,7 @@ void HtmlGenerator::endInclDepGraph(DotInclDepGraph &g)
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
 
-  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,TRUE,m_sectionCount);
+  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,true,TRUE,m_sectionCount);
 
   endSectionContent(m_t);
   m_sectionCount++;
@@ -2061,7 +2061,7 @@ void HtmlGenerator::endGroupCollaboration(DotGroupCollaboration &g)
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
 
-  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,TRUE,m_sectionCount);
+  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,true,TRUE,m_sectionCount);
 
   endSectionContent(m_t);
   m_sectionCount++;
@@ -2079,7 +2079,7 @@ void HtmlGenerator::endCallGraph(DotCallGraph &g)
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
 
-  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,TRUE,m_sectionCount);
+  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,true,TRUE,m_sectionCount);
 
   endSectionContent(m_t);
   m_sectionCount++;
@@ -2097,7 +2097,7 @@ void HtmlGenerator::endDirDepGraph(DotDirDeps &g)
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
 
-  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,TRUE,m_sectionCount);
+  g.writeGraph(m_t,GOF_BITMAP,EOF_Html,dir(),fileName(),m_relPath,true,TRUE,m_sectionCount);
 
   endSectionContent(m_t);
   m_sectionCount++;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1919,7 +1919,7 @@ void LatexDocVisitor::startDotFile(const QCString &fileName,
   baseName.prepend("dot_");
   QCString outDir = Config_getString(LATEX_OUTPUT);
   QCString name = fileName;
-  writeDotGraphFromFile(name,outDir,baseName,GOF_EPS,srcFile,srcLine);
+  writeDotGraphFromFile(name,outDir,baseName,GOF_EPS,srcFile,srcLine,false);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1950,7 +1950,7 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
   baseName.prepend("msc_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_EPS,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_EPS,srcFile,srcLine,false);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1970,7 +1970,7 @@ void LatexDocVisitor::writeMscFile(const QCString &baseName, DocVerbatim *s)
     shortName=shortName.right(shortName.length()-i-1);
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS,s->srcFile(),s->srcLine());
+  writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS,s->srcFile(),s->srcLine(),false);
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(),s->height());
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());
@@ -2038,7 +2038,7 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, DocVerbatim *s
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
   PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,
-                              s->useBitmap() ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS);
+                              s->useBitmap() ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS,false);
   visitPreStart(m_t, s->hasCaption(), shortName, s->width(), s->height());
   visitCaption(this, s->children());
   visitPostEnd(m_t, s->hasCaption());

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1800,7 +1800,7 @@ void LatexGenerator::startDotGraph()
 
 void LatexGenerator::endDotGraph(DotClassGraph &g)
 {
-  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath);
+  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath,false);
 }
 
 void LatexGenerator::startInclDepGraph()
@@ -1809,7 +1809,7 @@ void LatexGenerator::startInclDepGraph()
 
 void LatexGenerator::endInclDepGraph(DotInclDepGraph &g)
 {
-  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath);
+  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath,false);
 }
 
 void LatexGenerator::startGroupCollaboration()
@@ -1818,7 +1818,7 @@ void LatexGenerator::startGroupCollaboration()
 
 void LatexGenerator::endGroupCollaboration(DotGroupCollaboration &g)
 {
-  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath);
+  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath,false);
 }
 
 void LatexGenerator::startCallGraph()
@@ -1827,7 +1827,7 @@ void LatexGenerator::startCallGraph()
 
 void LatexGenerator::endCallGraph(DotCallGraph &g)
 {
-  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath);
+  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath,false);
 }
 
 void LatexGenerator::startDirDepGraph()
@@ -1836,7 +1836,7 @@ void LatexGenerator::startDirDepGraph()
 
 void LatexGenerator::endDirDepGraph(DotDirDeps &g)
 {
-  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath);
+  g.writeGraph(m_t,GOF_EPS,EOF_LaTeX,dir(),fileName(),m_relPath,false);
 }
 
 void LatexGenerator::startDescription()

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -91,10 +91,11 @@ static bool convertMapFile(TextStream &t,const QCString &mapName,const QCString 
 
 void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,MscOutputFormat format,
-                           const QCString &srcFile,int srcLine
+                           const QCString &srcFile,int srcLine,const bool toIndex
                           )
 {
   QCString absOutFile = outDir;
+  QCString localOutFile = outFile;
   absOutFile+=Portable::pathSeparator();
   absOutFile+=outFile;
 
@@ -105,14 +106,17 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
     case MSC_BITMAP:
       msc_format = mscgen_format_png;
       imgName+=".png";
+      localOutFile+=".png";
       break;
     case MSC_EPS:
       msc_format = mscgen_format_eps;
       imgName+=".eps";
+      localOutFile+=".eps";
       break;
     case MSC_SVG:
       msc_format = mscgen_format_svg;
       imgName+=".svg";
+      localOutFile+=".svg";
       break;
     default:
       return;
@@ -139,7 +143,7 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
     Portable::sysTimerStop();
   }
 
-  Doxygen::indexList->addImageFile(imgName);
+  if (toIndex) Doxygen::indexList->addImageFile(localOutFile);
 
 }
 

--- a/src/msc.h
+++ b/src/msc.h
@@ -23,7 +23,7 @@ enum MscOutputFormat { MSC_BITMAP , MSC_EPS, MSC_SVG };
 
 void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,MscOutputFormat format,
-                           const QCString &srcFile,int srcLine);
+                           const QCString &srcFile,int srcLine,const bool toIndex);
 
 QCString getMscImageMapFromFile(const QCString &inFile, const QCString &outDir,
                                 const QCString &relPath,const QCString &context,

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -88,7 +88,7 @@ QCString PlantumlManager::writePlantUMLSource(const QCString &outDirArg,const QC
   return baseName;
 }
 
-void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format)
+void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format,const bool toIndex)
 {
   QCString plantumlJarPath = Config_getString(PLANTUML_JAR_PATH);
   QCString plantumlConfigFile = Config_getString(PLANTUML_CFG_FILE);
@@ -115,7 +115,7 @@ void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCSt
       break;
   }
 
-  Doxygen::indexList->addImageFile(imgName);
+  if (toIndex) Doxygen::indexList->addImageFile(imgName);
 }
 
 //--------------------------------------------------------------------

--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -67,8 +67,9 @@ class PlantumlManager
      *  @param[in] baseName the name of the generated file (as returned by writePlantUMLSource())
      *  @param[in] outDir   the directory to write the resulting image into.
      *  @param[in] format   the image format to generate.
+     *  @param[in] toIndex  should the image be added to the image list?
      */
-    void generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format);
+    void generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format,const bool toIndex);
 
     using FilesMap   = std::map< std::string, StringVector    >;
     using ContentMap = std::map< std::string, PlantumlContent >;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1848,7 +1848,7 @@ void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption,
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeDotGraphFromFile(filename,outDir,baseName,GOF_BITMAP,srcFile,srcLine);
+  writeDotGraphFromFile(filename,outDir,baseName,GOF_BITMAP,srcFile,srcLine,false);
   QCString imgExt = getDotImageExtension();
   includePicturePreRTF(baseName + "." + imgExt, true, hasCaption);
 }
@@ -1867,7 +1867,7 @@ void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption,
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,srcFile,srcLine);
+  writeMscGraphFromFile(fileName,outDir,baseName,MSC_BITMAP,srcFile,srcLine,false);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
@@ -1893,6 +1893,6 @@ void RTFDocVisitor::writePlantUMLFile(const QCString &fileName, bool hasCaption)
     baseName=baseName.right(baseName.length()-i-1);
   }
   QCString outDir = Config_getString(RTF_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
+  PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP,false);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1691,7 +1691,7 @@ void RTFGenerator::endClassDiagram(const ClassDiagram &d,
   newParagraph();
 
   // create a png file
-  d.writeImage(m_t,dir(),m_relPath,fileName,FALSE);
+  d.writeImage(m_t,dir(),m_relPath,fileName,false,FALSE);
 
   // display the file
   m_t << "{\n";
@@ -2150,7 +2150,7 @@ void RTFGenerator::endDotGraph(DotClassGraph &g)
   newParagraph();
 
   QCString fn =
-    g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,TRUE,FALSE);
+    g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,false,TRUE,FALSE);
 
   // display the file
   m_t << "{\n";
@@ -2173,7 +2173,7 @@ void RTFGenerator::endInclDepGraph(DotInclDepGraph &g)
 {
   newParagraph();
 
-  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,FALSE);
+  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,false,FALSE);
 
   // display the file
   m_t << "{\n";
@@ -2203,7 +2203,7 @@ void RTFGenerator::endCallGraph(DotCallGraph &g)
 {
   newParagraph();
 
-  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,FALSE);
+  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,false,FALSE);
 
   // display the file
   m_t << "{\n";
@@ -2225,7 +2225,7 @@ void RTFGenerator::endDirDepGraph(DotDirDeps &g)
 {
   newParagraph();
 
-  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,FALSE);
+  QCString fn = g.writeGraph(m_t,GOF_BITMAP,EOF_Rtf,dir(),fileName(),m_relPath,false,FALSE);
 
   // display the file
   m_t << "{\n";

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3345,7 +3345,7 @@ void  FlowChart::printUmlTree()
 
   QCString n=convertNameToFileName();
   n=PlantumlManager::instance().writePlantUMLSource(htmlOutDir,n,qcs,PlantumlManager::PUML_SVG,"uml",n,1);
-  PlantumlManager::instance().generatePlantUMLOutput(n,htmlOutDir,PlantumlManager::PUML_SVG);
+  PlantumlManager::instance().generatePlantUMLOutput(n,htmlOutDir,PlantumlManager::PUML_SVG,true);
 }
 
 QCString FlowChart::convertNameToFileName()


### PR DESCRIPTION
When we have an example with dot / msc /plantuml / class / call graph we and we have LaTeX enabled an chm and / or qhp we get warnings when we generate the chm / qch file.
The warnings are (for chm) like:
```
HHC5003: Error: Compilation failed while compiling inline_mscgraph_1.eps.
HHC5003: Error: Compilation failed while compiling msc_tst.eps.
HHC5003: Error: Compilation failed while compiling inline_mscgraph_1.msc.png.
HHC5003: Error: Compilation failed while compiling tst.msc.png.
HHC5003: Error: Compilation failed while compiling classcls1__inherit__graph.pdf.
HHC5003: Error: Compilation failed while compiling classcls1_a50c27321727c278dc467aa3d909a2dc1_icgraph.pdf.
HHC5003: Error: Compilation failed while compiling classcls2__coll__graph.pdf.
HHC5003: Error: Compilation failed while compiling classcls2__inherit__graph.pdf.
HHC5003: Error: Compilation failed while compiling classcls2_a963159bbf5424f67f740056941f9c667_cgraph.pdf.
HHC5003: Error: Compilation failed while compiling inline_dotgraph_1.dot.png.
HHC5003: Error: Compilation failed while compiling inline_umlgraph_2.eps.
HHC5003: Error: Compilation failed while compiling inline_umlgraph_3.png.
HHC5003: Error: Compilation failed while compiling tsts.dot.png.

The following files were not compiled:
inline_mscgraph_1.eps
msc_tst.eps
inline_mscgraph_1.msc.png
tst.msc.png
classcls1__inherit__graph.pdf
classcls1_a50c27321727c278dc467aa3d909a2dc1_icgraph.pdf
classcls2__coll__graph.pdf
classcls2__inherit__graph.pdf
classcls2_a963159bbf5424f67f740056941f9c667_cgraph.pdf
inline_dotgraph_1.dot.png
inline_umlgraph_2.eps
inline_umlgraph_3.png
tsts.dot.png
```
as these files come from the LaTeX / RTF generation. (Analogous messages for the gch generation)
the used `Doxygen::indexList` is only for HTML like output, so the LaTeX etc output files should not be added.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7136767/example.tar.gz)
