### PR TITLE
Warnings when using `CREATE_SUBDIRS` and `HTMLHELP`

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -555,7 +555,7 @@ void HtmlHelp::Private::createProjectFile()
     }
     for (auto &s : imageFiles)
     {
-      t << FileInfo(s).fileName() << "\n";
+      t << s.c_str() << "\n";
     }
     t.close();
   }


### PR DESCRIPTION
When we have an example with generating `CALL_GRAOPH`s etc. together with `CREATE_SUBDIRS=YES` and HTMLHELP is  has to be generated we get warnings like:
```
HHC5003: Error: Compilation failed while compiling classcls2__inherit__graph.png.
HHC5003: Error: Compilation failed while compiling classcls1__inherit__graph.png.
HHC5003: Error: Compilation failed while compiling classcls2__coll__graph.png.
HHC5003: Error: Compilation failed while compiling classcls2_a963159bbf5424f67f740056941f9c667_cgraph.png.
HHC5003: Error: Compilation failed while compiling classcls1_a50c27321727c278dc467aa3d909a2dc1_icgraph.png.

The following files were not compiled:
classcls2__inherit__graph.png
classcls1__inherit__graph.png
classcls2__coll__graph.png
classcls2_a963159bbf5424f67f740056941f9c667_cgraph.png
classcls1_a50c27321727c278dc467aa3d909a2dc1_icgraph.png
```
as in the `hhp` file the files are assumed to be in te main directory but in fact they are in the sub directories.
The problem occurs as the full path is stripped from the given filename.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7137048/example.tar.gz)
