### PR TITLE
Cleanup #includes for dotdirdeps.cpp

### DIFF
--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -13,19 +13,22 @@
 *
 */
 
-#include <algorithm>
-#include <iterator>
-#include <utility>
-#include <sstream>
-#include <cstdint>
-#include <cmath>
-#include <cassert>
-
 #include "dotdirdeps.h"
 #include "util.h"
 #include "doxygen.h"
 #include "config.h"
 #include "image.h"
+
+#include <algorithm>
+#include <iterator>
+#include <utility>
+#include <cstdint>
+#include <math.h>
+#include <cassert>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 using DirDefMap = std::map<std::string,const DirDef *>;
 


### PR DESCRIPTION
 - Added includes to header of standard library which were missing. The source file should include those headers directly in order to avoid false dependencies to other header files.
 - Replace cmath with math.h. As only the C library is used (pow) and not C++ (std::pow).
 - Remove unnecessary include of sstream. Moved includes to own headers before system includes. Own includes ("") should be before system includes (<>). Include to Own Header (dotdirdeps.h) Should be the First Include