### PR TITLE
Revives Fortran case-sensitivity + full Fortran 2018 syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+ParaMonte Doxygen
+=================
+
+This repository contains a variation of the original Doxygen software that is specially tailored for the needs of the ParaMonte library documentation website.
+
+Installation instructions on Windows
+====================================
+
+1. Download and install the [Microsoft Visual Studio Community version](https://visualstudio.microsoft.com/vs/community/) on your Windows system.
+1. Download and install a [recent GNU gcc compiler](https://github.com/LKedward/quickstart-fortran/releases) for Windows.
+1. Download and install a [recent version of Flex](https://gnuwin32.sourceforge.net/packages/flex.htm) on your Windows system.
+1. Download and install a recent version of GNU Bison.
+1. A recent version of the last two software above can be collectively found and installed from https://github.com/lexxmark/winflexbison/releases
+1. Download and install a recent version of [CMake software](https://cmake.org/download/) on yout Windows system.
+1. Esnure the path to `cmake.exe`, `bison.exe` and `flex.exe` and GNU compilers (`gcc.exe`, `g++.exe`) exist in the environmental `PATH` variable of your Windows CMD shell.
+1. Download the [ParaMonte Doxygen project](https://github.com/cdslaborg/doxygen) from github. 
+   If you have `git` software installed on your system, you can readily download via `git clone https://github.com/cdslaborg/doxygen` on a git-aware Windows command line.
+1. Navigate to the root directory of ParaMonte Doxygen project on the Windows command lind and type:
+   ```batch  
+   mkdir build
+   cd build
+   cmake -G "NMake Makefiles" ..
+   nmake
+   ```  
+1. The above commands will create a new folder `bin` within the current working directory (`build`) that contains the doxygen software eexecutable binary.
+1. You can now build the ParaMonte library documentation with this specific customized version of Doxygen software.
+
+Installation instructions on Linux/macOS
+========================================
+
+The installation instructions on Linux/macOS are identical to those offered by [Doxygen developers](https://www.doxygen.nl/manual/install.html).
+
 Doxygen
 ===============
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=9HHLRBCC8B2B8)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd build && cmake -G "Unix Makefiles" .. && make || {
+    echo
+    echo "Doxygen build failed."
+    echo
+}

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+if ! [ -d build/ ]; then
+    mkdir build
+fi
 cd build && cmake -G "Unix Makefiles" .. && make || {
     echo
     echo "Doxygen build failed."

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 if ! [ -d build/ ]; then
     mkdir build
 fi
-cd build && cmake -G "Unix Makefiles" .. && make || {
+cd build && cmake -G "Unix Makefiles" .. && make -j || {
     echo
     echo "Doxygen build failed."
     echo

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,7 @@ add_library(doxymain STATIC
     condparser.cpp
     context.cpp
     cppvalue.cpp
+    #datetime.cpp
     defgen.cpp
     definition.cpp
     dia.cpp

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2583,7 +2583,7 @@ static bool handleFileInfo(yyscan_t yyscanner,const QCString &, const StringVect
       addOutput(yyscanner,yyextra->fileName);
     }
   }
-  addOutput(yyscanner," ");
+  addOutput(yyscanner,"");
   return FALSE;
 }
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -35,6 +35,8 @@ typedef yyguts_t *yyscan_t;
 #include <stack>
 #include <string>
 #include <mutex>
+#include <functional>
+#include <unordered_map>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,6 +44,7 @@ typedef yyguts_t *yyscan_t;
 #include <ctype.h>
 
 #include "qcstring.h"
+#include "fileinfo.h"
 #include "cite.h"
 #include "commentscan.h"
 #include "condparser.h"
@@ -141,6 +144,8 @@ static bool handleParBlock(yyscan_t yyscanner,const QCString &, const StringVect
 static bool handleEndParBlock(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleParam(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleRetval(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleFileInfo(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleLineInfo(yyscan_t yyscanner,const QCString &, const StringVector &);
 
 #if USE_STATE2STRING
 static const char *stateToString(int state);
@@ -305,7 +310,9 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "weakgroup",       { &handleWeakGroup,        CommandSpacing::Invisible }},
   { "xmlinclude",      { 0,                       CommandSpacing::Inline    }},
   { "xmlonly",         { &handleFormatBlock,      CommandSpacing::Invisible }},
-  { "xrefitem",        { &handleXRefItem,         CommandSpacing::XRef      }}
+  { "xrefitem",        { &handleXRefItem,         CommandSpacing::XRef      }},
+  { "fileinfo",        { &handleFileInfo,         CommandSpacing::Inline    }},
+  { "lineinfo",        { &handleLineInfo,         CommandSpacing::Inline    }},
 };
 
 #define YY_NO_INPUT 1
@@ -445,6 +452,7 @@ static void handleGuard(yyscan_t yyscanner,const QCString &expr);
 static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static void addCite(yyscan_t yyscanner);
 static void addIline(yyscan_t yyscanner,int lineNr);
+static void addIlineBreak(yyscan_t yyscanner,int lineNr);
 
 #define unput_string(yytext,yyleng) do { for (int i=(int)yyleng-1;i>=0;i--) unput(yytext[i]); } while(0)
 
@@ -453,17 +461,21 @@ static void addIline(yyscan_t yyscanner,int lineNr);
 #undef        YY_INPUT
 #define        YY_INPUT(buf,result,max_size) result=yyread(yyscanner,buf,max_size);
 
+// otherwise the filename would be the name of the converted file (*.cpp instead of *.l)
+static inline const char *getLexerFILE() {return __FILE__;}
+#include "doxygen_lex.h"
+
 %}
 
        /* start command character */
-CMD          ("\\"|"@")
+CMD       ("\\"|"@")
 XREFCMD   {CMD}("bug"|"deprecated"|"test"|"todo"|"xrefitem")
 PRE       [pP][rR][eE]
-TABLE          [tT][aA][bB][lL][eE]
-P          [pP]
+TABLE     [tT][aA][bB][lL][eE]
+P         [pP]
 UL        [uU][lL]
-OL          [oO][lL]
-DL          [dD][lL]
+OL        [oO][lL]
+DL        [dD][lL]
 IMG       [iI][mM][gG]
 HR        [hH][rR]
 PARA      [pP][aA][rR][aA]
@@ -471,8 +483,13 @@ CODE      [cC][oO][dD][eE]
 CAPTION   [cC][aA][pP][tT][iI][oO][nN]
 CENTER    [cC][eE][nN][tT][eE][rR]
 DIV       [dD][iI][vV]
+DETAILS   [dD][eE][tT][aA][iI][lL][sS]
 DETAILEDHTML {CENTER}|{DIV}|{PRE}|{UL}|{TABLE}|{OL}|{DL}|{P}|[Hh][1-6]|{IMG}|{HR}|{PARA}
 DETAILEDHTMLOPT {CODE}
+SUMMARY   [sS][uU][mM][mM][aA][rR][yY]
+REMARKS   [rR][eE][mM][aA][rR][kK][sS]
+AHTML     [aA]{BN}*
+ANCHTML   ([iI][dD]|[nN][aA][mM][eE])"="("\""{LABELID}"\""|"'"{LABELID}"'"|{LABELID})
 BN        [ \t\n\r]
 BL        [ \t\r]*"\n"
 B         [ \t]
@@ -481,9 +498,9 @@ BS        ^(({B}*"/""/")?)(({B}*"*"+)?){B}*
 ATTR      ({B}+[^>\n]*)?
 DOCNL     "\n"|"\\ilinebr"
 LC        "\\"{B}*"\n"
-NW          [^a-z_A-Z0-9]
-FILESCHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+@&#]
-FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+@&#]
+NW        [^a-z_A-Z0-9]
+FILESCHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=@&#]
+FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=@&#]
 FILE      ({FILESCHAR}*{FILEECHAR}+("."{FILESCHAR}*{FILEECHAR}+)*)|("\""[^\n\"]*"\"")
 ID        [$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
@@ -493,7 +510,7 @@ CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{C
 SCOPEID   {ID}({ID}*{BN}*"::"{BN}*)*({ID}?)
 SCOPENAME "$"?(({ID}?{BN}*("::"|"."){BN}*)*)((~{BN}*)?{ID})
 TMPLSPEC  "<"{BN}*[^>]+{BN}*">"
-MAILADDR   [a-z_A-Z0-9.+\-]+"@"[a-z_A-Z0-9\-]+("."[a-z_A-Z0-9\-]+)+[a-z_A-Z0-9\-]+
+MAILADDR  ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a-z_A-Z0-9\x80-\xff\-]+)+[a-z_A-Z0-9\x80-\xff\-]+
 RCSTAG    "$"{ID}":"[^\n$]+"$"
 
   // C start comment 
@@ -551,6 +568,7 @@ STopt  [^\n@\\]*
 %x      ReadFormulaLong
 %x      AnchorLabel
 %x      HtmlComment
+%x      HtmlA
 %x      SkipLang
 %x      CiteLabel
 %x      CopyDoc
@@ -855,7 +873,7 @@ STopt  [^\n@\\]*
                                           addOutput(yyscanner,yytext[0]);
                                           addOutput(yyscanner,yytext[2]);
                                         }
-<Comment>".,"                           { // . with comma such as "e.g.,"
+<Comment>"."[,:;]                       { // . with some puntuations such as "e.g.," or "e.g.:"
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"...\\"[ \t]                   { // ellipsis with escaped space.
@@ -977,6 +995,7 @@ STopt  [^\n@\\]*
                                           yyextra->formulaNewLines++;
                                           yyextra->formulaText+=*yytext;
                                           yyextra->lineNr++;
+                                          addIline(yyscanner,yyextra->lineNr);
                                         }
 <ReadFormulaLong,ReadFormulaShort,ReadFormulaRound>.     { // any other character
                                           yyextra->formulaText+=*yytext;
@@ -1007,7 +1026,8 @@ STopt  [^\n@\\]*
   /* ------------ handle argument of namespace command --------------- */
 
 <NameSpaceDocArg1>{SCOPENAME}           { // handle argument
-                                          yyextra->current->name = substitute(QCString(yytext),QCString("."),QCString("::"));
+                                          lineCount(yyscanner);
+                                          yyextra->current->name = substitute(removeRedundantWhiteSpace(QCString(yytext)),QCString("."),QCString("::"));
                                           BEGIN( Comment );
                                         }
 <NameSpaceDocArg1>{LC}                  { // line continuation
@@ -1075,10 +1095,12 @@ STopt  [^\n@\\]*
   /* ------ handle argument of class/struct/union command --------------- */
 
 <ClassDocArg1>{SCOPENAME}{TMPLSPEC}     {
+                                          lineCount(yyscanner);
                                           yyextra->current->name = substitute(removeRedundantWhiteSpace(QCString(yytext)),".","::");
                                           BEGIN( ClassDocArg2 );
                                         }
 <ClassDocArg1>{SCOPENAME}               { // first argument
+                                          lineCount(yyscanner);
                                           yyextra->current->name = substitute(QCString(yytext),".","::");
                                           if (yyextra->current->section==Entry::PROTOCOLDOC_SEC)
                                           {
@@ -1088,6 +1110,7 @@ STopt  [^\n@\\]*
                                           BEGIN( ClassDocArg2 );
                                         }
 <CategoryDocArg1>{SCOPENAME}{B}*"("[^\)]+")" {
+                                          lineCount(yyscanner);
                                           yyextra->current->name = substitute(QCString(yytext),".","::");
                                           BEGIN( ClassDocArg2 );
                                         }
@@ -1148,7 +1171,7 @@ STopt  [^\n@\\]*
                                           //lastDefGroup.groupname = yytext;
                                           //lastDefGroup.pri = yyextra->current->groupingPri();
                                           // the .html stuff is for Qt compatibility
-                                          if (yyextra->current->name.right(5)==".html")
+                                          if (yyextra->current->name.endsWith(".html"))
                                           {
                                             yyextra->current->name=yyextra->current->name.left(yyextra->current->name.length()-5);
                                           }
@@ -1453,6 +1476,10 @@ STopt  [^\n@\\]*
                                           addOutput(yyscanner,'\n');
                                           BEGIN( Comment );
                                         }
+<SubpageLabel>.                         {
+                                          unput(yytext[0]);
+                                          BEGIN( Comment );
+                                        }
 <SubpageTitle>{DOCNL}                   { // no title, end command
                                           addOutput(yyscanner,yytext);
                                           BEGIN( Comment );
@@ -1579,7 +1606,7 @@ STopt  [^\n@\\]*
                                           if (*yytext=='\n') yyextra->lineNr++;
                                           //next line is commented out due to bug620924
                                           //addOutput(yyscanner,'\n');
-                                          addIline(yyscanner,yyextra->lineNr);
+                                          addIlineBreak(yyscanner,yyextra->lineNr);
                                           BEGIN( Comment );
                                         }
 <GuardParam>{LC}                        { // line continuation
@@ -1592,7 +1619,7 @@ STopt  [^\n@\\]*
 <GuardParamEnd>{B}*{DOCNL}              {
                                           lineCount(yyscanner);
                                           yyextra->spaceBeforeIf.resize(0);
-                                          addIline(yyscanner,yyextra->lineNr);
+                                          addIlineBreak(yyscanner,yyextra->lineNr);
                                           BEGIN(Comment);
                                         }
 <GuardParamEnd>{B}*                     {
@@ -1601,12 +1628,12 @@ STopt  [^\n@\\]*
                                             addOutput(yyscanner,yyextra->spaceBeforeIf);
                                           }
                                           yyextra->spaceBeforeIf.resize(0);
-                                          addIline(yyscanner,yyextra->lineNr);
+                                          addIlineBreak(yyscanner,yyextra->lineNr);
                                           BEGIN(Comment);
                                         }
 <GuardParamEnd>.                        {
                                           unput(*yytext);
-                                          addIline(yyscanner,yyextra->lineNr);
+                                          addIlineBreak(yyscanner,yyextra->lineNr);
                                           BEGIN(Comment);
                                         }
 
@@ -1935,19 +1962,40 @@ STopt  [^\n@\\]*
 
   /* ----- handle argument of the copydoc command ------- */
 
-<CopyDoc><<EOF>>                        |
-<CopyDoc>{DOCNL}                        {
-                                          if (*yytext=='\n') yyextra->lineNr++;
-                                          addOutput(yyscanner,'\n');
+<CopyDoc><<EOF>>                        {
                                           setOutput(yyscanner,OutputDoc);
-                                          addOutput(yyscanner," \\copydetails ");
+                                          addOutput(yyscanner," \\ilinebr\\ilinebr\\copydetails ");
                                           addOutput(yyscanner,yyextra->copyDocArg);
                                           addOutput(yyscanner,"\n");
                                           BEGIN(Comment);
                                         }
-<CopyDoc>[^\n\\]+                       {
+<CopyDoc>{DOCNL}                        {
+                                          if (*yytext=='\n') yyextra->lineNr++;
+                                          if (yyextra->braceCount==0)
+                                          {
+                                            setOutput(yyscanner,OutputDoc);
+                                            addOutput(yyscanner," \\ilinebr\\ilinebr\\copydetails ");
+                                            addOutput(yyscanner,yyextra->copyDocArg);
+                                            addOutput(yyscanner,"\n");
+                                            BEGIN(Comment);
+                                          }
+                                        }
+<CopyDoc>{LC}                           { // line continuation
+                                          yyextra->lineNr++;
+                                        }
+<CopyDoc>[^@\\\n()]+                    { // non-special characters
                                           yyextra->copyDocArg+=yytext;
                                           addOutput(yyscanner,yytext);
+                                        }
+<CopyDoc>"("                            {
+                                          yyextra->copyDocArg+=yytext;
+                                          addOutput(yyscanner,yytext);
+                                          yyextra->braceCount++;
+                                        }
+<CopyDoc>")"                            {
+                                          yyextra->copyDocArg+=yytext;
+                                          addOutput(yyscanner,yytext);
+                                          yyextra->braceCount--;
                                         }
 <CopyDoc>.                              {
                                           yyextra->copyDocArg+=yytext;
@@ -1955,9 +2003,9 @@ STopt  [^\n@\\]*
                                         }
 
  /*
-<*>.  { fprintf(stderr,"Lex scanner %s %sdefault rule for state %s: #%s#\n", __FILE__,yyextra->fileName ? ("(" + yyextra->fileName +") ").data(): "",stateToString(YY_START),yytext);}
-<*>\n  { fprintf(stderr,"Lex scanner %s %sdefault rule newline for state %s.\n", __FILE__, yyextra->fileName ? ("(" + yyextra->fileName +") ").data(): "",stateToString(YY_START));}
-  */
+<*>.  { fprintf(stderr,"Lex scanner %s %sdefault rule for state %s: #%s#\n", __FILE__,!yyextra->fileName.isEmpty() ? ("(" + yyextra->fileName +") ").data(): "",stateToString(YY_START),yytext);}
+<*>\n  { fprintf(stderr,"Lex scanner %s %sdefault rule newline for state %s.\n", __FILE__, !yyextra->fileName.isEmpty() ? ("(" + yyextra->fileName +") ").data(): "",stateToString(YY_START));}
+ */
 
 %%
 
@@ -2143,6 +2191,7 @@ static bool handleMainpage(yyscan_t yyscanner,const QCString &, const StringVect
   {
     yyextra->current->name = "mainpage";
   }
+  setOutput(yyscanner,OutputDoc);
   BEGIN( PageDocArg2 );
   return stop;
 }
@@ -2328,6 +2377,7 @@ static bool handleRelated(yyscan_t yyscanner,const QCString &cmd, const StringVe
         "found multiple \\relates, \\relatesalso or \\memberof commands in a comment block, using last definition");
   }
   yyextra->current->relatesType = Simple;
+  yyextra->currentCmd = cmd;
   BEGIN(RelatesParam1);
   return FALSE;
 }
@@ -2476,6 +2526,77 @@ static bool handleAddIndex(yyscan_t yyscanner,const QCString &, const StringVect
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   addOutput(yyscanner,"@addindex ");
   BEGIN(LineParam);
+  return FALSE;
+}
+
+
+static bool handleFileInfo(yyscan_t yyscanner,const QCString &, const StringVector &optList)
+{
+  using OutputWriter = std::function<void(yyscan_t,FileInfo &)>;
+  static std::unordered_map<std::string,OutputWriter> options =
+  { // name,        writer
+    { "name",      [](yyscan_t s,FileInfo &fi) { addOutput(s,fi.baseName());      } },
+    { "extension", [](yyscan_t s,FileInfo &fi) { addOutput(s,fi.extension(true)); } },
+    { "filename",  [](yyscan_t s,FileInfo &fi) { addOutput(s,fi.fileName());      } },
+    { "directory", [](yyscan_t s,FileInfo &fi) { addOutput(s,fi.dirPath());       } },
+    { "full",      [](yyscan_t s,FileInfo &fi) { addOutput(s,fi.absFilePath());   } },
+  };
+
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (!yyextra->spaceBeforeCmd.isEmpty())
+  {
+    addOutput(yyscanner,yyextra->spaceBeforeCmd);
+    yyextra->spaceBeforeCmd.resize(0);
+  }
+  bool first = true;
+  FileInfo fi(yyextra->fileName.str());
+  for (const auto &opt_ : optList)
+  {
+    QCString optStripped = QCString(opt_).stripWhiteSpace();
+    std::string opt = optStripped.lower().str();
+    auto it = options.find(opt);
+    if (it != options.end())
+    {
+      if (!first)
+      {
+        warn(yyextra->fileName,yyextra->lineNr,"Multiple options specified with \\fileinfo, discarding '%s'", qPrint(optStripped));
+      }
+      else
+      {
+        it->second(yyscanner,fi);
+      }
+      first = false;
+    }
+    else
+    {
+      warn(yyextra->fileName,yyextra->lineNr,"Unknown option specified with \\fileinfo: '%s'", qPrint(optStripped));
+    }
+  }
+  if (first) // no options specified
+  {
+    if (Config_getBool(FULL_PATH_NAMES))
+    {
+      addOutput(yyscanner,stripFromPath(yyextra->fileName));
+    }
+    else
+    {
+      addOutput(yyscanner,yyextra->fileName);
+    }
+  }
+  addOutput(yyscanner," ");
+  return FALSE;
+}
+
+static bool handleLineInfo(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (!yyextra->spaceBeforeCmd.isEmpty())
+  {
+    addOutput(yyscanner,yyextra->spaceBeforeCmd);
+    yyextra->spaceBeforeCmd.resize(0);
+  }
+  addOutput(yyscanner,QCString().setNum(yyextra->lineNr));
+  addOutput(yyscanner," ");
   return FALSE;
 }
 
@@ -2827,7 +2948,12 @@ static bool handleCopyDetails(yyscan_t yyscanner,const QCString &, const StringV
 static bool handleCopyDoc(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  setOutput(yyscanner,OutputBrief);
+  if (yyextra->current->brief.isEmpty() && yyextra->current->doc.isEmpty())
+  { // if we don't have a brief or detailed description yet,
+    // then the @copybrief should end up in the brief description.
+    // otherwise it will be copied inline (see bug691315 & bug700788)
+    setOutput(yyscanner,OutputBrief);
+  }
   if (!yyextra->spaceBeforeCmd.isEmpty())
   {
     addOutput(yyscanner,yyextra->spaceBeforeCmd);
@@ -2835,6 +2961,7 @@ static bool handleCopyDoc(yyscan_t yyscanner,const QCString &, const StringVecto
   }
   addOutput(yyscanner,"\\copybrief ");
   yyextra->copyDocArg.resize(0);
+  yyextra->braceCount = 0;
   BEGIN(CopyDoc);
   return FALSE;
 }
@@ -3021,8 +3148,7 @@ static QCString addFormula(yyscan_t yyscanner)
   std::unique_lock<std::mutex> lock(g_formulaMutex);
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   QCString formLabel;
-  QCString fText=yyextra->formulaText.simplifyWhiteSpace();
-  int id = FormulaManager::instance().addFormula(fText.str());
+  int id = FormulaManager::instance().addFormula(yyextra->formulaText.str());
   formLabel.sprintf("\\_form#%d",id);
   for (int i=0;i<yyextra->formulaNewLines;i++) formLabel+="@_fakenl"; // add fake newlines to
                                                          // keep the warnings
@@ -3206,6 +3332,7 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
       if (oldContext!=yyextra->inContext)
       {
         stripTrailingWhiteSpace(yyextra->current->doc);
+        if (yyextra->current->doc.isEmpty()) yyextra->current->docLine = yyextra->lineNr;
         if (yyextra->current->docFile.isEmpty())
         {
           yyextra->current->docFile = yyextra->fileName;
@@ -3217,6 +3344,7 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
     case OutputBrief:
       if (oldContext!=yyextra->inContext)
       {
+        if (yyextra->current->brief.isEmpty()) yyextra->current->briefLine = yyextra->lineNr;
         if (yyextra->current->briefFile.isEmpty())
         {
           yyextra->current->briefFile = yyextra->fileName;
@@ -3313,6 +3441,13 @@ static void addIline(yyscan_t yyscanner,int lineNr)
   addOutput(yyscanner, cmd);
 }
 
+static void addIlineBreak(yyscan_t yyscanner,int lineNr)
+{
+  char cmd[30];
+  sprintf(cmd,"\\iline %d \\ilinebr ",lineNr);
+  addOutput(yyscanner, cmd);
+}
+
 static void endBrief(yyscan_t yyscanner,bool addToOutput)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
@@ -3321,7 +3456,15 @@ static void endBrief(yyscan_t yyscanner,bool addToOutput)
     // found some brief description and not just whitespace
     yyextra->briefEndsAtDot=FALSE;
     setOutput(yyscanner,OutputDoc);
+    addIline(yyscanner,yyextra->lineNr);
     if (addToOutput) addOutput(yyscanner,yytext);
+  }
+  else
+  {
+    int saveLineNr = yyextra->lineNr;
+    lineCount(yyscanner);
+    yyextra->current->briefLine = yyextra->lineNr;
+    yyextra->lineNr = saveLineNr;
   }
 }
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3219,6 +3219,21 @@ static void addMethodToClass(const Entry *root,ClassDefMutable *cd,
   QCString name=removeRedundantWhiteSpace(rname);
   if (name.left(2)=="::") name=name.right(name.length()-2);
 
+  /*
+   * A Fortran generic member whose name is identical to the enclosing
+   * derived type is a constructor interface.  Normalize its displayed
+   * member type here, immediately before the MemberDef is created.
+   *
+   * Doing this here is intentional: this is the value that is copied into
+   * MemberDef::typeString() and subsequently rendered in the Public Member
+   * Functions table.
+   */
+  if (root->lang==SrcLangExt_Fortran && type.lower()=="generic" && cd &&
+      name.lower()==cd->localName().lower())
+  {
+    type="constructor";
+  }
+
   MemberType mtype;
   if (isFriend)                 mtype=MemberType_Friend;
   else if (root->mtype==Signal) mtype=MemberType_Signal;

--- a/src/doxygen_lex.h
+++ b/src/doxygen_lex.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2021 by Dimitri van Heesch.
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation under the terms of the GNU General Public License is hereby
+ * granted. No representations are made about the suitability of this software
+ * for any purpose. It is provided "as is" without express or implied warranty.
+ * See the GNU General Public License for more details.
+ *
+ * Documents produced by Doxygen are derivative works derived from the
+ * input used in their production; they are not affected by this license.
+ *
+ */
+
+#ifndef DOXYGEN_LEX_H
+#define DOXYGEN_LEX_H
+
+#ifndef LEX_NO_REENTRANT
+#ifndef LEX_NO_INPUT_FILENAME
+#define YY_FATAL_ERROR(msg)                                          \
+{                                                                    \
+  QCString msg1 = msg;                                               \
+  msg1 += "\n    lexical analyzer: ";                                \
+  msg1 += getLexerFILE();                                            \
+  if (!static_cast<yyguts_t*>(yyscanner)->yyextra_r->fileName.isEmpty()) \
+  {                                                                  \
+    msg1 += " (for: ";                                               \
+    msg1 += static_cast<yyguts_t*>(yyscanner)->yyextra_r->fileName;  \
+    msg1 += ")";                                                     \
+  }                                                                  \
+  msg1 += "\n";                                                      \
+  yy_fatal_error( qPrint(msg1) , yyscanner);                         \
+}
+#else
+#define YY_FATAL_ERROR(msg)                                          \
+{                                                                    \
+  QCString msg1 = msg;                                               \
+  msg1 += "\n    lexical analyzer: ";                                \
+  msg1 += getLexerFILE();                                            \
+  msg1 += "\n";                                                      \
+  yy_fatal_error( qPrint(msg1) , yyscanner);                         \
+}
+#endif
+#else
+#define YY_FATAL_ERROR(msg)                                          \
+{                                                                    \
+  QCString msg1 = msg;                                               \
+  msg1 += "\n    lexical analyzer: ";                                \
+  msg1 += getLexerFILE();                                            \
+  msg1 += "\n";                                                      \
+  yy_fatal_error( qPrint(msg1));                                     \
+}
+#endif
+
+#endif

--- a/src/fortrancode-genesis.l
+++ b/src/fortrancode-genesis.l
@@ -1,0 +1,1767 @@
+/******************************************************************************
+ *
+ * Parser for syntax highlighting and references for Fortran90 F subset
+ *
+ * Copyright (C) by Anke Visser
+ * based on the work of Dimitri van Heesch.
+ * Copyright (C) 2020 by Dimitri van Heesch.
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation under the terms of the GNU General Public License is hereby
+ * granted. No representations are made about the suitability of this software
+ * for any purpose. It is provided "as is" without express or implied warranty.
+ * See the GNU General Public License for more details.
+ *
+ * Documents produced by Doxygen are derivative works derived from the
+ * input used in their production; they are not affected by this license.
+ *
+ */
+
+/**
+ @todo - continuation lines not always recognized
+       - merging of use-statements with same module name and different only-names
+       - rename part of use-statement
+       - links to interface functions
+       - references to variables
+**/
+%option never-interactive
+%option case-insensitive
+%option reentrant
+%option prefix="fortrancodeYY"
+%option extra-type="struct fortrancodeYY_state *"
+%option noyy_top_state
+%top{
+#include <stdint.h>
+// forward declare yyscan_t to improve type safety
+#define YY_TYPEDEF_YY_SCANNER_T
+struct yyguts_t;
+typedef yyguts_t *yyscan_t;
+}
+
+%{
+
+/*
+ *      includes
+ */
+#include <stdio.h>
+#include <assert.h>
+#include <ctype.h>
+
+#include "doxygen.h"
+#include "message.h"
+#include "outputlist.h"
+#include "util.h"
+#include "membername.h"
+#include "defargs.h"
+#include "config.h"
+#include "groupdef.h"
+#include "classlist.h"
+#include "filedef.h"
+#include "namespacedef.h"
+#include "tooltip.h"
+#include "fortrancode.h"
+#include "fortranscanner.h"
+#include "containers.h"
+
+const int fixedCommentAfter = 10000;
+
+// Toggle for some debugging info
+//#define DBG_CTX(x) fprintf x
+#define DBG_CTX(x) do { } while(0)
+
+#define YY_NO_TOP_STATE 1
+#define YY_NO_INPUT 1
+#define YY_NO_UNISTD_H 1
+
+#define USE_STATE2STRING 0
+
+/*
+ * For fixed formatted code position 6 is of importance (continuation character).
+ * The following variables and macros keep track of the column number
+ * YY_USER_ACTION is always called for each scan action
+ * YY_FTN_RESET   is used to handle end of lines and reset the column counter
+ * YY_FTN_REJECT  resets the column counters when a pattern is rejected and thus rescanned.
+ */
+int yy_old_start = 0;
+int yy_my_start  = 0;
+int yy_end       = 1;
+#define YY_USER_ACTION {yy_old_start = yy_my_start; yy_my_start = yy_end; yy_end += static_cast<int>(yyleng);}
+#define YY_FTN_RESET   {yy_old_start = 0; yy_my_start = 0; yy_end = 1;}
+#define YY_FTN_REJECT  {yy_end = yy_my_start; yy_my_start = yy_old_start; REJECT;}
+
+//--------------------------------------------------------------------------------
+
+/**
+  data of an use-statement
+*/
+class UseEntry
+{
+ public:
+   QCString module; // just for debug
+   std::vector<QCString> onlyNames;   /* entries of the ONLY-part */
+};
+
+/**
+  module name -> list of ONLY/remote entries
+  (module name = name of the module, which can be accessed via use-directive)
+*/
+class UseMap : public std::map<std::string,UseEntry>
+{
+};
+
+/**
+  Contains names of used modules and names of local variables.
+*/
+class Scope
+{
+  public:
+    std::vector<QCString> useNames; //!< contains names of used modules
+    StringUnorderedSet localVars; //!< contains names of local variables
+    StringUnorderedSet externalVars; //!< contains names of external entities
+};
+
+/*===================================================================*/
+/*
+ *      statics
+ */
+
+struct fortrancodeYY_state
+{
+  QCString              docBlock;                   //!< contents of all lines of a documentation block
+  QCString              currentModule=QCString();   //!< name of the current enclosing module
+  UseMap                useMembers;                 //!< info about used modules
+  UseEntry              useEntry;                   //!< current use statement info
+  std::vector<Scope>    scopeStack;
+  bool                  isExternal = false;
+  QCString              str=QCString();             //!< contents of fortran string
+
+  CodeOutputInterface * code = 0;
+
+  const char *  inputString = 0;     //!< the code fragment as text
+  yy_size_t     inputPosition = 0;   //!< read offset during parsing
+  int           inputLines = 0;      //!< number of line in the code fragment
+  int           yyLineNr = 0;        //!< current line number
+  int           contLineNr = 0;      //!< current, local, line number for continuation determination
+  int          *hasContLine = 0;     //!< signals whether or not a line has a continuation line (fixed source form)
+  bool          needsTermination = false;
+  const Definition *searchCtx = 0;
+  bool          collectXRefs = false;
+  bool          isFixedForm = false;
+
+  bool          insideBody = false;      //!< inside subprog/program body? => create links
+  const char *  currentFontClass = 0;
+
+  bool          exampleBlock = false;
+  QCString      exampleName;
+  QCString      exampleFile;
+
+  const FileDef *    sourceFileDef = 0;
+  const Definition * currentDefinition = 0;
+  const MemberDef *  currentMemberDef = 0;
+  bool          includeCodeFragment = false;
+
+  char          stringStartSymbol = '\0'; // single or double quote
+// count in variable declaration to filter out
+//  declared from referenced names
+  int           bracketCount = 0;
+
+// signal when in type / class /procedure declaration
+  int           inTypeDecl = 0;
+
+  bool          endComment = false;
+  TooltipManager tooltipManager;
+};
+
+#if USE_STATE2STRING
+static const char *stateToString(int state);
+#endif
+
+static bool getFortranNamespaceDefs(const QCString &mname, NamespaceDef *&cd);
+static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName, ClassDef *&cd, const UseMap &useMap);
+
+//----------------------------------------------------------------------------
+
+static void endFontClass(yyscan_t yyscanner);
+static void startFontClass(yyscan_t yyscanner,const char *s);
+static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor);
+static void addToSearchIndex(yyscan_t yyscanner,const QCString &text);
+static void startCodeLine(yyscan_t yyscanner);
+static void endCodeLine(yyscan_t yyscanner);
+static void nextCodeLine(yyscan_t yyscanner);
+static void codifyLines(yyscan_t yyscanner,const QCString &text);
+static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol, Definition *d,const QCString &text);
+static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd, const QCString &memberText, CodeOutputInterface &ol);
+static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // map with used modules
+                    const QCString &memberText,  // exact member text
+                    CodeOutputInterface &ol,
+                    const QCString &text);
+static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const QCString &lname);
+static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const char *lname);
+static int countLines(yyscan_t yyscanner);
+static void startScope(yyscan_t yyscanner);
+static void endScope(yyscan_t yyscanner);
+static void addUse(yyscan_t yyscanner,const QCString &moduleName);
+static void addLocalVar(yyscan_t yyscanner,const QCString &varName);
+static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName, const UseMap &useMap);
+static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+
+
+//-------------------------------------------------------------------
+
+static std::mutex g_docCrossReferenceMutex;
+static std::mutex g_countFlowKeywordsMutex;
+
+/* -----------------------------------------------------------------*/
+#undef  YY_INPUT
+#define YY_INPUT(buf,result,max_size) result=yyread(yyscanner,buf,max_size);
+
+%}
+
+IDSYM     [a-z_A-Z0-9]
+ID        [a-z_A-Z]+{IDSYM}*
+B         [ \t]
+BS        [ \t]*
+BS_       [ \t]+
+COMMA     {BS},{BS}
+ARGS_L0   ("("[^)]*")")
+ARGS_L1a  [^()]*"("[^)]*")"[^)]*
+ARGS_L1   ("("{ARGS_L1a}*")")
+ARGS_L2   "("({ARGS_L0}|[^()]|{ARGS_L1a}|{ARGS_L1})*")"
+ARGS      {BS}({ARGS_L0}|{ARGS_L1}|{ARGS_L2})
+
+/* The following appear in submodules as (subroutine|function|procedure) */
+SUBPROG   (subroutine|function|procedure)
+
+/* REAL and LOGICAL are treated separately as it can also be a function */
+NUM_TYPE            (COMPLEX|INTEGER)
+OPERATOR_LOGICAL    (\.and\.|\.eq\.|\.eqv\.|\.ge\.|\.gt\.|\.le\.|\.lt\.|\.ne\.|\.neqv\.|\.or\.|\.not\.)
+OPERATOR_SYMBOLS    [\+\-\*/%::><=&]
+KIND      {ARGS}
+
+/* The pattern CHARACTER{ARGS}? is inconsistent with Fortran syntax and as such, removed from CHAR */
+CHAR      (CHARACTER|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
+
+/* The patterns ({NUM_TYPE}{KIND}) and ({NUM_TYPE}({BS}"*"{BS}[0-9]+)?) are inconsistent with Fortran syntax and as such, was removed from TYPE_SPEC */
+TYPE_SPEC ({NUM_TYPE}|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
+
+ACCESS_SPEC         (PROTECTED|PRIVATE|PUBLIC)
+INTENT_SPEC         INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"
+
+/* Fortran attributes except BIND and C which are treated separately */
+ATTR_SPEC           (ALLOCATABLE|ASSIGNMENT|ASYNCHRONOUS|ABSTRACT|BIND|CODIMENSION|CONTIGUOUS|DEFERRED|DIMENSION|ELEMENTAL|EXTENDS|EXTERNAL|IMPURE|INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"|INTRINSIC|LOCAL|LOCAL_INIT|NON_INTRINSIC|NON_OVERRIDABLE|NON_RECURSIVE|NOPASS|OPERATOR|OPTIONAL|OVERRIDABLE|PARAMETER|PASS|POINTER|PRIVATE|PROTECTED|PUBLIC|PURE|RECURSIVE|SAVE|SEQUENCE|SHARED|TARGET|VALUE|VOLATILE)
+
+/* attributes that take arguments */
+ATTR_SPEC_WARG      (CODIMENSION|DIMENSION|EXTENDS|OPERATOR|PASS|BIND)
+
+/* Assume that attribute statements are almost the same as attributes. */
+ATTR_STMT           {ATTR_SPEC}
+
+/* Intel directive statement and attributes. */
+DIR_INTEL_STATEMENT (ALIAS|ASSUME|ASSUME_ALIGNED|ATTRIBUTES|DLLEXPORT|BLOCK_LOOP|DECLARE|DEFINE|DISTRIBUTE{BS_}POINT|FIXEDFORMLINESIZE|FMA|FORCEINLINE|FREEFORM|IDENT|IF|IF{BS_}DEFINED|INLINE|INTEGER|IVDEP|LOOP{BS_}COUNT|MESSAGE|NOBLOCK_LOOP|NODECLARE|NOFMA|NOFREEFORM|NOFUSION|NOINLINE|NOOPTIMIZE|NOPARALLEL|NOPREFETCH|NOSTRICT|NOUNROLL|NOUNROLL_AND_JAM|NOVECTOR|OBJCOMMENT|OPTIMIZE|OPTIONS|PACK|PARALLEL|PREFETCH|PSECT|REAL|SIMD|STRICT|UNDEFINE|UNROLL|UNROLL_AND_JAM|VECTOR|ALIGN|ALLOCATABLE|ALLOW_NULL|C|CODE_ALIGN|CONCURRENCY_SAFE|CVF|DECORATE|DEFAULT|DLLIMPORT|EXTERN|FASTMEM|IGNORE_LOC|INLINE|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING)
+
+/* ("ATTRIBUTE"{BS}[,]?{BS} */
+/* |ALLOCATABLE|C|DEFAULT|DLLEXPORT|DLLIMPORT|EXTERN|FASTMEM|INLINE|FORCEINLINE|IGNORE_LOC|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|NOINLINE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING|VECTOR */
+
+/* IEEE constants can be merged with NAMED_CONST in the future.
+Currently, including IEEE objects increases the number of flex rules to beyond what GNU flex can handle.
+The flex "flex: input rules are too complicated (>= 32000 NFA states)" error can be resolved by increasing
+the definitions in flexdef.h of flex source code for:
+    #define JAMSTATE -32766
+    #define MAXIMUM_MNS 31999
+    #define BAD_SUBSCRIPT -32767
+before compiling th flex library. However, the default distributed versions of flex cannot handle this.
+*/
+
+NAMED_CONST_IEEE                (IEEE_ALL|IEEE_ALL|IEEE_AWAY|IEEE_DATATYPE|IEEE_DENORMAL|IEEE_DIVIDE|IEEE_DIVIDE_BY_ZERO|IEEE_DOWN|IEEE_HALTING|IEEE_INEXACT|IEEE_INEXACT_FLAG|IEEE_INF|IEEE_INVALID|IEEE_INVALID_FLAG|IEEE_NAN|IEEE_NEAREST|IEEE_NEGATIVE_DENORMAL|IEEE_NEGATIVE_INF|IEEE_NEGATIVE_NORMAL|IEEE_NEGATIVE_SUBNORMAL|IEEE_NEGATIVE_ZERO|IEEE_OTHER|IEEE_OTHER_VALUE|IEEE_OVERFLOW|IEEE_POSITIVE_DENORMAL|IEEE_POSITIVE_INF|IEEE_POSITIVE_NORMAL|IEEE_POSITIVE_SUBNORMAL|IEEE_POSITIVE_ZERO|IEEE_ROUNDING|IEEE_SIGNALING_NAN|IEEE_SQRT|IEEE_SUBNORMAL|IEEE_TO_ZERO|IEEE_UNDERFLOW|IEEE_UNDERFLOW_FLAG|IEEE_UP|IEEE_USUAL)
+
+NAMED_CONST                     ({NAMED_CONST_IEEE}|C_ALERT|C_BACKSPACE|C_BOOL|C_CARRIAGE_RETURN|C_CHAR|C_DOUBLE|C_DOUBLE_COMPLEX|C_FLOAT|C_FLOAT_COMPLEX|C_FORM_FEED|C_HORIZONTAL_TAB|C_INT|C_INT16_T|C_INT32_T|C_INT64_T|C_INT8_T|C_INT_FAST16_T|C_INT_FAST32_T|C_INT_FAST64_T|C_INT_FAST8_T|C_INT_LEAST16_T|C_INT_LEAST32_T|C_INT_LEAST64_T|C_INT_LEAST8_T|C_INTMAX_T|C_INTPTR_T|C_LONG|C_LONG_DOUBLE|C_LONG_DOUBLE_COMPLEX|C_LONG_LONG|C_NEW_LINE|C_NULL_CHAR|C_NULL_FUNPTR|C_NULL_PTR|C_SHORT|C_SIGNED_CHAR|C_SIZE_T|C_VERTICAL_TAB|CHARACTER_KINDS|CHARACTER_STORAGE_SIZE|CURRENT_TEAM|ERROR_UNIT|FILE_STORAGE_SIZE|INITIAL_TEAM|INPUT_UNIT|INT16|INT32|INT64|INT8|INTEGER_KINDS|IOSTAT_END|IOSTAT_EOR|IOSTAT_INQUIRE_INTERNAL_UNIT|LOGICAL_KINDS|NUMERIC_STORAGE_SIZE|OUTPUT_UNIT|PARENT_TEAM|REAL128|REAL64|REAL32|REAL_KINDS|STAT_FAILED_IMAGE|STAT_LOCKED|STAT_LOCKED_OTHER_IMAGE|STAT_STOPPED_IMAGE|STAT_UNLOCKED|STAT_UNLOCKED_FAILED_IMAGE|\.FALSE\.|\.TRUE\.)
+
+FLOW                            (DO|DO{BS}CONCURRENT|SELECT{BS}(CASE|TYPE|RANK)|CASE|IF|THEN|ELSE{BS}IF|ELSE|DO{BS}WHILE|WHERE|ELSEWHERE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
+
+FLOW_END                        (DO|SELECT|WHERE|IF|WHILE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
+
+PREFIX                          ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
+SUFFIX                          (RESULT{ARGS})
+/* The specified syntax is too generic and does not respect NAME and C as a specifiers. Also "bind" as an attribute takes precedence over its statement format.
+LANGUAGE_BIND_SPEC              BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
+*/
+
+/* INTRINSIC_FUNC_ELEMENTAL_IEEE can be merged with INTRINSIC_FUNC_ELEMENTAL when the flex bug gets resolved in the future */
+INTRINSIC_FUNC_ELEMENTAL_IEEE   (IEEE_CLASS|IEEE_COPY_SIGN|IEEE_FMA|IEEE_GET_FLAG|IEEE_GET_HALTING_MODE|IEEE_INT|IEEE_IS_FINITE|IEEE_IS_NAN|IEEE_IS_NEGATIVE|IEEE_IS_NORMAL|IEEE_LOGB|IEEE_MAX_NUM|IEEE_MAX_NUM_MAG|IEEE_MIN_NUM|IEEE_MIN_NUM_MAG|IEEE_NEXT_AFTER|IEEE_NEXT_DOWN|IEEE_NEXT_UP|IEEE_QUIET_EQ|IEEE_QUIET_GE|IEEE_QUIET_GT|IEEE_QUIET_LE|IEEE_QUIET_LT|IEEE_QUIET_NAN|IEEE_QUIET_NE|IEEE_REAL|IEEE_REM|IEEE_RINT|IEEE_SCALB|IEEE_SIGNALING_EQ|IEEE_SIGNALING_GE|IEEE_SIGNALING_GT|IEEE_SIGNALING_LE|IEEE_SIGNALING_LT|IEEE_SIGNALING_NE|IEEE_SIGNBIT|IEEE_UNORDERED|IEEE_VALUE)
+
+INTRINSIC_FUNC_ELEMENTAL        (ACHAR|ACOS|ACOSH|ADJUSTL|ADJUSTR|AIMAG|AINT|ANINT|ASIN|ASINH|ATAN|ATAN2|ATANH|BESSEL_J0|BESSEL_J1|BESSEL_JN|BESSEL_Y0|BESSEL_Y1|BESSEL_YN|BGE|BGT|BLE|BLT|BTEST|CEILING|CHAR|CMPLX|CONJG|COS|COSH|DBLE|DIM|DPROD|DSHIFTL|DSHIFTR|ERF|ERFC|ERFC_SCALED|EXP|EXPONENT|FLOOR|FRACTION|GAMMA|HYPOT|IACHAR|IAND|IBCLR|IBITS|IBSET|ICHAR|IEOR|IMAGE_STATUS|INT|IOR|ISHFT|ISHFTC|LEADZ|LEN_TRIM|LGE|LGT|LLE|LLT|LOG|LOG10|LOG_GAMMA|LOGICAL|MASKL|MASKR|MAX|MIN|MOD|MODULO|MVBITS|NEAREST|NINT|NOT|OUT_OF_RANGE|POPCNT|POPPAR|REAL|SCALE|SCAN|SET_EXPONENT|SHAPE|SHIFTA|SHIFTL|SHIFTR|SIGN|SIN|SINH|SPACING|SQRT|TAN|TANH|TRAILZ|TRIM|VERIFY)
+
+/* INTRINSIC_FUNC_INQUIRY_IEEE can be merged with INTRINSIC_FUNC_INQUIRY when the flex bug gets resolved in the future */
+INTRINSIC_FUNC_INQUIRY_IEEE     (IEEE_SUPPORT_DATATYPE|IEEE_SUPPORT_DENORMAL|IEEE_SUPPORT_DIVIDE|IEEE_SUPPORT_INF|IEEE_SUPPORT_IO|IEEE_SUPPORT_NAN|IEEE_SUPPORT_SQRT|IEEE_SUPPORT_STANDARD|IEEE_SUPPORT_SUBNORMAL|IEEE_SUPPORT_UNDERFLOW_CONTROL)
+
+INTRINSIC_FUNC_INQUIRY          ({INTRINSIC_FUNC_INQUIRY_IEEE}|ALLOCATED|ASSOCIATED|BIT_SIZE|C_SIZEOF|COSHAPE|DIGITS|EPSILON|EXTENDS_TYPE_OF|FAILED_IMAGES|HUGE|IS_CONTIGUOUS|IS_IOSTAT_END|IS_IOSTAT_EOR|KIND|LBOUND|LCOBOUND|LEN|MAXEXPONENT|MINEXPONENT|NEW_LINE|PRECISION|PRESENT|RADIX|RANGE|RANK|SAME_TYPE_AS|SIZE|STORAGE_SIZE|TINY|UBOUND|UCOBOUND)
+
+INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE (IEEE_SELECTED_REAL_KIND|IEEE_SUPPORT_FLAG|IEEE_SUPPORT_HALTING|IEEE_SUPPORT_ROUNDING)
+
+INTRINSIC_FUNC_TRANSFORMATIONAL ({INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE}|ALL|ANY|BESSEL_JN|BESSEL_YN|C_ASSOCIATED|C_FUNLOC|C_LOC|COMMAND_ARGUMENT_COUNT|COMPILER_OPTIONS|COMPILER_VERSION|COUNT|CSHIFT|DOT_PRODUCT|EOSHIFT|FINDLOC|GET_TEAM|IALL|IANY|IMAGE_INDEX|INDEX|IPARITY|MATMUL|MAXLOC|MAXVAL|MERGE|MERGE_BITS|MINLOC|MINVAL|NORM2|NULL|NUM_IMAGES|PACK|PARITY|PRODUCT|REDUCE|REPEAT|RESHAPE|SELECTED_CHAR_KIND|SELECTED_INT_KIND|SELECTED_REAL_KIND|SPREAD|STOPPED_IMAGES|SUM|TEAM_NUMBER|THIS_IMAGE|TRANSPOSE|UNPACK)
+
+INTRINSIC_FUNC_VOID             (CFI_address|CFI_allocate|CFI_deallocate|CFI_establish|CFI_is_contiguous|CFI_section|CFI_select_part|CFI_setpointer)
+
+INTRINSIC_FUNC                  ({INTRINSIC_FUNC_ELEMENTAL}|{INTRINSIC_FUNC_INQUIRY}|{INTRINSIC_FUNC_TRANSFORMATIONAL})
+
+/* intrinsic subroutines */
+
+INTRINSIC_SUB_ATOMIC            (ATOMIC_ADD|ATOMIC_AND|ATOMIC_CAS|ATOMIC_DEFINE|ATOMIC_FETCH_ADD|ATOMIC_FETCH_AND|ATOMIC_FETCH_OR|ATOMIC_FETCH_XOR|ATOMIC_INT_KIND|ATOMIC_LOGICAL_KIND|ATOMIC_OR|ATOMIC_REF|ATOMIC_XOR)
+
+INTRINSIC_SUB_COLLECTIVE        (CO_BROADCAST|CO_MAX|CO_MIN|CO_REDUCE|CO_SUM)
+
+/* INTRINSIC_SUB_IMPURE_IEEE can be merged with INTRINSIC_SUB_IMPURE when the flex bug gets resolved in the future */
+INTRINSIC_SUB_IMPURE_IEEE       (IEEE_GET_MODES|IEEE_GET_ROUNDING_MODE|IEEE_GET_STATUS|IEEE_GET_UNDERFLOW_MODE|IEEE_SET_MODES|IEEE_SET_ROUNDING_MODE|IEEE_SET_STATUS|IEEE_SET_UNDERFLOW_MODE)
+INTRINSIC_SUB_IMPURE            ({INTRINSIC_SUB_IMPURE_IEEE}|C_F_POINTER|CPU_TIME|DATE_AND_TIME|EVENT_QUERY|EXECUTE_COMMAND_LINE|GET_COMMAND|GET_COMMAND_ARGUMENT|GET_ENVIRONMENT_VARIABLE|RANDOM_INIT|RANDOM_NUMBER|RANDOM_SEED|SYSTEM_CLOCK)
+
+/* INTRINSIC_SUB_PURE_IEEE can be merged with INTRINSIC_SUB_PURE when the flex bug gets resolved in the future */
+INTRINSIC_SUB_PURE_IEEE         (IEEE_SET_FLAG|IEEE_SET_HALTING_MODE)
+INTRINSIC_SUB_PURE              ({INTRINSIC_SUB_PURE_IEEE}|C_F_PROCPOINTER|MOVE_ALLOC)
+
+INTRINSIC_SUB                   ({INTRINSIC_SUB_ATOMIC}|{INTRINSIC_SUB_COLLECTIVE}|{INTRINSIC_SUB_IMPURE}|{INTRINSIC_SUB_PURE})
+
+INTRINSIC_PROC                  ({INTRINSIC_SUB}|{INTRINSIC_FUNC})
+
+/* INTRINSIC_MODULE_IEEE can be merged with INTRINSIC_MODULE when the flex bug gets resolved in the future */
+INTRINSIC_MODULE_IEEE           (IEEE_ARITHMETIC|IEEE_EXCEPTIONS|IEEE_FEATURES)
+INTRINSIC_MODULE                ({INTRINSIC_MODULE_IEEE}|ISO_C_BINDING|ISO_FORTRAN_ENV)
+
+SPECIFIER                       (ACCESS|ACQUIRED_LOCK|ACTION|ADVANCE|ASYNCHRONOUS|BLANK|DECIMAL|DELIM|DIM|DIRECT|ENCODING|EOR|ERR|ERRMSG|EXIST|FILE|FMT|FORM|FORMATTED|ID|IOLENGTH|IOMSG|IOSTAT|KIND|LEN|MOLD|NAME|NAMED|NEW_INDEX|NEWUNIT|NEXTREC|NML|NUMBER|OPENED|PAD|PENDING|POS|POSITION|QUIET|READ|READWRITE|REC|RECL|ROUND|SEQUENTIAL|SIGN|SIZE|SOURCE|STAT|STATUS|STREAM|TEAM|TEAM_NUMBER|UNFORMATTED|UNIT|UNTIL_COUNT|WRITE)
+
+/* FUNCTION and SUBROUTINE are excluded from STATEMENT below to prevent dot-graph self-reference misrepresentations. */
+STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|SUBMODULE|END{BS}SUBMODULE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
+
+/* INTRINSIC_DERIVED_TYPE_IEEE and INTRINSIC_DERIVED_TYPE_CFI can be merged with INTRINSIC_DERIVED_TYPE when the flex bug gets resolved in the future */
+INTRINSIC_DERIVED_TYPE_IEEE     (IEEE_CLASS_TYPE|IEEE_FEATURES_TYPE|IEEE_FLAG_TYPE|IEEE_MODES_TYPE|IEEE_ROUND_TYPE|IEEE_STATUS_TYPE)
+INTRINSIC_DERIVED_TYPE_CFI      (CFI_cdesc_t)
+INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
+
+/* |  */
+
+%option noyywrap
+%option stack
+%option caseless
+/*%option debug*/
+
+%x Start
+%x SubCall
+%x FuncDef
+%x ClassName
+%x ClassVar
+%x Subprog
+%x DocBlock
+%x Use
+%x UseOnly
+%x Import
+%x Declaration
+%x DeclarationBinding
+%x DeclContLine
+%x Parameterlist
+%x String
+%x Subprogend
+
+%%
+ /*==================================================================*/
+
+ /*-------- inner construct ---------------------------------------------------*/
+
+<Start>{BS}"%"/{BS}[a-zA-Z]+.*                                  {   // highlight rule for the percent-symbol separator of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}[.]*{BS}("+"|"-"|"*"|"/"|"<"|">"|"="|"&"){BS}            {   // highlight rule for the operators of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}(0|[1-9]\d*)(\.\d*)?(e[-\+]?(0|[1-9]\d*))?(_([a-zA-Z])+)?    {   // highlight rule for the numeric values of Fortran.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_numeric_literal");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{NAMED_CONST}{BS}                                        {   // highlight rule for the named constants of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_named_const");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"bind"/{BS}"("[.]*                                   {   // highlight rule for the bind attribute of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"C"/{BS}(","{BS}"name"{BS}"="{BS}(.)+)("&"|")"){BS}  {   // highlight rule for the bind C attribute of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Declaration>{BS}{ATTR_SPEC}/({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    if (QCString(yytext) == "external") yyextra->isExternal = true;
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Declaration>{BS}{ATTR_SPEC_WARG}/("("[.*]")")?({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes that take argument: DIMENSION(:,:).
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}"("{BS}{INTRINSIC_DERIVED_TYPE}{BS}")"{BS}               {   // highlight rule for Fortran intrinsic derived types.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{INTRINSIC_DERIVED_TYPE}{BS}                             {   // highlight rule for Fortran intrinsic module names.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{INTRINSIC_MODULE}{BS}                                   {   // highlight rule for Fortran intrinsic module names.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_module");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start,Declaration>{BS}{SPECIFIER}/{BS}={BS}[a-zA-Z0-9_\.\-\+(\[][a-zA-Z0-9_)(\[\]!%,\.\-\+/=><\t ]*{BS}(")"|"&")  {   // highlight rule for Fortran intrinsic specifier (intrinsic procedure argument) names.
+                                                                    // \todo: A specifier must be enclosed with parentheses. This is not currently enforced.
+                                                                    startFontClass(yyscanner,"fortran_spcifier");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+
+ /* Fortran intrinsic procedures */
+
+<Start>^{BS}"real"/[,:( ].*                                     {   // real is a data type but also an elemental function, which makes it a bit tricky.
+                                                                    yy_push_state(YY_START,yyscanner);
+                                                                    BEGIN(Declaration);
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    yyextra->code->codify(QCString(yytext));
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>^{BS}"logical"/[,:( ].*                                  {   // logical is a data type but also an elemental function, which makes it a bit tricky.
+                                                                    yy_push_state(YY_START,yyscanner);
+                                                                    BEGIN(Declaration);
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    yyextra->code->codify(QCString(yytext));
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start,Declaration>{BS}{INTRINSIC_FUNC}/{BS}[(]                 {   // highlight rule for Fortran intrinsic functions.
+                                                                    // \todo This must be improved when function name appears in an intrinsic module USE statement.
+                                                                    // \todo The current rule only captures function names when followed by "(".
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_function");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}{INTRINSIC_SUB}/{BS}[(]                              {   // highlight rule for Fortran intrinsic subroutines.
+                                                                    // \todo This must be improved when subroutine name appears in an intrinsic module USE statement.
+                                                                    // \todo The current rule only captures subroutine names when followed by "(".
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_subroutine");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"MPI_"{BS}[a-zA-Z_]+/{BS}                            {   // highlight rule for MPI module intrinsic entities.
+                                                                    // \todo The current search pattern is too generic. In the future, all MPI entities from
+                                                                    // \todo the standard MPI module must be listed here and explicitly searched for.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_mpi");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+
+ /* Fortran intrinsic statements */
+
+<Start>{BS}{STATEMENT}/{BS}[;( \t\n]                            {   // highlight rule for Fortran intrinsic statements.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{FLOW}/{BS}[;( \t\n]                                     {   // highlight rule for Fortran flow-control statements.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    if (yyextra->isFixedForm)
+                                                                    {
+                                                                        if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;
+                                                                    }
+                                                                    if (yyextra->currentMemberDef && yyextra->currentMemberDef->isFunction())
+                                                                    {
+                                                                        std::lock_guard<std::mutex> lock(g_countFlowKeywordsMutex);
+                                                                        MemberDefMutable *mdm = toMemberDefMutable(yyextra->currentMemberDef);
+                                                                        if (mdm)
+                                                                        {
+                                                                            mdm->incrementFlowKeyWordCount();
+                                                                        }
+                                                                    }
+                                                                    /* font class is defined e.g. in doxygen.css */
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>(CASE|CLASS|TYPE|RANK){BS_}(IS|DEFAULT)                  {
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}"end"{BS}{FLOW_END}/[ ;\t\n]                             {   // list is a bit long as not all have possible end. <*> needed since the FLOW could be all in one line.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>"implicit"{BS}("none"|{TYPE_SPEC})                       {
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+ /*-------- use statement -------------------------------------------*/
+<Start>"use"{BS}                        {
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Use);
+                                        }
+<Use>("intrinsic"|"non_intrinsic")      { // TODO: rename
+                                          startFontClass(yyscanner,"fortran_attribute");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Use);
+                                        }
+<Use>"ONLY"                             { // TODO: rename
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(UseOnly);
+                                        }
+<Use>{ID}                               {
+                                          QCString tmp(yytext);
+                                          // tmp = tmp.lower();
+                                          yyextra->insideBody=TRUE;
+                                          generateLink(yyscanner,*yyextra->code, yytext);
+                                          yyextra->insideBody=FALSE;
+
+                                          /* append module name to use dict */
+                                          yyextra->useEntry = UseEntry();
+                                          yyextra->useEntry.module = tmp;
+                                          yyextra->useMembers.insert(std::make_pair(tmp.str(), yyextra->useEntry));
+                                          addUse(yyscanner,tmp);
+                                        }
+<Use,UseOnly,Import>{BS},{BS}           { codifyLines(yyscanner,yytext); }
+<UseOnly,Import>{BS}&{BS}"\n"           { codifyLines(yyscanner,yytext);
+                                          yyextra->contLineNr++;
+                                          YY_FTN_RESET}
+<UseOnly>{ID}                           {
+                                          QCString tmp(yytext);
+                                          // tmp = tmp.lower();
+                                          yyextra->useEntry.onlyNames.push_back(tmp);
+                                          yyextra->insideBody=TRUE;
+                                          generateLink(yyscanner,*yyextra->code, yytext);
+                                          yyextra->insideBody=FALSE;
+                                        }
+<Use,UseOnly,Import>"\n"                {
+                                          unput(*yytext);
+                                          yy_pop_state(yyscanner);
+                                          YY_FTN_RESET
+                                        }
+<*>"import"{BS}/"\n"                    |
+<*>"import"{BS_}                        {
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Import);
+                                        }
+<Import>{ID}                            {
+                                          yyextra->insideBody=TRUE;
+                                          generateLink(yyscanner,*yyextra->code, yytext);
+                                          yyextra->insideBody=FALSE;
+                                        }
+<Import>("ONLY"|"NONE"|"ALL")           {
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+ /*-------- fortran module  -----------------------------------------*/
+<Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n { //
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
+                                            if (!qstricmp(yytext,"module")) yyextra->currentModule="module";
+                                        }
+<Start>^{BS}"enum"/{BS}("&"|",")        {   // rule for enum statement
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
+                                        }
+<Start>("type")/{BS}[:,]{BS}            {   // rule for type-definition construct. Do NOT put "(" in [:,] as it leads to confusion with variable declaration.
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
+                                        }
+<ClassName>{ID}                         {
+                                            if (yyextra->currentModule == "module")
+                                            {
+                                                yyextra->currentModule=yytext;
+                                                yyextra->currentModule = yyextra->currentModule;//.lower();
+                                            }
+                                            generateLink(yyscanner,*yyextra->code,yytext);
+                                            yy_pop_state(yyscanner);
+                                        }
+<ClassName>{BS}({ATTR_SPEC})/{BS}[,:( ]{BS} { // variable declaration
+                                            if (QCString(yytext) == "external") yyextra->isExternal = true;
+                                            startFontClass(yyscanner,"fortran_attribute");
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                        }
+<Start>^{BS}{ACCESS_SPEC}/{BS}[,: ]     {   // access attribute declaration. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
+                                            startFontClass(yyscanner,"fortran_attribute");
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                        }
+<ClassName>\n                           {   // interface may be without name
+                                            yy_pop_state(yyscanner);
+                                            YY_FTN_REJECT;
+                                        }
+<Start>^{BS}"end"({BS_}"enum").*        {
+                                            YY_FTN_REJECT;
+                                        }
+<Start>^{BS}"end"({BS_}"type").*        {
+                                            YY_FTN_REJECT;
+                                        }
+<Start>^{BS}"end"({BS_}"module").*      {   // just reset yyextra->currentModule, rest is done in following rule
+                                            yyextra->currentModule=0;
+                                            YY_FTN_REJECT;
+                                        }
+ /*-------- subprog definition -------------------------------------*/
+ /*
+ <Start>({PREFIX}{BS_})?({TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
+                                          startFontClass(yyscanner,"fortran_prefix");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+ */
+<Start>("module"{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
+                                          startFontClass(yyscanner,"fortran_prefix");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Subprog);
+                                        }
+<Subprog>{ID}                           { // subroutine/function name
+                                          DBG_CTX((stderr, "===> start subprogram %s\n", yytext));
+                                          startScope(yyscanner);
+                                          generateLink(yyscanner,*yyextra->code,yytext);
+                                        }
+<Subprog>"result"/{BS}"("[^)]*")"       {
+                                          startFontClass(yyscanner,"fortran_suffix");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+<Subprog>"("[^)]*")"                    { // ignore rest of line
+                                          codifyLines(yyscanner,yytext);
+                                        }
+<Subprog,Subprogend>"\n"                { codifyLines(yyscanner,yytext);
+                                          yyextra->contLineNr++;
+                                          yy_pop_state(yyscanner);
+                                          YY_FTN_RESET
+                                        }
+<Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface")?{BS}     {  // Fortran subroutine or function ends
+                                          //cout << "===> end function " << yytext << endl;
+                                          endScope(yyscanner);
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Subprogend);
+                                        }
+<Subprogend>{ID}/{BS}(\n|!|;)           {
+                                          generateLink(yyscanner,*yyextra->code,yytext);
+                                          yy_pop_state(yyscanner);
+                                        }
+<Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface"){BS}/(\n|!|;) {  // Fortran subroutine or function ends
+                                          //cout << "===> end function " << yytext << endl;
+                                          endScope(yyscanner);
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+ /*-------- variable declaration ----------------------------------*/
+<Start>{TYPE_SPEC}/{BS}[,:( ]           {
+                                          QCString typ(yytext);
+                                          typ = removeRedundantWhiteSpace(typ.lower());
+                                          if (typ.startsWith("real")) YY_FTN_REJECT;
+                                          if (typ.startsWith("logical")) YY_FTN_REJECT;
+                                          if (typ == "type" || typ == "class" || typ == "procedure") yyextra->inTypeDecl = 1;
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Declaration);
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          yyextra->code->codify(QCString(yytext));
+                                          endFontClass(yyscanner);
+                                        }
+<Start>^{BS}({ATTR_SPEC}{BS_})+         { // declare attribute statement. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
+                                          if (QCString(yytext) == "external")
+                                          {
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(Declaration);
+                                            yyextra->isExternal = true;
+                                          }
+                                          startFontClass(yyscanner,"fortran_attribute");
+                                          yyextra->code->codify(QCString(yytext));
+                                          endFontClass(yyscanner);
+                                        }
+<Declaration>({TYPE_SPEC})/{BS}[(,: ]   { //| variable declaration
+                                          if (QCString(yytext) == "external") yyextra->isExternal = true;
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          yyextra->code->codify(QCString(yytext));
+                                          endFontClass(yyscanner);
+                                        }
+<Declaration>{ID}                       { // local var
+                                          if (yyextra->isFixedForm && yy_my_start == 1)
+                                          {
+                                            startFontClass(yyscanner,"fortran_comment");
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                          }
+                                          else if (yyextra->currentMemberDef &&
+                                                   ((yyextra->currentMemberDef->isFunction() && (yyextra->currentMemberDef->typeString()!=QCString("subroutine") || yyextra->inTypeDecl)) ||
+                                                     yyextra->currentMemberDef->isVariable() || yyextra->currentMemberDef->isEnumValue()
+                                                    )
+                                                   )
+                                          {
+                                            generateLink(yyscanner,*yyextra->code, yytext);
+                                          }
+                                          else
+                                          {
+                                            yyextra->code->codify(QCString(yytext));
+                                            addLocalVar(yyscanner,QCString(yytext));
+                                          }
+                                        }
+<Declaration>{BS}("=>"|"="){BS}         { // Procedure binding
+                                          BEGIN(DeclarationBinding);
+                                          yyextra->code->codify(QCString(yytext));
+                                        }
+<DeclarationBinding>{ID}                { // Type bound procedure link
+                                          generateLink(yyscanner,*yyextra->code, yytext);
+                                          yy_pop_state(yyscanner);
+                                        }
+<Declaration>[(]                        { // start of array or type / class specification
+                                          yyextra->bracketCount++;
+                                          yyextra->code->codify(QCString(yytext));
+                                        }
+
+<Declaration>[)]                        { // end array specification
+                                          yyextra->bracketCount--;
+                                          if (!yyextra->bracketCount) yyextra->inTypeDecl = 0;
+                                          yyextra->code->codify(QCString(yytext));
+                                        }
+
+<Declaration,DeclarationBinding>"&"     { // continuation line
+                                          yyextra->code->codify(QCString(yytext));
+                                          if (!yyextra->isFixedForm)
+                                          {
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(DeclContLine);
+                                          }
+                                        }
+<DeclContLine>"\n"                      { // declaration not yet finished
+                                          yyextra->contLineNr++;
+                                          codifyLines(yyscanner,yytext);
+                                          yyextra->bracketCount = 0;
+                                          yy_pop_state(yyscanner);
+                                          YY_FTN_RESET
+                                        }
+<Declaration,DeclarationBinding>"\n"    { // end declaration line (?)
+                                          if (yyextra->endComment)
+                                          {
+                                            yyextra->endComment=FALSE;
+                                          }
+                                          else
+                                          {
+                                            codifyLines(yyscanner,yytext);
+                                          }
+                                          yyextra->bracketCount = 0;
+                                          yyextra->contLineNr++;
+                                          if (!(yyextra->hasContLine && yyextra->hasContLine[yyextra->contLineNr - 1]))
+                                          {
+                                            yyextra->isExternal = false;
+                                            yy_pop_state(yyscanner);
+                                          }
+                                          YY_FTN_RESET
+                                        }
+
+ /*-------- subprog calls  -----------------------------------------*/
+
+<Start>"call"{BS_}                      {
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(SubCall);
+                                        }
+<SubCall>{ID}                           { // subroutine call
+                                          yyextra->insideBody=TRUE;
+                                          generateLink(yyscanner,*yyextra->code, yytext);
+                                          yyextra->insideBody=FALSE;
+                                          yy_pop_state(yyscanner);
+                                        }
+<Start>{ID}{BS}/"("                     { // function call
+                                          if (yyextra->isFixedForm && yy_my_start == 6)
+                                          {
+                                            // fixed form continuation line
+                                            YY_FTN_REJECT;
+                                          }
+                                          else if (QCString(yytext).stripWhiteSpace().lower() == "type")
+                                          {
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(Declaration);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            yyextra->code->codify(QCString(yytext).stripWhiteSpace());
+                                            endFontClass(yyscanner);
+                                            yyextra->code->codify(QCString(yytext + 4));
+                                          }
+                                          else
+                                          {
+                                            yyextra->insideBody=TRUE;
+                                            generateLink(yyscanner,*yyextra->code,yytext);
+                                            yyextra->insideBody=FALSE;
+                                          }
+                                        }
+
+ /*-------- comments ---------------------------------------------------*/
+<Start,Declaration,DeclarationBinding>\n?{BS}"!>"|"!<"                 { // start comment line or comment block
+                                          if (yytext[0] == '\n')
+                                          {
+                                            yyextra->contLineNr++;
+                                            yy_old_start = 0;
+                                            yy_my_start = 1;
+                                            yy_end = static_cast<int>(yyleng);
+                                          }
+                                          // Actually we should see if ! on position 6, can be continuation
+                                          // but the chance is very unlikely, so no effort to solve it here
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(DocBlock);
+                                          yyextra->docBlock=yytext;
+                                        }
+<Declaration,DeclarationBinding>{BS}"!<"                   { // start comment line or comment block
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(DocBlock);
+                                          yyextra->docBlock=yytext;
+                                        }
+
+<DocBlock>.*                            { // contents of current comment line
+                                          yyextra->docBlock+=yytext;
+                                        }
+<DocBlock>"\n"{BS}("!>"|"!<"|"!!")      { // comment block (next line is also comment line)
+                                          yyextra->contLineNr++;
+                                          yy_old_start = 0;
+                                          yy_my_start = 1;
+                                          yy_end = static_cast<int>(yyleng);
+                                          // Actually we should see if ! on position 6, can be continuation
+                                          // but the chance is very unlikely, so no effort to solve it here
+                                          yyextra->docBlock+=yytext;
+                                        }
+<DocBlock>"\n"                          { // comment block ends at the end of this line
+                                          // remove special comment (default config)
+                                          yyextra->contLineNr++;
+                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          {
+                                            yyextra->yyLineNr+=((QCString)yyextra->docBlock).contains('\n');
+                                            yyextra->yyLineNr+=1;
+                                            nextCodeLine(yyscanner);
+                                            yyextra->endComment=TRUE;
+                                          }
+                                          else // do not remove comment
+                                          {
+                                            startFontClass(yyscanner,"fortran_comment");
+                                            codifyLines(yyscanner,yyextra->docBlock);
+                                            endFontClass(yyscanner);
+                                          }
+                                          unput(*yytext);
+                                          yyextra->contLineNr--;
+                                          yy_pop_state(yyscanner);
+                                          YY_FTN_RESET
+                                        }
+<Start>^{BS}[!C]("DEC"|"DIR")"$"{BS}"ATTRIBUTES".*/"::" {   // ATTRIBUTES directive is treated separately as its argument (procedure name) needs to be recognized by Doxygen).
+                                                            startFontClass(yyscanner,"fortran_directive_intel");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+<Start>^{BS}[!C]("DEC"|"DIR")"$".*                      {   // highlight rule for Intel Fortran Compiler directives (except ATTRIBUTES).
+                                                            QCString directive(yytext);
+                                                            directive = removeRedundantWhiteSpace(directive.lower());
+                                                            if (directive.contains("attributes",true)) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_directive_intel");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+<Start>^{BS}[\!c]"$OMP".*                               {   // OpenMP directives
+                                                            yy_push_state(YY_START,yyscanner);
+                                                            BEGIN(Declaration);
+                                                            startFontClass(yyscanner,"fortran_directive_omp");
+                                                            yyextra->code->codify(QCString(yytext));
+                                                            endFontClass(yyscanner);
+                                                        }
+<*>"!"[^><\n].*|"!"$                                    {   // normal comment
+                                                            if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                            if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_comment");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+ /*
+<*>^[Cc*].*                                             {   // normal comment
+                                                            if(! yyextra->isFixedForm) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_comment");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+ */
+<*>"assignment"/{BS}"("{BS}"="{BS}")"   {
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+<*>"operator"/{BS}"("[^)]*")"           {
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+
+ /*------ preprocessor  --------------------------------------------*/
+<Start>"#".*\n                          {
+                                          if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
+                                          yyextra->contLineNr++;
+                                          startFontClass(yyscanner,"preprocessor");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          YY_FTN_RESET
+                                        }
+ /*------ variable references?  -------------------------------------*/
+
+<Start>"%"{BS}{ID}                      { // ignore references to elements
+                                          yyextra->code->codify(QCString(yytext));
+                                        }
+<Start>{ID}                             {
+                                            //yyextra->insideBody=TRUE; // why is this needed? It messes up the dot-graph representations by generating artificial self-references.
+                                            generateLink(yyscanner,*yyextra->code, yytext);
+                                            //yyextra->insideBody=FALSE;
+                                        }
+ /*------ strings --------------------------------------------------*/
+<String>\n                              { // string with \n inside
+                                          yyextra->contLineNr++;
+                                          yyextra->str+=yytext;
+                                          startFontClass(yyscanner,"fortran_string");
+                                          codifyLines(yyscanner,yyextra->str);
+                                          endFontClass(yyscanner);
+                                          yyextra->str = "";
+                                          YY_FTN_RESET
+                                        }
+<String>\"|\'                           { // string ends with next quote without previous backspace
+                                          if(yytext[0]!=yyextra->stringStartSymbol) YY_FTN_REJECT; // single vs double quote
+                                          yyextra->str+=yytext;
+                                          startFontClass(yyscanner,"fortran_string");
+                                          codifyLines(yyscanner,yyextra->str);
+                                          endFontClass(yyscanner);
+                                          yy_pop_state(yyscanner);
+                                        }
+<String>.                               {yyextra->str+=yytext;}
+
+<*>\"|\'                                { /* string starts */
+                                          /* if(YY_START == StrIgnore) YY_FTN_REJECT; // ignore in simple comments */
+                                          if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
+                                          yy_push_state(YY_START,yyscanner);
+                                          yyextra->stringStartSymbol=yytext[0]; // single or double quote
+                                          BEGIN(String);
+                                          yyextra->str=yytext;
+                                        }
+ /*-----------------------------------------------------------------------------*/
+
+<*>\n                                   {
+                                          if (yyextra->endComment)
+                                          {
+                                            yyextra->endComment=FALSE;
+                                          }
+                                          else
+                                          {
+                                            codifyLines(yyscanner,yytext);
+                                            // comment cannot extend over the end of a line so should always be terminated at the end of the line.
+                                            if (yyextra->currentFontClass && !strcmp(yyextra->currentFontClass,"fortran_comment")) endFontClass(yyscanner);
+                                          }
+                                          yyextra->contLineNr++;
+                                          YY_FTN_RESET
+                                        }
+<*>^{BS}"type"{BS}"="                   { yyextra->code->codify(QCString(yytext)); }
+
+<*>[\x80-\xFF]*                         { // keep utf8 characters together...
+                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
+                                          {
+                                            startFontClass(yyscanner,"fortran_comment");
+                                            codifyLines(yyscanner,yytext);
+                                          }
+                                          else
+                                          {
+                                            yyextra->code->codify(QCString(yytext));
+                                          }
+                                        }
+<*>.                                    {
+                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
+                                          {
+                                            //yy_push_state(YY_START,yyscanner);
+                                            //BEGIN(DocBlock);
+                                            //yyextra->docBlock=yytext;
+                                            startFontClass(yyscanner,"fortran_comment");
+                                            codifyLines(yyscanner,yytext);
+                                          }
+                                          else
+                                          {
+                                            yyextra->code->codify(QCString(yytext));
+                                          }
+                                        }
+<*>{OPERATOR_LOGICAL}                   {   // Fortran logical comparison keywords
+                                            startFontClass(yyscanner,"fortran_operator_logical");
+                                            //codifyLines(yyscanner,yyextra->docBlock);
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                        }
+<*>{OPERATOR_SYMBOLS}                   { // Fortran operator symbols
+                                            startFontClass(yyscanner,"fortran_operator_symbols");
+                                            //codifyLines(yyscanner,yyextra->docBlock);
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                        }
+<*><<EOF>>                              {
+                                            if (YY_START == DocBlock) {
+                                                if  (!Config_getBool(STRIP_CODE_COMMENTS))
+                                                {
+                                                    startFontClass(yyscanner,"fortran_comment");
+                                                    codifyLines(yyscanner,yyextra->docBlock);
+                                                    endFontClass(yyscanner);
+                                                }
+                                            }
+                                          yyterminate();
+                                        }
+%%
+
+/*@ ----------------------------------------------------------------------------
+ */
+
+static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yy_size_t inputPosition = yyextra->inputPosition;
+  const char *s = yyextra->inputString + inputPosition;
+  yy_size_t c=0;
+  while( c < max_size && *s)
+  {
+    *buf++ = *s++;
+    c++;
+  }
+  yyextra->inputPosition += c;
+  return c;
+}
+
+static void endFontClass(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (yyextra->currentFontClass)
+  {
+    yyextra->code->endFontClass();
+    yyextra->currentFontClass=0;
+  }
+}
+
+static void startFontClass(yyscan_t yyscanner,const char *s)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  // if font class is already set don't stop and start it.
+  // strcmp does not like null pointers as input.
+  if (!yyextra->currentFontClass || !s || strcmp(yyextra->currentFontClass,s))
+  {
+    endFontClass(yyscanner);
+    yyextra->code->startFontClass(QCString(s));
+    yyextra->currentFontClass=s;
+  }
+}
+
+static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (Doxygen::searchIndex)
+  {
+    if (yyextra->searchCtx)
+    {
+      yyextra->code->setCurrentDoc(yyextra->searchCtx,yyextra->searchCtx->anchor(),FALSE);
+    }
+    else
+    {
+      yyextra->code->setCurrentDoc(yyextra->sourceFileDef,anchor,TRUE);
+    }
+  }
+}
+
+static void addToSearchIndex(yyscan_t yyscanner,const QCString &text)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (Doxygen::searchIndex)
+  {
+    yyextra->code->addWord(text,FALSE);
+  }
+}
+
+/*! start a new line of code, inserting a line number if yyextra->sourceFileDef
+ * is TRUE. If a definition starts at the current line, then the line
+ * number is linked to the documentation of that definition.
+ */
+static void startCodeLine(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (yyextra->sourceFileDef)
+  {
+    //QCString lineNumber,lineAnchor;
+    //lineNumber.sprintf("%05d",yyextra->yyLineNr);
+    //lineAnchor.sprintf("l%05d",yyextra->yyLineNr);
+
+    const Definition *d = yyextra->sourceFileDef->getSourceDefinition(yyextra->yyLineNr);
+    //printf("startCodeLine %d d=%s\n", yyextra->yyLineNr,d ? qPrint(d->name()) : "<null>");
+    if (!yyextra->includeCodeFragment && d)
+    {
+      yyextra->currentDefinition = d;
+      yyextra->currentMemberDef = yyextra->sourceFileDef->getSourceMember(yyextra->yyLineNr);
+      yyextra->insideBody = FALSE;
+      yyextra->endComment = FALSE;
+      QCString lineAnchor;
+      lineAnchor.sprintf("l%05d",yyextra->yyLineNr);
+      if (yyextra->currentMemberDef)
+      {
+        yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
+                                yyextra->currentMemberDef->getOutputFileBase(),
+                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+        setCurrentDoc(yyscanner,lineAnchor);
+      }
+      else if (d->isLinkableInProject())
+      {
+        yyextra->code->writeLineNumber( d->getReference(),
+                                        d->getOutputFileBase(),
+                                        QCString(),yyextra->yyLineNr
+                                        );
+        setCurrentDoc(yyscanner,lineAnchor);
+      }
+    }
+    else
+    {
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+    }
+  }
+  yyextra->code->startCodeLine(yyextra->sourceFileDef);
+  if (yyextra->currentFontClass)
+  {
+    yyextra->code->startFontClass(QCString(yyextra->currentFontClass));
+  }
+}
+
+
+static void endCodeLine(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  endFontClass(yyscanner);
+  yyextra->code->endCodeLine();
+}
+
+static void nextCodeLine(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  const char * fc = yyextra->currentFontClass;
+  endCodeLine(yyscanner);
+  if (yyextra->yyLineNr<yyextra->inputLines)
+  {
+    yyextra->currentFontClass = fc;
+    startCodeLine(yyscanner);
+  }
+}
+
+/*! write a code fragment 'text' that may span multiple lines, inserting
+ * line numbers for each line.
+ */
+static void codifyLines(yyscan_t yyscanner,const QCString &text)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  //printf("codifyLines(%d,\"%s\")\n",yyextra->yyLineNr,text);
+  if (text.isEmpty()) return;
+  const char *p=text.data(),*sp=p;
+  char c;
+  bool done=FALSE;
+  while (!done)
+  {
+    sp=p;
+    while ((c=*p++) && c!='\n') { }
+    if (c=='\n')
+    {
+      yyextra->yyLineNr++;
+      int l = (int)(p-sp-1);
+      char *tmp = (char*)malloc(l+1);
+      memcpy(tmp,sp,l);
+      tmp[l]='\0';
+      yyextra->code->codify(QCString(tmp));
+      free(tmp);
+      nextCodeLine(yyscanner);
+    }
+    else
+    {
+      yyextra->code->codify(QCString(sp));
+      done=TRUE;
+    }
+  }
+}
+
+/*! writes a link to a fragment \a text that may span multiple lines, inserting
+ * line numbers for each line. If \a text contains newlines, the link will be
+ * split into multiple links with the same destination, one for each line.
+ */
+static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
+                  Definition *d,const QCString &text)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
+  yyextra->tooltipManager.addTooltip(ol,d);
+  QCString ref  = d->getReference();
+  QCString file = d->getOutputFileBase();
+  QCString anchor = d->anchor();
+  QCString tooltip;
+  if (!sourceTooltips) // fall back to simple "title" tooltips
+  {
+    tooltip = d->briefDescriptionAsTooltip();
+  }
+  bool done=FALSE;
+  const char *p=text.data();
+  while (!done)
+  {
+    const char *sp=p;
+    char c;
+    while ((c=*p++) && c!='\n') { }
+    if (c=='\n')
+    {
+      yyextra->yyLineNr++;
+      //printf("writeCodeLink(%s,%s,%s,%s)\n",ref,file,anchor,sp);
+      ol.writeCodeLink(d->codeSymbolType(),ref,file,anchor,QCString(sp,p-sp-1),tooltip);
+      nextCodeLine(yyscanner);
+    }
+    else
+    {
+      //printf("writeCodeLink(%s,%s,%s,%s)\n",ref,file,anchor,sp);
+      ol.writeCodeLink(d->codeSymbolType(),ref,file,anchor,sp,tooltip);
+      done=TRUE;
+    }
+  }
+}
+//-------------------------------------------------------------------------------
+/**
+  searches for definition of a module (Namespace)
+  @param mname the name of the module
+  @param cd the entry, if found or null
+  @returns true, if module is found
+*/
+static bool getFortranNamespaceDefs(const QCString &mname,
+                               NamespaceDef *&cd)
+{
+  if (mname.isEmpty()) return FALSE; /* empty name => nothing to link */
+
+  // search for module
+  if ((cd=Doxygen::namespaceLinkedMap->find(mname))) return TRUE;
+
+  return FALSE;
+}
+//-------------------------------------------------------------------------------
+/**
+  searches for definition of a type
+  @param tname the name of the type
+  @param moduleName name of enclosing module or null, if global entry
+  @param cd the entry, if found or null
+  @param useMap map of data of USE-statement
+  @returns true, if type is found
+*/
+static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName,
+                               ClassDef *&cd, const UseMap &useMap)
+{
+  if (tname.isEmpty()) return FALSE; /* empty name => nothing to link */
+
+  //cout << "=== search for type: " << tname << endl;
+
+  // search for type
+  if ((cd=Doxygen::classLinkedMap->find(tname)))
+  {
+    //cout << "=== type found in global module" << endl;
+    return TRUE;
+  }
+  else if (!moduleName.isEmpty() && (cd= Doxygen::classLinkedMap->find(moduleName+"::"+tname)))
+  {
+    //cout << "=== type found in local module" << endl;
+    return TRUE;
+  }
+  else
+  {
+    for (const auto &kv : useMap)
+    {
+      if ((cd= Doxygen::classLinkedMap->find(kv.second.module+"::"+tname)))
+      {
+        //cout << "===  type found in used module" << endl;
+        return TRUE;
+      }
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  searches for definition of function memberName
+  @param yyscanner the scanner data to be used
+  @param memberName the name of the function/variable
+  @param moduleName name of enclosing module or null, if global entry
+  @param useMap map of data of USE-statement
+  @returns MemberDef pointer, if found, or nullptr otherwise
+*/
+static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName,
+                                 const UseMap &useMap)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (memberName.isEmpty()) return nullptr; /* empty name => nothing to link */
+
+  // look in local variables
+  for (auto it = yyextra->scopeStack.rbegin(); it!=yyextra->scopeStack.rend(); ++it)
+  {
+    const Scope &scope = *it;
+    //std::string lowMemName = memberName.lower().str();
+    std::string lowMemName = memberName.str();
+    if (scope.localVars   .find(lowMemName)!=std::end(scope.localVars)     &&  // local var
+        scope.externalVars.find(lowMemName)==std::end(scope.externalVars))     // and not external
+    {
+      return nullptr;
+    }
+  }
+
+  // search for function
+  MemberName *mn = Doxygen::functionNameLinkedMap->find(memberName);
+  if (!mn)
+  {
+    mn = Doxygen::memberNameLinkedMap->find(memberName);
+  }
+
+  if (mn) // name is known
+  {
+    // all found functions with given name
+    for (const auto &md : *mn)
+    {
+      const FileDef  *fd=md->getFileDef();
+      const GroupDef *gd=md->getGroupDef();
+      const ClassDef *cd=md->getClassDef();
+
+      //cout << "found link with same name: " << fd->fileName() << "  " <<  memberName;
+      //if (md->getNamespaceDef() != 0) cout << " in namespace " << md->getNamespaceDef()->name();cout << endl;
+
+      if ((gd && gd->isLinkable()) || (fd && fd->isLinkable()))
+      {
+        const NamespaceDef *nspace= md->getNamespaceDef();
+
+        if (nspace == 0)
+        { // found function in global scope
+          if(cd == 0)
+          { // Skip if bound to type
+            return md.get();
+          }
+        }
+        else if (moduleName == nspace->name())
+        { // found in local scope
+          return md.get();
+        }
+        else
+        { // else search in used modules
+          QCString usedModuleName= nspace->name();
+          auto use_it = useMap.find(usedModuleName.str());
+          if (use_it!=useMap.end())
+          {
+            const UseEntry &ue = use_it->second;
+            // check if only-list exists and if current entry exists is this list
+            if (ue.onlyNames.empty())
+            {
+              //cout << " found in module " << usedModuleName << " entry " << memberName <<  endl;
+              return md.get(); // whole module used
+            }
+            else
+            {
+              for ( const auto &name : ue.onlyNames)
+              {
+                //cout << " search in only: " << usedModuleName << ":: " << memberName << "==" << (*it)<<  endl;
+                if (memberName == name)
+                {
+                  return md.get(); // found in ONLY-part of use list
+                }
+              }
+            }
+          }
+        }
+      } // if linkable
+    } // for
+  }
+  return nullptr;
+}
+
+/**
+ gets the link to a generic procedure which depends not on the name, but on the parameter list
+ @todo implementation
+*/
+static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd,
+                                    const QCString &memberText,
+                                    CodeOutputInterface &ol)
+{
+  (void)cd;
+  (void)memberText;
+  (void)ol;
+  return FALSE;
+}
+
+static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // dictionary with used modules
+                    const QCString &memberText,  // exact member text
+                    CodeOutputInterface &ol,
+                    const QCString &text)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  MemberDef *md=0;
+  QCString memberName= removeRedundantWhiteSpace(memberText);
+
+  if ((md=getFortranDefs(yyscanner,memberName, yyextra->currentModule, useMap)) && md->isLinkable())
+  {
+    if (md->isVariable() && (md->getLanguage()!=SrcLangExt_Fortran)) return FALSE; // Non Fortran variables aren't handled yet,
+                                                                                   // see also linkifyText in util.cpp
+
+    const Definition *d = md->getOuterScope()==Doxygen::globalScope ?
+                          md->getBodyDef() : md->getOuterScope();
+    if (md->getGroupDef()) d = md->getGroupDef();
+    if (d && d->isLinkable())
+    {
+      if (yyextra->currentDefinition && yyextra->currentMemberDef &&
+          yyextra->insideBody && yyextra->collectXRefs)
+      {
+        std::lock_guard<std::mutex> lock(g_docCrossReferenceMutex);
+        addDocCrossReference(toMemberDefMutable(yyextra->currentMemberDef),toMemberDefMutable(md));
+      }
+      writeMultiLineCodeLink(yyscanner,ol,md,!text.isEmpty() ? text : memberText);
+      addToSearchIndex(yyscanner, !text.isEmpty() ? text : memberText);
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+
+static void generateLink(yyscan_t yyscanner, CodeOutputInterface &ol, const QCString &lname)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  ClassDef *cd=0;
+  NamespaceDef *nsd=0;
+  QCString name = lname;
+  // name = removeRedundantWhiteSpace(name.lower());
+  name = removeRedundantWhiteSpace(name);
+
+  // check if lowercase lname is a linkable type or interface
+  if ( (getFortranTypeDefs(name, yyextra->currentModule, cd, yyextra->useMembers)) && cd->isLinkable() )
+  {
+    if ( (cd->compoundType() == ClassDef::Class) && // was  Entry::INTERFACE_SEC) &&
+         (getGenericProcedureLink(yyscanner, cd, name, ol)) )
+    {
+      //cout << "=== generic procedure resolved" << endl;
+    }
+    else
+    { // write type or interface link
+      writeMultiLineCodeLink(yyscanner, ol, cd, name);
+      addToSearchIndex(yyscanner, name);
+    }
+  }
+  // check for module
+  else if ( (getFortranNamespaceDefs(name, nsd)) && nsd->isLinkable() )
+  { // write module link
+    writeMultiLineCodeLink(yyscanner,ol,nsd,name);
+    addToSearchIndex(yyscanner,name);
+  }
+  // check for function/variable
+  else if (getLink(yyscanner,yyextra->useMembers, name, ol, name))
+  {
+    //cout << "=== found link for lowercase " << lname << endl;
+  }
+  else
+  {
+    // nothing found, just write out the word
+    //startFontClass("charliteral"); //test
+    codifyLines(yyscanner,name);
+    //endFontClass(yyscanner); //test
+    addToSearchIndex(yyscanner,name);
+  }
+}
+
+static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const char *lname)
+{
+  generateLink(yyscanner,ol,QCString(lname));
+}
+
+/*! counts the number of lines in the input */
+static int countLines(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  const char *p=yyextra->inputString;
+  char c;
+  int count=1;
+  while ((c=*p))
+  {
+    p++ ;
+    if (c=='\n') count++;
+  }
+  if (p>yyextra->inputString && *(p-1)!='\n')
+  { // last line does not end with a \n, so we add an extra
+    // line and explicitly terminate the line after parsing.
+    count++,
+    yyextra->needsTermination=TRUE;
+  }
+  return count;
+}
+
+//----------------------------------------------------------------------------
+/** start scope */
+static void startScope(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  DBG_CTX((stderr, "===> startScope %s",yytext));
+  yyextra->scopeStack.push_back(Scope());
+}
+
+/** end scope */
+static void endScope(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  DBG_CTX((stderr,"===> endScope %s",yytext));
+  if (yyextra->scopeStack.empty())
+  {
+    DBG_CTX((stderr,"WARNING: fortrancode.l: stack empty!\n"));
+    return;
+  }
+
+  Scope &scope = yyextra->scopeStack.back();
+  for ( const auto &name : scope.useNames)
+  {
+    yyextra->useMembers.erase(name.str());
+  }
+  yyextra->scopeStack.pop_back();
+}
+
+static void addUse(yyscan_t yyscanner,const QCString &moduleName)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (!yyextra->scopeStack.empty())
+    yyextra->scopeStack.back().useNames.push_back(moduleName);
+}
+
+static void addLocalVar(yyscan_t yyscanner,const QCString &varName)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (!yyextra->scopeStack.empty())
+  {
+    // std::string lowVarName = varName.lower().str();
+    std::string lowVarName = varName.str();
+    yyextra->scopeStack.back().localVars.insert(lowVarName);
+    if (yyextra->isExternal) yyextra->scopeStack.back().externalVars.insert(lowVarName);
+  }
+}
+
+/*===================================================================*/
+
+
+static void checkContLines(yyscan_t yyscanner,const char *s)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  int numLines = 0;
+  int i = 0;
+  const char *p = s;
+
+  numLines = 2; // one for element 0, one in case no \n at end
+  while (*p)
+  {
+    if (*p == '\n') numLines++;
+    p++;
+  }
+
+  yyextra->hasContLine = (int *) malloc((numLines) * sizeof(int));
+  for (i = 0; i < numLines; i++)
+    yyextra->hasContLine[i] = 0;
+  p = prepassFixedForm(s, yyextra->hasContLine);
+  yyextra->hasContLine[0] = 0;
+}
+
+void parseFortranCode(CodeOutputInterface &od,const char *,const QCString &s,
+                  bool exBlock, const char *exName,const FileDef *fd,
+                  int startLine,int endLine,bool inlineFragment,
+                  const MemberDef *,bool,const Definition *searchCtx,
+                  bool collectXRefs, FortranFormat format)
+{
+  //printf("***parseCode() exBlock=%d exName=%s fd=%p\n",exBlock,exName,fd);
+
+  return;
+}
+
+//---------------------------------------------------------
+
+struct FortranCodeParser::Private
+{
+  yyscan_t yyscanner;
+  fortrancodeYY_state state;
+  FortranFormat format;
+};
+
+FortranCodeParser::FortranCodeParser(FortranFormat format) : p(std::make_unique<Private>())
+{
+  p->format = format;
+  fortrancodeYYlex_init_extra(&p->state,&p->yyscanner);
+#ifdef FLEX_DEBUG
+  fortrancodeYYset_debug(1,p->yyscanner);
+#endif
+  resetCodeParserState();
+}
+
+FortranCodeParser::~FortranCodeParser()
+{
+  fortrancodeYYlex_destroy(p->yyscanner);
+}
+
+void FortranCodeParser::resetCodeParserState()
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)p->yyscanner;
+  yyextra->currentDefinition = 0;
+  yyextra->currentMemberDef = 0;
+  yyextra->currentFontClass = 0;
+  yyextra->needsTermination = FALSE;
+  BEGIN( Start );
+}
+
+void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
+                   const QCString & scopeName,
+                   const QCString & input,
+                   SrcLangExt /*lang*/,
+                   bool isExampleBlock,
+                   const QCString & exampleName,
+                   const FileDef * fileDef,
+                   int startLine,
+                   int endLine,
+                   bool inlineFragment,
+                   const MemberDef *memberDef,
+                   bool showLineNumbers,
+                   const Definition *searchCtx,
+                   bool collectXRefs
+                  )
+{
+  yyscan_t yyscanner = p->yyscanner;
+  struct yyguts_t *yyg = (struct yyguts_t*)p->yyscanner;
+  //::parseFortranCode(codeOutIntf,scopeName,input,isExampleBlock,exampleName,
+  //                   fileDef,startLine,endLine,inlineFragment,memberDef,
+  //                   showLineNumbers,searchCtx,collectXRefs,m_format);
+  //  parseFortranCode(CodeOutputInterface &od,const char *,const QCString &s,
+  //                bool exBlock, const char *exName,FileDef *fd,
+  //                int startLine,int endLine,bool inlineFragment,
+  //                const MemberDef *,bool,const Definition *searchCtx,
+  //                bool collectXRefs, FortranFormat format)
+  if (input.isEmpty()) return;
+  printlex(yy_flex_debug, TRUE, __FILE__, fileDef ? qPrint(fileDef->fileName()): NULL);
+  yyextra->code = &codeOutIntf;
+  yyextra->inputString   = input.data();
+  yyextra->inputPosition = 0;
+  yyextra->isFixedForm = recognizeFixedForm(input,p->format);
+  yyextra->contLineNr = 1;
+  yyextra->hasContLine = NULL;
+  if (yyextra->isFixedForm)
+  {
+    checkContLines(yyscanner,yyextra->inputString);
+  }
+  yyextra->currentFontClass = 0;
+  yyextra->needsTermination = FALSE;
+  yyextra->searchCtx = searchCtx;
+  yyextra->collectXRefs = collectXRefs;
+  if (startLine!=-1)
+    yyextra->yyLineNr    = startLine;
+  else
+    yyextra->yyLineNr    = 1;
+
+  if (endLine!=-1)
+    yyextra->inputLines  = endLine+1;
+  else
+    yyextra->inputLines  = yyextra->yyLineNr + countLines(yyscanner) - 1;
+
+  yyextra->exampleBlock  = isExampleBlock;
+  yyextra->exampleName   = exampleName;
+  yyextra->sourceFileDef = fileDef;
+  if (isExampleBlock && fileDef==0)
+  {
+    // create a dummy filedef for the example
+    yyextra->sourceFileDef = createFileDef(QCString(),exampleName);
+  }
+  if (yyextra->sourceFileDef)
+  {
+    setCurrentDoc(yyscanner,QCString("l00001"));
+  }
+  yyextra->currentDefinition = 0;
+  yyextra->currentMemberDef = 0;
+  if (!yyextra->exampleName.isEmpty())
+  {
+    yyextra->exampleFile = convertNameToFile(yyextra->exampleName+"-example");
+  }
+  yyextra->includeCodeFragment = inlineFragment;
+  startCodeLine(yyscanner);
+  fortrancodeYYrestart(0, yyscanner);
+  BEGIN( Start );
+  fortrancodeYYlex(yyscanner);
+  if (yyextra->needsTermination)
+  {
+    endFontClass(yyscanner);
+    yyextra->code->endCodeLine();
+  }
+// The correction `!fileDef && ` is introduced in Doxygen 1.9.5 to resolve the Fortran parser segfault, but does not appear to resolve it.
+  if (!fileDef && isExampleBlock && yyextra->sourceFileDef) 
+  {
+    // delete the temporary file definition used for this example
+    delete yyextra->sourceFileDef;
+    yyextra->sourceFileDef=0;
+  }
+  if (yyextra->hasContLine) free(yyextra->hasContLine);
+  yyextra->hasContLine = NULL;
+
+  // write the tooltips
+  yyextra->tooltipManager.writeTooltips(codeOutIntf);
+
+  printlex(yy_flex_debug, FALSE, __FILE__, fileDef ? qPrint(fileDef->fileName()): NULL);
+}
+
+//---------------------------------------------------------
+
+#if USE_STATE2STRING
+#include "fortrancode.l.h"
+#endif

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -244,10 +244,14 @@ CHAR      (CHARACTER|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
 /* The patterns ({NUM_TYPE}{KIND}) and ({NUM_TYPE}({BS}"*"{BS}[0-9]+)?) are inconsistent with Fortran syntax and as such, was removed from TYPE_SPEC */
 TYPE_SPEC ({NUM_TYPE}|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
 
-INTENT_SPEC         INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"
 ACCESS_SPEC         (PROTECTED|PRIVATE|PUBLIC)
+INTENT_SPEC         INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"
 
+/* Fortran attributes except BIND and C which are treated separately */
 ATTR_SPEC           (ALLOCATABLE|ASSIGNMENT|ASYNCHRONOUS|ABSTRACT|BIND|CODIMENSION|CONTIGUOUS|DEFERRED|DIMENSION|ELEMENTAL|EXTENDS|EXTERNAL|IMPURE|INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"|INTRINSIC|LOCAL|LOCAL_INIT|NON_INTRINSIC|NON_OVERRIDABLE|NON_RECURSIVE|NOPASS|OPERATOR|OPTIONAL|OVERRIDABLE|PARAMETER|PASS|POINTER|PRIVATE|PROTECTED|PUBLIC|PURE|RECURSIVE|SAVE|SEQUENCE|SHARED|TARGET|VALUE|VOLATILE)
+
+/* attributes that take arguments */
+ATTR_SPEC_WARG      (CODIMENSION|DIMENSION|EXTENDS|OPERATOR|PASS|BIND)
 
 /* Assume that attribute statements are almost the same as attributes. */
 ATTR_STMT           {ATTR_SPEC}
@@ -278,7 +282,9 @@ FLOW_END                        (DO|SELECT|WHERE|IF|WHILE|FORALL|CRITICAL|BLOCK|
 
 PREFIX                          ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
 SUFFIX                          (RESULT{ARGS})
+/* The specified syntax is too generic and does not respect NAME and C as a specifiers. Also "bind" as an attribute takes precedence over its statement format.
 LANGUAGE_BIND_SPEC              BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
+*/
 
 /* INTRINSIC_FUNC_ELEMENTAL_IEEE can be merged with INTRINSIC_FUNC_ELEMENTAL when the flex bug gets resolved in the future */
 INTRINSIC_FUNC_ELEMENTAL_IEEE   (IEEE_CLASS|IEEE_COPY_SIGN|IEEE_FMA|IEEE_GET_FLAG|IEEE_GET_HALTING_MODE|IEEE_INT|IEEE_IS_FINITE|IEEE_IS_NAN|IEEE_IS_NEGATIVE|IEEE_IS_NORMAL|IEEE_LOGB|IEEE_MAX_NUM|IEEE_MAX_NUM_MAG|IEEE_MIN_NUM|IEEE_MIN_NUM_MAG|IEEE_NEXT_AFTER|IEEE_NEXT_DOWN|IEEE_NEXT_UP|IEEE_QUIET_EQ|IEEE_QUIET_GE|IEEE_QUIET_GT|IEEE_QUIET_LE|IEEE_QUIET_LT|IEEE_QUIET_NAN|IEEE_QUIET_NE|IEEE_REAL|IEEE_REM|IEEE_RINT|IEEE_SCALB|IEEE_SIGNALING_EQ|IEEE_SIGNALING_GE|IEEE_SIGNALING_GT|IEEE_SIGNALING_LE|IEEE_SIGNALING_LT|IEEE_SIGNALING_NE|IEEE_SIGNBIT|IEEE_UNORDERED|IEEE_VALUE)
@@ -322,7 +328,7 @@ INTRINSIC_MODULE                ({INTRINSIC_MODULE_IEEE}|ISO_C_BINDING|ISO_FORTR
 
 SPECIFIER                       (ACCESS|ACQUIRED_LOCK|ACTION|ADVANCE|ASYNCHRONOUS|BLANK|DECIMAL|DELIM|DIM|DIRECT|ENCODING|EOR|ERR|ERRMSG|EXIST|FILE|FMT|FORM|FORMATTED|ID|IOLENGTH|IOMSG|IOSTAT|KIND|LEN|MOLD|NAME|NAMED|NEW_INDEX|NEWUNIT|NEXTREC|NML|NUMBER|OPENED|PAD|PENDING|POS|POSITION|QUIET|READ|READWRITE|REC|RECL|ROUND|SEQUENTIAL|SIGN|SIZE|SOURCE|STAT|STATUS|STREAM|TEAM|TEAM_NUMBER|UNFORMATTED|UNIT|UNTIL_COUNT|WRITE)
 
-STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ENUM|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|FUNCTION|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|END{BS}SUBMODULE|SUBROUTINE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
+STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|FUNCTION|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|END{BS}SUBMODULE|SUBROUTINE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
 
 /* INTRINSIC_DERIVED_TYPE_IEEE and INTRINSIC_DERIVED_TYPE_CFI can be merged with INTRINSIC_DERIVED_TYPE when the flex bug gets resolved in the future */
 INTRINSIC_DERIVED_TYPE_IEEE     (IEEE_CLASS_TYPE|IEEE_FEATURES_TYPE|IEEE_FLAG_TYPE|IEEE_MODES_TYPE|IEEE_ROUND_TYPE|IEEE_STATUS_TYPE)
@@ -364,7 +370,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                                                     codifyLines(yyscanner,yytext);
                                                                     endFontClass(yyscanner);
                                                                 }
-<*>{BS}[.]*("+"|"-"|"*"|"/"|"<"|">"|"="|"&"){BS}                {   // highlight rule for the operators of Fortran standard.
+<*>{BS}[.]*{BS}("+"|"-"|"*"|"/"|"<"|">"|"="|"&"){BS}            {   // highlight rule for the operators of Fortran standard.
                                                                     if(YY_START == String) YY_FTN_REJECT; // ignore in strings
                                                                     startFontClass(yyscanner,"fortran_operator_symbols");
                                                                     codifyLines(yyscanner,yytext);
@@ -382,7 +388,26 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                                                     codifyLines(yyscanner,yytext);
                                                                     endFontClass(yyscanner);
                                                                 }
-<Declaration>{BS}{ATTR_SPEC}[^0-9a-zA-Z]{BS}                    {   // highlight rule for the attributes of Fortran standard.
+<Start>{BS}"bind"/{BS}"("[.]*                       {   // highlight rule for the bind attribute of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"C"/{BS}(","{BS}"name"{BS}"="{BS}(.)+)("&"|")"){BS}  {   // highlight rule for the bind C attribute of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Declaration>{BS}{ATTR_SPEC}/({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    if (QCString(yytext) == "external") yyextra->isExternal = true;
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Declaration>{BS}{ATTR_SPEC_WARG}/("("[.*]")")?({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes that take argument: DIMENSION(:,:).
                                                                     if(YY_START == String) YY_FTN_REJECT; // ignore in strings
                                                                     startFontClass(yyscanner,"fortran_attribute");
                                                                     codifyLines(yyscanner,yytext);
@@ -572,76 +597,74 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           endFontClass(yyscanner);
                                         }
  /*-------- fortran module  -----------------------------------------*/
-<Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n {  //
-                                          startScope(yyscanner);
-                                          startFontClass(yyscanner,"fortran_statement");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(ClassName);
-                                          if (!qstricmp(yytext,"module")) yyextra->currentModule="module";
+<Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n { //
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
+                                            if (!qstricmp(yytext,"module")) yyextra->currentModule="module";
                                         }
-<Start>("enum")/{BS_}|{BS}{COMMA}{BS}{LANGUAGE_BIND_SPEC}|\n {  //
-                                          startScope(yyscanner);
-                                          startFontClass(yyscanner,"fortran_statement");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(ClassName);
+<Start>^{BS}"enum"/{BS}("&"|",")        {   // rule for enum statement
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
                                         }
-<*>{LANGUAGE_BIND_SPEC}                 {  //
-                                          startFontClass(yyscanner,"fortran_statement");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>("type")/{BS_}|({COMMA}({ACCESS_SPEC}|ABSTRACT|EXTENDS))|\n {  //
-                                          startScope(yyscanner);
-                                          startFontClass(yyscanner,"fortran_statement");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(ClassName);
+<Start>("type")/{BS}[:,]{BS}            {   // rule for type-definition construct. Do NOT put "(" in [:,] as it leads to confusion with variable declaration.
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
                                         }
 <ClassName>{ID}                         {
-                                          if (yyextra->currentModule == "module")
-                                          {
-                                            yyextra->currentModule=yytext;
-                                            yyextra->currentModule = yyextra->currentModule;//.lower();
-                                          }
-                                          generateLink(yyscanner,*yyextra->code,yytext);
-                                          yy_pop_state(yyscanner);
+                                            if (yyextra->currentModule == "module")
+                                            {
+                                                yyextra->currentModule=yytext;
+                                                yyextra->currentModule = yyextra->currentModule;//.lower();
+                                            }
+                                            generateLink(yyscanner,*yyextra->code,yytext);
+                                            yy_pop_state(yyscanner);
                                         }
-<ClassName>({ACCESS_SPEC}|ABSTRACT|EXTENDS)/[,:( ] { // variable declaration
-                                          startFontClass(yyscanner,"fortran_attribute");
-                                          yyextra->code->codify(QCString(yytext));
-                                          endFontClass(yyscanner);
+<ClassName>{BS}({ATTR_SPEC})/{BS}[,:( ]{BS} { // variable declaration
+                                            if (QCString(yytext) == "external") yyextra->isExternal = true;
+                                            startFontClass(yyscanner,"fortran_attribute");
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
                                         }
-<Start>{ACCESS_SPEC}/[,: ]              { // access attribute declaration
-                                          startFontClass(yyscanner,"fortran_attribute");
-                                          yyextra->code->codify(QCString(yytext));
-                                          endFontClass(yyscanner);
+<Start>^{BS}{ACCESS_SPEC}/{BS}[,: ]     {   // access attribute declaration. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
+                                            startFontClass(yyscanner,"fortran_attribute");
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
                                         }
-<ClassName>\n                           { // interface may be without name
-                                          yy_pop_state(yyscanner);
-                                          YY_FTN_REJECT;
+<ClassName>\n                           {   // interface may be without name
+                                            yy_pop_state(yyscanner);
+                                            YY_FTN_REJECT;
                                         }
 <Start>^{BS}"end"({BS_}"enum").*        {
-                                          YY_FTN_REJECT;
+                                            YY_FTN_REJECT;
                                         }
 <Start>^{BS}"end"({BS_}"type").*        {
-                                          YY_FTN_REJECT;
+                                            YY_FTN_REJECT;
                                         }
-<Start>^{BS}"end"({BS_}"module").*      { // just reset yyextra->currentModule, rest is done in following rule
-                                          yyextra->currentModule=0;
-                                          YY_FTN_REJECT;
+<Start>^{BS}"end"({BS_}"module").*      {   // just reset yyextra->currentModule, rest is done in following rule
+                                            yyextra->currentModule=0;
+                                            YY_FTN_REJECT;
                                         }
  /*-------- subprog definition -------------------------------------*/
+ /*
 <Start>({PREFIX}{BS_})?{TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
                                           startFontClass(yyscanner,"fortran_prefix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
-<Start>({PREFIX}{BS_})?("module"{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
+ */
+<Start>("module"{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
                                           startFontClass(yyscanner,"fortran_prefix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
@@ -687,7 +710,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           endFontClass(yyscanner);
                                         }
  /*-------- variable declaration ----------------------------------*/
-<Start>{TYPE_SPEC}/[,:( ]               {
+<Start>{TYPE_SPEC}/{BS}[,:( ]           {
                                           QCString typ(yytext);
                                           typ = removeRedundantWhiteSpace(typ.lower());
                                           if (typ.startsWith("real")) YY_FTN_REJECT;
@@ -699,7 +722,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
-<Start>{ATTR_SPEC}                      {
+<Start>^{BS}{ATTR_SPEC}                 { // declare attribute statement. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
                                           if (QCString(yytext) == "external")
                                           {
                                             yy_push_state(YY_START,yyscanner);
@@ -710,7 +733,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
-<Declaration>({TYPE_SPEC}|{ATTR_SPEC})/[,:( ] { //| variable declaration
+<Declaration>({TYPE_SPEC})/{BS}[(,: ]   { //| variable declaration
                                           if (QCString(yytext) == "external") yyextra->isExternal = true;
                                           startFontClass(yyscanner,"fortran_statement");
                                           yyextra->code->codify(QCString(yytext));

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -328,7 +328,7 @@ INTRINSIC_MODULE                ({INTRINSIC_MODULE_IEEE}|ISO_C_BINDING|ISO_FORTR
 
 SPECIFIER                       (ACCESS|ACQUIRED_LOCK|ACTION|ADVANCE|ASYNCHRONOUS|BLANK|DECIMAL|DELIM|DIM|DIRECT|ENCODING|EOR|ERR|ERRMSG|EXIST|FILE|FMT|FORM|FORMATTED|ID|IOLENGTH|IOMSG|IOSTAT|KIND|LEN|MOLD|NAME|NAMED|NEW_INDEX|NEWUNIT|NEXTREC|NML|NUMBER|OPENED|PAD|PENDING|POS|POSITION|QUIET|READ|READWRITE|REC|RECL|ROUND|SEQUENTIAL|SIGN|SIZE|SOURCE|STAT|STATUS|STREAM|TEAM|TEAM_NUMBER|UNFORMATTED|UNIT|UNTIL_COUNT|WRITE)
 
-STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|FUNCTION|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|END{BS}SUBMODULE|SUBROUTINE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
+STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|FUNCTION|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|SUBMODULE|END{BS}SUBMODULE|SUBROUTINE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
 
 /* INTRINSIC_DERIVED_TYPE_IEEE and INTRINSIC_DERIVED_TYPE_CFI can be merged with INTRINSIC_DERIVED_TYPE when the flex bug gets resolved in the future */
 INTRINSIC_DERIVED_TYPE_IEEE     (IEEE_CLASS_TYPE|IEEE_FEATURES_TYPE|IEEE_FLAG_TYPE|IEEE_MODES_TYPE|IEEE_ROUND_TYPE|IEEE_STATUS_TYPE)
@@ -388,7 +388,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                                                     codifyLines(yyscanner,yytext);
                                                                     endFontClass(yyscanner);
                                                                 }
-<Start>{BS}"bind"/{BS}"("[.]*                       {   // highlight rule for the bind attribute of Fortran standard.
+<Start>{BS}"bind"/{BS}"("[.]*                                   {   // highlight rule for the bind attribute of Fortran standard.
                                                                     if(YY_START == String) YY_FTN_REJECT; // ignore in strings
                                                                     startFontClass(yyscanner,"fortran_attribute");
                                                                     codifyLines(yyscanner,yytext);
@@ -431,7 +431,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                                                     codifyLines(yyscanner,yytext);
                                                                     endFontClass(yyscanner);
                                                                 }
-<Start,Declaration>{BS}[^%]{SPECIFIER}/{BS}={BS}                {   // highlight rule for Fortran intrinsic specifier (intrinsic procedure argument) names.
+<Start,Declaration>{BS}{SPECIFIER}/{BS}={BS}[a-zA-Z0-9_\.\-\+(\[][a-zA-Z0-9_)(\[\]!%,\.\-\+/=><\t ]*{BS}(")"|"&")  {   // highlight rule for Fortran intrinsic specifier (intrinsic procedure argument) names.
                                                                     // \todo: A specifier must be enclosed with parentheses. This is not currently enforced.
                                                                     startFontClass(yyscanner,"fortran_spcifier");
                                                                     codifyLines(yyscanner,yytext);

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -127,13 +127,13 @@ class Scope
 
 struct fortrancodeYY_state
 {
-  QCString      docBlock;                   //!< contents of all lines of a documentation block
-  QCString      currentModule=QCString();   //!< name of the current enclosing module
-  UseMap      useMembers;                   //!< info about used modules
-  UseEntry      useEntry;                   //!< current use statement info
-  std::vector<Scope>  scopeStack;
-  bool          isExternal = false;
-  QCString      str=QCString();             //!< contents of fortran string
+  QCString              docBlock;                   //!< contents of all lines of a documentation block
+  QCString              currentModule=QCString();   //!< name of the current enclosing module
+  UseMap                useMembers;                 //!< info about used modules
+  UseEntry              useEntry;                   //!< current use statement info
+  std::vector<Scope>    scopeStack;
+  bool                  isExternal = false;
+  QCString              str=QCString();             //!< contents of fortran string
 
   CodeOutputInterface * code = 0;
 
@@ -176,10 +176,8 @@ struct fortrancodeYY_state
 static const char *stateToString(int state);
 #endif
 
-static bool getFortranNamespaceDefs(const QCString &mname,
-                               NamespaceDef *&cd);
-static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName,
-                               ClassDef *&cd, const UseMap &useMap);
+static bool getFortranNamespaceDefs(const QCString &mname, NamespaceDef *&cd);
+static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName, ClassDef *&cd, const UseMap &useMap);
 
 //----------------------------------------------------------------------------
 
@@ -191,11 +189,8 @@ static void startCodeLine(yyscan_t yyscanner);
 static void endCodeLine(yyscan_t yyscanner);
 static void nextCodeLine(yyscan_t yyscanner);
 static void codifyLines(yyscan_t yyscanner,const QCString &text);
-static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
-                  Definition *d,const QCString &text);
-static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd,
-                                    const QCString &memberText,
-                                    CodeOutputInterface &ol);
+static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol, Definition *d,const QCString &text);
+static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd, const QCString &memberText, CodeOutputInterface &ol);
 static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // map with used modules
                     const QCString &memberText,  // exact member text
                     CodeOutputInterface &ol,
@@ -207,8 +202,7 @@ static void startScope(yyscan_t yyscanner);
 static void endScope(yyscan_t yyscanner);
 static void addUse(yyscan_t yyscanner,const QCString &moduleName);
 static void addLocalVar(yyscan_t yyscanner,const QCString &varName);
-static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName,
-                                 const UseMap &useMap);
+static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName, const UseMap &useMap);
 static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 
@@ -225,7 +219,6 @@ static std::mutex g_countFlowKeywordsMutex;
 
 IDSYM     [a-z_A-Z0-9]
 ID        [a-z_A-Z]+{IDSYM}*
-SUBPROG   (subroutine|function)
 B         [ \t]
 BS        [ \t]*
 BS_       [ \t]+
@@ -236,22 +229,105 @@ ARGS_L1   ("("{ARGS_L1a}*")")
 ARGS_L2   "("({ARGS_L0}|[^()]|{ARGS_L1a}|{ARGS_L1})*")"
 ARGS      {BS}({ARGS_L0}|{ARGS_L1}|{ARGS_L2})
 
-NUM_TYPE  (complex|integer|logical|real)
-LOG_OPER  (\.and\.|\.eq\.|\.eqv\.|\.ge\.|\.gt\.|\.le\.|\.lt\.|\.ne\.|\.neqv\.|\.or\.|\.not\.)
-KIND      {ARGS}
-CHAR      (CHARACTER{ARGS}?|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
-TYPE_SPEC (({NUM_TYPE}({BS}"*"{BS}[0-9]+)?)|({NUM_TYPE}{KIND})|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
+/* The following appear in submodules as (subroutine|function|procedure) */
+SUBPROG   (subroutine|function|procedure)
 
-INTENT_SPEC intent{BS}"("{BS}(in|out|in{BS}out){BS}")"
-ATTR_SPEC (IMPLICIT|ALLOCATABLE|DIMENSION{ARGS}|EXTERNAL|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|(NON_)?RECURSIVE|PURE|IMPURE|ELEMENTAL|VALUE|NOPASS|DEFERRED|CONTIGUOUS|VOLATILE)
-ACCESS_SPEC (PROTECTED|PRIVATE|PUBLIC)
+/* REAL and LOGICAL are treated separately as it can also be a function */
+NUM_TYPE            (COMPLEX|INTEGER)
+OPERATOR_LOGICAL    (\.and\.|\.eq\.|\.eqv\.|\.ge\.|\.gt\.|\.le\.|\.lt\.|\.ne\.|\.neqv\.|\.or\.|\.not\.)
+OPERATOR_SYMBOLS    [\+\-\*/%::><=&]
+KIND      {ARGS}
+
+/* The pattern CHARACTER{ARGS}? is inconsistent with Fortran syntax and as such, removed from CHAR */
+CHAR      (CHARACTER|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
+
+/* The patterns ({NUM_TYPE}{KIND}) and ({NUM_TYPE}({BS}"*"{BS}[0-9]+)?) are inconsistent with Fortran syntax and as such, was removed from TYPE_SPEC */
+TYPE_SPEC ({NUM_TYPE}|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
+
+INTENT_SPEC         INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"
+ACCESS_SPEC         (PROTECTED|PRIVATE|PUBLIC)
+
+ATTR_SPEC           (ALLOCATABLE|ASSIGNMENT|ASYNCHRONOUS|ABSTRACT|BIND|CODIMENSION|CONTIGUOUS|DEFERRED|DIMENSION|ELEMENTAL|EXTENDS|EXTERNAL|IMPURE|INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"|INTRINSIC|LOCAL|LOCAL_INIT|NON_INTRINSIC|NON_OVERRIDABLE|NON_RECURSIVE|NOPASS|OPERATOR|OPTIONAL|OVERRIDABLE|PARAMETER|PASS|POINTER|PRIVATE|PROTECTED|PUBLIC|PURE|RECURSIVE|SAVE|SEQUENCE|SHARED|TARGET|VALUE|VOLATILE)
+
 /* Assume that attribute statements are almost the same as attributes. */
-ATTR_STMT {ATTR_SPEC}|DIMENSION
-FLOW      (DO|SELECT|CASE|SELECT{BS}(CASE|TYPE)|WHERE|IF|THEN|ELSE|WHILE|FORALL|ELSEWHERE|ELSEIF|RETURN|CONTINUE|EXIT|GO{BS}TO)
-COMMANDS  (FORMAT|CONTAINS|MODULE{BS_}PROCEDURE|WRITE|READ|ALLOCATE|ALLOCATED|ASSOCIATED|PRESENT|DEALLOCATE|NULLIFY|SIZE|INQUIRE|OPEN|CLOSE|FLUSH|DATA|COMMON)
-IGNORE    (CALL)
-PREFIX    ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
-LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
+ATTR_STMT           {ATTR_SPEC}
+
+/* Intel directive statement and attributes. */
+DIR_INTEL_STATEMENT (ALIAS|ASSUME|ASSUME_ALIGNED|ATTRIBUTES|DLLEXPORT|BLOCK_LOOP|DECLARE|DEFINE|DISTRIBUTE{BS_}POINT|FIXEDFORMLINESIZE|FMA|FORCEINLINE|FREEFORM|IDENT|IF|IF{BS_}DEFINED|INLINE|INTEGER|IVDEP|LOOP{BS_}COUNT|MESSAGE|NOBLOCK_LOOP|NODECLARE|NOFMA|NOFREEFORM|NOFUSION|NOINLINE|NOOPTIMIZE|NOPARALLEL|NOPREFETCH|NOSTRICT|NOUNROLL|NOUNROLL_AND_JAM|NOVECTOR|OBJCOMMENT|OPTIMIZE|OPTIONS|PACK|PARALLEL|PREFETCH|PSECT|REAL|SIMD|STRICT|UNDEFINE|UNROLL|UNROLL_AND_JAM|VECTOR|ALIGN|ALLOCATABLE|ALLOW_NULL|C|CODE_ALIGN|CONCURRENCY_SAFE|CVF|DECORATE|DEFAULT|DLLIMPORT|EXTERN|FASTMEM|IGNORE_LOC|INLINE|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING)
+
+/* ("ATTRIBUTE"{BS}[,]?{BS} */
+/* |ALLOCATABLE|C|DEFAULT|DLLEXPORT|DLLIMPORT|EXTERN|FASTMEM|INLINE|FORCEINLINE|IGNORE_LOC|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|NOINLINE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING|VECTOR */
+
+/* IEEE constants can be merged with NAMED_CONST in the future.
+Currently, including IEEE objects increases the number of flex rules to beyond what GNU flex can handle.
+The flex "flex: input rules are too complicated (>= 32000 NFA states)" error can be resolved by increasing
+the definitions in flexdef.h of flex source code for:
+    #define JAMSTATE -32766
+    #define MAXIMUM_MNS 31999
+    #define BAD_SUBSCRIPT -32767
+before compiling th flex library. However, the default distributed versions of flex cannot handle this.
+*/
+
+NAMED_CONST_IEEE                (IEEE_ALL|IEEE_ALL|IEEE_AWAY|IEEE_DATATYPE|IEEE_DENORMAL|IEEE_DIVIDE|IEEE_DIVIDE_BY_ZERO|IEEE_DOWN|IEEE_HALTING|IEEE_INEXACT|IEEE_INEXACT_FLAG|IEEE_INF|IEEE_INVALID|IEEE_INVALID_FLAG|IEEE_NAN|IEEE_NEAREST|IEEE_NEGATIVE_DENORMAL|IEEE_NEGATIVE_INF|IEEE_NEGATIVE_NORMAL|IEEE_NEGATIVE_SUBNORMAL|IEEE_NEGATIVE_ZERO|IEEE_OTHER|IEEE_OTHER_VALUE|IEEE_OVERFLOW|IEEE_POSITIVE_DENORMAL|IEEE_POSITIVE_INF|IEEE_POSITIVE_NORMAL|IEEE_POSITIVE_SUBNORMAL|IEEE_POSITIVE_ZERO|IEEE_ROUNDING|IEEE_SIGNALING_NAN|IEEE_SQRT|IEEE_SUBNORMAL|IEEE_TO_ZERO|IEEE_UNDERFLOW|IEEE_UNDERFLOW_FLAG|IEEE_UP|IEEE_USUAL)
+
+NAMED_CONST                     ({NAMED_CONST_IEEE}|C_ALERT|C_BACKSPACE|C_BOOL|C_CARRIAGE_RETURN|C_CHAR|C_DOUBLE|C_DOUBLE_COMPLEX|C_FLOAT|C_FLOAT_COMPLEX|C_FORM_FEED|C_HORIZONTAL_TAB|C_INT|C_INT16_T|C_INT32_T|C_INT64_T|C_INT8_T|C_INT_FAST16_T|C_INT_FAST32_T|C_INT_FAST64_T|C_INT_FAST8_T|C_INT_LEAST16_T|C_INT_LEAST32_T|C_INT_LEAST64_T|C_INT_LEAST8_T|C_INTMAX_T|C_INTPTR_T|C_LONG|C_LONG_DOUBLE|C_LONG_DOUBLE_COMPLEX|C_LONG_LONG|C_NEW_LINE|C_NULL_CHAR|C_NULL_FUNPTR|C_NULL_PTR|C_SHORT|C_SIGNED_CHAR|C_SIZE_T|C_VERTICAL_TAB|CHARACTER_KINDS|CHARACTER_STORAGE_SIZE|CURRENT_TEAM|ERROR_UNIT|FILE_STORAGE_SIZE|INITIAL_TEAM|INPUT_UNIT|INT16|INT32|INT64|INT8|INTEGER_KINDS|IOSTAT_END|IOSTAT_EOR|IOSTAT_INQUIRE_INTERNAL_UNIT|LOGICAL_KINDS|NUMERIC_STORAGE_SIZE|OUTPUT_UNIT|PARENT_TEAM|REAL128|REAL64|REAL32|REAL_KINDS|STAT_FAILED_IMAGE|STAT_LOCKED|STAT_LOCKED_OTHER_IMAGE|STAT_STOPPED_IMAGE|STAT_UNLOCKED|STAT_UNLOCKED_FAILED_IMAGE|\.FALSE\.|\.TRUE\.)
+
+FLOW                            (DO|DO{BS}CONCURRENT|SELECT{BS}(CASE|TYPE|RANK)|CASE|IF|THEN|ELSE{BS}IF|ELSE|DO{BS}WHILE|WHERE|ELSEWHERE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
+
+FLOW_END                        (DO|SELECT|WHERE|IF|WHILE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
+
+PREFIX                          ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
+SUFFIX                          (RESULT{ARGS})
+LANGUAGE_BIND_SPEC              BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
+
+/* INTRINSIC_FUNC_ELEMENTAL_IEEE can be merged with INTRINSIC_FUNC_ELEMENTAL when the flex bug gets resolved in the future */
+INTRINSIC_FUNC_ELEMENTAL_IEEE   (IEEE_CLASS|IEEE_COPY_SIGN|IEEE_FMA|IEEE_GET_FLAG|IEEE_GET_HALTING_MODE|IEEE_INT|IEEE_IS_FINITE|IEEE_IS_NAN|IEEE_IS_NEGATIVE|IEEE_IS_NORMAL|IEEE_LOGB|IEEE_MAX_NUM|IEEE_MAX_NUM_MAG|IEEE_MIN_NUM|IEEE_MIN_NUM_MAG|IEEE_NEXT_AFTER|IEEE_NEXT_DOWN|IEEE_NEXT_UP|IEEE_QUIET_EQ|IEEE_QUIET_GE|IEEE_QUIET_GT|IEEE_QUIET_LE|IEEE_QUIET_LT|IEEE_QUIET_NAN|IEEE_QUIET_NE|IEEE_REAL|IEEE_REM|IEEE_RINT|IEEE_SCALB|IEEE_SIGNALING_EQ|IEEE_SIGNALING_GE|IEEE_SIGNALING_GT|IEEE_SIGNALING_LE|IEEE_SIGNALING_LT|IEEE_SIGNALING_NE|IEEE_SIGNBIT|IEEE_UNORDERED|IEEE_VALUE)
+
+INTRINSIC_FUNC_ELEMENTAL        (ACHAR|ACOS|ACOSH|ADJUSTL|ADJUSTR|AIMAG|AINT|ANINT|ASIN|ASINH|ATAN|ATAN2|ATANH|BESSEL_J0|BESSEL_J1|BESSEL_JN|BESSEL_Y0|BESSEL_Y1|BESSEL_YN|BGE|BGT|BLE|BLT|BTEST|CEILING|CHAR|CMPLX|CONJG|COS|COSH|DBLE|DIM|DPROD|DSHIFTL|DSHIFTR|ERF|ERFC|ERFC_SCALED|EXP|EXPONENT|FLOOR|FRACTION|GAMMA|HYPOT|IACHAR|IAND|IBCLR|IBITS|IBSET|ICHAR|IEOR|IMAGE_STATUS|INT|IOR|ISHFT|ISHFTC|LEADZ|LEN_TRIM|LGE|LGT|LLE|LLT|LOG|LOG10|LOG_GAMMA|LOGICAL|MASKL|MASKR|MAX|MIN|MOD|MODULO|MVBITS|NEAREST|NINT|NOT|OUT_OF_RANGE|POPCNT|POPPAR|REAL|SCALE|SCAN|SET_EXPONENT|SHAPE|SHIFTA|SHIFTL|SHIFTR|SIGN|SIN|SINH|SPACING|SQRT|TAN|TANH|TRAILZ|TRIM|VERIFY)
+
+/* INTRINSIC_FUNC_INQUIRY_IEEE can be merged with INTRINSIC_FUNC_INQUIRY when the flex bug gets resolved in the future */
+INTRINSIC_FUNC_INQUIRY_IEEE     (IEEE_SUPPORT_DATATYPE|IEEE_SUPPORT_DENORMAL|IEEE_SUPPORT_DIVIDE|IEEE_SUPPORT_INF|IEEE_SUPPORT_IO|IEEE_SUPPORT_NAN|IEEE_SUPPORT_SQRT|IEEE_SUPPORT_STANDARD|IEEE_SUPPORT_SUBNORMAL|IEEE_SUPPORT_UNDERFLOW_CONTROL)
+
+INTRINSIC_FUNC_INQUIRY          ({INTRINSIC_FUNC_INQUIRY_IEEE}|ALLOCATED|ASSOCIATED|BIT_SIZE|C_SIZEOF|COSHAPE|DIGITS|EPSILON|EXTENDS_TYPE_OF|FAILED_IMAGES|HUGE|IS_CONTIGUOUS|IS_IOSTAT_END|IS_IOSTAT_EOR|KIND|LBOUND|LCOBOUND|LEN|MAXEXPONENT|MINEXPONENT|NEW_LINE|PRECISION|PRESENT|RADIX|RANGE|RANK|SAME_TYPE_AS|SIZE|STORAGE_SIZE|TINY|UBOUND|UCOBOUND)
+
+INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE (IEEE_SELECTED_REAL_KIND|IEEE_SUPPORT_FLAG|IEEE_SUPPORT_HALTING|IEEE_SUPPORT_ROUNDING)
+
+INTRINSIC_FUNC_TRANSFORMATIONAL ({INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE}|ALL|ANY|BESSEL_JN|BESSEL_YN|C_ASSOCIATED|C_FUNLOC|C_LOC|COMMAND_ARGUMENT_COUNT|COMPILER_OPTIONS|COMPILER_VERSION|COUNT|CSHIFT|DOT_PRODUCT|EOSHIFT|FINDLOC|GET_TEAM|IALL|IANY|IMAGE_INDEX|INDEX|IPARITY|MATMUL|MAXLOC|MAXVAL|MERGE|MERGE_BITS|MINLOC|MINVAL|NORM2|NULL|NUM_IMAGES|PACK|PARITY|PRODUCT|REDUCE|REPEAT|RESHAPE|SELECTED_CHAR_KIND|SELECTED_INT_KIND|SELECTED_REAL_KIND|SPREAD|STOPPED_IMAGES|SUM|TEAM_NUMBER|THIS_IMAGE|TRANSPOSE|UNPACK)
+
+INTRINSIC_FUNC_VOID             (CFI_address|CFI_allocate|CFI_deallocate|CFI_establish|CFI_is_contiguous|CFI_section|CFI_select_part|CFI_setpointer)
+
+INTRINSIC_FUNC                  ({INTRINSIC_FUNC_ELEMENTAL}|{INTRINSIC_FUNC_INQUIRY}|{INTRINSIC_FUNC_TRANSFORMATIONAL})
+
+/* intrinsic subroutines */
+
+INTRINSIC_SUB_ATOMIC            (ATOMIC_ADD|ATOMIC_AND|ATOMIC_CAS|ATOMIC_DEFINE|ATOMIC_FETCH_ADD|ATOMIC_FETCH_AND|ATOMIC_FETCH_OR|ATOMIC_FETCH_XOR|ATOMIC_INT_KIND|ATOMIC_LOGICAL_KIND|ATOMIC_OR|ATOMIC_REF|ATOMIC_XOR)
+
+INTRINSIC_SUB_COLLECTIVE        (CO_BROADCAST|CO_MAX|CO_MIN|CO_REDUCE|CO_SUM)
+
+/* INTRINSIC_SUB_IMPURE_IEEE can be merged with INTRINSIC_SUB_IMPURE when the flex bug gets resolved in the future */
+INTRINSIC_SUB_IMPURE_IEEE       (IEEE_GET_MODES|IEEE_GET_ROUNDING_MODE|IEEE_GET_STATUS|IEEE_GET_UNDERFLOW_MODE|IEEE_SET_MODES|IEEE_SET_ROUNDING_MODE|IEEE_SET_STATUS|IEEE_SET_UNDERFLOW_MODE)
+INTRINSIC_SUB_IMPURE            ({INTRINSIC_SUB_IMPURE_IEEE}|C_F_POINTER|CPU_TIME|DATE_AND_TIME|EVENT_QUERY|EXECUTE_COMMAND_LINE|GET_COMMAND|GET_COMMAND_ARGUMENT|GET_ENVIRONMENT_VARIABLE|RANDOM_INIT|RANDOM_NUMBER|RANDOM_SEED|SYSTEM_CLOCK)
+
+/* INTRINSIC_SUB_PURE_IEEE can be merged with INTRINSIC_SUB_PURE when the flex bug gets resolved in the future */
+INTRINSIC_SUB_PURE_IEEE         (IEEE_SET_FLAG|IEEE_SET_HALTING_MODE)
+INTRINSIC_SUB_PURE              ({INTRINSIC_SUB_PURE_IEEE}|C_F_PROCPOINTER|MOVE_ALLOC)
+
+INTRINSIC_SUB                   ({INTRINSIC_SUB_ATOMIC}|{INTRINSIC_SUB_COLLECTIVE}|{INTRINSIC_SUB_IMPURE}|{INTRINSIC_SUB_PURE})
+
+INTRINSIC_PROC                  ({INTRINSIC_SUB}|{INTRINSIC_FUNC})
+
+/* INTRINSIC_MODULE_IEEE can be merged with INTRINSIC_MODULE when the flex bug gets resolved in the future */
+INTRINSIC_MODULE_IEEE           (IEEE_ARITHMETIC|IEEE_EXCEPTIONS|IEEE_FEATURES)
+INTRINSIC_MODULE                ({INTRINSIC_MODULE_IEEE}|ISO_C_BINDING|ISO_FORTRAN_ENV)
+
+SPECIFIER                       (ACCESS|ACQUIRED_LOCK|ACTION|ADVANCE|ASYNCHRONOUS|BLANK|DECIMAL|DELIM|DIM|DIRECT|ENCODING|EOR|ERR|ERRMSG|EXIST|FILE|FMT|FORM|FORMATTED|ID|IOLENGTH|IOMSG|IOSTAT|KIND|LEN|MOLD|NAME|NAMED|NEW_INDEX|NEWUNIT|NEXTREC|NML|NUMBER|OPENED|PAD|PENDING|POS|POSITION|QUIET|READ|READWRITE|REC|RECL|ROUND|SEQUENTIAL|SIGN|SIZE|SOURCE|STAT|STATUS|STREAM|TEAM|TEAM_NUMBER|UNFORMATTED|UNIT|UNTIL_COUNT|WRITE)
+
+STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ENUM|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|FUNCTION|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|END{BS}SUBMODULE|SUBROUTINE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
+
+/* INTRINSIC_DERIVED_TYPE_IEEE and INTRINSIC_DERIVED_TYPE_CFI can be merged with INTRINSIC_DERIVED_TYPE when the flex bug gets resolved in the future */
+INTRINSIC_DERIVED_TYPE_IEEE     (IEEE_CLASS_TYPE|IEEE_FEATURES_TYPE|IEEE_FLAG_TYPE|IEEE_MODES_TYPE|IEEE_ROUND_TYPE|IEEE_STATUS_TYPE)
+INTRINSIC_DERIVED_TYPE_CFI      (CFI_cdesc_t)
+INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
 
 /* |  */
 
@@ -280,68 +356,168 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 %%
  /*==================================================================*/
 
- /*-------- ignore ------------------------------------------------------------*/
-
-<Start>{IGNORE}/{BS}"("                   { // do not search keywords, intrinsics... TODO: complete list
-                                            codifyLines(yyscanner,yytext);
-                                          }
  /*-------- inner construct ---------------------------------------------------*/
 
-<Start>{COMMANDS}/{BS}[,( \t\n]           {  // highlight
-                                            /* font class is defined e.g. in doxygen.css */
-                                            startFontClass(yyscanner,"keyword");
-                                            codifyLines(yyscanner,yytext);
-                                            endFontClass(yyscanner);
-                                          }
-<Start>{FLOW}/{BS}[,( \t\n]               {
-                                          if (yyextra->isFixedForm)
-                                          {
-                                            if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;
-                                          }
-                                          if (yyextra->currentMemberDef && yyextra->currentMemberDef->isFunction())
-                                          {
-                                            std::lock_guard<std::mutex> lock(g_countFlowKeywordsMutex);
-                                            MemberDefMutable *mdm = toMemberDefMutable(yyextra->currentMemberDef);
-                                            if (mdm)
-                                            {
-                                              mdm->incrementFlowKeyWordCount();
-                                            }
-                                          }
-                                          /* font class is defined e.g. in doxygen.css */
-                                          startFontClass(yyscanner,"keywordflow");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>{BS}(CASE|CLASS|TYPE){BS_}(IS|DEFAULT) {
-                                          startFontClass(yyscanner,"keywordflow");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>{BS}"end"({BS}{FLOW})/[ \t\n]       { // list is a bit long as not all have possible end
-                                          startFontClass(yyscanner,"keywordflow");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>"implicit"{BS}("none"|{TYPE_SPEC})  {
-                                          startFontClass(yyscanner,"keywordtype");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>^{BS}"namelist"/[/]              {  // Namelist specification
-                                          startFontClass(yyscanner,"keywordtype");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
+<Start>{BS}"%"/{BS}[a-zA-Z]+.*                                  {   // highlight rule for the percent-symbol separator of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}[.]*("+"|"-"|"*"|"/"|"<"|">"|"="|"&"){BS}                {   // highlight rule for the operators of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}(0|[1-9]\d*)(\.\d*)?(e[-\+]?(0|[1-9]\d*))?(_([a-zA-Z])+)?    {   // highlight rule for the numeric values of Fortran.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_numeric_literal");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{NAMED_CONST}{BS}                                        {   // highlight rule for the named constants of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_named_const");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Declaration>{BS}{ATTR_SPEC}[^0-9a-zA-Z]{BS}                    {   // highlight rule for the attributes of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}"("{BS}{INTRINSIC_DERIVED_TYPE}{BS}")"{BS}               {   // highlight rule for Fortran intrinsic derived types.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{INTRINSIC_DERIVED_TYPE}{BS}                             {   // highlight rule for Fortran intrinsic module names.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{INTRINSIC_MODULE}{BS}                                   {   // highlight rule for Fortran intrinsic module names.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_module");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start,Declaration>{BS}[^%]{SPECIFIER}/{BS}={BS}                {   // highlight rule for Fortran intrinsic specifier (intrinsic procedure argument) names.
+                                                                    // \todo: A specifier must be enclosed with parentheses. This is not currently enforced.
+                                                                    startFontClass(yyscanner,"fortran_spcifier");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+
+ /* Fortran intrinsic procedures */
+
+<Start>^{BS}"real"/[,:( ].*                                     {   // real is a data type but also an elemental function, which makes it a bit tricky.
+                                                                    yy_push_state(YY_START,yyscanner);
+                                                                    BEGIN(Declaration);
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    yyextra->code->codify(QCString(yytext));
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>^{BS}"logical"/[,:( ].*                                  {   // logical is a data type but also an elemental function, which makes it a bit tricky.
+                                                                    yy_push_state(YY_START,yyscanner);
+                                                                    BEGIN(Declaration);
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    yyextra->code->codify(QCString(yytext));
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start,Declaration>{BS}{INTRINSIC_FUNC}/{BS}[(]                 {   // highlight rule for Fortran intrinsic functions.
+                                                                    // \todo This must be improved when function name appears in an intrinsic module USE statement.
+                                                                    // \todo The current rule only captures function names when followed by "(".
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_function");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}{INTRINSIC_SUB}/{BS}[(]                              {   // highlight rule for Fortran intrinsic subroutines.
+                                                                    // \todo This must be improved when subroutine name appears in an intrinsic module USE statement.
+                                                                    // \todo The current rule only captures subroutine names when followed by "(".
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_subroutine");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"MPI_"{BS}[a-zA-Z_]+/{BS}                            {   // highlight rule for MPI module intrinsic entities.
+                                                                    // \todo The current search pattern is too generic. In the future, all MPI entities from
+                                                                    // \todo the standard MPI module must be listed here and explicitly searched for.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_mpi");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+
+ /* Fortran intrinsic statements */
+
+<Start>{BS}{STATEMENT}/{BS}[;( \t\n]                            {   // highlight rule for Fortran intrinsic statements.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{FLOW}/{BS}[;( \t\n]                                     {   // highlight rule for Fortran flow-control statements.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    if (yyextra->isFixedForm)
+                                                                    {
+                                                                        if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;
+                                                                    }
+                                                                    if (yyextra->currentMemberDef && yyextra->currentMemberDef->isFunction())
+                                                                    {
+                                                                        std::lock_guard<std::mutex> lock(g_countFlowKeywordsMutex);
+                                                                        MemberDefMutable *mdm = toMemberDefMutable(yyextra->currentMemberDef);
+                                                                        if (mdm)
+                                                                        {
+                                                                            mdm->incrementFlowKeyWordCount();
+                                                                        }
+                                                                    }
+                                                                    /* font class is defined e.g. in doxygen.css */
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>(CASE|CLASS|TYPE|RANK){BS_}(IS|DEFAULT)                  {
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}"end"{BS}{FLOW_END}/[ ;\t\n]                             {   // list is a bit long as not all have possible end. <*> needed since the FLOW could be all in one line.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>"implicit"{BS}("none"|{TYPE_SPEC})                       {
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
  /*-------- use statement -------------------------------------------*/
-<Start>"use"{BS_}                       {
-                                          startFontClass(yyscanner,"keywordtype");
+<Start>"use"{BS}                        {
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Use);
+                                        }
+<Use>("intrinsic"|"non_intrinsic")      { // TODO: rename
+                                          startFontClass(yyscanner,"fortran_attribute");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN(Use);
                                         }
 <Use>"ONLY"                             { // TODO: rename
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -349,7 +525,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Use>{ID}                               {
                                           QCString tmp(yytext);
-                                          tmp = tmp.lower();
+                                          // tmp = tmp.lower();
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
                                           yyextra->insideBody=FALSE;
@@ -366,7 +542,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           YY_FTN_RESET}
 <UseOnly>{ID}                           {
                                           QCString tmp(yytext);
-                                          tmp = tmp.lower();
+                                          // tmp = tmp.lower();
                                           yyextra->useEntry.onlyNames.push_back(tmp);
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
@@ -379,7 +555,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <*>"import"{BS}/"\n"                    |
 <*>"import"{BS_}                        {
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -391,14 +567,14 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->insideBody=FALSE;
                                         }
 <Import>("ONLY"|"NONE"|"ALL")           {
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
  /*-------- fortran module  -----------------------------------------*/
 <Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n {  //
                                           startScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -407,20 +583,20 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Start>("enum")/{BS_}|{BS}{COMMA}{BS}{LANGUAGE_BIND_SPEC}|\n {  //
                                           startScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN(ClassName);
                                         }
 <*>{LANGUAGE_BIND_SPEC}                 {  //
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
 <Start>("type")/{BS_}|({COMMA}({ACCESS_SPEC}|ABSTRACT|EXTENDS))|\n {  //
                                           startScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -430,13 +606,13 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           if (yyextra->currentModule == "module")
                                           {
                                             yyextra->currentModule=yytext;
-                                            yyextra->currentModule = yyextra->currentModule.lower();
+                                            yyextra->currentModule = yyextra->currentModule;//.lower();
                                           }
                                           generateLink(yyscanner,*yyextra->code,yytext);
                                           yy_pop_state(yyscanner);
                                         }
 <ClassName>({ACCESS_SPEC}|ABSTRACT|EXTENDS)/[,:( ] { //| variable declaration
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_attribute");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
@@ -456,12 +632,12 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
  /*-------- subprog definition -------------------------------------*/
 <Start>({PREFIX}{BS_})?{TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_prefix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
-<Start>({PREFIX}{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
-                                          startFontClass(yyscanner,"keyword");
+<Start>({PREFIX}{BS_})?("module"{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
+                                          startFontClass(yyscanner,"fortran_prefix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -473,7 +649,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           generateLink(yyscanner,*yyextra->code,yytext);
                                         }
 <Subprog>"result"/{BS}"("[^)]*")"       {
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_suffix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
@@ -488,7 +664,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface")?{BS}     {  // Fortran subroutine or function ends
                                           //cout << "===> end function " << yytext << endl;
                                           endScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -501,26 +677,20 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface"){BS}/(\n|!|;) {  // Fortran subroutine or function ends
                                           //cout << "===> end function " << yytext << endl;
                                           endScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
  /*-------- variable declaration ----------------------------------*/
-<Start>^{BS}"real"/[,:( ]               { // real is a bit tricky as it is a data type but also a function.
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(Declaration);
-                                          startFontClass(yyscanner,"keywordtype");
-                                          yyextra->code->codify(QCString(yytext));
-                                          endFontClass(yyscanner);
-                                        }
 <Start>{TYPE_SPEC}/[,:( ]               {
                                           QCString typ(yytext);
                                           typ = removeRedundantWhiteSpace(typ.lower());
                                           if (typ.startsWith("real")) YY_FTN_REJECT;
+                                          if (typ.startsWith("logical")) YY_FTN_REJECT;
                                           if (typ == "type" || typ == "class" || typ == "procedure") yyextra->inTypeDecl = 1;
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN(Declaration);
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
@@ -531,20 +701,20 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                             BEGIN(Declaration);
                                             yyextra->isExternal = true;
                                           }
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_attribute");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
 <Declaration>({TYPE_SPEC}|{ATTR_SPEC})/[,:( ] { //| variable declaration
                                           if (QCString(yytext) == "external") yyextra->isExternal = true;
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
 <Declaration>{ID}                       { // local var
                                           if (yyextra->isFixedForm && yy_my_start == 1)
                                           {
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             yyextra->code->codify(QCString(yytext));
                                             endFontClass(yyscanner);
                                           }
@@ -618,7 +788,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
  /*-------- subprog calls  -----------------------------------------*/
 
 <Start>"call"{BS_}                      {
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -640,7 +810,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           {
                                             yy_push_state(YY_START,yyscanner);
                                             BEGIN(Declaration);
-                                            startFontClass(yyscanner,"keywordtype");
+                                            startFontClass(yyscanner,"fortran_statement");
                                             yyextra->code->codify(QCString(yytext).stripWhiteSpace());
                                             endFontClass(yyscanner);
                                             yyextra->code->codify(QCString(yytext + 4));
@@ -698,7 +868,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           }
                                           else // do not remove comment
                                           {
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             codifyLines(yyscanner,yyextra->docBlock);
                                             endFontClass(yyscanner);
                                           }
@@ -707,29 +877,48 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yy_pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
+<Start>^{BS}[!C]("DEC"|"DIR")"$"{BS}"ATTRIBUTES".*/"::" {   // ATTRIBUTES directive is treated separately as its argument (procedure name) needs to be recognized by Doxygen).
+                                                            startFontClass(yyscanner,"fortran_directive_intel");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+<Start>^{BS}[!C]("DEC"|"DIR")"$".*                      {   // highlight rule for Intel Fortran Compiler directives (except ATTRIBUTES).
+                                                            QCString directive(yytext);
+                                                            directive = removeRedundantWhiteSpace(directive.lower());
+                                                            if (directive.contains("attributes",true)) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_directive_intel");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+<Start>^{BS}[\!c]"$OMP".*                               {   // OpenMP directives
+                                                            yy_push_state(YY_START,yyscanner);
+                                                            BEGIN(Declaration);
+                                                            startFontClass(yyscanner,"fortran_directive_omp");
+                                                            yyextra->code->codify(QCString(yytext));
+                                                            endFontClass(yyscanner);
+                                                        }
+<*>"!"[^><\n].*|"!"$                                    {   // normal comment
+                                                            if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                            if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_comment");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
 
-<*>"!"[^><\n].*|"!"$                    { // normal comment
-                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                          if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
-                                          startFontClass(yyscanner,"comment");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
+<*>^[Cc*].*                                             {   // normal comment
+                                                            if(! yyextra->isFixedForm) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_comment");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
 
-<*>^[Cc*].*                             { // normal comment
-                                          if(! yyextra->isFixedForm) YY_FTN_REJECT;
-
-                                          startFontClass(yyscanner,"comment");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
 <*>"assignment"/{BS}"("{BS}"="{BS}")"   {
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
 <*>"operator"/{BS}"("[^)]*")"           {
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
@@ -757,7 +946,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <String>\n                              { // string with \n inside
                                           yyextra->contLineNr++;
                                           yyextra->str+=yytext;
-                                          startFontClass(yyscanner,"stringliteral");
+                                          startFontClass(yyscanner,"fortran_string");
                                           codifyLines(yyscanner,yyextra->str);
                                           endFontClass(yyscanner);
                                           yyextra->str = "";
@@ -766,7 +955,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <String>\"|\'                           { // string ends with next quote without previous backspace
                                           if(yytext[0]!=yyextra->stringStartSymbol) YY_FTN_REJECT; // single vs double quote
                                           yyextra->str+=yytext;
-                                          startFontClass(yyscanner,"stringliteral");
+                                          startFontClass(yyscanner,"fortran_string");
                                           codifyLines(yyscanner,yyextra->str);
                                           endFontClass(yyscanner);
                                           yy_pop_state(yyscanner);
@@ -792,7 +981,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           {
                                             codifyLines(yyscanner,yytext);
                                             // comment cannot extend over the end of a line so should always be terminated at the end of the line.
-                                            if (yyextra->currentFontClass && !strcmp(yyextra->currentFontClass,"comment")) endFontClass(yyscanner);
+                                            if (yyextra->currentFontClass && !strcmp(yyextra->currentFontClass,"fortran_comment")) endFontClass(yyscanner);
                                           }
                                           yyextra->contLineNr++;
                                           YY_FTN_RESET
@@ -802,7 +991,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <*>[\x80-\xFF]*                         { // keep utf8 characters together...
                                           if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
                                           {
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             codifyLines(yyscanner,yytext);
                                           }
                                           else
@@ -816,7 +1005,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                             //yy_push_state(YY_START,yyscanner);
                                             //BEGIN(DocBlock);
                                             //yyextra->docBlock=yytext;
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             codifyLines(yyscanner,yytext);
                                           }
                                           else
@@ -824,18 +1013,27 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                             yyextra->code->codify(QCString(yytext));
                                           }
                                         }
-<*>{LOG_OPER}                           { // Fortran logical comparison keywords
-                                          yyextra->code->codify(QCString(yytext));
+<*>{OPERATOR_LOGICAL}                   {   // Fortran logical comparison keywords
+                                            startFontClass(yyscanner,"fortran_operator_logical");
+                                            //codifyLines(yyscanner,yyextra->docBlock);
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                        }
+<*>{OPERATOR_SYMBOLS}                   { // Fortran operator symbols
+                                            startFontClass(yyscanner,"fortran_operator_symbols");
+                                            //codifyLines(yyscanner,yyextra->docBlock);
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
                                         }
 <*><<EOF>>                              {
-                                          if (YY_START == DocBlock) {
-                                            if (!Config_getBool(STRIP_CODE_COMMENTS))
-                                            {
-                                              startFontClass(yyscanner,"comment");
-                                              codifyLines(yyscanner,yyextra->docBlock);
-                                              endFontClass(yyscanner);
+                                            if (YY_START == DocBlock) {
+                                                if  (!Config_getBool(STRIP_CODE_COMMENTS))
+                                                {
+                                                    startFontClass(yyscanner,"fortran_comment");
+                                                    codifyLines(yyscanner,yyextra->docBlock);
+                                                    endFontClass(yyscanner);
+                                                }
                                             }
-                                          }
                                           yyterminate();
                                         }
 %%
@@ -938,9 +1136,10 @@ static void startCodeLine(yyscan_t yyscanner)
       }
       else if (d->isLinkableInProject())
       {
-        yyextra->code->writeLineNumber(d->getReference(),
-                                d->getOutputFileBase(),
-                                QCString(),yyextra->yyLineNr);
+        yyextra->code->writeLineNumber( d->getReference(),
+                                        d->getOutputFileBase(),
+                                        QCString(),yyextra->yyLineNr
+                                        );
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
@@ -1127,7 +1326,8 @@ static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, 
   for (auto it = yyextra->scopeStack.rbegin(); it!=yyextra->scopeStack.rend(); ++it)
   {
     const Scope &scope = *it;
-    std::string lowMemName = memberName.lower().str();
+    //std::string lowMemName = memberName.lower().str();
+    std::string lowMemName = memberName.str();
     if (scope.localVars   .find(lowMemName)!=std::end(scope.localVars)     &&  // local var
         scope.externalVars.find(lowMemName)==std::end(scope.externalVars))     // and not external
     {
@@ -1255,7 +1455,8 @@ static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const QCStr
   ClassDef *cd=0;
   NamespaceDef *nsd=0;
   QCString name = lname;
-  name = removeRedundantWhiteSpace(name.lower());
+  // name = removeRedundantWhiteSpace(name.lower());
+  name = removeRedundantWhiteSpace(name);
 
   // check if lowercase lname is a linkable type or interface
   if ( (getFortranTypeDefs(name, yyextra->currentModule, cd, yyextra->useMembers)) && cd->isLinkable() )
@@ -1358,7 +1559,8 @@ static void addLocalVar(yyscan_t yyscanner,const QCString &varName)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (!yyextra->scopeStack.empty())
   {
-    std::string lowVarName = varName.lower().str();
+    // std::string lowVarName = varName.lower().str();
+    std::string lowVarName = varName.str();
     yyextra->scopeStack.back().localVars.insert(lowVarName);
     if (yyextra->isExternal) yyextra->scopeStack.back().externalVars.insert(lowVarName);
   }

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -611,7 +611,12 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           generateLink(yyscanner,*yyextra->code,yytext);
                                           yy_pop_state(yyscanner);
                                         }
-<ClassName>({ACCESS_SPEC}|ABSTRACT|EXTENDS)/[,:( ] { //| variable declaration
+<ClassName>({ACCESS_SPEC}|ABSTRACT|EXTENDS)/[,:( ] { // variable declaration
+                                          startFontClass(yyscanner,"fortran_attribute");
+                                          yyextra->code->codify(QCString(yytext));
+                                          endFontClass(yyscanner);
+                                        }
+<Start>{ACCESS_SPEC}/[,: ]              { // access attribute declaration
                                           startFontClass(yyscanner,"fortran_attribute");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -932,14 +932,14 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                                             codifyLines(yyscanner,yytext);
                                                             endFontClass(yyscanner);
                                                         }
-
+ /*
 <*>^[Cc*].*                                             {   // normal comment
                                                             if(! yyextra->isFixedForm) YY_FTN_REJECT;
                                                             startFontClass(yyscanner,"fortran_comment");
                                                             codifyLines(yyscanner,yytext);
                                                             endFontClass(yyscanner);
                                                         }
-
+ */
 <*>"assignment"/{BS}"("{BS}"="{BS}")"   {
                                           startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -328,7 +328,8 @@ INTRINSIC_MODULE                ({INTRINSIC_MODULE_IEEE}|ISO_C_BINDING|ISO_FORTR
 
 SPECIFIER                       (ACCESS|ACQUIRED_LOCK|ACTION|ADVANCE|ASYNCHRONOUS|BLANK|DECIMAL|DELIM|DIM|DIRECT|ENCODING|EOR|ERR|ERRMSG|EXIST|FILE|FMT|FORM|FORMATTED|ID|IOLENGTH|IOMSG|IOSTAT|KIND|LEN|MOLD|NAME|NAMED|NEW_INDEX|NEWUNIT|NEXTREC|NML|NUMBER|OPENED|PAD|PENDING|POS|POSITION|QUIET|READ|READWRITE|REC|RECL|ROUND|SEQUENTIAL|SIGN|SIZE|SOURCE|STAT|STATUS|STREAM|TEAM|TEAM_NUMBER|UNFORMATTED|UNIT|UNTIL_COUNT|WRITE)
 
-STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|FUNCTION|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|SUBMODULE|END{BS}SUBMODULE|SUBROUTINE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
+/* FUNCTION and SUBROUTINE are excluded from STATEMENT below to prevent dot-graph self-reference misrepresentations. */
+STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|SUBMODULE|END{BS}SUBMODULE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
 
 /* INTRINSIC_DERIVED_TYPE_IEEE and INTRINSIC_DERIVED_TYPE_CFI can be merged with INTRINSIC_DERIVED_TYPE when the flex bug gets resolved in the future */
 INTRINSIC_DERIVED_TYPE_IEEE     (IEEE_CLASS_TYPE|IEEE_FEATURES_TYPE|IEEE_FLAG_TYPE|IEEE_MODES_TYPE|IEEE_ROUND_TYPE|IEEE_STATUS_TYPE)
@@ -658,7 +659,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                         }
  /*-------- subprog definition -------------------------------------*/
  /*
-<Start>({PREFIX}{BS_})?{TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
+ <Start>({PREFIX}{BS_})?({TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
                                           startFontClass(yyscanner,"fortran_prefix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
@@ -722,7 +723,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
-<Start>^{BS}{ATTR_SPEC}                 { // declare attribute statement. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
+<Start>^{BS}({ATTR_SPEC}{BS_})+         { // declare attribute statement. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
                                           if (QCString(yytext) == "external")
                                           {
                                             yy_push_state(YY_START,yyscanner);
@@ -966,9 +967,9 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->code->codify(QCString(yytext));
                                         }
 <Start>{ID}                             {
-                                            yyextra->insideBody=TRUE;
+                                            //yyextra->insideBody=TRUE; // why is this needed? It messes up the dot-graph representations by generating artificial self-references.
                                             generateLink(yyscanner,*yyextra->code, yytext);
-                                            yyextra->insideBody=FALSE;
+                                            //yyextra->insideBody=FALSE;
                                         }
  /*------ strings --------------------------------------------------*/
 <String>\n                              { // string with \n inside
@@ -1477,7 +1478,7 @@ static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // dictionary with 
 }
 
 
-static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const QCString &lname)
+static void generateLink(yyscan_t yyscanner, CodeOutputInterface &ol, const QCString &lname)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   ClassDef *cd=0;
@@ -1496,7 +1497,7 @@ static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const QCStr
     }
     else
     { // write type or interface link
-      writeMultiLineCodeLink(yyscanner, ol,cd,name);
+      writeMultiLineCodeLink(yyscanner, ol, cd, name);
       addToSearchIndex(yyscanner, name);
     }
   }

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1744,7 +1744,8 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
     endFontClass(yyscanner);
     yyextra->code->endCodeLine();
   }
-  if (!fileDef && isExampleBlock && yyextra->sourceFileDef)
+// The correction `!fileDef && ` is introduced in Doxygen 1.9.5 to resolve the Fortran parser segfault, but does not appear to resolve it.
+  if (!fileDef && isExampleBlock && yyextra->sourceFileDef) 
   {
     // delete the temporary file definition used for this example
     delete yyextra->sourceFileDef;

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1744,7 +1744,7 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
     endFontClass(yyscanner);
     yyextra->code->endCodeLine();
   }
-  if (isExampleBlock && yyextra->sourceFileDef)
+  if (!fileDef && isExampleBlock && yyextra->sourceFileDef)
   {
     // delete the temporary file definition used for this example
     delete yyextra->sourceFileDef;

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -63,6 +63,8 @@ typedef yyguts_t *yyscan_t;
 #include "fortranscanner.h"
 #include "containers.h"
 
+const int fixedCommentAfter = 72;
+
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
@@ -125,24 +127,23 @@ class Scope
 
 struct fortrancodeYY_state
 {
-  QCString      docBlock;                   //!< contents of all lines of a documentation block
-  QCString      currentModule=QCString();   //!< name of the current enclosing module
-  UseMap      useMembers;                   //!< info about used modules
-  UseEntry      useEntry;                   //!< current use statement info
-  std::vector<Scope>  scopeStack;
-  bool          isExternal = false;
-  QCString      str=QCString();             //!< contents of fortran string
+  QCString              docBlock;                   //!< contents of all lines of a documentation block
+  QCString              currentModule=QCString();   //!< name of the current enclosing module
+  UseMap                useMembers;                 //!< info about used modules
+  UseEntry              useEntry;                   //!< current use statement info
+  std::vector<Scope>    scopeStack;
+  bool                  isExternal = false;
+  QCString              str=QCString();             //!< contents of fortran string
 
   CodeOutputInterface * code = 0;
 
   const char *  inputString = 0;     //!< the code fragment as text
   yy_size_t     inputPosition = 0;   //!< read offset during parsing
   int           inputLines = 0;      //!< number of line in the code fragment
-  QCString      fileName;
   int           yyLineNr = 0;        //!< current line number
   int           contLineNr = 0;      //!< current, local, line number for continuation determination
   int          *hasContLine = 0;     //!< signals whether or not a line has a continuation line (fixed source form)
-  bool          insideCodeLine = false;
+  bool          needsTermination = false;
   const Definition *searchCtx = 0;
   bool          collectXRefs = false;
   bool          isFixedForm = false;
@@ -169,18 +170,14 @@ struct fortrancodeYY_state
 
   bool          endComment = false;
   TooltipManager tooltipManager;
-
-   int fixedCommentAfter = 72;
 };
 
 #if USE_STATE2STRING
 static const char *stateToString(int state);
 #endif
 
-static bool getFortranNamespaceDefs(const QCString &mname,
-                               NamespaceDef *&cd);
-static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName,
-                               ClassDef *&cd, const UseMap &useMap);
+static bool getFortranNamespaceDefs(const QCString &mname, NamespaceDef *&cd);
+static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName, ClassDef *&cd, const UseMap &useMap);
 
 //----------------------------------------------------------------------------
 
@@ -192,11 +189,8 @@ static void startCodeLine(yyscan_t yyscanner);
 static void endCodeLine(yyscan_t yyscanner);
 static void nextCodeLine(yyscan_t yyscanner);
 static void codifyLines(yyscan_t yyscanner,const QCString &text);
-static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
-                  Definition *d,const QCString &text);
-static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd,
-                                    const QCString &memberText,
-                                    CodeOutputInterface &ol);
+static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol, Definition *d,const QCString &text);
+static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd, const QCString &memberText, CodeOutputInterface &ol);
 static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // map with used modules
                     const QCString &memberText,  // exact member text
                     CodeOutputInterface &ol,
@@ -208,10 +202,8 @@ static void startScope(yyscan_t yyscanner);
 static void endScope(yyscan_t yyscanner);
 static void addUse(yyscan_t yyscanner,const QCString &moduleName);
 static void addLocalVar(yyscan_t yyscanner,const QCString &varName);
-static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName,
-                                 const UseMap &useMap);
+static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName, const UseMap &useMap);
 static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
-static inline void pop_state(yyscan_t yyscanner);
 
 
 //-------------------------------------------------------------------
@@ -223,15 +215,10 @@ static std::mutex g_countFlowKeywordsMutex;
 #undef  YY_INPUT
 #define YY_INPUT(buf,result,max_size) result=yyread(yyscanner,buf,max_size);
 
-// otherwise the filename would be the name of the converted file (*.cpp instead of *.l)
-static inline const char *getLexerFILE() {return __FILE__;}
-#include "doxygen_lex.h"
-
 %}
 
 IDSYM     [a-z_A-Z0-9]
 ID        [a-z_A-Z]+{IDSYM}*
-SUBPROG   (subroutine|function)
 B         [ \t]
 BS        [ \t]*
 BS_       [ \t]+
@@ -242,22 +229,112 @@ ARGS_L1   ("("{ARGS_L1a}*")")
 ARGS_L2   "("({ARGS_L0}|[^()]|{ARGS_L1a}|{ARGS_L1})*")"
 ARGS      {BS}({ARGS_L0}|{ARGS_L1}|{ARGS_L2})
 
-NUM_TYPE  (complex|integer|logical|real)
-LOG_OPER  (\.and\.|\.eq\.|\.eqv\.|\.ge\.|\.gt\.|\.le\.|\.lt\.|\.ne\.|\.neqv\.|\.or\.|\.not\.)
-KIND      {ARGS}
-CHAR      (CHARACTER{ARGS}?|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
-TYPE_SPEC (({NUM_TYPE}({BS}"*"{BS}[0-9]+)?)|({NUM_TYPE}{KIND})|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
+/* The following appear in submodules as (subroutine|function|procedure) */
+SUBPROG   (subroutine|function|procedure)
 
-INTENT_SPEC intent{BS}"("{BS}(in|out|in{BS}out){BS}")"
-ATTR_SPEC (IMPLICIT|ALLOCATABLE|DIMENSION{ARGS}|EXTERNAL|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|(NON_)?RECURSIVE|PURE|IMPURE|ELEMENTAL|VALUE|NOPASS|DEFERRED|CONTIGUOUS|VOLATILE)
-ACCESS_SPEC (PROTECTED|PRIVATE|PUBLIC)
+/* REAL and LOGICAL are treated separately as it can also be a function */
+NUM_TYPE            (COMPLEX|INTEGER)
+OPERATOR_LOGICAL    (\.and\.|\.eq\.|\.eqv\.|\.ge\.|\.gt\.|\.le\.|\.lt\.|\.ne\.|\.neqv\.|\.or\.|\.not\.)
+OPERATOR_SYMBOLS    [\+\-\*/%::><=&]
+KIND      {ARGS}
+
+/* The pattern CHARACTER{ARGS}? is inconsistent with Fortran syntax and as such, removed from CHAR */
+CHAR      (CHARACTER|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
+
+/* The patterns ({NUM_TYPE}{KIND}) and ({NUM_TYPE}({BS}"*"{BS}[0-9]+)?) are inconsistent with Fortran syntax and as such, was removed from TYPE_SPEC */
+TYPE_SPEC ({NUM_TYPE}|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
+
+ACCESS_SPEC         (PROTECTED|PRIVATE|PUBLIC)
+INTENT_SPEC         INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"
+
+/* Fortran attributes except BIND and C which are treated separately */
+ATTR_SPEC           (ALLOCATABLE|ASSIGNMENT|ASYNCHRONOUS|ABSTRACT|BIND|CODIMENSION|CONTIGUOUS|DEFERRED|DIMENSION|ELEMENTAL|EXTENDS|EXTERNAL|IMPURE|INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"|INTRINSIC|LOCAL|LOCAL_INIT|NON_INTRINSIC|NON_OVERRIDABLE|NON_RECURSIVE|NOPASS|OPERATOR|OPTIONAL|OVERRIDABLE|PARAMETER|PASS|POINTER|PRIVATE|PROTECTED|PUBLIC|PURE|RECURSIVE|SAVE|SEQUENCE|SHARED|TARGET|VALUE|VOLATILE)
+
+/* attributes that take arguments */
+ATTR_SPEC_WARG      (CODIMENSION|DIMENSION|EXTENDS|OPERATOR|PASS|BIND)
+
 /* Assume that attribute statements are almost the same as attributes. */
-ATTR_STMT {ATTR_SPEC}|DIMENSION
-FLOW      (DO|SELECT|CASE|SELECT{BS}(CASE|TYPE)|WHERE|IF|THEN|ELSE|WHILE|FORALL|ELSEWHERE|ELSEIF|RETURN|CONTINUE|EXIT|GO{BS}TO)
-COMMANDS  (FORMAT|CONTAINS|MODULE{BS_}PROCEDURE|WRITE|READ|ALLOCATE|ALLOCATED|ASSOCIATED|PRESENT|DEALLOCATE|NULLIFY|SIZE|INQUIRE|OPEN|CLOSE|FLUSH|DATA|COMMON)
-IGNORE    (CALL)
-PREFIX    ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
-LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
+ATTR_STMT           {ATTR_SPEC}
+
+/* Intel directive statement and attributes. */
+DIR_INTEL_STATEMENT (ALIAS|ASSUME|ASSUME_ALIGNED|ATTRIBUTES|DLLEXPORT|BLOCK_LOOP|DECLARE|DEFINE|DISTRIBUTE{BS_}POINT|FIXEDFORMLINESIZE|FMA|FORCEINLINE|FREEFORM|IDENT|IF|IF{BS_}DEFINED|INLINE|INTEGER|IVDEP|LOOP{BS_}COUNT|MESSAGE|NOBLOCK_LOOP|NODECLARE|NOFMA|NOFREEFORM|NOFUSION|NOINLINE|NOOPTIMIZE|NOPARALLEL|NOPREFETCH|NOSTRICT|NOUNROLL|NOUNROLL_AND_JAM|NOVECTOR|OBJCOMMENT|OPTIMIZE|OPTIONS|PACK|PARALLEL|PREFETCH|PSECT|REAL|SIMD|STRICT|UNDEFINE|UNROLL|UNROLL_AND_JAM|VECTOR|ALIGN|ALLOCATABLE|ALLOW_NULL|C|CODE_ALIGN|CONCURRENCY_SAFE|CVF|DECORATE|DEFAULT|DLLIMPORT|EXTERN|FASTMEM|IGNORE_LOC|INLINE|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING)
+
+/* ("ATTRIBUTE"{BS}[,]?{BS} */
+/* |ALLOCATABLE|C|DEFAULT|DLLEXPORT|DLLIMPORT|EXTERN|FASTMEM|INLINE|FORCEINLINE|IGNORE_LOC|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|NOINLINE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING|VECTOR */
+
+/* IEEE constants can be merged with NAMED_CONST in the future.
+Currently, including IEEE objects increases the number of flex rules to beyond what GNU flex can handle.
+The flex "flex: input rules are too complicated (>= 32000 NFA states)" error can be resolved by increasing
+the definitions in flexdef.h of flex source code for:
+    #define JAMSTATE -32766
+    #define MAXIMUM_MNS 31999
+    #define BAD_SUBSCRIPT -32767
+before compiling th flex library. However, the default distributed versions of flex cannot handle this.
+*/
+
+NAMED_CONST_IEEE                (IEEE_ALL|IEEE_ALL|IEEE_AWAY|IEEE_DATATYPE|IEEE_DENORMAL|IEEE_DIVIDE|IEEE_DIVIDE_BY_ZERO|IEEE_DOWN|IEEE_HALTING|IEEE_INEXACT|IEEE_INEXACT_FLAG|IEEE_INF|IEEE_INVALID|IEEE_INVALID_FLAG|IEEE_NAN|IEEE_NEAREST|IEEE_NEGATIVE_DENORMAL|IEEE_NEGATIVE_INF|IEEE_NEGATIVE_NORMAL|IEEE_NEGATIVE_SUBNORMAL|IEEE_NEGATIVE_ZERO|IEEE_OTHER|IEEE_OTHER_VALUE|IEEE_OVERFLOW|IEEE_POSITIVE_DENORMAL|IEEE_POSITIVE_INF|IEEE_POSITIVE_NORMAL|IEEE_POSITIVE_SUBNORMAL|IEEE_POSITIVE_ZERO|IEEE_ROUNDING|IEEE_SIGNALING_NAN|IEEE_SQRT|IEEE_SUBNORMAL|IEEE_TO_ZERO|IEEE_UNDERFLOW|IEEE_UNDERFLOW_FLAG|IEEE_UP|IEEE_USUAL)
+
+NAMED_CONST                     ({NAMED_CONST_IEEE}|C_ALERT|C_BACKSPACE|C_BOOL|C_CARRIAGE_RETURN|C_CHAR|C_DOUBLE|C_DOUBLE_COMPLEX|C_FLOAT|C_FLOAT_COMPLEX|C_FORM_FEED|C_HORIZONTAL_TAB|C_INT|C_INT16_T|C_INT32_T|C_INT64_T|C_INT8_T|C_INT_FAST16_T|C_INT_FAST32_T|C_INT_FAST64_T|C_INT_FAST8_T|C_INT_LEAST16_T|C_INT_LEAST32_T|C_INT_LEAST64_T|C_INT_LEAST8_T|C_INTMAX_T|C_INTPTR_T|C_LONG|C_LONG_DOUBLE|C_LONG_DOUBLE_COMPLEX|C_LONG_LONG|C_NEW_LINE|C_NULL_CHAR|C_NULL_FUNPTR|C_NULL_PTR|C_SHORT|C_SIGNED_CHAR|C_SIZE_T|C_VERTICAL_TAB|CHARACTER_KINDS|CHARACTER_STORAGE_SIZE|CURRENT_TEAM|ERROR_UNIT|FILE_STORAGE_SIZE|INITIAL_TEAM|INPUT_UNIT|INT16|INT32|INT64|INT8|INTEGER_KINDS|IOSTAT_END|IOSTAT_EOR|IOSTAT_INQUIRE_INTERNAL_UNIT|LOGICAL_KINDS|NUMERIC_STORAGE_SIZE|OUTPUT_UNIT|PARENT_TEAM|REAL128|REAL64|REAL32|REAL_KINDS|STAT_FAILED_IMAGE|STAT_LOCKED|STAT_LOCKED_OTHER_IMAGE|STAT_STOPPED_IMAGE|STAT_UNLOCKED|STAT_UNLOCKED_FAILED_IMAGE|\.FALSE\.|\.TRUE\.)
+
+FLOW                            (DO|DO{BS}CONCURRENT|SELECT{BS}(CASE|TYPE|RANK)|CASE|IF|THEN|ELSE{BS}IF|ELSE|DO{BS}WHILE|WHERE|ELSEWHERE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
+
+FLOW_END                        (DO|SELECT|WHERE|IF|WHILE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
+
+PREFIX                          ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
+SUFFIX                          (RESULT{ARGS})
+/* The specified syntax is too generic and does not respect NAME and C as a specifiers. Also "bind" as an attribute takes precedence over its statement format.
+LANGUAGE_BIND_SPEC              BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
+*/
+
+/* INTRINSIC_FUNC_ELEMENTAL_IEEE can be merged with INTRINSIC_FUNC_ELEMENTAL when the flex bug gets resolved in the future */
+INTRINSIC_FUNC_ELEMENTAL_IEEE   (IEEE_CLASS|IEEE_COPY_SIGN|IEEE_FMA|IEEE_GET_FLAG|IEEE_GET_HALTING_MODE|IEEE_INT|IEEE_IS_FINITE|IEEE_IS_NAN|IEEE_IS_NEGATIVE|IEEE_IS_NORMAL|IEEE_LOGB|IEEE_MAX_NUM|IEEE_MAX_NUM_MAG|IEEE_MIN_NUM|IEEE_MIN_NUM_MAG|IEEE_NEXT_AFTER|IEEE_NEXT_DOWN|IEEE_NEXT_UP|IEEE_QUIET_EQ|IEEE_QUIET_GE|IEEE_QUIET_GT|IEEE_QUIET_LE|IEEE_QUIET_LT|IEEE_QUIET_NAN|IEEE_QUIET_NE|IEEE_REAL|IEEE_REM|IEEE_RINT|IEEE_SCALB|IEEE_SIGNALING_EQ|IEEE_SIGNALING_GE|IEEE_SIGNALING_GT|IEEE_SIGNALING_LE|IEEE_SIGNALING_LT|IEEE_SIGNALING_NE|IEEE_SIGNBIT|IEEE_UNORDERED|IEEE_VALUE)
+
+INTRINSIC_FUNC_ELEMENTAL        (ACHAR|ACOS|ACOSH|ADJUSTL|ADJUSTR|AIMAG|AINT|ANINT|ASIN|ASINH|ATAN|ATAN2|ATANH|BESSEL_J0|BESSEL_J1|BESSEL_JN|BESSEL_Y0|BESSEL_Y1|BESSEL_YN|BGE|BGT|BLE|BLT|BTEST|CEILING|CHAR|CMPLX|CONJG|COS|COSH|DBLE|DIM|DPROD|DSHIFTL|DSHIFTR|ERF|ERFC|ERFC_SCALED|EXP|EXPONENT|FLOOR|FRACTION|GAMMA|HYPOT|IACHAR|IAND|IBCLR|IBITS|IBSET|ICHAR|IEOR|IMAGE_STATUS|INT|IOR|ISHFT|ISHFTC|LEADZ|LEN_TRIM|LGE|LGT|LLE|LLT|LOG|LOG10|LOG_GAMMA|LOGICAL|MASKL|MASKR|MAX|MIN|MOD|MODULO|MVBITS|NEAREST|NINT|NOT|OUT_OF_RANGE|POPCNT|POPPAR|REAL|SCALE|SCAN|SET_EXPONENT|SHAPE|SHIFTA|SHIFTL|SHIFTR|SIGN|SIN|SINH|SPACING|SQRT|TAN|TANH|TRAILZ|TRIM|VERIFY)
+
+/* INTRINSIC_FUNC_INQUIRY_IEEE can be merged with INTRINSIC_FUNC_INQUIRY when the flex bug gets resolved in the future */
+INTRINSIC_FUNC_INQUIRY_IEEE     (IEEE_SUPPORT_DATATYPE|IEEE_SUPPORT_DENORMAL|IEEE_SUPPORT_DIVIDE|IEEE_SUPPORT_INF|IEEE_SUPPORT_IO|IEEE_SUPPORT_NAN|IEEE_SUPPORT_SQRT|IEEE_SUPPORT_STANDARD|IEEE_SUPPORT_SUBNORMAL|IEEE_SUPPORT_UNDERFLOW_CONTROL)
+
+INTRINSIC_FUNC_INQUIRY          ({INTRINSIC_FUNC_INQUIRY_IEEE}|ALLOCATED|ASSOCIATED|BIT_SIZE|C_SIZEOF|COSHAPE|DIGITS|EPSILON|EXTENDS_TYPE_OF|FAILED_IMAGES|HUGE|IS_CONTIGUOUS|IS_IOSTAT_END|IS_IOSTAT_EOR|KIND|LBOUND|LCOBOUND|LEN|MAXEXPONENT|MINEXPONENT|NEW_LINE|PRECISION|PRESENT|RADIX|RANGE|RANK|SAME_TYPE_AS|SIZE|STORAGE_SIZE|TINY|UBOUND|UCOBOUND)
+
+INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE (IEEE_SELECTED_REAL_KIND|IEEE_SUPPORT_FLAG|IEEE_SUPPORT_HALTING|IEEE_SUPPORT_ROUNDING)
+
+INTRINSIC_FUNC_TRANSFORMATIONAL ({INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE}|ALL|ANY|BESSEL_JN|BESSEL_YN|C_ASSOCIATED|C_FUNLOC|C_LOC|COMMAND_ARGUMENT_COUNT|COMPILER_OPTIONS|COMPILER_VERSION|COUNT|CSHIFT|DOT_PRODUCT|EOSHIFT|FINDLOC|GET_TEAM|IALL|IANY|IMAGE_INDEX|INDEX|IPARITY|MATMUL|MAXLOC|MAXVAL|MERGE|MERGE_BITS|MINLOC|MINVAL|NORM2|NULL|NUM_IMAGES|PACK|PARITY|PRODUCT|REDUCE|REPEAT|RESHAPE|SELECTED_CHAR_KIND|SELECTED_INT_KIND|SELECTED_REAL_KIND|SPREAD|STOPPED_IMAGES|SUM|TEAM_NUMBER|THIS_IMAGE|TRANSPOSE|UNPACK)
+
+INTRINSIC_FUNC_VOID             (CFI_address|CFI_allocate|CFI_deallocate|CFI_establish|CFI_is_contiguous|CFI_section|CFI_select_part|CFI_setpointer)
+
+INTRINSIC_FUNC                  ({INTRINSIC_FUNC_ELEMENTAL}|{INTRINSIC_FUNC_INQUIRY}|{INTRINSIC_FUNC_TRANSFORMATIONAL})
+
+/* intrinsic subroutines */
+
+INTRINSIC_SUB_ATOMIC            (ATOMIC_ADD|ATOMIC_AND|ATOMIC_CAS|ATOMIC_DEFINE|ATOMIC_FETCH_ADD|ATOMIC_FETCH_AND|ATOMIC_FETCH_OR|ATOMIC_FETCH_XOR|ATOMIC_INT_KIND|ATOMIC_LOGICAL_KIND|ATOMIC_OR|ATOMIC_REF|ATOMIC_XOR)
+
+INTRINSIC_SUB_COLLECTIVE        (CO_BROADCAST|CO_MAX|CO_MIN|CO_REDUCE|CO_SUM)
+
+/* INTRINSIC_SUB_IMPURE_IEEE can be merged with INTRINSIC_SUB_IMPURE when the flex bug gets resolved in the future */
+INTRINSIC_SUB_IMPURE_IEEE       (IEEE_GET_MODES|IEEE_GET_ROUNDING_MODE|IEEE_GET_STATUS|IEEE_GET_UNDERFLOW_MODE|IEEE_SET_MODES|IEEE_SET_ROUNDING_MODE|IEEE_SET_STATUS|IEEE_SET_UNDERFLOW_MODE)
+INTRINSIC_SUB_IMPURE            ({INTRINSIC_SUB_IMPURE_IEEE}|C_F_POINTER|CPU_TIME|DATE_AND_TIME|EVENT_QUERY|EXECUTE_COMMAND_LINE|GET_COMMAND|GET_COMMAND_ARGUMENT|GET_ENVIRONMENT_VARIABLE|RANDOM_INIT|RANDOM_NUMBER|RANDOM_SEED|SYSTEM_CLOCK)
+
+/* INTRINSIC_SUB_PURE_IEEE can be merged with INTRINSIC_SUB_PURE when the flex bug gets resolved in the future */
+INTRINSIC_SUB_PURE_IEEE         (IEEE_SET_FLAG|IEEE_SET_HALTING_MODE)
+INTRINSIC_SUB_PURE              ({INTRINSIC_SUB_PURE_IEEE}|C_F_PROCPOINTER|MOVE_ALLOC)
+
+INTRINSIC_SUB                   ({INTRINSIC_SUB_ATOMIC}|{INTRINSIC_SUB_COLLECTIVE}|{INTRINSIC_SUB_IMPURE}|{INTRINSIC_SUB_PURE})
+
+INTRINSIC_PROC                  ({INTRINSIC_SUB}|{INTRINSIC_FUNC})
+
+/* INTRINSIC_MODULE_IEEE can be merged with INTRINSIC_MODULE when the flex bug gets resolved in the future */
+INTRINSIC_MODULE_IEEE           (IEEE_ARITHMETIC|IEEE_EXCEPTIONS|IEEE_FEATURES)
+INTRINSIC_MODULE                ({INTRINSIC_MODULE_IEEE}|ISO_C_BINDING|ISO_FORTRAN_ENV)
+
+SPECIFIER                       (ACCESS|ACQUIRED_LOCK|ACTION|ADVANCE|ASYNCHRONOUS|BLANK|DECIMAL|DELIM|DIM|DIRECT|ENCODING|EOR|ERR|ERRMSG|EXIST|FILE|FMT|FORM|FORMATTED|ID|IOLENGTH|IOMSG|IOSTAT|KIND|LEN|MOLD|NAME|NAMED|NEW_INDEX|NEWUNIT|NEXTREC|NML|NUMBER|OPENED|PAD|PENDING|POS|POSITION|QUIET|READ|READWRITE|REC|RECL|ROUND|SEQUENTIAL|SIGN|SIZE|SOURCE|STAT|STATUS|STREAM|TEAM|TEAM_NUMBER|UNFORMATTED|UNIT|UNTIL_COUNT|WRITE)
+
+/* FUNCTION and SUBROUTINE are excluded from STATEMENT below to prevent dot-graph self-reference misrepresentations. */
+STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|SUBMODULE|END{BS}SUBMODULE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
+
+/* INTRINSIC_DERIVED_TYPE_IEEE and INTRINSIC_DERIVED_TYPE_CFI can be merged with INTRINSIC_DERIVED_TYPE when the flex bug gets resolved in the future */
+INTRINSIC_DERIVED_TYPE_IEEE     (IEEE_CLASS_TYPE|IEEE_FEATURES_TYPE|IEEE_FLAG_TYPE|IEEE_MODES_TYPE|IEEE_ROUND_TYPE|IEEE_STATUS_TYPE)
+INTRINSIC_DERIVED_TYPE_CFI      (CFI_cdesc_t)
+INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
 
 /* |  */
 
@@ -268,7 +345,9 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 
 %x Start
 %x SubCall
+%x FuncDef
 %x ClassName
+%x ClassVar
 %x Subprog
 %x DocBlock
 %x Use
@@ -277,74 +356,194 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 %x Declaration
 %x DeclarationBinding
 %x DeclContLine
+%x Parameterlist
 %x String
 %x Subprogend
 
 %%
  /*==================================================================*/
 
- /*-------- ignore ------------------------------------------------------------*/
-
-<Start>{IGNORE}/{BS}"("                   { // do not search keywords, intrinsics... TODO: complete list
-                                            codifyLines(yyscanner,yytext);
-                                          }
  /*-------- inner construct ---------------------------------------------------*/
 
-<Start>{COMMANDS}/{BS}[,( \t\n]           {  // highlight
-                                            /* font class is defined e.g. in doxygen.css */
-                                            startFontClass(yyscanner,"keyword");
-                                            codifyLines(yyscanner,yytext);
-                                            endFontClass(yyscanner);
-                                          }
-<Start>{FLOW}/{BS}[,( \t\n]               {
-                                          if (yyextra->isFixedForm)
-                                          {
-                                            if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;
-                                          }
-                                          if (yyextra->currentMemberDef && yyextra->currentMemberDef->isFunction())
-                                          {
-                                            std::lock_guard<std::mutex> lock(g_countFlowKeywordsMutex);
-                                            MemberDefMutable *mdm = toMemberDefMutable(yyextra->currentMemberDef);
-                                            if (mdm)
-                                            {
-                                              mdm->incrementFlowKeyWordCount();
-                                            }
-                                          }
-                                          /* font class is defined e.g. in doxygen.css */
-                                          startFontClass(yyscanner,"keywordflow");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>{BS}(CASE|CLASS|TYPE){BS_}(IS|DEFAULT) {
-                                          startFontClass(yyscanner,"keywordflow");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>{BS}"end"({BS}{FLOW})/[ \t\n]       { // list is a bit long as not all have possible end
-                                          startFontClass(yyscanner,"keywordflow");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>"implicit"{BS}("none"|{TYPE_SPEC})  {
-                                          startFontClass(yyscanner,"keywordtype");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>^{BS}"namelist"/[/]              {  // Namelist specification
-                                          startFontClass(yyscanner,"keywordtype");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
+<Start>{BS}"%"/{BS}[a-zA-Z]+.*                                  {   // highlight rule for the percent-symbol separator of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}[.]*{BS}("+"|"-"|"*"|"/"|"<"|">"|"="|"&"){BS}            {   // highlight rule for the operators of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}(0|[1-9]\d*)(\.\d*)?(e[-\+]?(0|[1-9]\d*))?(_([a-zA-Z])+)?    {   // highlight rule for the numeric values of Fortran.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_numeric_literal");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{NAMED_CONST}{BS}                                        {   // highlight rule for the named constants of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_named_const");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"bind"/{BS}"("[.]*                                   {   // highlight rule for the bind attribute of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"C"/{BS}(","{BS}"name"{BS}"="{BS}(.)+)("&"|")"){BS}  {   // highlight rule for the bind C attribute of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Declaration>{BS}{ATTR_SPEC}/({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes of Fortran standard.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    if (QCString(yytext) == "external") yyextra->isExternal = true;
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Declaration>{BS}{ATTR_SPEC_WARG}/("("[.*]")")?({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes that take argument: DIMENSION(:,:).
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_attribute");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}"("{BS}{INTRINSIC_DERIVED_TYPE}{BS}")"{BS}               {   // highlight rule for Fortran intrinsic derived types.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{INTRINSIC_DERIVED_TYPE}{BS}                             {   // highlight rule for Fortran intrinsic module names.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}{INTRINSIC_MODULE}{BS}                                   {   // highlight rule for Fortran intrinsic module names.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_inrinsic_module");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start,Declaration>{BS}{SPECIFIER}/{BS}={BS}[a-zA-Z0-9_\.\-\+(\[][a-zA-Z0-9_)(\[\]!%,\.\-\+/=><\t ]*{BS}(")"|"&")  {   // highlight rule for Fortran intrinsic specifier (intrinsic procedure argument) names.
+                                                                    // \todo: A specifier must be enclosed with parentheses. This is not currently enforced.
+                                                                    startFontClass(yyscanner,"fortran_spcifier");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+
+ /* Fortran intrinsic procedures */
+
+<Start>^{BS}"real"/[,:( ].*                                     {   // real is a data type but also an elemental function, which makes it a bit tricky.
+                                                                    yy_push_state(YY_START,yyscanner);
+                                                                    BEGIN(Declaration);
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    yyextra->code->codify(QCString(yytext));
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>^{BS}"logical"/[,:( ].*                                  {   // logical is a data type but also an elemental function, which makes it a bit tricky.
+                                                                    yy_push_state(YY_START,yyscanner);
+                                                                    BEGIN(Declaration);
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    yyextra->code->codify(QCString(yytext));
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start,Declaration>{BS}{INTRINSIC_FUNC}/{BS}[(]                 {   // highlight rule for Fortran intrinsic functions.
+                                                                    // \todo This must be improved when function name appears in an intrinsic module USE statement.
+                                                                    // \todo The current rule only captures function names when followed by "(".
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_function");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}{INTRINSIC_SUB}/{BS}[(]                              {   // highlight rule for Fortran intrinsic subroutines.
+                                                                    // \todo This must be improved when subroutine name appears in an intrinsic module USE statement.
+                                                                    // \todo The current rule only captures subroutine names when followed by "(".
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_subroutine");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{BS}"MPI_"{BS}[a-zA-Z_]+/{BS}                            {   // highlight rule for MPI module intrinsic entities.
+                                                                    // \todo The current search pattern is too generic. In the future, all MPI entities from
+                                                                    // \todo the standard MPI module must be listed here and explicitly searched for.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_mpi");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+
+ /* Fortran intrinsic statements */
+
+<Start>{BS}{STATEMENT}/{BS}[;( \t\n]                            {   // highlight rule for Fortran intrinsic statements.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>{FLOW}/{BS}[;( \t\n]                                     {   // highlight rule for Fortran flow-control statements.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    if (yyextra->isFixedForm)
+                                                                    {
+                                                                        if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;
+                                                                    }
+                                                                    if (yyextra->currentMemberDef && yyextra->currentMemberDef->isFunction())
+                                                                    {
+                                                                        std::lock_guard<std::mutex> lock(g_countFlowKeywordsMutex);
+                                                                        MemberDefMutable *mdm = toMemberDefMutable(yyextra->currentMemberDef);
+                                                                        if (mdm)
+                                                                        {
+                                                                            mdm->incrementFlowKeyWordCount();
+                                                                        }
+                                                                    }
+                                                                    /* font class is defined e.g. in doxygen.css */
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>(CASE|CLASS|TYPE|RANK){BS_}(IS|DEFAULT)                  {
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<*>{BS}"end"{BS}{FLOW_END}/[ ;\t\n]                             {   // list is a bit long as not all have possible end. <*> needed since the FLOW could be all in one line.
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_keywordflow");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
+<Start>"implicit"{BS}("none"|{TYPE_SPEC})                       {
+                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                                    startFontClass(yyscanner,"fortran_statement");
+                                                                    codifyLines(yyscanner,yytext);
+                                                                    endFontClass(yyscanner);
+                                                                }
  /*-------- use statement -------------------------------------------*/
-<Start>"use"{BS_}                       {
-                                          startFontClass(yyscanner,"keywordtype");
+<Start>"use"{BS}                        {
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          startFontClass(yyscanner,"fortran_statement");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Use);
+                                        }
+<Use>("intrinsic"|"non_intrinsic")      { // TODO: rename
+                                          startFontClass(yyscanner,"fortran_attribute");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN(Use);
                                         }
 <Use>"ONLY"                             { // TODO: rename
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -352,7 +551,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Use>{ID}                               {
                                           QCString tmp(yytext);
-                                          tmp = tmp.lower();
+                                          // tmp = tmp.lower();
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
                                           yyextra->insideBody=FALSE;
@@ -369,7 +568,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           YY_FTN_RESET}
 <UseOnly>{ID}                           {
                                           QCString tmp(yytext);
-                                          tmp = tmp.lower();
+                                          // tmp = tmp.lower();
                                           yyextra->useEntry.onlyNames.push_back(tmp);
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
@@ -377,13 +576,12 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Use,UseOnly,Import>"\n"                {
                                           unput(*yytext);
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <*>"import"{BS}/"\n"                    |
 <*>"import"{BS_}                        {
-                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -395,78 +593,80 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->insideBody=FALSE;
                                         }
 <Import>("ONLY"|"NONE"|"ALL")           {
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
  /*-------- fortran module  -----------------------------------------*/
-<Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n {  //
-                                          startScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(ClassName);
-                                          if (!qstricmp(yytext,"module")) yyextra->currentModule="module";
+<Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n { //
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
+                                            if (!qstricmp(yytext,"module")) yyextra->currentModule="module";
                                         }
-<Start>("enum")/{BS_}|{BS}{COMMA}{BS}{LANGUAGE_BIND_SPEC}|\n {  //
-                                          startScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(ClassName);
+<Start>^{BS}"enum"/{BS}("&"|",")        {   // rule for enum statement
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
                                         }
-<*>{LANGUAGE_BIND_SPEC}                 {  //
-                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                          startFontClass(yyscanner,"keyword");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-<Start>("type")/{BS_}|({COMMA}({ACCESS_SPEC}|ABSTRACT|EXTENDS))|\n {  //
-                                          startScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(ClassName);
+<Start>("type")/{BS}[:,]{BS}            {   // rule for type-definition construct. Do NOT put "(" in [:,] as it leads to confusion with variable declaration.
+                                            startScope(yyscanner);
+                                            startFontClass(yyscanner,"fortran_statement");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                            yy_push_state(YY_START,yyscanner);
+                                            BEGIN(ClassName);
                                         }
 <ClassName>{ID}                         {
-                                          if (yyextra->currentModule == "module")
-                                          {
-                                            yyextra->currentModule=yytext;
-                                            yyextra->currentModule = yyextra->currentModule.lower();
-                                          }
-                                          generateLink(yyscanner,*yyextra->code,yytext);
-                                          pop_state(yyscanner);
+                                            if (yyextra->currentModule == "module")
+                                            {
+                                                yyextra->currentModule=yytext;
+                                                yyextra->currentModule = yyextra->currentModule;//.lower();
+                                            }
+                                            generateLink(yyscanner,*yyextra->code,yytext);
+                                            yy_pop_state(yyscanner);
                                         }
-<ClassName>({ACCESS_SPEC}|ABSTRACT|EXTENDS)/[,:( ] { //| variable declaration
-                                          startFontClass(yyscanner,"keyword");
-                                          yyextra->code->codify(QCString(yytext));
-                                          endFontClass(yyscanner);
+<ClassName>{BS}({ATTR_SPEC})/{BS}[,:( ]{BS} { // variable declaration
+                                            if (QCString(yytext) == "external") yyextra->isExternal = true;
+                                            startFontClass(yyscanner,"fortran_attribute");
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
                                         }
-<ClassName>\n                           { // interface may be without name
-                                          pop_state(yyscanner);
-                                          YY_FTN_REJECT;
+<Start>^{BS}{ACCESS_SPEC}/{BS}[,: ]     {   // access attribute declaration. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
+                                            startFontClass(yyscanner,"fortran_attribute");
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                        }
+<ClassName>\n                           {   // interface may be without name
+                                            yy_pop_state(yyscanner);
+                                            YY_FTN_REJECT;
                                         }
 <Start>^{BS}"end"({BS_}"enum").*        {
-                                          YY_FTN_REJECT;
+                                            YY_FTN_REJECT;
                                         }
 <Start>^{BS}"end"({BS_}"type").*        {
-                                          YY_FTN_REJECT;
+                                            YY_FTN_REJECT;
                                         }
-<Start>^{BS}"end"({BS_}"module").*      { // just reset yyextra->currentModule, rest is done in following rule
-                                          yyextra->currentModule=0;
-                                          YY_FTN_REJECT;
+<Start>^{BS}"end"({BS_}"module").*      {   // just reset yyextra->currentModule, rest is done in following rule
+                                            yyextra->currentModule=0;
+                                            YY_FTN_REJECT;
                                         }
  /*-------- subprog definition -------------------------------------*/
-<Start>({PREFIX}{BS_})?{TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
-                                          startFontClass(yyscanner,"keyword");
+ /*
+ <Start>({PREFIX}{BS_})?({TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
+                                          startFontClass(yyscanner,"fortran_prefix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
-<Start>({PREFIX}{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
-                                          startFontClass(yyscanner,"keyword");
+ */
+<Start>("module"{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
+                                          startFontClass(yyscanner,"fortran_prefix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -478,7 +678,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           generateLink(yyscanner,*yyextra->code,yytext);
                                         }
 <Subprog>"result"/{BS}"("[^)]*")"       {
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_suffix");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
@@ -487,13 +687,13 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Subprog,Subprogend>"\n"                { codifyLines(yyscanner,yytext);
                                           yyextra->contLineNr++;
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface")?{BS}     {  // Fortran subroutine or function ends
                                           //cout << "===> end function " << yytext << endl;
                                           endScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -501,55 +701,49 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Subprogend>{ID}/{BS}(\n|!|;)           {
                                           generateLink(yyscanner,*yyextra->code,yytext);
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                         }
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface"){BS}/(\n|!|;) {  // Fortran subroutine or function ends
                                           //cout << "===> end function " << yytext << endl;
                                           endScope(yyscanner);
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
  /*-------- variable declaration ----------------------------------*/
-<Start>^{BS}"real"/[,:( ]               { // real is a bit tricky as it is a data type but also a function.
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(Declaration);
-                                          startFontClass(yyscanner,"keywordtype");
-                                          yyextra->code->codify(QCString(yytext));
-                                          endFontClass(yyscanner);
-                                        }
-<Start>{TYPE_SPEC}/[,:( ]               {
+<Start>{TYPE_SPEC}/{BS}[,:( ]           {
                                           QCString typ(yytext);
                                           typ = removeRedundantWhiteSpace(typ.lower());
                                           if (typ.startsWith("real")) YY_FTN_REJECT;
+                                          if (typ.startsWith("logical")) YY_FTN_REJECT;
                                           if (typ == "type" || typ == "class" || typ == "procedure") yyextra->inTypeDecl = 1;
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN(Declaration);
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
-<Start>{ATTR_SPEC}                      {
+<Start>^{BS}({ATTR_SPEC}{BS_})+         { // declare attribute statement. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
                                           if (QCString(yytext) == "external")
                                           {
                                             yy_push_state(YY_START,yyscanner);
                                             BEGIN(Declaration);
                                             yyextra->isExternal = true;
                                           }
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_attribute");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
-<Declaration>({TYPE_SPEC}|{ATTR_SPEC})/[,:( ] { //| variable declaration
+<Declaration>({TYPE_SPEC})/{BS}[(,: ]   { //| variable declaration
                                           if (QCString(yytext) == "external") yyextra->isExternal = true;
-                                          startFontClass(yyscanner,"keywordtype");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
 <Declaration>{ID}                       { // local var
                                           if (yyextra->isFixedForm && yy_my_start == 1)
                                           {
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             yyextra->code->codify(QCString(yytext));
                                             endFontClass(yyscanner);
                                           }
@@ -573,7 +767,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <DeclarationBinding>{ID}                { // Type bound procedure link
                                           generateLink(yyscanner,*yyextra->code, yytext);
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                         }
 <Declaration>[(]                        { // start of array or type / class specification
                                           yyextra->bracketCount++;
@@ -598,7 +792,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->contLineNr++;
                                           codifyLines(yyscanner,yytext);
                                           yyextra->bracketCount = 0;
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <Declaration,DeclarationBinding>"\n"    { // end declaration line (?)
@@ -615,7 +809,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           if (!(yyextra->hasContLine && yyextra->hasContLine[yyextra->contLineNr - 1]))
                                           {
                                             yyextra->isExternal = false;
-                                            pop_state(yyscanner);
+                                            yy_pop_state(yyscanner);
                                           }
                                           YY_FTN_RESET
                                         }
@@ -623,7 +817,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
  /*-------- subprog calls  -----------------------------------------*/
 
 <Start>"call"{BS_}                      {
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -633,7 +827,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
                                           yyextra->insideBody=FALSE;
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                         }
 <Start>{ID}{BS}/"("                     { // function call
                                           if (yyextra->isFixedForm && yy_my_start == 6)
@@ -645,7 +839,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           {
                                             yy_push_state(YY_START,yyscanner);
                                             BEGIN(Declaration);
-                                            startFontClass(yyscanner,"keywordtype");
+                                            startFontClass(yyscanner,"fortran_statement");
                                             yyextra->code->codify(QCString(yytext).stripWhiteSpace());
                                             endFontClass(yyscanner);
                                             yyextra->code->codify(QCString(yytext + 4));
@@ -696,47 +890,64 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->contLineNr++;
                                           if (Config_getBool(STRIP_CODE_COMMENTS))
                                           {
-                                            yyextra->yyLineNr+=yyextra->docBlock.contains('\n');
+                                            yyextra->yyLineNr+=((QCString)yyextra->docBlock).contains('\n');
                                             yyextra->yyLineNr+=1;
                                             nextCodeLine(yyscanner);
                                             yyextra->endComment=TRUE;
                                           }
                                           else // do not remove comment
                                           {
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             codifyLines(yyscanner,yyextra->docBlock);
                                             endFontClass(yyscanner);
                                           }
                                           unput(*yytext);
                                           yyextra->contLineNr--;
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
-
-<*>"!"[^><\n].*|"!"$                    { // normal comment
-                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                          if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
-                                          startFontClass(yyscanner,"comment");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
-
-<*>^[Cc*].*                             { // normal comment
-                                          if(! yyextra->isFixedForm) YY_FTN_REJECT;
-
-                                          startFontClass(yyscanner,"comment");
-                                          codifyLines(yyscanner,yytext);
-                                          endFontClass(yyscanner);
-                                        }
+<Start>^{BS}[!C]("DEC"|"DIR")"$"{BS}"ATTRIBUTES".*/"::" {   // ATTRIBUTES directive is treated separately as its argument (procedure name) needs to be recognized by Doxygen).
+                                                            startFontClass(yyscanner,"fortran_directive_intel");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+<Start>^{BS}[!C]("DEC"|"DIR")"$".*                      {   // highlight rule for Intel Fortran Compiler directives (except ATTRIBUTES).
+                                                            QCString directive(yytext);
+                                                            directive = removeRedundantWhiteSpace(directive.lower());
+                                                            if (directive.contains("attributes",true)) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_directive_intel");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+<Start>^{BS}[\!c]"$OMP".*                               {   // OpenMP directives
+                                                            yy_push_state(YY_START,yyscanner);
+                                                            BEGIN(Declaration);
+                                                            startFontClass(yyscanner,"fortran_directive_omp");
+                                                            yyextra->code->codify(QCString(yytext));
+                                                            endFontClass(yyscanner);
+                                                        }
+<*>"!"[^><\n].*|"!"$                                    {   // normal comment
+                                                            if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                                            if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_comment");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+ /*
+<*>^[Cc*].*                                             {   // normal comment
+                                                            if(! yyextra->isFixedForm) YY_FTN_REJECT;
+                                                            startFontClass(yyscanner,"fortran_comment");
+                                                            codifyLines(yyscanner,yytext);
+                                                            endFontClass(yyscanner);
+                                                        }
+ */
 <*>"assignment"/{BS}"("{BS}"="{BS}")"   {
-                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
 <*>"operator"/{BS}"("[^)]*")"           {
-                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                          startFontClass(yyscanner,"keyword");
+                                          startFontClass(yyscanner,"fortran_statement");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
@@ -756,15 +967,15 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->code->codify(QCString(yytext));
                                         }
 <Start>{ID}                             {
-                                            yyextra->insideBody=TRUE;
+                                            //yyextra->insideBody=TRUE; // why is this needed? It messes up the dot-graph representations by generating artificial self-references.
                                             generateLink(yyscanner,*yyextra->code, yytext);
-                                            yyextra->insideBody=FALSE;
+                                            //yyextra->insideBody=FALSE;
                                         }
  /*------ strings --------------------------------------------------*/
 <String>\n                              { // string with \n inside
                                           yyextra->contLineNr++;
                                           yyextra->str+=yytext;
-                                          startFontClass(yyscanner,"stringliteral");
+                                          startFontClass(yyscanner,"fortran_string");
                                           codifyLines(yyscanner,yyextra->str);
                                           endFontClass(yyscanner);
                                           yyextra->str = "";
@@ -773,10 +984,10 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <String>\"|\'                           { // string ends with next quote without previous backspace
                                           if(yytext[0]!=yyextra->stringStartSymbol) YY_FTN_REJECT; // single vs double quote
                                           yyextra->str+=yytext;
-                                          startFontClass(yyscanner,"stringliteral");
+                                          startFontClass(yyscanner,"fortran_string");
                                           codifyLines(yyscanner,yyextra->str);
                                           endFontClass(yyscanner);
-                                          pop_state(yyscanner);
+                                          yy_pop_state(yyscanner);
                                         }
 <String>.                               {yyextra->str+=yytext;}
 
@@ -799,7 +1010,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           {
                                             codifyLines(yyscanner,yytext);
                                             // comment cannot extend over the end of a line so should always be terminated at the end of the line.
-                                            if (yyextra->currentFontClass && !strcmp(yyextra->currentFontClass,"comment")) endFontClass(yyscanner);
+                                            if (yyextra->currentFontClass && !strcmp(yyextra->currentFontClass,"fortran_comment")) endFontClass(yyscanner);
                                           }
                                           yyextra->contLineNr++;
                                           YY_FTN_RESET
@@ -807,9 +1018,9 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <*>^{BS}"type"{BS}"="                   { yyextra->code->codify(QCString(yytext)); }
 
 <*>[\x80-\xFF]*                         { // keep utf8 characters together...
-                                          if (yyextra->isFixedForm && yy_my_start > yyextra->fixedCommentAfter)
+                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
                                           {
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             codifyLines(yyscanner,yytext);
                                           }
                                           else
@@ -818,12 +1029,12 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           }
                                         }
 <*>.                                    {
-                                          if (yyextra->isFixedForm && yy_my_start > yyextra->fixedCommentAfter)
+                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
                                           {
                                             //yy_push_state(YY_START,yyscanner);
                                             //BEGIN(DocBlock);
                                             //yyextra->docBlock=yytext;
-                                            startFontClass(yyscanner,"comment");
+                                            startFontClass(yyscanner,"fortran_comment");
                                             codifyLines(yyscanner,yytext);
                                           }
                                           else
@@ -831,18 +1042,27 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                             yyextra->code->codify(QCString(yytext));
                                           }
                                         }
-<*>{LOG_OPER}                           { // Fortran logical comparison keywords
-                                          yyextra->code->codify(QCString(yytext));
+<*>{OPERATOR_LOGICAL}                   {   // Fortran logical comparison keywords
+                                            startFontClass(yyscanner,"fortran_operator_logical");
+                                            //codifyLines(yyscanner,yyextra->docBlock);
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
+                                        }
+<*>{OPERATOR_SYMBOLS}                   { // Fortran operator symbols
+                                            startFontClass(yyscanner,"fortran_operator_symbols");
+                                            //codifyLines(yyscanner,yyextra->docBlock);
+                                            yyextra->code->codify(QCString(yytext));
+                                            endFontClass(yyscanner);
                                         }
 <*><<EOF>>                              {
-                                          if (YY_START == DocBlock) {
-                                            if (!Config_getBool(STRIP_CODE_COMMENTS))
-                                            {
-                                              startFontClass(yyscanner,"comment");
-                                              codifyLines(yyscanner,yyextra->docBlock);
-                                              endFontClass(yyscanner);
+                                            if (YY_START == DocBlock) {
+                                                if  (!Config_getBool(STRIP_CODE_COMMENTS))
+                                                {
+                                                    startFontClass(yyscanner,"fortran_comment");
+                                                    codifyLines(yyscanner,yyextra->docBlock);
+                                                    endFontClass(yyscanner);
+                                                }
                                             }
-                                          }
                                           yyterminate();
                                         }
 %%
@@ -940,27 +1160,24 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                                 yyextra->currentMemberDef->getOutputFileBase(),
-                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,
-                                !yyextra->includeCodeFragment);
+                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else if (d->isLinkableInProject())
       {
-        yyextra->code->writeLineNumber(d->getReference(),
-                                d->getOutputFileBase(),
-                                QCString(),yyextra->yyLineNr,
-                                !yyextra->includeCodeFragment);
+        yyextra->code->writeLineNumber( d->getReference(),
+                                        d->getOutputFileBase(),
+                                        QCString(),yyextra->yyLineNr
+                                        );
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,
-                                     !yyextra->includeCodeFragment);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
     }
   }
   yyextra->code->startCodeLine(yyextra->sourceFileDef);
-  yyextra->insideCodeLine=true;
   if (yyextra->currentFontClass)
   {
     yyextra->code->startFontClass(QCString(yyextra->currentFontClass));
@@ -973,7 +1190,6 @@ static void endCodeLine(yyscan_t yyscanner)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   endFontClass(yyscanner);
   yyextra->code->endCodeLine();
-  yyextra->insideCodeLine=false;
 }
 
 static void nextCodeLine(yyscan_t yyscanner)
@@ -1030,7 +1246,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
                   Definition *d,const QCString &text)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
+  static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
   yyextra->tooltipManager.addTooltip(ol,d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();
@@ -1139,7 +1355,8 @@ static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, 
   for (auto it = yyextra->scopeStack.rbegin(); it!=yyextra->scopeStack.rend(); ++it)
   {
     const Scope &scope = *it;
-    std::string lowMemName = memberName.lower().str();
+    //std::string lowMemName = memberName.lower().str();
+    std::string lowMemName = memberName.str();
     if (scope.localVars   .find(lowMemName)!=std::end(scope.localVars)     &&  // local var
         scope.externalVars.find(lowMemName)==std::end(scope.externalVars))     // and not external
     {
@@ -1261,13 +1478,14 @@ static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // dictionary with 
 }
 
 
-static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const QCString &lname)
+static void generateLink(yyscan_t yyscanner, CodeOutputInterface &ol, const QCString &lname)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   ClassDef *cd=0;
   NamespaceDef *nsd=0;
   QCString name = lname;
-  name = removeRedundantWhiteSpace(name.lower());
+  // name = removeRedundantWhiteSpace(name.lower());
+  name = removeRedundantWhiteSpace(name);
 
   // check if lowercase lname is a linkable type or interface
   if ( (getFortranTypeDefs(name, yyextra->currentModule, cd, yyextra->useMembers)) && cd->isLinkable() )
@@ -1279,7 +1497,7 @@ static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const QCStr
     }
     else
     { // write type or interface link
-      writeMultiLineCodeLink(yyscanner, ol,cd,name);
+      writeMultiLineCodeLink(yyscanner, ol, cd, name);
       addToSearchIndex(yyscanner, name);
     }
   }
@@ -1324,7 +1542,8 @@ static int countLines(yyscan_t yyscanner)
   if (p>yyextra->inputString && *(p-1)!='\n')
   { // last line does not end with a \n, so we add an extra
     // line and explicitly terminate the line after parsing.
-    count++;
+    count++,
+    yyextra->needsTermination=TRUE;
   }
   return count;
 }
@@ -1369,7 +1588,8 @@ static void addLocalVar(yyscan_t yyscanner,const QCString &varName)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (!yyextra->scopeStack.empty())
   {
-    std::string lowVarName = varName.lower().str();
+    // std::string lowVarName = varName.lower().str();
+    std::string lowVarName = varName.str();
     yyextra->scopeStack.back().localVars.insert(lowVarName);
     if (yyextra->isExternal) yyextra->scopeStack.back().externalVars.insert(lowVarName);
   }
@@ -1395,7 +1615,7 @@ static void checkContLines(yyscan_t yyscanner,const char *s)
   yyextra->hasContLine = (int *) malloc((numLines) * sizeof(int));
   for (i = 0; i < numLines; i++)
     yyextra->hasContLine[i] = 0;
-  p = prepassFixedForm(s, yyextra->hasContLine,yyextra->fixedCommentAfter);
+  p = prepassFixedForm(s, yyextra->hasContLine);
   yyextra->hasContLine[0] = 0;
 }
 
@@ -1440,7 +1660,7 @@ void FortranCodeParser::resetCodeParserState()
   yyextra->currentDefinition = 0;
   yyextra->currentMemberDef = 0;
   yyextra->currentFontClass = 0;
-  yyextra->insideCodeLine = FALSE;
+  yyextra->needsTermination = FALSE;
   BEGIN( Start );
 }
 
@@ -1475,17 +1695,15 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   yyextra->code = &codeOutIntf;
   yyextra->inputString   = input.data();
   yyextra->inputPosition = 0;
-  yyextra->fileName      = fileDef ? fileDef->fileName():"";
   yyextra->isFixedForm = recognizeFixedForm(input,p->format);
   yyextra->contLineNr = 1;
   yyextra->hasContLine = NULL;
   if (yyextra->isFixedForm)
   {
     checkContLines(yyscanner,yyextra->inputString);
-    yyextra->fixedCommentAfter = Config_getInt(FORTRAN_COMMENT_AFTER);
   }
   yyextra->currentFontClass = 0;
-  yyextra->insideCodeLine = FALSE;
+  yyextra->needsTermination = FALSE;
   yyextra->searchCtx = searchCtx;
   yyextra->collectXRefs = collectXRefs;
   if (startLine!=-1)
@@ -1521,9 +1739,10 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   fortrancodeYYrestart(0, yyscanner);
   BEGIN( Start );
   fortrancodeYYlex(yyscanner);
-  if (yyextra->insideCodeLine)
+  if (yyextra->needsTermination)
   {
-    endCodeLine(yyscanner);
+    endFontClass(yyscanner);
+    yyextra->code->endCodeLine();
   }
   if (!fileDef && isExampleBlock && yyextra->sourceFileDef)
   {
@@ -1540,14 +1759,6 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   printlex(yy_flex_debug, FALSE, __FILE__, fileDef ? qPrint(fileDef->fileName()): NULL);
 }
 
-static inline void pop_state(yyscan_t yyscanner)
-{
-  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  if ( yyg->yy_start_stack_ptr <= 0 )
-    warn(yyextra->fileName,yyextra->yyLineNr,"Unexpected statement '%s'",yytext );
-  else
-    yy_pop_state(yyscanner);
-}
 //---------------------------------------------------------
 
 #if USE_STATE2STRING

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -63,8 +63,6 @@ typedef yyguts_t *yyscan_t;
 #include "fortranscanner.h"
 #include "containers.h"
 
-const int fixedCommentAfter = 72;
-
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
@@ -127,23 +125,24 @@ class Scope
 
 struct fortrancodeYY_state
 {
-  QCString              docBlock;                   //!< contents of all lines of a documentation block
-  QCString              currentModule=QCString();   //!< name of the current enclosing module
-  UseMap                useMembers;                 //!< info about used modules
-  UseEntry              useEntry;                   //!< current use statement info
-  std::vector<Scope>    scopeStack;
-  bool                  isExternal = false;
-  QCString              str=QCString();             //!< contents of fortran string
+  QCString      docBlock;                   //!< contents of all lines of a documentation block
+  QCString      currentModule=QCString();   //!< name of the current enclosing module
+  UseMap      useMembers;                   //!< info about used modules
+  UseEntry      useEntry;                   //!< current use statement info
+  std::vector<Scope>  scopeStack;
+  bool          isExternal = false;
+  QCString      str=QCString();             //!< contents of fortran string
 
   CodeOutputInterface * code = 0;
 
   const char *  inputString = 0;     //!< the code fragment as text
   yy_size_t     inputPosition = 0;   //!< read offset during parsing
   int           inputLines = 0;      //!< number of line in the code fragment
+  QCString      fileName;
   int           yyLineNr = 0;        //!< current line number
   int           contLineNr = 0;      //!< current, local, line number for continuation determination
   int          *hasContLine = 0;     //!< signals whether or not a line has a continuation line (fixed source form)
-  bool          needsTermination = false;
+  bool          insideCodeLine = false;
   const Definition *searchCtx = 0;
   bool          collectXRefs = false;
   bool          isFixedForm = false;
@@ -170,14 +169,18 @@ struct fortrancodeYY_state
 
   bool          endComment = false;
   TooltipManager tooltipManager;
+
+   int fixedCommentAfter = 72;
 };
 
 #if USE_STATE2STRING
 static const char *stateToString(int state);
 #endif
 
-static bool getFortranNamespaceDefs(const QCString &mname, NamespaceDef *&cd);
-static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName, ClassDef *&cd, const UseMap &useMap);
+static bool getFortranNamespaceDefs(const QCString &mname,
+                               NamespaceDef *&cd);
+static bool getFortranTypeDefs(const QCString &tname, const QCString &moduleName,
+                               ClassDef *&cd, const UseMap &useMap);
 
 //----------------------------------------------------------------------------
 
@@ -189,8 +192,11 @@ static void startCodeLine(yyscan_t yyscanner);
 static void endCodeLine(yyscan_t yyscanner);
 static void nextCodeLine(yyscan_t yyscanner);
 static void codifyLines(yyscan_t yyscanner,const QCString &text);
-static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol, Definition *d,const QCString &text);
-static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd, const QCString &memberText, CodeOutputInterface &ol);
+static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
+                  Definition *d,const QCString &text);
+static bool getGenericProcedureLink(yyscan_t yyscanner,const ClassDef *cd,
+                                    const QCString &memberText,
+                                    CodeOutputInterface &ol);
 static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // map with used modules
                     const QCString &memberText,  // exact member text
                     CodeOutputInterface &ol,
@@ -202,8 +208,10 @@ static void startScope(yyscan_t yyscanner);
 static void endScope(yyscan_t yyscanner);
 static void addUse(yyscan_t yyscanner,const QCString &moduleName);
 static void addLocalVar(yyscan_t yyscanner,const QCString &varName);
-static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName, const UseMap &useMap);
+static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName,
+                                 const UseMap &useMap);
 static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static inline void pop_state(yyscan_t yyscanner);
 
 
 //-------------------------------------------------------------------
@@ -215,10 +223,15 @@ static std::mutex g_countFlowKeywordsMutex;
 #undef  YY_INPUT
 #define YY_INPUT(buf,result,max_size) result=yyread(yyscanner,buf,max_size);
 
+// otherwise the filename would be the name of the converted file (*.cpp instead of *.l)
+static inline const char *getLexerFILE() {return __FILE__;}
+#include "doxygen_lex.h"
+
 %}
 
 IDSYM     [a-z_A-Z0-9]
 ID        [a-z_A-Z]+{IDSYM}*
+SUBPROG   (subroutine|function)
 B         [ \t]
 BS        [ \t]*
 BS_       [ \t]+
@@ -229,112 +242,22 @@ ARGS_L1   ("("{ARGS_L1a}*")")
 ARGS_L2   "("({ARGS_L0}|[^()]|{ARGS_L1a}|{ARGS_L1})*")"
 ARGS      {BS}({ARGS_L0}|{ARGS_L1}|{ARGS_L2})
 
-/* The following appear in submodules as (subroutine|function|procedure) */
-SUBPROG   (subroutine|function|procedure)
-
-/* REAL and LOGICAL are treated separately as it can also be a function */
-NUM_TYPE            (COMPLEX|INTEGER)
-OPERATOR_LOGICAL    (\.and\.|\.eq\.|\.eqv\.|\.ge\.|\.gt\.|\.le\.|\.lt\.|\.ne\.|\.neqv\.|\.or\.|\.not\.)
-OPERATOR_SYMBOLS    [\+\-\*/%::><=&]
+NUM_TYPE  (complex|integer|logical|real)
+LOG_OPER  (\.and\.|\.eq\.|\.eqv\.|\.ge\.|\.gt\.|\.le\.|\.lt\.|\.ne\.|\.neqv\.|\.or\.|\.not\.)
 KIND      {ARGS}
+CHAR      (CHARACTER{ARGS}?|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
+TYPE_SPEC (({NUM_TYPE}({BS}"*"{BS}[0-9]+)?)|({NUM_TYPE}{KIND})|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
 
-/* The pattern CHARACTER{ARGS}? is inconsistent with Fortran syntax and as such, removed from CHAR */
-CHAR      (CHARACTER|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
-
-/* The patterns ({NUM_TYPE}{KIND}) and ({NUM_TYPE}({BS}"*"{BS}[0-9]+)?) are inconsistent with Fortran syntax and as such, was removed from TYPE_SPEC */
-TYPE_SPEC ({NUM_TYPE}|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|{CHAR}|TYPE|CLASS|PROCEDURE|ENUMERATOR)
-
-ACCESS_SPEC         (PROTECTED|PRIVATE|PUBLIC)
-INTENT_SPEC         INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"
-
-/* Fortran attributes except BIND and C which are treated separately */
-ATTR_SPEC           (ALLOCATABLE|ASSIGNMENT|ASYNCHRONOUS|ABSTRACT|BIND|CODIMENSION|CONTIGUOUS|DEFERRED|DIMENSION|ELEMENTAL|EXTENDS|EXTERNAL|IMPURE|INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"|INTRINSIC|LOCAL|LOCAL_INIT|NON_INTRINSIC|NON_OVERRIDABLE|NON_RECURSIVE|NOPASS|OPERATOR|OPTIONAL|OVERRIDABLE|PARAMETER|PASS|POINTER|PRIVATE|PROTECTED|PUBLIC|PURE|RECURSIVE|SAVE|SEQUENCE|SHARED|TARGET|VALUE|VOLATILE)
-
-/* attributes that take arguments */
-ATTR_SPEC_WARG      (CODIMENSION|DIMENSION|EXTENDS|OPERATOR|PASS|BIND)
-
+INTENT_SPEC intent{BS}"("{BS}(in|out|in{BS}out){BS}")"
+ATTR_SPEC (IMPLICIT|ALLOCATABLE|DIMENSION{ARGS}|EXTERNAL|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|(NON_)?RECURSIVE|PURE|IMPURE|ELEMENTAL|VALUE|NOPASS|DEFERRED|CONTIGUOUS|VOLATILE)
+ACCESS_SPEC (PROTECTED|PRIVATE|PUBLIC)
 /* Assume that attribute statements are almost the same as attributes. */
-ATTR_STMT           {ATTR_SPEC}
-
-/* Intel directive statement and attributes. */
-DIR_INTEL_STATEMENT (ALIAS|ASSUME|ASSUME_ALIGNED|ATTRIBUTES|DLLEXPORT|BLOCK_LOOP|DECLARE|DEFINE|DISTRIBUTE{BS_}POINT|FIXEDFORMLINESIZE|FMA|FORCEINLINE|FREEFORM|IDENT|IF|IF{BS_}DEFINED|INLINE|INTEGER|IVDEP|LOOP{BS_}COUNT|MESSAGE|NOBLOCK_LOOP|NODECLARE|NOFMA|NOFREEFORM|NOFUSION|NOINLINE|NOOPTIMIZE|NOPARALLEL|NOPREFETCH|NOSTRICT|NOUNROLL|NOUNROLL_AND_JAM|NOVECTOR|OBJCOMMENT|OPTIMIZE|OPTIONS|PACK|PARALLEL|PREFETCH|PSECT|REAL|SIMD|STRICT|UNDEFINE|UNROLL|UNROLL_AND_JAM|VECTOR|ALIGN|ALLOCATABLE|ALLOW_NULL|C|CODE_ALIGN|CONCURRENCY_SAFE|CVF|DECORATE|DEFAULT|DLLIMPORT|EXTERN|FASTMEM|IGNORE_LOC|INLINE|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING)
-
-/* ("ATTRIBUTE"{BS}[,]?{BS} */
-/* |ALLOCATABLE|C|DEFAULT|DLLEXPORT|DLLIMPORT|EXTERN|FASTMEM|INLINE|FORCEINLINE|IGNORE_LOC|MIXED_STR_LEN_ARG|NO_ARG_CHECK|NOCLONE|NOINLINE|OPTIMIZATION_PARAMETER|REFERENCE|STDCALL|VALUE|VARYING|VECTOR */
-
-/* IEEE constants can be merged with NAMED_CONST in the future.
-Currently, including IEEE objects increases the number of flex rules to beyond what GNU flex can handle.
-The flex "flex: input rules are too complicated (>= 32000 NFA states)" error can be resolved by increasing
-the definitions in flexdef.h of flex source code for:
-    #define JAMSTATE -32766
-    #define MAXIMUM_MNS 31999
-    #define BAD_SUBSCRIPT -32767
-before compiling th flex library. However, the default distributed versions of flex cannot handle this.
-*/
-
-NAMED_CONST_IEEE                (IEEE_ALL|IEEE_ALL|IEEE_AWAY|IEEE_DATATYPE|IEEE_DENORMAL|IEEE_DIVIDE|IEEE_DIVIDE_BY_ZERO|IEEE_DOWN|IEEE_HALTING|IEEE_INEXACT|IEEE_INEXACT_FLAG|IEEE_INF|IEEE_INVALID|IEEE_INVALID_FLAG|IEEE_NAN|IEEE_NEAREST|IEEE_NEGATIVE_DENORMAL|IEEE_NEGATIVE_INF|IEEE_NEGATIVE_NORMAL|IEEE_NEGATIVE_SUBNORMAL|IEEE_NEGATIVE_ZERO|IEEE_OTHER|IEEE_OTHER_VALUE|IEEE_OVERFLOW|IEEE_POSITIVE_DENORMAL|IEEE_POSITIVE_INF|IEEE_POSITIVE_NORMAL|IEEE_POSITIVE_SUBNORMAL|IEEE_POSITIVE_ZERO|IEEE_ROUNDING|IEEE_SIGNALING_NAN|IEEE_SQRT|IEEE_SUBNORMAL|IEEE_TO_ZERO|IEEE_UNDERFLOW|IEEE_UNDERFLOW_FLAG|IEEE_UP|IEEE_USUAL)
-
-NAMED_CONST                     ({NAMED_CONST_IEEE}|C_ALERT|C_BACKSPACE|C_BOOL|C_CARRIAGE_RETURN|C_CHAR|C_DOUBLE|C_DOUBLE_COMPLEX|C_FLOAT|C_FLOAT_COMPLEX|C_FORM_FEED|C_HORIZONTAL_TAB|C_INT|C_INT16_T|C_INT32_T|C_INT64_T|C_INT8_T|C_INT_FAST16_T|C_INT_FAST32_T|C_INT_FAST64_T|C_INT_FAST8_T|C_INT_LEAST16_T|C_INT_LEAST32_T|C_INT_LEAST64_T|C_INT_LEAST8_T|C_INTMAX_T|C_INTPTR_T|C_LONG|C_LONG_DOUBLE|C_LONG_DOUBLE_COMPLEX|C_LONG_LONG|C_NEW_LINE|C_NULL_CHAR|C_NULL_FUNPTR|C_NULL_PTR|C_SHORT|C_SIGNED_CHAR|C_SIZE_T|C_VERTICAL_TAB|CHARACTER_KINDS|CHARACTER_STORAGE_SIZE|CURRENT_TEAM|ERROR_UNIT|FILE_STORAGE_SIZE|INITIAL_TEAM|INPUT_UNIT|INT16|INT32|INT64|INT8|INTEGER_KINDS|IOSTAT_END|IOSTAT_EOR|IOSTAT_INQUIRE_INTERNAL_UNIT|LOGICAL_KINDS|NUMERIC_STORAGE_SIZE|OUTPUT_UNIT|PARENT_TEAM|REAL128|REAL64|REAL32|REAL_KINDS|STAT_FAILED_IMAGE|STAT_LOCKED|STAT_LOCKED_OTHER_IMAGE|STAT_STOPPED_IMAGE|STAT_UNLOCKED|STAT_UNLOCKED_FAILED_IMAGE|\.FALSE\.|\.TRUE\.)
-
-FLOW                            (DO|DO{BS}CONCURRENT|SELECT{BS}(CASE|TYPE|RANK)|CASE|IF|THEN|ELSE{BS}IF|ELSE|DO{BS}WHILE|WHERE|ELSEWHERE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
-
-FLOW_END                        (DO|SELECT|WHERE|IF|WHILE|FORALL|CRITICAL|BLOCK|ASSOCIATE)
-
-PREFIX                          ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
-SUFFIX                          (RESULT{ARGS})
-/* The specified syntax is too generic and does not respect NAME and C as a specifiers. Also "bind" as an attribute takes precedence over its statement format.
-LANGUAGE_BIND_SPEC              BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
-*/
-
-/* INTRINSIC_FUNC_ELEMENTAL_IEEE can be merged with INTRINSIC_FUNC_ELEMENTAL when the flex bug gets resolved in the future */
-INTRINSIC_FUNC_ELEMENTAL_IEEE   (IEEE_CLASS|IEEE_COPY_SIGN|IEEE_FMA|IEEE_GET_FLAG|IEEE_GET_HALTING_MODE|IEEE_INT|IEEE_IS_FINITE|IEEE_IS_NAN|IEEE_IS_NEGATIVE|IEEE_IS_NORMAL|IEEE_LOGB|IEEE_MAX_NUM|IEEE_MAX_NUM_MAG|IEEE_MIN_NUM|IEEE_MIN_NUM_MAG|IEEE_NEXT_AFTER|IEEE_NEXT_DOWN|IEEE_NEXT_UP|IEEE_QUIET_EQ|IEEE_QUIET_GE|IEEE_QUIET_GT|IEEE_QUIET_LE|IEEE_QUIET_LT|IEEE_QUIET_NAN|IEEE_QUIET_NE|IEEE_REAL|IEEE_REM|IEEE_RINT|IEEE_SCALB|IEEE_SIGNALING_EQ|IEEE_SIGNALING_GE|IEEE_SIGNALING_GT|IEEE_SIGNALING_LE|IEEE_SIGNALING_LT|IEEE_SIGNALING_NE|IEEE_SIGNBIT|IEEE_UNORDERED|IEEE_VALUE)
-
-INTRINSIC_FUNC_ELEMENTAL        (ACHAR|ACOS|ACOSH|ADJUSTL|ADJUSTR|AIMAG|AINT|ANINT|ASIN|ASINH|ATAN|ATAN2|ATANH|BESSEL_J0|BESSEL_J1|BESSEL_JN|BESSEL_Y0|BESSEL_Y1|BESSEL_YN|BGE|BGT|BLE|BLT|BTEST|CEILING|CHAR|CMPLX|CONJG|COS|COSH|DBLE|DIM|DPROD|DSHIFTL|DSHIFTR|ERF|ERFC|ERFC_SCALED|EXP|EXPONENT|FLOOR|FRACTION|GAMMA|HYPOT|IACHAR|IAND|IBCLR|IBITS|IBSET|ICHAR|IEOR|IMAGE_STATUS|INT|IOR|ISHFT|ISHFTC|LEADZ|LEN_TRIM|LGE|LGT|LLE|LLT|LOG|LOG10|LOG_GAMMA|LOGICAL|MASKL|MASKR|MAX|MIN|MOD|MODULO|MVBITS|NEAREST|NINT|NOT|OUT_OF_RANGE|POPCNT|POPPAR|REAL|SCALE|SCAN|SET_EXPONENT|SHAPE|SHIFTA|SHIFTL|SHIFTR|SIGN|SIN|SINH|SPACING|SQRT|TAN|TANH|TRAILZ|TRIM|VERIFY)
-
-/* INTRINSIC_FUNC_INQUIRY_IEEE can be merged with INTRINSIC_FUNC_INQUIRY when the flex bug gets resolved in the future */
-INTRINSIC_FUNC_INQUIRY_IEEE     (IEEE_SUPPORT_DATATYPE|IEEE_SUPPORT_DENORMAL|IEEE_SUPPORT_DIVIDE|IEEE_SUPPORT_INF|IEEE_SUPPORT_IO|IEEE_SUPPORT_NAN|IEEE_SUPPORT_SQRT|IEEE_SUPPORT_STANDARD|IEEE_SUPPORT_SUBNORMAL|IEEE_SUPPORT_UNDERFLOW_CONTROL)
-
-INTRINSIC_FUNC_INQUIRY          ({INTRINSIC_FUNC_INQUIRY_IEEE}|ALLOCATED|ASSOCIATED|BIT_SIZE|C_SIZEOF|COSHAPE|DIGITS|EPSILON|EXTENDS_TYPE_OF|FAILED_IMAGES|HUGE|IS_CONTIGUOUS|IS_IOSTAT_END|IS_IOSTAT_EOR|KIND|LBOUND|LCOBOUND|LEN|MAXEXPONENT|MINEXPONENT|NEW_LINE|PRECISION|PRESENT|RADIX|RANGE|RANK|SAME_TYPE_AS|SIZE|STORAGE_SIZE|TINY|UBOUND|UCOBOUND)
-
-INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE (IEEE_SELECTED_REAL_KIND|IEEE_SUPPORT_FLAG|IEEE_SUPPORT_HALTING|IEEE_SUPPORT_ROUNDING)
-
-INTRINSIC_FUNC_TRANSFORMATIONAL ({INTRINSIC_FUNC_TRANSFORMATIONAL_IEEE}|ALL|ANY|BESSEL_JN|BESSEL_YN|C_ASSOCIATED|C_FUNLOC|C_LOC|COMMAND_ARGUMENT_COUNT|COMPILER_OPTIONS|COMPILER_VERSION|COUNT|CSHIFT|DOT_PRODUCT|EOSHIFT|FINDLOC|GET_TEAM|IALL|IANY|IMAGE_INDEX|INDEX|IPARITY|MATMUL|MAXLOC|MAXVAL|MERGE|MERGE_BITS|MINLOC|MINVAL|NORM2|NULL|NUM_IMAGES|PACK|PARITY|PRODUCT|REDUCE|REPEAT|RESHAPE|SELECTED_CHAR_KIND|SELECTED_INT_KIND|SELECTED_REAL_KIND|SPREAD|STOPPED_IMAGES|SUM|TEAM_NUMBER|THIS_IMAGE|TRANSPOSE|UNPACK)
-
-INTRINSIC_FUNC_VOID             (CFI_address|CFI_allocate|CFI_deallocate|CFI_establish|CFI_is_contiguous|CFI_section|CFI_select_part|CFI_setpointer)
-
-INTRINSIC_FUNC                  ({INTRINSIC_FUNC_ELEMENTAL}|{INTRINSIC_FUNC_INQUIRY}|{INTRINSIC_FUNC_TRANSFORMATIONAL})
-
-/* intrinsic subroutines */
-
-INTRINSIC_SUB_ATOMIC            (ATOMIC_ADD|ATOMIC_AND|ATOMIC_CAS|ATOMIC_DEFINE|ATOMIC_FETCH_ADD|ATOMIC_FETCH_AND|ATOMIC_FETCH_OR|ATOMIC_FETCH_XOR|ATOMIC_INT_KIND|ATOMIC_LOGICAL_KIND|ATOMIC_OR|ATOMIC_REF|ATOMIC_XOR)
-
-INTRINSIC_SUB_COLLECTIVE        (CO_BROADCAST|CO_MAX|CO_MIN|CO_REDUCE|CO_SUM)
-
-/* INTRINSIC_SUB_IMPURE_IEEE can be merged with INTRINSIC_SUB_IMPURE when the flex bug gets resolved in the future */
-INTRINSIC_SUB_IMPURE_IEEE       (IEEE_GET_MODES|IEEE_GET_ROUNDING_MODE|IEEE_GET_STATUS|IEEE_GET_UNDERFLOW_MODE|IEEE_SET_MODES|IEEE_SET_ROUNDING_MODE|IEEE_SET_STATUS|IEEE_SET_UNDERFLOW_MODE)
-INTRINSIC_SUB_IMPURE            ({INTRINSIC_SUB_IMPURE_IEEE}|C_F_POINTER|CPU_TIME|DATE_AND_TIME|EVENT_QUERY|EXECUTE_COMMAND_LINE|GET_COMMAND|GET_COMMAND_ARGUMENT|GET_ENVIRONMENT_VARIABLE|RANDOM_INIT|RANDOM_NUMBER|RANDOM_SEED|SYSTEM_CLOCK)
-
-/* INTRINSIC_SUB_PURE_IEEE can be merged with INTRINSIC_SUB_PURE when the flex bug gets resolved in the future */
-INTRINSIC_SUB_PURE_IEEE         (IEEE_SET_FLAG|IEEE_SET_HALTING_MODE)
-INTRINSIC_SUB_PURE              ({INTRINSIC_SUB_PURE_IEEE}|C_F_PROCPOINTER|MOVE_ALLOC)
-
-INTRINSIC_SUB                   ({INTRINSIC_SUB_ATOMIC}|{INTRINSIC_SUB_COLLECTIVE}|{INTRINSIC_SUB_IMPURE}|{INTRINSIC_SUB_PURE})
-
-INTRINSIC_PROC                  ({INTRINSIC_SUB}|{INTRINSIC_FUNC})
-
-/* INTRINSIC_MODULE_IEEE can be merged with INTRINSIC_MODULE when the flex bug gets resolved in the future */
-INTRINSIC_MODULE_IEEE           (IEEE_ARITHMETIC|IEEE_EXCEPTIONS|IEEE_FEATURES)
-INTRINSIC_MODULE                ({INTRINSIC_MODULE_IEEE}|ISO_C_BINDING|ISO_FORTRAN_ENV)
-
-SPECIFIER                       (ACCESS|ACQUIRED_LOCK|ACTION|ADVANCE|ASYNCHRONOUS|BLANK|DECIMAL|DELIM|DIM|DIRECT|ENCODING|EOR|ERR|ERRMSG|EXIST|FILE|FMT|FORM|FORMATTED|ID|IOLENGTH|IOMSG|IOSTAT|KIND|LEN|MOLD|NAME|NAMED|NEW_INDEX|NEWUNIT|NEXTREC|NML|NUMBER|OPENED|PAD|PENDING|POS|POSITION|QUIET|READ|READWRITE|REC|RECL|ROUND|SEQUENTIAL|SIGN|SIZE|SOURCE|STAT|STATUS|STREAM|TEAM|TEAM_NUMBER|UNFORMATTED|UNIT|UNTIL_COUNT|WRITE)
-
-/* FUNCTION and SUBROUTINE are excluded from STATEMENT below to prevent dot-graph self-reference misrepresentations. */
-STATEMENT                       (ALLOCATE|ASSIGN|BACKSPACE|BLOCK{BS}DATA|CALL|CHANGE{BS}TEAM|CLOSE|COMMON|CONTAINS|CONTINUE|CYCLE|DATA|DEALLOCATE|ENTRY|ERROR{BS}STOP|EQUIVALENCE|EVENT{BS_}POST|EVENT{BS_}WAIT|EXIT|FAIL{BS_}IMAGE|FINAL|FLUSH|FORM{BS_}TEAM|FORMAT|FORMATTED|GENERIC|GO{BS}TO|INCLUDE|INQUIRE|LOCK|MODULE{BS_}PROCEDURE|NAMELIST|NULLIFY|OPEN|PAUSE|PRINT|PROGRAM|READ|RESULT|RETURN|REWIND|STOP|SUBMODULE|END{BS}SUBMODULE|SYNC{BS_}(ALL|MEMORY|IMAGES|TEAM)|UNFORMATTED|UNLOCK|WAIT|WRITE)
-
-/* INTRINSIC_DERIVED_TYPE_IEEE and INTRINSIC_DERIVED_TYPE_CFI can be merged with INTRINSIC_DERIVED_TYPE when the flex bug gets resolved in the future */
-INTRINSIC_DERIVED_TYPE_IEEE     (IEEE_CLASS_TYPE|IEEE_FEATURES_TYPE|IEEE_FLAG_TYPE|IEEE_MODES_TYPE|IEEE_ROUND_TYPE|IEEE_STATUS_TYPE)
-INTRINSIC_DERIVED_TYPE_CFI      (CFI_cdesc_t)
-INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
+ATTR_STMT {ATTR_SPEC}|DIMENSION
+FLOW      (DO|SELECT|CASE|SELECT{BS}(CASE|TYPE)|WHERE|IF|THEN|ELSE|WHILE|FORALL|ELSEWHERE|ELSEIF|RETURN|CONTINUE|EXIT|GO{BS}TO)
+COMMANDS  (FORMAT|CONTAINS|MODULE{BS_}PROCEDURE|WRITE|READ|ALLOCATE|ALLOCATED|ASSOCIATED|PRESENT|DEALLOCATE|NULLIFY|SIZE|INQUIRE|OPEN|CLOSE|FLUSH|DATA|COMMON)
+IGNORE    (CALL)
+PREFIX    ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?0
+LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")"
 
 /* |  */
 
@@ -345,9 +268,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
 
 %x Start
 %x SubCall
-%x FuncDef
 %x ClassName
-%x ClassVar
 %x Subprog
 %x DocBlock
 %x Use
@@ -356,194 +277,74 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
 %x Declaration
 %x DeclarationBinding
 %x DeclContLine
-%x Parameterlist
 %x String
 %x Subprogend
 
 %%
  /*==================================================================*/
 
+ /*-------- ignore ------------------------------------------------------------*/
+
+<Start>{IGNORE}/{BS}"("                   { // do not search keywords, intrinsics... TODO: complete list
+                                            codifyLines(yyscanner,yytext);
+                                          }
  /*-------- inner construct ---------------------------------------------------*/
 
-<Start>{BS}"%"/{BS}[a-zA-Z]+.*                                  {   // highlight rule for the percent-symbol separator of Fortran standard.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<*>{BS}[.]*{BS}("+"|"-"|"*"|"/"|"<"|">"|"="|"&"){BS}            {   // highlight rule for the operators of Fortran standard.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_operator_symbols");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<*>{BS}(0|[1-9]\d*)(\.\d*)?(e[-\+]?(0|[1-9]\d*))?(_([a-zA-Z])+)?    {   // highlight rule for the numeric values of Fortran.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_numeric_literal");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<*>{BS}{NAMED_CONST}{BS}                                        {   // highlight rule for the named constants of Fortran standard.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_named_const");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>{BS}"bind"/{BS}"("[.]*                                   {   // highlight rule for the bind attribute of Fortran standard.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_attribute");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>{BS}"C"/{BS}(","{BS}"name"{BS}"="{BS}(.)+)("&"|")"){BS}  {   // highlight rule for the bind C attribute of Fortran standard.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_attribute");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Declaration>{BS}{ATTR_SPEC}/({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes of Fortran standard.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    if (QCString(yytext) == "external") yyextra->isExternal = true;
-                                                                    startFontClass(yyscanner,"fortran_attribute");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Declaration>{BS}{ATTR_SPEC_WARG}/("("[.*]")")?({BS},|{BS_}([a-zA-Z]|"::")){BS}   {   // highlight rule for the attributes that take argument: DIMENSION(:,:).
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_attribute");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<*>{BS}"("{BS}{INTRINSIC_DERIVED_TYPE}{BS}")"{BS}               {   // highlight rule for Fortran intrinsic derived types.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<*>{BS}{INTRINSIC_DERIVED_TYPE}{BS}                             {   // highlight rule for Fortran intrinsic module names.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_inrinsic_dtype");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<*>{BS}{INTRINSIC_MODULE}{BS}                                   {   // highlight rule for Fortran intrinsic module names.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_inrinsic_module");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start,Declaration>{BS}{SPECIFIER}/{BS}={BS}[a-zA-Z0-9_\.\-\+(\[][a-zA-Z0-9_)(\[\]!%,\.\-\+/=><\t ]*{BS}(")"|"&")  {   // highlight rule for Fortran intrinsic specifier (intrinsic procedure argument) names.
-                                                                    // \todo: A specifier must be enclosed with parentheses. This is not currently enforced.
-                                                                    startFontClass(yyscanner,"fortran_spcifier");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-
- /* Fortran intrinsic procedures */
-
-<Start>^{BS}"real"/[,:( ].*                                     {   // real is a data type but also an elemental function, which makes it a bit tricky.
-                                                                    yy_push_state(YY_START,yyscanner);
-                                                                    BEGIN(Declaration);
-                                                                    startFontClass(yyscanner,"fortran_statement");
-                                                                    yyextra->code->codify(QCString(yytext));
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>^{BS}"logical"/[,:( ].*                                  {   // logical is a data type but also an elemental function, which makes it a bit tricky.
-                                                                    yy_push_state(YY_START,yyscanner);
-                                                                    BEGIN(Declaration);
-                                                                    startFontClass(yyscanner,"fortran_statement");
-                                                                    yyextra->code->codify(QCString(yytext));
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start,Declaration>{BS}{INTRINSIC_FUNC}/{BS}[(]                 {   // highlight rule for Fortran intrinsic functions.
-                                                                    // \todo This must be improved when function name appears in an intrinsic module USE statement.
-                                                                    // \todo The current rule only captures function names when followed by "(".
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_function");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>{BS}{INTRINSIC_SUB}/{BS}[(]                              {   // highlight rule for Fortran intrinsic subroutines.
-                                                                    // \todo This must be improved when subroutine name appears in an intrinsic module USE statement.
-                                                                    // \todo The current rule only captures subroutine names when followed by "(".
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_subroutine");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>{BS}"MPI_"{BS}[a-zA-Z_]+/{BS}                            {   // highlight rule for MPI module intrinsic entities.
-                                                                    // \todo The current search pattern is too generic. In the future, all MPI entities from
-                                                                    // \todo the standard MPI module must be listed here and explicitly searched for.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_mpi");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-
- /* Fortran intrinsic statements */
-
-<Start>{BS}{STATEMENT}/{BS}[;( \t\n]                            {   // highlight rule for Fortran intrinsic statements.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_statement");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>{FLOW}/{BS}[;( \t\n]                                     {   // highlight rule for Fortran flow-control statements.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    if (yyextra->isFixedForm)
-                                                                    {
-                                                                        if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;
-                                                                    }
-                                                                    if (yyextra->currentMemberDef && yyextra->currentMemberDef->isFunction())
-                                                                    {
-                                                                        std::lock_guard<std::mutex> lock(g_countFlowKeywordsMutex);
-                                                                        MemberDefMutable *mdm = toMemberDefMutable(yyextra->currentMemberDef);
-                                                                        if (mdm)
-                                                                        {
-                                                                            mdm->incrementFlowKeyWordCount();
-                                                                        }
-                                                                    }
-                                                                    /* font class is defined e.g. in doxygen.css */
-                                                                    startFontClass(yyscanner,"fortran_keywordflow");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>(CASE|CLASS|TYPE|RANK){BS_}(IS|DEFAULT)                  {
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_keywordflow");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<*>{BS}"end"{BS}{FLOW_END}/[ ;\t\n]                             {   // list is a bit long as not all have possible end. <*> needed since the FLOW could be all in one line.
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_keywordflow");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
-<Start>"implicit"{BS}("none"|{TYPE_SPEC})                       {
-                                                                    if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                                    startFontClass(yyscanner,"fortran_statement");
-                                                                    codifyLines(yyscanner,yytext);
-                                                                    endFontClass(yyscanner);
-                                                                }
- /*-------- use statement -------------------------------------------*/
-<Start>"use"{BS}                        {
-                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                          startFontClass(yyscanner,"fortran_statement");
+<Start>{COMMANDS}/{BS}[,( \t\n]           {  // highlight
+                                            /* font class is defined e.g. in doxygen.css */
+                                            startFontClass(yyscanner,"keyword");
+                                            codifyLines(yyscanner,yytext);
+                                            endFontClass(yyscanner);
+                                          }
+<Start>{FLOW}/{BS}[,( \t\n]               {
+                                          if (yyextra->isFixedForm)
+                                          {
+                                            if ((yy_my_start == 1) && ((yytext[0] == 'c') || (yytext[0] == 'C'))) YY_FTN_REJECT;
+                                          }
+                                          if (yyextra->currentMemberDef && yyextra->currentMemberDef->isFunction())
+                                          {
+                                            std::lock_guard<std::mutex> lock(g_countFlowKeywordsMutex);
+                                            MemberDefMutable *mdm = toMemberDefMutable(yyextra->currentMemberDef);
+                                            if (mdm)
+                                            {
+                                              mdm->incrementFlowKeyWordCount();
+                                            }
+                                          }
+                                          /* font class is defined e.g. in doxygen.css */
+                                          startFontClass(yyscanner,"keywordflow");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
-                                          yy_push_state(YY_START,yyscanner);
-                                          BEGIN(Use);
                                         }
-<Use>("intrinsic"|"non_intrinsic")      { // TODO: rename
-                                          startFontClass(yyscanner,"fortran_attribute");
+<Start>{BS}(CASE|CLASS|TYPE){BS_}(IS|DEFAULT) {
+                                          startFontClass(yyscanner,"keywordflow");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+<Start>{BS}"end"({BS}{FLOW})/[ \t\n]       { // list is a bit long as not all have possible end
+                                          startFontClass(yyscanner,"keywordflow");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+<Start>"implicit"{BS}("none"|{TYPE_SPEC})  {
+                                          startFontClass(yyscanner,"keywordtype");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+<Start>^{BS}"namelist"/[/]              {  // Namelist specification
+                                          startFontClass(yyscanner,"keywordtype");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+ /*-------- use statement -------------------------------------------*/
+<Start>"use"{BS_}                       {
+                                          startFontClass(yyscanner,"keywordtype");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN(Use);
                                         }
 <Use>"ONLY"                             { // TODO: rename
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          startFontClass(yyscanner,"keywordtype");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -551,7 +352,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                         }
 <Use>{ID}                               {
                                           QCString tmp(yytext);
-                                          // tmp = tmp.lower();
+                                          tmp = tmp.lower();
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
                                           yyextra->insideBody=FALSE;
@@ -568,7 +369,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           YY_FTN_RESET}
 <UseOnly>{ID}                           {
                                           QCString tmp(yytext);
-                                          // tmp = tmp.lower();
+                                          tmp = tmp.lower();
                                           yyextra->useEntry.onlyNames.push_back(tmp);
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
@@ -576,12 +377,13 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                         }
 <Use,UseOnly,Import>"\n"                {
                                           unput(*yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <*>"import"{BS}/"\n"                    |
 <*>"import"{BS_}                        {
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          startFontClass(yyscanner,"keywordtype");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -593,80 +395,78 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->insideBody=FALSE;
                                         }
 <Import>("ONLY"|"NONE"|"ALL")           {
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          startFontClass(yyscanner,"keywordtype");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
  /*-------- fortran module  -----------------------------------------*/
-<Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n { //
-                                            startScope(yyscanner);
-                                            startFontClass(yyscanner,"fortran_statement");
-                                            codifyLines(yyscanner,yytext);
-                                            endFontClass(yyscanner);
-                                            yy_push_state(YY_START,yyscanner);
-                                            BEGIN(ClassName);
-                                            if (!qstricmp(yytext,"module")) yyextra->currentModule="module";
+<Start>("block"{BS}"data"|"program"|"module"|"interface")/{BS_}|({COMMA}{ACCESS_SPEC})|\n {  //
+                                          startScope(yyscanner);
+                                          startFontClass(yyscanner,"keyword");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(ClassName);
+                                          if (!qstricmp(yytext,"module")) yyextra->currentModule="module";
                                         }
-<Start>^{BS}"enum"/{BS}("&"|",")        {   // rule for enum statement
-                                            startScope(yyscanner);
-                                            startFontClass(yyscanner,"fortran_statement");
-                                            codifyLines(yyscanner,yytext);
-                                            endFontClass(yyscanner);
-                                            yy_push_state(YY_START,yyscanner);
-                                            BEGIN(ClassName);
+<Start>("enum")/{BS_}|{BS}{COMMA}{BS}{LANGUAGE_BIND_SPEC}|\n {  //
+                                          startScope(yyscanner);
+                                          startFontClass(yyscanner,"keyword");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(ClassName);
                                         }
-<Start>("type")/{BS}[:,]{BS}            {   // rule for type-definition construct. Do NOT put "(" in [:,] as it leads to confusion with variable declaration.
-                                            startScope(yyscanner);
-                                            startFontClass(yyscanner,"fortran_statement");
-                                            codifyLines(yyscanner,yytext);
-                                            endFontClass(yyscanner);
-                                            yy_push_state(YY_START,yyscanner);
-                                            BEGIN(ClassName);
-                                        }
-<ClassName>{ID}                         {
-                                            if (yyextra->currentModule == "module")
-                                            {
-                                                yyextra->currentModule=yytext;
-                                                yyextra->currentModule = yyextra->currentModule;//.lower();
-                                            }
-                                            generateLink(yyscanner,*yyextra->code,yytext);
-                                            yy_pop_state(yyscanner);
-                                        }
-<ClassName>{BS}({ATTR_SPEC})/{BS}[,:( ]{BS} { // variable declaration
-                                            if (QCString(yytext) == "external") yyextra->isExternal = true;
-                                            startFontClass(yyscanner,"fortran_attribute");
-                                            yyextra->code->codify(QCString(yytext));
-                                            endFontClass(yyscanner);
-                                        }
-<Start>^{BS}{ACCESS_SPEC}/{BS}[,: ]     {   // access attribute declaration. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
-                                            startFontClass(yyscanner,"fortran_attribute");
-                                            yyextra->code->codify(QCString(yytext));
-                                            endFontClass(yyscanner);
-                                        }
-<ClassName>\n                           {   // interface may be without name
-                                            yy_pop_state(yyscanner);
-                                            YY_FTN_REJECT;
-                                        }
-<Start>^{BS}"end"({BS_}"enum").*        {
-                                            YY_FTN_REJECT;
-                                        }
-<Start>^{BS}"end"({BS_}"type").*        {
-                                            YY_FTN_REJECT;
-                                        }
-<Start>^{BS}"end"({BS_}"module").*      {   // just reset yyextra->currentModule, rest is done in following rule
-                                            yyextra->currentModule=0;
-                                            YY_FTN_REJECT;
-                                        }
- /*-------- subprog definition -------------------------------------*/
- /*
- <Start>({PREFIX}{BS_})?({TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
-                                          startFontClass(yyscanner,"fortran_prefix");
+<*>{LANGUAGE_BIND_SPEC}                 {  //
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
- */
-<Start>("module"{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
-                                          startFontClass(yyscanner,"fortran_prefix");
+<Start>("type")/{BS_}|({COMMA}({ACCESS_SPEC}|ABSTRACT|EXTENDS))|\n {  //
+                                          startScope(yyscanner);
+                                          startFontClass(yyscanner,"keyword");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(ClassName);
+                                        }
+<ClassName>{ID}                         {
+                                          if (yyextra->currentModule == "module")
+                                          {
+                                            yyextra->currentModule=yytext;
+                                            yyextra->currentModule = yyextra->currentModule.lower();
+                                          }
+                                          generateLink(yyscanner,*yyextra->code,yytext);
+                                          pop_state(yyscanner);
+                                        }
+<ClassName>({ACCESS_SPEC}|ABSTRACT|EXTENDS)/[,:( ] { //| variable declaration
+                                          startFontClass(yyscanner,"keyword");
+                                          yyextra->code->codify(QCString(yytext));
+                                          endFontClass(yyscanner);
+                                        }
+<ClassName>\n                           { // interface may be without name
+                                          pop_state(yyscanner);
+                                          YY_FTN_REJECT;
+                                        }
+<Start>^{BS}"end"({BS_}"enum").*        {
+                                          YY_FTN_REJECT;
+                                        }
+<Start>^{BS}"end"({BS_}"type").*        {
+                                          YY_FTN_REJECT;
+                                        }
+<Start>^{BS}"end"({BS_}"module").*      { // just reset yyextra->currentModule, rest is done in following rule
+                                          yyextra->currentModule=0;
+                                          YY_FTN_REJECT;
+                                        }
+ /*-------- subprog definition -------------------------------------*/
+<Start>({PREFIX}{BS_})?{TYPE_SPEC}{BS_}({PREFIX}{BS_})?{BS}/{SUBPROG}{BS_}  {   // TYPE_SPEC is for old function style function result
+                                          startFontClass(yyscanner,"keyword");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+<Start>({PREFIX}{BS_})?{SUBPROG}{BS_}   {  // Fortran subroutine or function found
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -678,7 +478,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           generateLink(yyscanner,*yyextra->code,yytext);
                                         }
 <Subprog>"result"/{BS}"("[^)]*")"       {
-                                          startFontClass(yyscanner,"fortran_suffix");
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
@@ -687,13 +487,13 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                         }
 <Subprog,Subprogend>"\n"                { codifyLines(yyscanner,yytext);
                                           yyextra->contLineNr++;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface")?{BS}     {  // Fortran subroutine or function ends
                                           //cout << "===> end function " << yytext << endl;
                                           endScope(yyscanner);
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -701,49 +501,55 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                         }
 <Subprogend>{ID}/{BS}(\n|!|;)           {
                                           generateLink(yyscanner,*yyextra->code,yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface"){BS}/(\n|!|;) {  // Fortran subroutine or function ends
                                           //cout << "===> end function " << yytext << endl;
                                           endScope(yyscanner);
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
  /*-------- variable declaration ----------------------------------*/
-<Start>{TYPE_SPEC}/{BS}[,:( ]           {
-                                          QCString typ(yytext);
-                                          typ = removeRedundantWhiteSpace(typ.lower());
-                                          if (typ.startsWith("real")) YY_FTN_REJECT;
-                                          if (typ.startsWith("logical")) YY_FTN_REJECT;
-                                          if (typ == "type" || typ == "class" || typ == "procedure") yyextra->inTypeDecl = 1;
+<Start>^{BS}"real"/[,:( ]               { // real is a bit tricky as it is a data type but also a function.
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN(Declaration);
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          startFontClass(yyscanner,"keywordtype");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
-<Start>^{BS}({ATTR_SPEC}{BS_})+         { // declare attribute statement. Highlighting must be "fortran_attribute" as attribute has precedence over statement.
+<Start>{TYPE_SPEC}/[,:( ]               {
+                                          QCString typ(yytext);
+                                          typ = removeRedundantWhiteSpace(typ.lower());
+                                          if (typ.startsWith("real")) YY_FTN_REJECT;
+                                          if (typ == "type" || typ == "class" || typ == "procedure") yyextra->inTypeDecl = 1;
+                                          yy_push_state(YY_START,yyscanner);
+                                          BEGIN(Declaration);
+                                          startFontClass(yyscanner,"keywordtype");
+                                          yyextra->code->codify(QCString(yytext));
+                                          endFontClass(yyscanner);
+                                        }
+<Start>{ATTR_SPEC}                      {
                                           if (QCString(yytext) == "external")
                                           {
                                             yy_push_state(YY_START,yyscanner);
                                             BEGIN(Declaration);
                                             yyextra->isExternal = true;
                                           }
-                                          startFontClass(yyscanner,"fortran_attribute");
+                                          startFontClass(yyscanner,"keywordtype");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
-<Declaration>({TYPE_SPEC})/{BS}[(,: ]   { //| variable declaration
+<Declaration>({TYPE_SPEC}|{ATTR_SPEC})/[,:( ] { //| variable declaration
                                           if (QCString(yytext) == "external") yyextra->isExternal = true;
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          startFontClass(yyscanner,"keywordtype");
                                           yyextra->code->codify(QCString(yytext));
                                           endFontClass(yyscanner);
                                         }
 <Declaration>{ID}                       { // local var
                                           if (yyextra->isFixedForm && yy_my_start == 1)
                                           {
-                                            startFontClass(yyscanner,"fortran_comment");
+                                            startFontClass(yyscanner,"comment");
                                             yyextra->code->codify(QCString(yytext));
                                             endFontClass(yyscanner);
                                           }
@@ -767,7 +573,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                         }
 <DeclarationBinding>{ID}                { // Type bound procedure link
                                           generateLink(yyscanner,*yyextra->code, yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Declaration>[(]                        { // start of array or type / class specification
                                           yyextra->bracketCount++;
@@ -792,7 +598,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->contLineNr++;
                                           codifyLines(yyscanner,yytext);
                                           yyextra->bracketCount = 0;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <Declaration,DeclarationBinding>"\n"    { // end declaration line (?)
@@ -809,7 +615,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           if (!(yyextra->hasContLine && yyextra->hasContLine[yyextra->contLineNr - 1]))
                                           {
                                             yyextra->isExternal = false;
-                                            yy_pop_state(yyscanner);
+                                            pop_state(yyscanner);
                                           }
                                           YY_FTN_RESET
                                         }
@@ -817,7 +623,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
  /*-------- subprog calls  -----------------------------------------*/
 
 <Start>"call"{BS_}                      {
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                           yy_push_state(YY_START,yyscanner);
@@ -827,7 +633,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
                                           yyextra->insideBody=FALSE;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Start>{ID}{BS}/"("                     { // function call
                                           if (yyextra->isFixedForm && yy_my_start == 6)
@@ -839,7 +645,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           {
                                             yy_push_state(YY_START,yyscanner);
                                             BEGIN(Declaration);
-                                            startFontClass(yyscanner,"fortran_statement");
+                                            startFontClass(yyscanner,"keywordtype");
                                             yyextra->code->codify(QCString(yytext).stripWhiteSpace());
                                             endFontClass(yyscanner);
                                             yyextra->code->codify(QCString(yytext + 4));
@@ -890,64 +696,47 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->contLineNr++;
                                           if (Config_getBool(STRIP_CODE_COMMENTS))
                                           {
-                                            yyextra->yyLineNr+=((QCString)yyextra->docBlock).contains('\n');
+                                            yyextra->yyLineNr+=yyextra->docBlock.contains('\n');
                                             yyextra->yyLineNr+=1;
                                             nextCodeLine(yyscanner);
                                             yyextra->endComment=TRUE;
                                           }
                                           else // do not remove comment
                                           {
-                                            startFontClass(yyscanner,"fortran_comment");
+                                            startFontClass(yyscanner,"comment");
                                             codifyLines(yyscanner,yyextra->docBlock);
                                             endFontClass(yyscanner);
                                           }
                                           unput(*yytext);
                                           yyextra->contLineNr--;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
-<Start>^{BS}[!C]("DEC"|"DIR")"$"{BS}"ATTRIBUTES".*/"::" {   // ATTRIBUTES directive is treated separately as its argument (procedure name) needs to be recognized by Doxygen).
-                                                            startFontClass(yyscanner,"fortran_directive_intel");
-                                                            codifyLines(yyscanner,yytext);
-                                                            endFontClass(yyscanner);
-                                                        }
-<Start>^{BS}[!C]("DEC"|"DIR")"$".*                      {   // highlight rule for Intel Fortran Compiler directives (except ATTRIBUTES).
-                                                            QCString directive(yytext);
-                                                            directive = removeRedundantWhiteSpace(directive.lower());
-                                                            if (directive.contains("attributes",true)) YY_FTN_REJECT;
-                                                            startFontClass(yyscanner,"fortran_directive_intel");
-                                                            codifyLines(yyscanner,yytext);
-                                                            endFontClass(yyscanner);
-                                                        }
-<Start>^{BS}[\!c]"$OMP".*                               {   // OpenMP directives
-                                                            yy_push_state(YY_START,yyscanner);
-                                                            BEGIN(Declaration);
-                                                            startFontClass(yyscanner,"fortran_directive_omp");
-                                                            yyextra->code->codify(QCString(yytext));
-                                                            endFontClass(yyscanner);
-                                                        }
-<*>"!"[^><\n].*|"!"$                                    {   // normal comment
-                                                            if(YY_START == String) YY_FTN_REJECT; // ignore in strings
-                                                            if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
-                                                            startFontClass(yyscanner,"fortran_comment");
-                                                            codifyLines(yyscanner,yytext);
-                                                            endFontClass(yyscanner);
-                                                        }
- /*
-<*>^[Cc*].*                                             {   // normal comment
-                                                            if(! yyextra->isFixedForm) YY_FTN_REJECT;
-                                                            startFontClass(yyscanner,"fortran_comment");
-                                                            codifyLines(yyscanner,yytext);
-                                                            endFontClass(yyscanner);
-                                                        }
- */
+
+<*>"!"[^><\n].*|"!"$                    { // normal comment
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          if (yyextra->isFixedForm && yy_my_start == 6) YY_FTN_REJECT;
+                                          startFontClass(yyscanner,"comment");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
+
+<*>^[Cc*].*                             { // normal comment
+                                          if(! yyextra->isFixedForm) YY_FTN_REJECT;
+
+                                          startFontClass(yyscanner,"comment");
+                                          codifyLines(yyscanner,yytext);
+                                          endFontClass(yyscanner);
+                                        }
 <*>"assignment"/{BS}"("{BS}"="{BS}")"   {
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
 <*>"operator"/{BS}"("[^)]*")"           {
-                                          startFontClass(yyscanner,"fortran_statement");
+                                          if(YY_START == String) YY_FTN_REJECT; // ignore in strings
+                                          startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);
                                         }
@@ -967,15 +756,15 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           yyextra->code->codify(QCString(yytext));
                                         }
 <Start>{ID}                             {
-                                            //yyextra->insideBody=TRUE; // why is this needed? It messes up the dot-graph representations by generating artificial self-references.
+                                            yyextra->insideBody=TRUE;
                                             generateLink(yyscanner,*yyextra->code, yytext);
-                                            //yyextra->insideBody=FALSE;
+                                            yyextra->insideBody=FALSE;
                                         }
  /*------ strings --------------------------------------------------*/
 <String>\n                              { // string with \n inside
                                           yyextra->contLineNr++;
                                           yyextra->str+=yytext;
-                                          startFontClass(yyscanner,"fortran_string");
+                                          startFontClass(yyscanner,"stringliteral");
                                           codifyLines(yyscanner,yyextra->str);
                                           endFontClass(yyscanner);
                                           yyextra->str = "";
@@ -984,10 +773,10 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
 <String>\"|\'                           { // string ends with next quote without previous backspace
                                           if(yytext[0]!=yyextra->stringStartSymbol) YY_FTN_REJECT; // single vs double quote
                                           yyextra->str+=yytext;
-                                          startFontClass(yyscanner,"fortran_string");
+                                          startFontClass(yyscanner,"stringliteral");
                                           codifyLines(yyscanner,yyextra->str);
                                           endFontClass(yyscanner);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <String>.                               {yyextra->str+=yytext;}
 
@@ -1010,7 +799,7 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           {
                                             codifyLines(yyscanner,yytext);
                                             // comment cannot extend over the end of a line so should always be terminated at the end of the line.
-                                            if (yyextra->currentFontClass && !strcmp(yyextra->currentFontClass,"fortran_comment")) endFontClass(yyscanner);
+                                            if (yyextra->currentFontClass && !strcmp(yyextra->currentFontClass,"comment")) endFontClass(yyscanner);
                                           }
                                           yyextra->contLineNr++;
                                           YY_FTN_RESET
@@ -1018,9 +807,9 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
 <*>^{BS}"type"{BS}"="                   { yyextra->code->codify(QCString(yytext)); }
 
 <*>[\x80-\xFF]*                         { // keep utf8 characters together...
-                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
+                                          if (yyextra->isFixedForm && yy_my_start > yyextra->fixedCommentAfter)
                                           {
-                                            startFontClass(yyscanner,"fortran_comment");
+                                            startFontClass(yyscanner,"comment");
                                             codifyLines(yyscanner,yytext);
                                           }
                                           else
@@ -1029,12 +818,12 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                           }
                                         }
 <*>.                                    {
-                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
+                                          if (yyextra->isFixedForm && yy_my_start > yyextra->fixedCommentAfter)
                                           {
                                             //yy_push_state(YY_START,yyscanner);
                                             //BEGIN(DocBlock);
                                             //yyextra->docBlock=yytext;
-                                            startFontClass(yyscanner,"fortran_comment");
+                                            startFontClass(yyscanner,"comment");
                                             codifyLines(yyscanner,yytext);
                                           }
                                           else
@@ -1042,27 +831,18 @@ INTRINSIC_DERIVED_TYPE          (C_FUNPTR|C_PTR|EVENT_TYPE|LOCK_TYPE|TEAM_TYPE)
                                             yyextra->code->codify(QCString(yytext));
                                           }
                                         }
-<*>{OPERATOR_LOGICAL}                   {   // Fortran logical comparison keywords
-                                            startFontClass(yyscanner,"fortran_operator_logical");
-                                            //codifyLines(yyscanner,yyextra->docBlock);
-                                            yyextra->code->codify(QCString(yytext));
-                                            endFontClass(yyscanner);
-                                        }
-<*>{OPERATOR_SYMBOLS}                   { // Fortran operator symbols
-                                            startFontClass(yyscanner,"fortran_operator_symbols");
-                                            //codifyLines(yyscanner,yyextra->docBlock);
-                                            yyextra->code->codify(QCString(yytext));
-                                            endFontClass(yyscanner);
+<*>{LOG_OPER}                           { // Fortran logical comparison keywords
+                                          yyextra->code->codify(QCString(yytext));
                                         }
 <*><<EOF>>                              {
-                                            if (YY_START == DocBlock) {
-                                                if  (!Config_getBool(STRIP_CODE_COMMENTS))
-                                                {
-                                                    startFontClass(yyscanner,"fortran_comment");
-                                                    codifyLines(yyscanner,yyextra->docBlock);
-                                                    endFontClass(yyscanner);
-                                                }
+                                          if (YY_START == DocBlock) {
+                                            if (!Config_getBool(STRIP_CODE_COMMENTS))
+                                            {
+                                              startFontClass(yyscanner,"comment");
+                                              codifyLines(yyscanner,yyextra->docBlock);
+                                              endFontClass(yyscanner);
                                             }
+                                          }
                                           yyterminate();
                                         }
 %%
@@ -1160,24 +940,27 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                                 yyextra->currentMemberDef->getOutputFileBase(),
-                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,
+                                !yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else if (d->isLinkableInProject())
       {
-        yyextra->code->writeLineNumber( d->getReference(),
-                                        d->getOutputFileBase(),
-                                        QCString(),yyextra->yyLineNr
-                                        );
+        yyextra->code->writeLineNumber(d->getReference(),
+                                d->getOutputFileBase(),
+                                QCString(),yyextra->yyLineNr,
+                                !yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,
+                                     !yyextra->includeCodeFragment);
     }
   }
   yyextra->code->startCodeLine(yyextra->sourceFileDef);
+  yyextra->insideCodeLine=true;
   if (yyextra->currentFontClass)
   {
     yyextra->code->startFontClass(QCString(yyextra->currentFontClass));
@@ -1190,6 +973,7 @@ static void endCodeLine(yyscan_t yyscanner)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   endFontClass(yyscanner);
   yyextra->code->endCodeLine();
+  yyextra->insideCodeLine=false;
 }
 
 static void nextCodeLine(yyscan_t yyscanner)
@@ -1246,7 +1030,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
                   Definition *d,const QCString &text)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
+  bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
   yyextra->tooltipManager.addTooltip(ol,d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();
@@ -1355,8 +1139,7 @@ static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, 
   for (auto it = yyextra->scopeStack.rbegin(); it!=yyextra->scopeStack.rend(); ++it)
   {
     const Scope &scope = *it;
-    //std::string lowMemName = memberName.lower().str();
-    std::string lowMemName = memberName.str();
+    std::string lowMemName = memberName.lower().str();
     if (scope.localVars   .find(lowMemName)!=std::end(scope.localVars)     &&  // local var
         scope.externalVars.find(lowMemName)==std::end(scope.externalVars))     // and not external
     {
@@ -1478,14 +1261,13 @@ static bool getLink(yyscan_t yyscanner,const UseMap &useMap, // dictionary with 
 }
 
 
-static void generateLink(yyscan_t yyscanner, CodeOutputInterface &ol, const QCString &lname)
+static void generateLink(yyscan_t yyscanner,CodeOutputInterface &ol, const QCString &lname)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   ClassDef *cd=0;
   NamespaceDef *nsd=0;
   QCString name = lname;
-  // name = removeRedundantWhiteSpace(name.lower());
-  name = removeRedundantWhiteSpace(name);
+  name = removeRedundantWhiteSpace(name.lower());
 
   // check if lowercase lname is a linkable type or interface
   if ( (getFortranTypeDefs(name, yyextra->currentModule, cd, yyextra->useMembers)) && cd->isLinkable() )
@@ -1497,7 +1279,7 @@ static void generateLink(yyscan_t yyscanner, CodeOutputInterface &ol, const QCSt
     }
     else
     { // write type or interface link
-      writeMultiLineCodeLink(yyscanner, ol, cd, name);
+      writeMultiLineCodeLink(yyscanner, ol,cd,name);
       addToSearchIndex(yyscanner, name);
     }
   }
@@ -1542,8 +1324,7 @@ static int countLines(yyscan_t yyscanner)
   if (p>yyextra->inputString && *(p-1)!='\n')
   { // last line does not end with a \n, so we add an extra
     // line and explicitly terminate the line after parsing.
-    count++,
-    yyextra->needsTermination=TRUE;
+    count++;
   }
   return count;
 }
@@ -1588,8 +1369,7 @@ static void addLocalVar(yyscan_t yyscanner,const QCString &varName)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (!yyextra->scopeStack.empty())
   {
-    // std::string lowVarName = varName.lower().str();
-    std::string lowVarName = varName.str();
+    std::string lowVarName = varName.lower().str();
     yyextra->scopeStack.back().localVars.insert(lowVarName);
     if (yyextra->isExternal) yyextra->scopeStack.back().externalVars.insert(lowVarName);
   }
@@ -1615,7 +1395,7 @@ static void checkContLines(yyscan_t yyscanner,const char *s)
   yyextra->hasContLine = (int *) malloc((numLines) * sizeof(int));
   for (i = 0; i < numLines; i++)
     yyextra->hasContLine[i] = 0;
-  p = prepassFixedForm(s, yyextra->hasContLine);
+  p = prepassFixedForm(s, yyextra->hasContLine,yyextra->fixedCommentAfter);
   yyextra->hasContLine[0] = 0;
 }
 
@@ -1660,7 +1440,7 @@ void FortranCodeParser::resetCodeParserState()
   yyextra->currentDefinition = 0;
   yyextra->currentMemberDef = 0;
   yyextra->currentFontClass = 0;
-  yyextra->needsTermination = FALSE;
+  yyextra->insideCodeLine = FALSE;
   BEGIN( Start );
 }
 
@@ -1695,15 +1475,17 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   yyextra->code = &codeOutIntf;
   yyextra->inputString   = input.data();
   yyextra->inputPosition = 0;
+  yyextra->fileName      = fileDef ? fileDef->fileName():"";
   yyextra->isFixedForm = recognizeFixedForm(input,p->format);
   yyextra->contLineNr = 1;
   yyextra->hasContLine = NULL;
   if (yyextra->isFixedForm)
   {
     checkContLines(yyscanner,yyextra->inputString);
+    yyextra->fixedCommentAfter = Config_getInt(FORTRAN_COMMENT_AFTER);
   }
   yyextra->currentFontClass = 0;
-  yyextra->needsTermination = FALSE;
+  yyextra->insideCodeLine = FALSE;
   yyextra->searchCtx = searchCtx;
   yyextra->collectXRefs = collectXRefs;
   if (startLine!=-1)
@@ -1739,10 +1521,9 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   fortrancodeYYrestart(0, yyscanner);
   BEGIN( Start );
   fortrancodeYYlex(yyscanner);
-  if (yyextra->needsTermination)
+  if (yyextra->insideCodeLine)
   {
-    endFontClass(yyscanner);
-    yyextra->code->endCodeLine();
+    endCodeLine(yyscanner);
   }
   if (!fileDef && isExampleBlock && yyextra->sourceFileDef)
   {
@@ -1759,6 +1540,14 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   printlex(yy_flex_debug, FALSE, __FILE__, fileDef ? qPrint(fileDef->fileName()): NULL);
 }
 
+static inline void pop_state(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if ( yyg->yy_start_stack_ptr <= 0 )
+    warn(yyextra->fileName,yyextra->yyLineNr,"Unexpected statement '%s'",yytext );
+  else
+    yy_pop_state(yyscanner);
+}
 //---------------------------------------------------------
 
 #if USE_STATE2STRING

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -63,7 +63,7 @@ typedef yyguts_t *yyscan_t;
 #include "fortranscanner.h"
 #include "containers.h"
 
-const int fixedCommentAfter = 72;
+const int fixedCommentAfter = 10000;
 
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x

--- a/src/fortranscanner-independence.l
+++ b/src/fortranscanner-independence.l
@@ -789,10 +789,27 @@ private                                 {
                                           yyextra->current->startLine  = yyextra->lineNr;
                                           addCurrentEntry(yyscanner,true);
                                         }
+{BS}"=>"[^(\n|\!)]*                     {
+                                          /*
+                                           * Specific bindings come after the ID.
+                                           *
+                                           * Do not store the specific binding target as args for generic
+                                           * type-bound bindings.  It is not a callable argument list.
+                                           */
+                                          if (yyextra->last_entry &&
+                                              yyextra->last_entry->type.lower() != "generic")
+                                          {
+                                            QCString args = yytext;
+                                            yyextra->last_entry->args = args.lower();
+                                          }
+                                        }
+/*
 {BS}"=>"[^(\n|\!)]*                     { // Specific bindings come after the ID.
                                           QCString args = yytext;
-                                          yyextra->last_entry->args = args.lower();
+                                          // yyextra->last_entry->args = args.lower();
+                                          yyextra->last_entry->args = args;
                                         }
+*/
 "\n"                                    {
                                           yyextra->currentModifiers = SymbolModifiers();
                                           newLine(yyscanner);
@@ -2307,88 +2324,6 @@ static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot)
     return FALSE;
   }
 
-  /*
-   * Fortran type-bound generic bindings can be split across lines:
-   *
-   *   generic :: foo => foo_i
-   *   generic :: foo => foo_r
-   *
-   * They define one generic binding named "foo".  Doxygen 1.9.3 creates
-   * one Entry per line while parsing the Type Bound Procedures block, so
-   * remove duplicate generic bindings when the derived-type scope closes.
-   */
-  if (scope->section == Entry::CLASS_SEC)
-  {
-    std::map<std::string,Entry*> seenGenericBindings;
-    std::map<std::string,bool> genericBindingTargets;
-    std::vector<Entry*> duplicateGenericBindings;
-    std::vector<Entry*> hiddenGenericTargets;
-
-    for (const auto &ce : scope->children())
-    {
-      if (ce->section == Entry::FUNCTION_SEC &&
-          ce->type.lower() == "generic")
-      {
-        std::string args = ce->args.str();
-        std::string::size_type p = args.find("=>");
-        if (p != std::string::npos)
-        {
-          std::string name;
-          for (std::string::size_type i=p+2; i<args.length(); i++)
-          {
-            char c = args[i];
-            if ((c>='a' && c<='z') || (c>='A' && c<='Z') || c=='_' ||
-                (c>='0' && c<='9' && !name.empty()))
-            {
-              if (c>='A' && c<='Z') c += 'a'-'A';
-              name += c;
-            }
-            else if (!name.empty())
-            {
-              genericBindingTargets[name] = true;
-              name.clear();
-            }
-          }
-          if (!name.empty()) genericBindingTargets[name] = true;
-        }
-
-        std::string key = ce->name.lower().str();
-        if (seenGenericBindings.find(key) == seenGenericBindings.end())
-        {
-          seenGenericBindings[key] = ce.get();
-
-          /* The specific target after "=>" is not a callable argument list. */
-          ce->args = QCString();
-          ce->argList.clear();
-        }
-        else
-        {
-          duplicateGenericBindings.push_back(ce.get());
-        }
-      }
-    }
-
-    for (const auto &ce : scope->children())
-    {
-      if (ce->section == Entry::FUNCTION_SEC &&
-          ce->type.lower() != "generic" &&
-          genericBindingTargets.find(ce->name.lower().str()) != genericBindingTargets.end())
-      {
-        hiddenGenericTargets.push_back(ce.get());
-      }
-    }
-
-    for (Entry *e : hiddenGenericTargets)
-    {
-      scope->removeSubEntry(e);
-    }
-
-    for (Entry *e : duplicateGenericBindings)
-    {
-      scope->removeSubEntry(e);
-    }
-  }
-
   // update variables or subprogram arguments with yyextra->modifiers
   std::map<std::string,SymbolModifiers>& mdfsMap = yyextra->modifiers[scope];
 
@@ -2512,17 +2447,59 @@ static void initEntry(yyscan_t yyscanner)
 
 /**
   adds yyextra->current entry to yyextra->current_root and creates new yyextra->current
+
+static void addCurrentEntry(yyscan_t yyscanner,bool case_insens)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  //if (case_insens) yyextra->current->name = yyextra->current->name.lower();
+  if (case_insens) yyextra->current->name = yyextra->current->name;
+  //printf("===Adding entry %s to %s\n", qPrint(yyextra->current->name), qPrint(yyextra->current_root->name));
+  yyextra->last_entry = yyextra->current;
+  yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
+  initEntry(yyscanner);
+}
 */
 static void addCurrentEntry(yyscan_t yyscanner,bool case_insens)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+
+  if (case_insens)
+  {
+    yyextra->current->name = yyextra->current->name.lower();
+  }
+
   /*
-   * Your local tree had case preservation here.  If you want stock
-   * Doxygen 1.9.3 behavior, replace the next line with:
-   *   if (case_insens) yyextra->current->name = yyextra->current->name.lower();
+   * Fortran type-bound generic binding:
+   *
+   *   generic :: foo => foo_i
+   *   generic :: foo => foo_r
+   *
+   * These lines define one generic binding named "foo", not two
+   * documented members.  Doxygen 1.9.3 creates one FUNCTION_SEC entry
+   * per line, so suppress duplicate generic entries here.
    */
-  if (case_insens) yyextra->current->name = yyextra->current->name;
-  //printf("===Adding entry %s to %s\n", qPrint(yyextra->current->name), qPrint(yyextra->current_root->name));
+  if (yyextra->current_root &&
+      yyextra->current->section == Entry::FUNCTION_SEC &&
+      yyextra->current->type.lower() == "generic")
+  {
+    for (const auto &ce : yyextra->current_root->children())
+    {
+      if (ce->section == Entry::FUNCTION_SEC &&
+          ce->type.lower() == "generic" &&
+          ce->name.lower() == yyextra->current->name.lower())
+      {
+        /*
+         * Drop the duplicate, but still refresh yyextra->current exactly
+         * as moveToSubEntryAndRefresh() normally does.
+         */
+        yyextra->last_entry.reset();
+        yyextra->current = std::make_shared<Entry>();
+        initEntry(yyscanner);
+        return;
+      }
+    }
+  }
+
   yyextra->last_entry = yyextra->current;
   yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
   initEntry(yyscanner);

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -288,11 +288,18 @@ CHAR      (CHARACTER{ARGS}?|CHARACTER{BS}"*"({BS}[0-9]+|{ARGS}))
 TYPE_SPEC (({NUM_TYPE}({BS}"*"{BS}[0-9]+)?)|({NUM_TYPE}{KIND})|DOUBLE{BS}COMPLEX|DOUBLE{BS}PRECISION|ENUMERATOR|{CHAR}|TYPE{ARGS}|CLASS{ARGS}|PROCEDURE{ARGS}?)
 
 INTENT_SPEC intent{BS}"("{BS}(in|out|in{BS}out){BS}")"
+/*
+ATTR_SPEC           (ALLOCATABLE|ASSIGNMENT|ASYNCHRONOUS|ABSTRACT|CODIMENSION|CONTIGUOUS|DEFERRED|DIMENSION|EXTENDS|EXTERNAL|INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"|INTRINSIC|LOCAL|LOCAL_INIT|NON_INTRINSIC|NON_OVERRIDABLE|NOPASS|OPERATOR|OPTIONAL|OVERRIDABLE|PARAMETER|PASS{ARGS}?|POINTER|PRIVATE|PROTECTED|PUBLIC|SAVE|SEQUENCE|SHARED|TARGET|VALUE|VOLATILE)
+ */
 ATTR_SPEC (EXTERNAL|ALLOCATABLE|DIMENSION{ARGS}|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|NOPASS|PASS{ARGS}?|DEFERRED|NON_OVERRIDABLE|CONTIGUOUS|VOLATILE|VALUE)
+
 ACCESS_SPEC (PRIVATE|PUBLIC)
+
 LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}((,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})|(,{BS}NAME{BS}"="{BS}"'"(.*)"'"{BS}))?")"
+
 /* Assume that attribute statements are almost the same as attributes. */
 ATTR_STMT {ATTR_SPEC}|DIMENSION|{ACCESS_SPEC}
+
 EXTERNAL_STMT (EXTERNAL)
 
 CONTAINS  CONTAINS
@@ -640,12 +647,14 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                             BEGIN(ModuleBody);
                                         }
 
-  /*------- access specification --------------------------------------------------------------------------*/
+ /*------- access specification --------------------------------------------------------------------------*/
 
-<ModuleBody>private/{BS}(\n|"!")        { yyextra->defaultProtection = Private;
+ /*
+<ModuleBody>private/{BS}("::"|\n|"!")   { yyextra->defaultProtection = Private;
                                           yyextra->current->protection = yyextra->defaultProtection ;
                                         }
-<ModuleBody>public/{BS}(\n|"!")         { yyextra->defaultProtection = Public;
+ */
+<ModuleBody>public/{BS}("::"|\n|"!")    { yyextra->defaultProtection = Public;
                                           yyextra->current->protection = yyextra->defaultProtection ;
                                         }
 
@@ -680,10 +689,12 @@ public                                  {
                                           yyextra->current->protection = Public;
                                           yyextra->typeProtection = Public;
                                         }
+ /*
 private                                 {
                                           yyextra->current->protection = Private;
                                           yyextra->typeProtection = Private;
                                         }
+ */
 {LANGUAGE_BIND_SPEC}                    {
                                           /* ignored for now */
                                         }
@@ -1943,10 +1954,12 @@ SymbolModifiers& SymbolModifiers::operator|=(QCString mdfStringArg)
   {
     newMdf.protection = SymbolModifiers::PUBLIC;
   }
+  /*
   else if (mdfString=="private")
   {
     newMdf.protection = SymbolModifiers::PRIVATE;
   }
+  */
   else if (mdfString=="protected")
   {
     newMdf.protect = TRUE;
@@ -2143,11 +2156,13 @@ static QCString applyModifiers(QCString typeName, const SymbolModifiers& mdfs)
     if (!typeName.isEmpty()) typeName += ", ";
     typeName += "public";
   }
+  /*
   else if (mdfs.protection == SymbolModifiers::PRIVATE)
   {
     if (!typeName.isEmpty()) typeName += ", ";
     typeName += "private";
   }
+  */
   if (mdfs.protect)
   {
     if (!typeName.isEmpty()) typeName += ", ";
@@ -2187,8 +2202,10 @@ static void applyModifiers(Entry *ent, const SymbolModifiers& mdfs)
 
   if (mdfs.protection == SymbolModifiers::PUBLIC)
     ent->protection = Public;
+  /*
   else if (mdfs.protection == SymbolModifiers::PRIVATE)
     ent->protection = Private;
+  */
 }
 
 /*! Starts the new scope in fortran program. Consider using this function when

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -29,6 +29,17 @@
  * On one side we have arg->name and entry->name, on another side modifierMap[name].
  * In entries and arguments case is the same as in code, in modifier map case is lowered and
  * then it is compared to lowered entry/argument names.
+ * UPDATE:
+ * While it is true that Fortran is case-insensitive, modern-Fortran programmers (and even the old-schools) 
+ * hardly modify the case of Fortran entities throughout their codebase. As such, if a decision is to be made
+ * on whether to keep case-sensitivity, the readability of the generated documentation should be given more weight
+ * than the remote scenario where a Fortran developer uses mixed-case programming. In particular, several Fortran
+ * codebases use CameCase style, which become unreadable when Doxygen lowers the case of all letters.
+ * This updated file removes all lowering of the cases of the Fortran entities.
+ * This effectively means that Doxygen treats Fortran code as text-sensitive,
+ * and Fortran users of Doxygen must respect the case-sensitivity.
+ *
+ * Amir Shahmoradi, Sunday Sep 12, 2021, Dallas, TX, shahmoradi@utexas.edu
  *
  * - Do not like constructs like aa{BS} or {BS}bb. Should try to handle blank space
  * with separate rule?: It seems it is often necessary, because we may parse something like
@@ -468,7 +479,8 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 <Use>{ID}                               {
                                           DBG_CTX((stderr,"using dir %s\n",yytext));
                                           yyextra->current->name=yytext;
-                                          yyextra->current->name=yyextra->current->name.lower();
+                                          // yyextra->current->name=yyextra->current->name.lower();
+                                          yyextra->current->name=yyextra->current->name;
                                           yyextra->current->fileName = yyextra->fileName;
                                           yyextra->current->section=Entry::USINGDIR_SEC;
                                           yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
@@ -477,14 +489,16 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                         }
 <Use>{ID}/,                             {
                                           yyextra->useModuleName=yytext;
-                                          yyextra->useModuleName=yyextra->useModuleName.lower();
+                                          // yyextra->useModuleName=yyextra->useModuleName.lower();
+                                          yyextra->useModuleName=yyextra->useModuleName;
                                         }
 <Use>,{BS}"ONLY"                        { BEGIN(UseOnly);
                                         }
 <UseOnly>{BS},{BS}                      {}
 <UseOnly>{ID}                           {
                                           yyextra->current->name= yyextra->useModuleName+"::"+yytext;
-                                          yyextra->current->name=yyextra->current->name.lower();
+                                          // yyextra->current->name=yyextra->current->name.lower();
+                                          yyextra->current->name=yyextra->current->name;
                                           yyextra->current->fileName = yyextra->fileName;
                                           yyextra->current->section=Entry::USINGDECL_SEC;
                                           yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
@@ -517,7 +531,8 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
                                           // extract generic name
                                           QCString name = QCString(yytext).stripWhiteSpace();
-                                          name = name.right(name.length() - 9).stripWhiteSpace().lower();
+                                          // name = name.right(name.length() - 9).stripWhiteSpace().lower();
+                                          name = name.right(name.length() - 9).stripWhiteSpace();
                                           addInterface(yyscanner,name, yyextra->ifType);
                                           startScope(yyscanner,yyextra->last_entry.get());
                                         }
@@ -657,7 +672,8 @@ abstract                                {
                                           yyextra->current->spec |= Entry::AbstractClass;
                                         }
 extends{ARGS}                           {
-                                          QCString basename = extractFromParens(yytext).lower();
+                                          // QCString basename = extractFromParens(yytext).lower();
+                                          QCString basename = extractFromParens(yytext);
                                           yyextra->current->extends.push_back(BaseInfo(basename, Public, Normal));
                                         }
 public                                  {
@@ -713,7 +729,8 @@ private                                 {
                                         }
 {ID}                                    {
                                           QCString name = yytext;
-                                          yyextra->modifiers[yyextra->current_root][name.lower().str()] |= yyextra->currentModifiers;
+                                          // yyextra->modifiers[yyextra->current_root][name.lower().str()] |= yyextra->currentModifiers;
+                                          yyextra->modifiers[yyextra->current_root][name.str()] |= yyextra->currentModifiers;
                                           yyextra->current->section  = Entry::FUNCTION_SEC;
                                           yyextra->current->name     = name;
                                           yyextra->current->fileName = yyextra->fileName;
@@ -723,7 +740,8 @@ private                                 {
                                         }
 {BS}"=>"[^(\n|\!)]*                     { /* Specific bindings come after the ID. */
                                           QCString args = yytext;
-                                          yyextra->last_entry->args = args.lower();
+                                          // yyextra->last_entry->args = args.lower();
+                                          yyextra->last_entry->args = args;
                                         }
 "\n"                                    {
                                           yyextra->currentModifiers = SymbolModifiers();
@@ -791,7 +809,8 @@ private                                 {
                                           }
                                           else
                                           {
-                                            yyextra->argType = QCString(yytext).simplifyWhiteSpace().lower();
+                                            // yyextra->argType = QCString(yytext).simplifyWhiteSpace().lower();
+                                            yyextra->argType = QCString(yytext).simplifyWhiteSpace();
                                           }
                                           yyextra->current->bodyLine = yyextra->lineNr + 1;
                                           yyextra->current->endBodyLine = yyextra->lineNr + yyextra->lineCountPrepass;
@@ -812,7 +831,8 @@ private                                 {
                                           }
                                           QCString tmp = yytext;
                                           yyextra->currentModifiers |= tmp.stripWhiteSpace();
-                                          yyextra->argType = QCString(yytext).simplifyWhiteSpace().lower();
+                                          // yyextra->argType = QCString(yytext).simplifyWhiteSpace().lower();
+                                          yyextra->argType = QCString(yytext).simplifyWhiteSpace();
                                           yy_push_state(AttributeList,yyscanner);
                                         }
 {ATTR_STMT}/{BS_}{ID}                   |
@@ -871,9 +891,10 @@ private                                 {
                                           //cout << "5=========> got variable: " << yyextra->argType << "::" << yytext << endl;
                                           /* work around for bug in QCString.replace (QCString works) */
                                           QCString name=yytext;
-                                          name = name.lower();
+                                          // name = name.lower();
                                           /* remember attributes for the symbol */
-                                          yyextra->modifiers[yyextra->current_root][name.lower().str()] |= yyextra->currentModifiers;
+                                          // yyextra->modifiers[yyextra->current_root][name.lower().str()] |= yyextra->currentModifiers;
+                                          yyextra->modifiers[yyextra->current_root][name.str()] |= yyextra->currentModifiers;
                                           yyextra->argName= name;
 
                                           yyextra->vtype= V_IGNORE;
@@ -914,12 +935,15 @@ private                                 {
                                             // save, it may be function return type
                                             if (parameter)
                                             {
-                                              yyextra->modifiers[yyextra->current_root][name.lower().str()].type = yyextra->argType;
+                                              // yyextra->modifiers[yyextra->current_root][name.lower().str()].type = yyextra->argType;
+                                              yyextra->modifiers[yyextra->current_root][name.str()].type = yyextra->argType;
                                             }
                                             else
                                             {
-                                              if ((yyextra->current_root->name.lower() == yyextra->argName.lower()) ||
-                                                  (yyextra->modifiers[yyextra->current_root->parent()][yyextra->current_root->name.lower().str()].returnName.lower() == yyextra->argName.lower()))
+                                              // if ((yyextra->current_root->name.lower() == yyextra->argName.lower()) ||
+                                              if ((yyextra->current_root->name == yyextra->argName) ||
+                                                  // (yyextra->modifiers[yyextra->current_root->parent()][yyextra->current_root->name.lower().str()].returnName.lower() == yyextra->argName.lower()))
+                                                  (yyextra->modifiers[yyextra->current_root->parent()][yyextra->current_root->name.str()].returnName == yyextra->argName))
                                               {
                                                 int strt = yyextra->current_root->type.find("function");
                                                 QCString lft;
@@ -957,11 +981,13 @@ private                                 {
                                                   yyextra->current_root->type += " " + yyextra->argType.stripWhiteSpace();
                                                 }
                                                 yyextra->current_root->type = yyextra->current_root->type.stripWhiteSpace();
-                                                yyextra->modifiers[yyextra->current_root][name.lower().str()].type = yyextra->current_root->type;
+                                                // yyextra->modifiers[yyextra->current_root][name.lower().str()].type = yyextra->current_root->type;
+                                                yyextra->modifiers[yyextra->current_root][name.str()].type = yyextra->current_root->type;
                                               }
                                               else
                                               {
-                                                yyextra->modifiers[yyextra->current_root][name.lower().str()].type = yyextra->argType;
+                                                // yyextra->modifiers[yyextra->current_root][name.lower().str()].type = yyextra->argType;
+                                                yyextra->modifiers[yyextra->current_root][name.str()].type = yyextra->argType;
                                               }
                                             }
                                             // any accumulated doc for argument should be emptied,
@@ -975,7 +1001,8 @@ private                                 {
                                           QCString name(yyextra->argName);
                                           QCString attr("dimension");
                                           attr += yytext;
-                                          yyextra->modifiers[yyextra->current_root][name.lower().str()] |= attr;
+                                          // yyextra->modifiers[yyextra->current_root][name.lower().str()] |= attr;
+                                          yyextra->modifiers[yyextra->current_root][name.str()] |= attr;
                                         }
 <Variable>{COMMA}                       { //printf("COMMA: %d<=..<=%d\n", yyextra->colNr-(int)yyleng, yyextra->colNr);
                                           // locate !< comment
@@ -1114,7 +1141,8 @@ private                                 {
                                           }
 
                                           // TYPE_SPEC is for old function style function result
-                                          QCString result = QCString(yytext).stripWhiteSpace().lower();
+                                          // QCString result = QCString(yytext).stripWhiteSpace().lower();
+                                          QCString result = QCString(yytext).stripWhiteSpace();
                                           yyextra->current->type = result;
                                           yy_push_state(SubprogPrefix,yyscanner);
                                         }
@@ -1149,7 +1177,8 @@ private                                 {
 <Subprog>{BS}                           {   /* ignore white space */   }
 <Subprog>{ID}                           { yyextra->current->name = yytext;
                                           //cout << "1a==========> got " << yyextra->current->type << " " << yytext << " " << yyextra->lineNr << endl;
-                                          yyextra->modifiers[yyextra->current_root][yyextra->current->name.lower().str()].returnName = yyextra->current->name.lower();
+                                          // yyextra->modifiers[yyextra->current_root][yyextra->current->name.lower().str()].returnName = yyextra->current->name.lower();
+                                          yyextra->modifiers[yyextra->current_root][yyextra->current->name.str()].returnName = yyextra->current->name;
 
                                           if (yyextra->ifType == IF_ABSTRACT || yyextra->ifType == IF_SPECIFIC)
                                           {
@@ -1199,7 +1228,8 @@ private                                 {
                                             QCString result= yytext;
                                             result= result.right(result.length()-result.find("(")-1);
                                             result= result.stripWhiteSpace();
-                                            yyextra->modifiers[yyextra->current_root->parent()][yyextra->current_root->name.lower().str()].returnName = result;
+                                            //yyextra->modifiers[yyextra->current_root->parent()][yyextra->current_root->name.lower().str()].returnName = result;
+                                            yyextra->modifiers[yyextra->current_root->parent()][yyextra->current_root->name.str()].returnName = result;
                                           }
                                           //cout << "=====> got result " <<  result << endl;
                                          }
@@ -1305,7 +1335,8 @@ private                                 {
                                           BEGIN(PrototypeSubprog);
                                         }
 <Prototype,PrototypeSubprog>{BS}{SCOPENAME}?{BS}{ID} {
-                                          yyextra->current->name = QCString(yytext).lower();
+                                          //yyextra->current->name = QCString(yytext).lower();
+                                          yyextra->current->name = QCString(yytext);
                                           yyextra->current->name.stripWhiteSpace();
                                           BEGIN(PrototypeArgs);
                                         }
@@ -1313,7 +1344,8 @@ private                                 {
 "("|")"|","|{BS_}                       { yyextra->current->args += yytext; }
 {ID}                                    { yyextra->current->args += yytext;
                                           Argument a;
-                                          a.name = QCString(yytext).lower();
+                                          //a.name = QCString(yytext).lower();
+                                          a.name = QCString(yytext);
                                           yyextra->current->argList.push_back(a);
                                         }
 }
@@ -1890,7 +1922,8 @@ SymbolModifiers& SymbolModifiers::operator|=(const SymbolModifiers &mdfs)
 /*! Extracts and adds passed modifier to these yyextra->modifiers.*/
 SymbolModifiers& SymbolModifiers::operator|=(QCString mdfStringArg)
 {
-  QCString mdfString = mdfStringArg.lower();
+  //QCString mdfString = mdfStringArg.lower();
+  QCString mdfString = mdfStringArg;
   SymbolModifiers newMdf;
 
   if (mdfString.find("dimension")==0)
@@ -2006,10 +2039,13 @@ SymbolModifiers& SymbolModifiers::operator|=(QCString mdfStringArg)
 static Argument *findArgument(Entry* subprog, QCString name, bool byTypeName = FALSE)
 {
   QCString cname(name.lower());
+  //QCString cname(name);
   for (Argument &arg : subprog->argList)
   {
-    if ((!byTypeName && arg.name.lower() == cname) ||
-         (byTypeName && arg.type.lower() == cname)
+    //if ((!byTypeName && arg.name.lower() == cname) ||
+    if ((!byTypeName && arg.name == cname) ||
+         //(byTypeName && arg.type.lower() == cname)
+         (byTypeName && arg.type == cname)
        )
     {
       return &arg;
@@ -2214,7 +2250,8 @@ static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot)
 
     // find return type for function
     //cout<<"RETURN NAME "<<yyextra->modifiers[yyextra->current_root][scope->name.lower()].returnName<<endl;
-    QCString returnName = yyextra->modifiers[yyextra->current_root][scope->name.lower().str()].returnName.lower();
+    //QCString returnName = yyextra->modifiers[yyextra->current_root][scope->name.lower().str()].returnName.lower();
+    QCString returnName = yyextra->modifiers[yyextra->current_root][scope->name.str()].returnName;
     if (yyextra->modifiers[scope].find(returnName.str())!=yyextra->modifiers[scope].end())
     {
       scope->type = yyextra->modifiers[scope][returnName.str()].type; // returning type works
@@ -2244,7 +2281,8 @@ static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot)
           arg->name = arg->type;
           arg->type = scope->name;
         }
-        if (ce->name.lower() == scope->name.lower()) found = TRUE;
+        //if (ce->name.lower() == scope->name.lower()) found = TRUE;
+        if (ce->name == scope->name) found = TRUE;
       }
       if ((count == 1) && found)
       {
@@ -2265,8 +2303,10 @@ static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot)
         continue;
 
       //cout<<ce->name<<", "<<mdfsMap.contains(ce->name.lower())<<mdfsMap.count()<<endl;
-      if (mdfsMap.find(ce->name.lower().str())!=mdfsMap.end())
-        applyModifiers(ce.get(), mdfsMap[ce->name.lower().str()]);
+      //if (mdfsMap.find(ce->name.lower().str())!=mdfsMap.end())
+      if (mdfsMap.find(ce->name.str())!=mdfsMap.end())
+        //applyModifiers(ce.get(), mdfsMap[ce->name.lower().str()]);
+        applyModifiers(ce.get(), mdfsMap[ce->name.str()]);
     }
   }
 
@@ -2318,7 +2358,8 @@ static void initEntry(yyscan_t yyscanner)
 static void addCurrentEntry(yyscan_t yyscanner,bool case_insens)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  if (case_insens) yyextra->current->name = yyextra->current->name.lower();
+  //if (case_insens) yyextra->current->name = yyextra->current->name.lower();
+  if (case_insens) yyextra->current->name = yyextra->current->name;
   //printf("===Adding entry %s to %s\n", qPrint(yyextra->current->name), qPrint(yyextra->current_root->name));
   yyextra->last_entry = yyextra->current;
   yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
@@ -2363,7 +2404,8 @@ static void addSubprogram(yyscan_t yyscanner,const QCString &text)
   DBG_CTX((stderr,"1=========> got subprog, type: %s\n",qPrint(text)));
   yyextra->subrCurrent.push_back(yyextra->current);
   yyextra->current->section = Entry::FUNCTION_SEC ;
-  QCString subtype = text; subtype=subtype.lower().stripWhiteSpace();
+  //QCString subtype = text; subtype=subtype.lower().stripWhiteSpace();
+  QCString subtype = text; subtype=subtype.stripWhiteSpace();
   yyextra->functionLine = (subtype.find("function") != -1);
   yyextra->current->type += " " + subtype;
   yyextra->current->type = yyextra->current->type.stripWhiteSpace();
@@ -2434,7 +2476,8 @@ static Argument *getParameter(yyscan_t yyscanner,const QCString &name)
   Argument *ret = 0;
   for (Argument &a:yyextra->current_root->argList)
   {
-    if (a.name.lower()==name.lower())
+    //if (a.name.lower()==name.lower())
+    if (a.name==name)
     {
       ret=&a;
       //printf("parameter found: %s\n",(const char*)name);
@@ -2522,9 +2565,11 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
   loc_doc.stripWhiteSpace();
 
   // direction as defined with the declaration of the parameter
-  int dir1 = yyextra->modifiers[yyextra->current_root][yyextra->argName.lower().str()].direction;
+  //int dir1 = yyextra->modifiers[yyextra->current_root][yyextra->argName.lower().str()].direction;
+  int dir1 = yyextra->modifiers[yyextra->current_root][yyextra->argName.str()].direction;
   // in description [in] is specified
-  if (loc_doc.lower().find(directionParam[SymbolModifiers::IN]) == 0)
+  //if (loc_doc.lower().find(directionParam[SymbolModifiers::IN]) == 0)
+  if (loc_doc.find(directionParam[SymbolModifiers::IN]) == 0)
   {
     // check if with the declaration intent(in) or nothing has been specified
     if ((directionParam[dir1] == directionParam[SymbolModifiers::NONE_D]) ||
@@ -2534,7 +2579,8 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
       loc_doc = loc_doc.right(loc_doc.length()-(int)strlen(directionParam[SymbolModifiers::IN]));
       loc_doc.stripWhiteSpace();
       // in case of empty documentation or (now) just name, consider it as no documentation
-      if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+      //if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+      if (!loc_doc.isEmpty() && (loc_doc != yyextra->argName))
       {
         handleCommentBlock(yyscanner,QCString("\n\n@param ") + directionParam[SymbolModifiers::IN] + " " +
                          yyextra->argName + " " + loc_doc,brief);
@@ -2550,14 +2596,16 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
     }
   }
   // analogous to the [in] case, here [out] direction specified
-  else if (loc_doc.lower().find(directionParam[SymbolModifiers::OUT]) == 0)
+  //else if (loc_doc.lower().find(directionParam[SymbolModifiers::OUT]) == 0)
+  else if (loc_doc.find(directionParam[SymbolModifiers::OUT]) == 0)
   {
     if ((directionParam[dir1] == directionParam[SymbolModifiers::NONE_D]) ||
         (directionParam[dir1] == directionParam[SymbolModifiers::OUT]))
     {
       loc_doc = loc_doc.right(loc_doc.length()-(int)strlen(directionParam[SymbolModifiers::OUT]));
       loc_doc.stripWhiteSpace();
-      if (loc_doc.isEmpty() || (loc_doc.lower() == yyextra->argName.lower()))
+      //if (loc_doc.isEmpty() || (loc_doc.lower() == yyextra->argName.lower()))
+      if (loc_doc.isEmpty() || (loc_doc == yyextra->argName))
       {
         yyextra->current = tmp_entry;
         return;
@@ -2574,14 +2622,16 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
     }
   }
   // analogous to the [in] case, here [in,out] direction specified
-  else if (loc_doc.lower().find(directionParam[SymbolModifiers::INOUT]) == 0)
+  //else if (loc_doc.lower().find(directionParam[SymbolModifiers::INOUT]) == 0)
+  else if (loc_doc.find(directionParam[SymbolModifiers::INOUT]) == 0)
   {
     if ((directionParam[dir1] == directionParam[SymbolModifiers::NONE_D]) ||
         (directionParam[dir1] == directionParam[SymbolModifiers::INOUT]))
     {
       loc_doc = loc_doc.right(loc_doc.length()-(int)strlen(directionParam[SymbolModifiers::INOUT]));
       loc_doc.stripWhiteSpace();
-      if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+      //if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+      if (!loc_doc.isEmpty() && (loc_doc != yyextra->argName))
       {
         handleCommentBlock(yyscanner,QCString("\n\n@param ") + directionParam[SymbolModifiers::INOUT] + " " +
                            yyextra->argName + " " + loc_doc,brief);
@@ -2596,7 +2646,8 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
     }
   }
   // analogous to the [in] case; here no direction specified
-  else if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+  //else if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+  else if (!loc_doc.isEmpty() && (loc_doc != yyextra->argName))
   {
     handleCommentBlock(yyscanner,QCString("\n\n@param ") + directionParam[dir1] + " " +
                        yyextra->argName + " " + loc_doc,brief);
@@ -2627,7 +2678,8 @@ static void subrHandleCommentBlockResult(yyscan_t yyscanner,const QCString &doc,
      ) (void)loc_doc; // Do nothing work has been done by stripPrefix; (void)loc_doc: to overcome 'empty controlled statement' warning
   loc_doc.stripWhiteSpace();
 
-  if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+  //if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
+  if (!loc_doc.isEmpty() && (loc_doc != yyextra->argName))
   {
     handleCommentBlock(yyscanner,QCString("\n\n@returns ") + loc_doc,brief);
   }
@@ -2780,7 +2832,8 @@ void FortranOutlineParser::parseInput(const QCString &fileName,
 
 bool FortranOutlineParser::needsPreprocessing(const QCString &extension) const
 {
-  return extension!=extension.lower(); // use preprocessor only for upper case extensions
+  //return extension!=extension.lower(); // use preprocessor only for upper case extensions
+  return extension!=extension; // use preprocessor only for upper case extensions
 }
 
 void FortranOutlineParser::parsePrototype(const QCString &text)

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -660,6 +660,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
  /*------- type definition  -------------------------------------------------------------------------------*/
 
+<ModuleBody>^{BS}type{BS}"="            {}
 <Start,ModuleBody>^{BS}type/[^a-z0-9_]  {
                                           if (YY_START == Start)
                                           {

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -30,7 +30,7 @@
  * In entries and arguments case is the same as in code, in modifier map case is lowered and
  * then it is compared to lowered entry/argument names.
  * UPDATE:
- * While it is true that Fortran is case-insensitive, modern-Fortran programmers (and even the old-schools) 
+ * While it is true that Fortran is case-insensitive, modern-Fortran programmers (and even the old-schools)
  * hardly modify the case of Fortran entities throughout their codebase. As such, if a decision is to be made
  * on whether to keep case-sensitivity, the readability of the generated documentation should be given more weight
  * than the remote scenario where a Fortran developer uses mixed-case programming. In particular, several Fortran
@@ -118,6 +118,8 @@ struct SymbolModifiers
   bool pointer;
   bool target;
   bool save;
+  bool len;
+  bool kind;
   bool deferred;
   bool nonoverridable;
   bool nopass;
@@ -131,7 +133,7 @@ struct SymbolModifiers
   SymbolModifiers() : type(), returnName(), protection(NONE_P), direction(NONE_D),
     optional(FALSE), protect(FALSE), dimension(), allocatable(FALSE),
     external(FALSE), intrinsic(FALSE), parameter(FALSE),
-    pointer(FALSE), target(FALSE), save(FALSE), deferred(FALSE), nonoverridable(FALSE),
+    pointer(FALSE), target(FALSE), save(FALSE), len(FALSE), kind(FALSE), deferred(FALSE), nonoverridable(FALSE),
     nopass(FALSE), pass(FALSE), contiguous(FALSE), volat(FALSE), value(FALSE), passVar(),
     bindVar() {}
 
@@ -261,6 +263,18 @@ static const char *stateToString(int state);
 
  //-----------------------------------------------------------------------------
  //-----------------------------------------------------------------------------
+/*
+lexer macros for ignoring preprocessing fences.
+comment out to reactivate normal (and confusing)
+default behavior of Doxygen.
+ */
+
+PP_FENCE (if|ifdef|ifndef|elif|else|endif)
+PP_LINE_MARKER [0-9]+
+PP_DIRECTIVE ({PP_FENCE}|{PP_LINE_MARKER}|line)
+
+ //-----------------------------------------------------------------------------
+ //-----------------------------------------------------------------------------
 IDSYM     [a-z_A-Z0-9]
 NOTIDSYM  [^a-z_A-Z0-9]
 SEPARATE  [:, \t]
@@ -291,7 +305,7 @@ INTENT_SPEC intent{BS}"("{BS}(in|out|in{BS}out){BS}")"
 /*
 ATTR_SPEC           (ALLOCATABLE|ASSIGNMENT|ASYNCHRONOUS|ABSTRACT|CODIMENSION|CONTIGUOUS|DEFERRED|DIMENSION|EXTENDS|EXTERNAL|INTENT{BS}"("{BS}(IN|OUT|IN{BS}OUT){BS}")"|INTRINSIC|LOCAL|LOCAL_INIT|NON_INTRINSIC|NON_OVERRIDABLE|NOPASS|OPERATOR|OPTIONAL|OVERRIDABLE|PARAMETER|PASS{ARGS}?|POINTER|PRIVATE|PROTECTED|PUBLIC|SAVE|SEQUENCE|SHARED|TARGET|VALUE|VOLATILE)
  */
-ATTR_SPEC (EXTERNAL|ALLOCATABLE|DIMENSION{ARGS}|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|NOPASS|PASS{ARGS}?|DEFERRED|NON_OVERRIDABLE|CONTIGUOUS|VOLATILE|VALUE)
+ATTR_SPEC (KIND|LEN|EXTERNAL|ALLOCATABLE|DIMENSION{ARGS}|{INTENT_SPEC}|INTRINSIC|OPTIONAL|PARAMETER|POINTER|PROTECTED|PRIVATE|PUBLIC|SAVE|TARGET|NOPASS|PASS{ARGS}?|DEFERRED|NON_OVERRIDABLE|CONTIGUOUS|VOLATILE|VALUE)
 
 ACCESS_SPEC (PRIVATE|PUBLIC)
 
@@ -363,6 +377,31 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                         }
 <Prepass>^{BS}\n                        { /* skip empty lines */
                                           yyextra->lineCountPrepass ++;
+                                        }
+<*>^{BS}"#"{BS}{PP_DIRECTIVE}[^\n]*\n   {
+                                          /*
+                                           * Ignore Fortran preprocessing fence / line-marker lines.
+                                           *
+                                           * Important:
+                                           * If we are inside the Fortran continuation prepass state,
+                                           * do not terminate the continued statement. Just count the
+                                           * skipped physical line.
+                                           *
+                                           * Comment out this section along with the relevant lexer macros
+                                           * defined above (e.g., PP_FENCE, PP_LINE_MARKER, PP_DIRECTIVE)
+                                           * to revive the original (confusing) Doxygen behavior.
+                                           *
+                                           */
+                                          yyextra->colNr = 0;
+
+                                          if (YY_START == Prepass)
+                                          {
+                                            yyextra->lineCountPrepass++;
+                                          }
+                                          else
+                                          {
+                                            newLine(yyscanner);
+                                          }
                                         }
 <*>^.*\n                                { // prepass: look for line continuations
                                           yyextra->functionLine = FALSE;
@@ -1919,6 +1958,8 @@ SymbolModifiers& SymbolModifiers::operator|=(const SymbolModifiers &mdfs)
   pointer |= mdfs.pointer;
   target |= mdfs.target;
   save |= mdfs.save;
+  len |= mdfs.len;
+  kind |= mdfs.kind;
   deferred |= mdfs.deferred;
   nonoverridable |= mdfs.nonoverridable;
   nopass |= mdfs.nopass;
@@ -2000,6 +2041,14 @@ SymbolModifiers& SymbolModifiers::operator|=(QCString mdfStringArg)
   else if (mdfString=="nopass")
   {
     newMdf.nopass = TRUE;
+  }
+  else if (mdfString=="len")
+  {
+    newMdf.len = TRUE;
+  }
+  else if (mdfString=="kind")
+  {
+    newMdf.kind = TRUE;
   }
   else if (mdfString=="deferred")
   {
@@ -2124,6 +2173,16 @@ static QCString applyModifiers(QCString typeName, const SymbolModifiers& mdfs)
   {
     if (!typeName.isEmpty()) typeName += ", ";
     typeName += "save";
+  }
+  if (mdfs.len)
+  {
+    if (!typeName.isEmpty()) typeName += ", ";
+    typeName += "len";
+  }
+  if (mdfs.kind)
+  {
+    if (!typeName.isEmpty()) typeName += ", ";
+    typeName += "kind";
   }
   if (mdfs.deferred)
   {
@@ -2607,7 +2666,7 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
     else
     {
       // something different specified, give warning and leave error.
-      warn(yyextra->fileName,yyextra->lineNr, "Routine: %s%s inconsistency between intent attribute and documentation for parameter %s:", 
+      warn(yyextra->fileName,yyextra->lineNr, "Routine: %s%s inconsistency between intent attribute and documentation for parameter %s:",
              qPrint(yyextra->current->name),qPrint(yyextra->current->args),qPrint(yyextra->argName));
       handleCommentBlock(yyscanner,QCString("\n\n@param ") + directionParam[dir1] + " " +
                          yyextra->argName + " " + loc_doc,brief);
@@ -2633,7 +2692,7 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
     }
     else
     {
-      warn(yyextra->fileName,yyextra->lineNr, "Routine: %s%s inconsistency between intent attribute and documentation for parameter %s:", 
+      warn(yyextra->fileName,yyextra->lineNr, "Routine: %s%s inconsistency between intent attribute and documentation for parameter %s:",
              qPrint(yyextra->current->name),qPrint(yyextra->current->args),qPrint(yyextra->argName));
       handleCommentBlock(yyscanner,QCString("\n\n@param ") + directionParam[dir1] + " " +
                          yyextra->argName + " " + loc_doc,brief);
@@ -2657,7 +2716,7 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
     }
     else
     {
-      warn(yyextra->fileName,yyextra->lineNr, "Routine: %s%s inconsistency between intent attribute and documentation for parameter %s:", 
+      warn(yyextra->fileName,yyextra->lineNr, "Routine: %s%s inconsistency between intent attribute and documentation for parameter %s:",
              qPrint(yyextra->current->name),qPrint(yyextra->current->args),qPrint(yyextra->argName));
       handleCommentBlock(yyscanner,QCString("\n\n@param ") + directionParam[dir1] + " " +
                          yyextra->argName + " " + loc_doc,brief);

--- a/src/fortranscanner_old.l
+++ b/src/fortranscanner_old.l
@@ -242,7 +242,6 @@ static void scanner_abort(yyscan_t yyscanner);
 static void startScope(yyscan_t yyscanner,Entry *scope);
 static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot=FALSE);
 static void resolveModuleProcedures(yyscan_t yyscanner,Entry *current_root);
-static void foldGenericInterfacesIntoDerivedTypes(Entry *scope);
 static void truncatePrepass(yyscan_t yyscanner,int index);
 static void pushBuffer(yyscan_t yyscanner,const QCString &buffer);
 static void popBuffer(yyscan_t yyscanner);
@@ -656,7 +655,6 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                         }
 <Start,ModuleBody,ModuleBodyContains>"end"({BS}(module|program)({BS_}{ID})?)?{BS}/(\n|!|;) { // end module
                                           resolveModuleProcedures(yyscanner,yyextra->current_root);
-                                          foldGenericInterfacesIntoDerivedTypes(yyextra->current_root);
                                           if (!endScope(yyscanner,yyextra->current_root))
                                           {
                                             yyterminate();
@@ -1899,58 +1897,6 @@ void resolveModuleProcedures(yyscan_t yyscanner,Entry *current_root)
     } // for procedures in yyextra->current module
   } // for all interface module procedures
   yyextra->moduleProcedures.clear();
-}
-
-
-/** Make a generic interface with the same name as a derived type a member of that type. */
-static void foldGenericInterfacesIntoDerivedTypes(Entry *scope)
-{
-  if (scope == 0) return;
-
-  std::map<std::string,Entry *> derivedTypes;
-  std::vector<std::shared_ptr<Entry> > interfaces;
-
-  for (const auto &entry : scope->children())
-  {
-    if (entry->section != Entry::CLASS_SEC) continue;
-
-    if (entry->spec & Entry::Struct)
-    {
-      derivedTypes[entry->name.str()] = entry.get();
-    }
-    else if ((entry->spec & Entry::Interface) && entry->type.lower() == "generic")
-    {
-      interfaces.push_back(entry);
-    }
-  }
-
-  for (const auto &iface : interfaces)
-  {
-    auto it = derivedTypes.find(iface->name.str());
-    if (it == derivedTypes.end()) continue;
-
-    Entry *typeEntry = it->second;
-    std::vector<std::shared_ptr<Entry> > members(iface->children().begin(),iface->children().end());
-
-    for (const auto &member : members)
-    {
-      iface->removeSubEntry(member.get());
-    }
-    scope->removeSubEntry(iface.get());
-
-    iface->section = Entry::FUNCTION_SEC;
-    int i = iface->name.findRev(':');
-    if (i != -1) iface->name = iface->name.mid(i+1);
-    iface->args.resize(0);
-    iface->argList.clear();
-    iface->spec &= ~Entry::Interface;
-
-    typeEntry->moveToSubEntryAndKeep(iface);
-    for (const auto &member : members)
-    {
-      typeEntry->moveToSubEntryAndKeep(member);
-    }
-  }
 }
 
 /*! Extracts string which resides within parentheses of provided string. */

--- a/src/valgrindMermoryLeakAnalysis.txt
+++ b/src/valgrindMermoryLeakAnalysis.txt
@@ -1,0 +1,72 @@
+valgrind --leak-check=full ../../build/doxygen/build/bin/doxygen "${paramonte_doc_kernel_dir}/config.txt"
+
+lookup cache used 8338/65536 hits=17083 misses=10050
+finished...
+==23902==
+==23902== HEAP SUMMARY:
+==23902==     in use at exit: 10,054,832 bytes in 69,342 blocks
+==23902==   total heap usage: 43,651,527 allocs, 43,582,185 frees, 104,248,900,830 bytes allocated
+==23902==
+==23902== 16 bytes in 2 blocks are definitely lost in loss record 4 of 254
+==23902==    at 0x4842749: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
+==23902==    by 0x6FE0B9: pushBuffer(yyguts_t*, QCString const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x703982: FortranOutlineParser::parsePrototype(QCString const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x6BAF89: commentscanYYlex(yyguts_t*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x6C6338: CommentScanner::parseCommentBlock(OutlineParserInterface*, Entry*, QCString const&, QCString const&, int&, bool, bool, bool, Protection&, int&, bool&, bool) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7017AF: handleCommentBlock(yyguts_t*, QCString const&, bool) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x6FA33B: fortranscannerYYlex(yyguts_t*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7035B5: parseMain(yyguts_t*, QCString const&, char const*, std::shared_ptr<Entry> const&, FortranFormat) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7038D7: FortranOutlineParser::parseInput(QCString const&, char const*, std::shared_ptr<Entry> const&, ClangTUParser*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x24FD12: parseFile(OutlineParserInterface&, FileDef*, QCString const&, ClangTUParser*, bool) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25051F: parseFilesSingleThreading(std::shared_ptr<Entry> const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25AF05: parseInput() (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==
+==23902== 752 bytes in 94 blocks are definitely lost in loss record 83 of 254
+==23902==    at 0x4842749: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
+==23902==    by 0x6FE0B9: pushBuffer(yyguts_t*, QCString const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x6F7981: fortranscannerYYlex(yyguts_t*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7035B5: parseMain(yyguts_t*, QCString const&, char const*, std::shared_ptr<Entry> const&, FortranFormat) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7038D7: FortranOutlineParser::parseInput(QCString const&, char const*, std::shared_ptr<Entry> const&, ClangTUParser*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x24FD12: parseFile(OutlineParserInterface&, FileDef*, QCString const&, ClangTUParser*, bool) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25051F: parseFilesSingleThreading(std::shared_ptr<Entry> const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25AF05: parseInput() (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x2105C0: main (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==
+==23902== 1,464 bytes in 183 blocks are definitely lost in loss record 106 of 254
+==23902==    at 0x4842749: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
+==23902==    by 0x6FE0B9: pushBuffer(yyguts_t*, QCString const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x6F11A4: fortranscannerYYlex(yyguts_t*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7035B5: parseMain(yyguts_t*, QCString const&, char const*, std::shared_ptr<Entry> const&, FortranFormat) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7038D7: FortranOutlineParser::parseInput(QCString const&, char const*, std::shared_ptr<Entry> const&, ClangTUParser*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x24FD12: parseFile(OutlineParserInterface&, FileDef*, QCString const&, ClangTUParser*, bool) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25051F: parseFilesSingleThreading(std::shared_ptr<Entry> const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25AF05: parseInput() (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x2105C0: main (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==
+==23902== 2,736 bytes in 152 blocks are definitely lost in loss record 127 of 254
+==23902==    at 0x4847C73: realloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
+==23902==    by 0x6FE0B9: pushBuffer(yyguts_t*, QCString const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x6F7981: fortranscannerYYlex(yyguts_t*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7035B5: parseMain(yyguts_t*, QCString const&, char const*, std::shared_ptr<Entry> const&, FortranFormat) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x7038D7: FortranOutlineParser::parseInput(QCString const&, char const*, std::shared_ptr<Entry> const&, ClangTUParser*) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x24FD12: parseFile(OutlineParserInterface&, FileDef*, QCString const&, ClangTUParser*, bool) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25051F: parseFilesSingleThreading(std::shared_ptr<Entry> const&) (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x25AF05: parseInput() (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==    by 0x2105C0: main (in /home/amir/git/paramonte/build/doxygen/build/bin/doxygen)
+==23902==
+==23902== LEAK SUMMARY:
+==23902==    definitely lost: 4,968 bytes in 431 blocks
+==23902==    indirectly lost: 0 bytes in 0 blocks
+==23902==      possibly lost: 0 bytes in 0 blocks
+==23902==    still reachable: 10,049,864 bytes in 68,911 blocks
+==23902==                       of which reachable via heuristic:
+==23902==                         multipleinheritance: 36,960 bytes in 924 blocks
+==23902==         suppressed: 0 bytes in 0 blocks
+==23902== Reachable blocks (those to which a pointer was found) are not shown.
+==23902== To see them, rerun with: --leak-check=full --show-leak-kinds=all
+==23902==
+==23902== Use --track-origins=yes to see where uninitialised values come from
+==23902== For lists of detected and suppressed errors, rerun with: -s
+==23902== ERROR SUMMARY: 4889 errors from 22 contexts (suppressed: 0 from 0)
+./build.sh: line 185: syntax error near unexpected token `&'
+         ./build.sh: line 185: `&2'

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1333,8 +1333,8 @@ div.ingroups a
 
 div.header
 {
-        background-image:url('nav_h.png');
-        background-repeat:repeat-x;
+    background-image:url('nav_h.png');
+    background-repeat:repeat-x;
 	background-color: ##FA;
 	margin:  0px;
 	border-bottom: 1px solid ##CC;

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -519,6 +519,139 @@ span.vhdllogic {
 	color: #ff0000 
 }
 
+/* Begin Fortran Code Colorization */
+
+span.fortran_keywordflow {
+    /* dull orange
+	color: #e08000
+	color: #FF6600 bright orange
+    */
+	color: #ff8000
+}
+
+span.fortran_statement {
+    /* deep blue */
+	color: #0000EE
+}
+
+span.fortran_function {
+    /* purple */
+	color: #8000ff
+}
+
+span.fortran_subroutine {
+    /* purple */
+	color: #8000ff
+}
+
+span.fortran_named_const {
+    /* solid red */
+	color: #FF0000
+}
+
+span.fortran_numeric_literal {
+    /* solid red */
+	color: #FF0000
+}
+
+span.fortran_operator_logical {
+    /* solid red */
+	color: #FF1493
+}
+
+span.fortran_operator_symbols {
+    /* solid red */
+	color: #FF1493
+}
+
+span.fortran_inrinsic_module {
+    /* solid red
+    */
+	color: #FF0000
+    /* deep red
+	color: #9e0202
+    */
+}
+
+span.fortran_inrinsic_dtype {
+    /* solid red
+    */
+	color: #FF0000
+    /* deep red
+	color: #9e0202
+    */
+}
+
+span.fortran_attribute {
+    /* pink */
+	color: #FF1493
+}
+
+span.fortran_spcifier {
+    font-style: italic;
+    /* dark gray */
+	color: #820000
+    /* 
+	color: #4d4d54
+    */
+}
+
+span.fortran_prefix {
+    /* deep blue */
+	color: #0000EE
+}
+
+span.fortran_suffix {
+    /* deep blue */
+	color: #0000EE
+}
+
+span.fortran_string {
+    /* green */
+    /* 
+	color: #008080;
+	color: #00B000;
+    */
+	color: #00B000;
+}
+
+span.fortran_comment {
+    /* green */
+	color: #008000
+}
+
+span.fortran_directive_omp {
+    /* preprocessor color */
+	color: #02b4cc
+}
+
+span.fortran_mpi {
+    /* preprocessor color */
+	color: #A52A2A
+}
+
+span.fortran_directive_intel {
+    /* preprocessor color */
+    /* 
+	color: #806020
+	color: #04D4F0
+	color: #059DC0
+    */
+	color: #02b4cc
+}
+
+span.fortran_directive_intel_statement {
+    /* pink */
+	color: #02b4cc
+}
+
+span.fortran_directive_intel_attribute {
+    /* pink */
+	color: #FF1493
+}
+
+/* End Fortran Code Colorization */
+
 blockquote {
         background-color: ##F8;
         border-left: 2px solid ##AA;

--- a/valgrindMermoryLeakAnalysis.txt
+++ b/valgrindMermoryLeakAnalysis.txt
@@ -1,3 +1,5 @@
+flex 2.6.4
+bison (GNU Bison) 3.7.5
 valgrind --leak-check=full ../../build/doxygen/build/bin/doxygen "${paramonte_doc_kernel_dir}/config.txt"
 
 lookup cache used 8338/65536 hits=17083 misses=10050


### PR DESCRIPTION
While Fortran is case-insensitive, modern-Fortran programmers (and most old-school Fortranners) rarely modify the case of Fortran entities throughout their codebase. So, if a decision is to be made on whether to keep case sensitivity, the readability of the generated documentation should be given more weight than the remote scenario where a Fortran developer uses mixed-case coding. In particular, there are ample Fortran codebases that use the CameCase style which becomes unreadable when Doxygen lowers the case of all letters. This PR of the Doxygen repository resolves this issue by removing all case-lowering instances of the Fortran entities in Doxygen. This effectively means that Doxygen treats Fortran code as case-sensitive, and Fortran users of Doxygen should respect case sensitivity in their codebase if fully-functional hyperlinking is desired. This does not affect other aspects of the documentation such as syntax highlighting and the functionalities related to the `iso_c_binding` module and C-Fortran interoperations. If any, it should only enhance C-Fortran interoperations as it interoperation rules defined by the Fortran standard are case-sensitive.

This PR also implements the following major enhancements to the Fortran syntax highlighting rules of Doxygen:

+   This PR implements a clean classification of (almost) all keywords in recent Fortran standards (2018/2008/2003/1995/1990/1977), fully consistent with the formal classification of keywords presented in [Fortran 2018 standard](https://j3-fortran.org/doc/year/18/18-007r1.pdf). Among the major categories are:
    1. Fortran attributes
    1. Fortran constructs
    1. Fortran statements
    1. Fortran intrinsic elemental functions
    1. Fortran intrinsic inquiry functions
    1. Fortran intrinsic transcendental functions
    1. Fortran intrinsic impure subroutines
    1. Fortran intrinsic pure subroutines
    1. Fortran intrinsic atomic subroutines
    1. Fortran intrinsic Coarray collective subroutines
    1. Fortran intrinsic IEEE modules and their entities
    1. Fortran intrinsic `iso_c_binding` module and its entities
    1. Fortran intrinsic `iso_fortran_env` module and its entities
    1. Fortran intrinsic specifiers (intrinsic-procedure argument names)
    1. Fortran intrinsic derived types

+ Over 600 new names of Fortran intrinsic functions, subroutines, modules, named constants, and specifiers (e.g., intrinsic procedure argument names) are now recognized and properly highlighted by Doxygen. The new set effectively covers all Fortran keywords in the latest Fortran standard 2018 and covers all keywords in 5 older standards F2008, F2003, F95, F90, F77.

+   Syntax recognition for MPI subroutines and entities, OpenMP directives, and Intel Fortran Compiler
    directives are now added.

+   The `real` and `logical` intrinsic functions are now properly recognized and highlighted as intrinsic functions or type declarations where appropriate.

+   Syntax recognition for Fortran `submodule`s and `module (function|subroutine|procedure)` now added.

+   Syntax recognition for Fortran intrinsic modules, including IEEE modules and their entities, `iso_fortran_enc` and `iso_c_binding` and their entities are now added.

+   Syntax recognition for new and modern Fortran constructs now added, for example, `block` and `associate` constructs.

+   Syntax recognition for all Fortran intrinsic Coarray parallel procedures and entities now added.

+   syntax recognition for new procedure attributes added (e.g., IMPURE, `(non_)?overridable`, ...).

+   The Fortran component separator symbol `%` is now recognized and highlighted. This is
    very useful for enhanced readability of Fortran codes as `%` is a rather busy symbol.
    
+   All Fortran intrinsic operators are now properly recognized and highlighted.

[Here is an example of Fortran documentation built with the modified Doxygen-Fortran implemented in this PR](https://cdslaborg.github.io/paramonte-kernel-doc/html/Array__mod_8f90_source.html). 