### PR TITLE
Test for setting  MAX_DOT_GRAPH_DEPTH not working properly

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2051,6 +2051,13 @@ void Config::checkAndCorrect(bool quiet)
   }
 
   //------------------------
+  int depth = Config_getInt(MAX_DOT_GRAPH_DEPTH);
+  if (depth==0)
+  {
+    Config_updateInt(MAX_DOT_GRAPH_DEPTH,1000);
+  }
+
+  //------------------------
   // add default words if needed
   const StringVector &annotationFromBrief = Config_getList(ABBREVIATE_BRIEF);
   if (annotationFromBrief.empty())


### PR DESCRIPTION
The test for  `MAX_DOT_GRAPH_DEPTH == 0` (i.e, unlimited) should not heave been removed.

Commit: f2640ec6f05b8334417f9ad1127d3183dedf2f9e 

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7153722/example.tar.gz)
