### PR TITLE
Fix missing dependency on configvalues.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,6 +215,7 @@ add_library(doxymain STATIC
     ${GENERATED_SRC}/ce_parse.cpp
     # custom generated files
     ${GENERATED_SRC}/lang_cfg.h
+    ${GENERATED_SRC}/configvalues.h
     ${GENERATED_SRC}/ce_parse.h
     ${GENERATED_SRC}/resources.cpp
     #


### PR DESCRIPTION
It's referenced by config.h, which is referenced by most things.

This was failing to build for me with Ninja on the m68k Linux platform. I don't know why it works elsewhere, could just be luck.