### PR TITLE
Incorrect warning regarding SQLITE3 settings

### DIFF
--- a/src/configgen.py
+++ b/src/configgen.py
@@ -357,12 +357,12 @@ def parseGroups(node):
     print("  cfg->addInfo(\"%s\",\"%s\");" % (name, doc))
     print("%s%s" % ("  //-----------------------------------------",
                     "----------------------------------"))
+    if len(setting) > 0:
+        print("#endif")
     print("")
     for n in node.childNodes:
         if n.nodeType == Node.ELEMENT_NODE:
             parseOption(n)
-    if len(setting) > 0:
-        print("#endif")
 
 def parseGroupMapEnums(node):
     def escape(value):


### PR DESCRIPTION
When we have in the settings files settings that are not enabled in the current doxygen version we get for the CLANG part
```
warning: Tag 'CLANG_DATABASE_PATH' at line 391 of file 'Doxyfile' belongs to an option that was not enabled at compile time.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u", or recompile doxygen with this feature enabled.
```
though for the SQLITE3 part we get:
```
warning: ignoring unsupported tag 'GENERATE_SQLITE3' at line 392, file Doxyfile
```
this is due to the fact that the info of the group was closed after the complete group and not directly after the info.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7169278/example.tar.gz)
