### PR TITLE
Fix misspelled GENERATE_TREEVIEW

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2423,7 +2423,7 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
   https://docs.readthedocs.io with more room for contents,
   but less room for the project logo, title, and description.
 
-  If either \c GENERATOR_TREEVIEW or \c DISABLE_INDEX is set to \c NO, this option
+  If either \c GENERATE_TREEVIEW or \c DISABLE_INDEX is set to \c NO, this option
   has no effect.
 ]]>
       </docs>


### PR DESCRIPTION
I just updated one of my Doxyfiles from 1.9.1 to 1.9.2 and noticed this misspelling in the config. This tag should be `GENERATE_TREEVIEW`, not `GENERATOR_TREEVIEW`.