### PR TITLE
Fix misspelled GENERATE_TREEVIEW

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2416,14 +2416,16 @@ The \c DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
     <option type='bool' id='FULL_SIDEBAR' defval='0' depends='GENERATE_HTML'>
       <docs>
 <![CDATA[
-  When both \c GENERATE_TREEVIEW and \c DISABLE_INDEX are set to YES, then the
+  When both \ref cfg_generate_treeview "GENERATE_TREEVIEW" and \ref cfg_disable_index "DISABLE_INDEX"
+  are set to \c YES, then the
   \c FULL_SIDEBAR option determines if the side bar is limited to only the
   treeview area (value \c NO) or if it should extend to the full height of the
   window (value \c YES). Setting this to \c YES gives a layout similar to
   https://docs.readthedocs.io with more room for contents,
   but less room for the project logo, title, and description.
 
-  If either \c GENERATOR_TREEVIEW or \c DISABLE_INDEX is set to \c NO, this option
+  If either \ref cfg_generate_treeview "GENERATE_TREEVIEW" or \ref cfg_disable_index "DISABLE_INDEX"
+  is set to \c NO, this option
   has no effect.
 ]]>
       </docs>


### PR DESCRIPTION
The `GENERATE_TREEVIEW` is like shown in #8781 misspelled but not only should the spelling be corrected, but also a link should be made out of it (also `DISABLE_INDEX` should have a link).

Superseded #8781