### PR TITLE
issue #8785 Markdown runs on <PRE> if class attribute is specified

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2467,7 +2467,7 @@ void Markdown::findEndOfLine(const char *data,int size,
             )
     {
       if (tolower(data[end])=='p' && tolower(data[end+1])=='r' &&
-          tolower(data[end+2])=='e' && data[end+3]=='>') // <pre> tag
+          tolower(data[end+2])=='e' && (data[end+3]=='>' || data[end+3]==' ')) // <pre> tag
       {
         // skip part until including </pre>
         end  = end + processHtmlTagWrite(data+end-1,end-1,size-end+1,false) + 2;


### PR DESCRIPTION
A tag can have attributes and these were not taken into consideration as there was a hard test for a `>`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7189692/example.tar.gz)
