### PR TITLE
Handle decltype(*) return types in declinfo.l

### DIFF
--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -95,6 +95,7 @@ ID	([$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*)|(@[0-9]+)
 %x	Template
 %x	ReadArgs
 %x	Operator
+%x	DeclType
 %x	FuncPtr
 %x	EndTemplate
 %x	StripTempArgs
@@ -163,10 +164,28 @@ ID	([$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*)|(@[0-9]+)
 <Start>{B}*")"			{
   				  yyextra->type+=")";
   				}
+<Start>{B}*"decltype"/{B}*"("	{
+					  yyextra->roundCount=0;
+					  yyextra->type="decltype";
+					  BEGIN(DeclType);
+					}
+<DeclType>{B}*"("	{
+						++yyextra->roundCount;
+						yyextra->type+="(";
+					}
+<DeclType>{B}*")"	{
+						yyextra->type+=")";
+						if (--yyextra->roundCount == 0) {
+							BEGIN(Start);
+						}
+					}
+<DeclType>.	{
+						yyextra->type+=yytext;
+					}
 <Start>{B}*"("			{ // TODO: function pointers
-  				  yyextra->args+="(";
-  				  BEGIN(ReadArgs);
-  				}
+						yyextra->args+="(";
+						BEGIN(ReadArgs);
+					}
 <Start>{B}*"["			{
   				  yyextra->args+="[";
 				  BEGIN(ReadArgs);
@@ -365,7 +384,7 @@ void parseFuncDecl(const QCString &decl,const SrcLangExt lang,QCString &cl,QCStr
   a=removeRedundantWhiteSpace(yyextra->args);
   exc=removeRedundantWhiteSpace(yyextra->exceptionString);
   
-  if (!t.isEmpty() && t.at(t.length()-1)==')') // for function pointers
+  if (!t.isEmpty() && !t.startsWith("decltype") && t.at(t.length()-1)==')') // for function pointers
   {
     a.prepend(")");
     t=t.left(t.length()-1);


### PR DESCRIPTION
Fixes https://github.com/doxygen/doxygen/issues/7309. This has also been a problem in a project I'm involved with. It looks like `declinfo.l` has to catch up with `scanner.l`. This patch is first stab at it.