### PR TITLE
Remove obsolete states from lexer code

### DIFF
--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -385,9 +385,7 @@ static void readIncludeFile(const QString &incName)
 %x      Start
 %x      SkipInvalid
 %x      GetString
-%x      GetEnum
 %x      GetStrList
-%x      GetQuotedString
 %x      Include
 
 %%

--- a/src/code.l
+++ b/src/code.l
@@ -349,7 +349,6 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
 %x      SkipComment
 %x      SkipCxxComment
 %x      RemoveSpecialCComment
-%x      StripSpecialCComment
 %x      Body
 %x      FuncCall
 %x      MemberCall

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -95,10 +95,6 @@ ID	([$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*)|(@[0-9]+)
 %x	Template
 %x	ReadArgs
 %x	Operator
-%x	FuncPtr
-%x	EndTemplate
-%x	StripTempArgs
-%x	SkipSharp
 %x      ReadExceptions
 
 %%

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -262,9 +262,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 
 %x Start
 %x SubCall
-%x FuncDef
 %x ClassName
-%x ClassVar
 %x Subprog
 %x DocBlock
 %x Use
@@ -273,7 +271,6 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 %x Declaration
 %x DeclarationBinding
 %x DeclContLine
-%x Parameterlist
 %x String
 %x Subprogend
 

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -327,7 +327,6 @@ SCOPENAME ({ID}{BS}"::"{BS})*
  /** comment parsing states */
 %x      DocBlock
 %x      DocBackLine
-%x      EndDoc
 
 %x      BlockData
 

--- a/src/pre.l
+++ b/src/pre.l
@@ -390,8 +390,6 @@ WSopt [ \t\r]*
 %x      DefineArg
 %x      DefineText
 %x      SkipCPPBlock
-%x      Ifdef
-%x      Ifndef
 %x      SkipCComment
 %x      ArgCopyCComment
 %x      CopyCComment

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -289,9 +289,6 @@ TARGET            ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBU
 %x SuiteCaptureIndent
 %x SuiteStart
 %x SuiteMaintain
-%x SuiteContinuing
-
-%x LongString
 
 %x SingleQuoteString
 %x DoubleQuoteString

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -208,7 +208,6 @@ STARTDOCSYMS      "##"
 
   /* %x FuncDoubleComment */
   /* %x ClassDoubleComment */
-%x TryClassDocString
 %x TripleComment
 %x SpecialComment
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -305,7 +305,6 @@ NONLopt [^\n]*
 %x      FindMembersPHP
 %x      FindMemberName
 %x      FindFields
-%x      FindFieldArg
 %x      Function
 %x      FuncRound
 %x      ExcpRound
@@ -330,7 +329,6 @@ NONLopt [^\n]*
 %x      SkipC11Inits
 %x      SkipC11Attribute
 %x      SkipCPP
-%x      SkipCPPBlock
 %x      SkipComment
 %x      SkipCxxComment
 %x      SkipCurlyBlock
@@ -338,7 +336,6 @@ NONLopt [^\n]*
 %x      Sharp
 %x      SkipRound
 %x      SkipSquare
-%x      SkipRemainder
 %x      StaticAssert
 %x      DeclType
 %x      TypedefName
@@ -364,7 +361,6 @@ NONLopt [^\n]*
 %x      ObjCPropAttr
 %x      ObjCSkipStatement
 %x      QtPropType
-%x      QtPropName
 %x      QtPropAttr
 %x      QtPropRead
 %x      QtPropWrite
@@ -399,7 +395,6 @@ NONLopt [^\n]*
 %x      Specialization
 %x      SpecializationSingleQuote
 %x      SpecializationDoubleQuote
-%x      FuncPtrInit
 %x      FuncFunc
 %x      FuncFuncEnd
 %x      FuncFuncType
@@ -2650,7 +2645,7 @@ NONLopt [^\n]*
                                             BEGIN( DocBlock );
                                           }
                                         }
-<DefineEnd,FindFields,FindFieldArg,ReadInitializer,ReadInitializerPtr,OldStyleArgs>{BN}*{DCOMM}"<" {
+<DefineEnd,FindFields,ReadInitializer,ReadInitializerPtr,OldStyleArgs>{BN}*{DCOMM}"<" {
                                           if (yyextra->current->bodyLine==-1)
                                           {
                                             yyextra->current->bodyLine=yyextra->yyLineNr;
@@ -3739,10 +3734,6 @@ NONLopt [^\n]*
                                             REJECT;
                                           }
                                         }
-<SkipRemainder>\n                       {
-                                          lineCount(yyscanner);
-                                        }
-<SkipRemainder>[^\n]*
 <FindFields>","                         {
                                           //printf("adding '%s' '%s' '%s' to enum '%s' (mGrpId=%d)\n",
                                           //     qPrint(yyextra->current->type), qPrint(yyextra->current->name),
@@ -3784,9 +3775,6 @@ NONLopt [^\n]*
                                           yyextra->lastSquareContext = YY_START;
                                           BEGIN(SkipSquare);
                                         }
-  /*
-<FindFieldArg>","                       { unput(*yytext); BEGIN(FindFields); }
-  */
 <ReadBody,ReadNSBody,ReadBodyIntf>[^\r\n\#{}"@'/<]*     { yyextra->current->program << yytext ; }
 <ReadBody,ReadNSBody,ReadBodyIntf>{CPPC}.*                { yyextra->current->program << yytext ; }
 <ReadBody,ReadNSBody,ReadBodyIntf>"#".* { if (!yyextra->insidePHP)
@@ -4922,45 +4910,6 @@ NONLopt [^\n]*
                                           lineCount(yyscanner);
                                         }
 <CliOverride>.                          {
-                                        }
-<FuncPtrInit>[{;]                       {
-                                          unput(*yytext);
-                                          BEGIN(FuncQual);
-                                        }
-<FuncPtrInit>\"                         {
-                                          yyextra->current->args += *yytext;
-                                          yyextra->pCopyQuotedString=&yyextra->current->args;
-                                          yyextra->lastStringContext=FuncPtrInit;
-                                          BEGIN(CopyString);
-                                        }
-<FuncPtrInit>\'                         {
-                                          yyextra->current->args += *yytext;
-                                          if (yyextra->insidePHP)
-                                          {
-                                            yyextra->pCopyQuotedString=&yyextra->current->args;
-                                            yyextra->lastStringContext=FuncPtrInit;
-                                            BEGIN(CopyPHPString);
-                                          }
-                                        }
-<FuncPtrInit>{CHARLIT}                  {
-                                          if (yyextra->insidePHP)
-                                          {
-                                            REJECT;
-                                          }
-                                          else
-                                          {
-                                            yyextra->current->args += yytext;
-                                          }
-                                        }
-<FuncPtrInit>{ID}                       {
-                                          yyextra->current->args += yytext;
-                                        }
-<FuncPtrInit>.                          {
-                                          yyextra->current->args += *yytext;
-                                        }
-<FuncPtrInit>\n                         {
-                                          yyextra->current->args += *yytext;
-                                          lineCount(yyscanner);
                                         }
 <FuncQual>{ID}                          {
                                           if (yyextra->insideCpp && qstrcmp(yytext,"requires")==0)

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -206,13 +206,9 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
 %x ParseComponent
 %x ParsePackage
 %x ParseProcessProto
-%x ClassName
-%x PackageName
-%x ClassVar
 %x ClassesName
 %x Map
 %x End
-%x Body
 
 %%
 


### PR DESCRIPTION
Remove obsolete / non used states from the lexer code.
- scanner.l: the state `FuncPtrInit` is never reachable, same accounts for the state `SkipRemainder` and `FindFieldArg`, so the rules for these states are also removed