### PR TITLE
value attribute for <li> tag

### DIFF
--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -24,6 +24,16 @@
 class LatexCodeGenerator;
 class TextStream;
 
+
+struct LatexListItemInfo
+{
+  bool isEnum;
+};
+
+const int latex_maxIndentLevels = 5;
+
+extern LatexListItemInfo latex_listItemInfo[latex_maxIndentLevels];
+
 /*! @brief Concrete visitor implementation for LaTeX output. */
 class LatexDocVisitor : public DocVisitor
 {
@@ -176,6 +186,9 @@ class LatexDocVisitor : public DocVisitor
     void writeDiaFile(const QCString &fileName, DocVerbatim *s);
     void writePlantUMLFile(const QCString &fileName, DocVerbatim *s);
 
+    void incIndentLevel() {if (m_indentLevel<latex_maxIndentLevels-1) m_indentLevel++; else m_extra++;}
+    void decIndentLevel() {if (m_extra) {m_extra--;} else if (m_indentLevel>0) m_indentLevel--;}
+
     //--------------------------------------
     // state variables
     //--------------------------------------
@@ -187,7 +200,9 @@ class LatexDocVisitor : public DocVisitor
     bool m_hide;
     bool m_hideCaption;
     bool m_insideTabbing;
+    int m_indentLevel;
     QCString m_langExt;
+    int m_extra=0;
 
     struct TableState
     {
@@ -263,5 +278,4 @@ class LatexDocVisitor : public DocVisitor
     }
 
 };
-
 #endif

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -685,6 +685,15 @@ void ManDocVisitor::visitPre(DocHtmlListItem *li)
   m_t << ".IP \"" << ws;
   if (((DocHtmlList *)li->parent())->type()==DocHtmlList::Ordered)
   {
+    for (const auto &opt : li->attribs())
+    {
+      if (opt.name=="value")
+      {
+        bool ok;
+        int val = opt.value.toInt(&ok);
+        if (ok) man_listItemInfo[m_indent].number = val;
+      }
+    }
     switch (man_listItemInfo[m_indent].type)
     {
       case '1':

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -950,7 +950,17 @@ void PerlModDocVisitor::visitPost(DocHtmlList *)
   closeItem();
 }
 
-void PerlModDocVisitor::visitPre(DocHtmlListItem *) { openSubBlock(); }
+void PerlModDocVisitor::visitPre(DocHtmlListItem *l)
+{
+  for (const auto &opt : l->attribs())
+  {
+    if (opt.name=="value")
+    {
+      m_output.addFieldQuotedString("item_value", qPrint(opt.value));
+    }
+  }
+  openSubBlock();
+}
 void PerlModDocVisitor::visitPost(DocHtmlListItem *) { closeSubBlock(); }
 
 //void PerlModDocVisitor::visitPre(DocHtmlPre *)

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -402,10 +402,15 @@ class PrintDocVisitor : public DocVisitor
       indent_post();
       if (s->type()==DocHtmlList::Ordered) printf("</ol>\n"); else printf("</ul>\n");
     }
-    void visitPre(DocHtmlListItem *)
+    void visitPre(DocHtmlListItem *s)
     {
       indent_pre();
-      printf("<li>\n");
+      printf("<li");
+      for (const auto &opt : s->attribs())
+      {
+        printf(" %s=\"%s\"",qPrint(opt.name),qPrint(opt.value));
+      }
+      printf(">\n");
     }
     void visitPost(DocHtmlListItem *)
     {

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -71,12 +71,12 @@ QCString RTFDocVisitor::getStyle(const QCString &name)
 
 void RTFDocVisitor::incIndentLevel()
 {
-  if (m_indentLevel<rtf_maxIndentLevels-1) m_indentLevel++;
+  if (m_indentLevel<rtf_maxIndentLevels-1) m_indentLevel++; else m_extra++;
 }
 
 void RTFDocVisitor::decIndentLevel()
 {
-  if (m_indentLevel>0) m_indentLevel--;
+  if (m_extra) m_extra--; else if (m_indentLevel>0) m_indentLevel--;
 }
 
   //--------------------------------------
@@ -918,7 +918,7 @@ void RTFDocVisitor::visitPost(DocHtmlList *)
   m_lastIsPara=TRUE;
 }
 
-void RTFDocVisitor::visitPre(DocHtmlListItem *)
+void RTFDocVisitor::visitPre(DocHtmlListItem *l)
 {
   if (m_hide) return;
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocHtmlListItem)}\n");
@@ -926,6 +926,15 @@ void RTFDocVisitor::visitPre(DocHtmlListItem *)
   m_t << rtf_Style_Reset;
   if (rtf_listItemInfo[m_indentLevel].isEnum)
   {
+    for (const auto &opt : l->attribs())
+    {
+      if (opt.name=="value")
+      {
+        bool ok;
+        int val = opt.value.toInt(&ok);
+        if (ok) rtf_listItemInfo[m_indentLevel].number = val;
+      }
+    }
     m_t << getStyle("ListEnum") << "\n";
     switch (rtf_listItemInfo[m_indentLevel].type)
     {

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -170,6 +170,7 @@ class RTFDocVisitor : public DocVisitor
     int m_indentLevel;
     bool m_lastIsPara;
     QCString m_langExt;
+    int m_extra = 0;;
 };
 
 #endif

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -731,10 +731,18 @@ void XmlDocVisitor::visitPost(DocHtmlList *s)
     m_t << "</itemizedlist>\n";
 }
 
-void XmlDocVisitor::visitPre(DocHtmlListItem *)
+void XmlDocVisitor::visitPre(DocHtmlListItem *l)
 {
   if (m_hide) return;
-  m_t << "<listitem>\n";
+  m_t << "<listitem";
+  for (const auto &opt : l->attribs())
+  {
+    if (opt.name=="value")
+    {
+      m_t << " " << opt.name << "=\"" << opt.value << "\"";
+    }
+  }
+  m_t << ">\n";
 }
 
 void XmlDocVisitor::visitPost(DocHtmlListItem *)

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -520,6 +520,7 @@
     <xsd:sequence>
       <xsd:element name="para" type="docParaType" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
+    <xsd:attribute name="value" type="xsd:integer" use="optional"/>
   </xsd:complexType>
 
   <xsd:complexType name="docSimpleSectType">


### PR DESCRIPTION
With the `<li>` tag in HTML it is possible to have a `value=` attribute, this was only working for the HTML output, but has now been added to other output formats as well.
Also fixed small counting issue in case we have more than the supported number of levels.

(For docbook there is no solution yet)