### PR TITLE
value attribute for <li> tag for docbook

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -4065,7 +4065,7 @@ int DocHtmlList::parse()
             ) // found empty list
     {
       // add dummy item to obtain valid HTML
-      m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1));
+      m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1,!m_children.size()));
       warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"empty list!");
       retval = RetVal_EndList;
       goto endlist;
@@ -4073,7 +4073,7 @@ int DocHtmlList::parse()
     else // found some other tag
     {
       // add dummy item to obtain valid HTML
-      m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1));
+      m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1,!m_children.size()));
       warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"expected <li> tag but "
           "found <%s%s> instead!",m_parser.context.token->endTag?"/":"",qPrint(m_parser.context.token->name));
       m_parser.tokenizer.pushBackHtmlTag(m_parser.context.token->name);
@@ -4083,7 +4083,7 @@ int DocHtmlList::parse()
   else if (tok==0) // premature end of comment
   {
     // add dummy item to obtain valid HTML
-    m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1));
+    m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1,!m_children.size()));
     warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"unexpected end of comment while looking"
         " for a html list item");
     goto endlist;
@@ -4091,7 +4091,7 @@ int DocHtmlList::parse()
   else // token other than html token
   {
     // add dummy item to obtain valid HTML
-    m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1));
+    m_children.push_back(std::make_unique<DocHtmlListItem>(m_parser,this,HtmlAttribList(),1,!m_children.size()));
     warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"expected <li> tag but found %s token instead!",
         DocTokenizer::tokToString(tok));
     goto endlist;
@@ -4099,7 +4099,7 @@ int DocHtmlList::parse()
 
   do
   {
-    DocHtmlListItem *li=new DocHtmlListItem(m_parser,this,m_parser.context.token->attribs,num++);
+    DocHtmlListItem *li=new DocHtmlListItem(m_parser,this,m_parser.context.token->attribs,num++,!m_children.size());
     m_children.push_back(std::unique_ptr<DocHtmlListItem>(li));
     retval=li->parse();
   } while (retval==RetVal_ListItem);
@@ -4158,7 +4158,7 @@ int DocHtmlList::parseXml()
 
   do
   {
-    DocHtmlListItem *li=new DocHtmlListItem(m_parser,this,m_parser.context.token->attribs,num++);
+    DocHtmlListItem *li=new DocHtmlListItem(m_parser,this,m_parser.context.token->attribs,num++,!m_children.size());
     m_children.push_back(std::unique_ptr<DocHtmlListItem>(li));
     retval=li->parseXml();
     if (retval==0) break;

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -1286,17 +1286,20 @@ class DocSimpleListItem : public DocNode
 class DocHtmlListItem : public CompAccept<DocHtmlListItem>
 {
   public:
-    DocHtmlListItem(DocParser &parser,DocNode *parent,const HtmlAttribList &attribs,int num) :
-      CompAccept<DocHtmlListItem>(parser), m_attribs(attribs), m_itemNum(num) { m_parent = parent; }
+    DocHtmlListItem(DocParser &parser,DocNode *parent,const HtmlAttribList &attribs,int num,bool isFirst) :
+      CompAccept<DocHtmlListItem>(parser), m_attribs(attribs), m_itemNum(num) , m_isFirst(isFirst) { m_parent = parent; }
     Kind kind() const override                     { return Kind_HtmlListItem; }
     int itemNumber() const                { return m_itemNum; }
     const HtmlAttribList &attribs() const { return m_attribs; }
     int parse();
     int parseXml();
+    bool isFirst() const        { return m_isFirst; }
+    void markFirst(bool v=TRUE) { m_isFirst=v; }
 
   private:
     HtmlAttribList m_attribs;
     int            m_itemNum = 0;
+    bool           m_isFirst = false;
 };
 
 /** Node representing a HTML description data */


### PR DESCRIPTION
In the docbook listitem tag there is no option for the implementation of the value attribute.
We have to use a workaround as suggested from the support person of XMLMind: close the current ordered list and start a new list (i.e. at the same level).
As we need to know the type of list (Arabic numbers, lower / upper case Roman) we have to "reparse" the attributes of the List again.
Also special care has to be taken when we have a value attribute with the first list item (we have to prevent that we get an empty ordered docbook list (this results in the m_isFirst field with the list items).