### PR TITLE
Incorrect xml tags in source code listing (XML output)

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -297,7 +297,7 @@ void XMLCodeGenerator::endCodeLine()
     m_t << "</highlight>";
     m_normalHLNeedStartTag=TRUE;
   }
-  m_t << "</codeline>\n"; // non DocBook
+  if (m_insideCodeLine) m_t << "</codeline>\n"; // non DocBook
   m_lineNumber = -1;
   m_refId.resize(0);
   m_external.resize(0);


### PR DESCRIPTION
For the source code of the lex files in the XML documentation we get warnings like:

```
code_8l.xml:1447: parser error : Opening and ending tag mismatch: programlisting line 1432 and codeline
</codeline>
           ^
code_8l.xml:1458: parser error : Opening and ending tag mismatch: compounddef line 1432 and codeline
</codeline>
           ^
code_8l.xml:1707: parser error : Opening and ending tag mismatch: doxygen line 1432 and codeline
</codeline>
           ^
code_8l.xml:1708: parser error : Extra content at the end of the document
<codeline lineno="273"><highlight class="normal">%}</highlight></codeline>
^
```
this can be seen when using xsltproc and xmllint and is due to the fact that the closing of a source code line is not guarded like it is done e.g.  for html / rtf / latex

This can be observed e.g. when generating XML documentation of the internal doxygen files.