### PR TITLE
bug_684050 line continuation in \copydoc

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -554,6 +554,7 @@ STopt  [^\n@\\]*
 %x      SkipLang
 %x      CiteLabel
 %x      CopyDoc
+%x      CopyDocExpr
 %x      GuardExpr
 %x      CdataSection
 %x      Noop
@@ -1935,9 +1936,28 @@ STopt  [^\n@\\]*
 
   /* ----- handle argument of the copydoc command ------- */
 
+<CopyDoc>"("                            {
+                                          yyextra->copyDocArg+=yytext;
+                                          yyextra->roundCount=1;
+                                          BEGIN(CopyDocExpr);
+                                        }
+<CopyDocExpr>[^()]*                     {
+                                          yyextra->copyDocArg+=yytext;
+                                          lineCount(yyscanner);
+                                        }
+<CopyDocExpr>"("                        {
+                                          yyextra->copyDocArg+=yytext;
+                                          yyextra->roundCount++;
+                                        }
+<CopyDocExpr>")"                        {
+                                          yyextra->copyDocArg+=yytext;
+                                          yyextra->roundCount--;
+                                          if (yyextra->roundCount==0) BEGIN(CopyDoc);
+                                        }
 <CopyDoc><<EOF>>                        |
 <CopyDoc>{DOCNL}                        {
                                           if (*yytext=='\n') yyextra->lineNr++;
+                                          addOutput(yyscanner,yyextra->copyDocArg);
                                           addOutput(yyscanner,'\n');
                                           setOutput(yyscanner,OutputDoc);
                                           addOutput(yyscanner," \\copydetails ");
@@ -1945,13 +1965,11 @@ STopt  [^\n@\\]*
                                           addOutput(yyscanner,"\n");
                                           BEGIN(Comment);
                                         }
-<CopyDoc>[^\n\\]+                       {
+<CopyDoc>[^\n(\\]+                      {
                                           yyextra->copyDocArg+=yytext;
-                                          addOutput(yyscanner,yytext);
                                         }
 <CopyDoc>.                              {
                                           yyextra->copyDocArg+=yytext;
-                                          addOutput(yyscanner,yytext);
                                         }
 
  /*


### PR DESCRIPTION
Conform the documentation of `\copydoc` it cannot have an embedded linefeed and thus the `\copydoc` is terminated here when converted to `\copybrief` and `\copydetails`.
The rest of the "signature") is automatically added at the `\copydetails` leaving the `\copybrief` with just half a line (all can be observed with `doxygen -d commentscan`).
The round brackets were not handled and now a rudimentary  version has been implemented.

(Note the original issue contains 3 problems this is the last one of the 3 and about copydoc)