### PR TITLE
issue #8817 If \if, \else or \endif is in a list, the subsequent listentry is not formatted as list entry but in "raw format"

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3308,7 +3308,7 @@ static inline void addOutput(yyscan_t yyscanner,char c)
 
 static void addIline(yyscan_t yyscanner,int lineNr)
 {
-  char cmd[20];
+  char cmd[30];
   sprintf(cmd,"\\iline %d \\ilinebr ",lineNr);
   addOutput(yyscanner, cmd);
 }

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3309,7 +3309,7 @@ static inline void addOutput(yyscan_t yyscanner,char c)
 static void addIline(yyscan_t yyscanner,int lineNr)
 {
   char cmd[20];
-  sprintf(cmd,"\\iline %d ",lineNr);
+  sprintf(cmd,"\\iline %d \\ilinebr ",lineNr);
   addOutput(yyscanner, cmd);
 }
 


### PR DESCRIPTION
Looking at the results of the version 1.9.1 the result is OK, in the 1.9.2 version it is not OK.
Having:
```
/**

\mainpage

-# '1'
-# '2'
\if ASDF
-# '3' IF-CASE ASDF \line8
\else
-# '3' ELSE-CASE ASDF \line10
\endif
-# '4'

*/
```
we see with `doxygen -d commentscan` in the 1.9.2 version:
```
CommentScanner: D:/speeltuin/issue_8817/DoxyIfElse/Input.dox:3
output=[
brief=[line=-1
]
docs=[line=5
-# '1'
-# '2'
\iline 8 -# '3' IF-CASE ASDF \line8
\iline 12 -# '4']
inbody=[line=-1
]
]
```
i.e. the `-#` is not at the beginning of the line anymore  due to the `\iline` (which was necessary to have correct line numbers for warnings).
We need an extra newline, not a normal newline, as this would disturb the line counting process,  but a doxygen internal newline i.e. `\ilinebr `