### PR TITLE
Name of used struct

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -52,9 +52,9 @@ typedef yyguts_t *yyscan_t;
 
 #define USE_STATE2STRING 0
   
-struct CondCtx
+struct commentcnvYY_CondCtx
 {
-  CondCtx(int line,QCString id,bool b) 
+  commentcnvYY_CondCtx(int line,QCString id,bool b) 
     : lineNr(line),sectionId(id), skip(b) {}
   int lineNr;
   QCString sectionId;
@@ -81,7 +81,7 @@ struct commentcnvYY_state
   QCString fileName;
   int      lineNr = 0;
   int      condCtx = 0;
-  std::stack<CondCtx> condStack;
+  std::stack<commentcnvYY_CondCtx> condStack;
   std::stack<int> commentStack;
   QCString blockName;
   int      lastCommentContext = 0;
@@ -1061,7 +1061,7 @@ static void startCondSection(yyscan_t yyscanner,const QCString &sectId)
   //printf("startCondSection: skip=%d stack=%d\n",g_skip,g_condStack.count());
   CondParser prs;
   bool expResult = prs.parse(yyextra->fileName,yyextra->lineNr,sectId);
-  yyextra->condStack.push(CondCtx(yyextra->lineNr,sectId,yyextra->skip));
+  yyextra->condStack.push(commentcnvYY_CondCtx(yyextra->lineNr,sectId,yyextra->skip));
   if (!expResult) // not enabled
   {
     yyextra->skip=TRUE;
@@ -1078,7 +1078,7 @@ static void endCondSection(yyscan_t yyscanner)
   }
   else
   {
-    const CondCtx &ctx = yyextra->condStack.top();
+    const commentcnvYY_CondCtx &ctx = yyextra->condStack.top();
     yyextra->skip=ctx.skip;
     yyextra->condStack.pop();
   }
@@ -1209,7 +1209,7 @@ void convertCppComments(BufStr *inBuf,BufStr *outBuf,const QCString &fileName)
   yylex(yyscanner);
   while (!yyextra->condStack.empty())
   {
-    const CondCtx &ctx = yyextra->condStack.top();
+    const commentcnvYY_CondCtx &ctx = yyextra->condStack.top();
     QCString sectionInfo(" ");
     if (ctx.sectionId!=" ") sectionInfo.sprintf(" with label '%s' ",ctx.sectionId.stripWhiteSpace().data());
     warn(yyextra->fileName,ctx.lineNr,"Conditional section%sdoes not have "

--- a/src/pre.l
+++ b/src/pre.l
@@ -77,9 +77,9 @@ typedef yyguts_t *yyscan_t;
 static const char *stateToString(int state);
 #endif
 
-struct CondCtx
+struct preYY_CondCtx
 {
-  CondCtx(int line,QCString id,bool b)
+  preYY_CondCtx(int line,QCString id,bool b)
     : lineNr(line),sectionId(id), skip(b) {}
   int lineNr;
   QCString sectionId;
@@ -302,7 +302,7 @@ struct preYY_state
   StringVector                             pathList;
   IntMap                                   argMap;
   BoolStack                                levelGuard;
-  std::stack< std::unique_ptr<CondCtx> >   condStack;
+  std::stack< std::unique_ptr<preYY_CondCtx> >   condStack;
   std::deque< std::unique_ptr<FileState> > includeStack;
   std::unordered_map<std::string,Define*>  expandedDict;
   StringUnorderedSet                       expanded;
@@ -3168,7 +3168,7 @@ static void startCondSection(yyscan_t yyscanner,const QCString &sectId)
   //printf("startCondSection: skip=%d stack=%d\n",state->skip,state->condStack.size());
   CondParser prs;
   bool expResult = prs.parse(state->yyFileName.data(),state->yyLineNr,sectId.data());
-  state->condStack.emplace(std::make_unique<CondCtx>(state->yyLineNr,sectId,state->skip));
+  state->condStack.emplace(std::make_unique<preYY_CondCtx>(state->yyLineNr,sectId,state->skip));
   if (!expResult)
   {
     state->skip=TRUE;
@@ -3185,7 +3185,7 @@ static void endCondSection(yyscan_t yyscanner)
   }
   else
   {
-    const std::unique_ptr<CondCtx> &ctx = state->condStack.top();
+    const std::unique_ptr<preYY_CondCtx> &ctx = state->condStack.top();
     state->skip=ctx->skip;
     state->condStack.pop();
   }
@@ -3532,7 +3532,7 @@ void Preprocessor::processFile(const QCString &fileName,BufStr &input,BufStr &ou
 
   while (!state->condStack.empty())
   {
-    const std::unique_ptr<CondCtx> &ctx = state->condStack.top();
+    const std::unique_ptr<preYY_CondCtx> &ctx = state->condStack.top();
     QCString sectionInfo = " ";
     if (ctx->sectionId!=" ") sectionInfo.sprintf(" with label '%s' ",qPrint(ctx->sectionId.stripWhiteSpace()));
     warn(fileName,ctx->lineNr,"Conditional section%sdoes not have "


### PR DESCRIPTION
In the doxygen the struct name `CondCtx` is used twice (pre.l and commentcnv.l), although syntactically correct and no intersection between the 2 structs (and they are vene identical) the internal doxygen  documentation has some problems (especially we get multiple times the same label defined).
Analogous to the `state` struct it is better to use an unique name.