### PR TITLE
Better search criterion for RTF INCLUDETEXT

### DIFF
--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2104,7 +2104,7 @@ static bool preProcessFile(Dir &d,const QCString &infName, TextStream &t, bool b
   {
     line+='\n';
     size_t pos;
-    if ((pos=prevLine.find("INCLUDETEXT"))!=std::string::npos)
+    if ((pos=prevLine.find("INCLUDETEXT \""))!=std::string::npos)
     {
       size_t startNamePos  = prevLine.find('"',pos)+1;
       size_t endNamePos    = prevLine.find('"',startNamePos);


### PR DESCRIPTION
When combining the internal doxygen documentation not only the real INCLUDETEXT commands are joined but also an attempt is made to do this for the source code lines where INCLUDETEXT appears. This is prevented by slightly improving the search criterion.