### PR TITLE
Correcting labels

### DIFF
--- a/addon/doxyapp/doxyapp.cpp
+++ b/addon/doxyapp/doxyapp.cpp
@@ -49,7 +49,7 @@ class XRefDummyCodeGenerator : public CodeOutputInterface
     // and cross-linked version of the source code, but who needs that anyway ;-)
     void codify(const QCString &) override {}
     void writeCodeLink(CodeSymbolType,const QCString &,const QCString &,const QCString &,const QCString &,const QCString &) override  {}
-    void writeLineNumber(const QCString &,const QCString &,const QCString &,int) override {}
+    void writeLineNumber(const QCString &,const QCString &,const QCString &,int,bool) override {}
     virtual void writeTooltip(const QCString &,const DocLinkInfo &,
                               const QCString &,const QCString &,const SourceLinkInfo &,
                               const SourceLinkInfo &) override {}

--- a/addon/doxyparse/doxyparse.cpp
+++ b/addon/doxyparse/doxyparse.cpp
@@ -60,7 +60,7 @@ class Doxyparse : public CodeOutputInterface
     void writeCodeAnchor(const QCString &) override {}
     void startFontClass(const QCString &) override {}
     void endFontClass() override {}
-    void writeLineNumber(const QCString &,const QCString &,const QCString &,int) override {}
+    void writeLineNumber(const QCString &,const QCString &,const QCString &,int,bool) override {}
     virtual void writeTooltip(const QCString &,const DocLinkInfo &,
                               const QCString &,const QCString &,const SourceLinkInfo &,
                               const SourceLinkInfo &) override {}

--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -25,6 +25,7 @@
 //--------------------------------------------------------------------------
 
 static std::mutex g_clangMutex;
+static bool includeCodeFragment = false;
 
 ClangParser *ClangParser::instance()
 {
@@ -486,7 +487,7 @@ std::string ClangTUParser::lookup(uint line,const char *symbol)
 }
 
 
-void ClangTUParser::writeLineNumber(CodeOutputInterface &ol,const FileDef *fd,uint line)
+void ClangTUParser::writeLineNumber(CodeOutputInterface &ol,const FileDef *fd,uint line,bool includeCodeFragment)
 {
   const Definition *d = fd ? fd->getSourceDefinition(line) : 0;
   if (d && d->isLinkable())
@@ -505,7 +506,7 @@ void ClangTUParser::writeLineNumber(CodeOutputInterface &ol,const FileDef *fd,ui
       ol.writeLineNumber(md->getReference(),
                          md->getOutputFileBase(),
                          md->anchor(),
-                         line);
+                         line,includeCodeFragment);
     }
     else // link to compound
     {
@@ -513,12 +514,12 @@ void ClangTUParser::writeLineNumber(CodeOutputInterface &ol,const FileDef *fd,ui
       ol.writeLineNumber(d->getReference(),
                          d->getOutputFileBase(),
                          d->anchor(),
-                         line);
+                         line,includeCodeFragment);
     }
   }
   else // no link
   {
-    ol.writeLineNumber(QCString(),QCString(),QCString(),line);
+    ol.writeLineNumber(QCString(),QCString(),QCString(),line,includeCodeFragment);
   }
 
   // set search page target
@@ -556,7 +557,7 @@ void ClangTUParser::codifyLines(CodeOutputInterface &ol,const FileDef *fd,const 
       if (fontClass) ol.endFontClass();
       ol.endCodeLine();
       ol.startCodeLine(TRUE);
-      writeLineNumber(ol,fd,line);
+      writeLineNumber(ol,fd,line,includeCodeFragment);
       if (fontClass) ol.startFontClass(fontClass);
     }
     else
@@ -598,7 +599,7 @@ void ClangTUParser::writeMultiLineCodeLink(CodeOutputInterface &ol,
       ol.writeCodeLink(d->codeSymbolType(),ref,file,anchor,sp,tooltip);
       ol.endCodeLine();
       ol.startCodeLine(TRUE);
-      writeLineNumber(ol,fd,line);
+      writeLineNumber(ol,fd,line,includeCodeFragment);
     }
     else
     {
@@ -761,7 +762,7 @@ void ClangTUParser::writeSources(CodeOutputInterface &ol,const FileDef *fd)
   unsigned int line=1,column=1;
   QCString lineNumber,lineAnchor;
   ol.startCodeLine(TRUE);
-  writeLineNumber(ol,fd,line);
+  writeLineNumber(ol,fd,line,includeCodeFragment);
   for (unsigned int i=0;i<p->numTokens;i++)
   {
     CXSourceLocation start = clang_getTokenLocation(p->tu, p->tokens[i]);
@@ -773,7 +774,7 @@ void ClangTUParser::writeSources(CodeOutputInterface &ol,const FileDef *fd)
       line++;
       ol.endCodeLine();
       ol.startCodeLine(TRUE);
-      writeLineNumber(ol,fd,line);
+      writeLineNumber(ol,fd,line,includeCodeFragment);
     }
     while (column<c) { ol.codify(" "); column++; }
     CXString tokenString = clang_getTokenSpelling(p->tu, p->tokens[i]);

--- a/src/clangparser.h
+++ b/src/clangparser.h
@@ -50,7 +50,7 @@ class ClangTUParser
 
   private:
     void detectFunctionBody(const char *s);
-    void writeLineNumber(CodeOutputInterface &ol,const FileDef *fd,uint line);
+    void writeLineNumber(CodeOutputInterface &ol,const FileDef *fd,uint line,bool includeCodeFragment);
     void codifyLines(CodeOutputInterface &ol,const FileDef *fd,const char *text,
                      uint &line,uint &column,const char *fontClass=0);
     void writeMultiLineCodeLink(CodeOutputInterface &ol,

--- a/src/code.l
+++ b/src/code.l
@@ -2377,20 +2377,20 @@ static void startCodeLine(yyscan_t yyscanner)
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                                 yyextra->currentMemberDef->getOutputFileBase(),
                                 yyextra->currentMemberDef->anchor(),
-                                yyextra->yyLineNr);
+                                yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else if (d->isLinkableInProject())
       {
         yyextra->code->writeLineNumber(d->getReference(),
                                 d->getOutputFileBase(),
-                                QCString(),yyextra->yyLineNr);
+                                QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
     }
   }
   DBG_CTX((stderr,"startCodeLine(%d)\n",yyextra->yyLineNr));

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -168,9 +168,10 @@ void DocbookCodeGenerator::writeCodeLink(CodeSymbolType,
 void DocbookCodeGenerator::writeCodeLinkLine(CodeSymbolType,
     const QCString &,const QCString &file,
     const QCString &,const QCString &name,
-    const QCString &)
+    const QCString &,bool includeCodeFragment)
 {
   Docbook_DB(("(writeCodeLinkLine)\n"));
+  if (includeCodeFragment) return;
   m_t << "<anchor xml:id=\"_" << stripExtensionGeneral(stripPath(file),".xml");
   m_t << "_1l";
   writeDocbookString(m_t,name);
@@ -222,7 +223,7 @@ void DocbookCodeGenerator::writeCodeAnchor(const QCString &)
 }
 
 void DocbookCodeGenerator::writeLineNumber(const QCString &ref,const QCString &fileName,
-    const QCString &anchor,int l)
+    const QCString &anchor,int l,bool includeCodeFragment)
 {
   Docbook_DB(("(writeLineNumber)\n"));
   m_insideCodeLine = TRUE;
@@ -233,7 +234,7 @@ void DocbookCodeGenerator::writeLineNumber(const QCString &ref,const QCString &f
 
     if (!m_sourceFileName.isEmpty())
     {
-      writeCodeLinkLine(CodeSymbolType::Default,ref,m_sourceFileName,anchor,lineNumber,QCString());
+      writeCodeLinkLine(CodeSymbolType::Default,ref,m_sourceFileName,anchor,lineNumber,QCString(),includeCodeFragment);
     }
     if (!fileName.isEmpty())
     {

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -37,7 +37,7 @@ class DocbookCodeGenerator : public CodeOutputInterface
     void writeCodeLinkLine(CodeSymbolType type,
         const QCString &ref,const QCString &file,
         const QCString &anchor,const QCString &name,
-        const QCString &tooltip);
+        const QCString &tooltip, bool);
     void writeTooltip(const QCString &, const DocLinkInfo &, const QCString &,
                       const QCString &, const SourceLinkInfo &, const SourceLinkInfo &
                      );
@@ -47,7 +47,7 @@ class DocbookCodeGenerator : public CodeOutputInterface
     void endFontClass();
     void writeCodeAnchor(const QCString &);
     void writeLineNumber(const QCString &extRef,const QCString &compId,
-        const QCString &anchorId,int l);
+        const QCString &anchorId,int l, bool includeCodeFragment);
     void setCurrentDoc(const Definition *,const QCString &,bool);
     void addWord(const QCString &,bool);
     void finish();
@@ -112,8 +112,8 @@ class DocbookGenerator : public OutputGenerator
                        const QCString &anchor,const QCString &name,
                        const QCString &tooltip)
     { m_codeGen.writeCodeLink(type,ref,file,anchor,name,tooltip); }
-    void writeLineNumber(const QCString &ref,const QCString &file,const QCString &anchor,int lineNumber)
-    { m_codeGen.writeLineNumber(ref,file,anchor,lineNumber); }
+    void writeLineNumber(const QCString &ref,const QCString &file,const QCString &anchor,int lineNumber, bool includeCodeFragment)
+    { m_codeGen.writeLineNumber(ref,file,anchor,lineNumber,includeCodeFragment); }
     void writeTooltip(const QCString &id, const DocLinkInfo &docInfo, const QCString &decl,
                       const QCString &desc, const SourceLinkInfo &defInfo, const SourceLinkInfo &declInfo
                      )

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -208,7 +208,7 @@ class DevNullCodeDocInterface : public CodeOutputInterface
                               const QCString &, const SourceLinkInfo &, const SourceLinkInfo &
                              ) override {}
     virtual void writeLineNumber(const QCString &,const QCString &,
-                                 const QCString &,int) override {}
+                                 const QCString &,int,bool) override {}
     virtual void startCodeLine(bool) override {}
     virtual void endCodeLine() override {}
     virtual void startFontClass(const QCString &) override {}

--- a/src/fileparser.cpp
+++ b/src/fileparser.cpp
@@ -25,7 +25,7 @@ void FileCodeParser::parseCode(CodeOutputInterface &codeOutIntf,
                const FileDef *      fileDef,
                int                  startLine,
                int                  endLine,
-               bool,                // inlineFragment
+               bool                 inlineFragment, 
                const MemberDef *,   // memberDef
                bool                 showLineNumbers,
                const Definition *,  // searchCtx,
@@ -43,7 +43,7 @@ void FileCodeParser::parseCode(CodeOutputInterface &codeOutIntf,
     codeOutIntf.startCodeLine(fileDef != 0 && showLineNumbers);
     if (fileDef != 0 && showLineNumbers)
     {
-      codeOutIntf.writeLineNumber(QCString(),QCString(),QCString(),lineNr);
+      codeOutIntf.writeLineNumber(QCString(),QCString(),QCString(),lineNr,inlineFragment);
     }
     if (!lineStr.isEmpty()) codeOutIntf.codify(lineStr.data());
     codeOutIntf.endCodeLine();

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -933,20 +933,20 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                                 yyextra->currentMemberDef->getOutputFileBase(),
-                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else if (d->isLinkableInProject())
       {
         yyextra->code->writeLineNumber(d->getReference(),
                                 d->getOutputFileBase(),
-                                QCString(),yyextra->yyLineNr);
+                                QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
     }
   }
   yyextra->code->startCodeLine(yyextra->sourceFileDef);

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -696,7 +696,7 @@ void HtmlCodeGenerator::docify(const QCString &str)
 }
 
 void HtmlCodeGenerator::writeLineNumber(const QCString &ref,const QCString &filename,
-                                    const QCString &anchor,int l)
+                                    const QCString &anchor,int l,bool includeCodeFragment)
 {
   const int maxLineNrStr = 10;
   char lineNumber[maxLineNrStr];
@@ -710,7 +710,8 @@ void HtmlCodeGenerator::writeLineNumber(const QCString &ref,const QCString &file
     m_lineOpen = TRUE;
   }
 
-  m_t << "<a id=\"" << lineAnchor << "\" name=\"" << lineAnchor << "\"></a><span class=\"lineno\">";
+  if (!includeCodeFragment) m_t << "<a id=\"" << lineAnchor << "\" name=\"" << lineAnchor << "\"></a>";
+  m_t << "<span class=\"lineno\">";
   if (!filename.isEmpty())
   {
     _writeCodeLink("line",ref,filename,anchor,lineNumber,QCString());

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -38,7 +38,7 @@ class HtmlCodeGenerator : public CodeOutputInterface
                       const SourceLinkInfo &defInfo,
                       const SourceLinkInfo &declInfo
                      );
-    void writeLineNumber(const QCString &,const QCString &,const QCString &,int);
+    void writeLineNumber(const QCString &,const QCString &,const QCString &,int, bool);
     void startCodeLine(bool);
     void endCodeLine();
     void startFontClass(const QCString &s);
@@ -95,8 +95,8 @@ class HtmlGenerator : public OutputGenerator
                        const QCString &anchor,const QCString &name,
                        const QCString &tooltip)
     { m_codeGen.writeCodeLink(type,ref,file,anchor,name,tooltip); }
-    void writeLineNumber(const QCString &ref,const QCString &file,const QCString &anchor,int lineNumber)
-    { m_codeGen.writeLineNumber(ref,file,anchor,lineNumber); }
+    void writeLineNumber(const QCString &ref,const QCString &file,const QCString &anchor,int lineNumber, bool includeCodeFragment)
+    { m_codeGen.writeLineNumber(ref,file,anchor,lineNumber,includeCodeFragment); }
     void writeTooltip(const QCString &id, const DocLinkInfo &docInfo, const QCString &decl,
                       const QCString &desc, const SourceLinkInfo &defInfo, const SourceLinkInfo &declInfo
                      )

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -171,7 +171,7 @@ void LatexCodeGenerator::writeCodeLink(CodeSymbolType,
   m_col+=l;
 }
 
-void LatexCodeGenerator::writeLineNumber(const QCString &ref,const QCString &fileName,const QCString &anchor,int l)
+void LatexCodeGenerator::writeLineNumber(const QCString &ref,const QCString &fileName,const QCString &anchor,int l,bool includeCodeFragment)
 {
   bool usePDFLatex = Config_getBool(USE_PDFLATEX);
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
@@ -191,7 +191,7 @@ void LatexCodeGenerator::writeLineNumber(const QCString &ref,const QCString &fil
       lineAnchor.sprintf("_l%05d",l);
       lineAnchor.prepend(stripExtensionGeneral(m_sourceFileName, ".tex"));
     }
-    bool showTarget = usePDFLatex && pdfHyperlinks && !lineAnchor.isEmpty();
+    bool showTarget = usePDFLatex && pdfHyperlinks && !lineAnchor.isEmpty() && !includeCodeFragment;
     if (showTarget)
     {
       m_t << "\\Hypertarget{" << stripPath(lineAnchor) << "}";

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -44,7 +44,7 @@ class LatexCodeGenerator : public CodeOutputInterface
                       const SourceLinkInfo &,
                       const SourceLinkInfo &
                      )  override{}
-    void writeLineNumber(const QCString &,const QCString &,const QCString &,int) override;
+    void writeLineNumber(const QCString &,const QCString &,const QCString &,int,bool) override;
     void startCodeLine(bool) override;
     void endCodeLine() override;
     void startFontClass(const QCString &) override;
@@ -101,8 +101,8 @@ class LatexGenerator : public OutputGenerator
                        const QCString &anchor,const QCString &name,
                        const QCString &tooltip)
     { m_codeGen.writeCodeLink(type,ref,file,anchor,name,tooltip); }
-    void writeLineNumber(const QCString &ref,const QCString &file,const QCString &anchor,int lineNumber)
-    { m_codeGen.writeLineNumber(ref,file,anchor,lineNumber); }
+    void writeLineNumber(const QCString &ref,const QCString &file,const QCString &anchor,int lineNumber, bool includeCodeFragment)
+    { m_codeGen.writeLineNumber(ref,file,anchor,lineNumber,includeCodeFragment); }
     void writeTooltip(const QCString &id, const DocLinkInfo &docInfo, const QCString &decl,
                       const QCString &desc, const SourceLinkInfo &defInfo, const SourceLinkInfo &declInfo
                      )

--- a/src/lexcode.l
+++ b/src/lexcode.l
@@ -985,20 +985,20 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                             yyextra->currentMemberDef->getOutputFileBase(),
-                            yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+                            yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else
       {
         yyextra->code->writeLineNumber(d->getReference(),
                             d->getOutputFileBase(),
-                            QCString(),yyextra->yyLineNr);
+                            QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
     }
   }
 

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -126,7 +126,7 @@ class ManGenerator : public OutputGenerator
     void writeAnchor(const QCString &,const QCString &) {}
     void startCodeFragment(const QCString &);
     void endCodeFragment(const QCString &);
-    void writeLineNumber(const QCString &,const QCString &,const QCString &,int l) { m_t << l << " "; m_col=0; }
+    void writeLineNumber(const QCString &,const QCString &,const QCString &,int l, bool includeCodeFragment) { m_t << l << " "; m_col=0; }
     void startCodeLine(bool) {}
     void endCodeLine() { codify("\n"); m_col=0; }
     void startEmphasis() { m_t << "\\fI"; m_firstCol=FALSE; }

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -96,9 +96,12 @@ class CodeOutputInterface
      *  \param file       The file part of the URL pointing to the docs.
      *  \param anchor     The anchor part of the URL pointing to the docs.
      *  \param lineNumber The line number to write
+     *  \param includeCodeFragment Is it the real source code (false) or is it
+     *                             inline / included source code, in the later
+     *                             case no anchor should be writen.
      */
     virtual void writeLineNumber(const QCString &ref,const QCString &file,
-                                 const QCString &anchor,int lineNumber) = 0;
+                                 const QCString &anchor,int lineNumber, bool includeCodeFragment) = 0;
 
     /*! Writes a tool tip definition
      *  \param id       unique identifier for the tooltip

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -247,8 +247,8 @@ class OutputList : public OutputDocInterface
     void endCodeLine()
     { forall(&OutputGenerator::endCodeLine); }
     void writeLineNumber(const QCString &ref,const QCString &file,const QCString &anchor,
-                         int lineNumber)
-    { forall(&OutputGenerator::writeLineNumber,ref,file,anchor,lineNumber); }
+                         int lineNumber, bool includeCodeFragment)
+    { forall(&OutputGenerator::writeLineNumber,ref,file,anchor,lineNumber,includeCodeFragment); }
     void startEmphasis()
     { forall(&OutputGenerator::startEmphasis); }
     void endEmphasis()

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1039,21 +1039,21 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                                 yyextra->currentMemberDef->getOutputFileBase(),
-                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else
       {
         yyextra->code->writeLineNumber(d->getReference(),
                                 d->getOutputFileBase(),
-                                QCString(),yyextra->yyLineNr);
+                                QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
       //yyextra->code->codify(lineNumber);
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
     }
     //yyextra->code->endLineNumber();
   }

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -402,7 +402,7 @@ void RTFDocVisitor::visit(DocAnchor *anc)
   QCString anchor;
   if (!anc->file().isEmpty())
   {
-    anchor+=anc->file();
+    anchor+=stripPath(anc->file());
   }
   if (!anc->file().isEmpty() && !anc->anchor().isEmpty())
   {
@@ -860,8 +860,8 @@ void RTFDocVisitor::visitPre(DocSection *s)
   if (m_hide) return;
   DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocSection)}\n");
   if (!m_lastIsPara) m_t << "\\par\n";
-  m_t << "{\\bkmkstart " << rtfFormatBmkStr(s->file()+"_"+s->anchor()) << "}\n";
-  m_t << "{\\bkmkend " << rtfFormatBmkStr(s->file()+"_"+s->anchor()) << "}\n";
+  m_t << "{\\bkmkstart " << rtfFormatBmkStr(stripPath(s->file())+"_"+s->anchor()) << "}\n";
+  m_t << "{\\bkmkend " << rtfFormatBmkStr(stripPath(s->file())+"_"+s->anchor()) << "}\n";
   m_t << "{{" // start section
       << rtf_Style_Reset;
   QCString heading;
@@ -1624,7 +1624,7 @@ void RTFDocVisitor::visitPre(DocXRefItem *x)
     QCString refName;
     if (!x->file().isEmpty())
     {
-      refName+=x->file();
+      refName+=stripPath(x->file());
     }
     if (!x->file().isEmpty() && !x->anchor().isEmpty())
     {
@@ -1798,7 +1798,7 @@ void RTFDocVisitor::startLink(const QCString &ref,const QCString &file,const QCS
     QCString refName;
     if (!file.isEmpty())
     {
-      refName+=file;
+      refName+=stripPath(file);
     }
     if (!file.isEmpty() && !anchor.isEmpty())
     {

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1131,7 +1131,7 @@ void RTFGenerator::writeStartAnnoItem(const QCString &,const QCString &f,
   if (!f.isEmpty() && Config_getBool(RTF_HYPERLINKS))
   {
     m_t << "{\\field {\\*\\fldinst { HYPERLINK  \\\\l \"";
-    m_t << rtfFormatBmkStr(f);
+    m_t << rtfFormatBmkStr(stripPath(f));
     m_t << "\" }{}";
     m_t << "}{\\fldrslt {\\cs37\\ul\\cf2 ";
 
@@ -1236,7 +1236,7 @@ void RTFGenerator::startTextLink(const QCString &f,const QCString &anchor)
     QCString ref;
     if (!f.isEmpty())
     {
-      ref+=f;
+      ref+=stripPath(f);
     }
     if (!anchor.isEmpty())
     {
@@ -1267,7 +1267,7 @@ void RTFGenerator::writeObjectLink(const QCString &ref, const QCString &f,
     QCString refName;
     if (!f.isEmpty())
     {
-      refName+=f;
+      refName+=stripPath(f);
     }
     if (!anchor.isEmpty())
     {
@@ -1325,7 +1325,7 @@ void RTFGenerator::writeCodeLink(CodeSymbolType,
     QCString refName;
     if (!f.isEmpty())
     {
-      refName+=f;
+      refName+=stripPath(f);
     }
     if (!anchor.isEmpty())
     {
@@ -1458,7 +1458,7 @@ void RTFGenerator::endDoxyAnchor(const QCString &fName,const QCString &anchor)
   QCString ref;
   if (!fName.isEmpty())
   {
-    ref+=fName;
+    ref+=stripPath(fName);
   }
   if (!anchor.isEmpty())
   {
@@ -1719,7 +1719,7 @@ void RTFGenerator::writeAnchor(const QCString &fileName,const QCString &name)
   QCString anchor;
   if (!fileName.isEmpty())
   {
-    anchor+=fileName;
+    anchor+=stripPath(fileName);
   }
   if (!fileName.isEmpty() && !name.isEmpty())
   {
@@ -1739,7 +1739,7 @@ void RTFGenerator::writeAnchor(const QCString &fileName,const QCString &name)
 void RTFGenerator::writeRTFReference(const QCString &label)
 {
   m_t << "{\\field\\fldedit {\\*\\fldinst PAGEREF ";
-  m_t << rtfFormatBmkStr(label);
+  m_t << rtfFormatBmkStr(stripPath(label));
   m_t << " \\\\*MERGEFORMAT}{\\fldrslt pagenum}}";
 }
 
@@ -2079,7 +2079,7 @@ static bool preProcessFile(Dir &d,const QCString &infName, TextStream &t, bool b
   std::ifstream f(infName.str(),std::ifstream::in);
   if (!f.is_open())
   {
-    err("problems opening rtf file %s for reading\n",infName.data());
+    err("problems opening rtf file '%s' for reading\n",infName.data());
     return false;
   }
 
@@ -2665,7 +2665,7 @@ void RTFGenerator::endInlineMemberDoc()
   m_t << "\\cell }{\\row }\n";
 }
 
-void RTFGenerator::writeLineNumber(const QCString &ref,const QCString &fileName,const QCString &anchor,int l)
+void RTFGenerator::writeLineNumber(const QCString &ref,const QCString &fileName,const QCString &anchor,int l,bool includeCodeFragment)
 {
   bool rtfHyperlinks = Config_getBool(RTF_HYPERLINKS);
 
@@ -2679,9 +2679,9 @@ void RTFGenerator::writeLineNumber(const QCString &ref,const QCString &fileName,
     if (!m_sourceFileName.isEmpty())
     {
       lineAnchor.sprintf("_l%05d",l);
-      lineAnchor.prepend(stripExtensionGeneral(m_sourceFileName, ".rtf"));
+      lineAnchor.prepend(stripExtensionGeneral(stripPath(m_sourceFileName), ".rtf"));
     }
-    bool showTarget = rtfHyperlinks && !lineAnchor.isEmpty();
+    bool showTarget = rtfHyperlinks && !lineAnchor.isEmpty() && !includeCodeFragment;
     if (showTarget)
     {
         m_t << "{\\bkmkstart ";

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -127,7 +127,7 @@ class RTFGenerator : public OutputGenerator
     void writeAnchor(const QCString &fileName,const QCString &name);
     void startCodeFragment(const QCString &style);
     void endCodeFragment(const QCString &style);
-    void writeLineNumber(const QCString &,const QCString &,const QCString &,int l);
+    void writeLineNumber(const QCString &,const QCString &,const QCString &,int l, bool);
     void startCodeLine(bool);
     void endCodeLine();
     void startEmphasis() { m_t << "{\\i ";  }

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -242,20 +242,20 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                             yyextra->currentMemberDef->getOutputFileBase(),
-                            yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+                            yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else
       {
         yyextra->code->writeLineNumber(d->getReference(),
                             d->getOutputFileBase(),
-                            QCString(),yyextra->yyLineNr);
+                            QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
     }
   }
 

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1038,20 +1038,20 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                                 yyextra->currentMemberDef->getOutputFileBase(),
-                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+                                yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else if (d->isLinkableInProject())
       {
         yyextra->code->writeLineNumber(d->getReference(),
                                 d->getOutputFileBase(),
-                                QCString(),yyextra->yyLineNr);
+                                QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
     }
   }
   yyextra->code->startCodeLine(yyextra->sourceFileDef);

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -257,20 +257,20 @@ static void startCodeLine(yyscan_t yyscanner)
       {
         yyextra->code->writeLineNumber(yyextra->currentMemberDef->getReference(),
                             yyextra->currentMemberDef->getOutputFileBase(),
-                            yyextra->currentMemberDef->anchor(),yyextra->yyLineNr);
+                            yyextra->currentMemberDef->anchor(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
       else
       {
         yyextra->code->writeLineNumber(d->getReference(),
                             d->getOutputFileBase(),
-                            QCString(),yyextra->yyLineNr);
+                            QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
         setCurrentDoc(yyscanner,lineAnchor);
       }
     }
     else
     {
-      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr);
+      yyextra->code->writeLineNumber(QCString(),QCString(),QCString(),yyextra->yyLineNr,yyextra->includeCodeFragment);
     }
   }
 

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -325,7 +325,7 @@ void XMLCodeGenerator::writeCodeAnchor(const QCString &)
   XML_DB(("(writeCodeAnchor)\n"));
 }
 void XMLCodeGenerator::writeLineNumber(const QCString &extRef,const QCString &compId,
-                     const QCString &anchorId,int l)
+                     const QCString &anchorId,int l,bool includeCodeFragment)
 {
   XML_DB(("(writeLineNumber)\n"));
   // we remember the information provided here to use it

--- a/src/xmlgen.h
+++ b/src/xmlgen.h
@@ -38,7 +38,7 @@ class XMLCodeGenerator : public CodeOutputInterface
     void endFontClass() override;
     void writeCodeAnchor(const QCString &) override;
     void writeLineNumber(const QCString &extRef,const QCString &compId,
-                         const QCString &anchorId,int l) override;
+                         const QCString &anchorId,int l,bool includeCodeFragment) override;
     void setCurrentDoc(const Definition *,const QCString &,bool) override {}
     void addWord(const QCString &,bool) override {}
     void startCodeFragment(const QCString &) override;


### PR DESCRIPTION
In case we have included sources (e.g. due to `INLINE_SOURCES`) and also the `SOURCE_BROWSER` enabled it is possible that we get double labels.
Also the calculation of labels in RTF was not done consistently, sometimes the path was striped and on other moments it wasn't (especially seen in case CREATE_SUBDIRS
The problem was found using RTF / Docbook on the doxygen internal documentation (not standard) but will happen too in other projects