### PR TITLE
fix group close

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3428,6 +3428,7 @@ NONLopt [^\n]*
                                           {
                                             yyextra->mtype = Method;
                                             yyextra->virt = Normal;
+                                            yyextra->current->groups.clear();
                                             initEntry(yyscanner);
                                           }
                                         }

--- a/testing/019/group___a.xml
+++ b/testing/019/group___a.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___a" kind="group">
+    <compoundname>A</compoundname>
+    <title>A</title>
+    <innergroup refid="group___b">B</innergroup>
+    <innergroup refid="group___c">C</innergroup>
+    <innergroup refid="group___d">D</innergroup>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/019/group___b.xml
+++ b/testing/019/group___b.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___b" kind="group">
+    <compoundname>B</compoundname>
+    <title>B</title>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/019/group___c.xml
+++ b/testing/019/group___c.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___c" kind="group">
+    <compoundname>C</compoundname>
+    <title>C</title>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/019/group___d.xml
+++ b/testing/019/group___d.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___d" kind="group">
+    <compoundname>D</compoundname>
+    <title>D</title>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/019_defgroup.c
+++ b/testing/019_defgroup.c
@@ -46,3 +46,35 @@ void func_g3_add();
 
 /** \} */
 
+// check: group___a.xml
+// check: group___b.xml
+// check: group___c.xml
+// check: group___d.xml
+
+/**
+  @defgroup A A
+  @{
+ */
+
+/** @defgroup B B
+   @{
+ */
+
+/// \}
+
+/** @defgroup C C
+   @{
+ */
+
+/** @} */
+
+/**
+  @defgroup D D
+  @{
+ */
+
+/// @}
+
+/**
+@}
+*/


### PR DESCRIPTION
I don't know if it is the right solution. At least it has new unit test and all tests are passed.


single-line instructions
```
/// @}
/// \}
/**  @} */
```
don't close groups as expected.

fix #8815