### PR TITLE
bug_792690  Spaces MAKEINDEX_CMD_NAME don't work the same as other config options

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -295,8 +295,8 @@ static void writeLatexMakefile()
   }
   TextStream t(&f);
   // inserted by KONNO Akihisa <konno@researchers.jp> 2002-03-05
-  QCString latex_command = theTranslator->latexCommandName();
-  QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME);
+  QCString latex_command = escapePath(theTranslator->latexCommandName());
+  QCString mkidx_command = escapePath(Config_getString(MAKEINDEX_CMD_NAME));
   // end insertion by KONNO Akihisa <konno@researchers.jp> 2002-03-05
   if (!Config_getBool(USE_PDFLATEX)) // use plain old latex
   {
@@ -383,8 +383,8 @@ static void writeMakeBat()
 #if defined(_MSC_VER)
   QCString dir=Config_getString(LATEX_OUTPUT);
   QCString fileName=dir+"/make.bat";
-  QCString latex_command = theTranslator->latexCommandName();
-  QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME);
+  QCString latex_command = escapePath(theTranslator->latexCommandName());
+  QCString mkidx_command = escapePath(Config_getString(MAKEINDEX_CMD_NAME));
   bool generateBib = !CitationManager::instance().isEmpty();
   std::ofstream t(fileName.str(),std::ofstream::out | std::ofstream::binary);
   if (!t.is_open())

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7381,3 +7381,16 @@ QCString integerToRoman(int n, bool upper)
 
   return result;
 }
+
+QCString escapePath(QCString s)
+{
+  if (s.isEmpty()) return s;
+  QCString str = s;
+  str=str.stripWhiteSpace();
+  if (str.at(0)!='"' && str.find(' ')!=-1)
+  {
+    // add quotes around command as it contains spaces and is not quoted already
+    str="\""+str+"\"";
+  }
+  return str;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -430,4 +430,5 @@ FortranFormat convertFileNameFortranParserCode(QCString fn);
 QCString integerToAlpha(int n, bool upper=true);
 QCString integerToRoman(int n, bool upper=true);
 
+QCString escapePath(QCString s);
 #endif


### PR DESCRIPTION
The PDF generation in doxygen uses a 2 stage process:
- generate the tex files
- build (outside of doxygen!) the PDF file by means of the supplied `Makefile`  / `make.bat`

this is another  way than it happens for e.g. generating images where the external process is directly called from within doxygen, and here the path is quoted by doxygen (see `Portable::system) when necessary.

This discrepancy has been fixed.