### PR TITLE
bug_774167  Left nav pane

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -122,7 +122,14 @@ LayoutNavEntry *LayoutNavEntry::find(LayoutNavEntry::Kind kind,
   return result;
 }
 
-
+void LayoutNavEntry::adjustVisibility()
+{
+  if (parent()) setVisible(visible() & parent()->visible());
+  for (const auto &entry : m_children)
+  {
+    entry.get()->adjustVisibility();
+  }
+}
 
 QCString LayoutNavEntry::url() const
 {
@@ -247,7 +254,11 @@ class LayoutParser
     {
       m_scope="navindex/";
       m_rootNav = LayoutDocManager::instance().rootNavEntry();
-      if (m_rootNav) m_rootNav->clear();
+      if (m_rootNav)
+      {
+        m_rootNav->clear();
+        m_rootNav->setVisible(true);
+      }
     }
 
     void endNavIndex()
@@ -1564,6 +1575,7 @@ void LayoutDocManager::init()
   layoutParser.setDocumentLocator(&parser);
   QCString layout_default = ResourceMgr::instance().getAsString("layout_default.xml");
   parser.parse("layout_default.xml",layout_default.data(),Debug::isFlagSet(Debug::Lex));
+  d->rootNav->adjustVisibility();
 }
 
 LayoutDocManager::~LayoutDocManager()
@@ -1607,6 +1619,7 @@ void LayoutDocManager::parse(const QCString &fileName)
   XMLParser parser(handlers);
   layoutParser.setDocumentLocator(&parser);
   parser.parse(fileName.data(),fileToString(fileName).data(),Debug::isFlagSet(Debug::Lex));
+  d->rootNav->adjustVisibility();
 }
 
 //---------------------------------------------------------------------------------

--- a/src/layout.h
+++ b/src/layout.h
@@ -173,11 +173,13 @@ struct LayoutNavEntry
     QCString intro() const           { return m_intro; }
     QCString url() const;
     bool visible()                   { return m_visible; }
+    void setVisible(bool v)          { m_visible = v; }
     void clear()                     { m_children.clear(); }
     void addChild(LayoutNavEntry *e) { m_children.push_back(std::unique_ptr<LayoutNavEntry>(e)); }
     void prependChild(LayoutNavEntry *e) { m_children.insert(m_children.begin(),std::unique_ptr<LayoutNavEntry>(e)); }
     const LayoutNavEntryList &children() const { return m_children; }
     LayoutNavEntry *find(LayoutNavEntry::Kind k,const QCString &file=QCString()) const;
+    void adjustVisibility();
 
   private:
     LayoutNavEntry() : m_parent(0), m_kind(None), m_visible(FALSE) {}


### PR DESCRIPTION
In case a higher level visibility is set to `no` also the children should, automatically, not be visible.