### PR TITLE
bug_769634 no need for .map files when .svg is generated by DOT

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -340,14 +340,6 @@ void writeDotImageMapFromFile(TextStream &t,
   QCString imgName = baseName+"."+imgExt;
   QCString absOutFile = QCString(d.absPath())+"/"+mapName;
 
-  DotRunner dotRun(inFile);
-  dotRun.addJob(MAP_CMD,absOutFile,srcFile,srcLine);
-  dotRun.preventCleanUp();
-  if (!dotRun.run())
-  {
-    return;
-  }
-
   if (imgExt=="svg") // vector graphics
   {
     QCString svgName = outDir+"/"+baseName+".svg";
@@ -358,6 +350,14 @@ void writeDotImageMapFromFile(TextStream &t,
   }
   else // bitmap graphics
   {
+    DotRunner dotRun(inFile);
+    dotRun.addJob(MAP_CMD,absOutFile,srcFile,srcLine);
+    dotRun.preventCleanUp();
+    if (!dotRun.run())
+    {
+      return;
+    }
+
     TextStream tt;
     t << "<img src=\"" << relPath << imgName << "\" alt=\""
       << imgName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>\n";

--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -142,6 +142,7 @@ QCString DotGraph::writeGraph(
 
 bool DotGraph::prepareDotFile()
 {
+  static QCString imgExt = getDotImageExtension();
   if (!m_dir.exists())
   {
     term("Output dir %s does not exist!\n", m_dir.path().c_str());
@@ -158,7 +159,7 @@ bool DotGraph::prepareDotFile()
 
   if (sameMd5Signature(absBaseName(), sigStr) &&
       deliverablesPresent(absImgName(),
-                          m_graphFormat == GOF_BITMAP && m_generateImageMap ? absMapName() : QCString()
+                          m_graphFormat == GOF_BITMAP && m_generateImageMap && imgExt != "svg" ? absMapName() : QCString()
                          )
      )
   {
@@ -183,7 +184,7 @@ bool DotGraph::prepareDotFile()
     // run dot to create a bitmap image
     DotRunner * dotRun = DotManager::instance()->createRunner(absDotName(), sigStr);
     dotRun->addJob(Config_getEnumAsString(DOT_IMAGE_FORMAT), absImgName(), absDotName(), 1);
-    if (m_generateImageMap) dotRun->addJob(MAP_CMD, absMapName(), absDotName(), 1);
+    if (m_generateImageMap &&  imgExt != "svg") dotRun->addJob(MAP_CMD, absMapName(), absDotName(), 1);
   }
   else if (m_graphFormat == GOF_EPS)
   {


### PR DESCRIPTION
Don't generate the `map` files in case of dot format "svg"