### PR TITLE
bug_774111 GENERATE_LEGEND with svg graphs

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3891,7 +3891,7 @@ UML notation for the relationships.
 <![CDATA[
  If the \c GENERATE_LEGEND tag is set to \c YES doxygen will
  generate a legend page explaining the meaning of the various boxes and
- errows in the dot generated graphs.
+ arrows in the dot generated graphs.
  \note This tag requires that \ref cfg_uml_look "UML_LOOK" isn't set, i.e. the
  doxygen internal graphical representation for inheritance and collaboration diagrams
  is used.

--- a/src/config.xml
+++ b/src/config.xml
@@ -3891,7 +3891,10 @@ UML notation for the relationships.
 <![CDATA[
  If the \c GENERATE_LEGEND tag is set to \c YES doxygen will
  generate a legend page explaining the meaning of the various boxes and
- arrows in the dot generated graphs.
+ errows in the dot generated graphs.
+ \note This tag requires that \ref cfg_uml_look "UML_LOOK" isn't set, i.e. the
+ doxygen internal graphical representation for inheritance and collaboration diagrams
+ is used.
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
The graph legend is only shown when the `UML_LOOK=NO` (and `HAVE_DOT=YES` and `GRAPH_LEGEND=YES`).
Adding a small note to the `GRAPH_LEGEND` setting in this respect.