### PR TITLE
issue #8838 export "something" { } wrong parsing

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -474,7 +474,7 @@ WSopt [ \t\r]*
                                             BEGIN(CopyLine);
                                           }
                                         }
-<CopyLine,LexCopyLine>"extern"{BN}{0,80}"\"C\""*{BN}{0,80}"{"   {
+<CopyLine,LexCopyLine>"extern"{BN}*"\""[^\"]+"\""{BN}*("{")?  {
                                           QCString text=yytext;
                                           yyextra->yyLineNr+=text.contains('\n');
                                           outputArray(yyscanner,yytext,yyleng);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -189,7 +189,7 @@ struct scannerYY_state
   bool             odlProp = false;
 
   bool             lexInit = false;
-  bool             externC = false;
+  bool             externLinkage = false;
 
   QCString         delimiter;
 
@@ -2347,7 +2347,7 @@ NONLopt [^\n]*
                                             }
                                             else
                                             {
-                                              yyextra->externC=FALSE; // see bug759247
+                                              yyextra->externLinkage=FALSE; // see bug759247
                                               BEGIN(FindMembers);
                                             }
                                           }
@@ -3471,7 +3471,7 @@ NONLopt [^\n]*
                                           {
                                             yyextra->current->args += yytext ;
                                             yyextra->squareCount=1;
-                                            yyextra->externC=FALSE; // see bug759247
+                                            yyextra->externLinkage=FALSE; // see bug759247
                                             BEGIN( Array ) ;
                                           }
                                         }
@@ -6325,14 +6325,14 @@ NONLopt [^\n]*
                                           startCommentBlock(yyscanner,yyextra->current->brief.isEmpty());
                                           BEGIN( DocLine );
                                         }
-<FindMembers>"extern"{BN}*"\"C"("++")?"\""{BN}*("{")?  {
+<FindMembers>"extern"{BN}*"\""[^\"]+"\""{BN}*("{")?  {
                                           lineCount(yyscanner);
-                                          yyextra->externC=TRUE;
+                                          yyextra->externLinkage=TRUE;
                                         }
 <FindMembers>"{"                        {
-                                          if (yyextra->externC)
+                                          if (yyextra->externLinkage)
                                           {
-                                            yyextra->externC=FALSE;
+                                            yyextra->externLinkage=FALSE;
                                           }
                                           else if (yyextra->insideCS &&
                                               !yyextra->current->name.isEmpty() &&


### PR DESCRIPTION
According to the C++ standard "C" and "C++" have to be supported and other linkage types: "Use of a string-literal other than "C" or "C++" is conditionally-supported, with implementation-defined semantics."