### PR TITLE
bug_766164 Class Members is missing in the CHM.

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -636,6 +636,7 @@ void HtmlHelp::addContentsItem(bool isDir,
                                bool /* addToNavIndex */,
                                const Definition * /* def */)
 {
+  static bool binaryTOC = Config_getBool(BINARY_TOC);
   // If we're using a binary toc then folders cannot have links.
   // Tried this and I didn't see any problems, when not using
   // the resetting of file and anchor the TOC works better
@@ -657,14 +658,18 @@ void HtmlHelp::addContentsItem(bool isDir,
       if (file[0]=='^') p->cts << "URL"; else p->cts << "Local";
       p->cts << "\" value=\"";
       p->cts << &file[1];
+      p->cts << "\">";
     }
     else
     {
-      p->cts << "<param name=\"Local\" value=\"";
-      p->cts << file << Doxygen::htmlFileExtension;
-      if (!anchor.isEmpty()) p->cts << "#" << anchor;
+      if (!(binaryTOC && isDir))
+      {
+        p->cts << "<param name=\"Local\" value=\"";
+        p->cts << file << Doxygen::htmlFileExtension;
+        if (!anchor.isEmpty()) p->cts << "#" << anchor;
+        p->cts << "\">";
+      }
     }
-    p->cts << "\">";
   }
   p->cts << "<param name=\"ImageNumber\" value=\"";
   if (isDir)  // added - KPW


### PR DESCRIPTION
The "Local" part should only be added in case of a directory and BINARY_TOC