### PR TITLE
Correcting LaTeX counter name

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1006,9 +1006,7 @@ void LatexDocVisitor::visitPre(DocHtmlListItem *l)
         int val = opt.value.toInt(&ok);
         if (ok)
         {
-          QCString id;
-          id.fill('i',indentLevel()+1);
-          m_t << "\n\\setcounter{DoxyEnumerate" << id << "}{" << (val - 1) << "}";
+          m_t << "\n\\setcounter{DoxyEnumerate" << integerToRoman(indentLevel()+1,false) << "}{" << (val - 1) << "}";
         }
       }
     }


### PR DESCRIPTION
Due to the some changes regarding the indentation level:
```
Commit: 1d0eb05e5a5e0a927de81854d9ef482102761a19 [1d0eb05]
Date: Saturday, October 23, 2021 8:08:02 PM
Removed global variables for RTF and Latex, and made some fixes
```
 we got:
```
\setcounter{DoxyEnumerateiiiiii}{5}
```
instead of
```
\setcounter{DoxyEnumeratevi}{5}
```
We have to use proper Roman Numbers and not a repeat of `i`