### PR TITLE
Correction of alphabetical lists in LaTeX output

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -169,17 +169,17 @@
 \setlistdepth{12}
 \newlist{DoxyEnumerate}{enumerate}{12}
 \setlist[DoxyEnumerate,1]{label=\arabic*.}
-\setlist[DoxyEnumerate,2]{label=(\alph*)}
+\setlist[DoxyEnumerate,2]{label=(\enumalphalphcnt*)}
 \setlist[DoxyEnumerate,3]{label=\roman*.}
-\setlist[DoxyEnumerate,4]{label=\Alph*.}
+\setlist[DoxyEnumerate,4]{label=\enumAlphAlphcnt*.}
 \setlist[DoxyEnumerate,5]{label=\arabic*.}
-\setlist[DoxyEnumerate,6]{label=(\alph*)}
+\setlist[DoxyEnumerate,6]{label=(\enumalphalphcnt*)}
 \setlist[DoxyEnumerate,7]{label=\roman*.}
-\setlist[DoxyEnumerate,8]{label=\Alph*.}
+\setlist[DoxyEnumerate,8]{label=\enumAlphAlphcnt*.}
 \setlist[DoxyEnumerate,9]{label=\arabic*.}
-\setlist[DoxyEnumerate,10]{label=(\alph*)}
+\setlist[DoxyEnumerate,10]{label=(\enumalphalphcnt*)}
 \setlist[DoxyEnumerate,11]{label=\roman*.}
-\setlist[DoxyEnumerate,12]{label=\Alph*.}
+\setlist[DoxyEnumerate,12]{label=\enumAlphAlphcnt*.}
 
 % Used by bullet lists (using '-', @li, @arg, or <ul> ... </ul>)
 \setlistdepth{12}


### PR DESCRIPTION
There was a small discrepancy when using the default list in LaTeX and when specifying the type of list.
In the  default case still the `\alph*` and `\Alph*` representations were used resulting in problems when the number of items exceeded the6. In case we use a list with `type=`a"` or `type="A"` this problem was solved by using the dedicated lists `\enumaphaphcnt*` and `\enumAlphAlphcnt*`,.
Now always the dedicated lists are used.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7404759/example.tar.gz)
