### PR TITLE
Shadowed variable optind

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10578,15 +10578,15 @@ static void usage(const QCString &name,const QCString &versionString)
 
 //----------------------------------------------------------------------------
 // read the argument of option 'c' from the comment argument list and
-// update the option index 'optind'.
+// update the option index 'optInd'.
 
-static const char *getArg(int argc,char **argv,int &optind)
+static const char *getArg(int argc,char **argv,int &optInd)
 {
   char *s=0;
-  if (qstrlen(&argv[optind][2])>0)
-    s=&argv[optind][2];
-  else if (optind+1<argc && argv[optind+1][0]!='-')
-    s=argv[++optind];
+  if (qstrlen(&argv[optInd][2])>0)
+    s=&argv[optInd][2];
+  else if (optInd+1<argc && argv[optInd+1][0]!='-')
+    s=argv[++optInd];
   return s;
 }
 
@@ -10743,7 +10743,7 @@ void readConfiguration(int argc, char **argv)
    *             Handle arguments                                           *
    **************************************************************************/
 
-  int optind=1;
+  int optInd=1;
   QCString configName;
   QCString layoutName;
   QCString debugLabel;
@@ -10755,31 +10755,31 @@ void readConfiguration(int argc, char **argv)
   bool updateConfig=FALSE;
   int retVal;
   bool quiet = false;
-  while (optind<argc && argv[optind][0]=='-' &&
-               (isalpha(argv[optind][1]) || argv[optind][1]=='?' ||
-                argv[optind][1]=='-')
+  while (optInd<argc && argv[optInd][0]=='-' &&
+               (isalpha(argv[optInd][1]) || argv[optInd][1]=='?' ||
+                argv[optInd][1]=='-')
         )
   {
-    switch(argv[optind][1])
+    switch(argv[optInd][1])
     {
       case 'g':
         genConfig=TRUE;
         break;
       case 'l':
-        if (optind+1>=argc)
+        if (optInd+1>=argc)
         {
           layoutName="DoxygenLayout.xml";
         }
         else
         {
-          layoutName=argv[optind+1];
+          layoutName=argv[optInd+1];
         }
         writeDefaultLayoutFile(layoutName);
         cleanUpDoxygen();
         exit(0);
         break;
       case 'd':
-        debugLabel=getArg(argc,argv,optind);
+        debugLabel=getArg(argc,argv,optInd);
         if (debugLabel.isEmpty())
         {
           devUsage();
@@ -10805,7 +10805,7 @@ void readConfiguration(int argc, char **argv)
         updateConfig=TRUE;
         break;
       case 'e':
-        formatName=getArg(argc,argv,optind);
+        formatName=getArg(argc,argv,optInd);
         if (formatName.isEmpty())
         {
           err("option \"-e\" is missing format specifier rtf.\n");
@@ -10814,14 +10814,14 @@ void readConfiguration(int argc, char **argv)
         }
         if (qstricmp(formatName.data(),"rtf")==0)
         {
-          if (optind+1>=argc)
+          if (optInd+1>=argc)
           {
             err("option \"-e rtf\" is missing an extensions file name\n");
             cleanUpDoxygen();
             exit(1);
           }
           std::ofstream f;
-          if (openOutputFile(argv[optind+1],f))
+          if (openOutputFile(argv[optInd+1],f))
           {
             TextStream t(&f);
             RTFGenerator::writeExtensionsFile(t);
@@ -10834,7 +10834,7 @@ void readConfiguration(int argc, char **argv)
         exit(1);
         break;
       case 'f':
-        listName=getArg(argc,argv,optind);
+        listName=getArg(argc,argv,optInd);
         if (listName.isEmpty())
         {
           err("option \"-f\" is missing list specifier.\n");
@@ -10843,14 +10843,14 @@ void readConfiguration(int argc, char **argv)
         }
         if (qstricmp(listName.data(),"emoji")==0)
         {
-          if (optind+1>=argc)
+          if (optInd+1>=argc)
           {
             err("option \"-f emoji\" is missing an output file name\n");
             cleanUpDoxygen();
             exit(1);
           }
           std::ofstream f;
-          if (openOutputFile(argv[optind+1],f))
+          if (openOutputFile(argv[optInd+1],f))
           {
             TextStream t(&f);
             EmojiEntityMapper::instance()->writeEmojiFile(t);
@@ -10863,7 +10863,7 @@ void readConfiguration(int argc, char **argv)
         exit(1);
         break;
       case 'w':
-        formatName=getArg(argc,argv,optind);
+        formatName=getArg(argc,argv,optInd);
         if (formatName.isEmpty())
         {
           err("option \"-w\" is missing format specifier rtf, html or latex\n");
@@ -10872,14 +10872,14 @@ void readConfiguration(int argc, char **argv)
         }
         if (qstricmp(formatName.data(),"rtf")==0)
         {
-          if (optind+1>=argc)
+          if (optInd+1>=argc)
           {
             err("option \"-w rtf\" is missing a style sheet file name\n");
             cleanUpDoxygen();
             exit(1);
           }
           std::ofstream f;
-          if (openOutputFile(argv[optind+1],f))
+          if (openOutputFile(argv[optInd+1],f))
           {
             TextStream t(&f);
             RTFGenerator::writeStyleSheetFile(t);
@@ -10890,18 +10890,18 @@ void readConfiguration(int argc, char **argv)
         else if (qstricmp(formatName.data(),"html")==0)
         {
           Config::init();
-          if (optind+4<argc || FileInfo("Doxyfile").exists())
+          if (optInd+4<argc || FileInfo("Doxyfile").exists())
              // explicit config file mentioned or default found on disk
           {
-            QCString df = optind+4<argc ? argv[optind+4] : QCString("Doxyfile");
+            QCString df = optInd+4<argc ? argv[optInd+4] : QCString("Doxyfile");
             if (!Config::parse(df)) // parse the config file
             {
-              err("error opening or reading configuration file %s!\n",argv[optind+4]);
+              err("error opening or reading configuration file %s!\n",argv[optInd+4]);
               cleanUpDoxygen();
               exit(1);
             }
           }
-          if (optind+3>=argc)
+          if (optInd+3>=argc)
           {
             err("option \"-w html\" does not have enough arguments\n");
             cleanUpDoxygen();
@@ -10914,19 +10914,19 @@ void readConfiguration(int argc, char **argv)
           setTranslator(Config_getEnum(OUTPUT_LANGUAGE));
 
           std::ofstream f;
-          if (openOutputFile(argv[optind+1],f))
+          if (openOutputFile(argv[optInd+1],f))
           {
             TextStream t(&f);
-            HtmlGenerator::writeHeaderFile(t, argv[optind+3]);
+            HtmlGenerator::writeHeaderFile(t, argv[optInd+3]);
           }
           f.close();
-          if (openOutputFile(argv[optind+2],f))
+          if (openOutputFile(argv[optInd+2],f))
           {
             TextStream t(&f);
             HtmlGenerator::writeFooterFile(t);
           }
           f.close();
-          if (openOutputFile(argv[optind+3],f))
+          if (openOutputFile(argv[optInd+3],f))
           {
             TextStream t(&f);
             HtmlGenerator::writeStyleSheetFile(t);
@@ -10937,17 +10937,17 @@ void readConfiguration(int argc, char **argv)
         else if (qstricmp(formatName.data(),"latex")==0)
         {
           Config::init();
-          if (optind+4<argc || FileInfo("Doxyfile").exists())
+          if (optInd+4<argc || FileInfo("Doxyfile").exists())
           {
-            QCString df = optind+4<argc ? argv[optind+4] : QCString("Doxyfile");
+            QCString df = optInd+4<argc ? argv[optInd+4] : QCString("Doxyfile");
             if (!Config::parse(df))
             {
-              err("error opening or reading configuration file %s!\n",argv[optind+4]);
+              err("error opening or reading configuration file %s!\n",argv[optInd+4]);
               cleanUpDoxygen();
               exit(1);
             }
           }
-          if (optind+3>=argc)
+          if (optInd+3>=argc)
           {
             err("option \"-w latex\" does not have enough arguments\n");
             cleanUpDoxygen();
@@ -10960,19 +10960,19 @@ void readConfiguration(int argc, char **argv)
           setTranslator(Config_getEnum(OUTPUT_LANGUAGE));
 
           std::ofstream f;
-          if (openOutputFile(argv[optind+1],f))
+          if (openOutputFile(argv[optInd+1],f))
           {
             TextStream t(&f);
             LatexGenerator::writeHeaderFile(t);
           }
           f.close();
-          if (openOutputFile(argv[optind+2],f))
+          if (openOutputFile(argv[optInd+2],f))
           {
             TextStream t(&f);
             LatexGenerator::writeFooterFile(t);
           }
           f.close();
-          if (openOutputFile(argv[optind+3],f))
+          if (openOutputFile(argv[optInd+3],f))
           {
             TextStream t(&f);
             LatexGenerator::writeStyleSheetFile(t);
@@ -11001,19 +11001,19 @@ void readConfiguration(int argc, char **argv)
         exit(0);
         break;
       case '-':
-        if (qstrcmp(&argv[optind][2],"help")==0)
+        if (qstrcmp(&argv[optInd][2],"help")==0)
         {
           usage(argv[0],versionString);
           exit(0);
         }
-        else if (qstrcmp(&argv[optind][2],"version")==0)
+        else if (qstrcmp(&argv[optInd][2],"version")==0)
         {
           version(false);
           cleanUpDoxygen();
           exit(0);
         }
-        else if ((qstrcmp(&argv[optind][2],"Version")==0) ||
-                 (qstrcmp(&argv[optind][2],"VERSION")==0))
+        else if ((qstrcmp(&argv[optInd][2],"Version")==0) ||
+                 (qstrcmp(&argv[optInd][2],"VERSION")==0))
         {
           version(true);
           cleanUpDoxygen();
@@ -11021,7 +11021,7 @@ void readConfiguration(int argc, char **argv)
         }
         else
         {
-          err("Unknown option \"-%s\"\n",&argv[optind][1]);
+          err("Unknown option \"-%s\"\n",&argv[optInd][1]);
           usage(argv[0],versionString);
           exit(1);
         }
@@ -11044,11 +11044,11 @@ void readConfiguration(int argc, char **argv)
         exit(0);
         break;
       default:
-        err("Unknown option \"-%c\"\n",argv[optind][1]);
+        err("Unknown option \"-%c\"\n",argv[optInd][1]);
         usage(argv[0],versionString);
         exit(1);
     }
-    optind++;
+    optInd++;
   }
 
   /**************************************************************************
@@ -11058,7 +11058,7 @@ void readConfiguration(int argc, char **argv)
   Config::init();
 
   FileInfo configFileInfo1("Doxyfile"),configFileInfo2("doxyfile");
-  if (optind>=argc)
+  if (optInd>=argc)
   {
     if (configFileInfo1.exists())
     {
@@ -11081,14 +11081,14 @@ void readConfiguration(int argc, char **argv)
   }
   else
   {
-    FileInfo fi(argv[optind]);
-    if (fi.exists() || qstrcmp(argv[optind],"-")==0 || genConfig)
+    FileInfo fi(argv[optInd]);
+    if (fi.exists() || qstrcmp(argv[optInd],"-")==0 || genConfig)
     {
-      configName=argv[optind];
+      configName=argv[optInd];
     }
     else
     {
-      err("configuration file %s not found!\n",argv[optind]);
+      err("configuration file %s not found!\n",argv[optInd]);
       usage(argv[0],versionString);
       exit(1);
     }


### PR DESCRIPTION
With a build on Gentoo  we get (see issue #8855)
```
/var/tmp/portage/app-doc/doxygen-1.9.2/work/doxygen-1.9.2/src/doxygen.cpp: In function ‘const char* getArg(int, char**, int&)’:
/var/tmp/portage/app-doc/doxygen-1.9.2/work/doxygen-1.9.2/src/doxygen.cpp:10271:53: warning: declaration of ‘optind’ shadows a globa10271 | static const char *getArg(int argc,char **argv,int &optind)
      |                                                ~~~~~^~~~~~
In file included from /usr/include/bits/getopt_posix.h:27,
                 from /usr/include/unistd.h:900,
                 from /usr/include/bits/sigstksz.h:24,
                 from /usr/include/signal.h:328,
                 from /var/tmp/portage/app-doc/doxygen-1.9.2/work/doxygen-1.9.2/src/doxygen.cpp:121:
/usr/include/bits/getopt_core.h:50:12: note: shadowed declaration is here
   50 | extern int optind;
      |            ^~~~~~
/var/tmp/portage/app-doc/doxygen-1.9.2/work/doxygen-1.9.2/src/doxygen.cpp: In function ‘void readConfiguration(int, char**)’:
/var/tmp/portage/app-doc/doxygen-1.9.2/work/doxygen-1.9.2/src/doxygen.cpp:10434:7: warning: declaration of ‘optind’ shadows a global10434 |   int optind=1;
      |       ^~~~~~
In file included from /usr/include/bits/getopt_posix.h:27,
                 from /usr/include/unistd.h:900,
                 from /usr/include/bits/sigstksz.h:24,
                 from /usr/include/signal.h:328,
                 from /var/tmp/portage/app-doc/doxygen-1.9.2/work/doxygen-1.9.2/src/doxygen.cpp:121:
/usr/include/bits/getopt_core.h:50:12: note: shadowed declaration is here
   50 | extern int optind;
      |            ^~~~~~
```
by changing the name of the local variable / argument this shadowing behavior can be overcome.