### PR TITLE
Add the xml output format to the image command as generic format

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3356,7 +3356,7 @@ class Receiver
 
   The first argument specifies the output format in which the image should
   be embedded. Currently, the following values are supported:
-  \c html, \c latex, \c docbook and \c rtf.
+  \c html, \c latex, \c docbook, \c rtf and \c xml.
 
   The second argument specifies the file name of the image.
   doxygen will look for files in the paths (or files) that you specified

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -310,6 +310,10 @@ QCString DocParser::findAndCopyImage(const QCString &fileName, DocImage::Type ty
 	  if (!Config_getBool(GENERATE_RTF)) return result;
 	  outputDir = Config_getString(RTF_OUTPUT);
 	  break;
+        case DocImage::Xml:
+	  if (!Config_getBool(GENERATE_XML)) return result;
+	  outputDir = Config_getString(XML_OUTPUT);
+	  break;
       }
       QCString outputFile = outputDir+"/"+result;
       FileInfo outfi(outputFile.str());
@@ -4992,9 +4996,10 @@ void DocPara::handleImage(const QCString &cmdName)
   else if (imgType=="latex")   t=DocImage::Latex;
   else if (imgType=="docbook") t=DocImage::DocBook;
   else if (imgType=="rtf")     t=DocImage::Rtf;
+  else if (imgType=="xml")     t=DocImage::Xml;
   else
   {
-    warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"output format %s specified as the first argument of "
+    warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"output format `%s` specified as the first argument of "
         "%s command is not valid",
         qPrint(imgType),qPrint(saveCmdName));
     return;

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -771,7 +771,7 @@ class DocXRefItem : public CompAccept<DocXRefItem>
 class DocImage : public CompAccept<DocImage>
 {
   public:
-    enum Type { Html, Latex, Rtf, DocBook };
+    enum Type { Html, Latex, Rtf, DocBook, Xml };
     DocImage(DocParser &parser,DocNode *parent,const HtmlAttribList &attribs,
              const QCString &name,Type t,const QCString &url=QCString(), bool inlineImage = TRUE);
     Kind kind() const override           { return Kind_Image; }

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -540,6 +540,7 @@ class PrintDocVisitor : public DocVisitor
         case DocImage::Latex:   printf("latex"); break;
         case DocImage::Rtf:     printf("rtf"); break;
         case DocImage::DocBook: printf("docbook"); break;
+        case DocImage::Xml:     printf("xml"); break;
       }
       printf("\" %s %s inline=\"%s\">\n",qPrint(img->width()),qPrint(img->height()),img->isInlineImage() ? "yes" : "no");
     }

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -50,6 +50,7 @@ static void visitPreStart(TextStream &t, const char *cmd, bool doCaption,
       case DocImage::Latex:   t << "latex"; break;
       case DocImage::Rtf:     t << "rtf"; break;
       case DocImage::DocBook: t << "docbook"; break;
+      case DocImage::Xml:     t << "xml"; break;
     }
     t << "\"";
   }

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -917,6 +917,7 @@
       <xsd:enumeration value="latex" />
       <xsd:enumeration value="docbook" />
       <xsd:enumeration value="rtf" />
+      <xsd:enumeration value="xml" />
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
Add xml to the `\image` command as generic format, so the user does not have to specify other formats with the `\image` command when only the output format xml is requested.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7418632/example.tar.gz)
