### PR TITLE
issue #8854 Class hierarchy diagram is not correct, if inherited from Python built-in class ABC

### DIFF
--- a/src/dotgfxhierarchytable.cpp
+++ b/src/dotgfxhierarchytable.cpp
@@ -260,7 +260,7 @@ DotGfxHierarchyTable::DotGfxHierarchyTable(const QCString &prefix,ClassDef::Comp
   }
 
   //printf("Number of independent subgraphs: %d\n",curColor);
-  for (auto n : m_rootSubgraphs)
+  for (auto n : m_rootNodes)
   {
     //printf("Node %s color=%d (c=%d,p=%d)\n",
     //    qPrint(n->label()),n->m_subgraphId,

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -796,11 +796,7 @@ void DotNode::colorConnectedNodes(int curColor)
 
 void DotNode::renumberNodes(int &number)
 {
-  if (!m_renumbered)
-  {
-    m_renumbered = true;
-    m_number = number++;
-  }
+  m_number = number++;
   for (const auto &cn : m_children)
   {
     if (!cn->isRenumbered())


### PR DESCRIPTION
Check on renumbering of all node whether they have already been renumbered or not.