### PR TITLE
issue #8855 Unable to build 1.9.2

### DIFF
--- a/libmscgen/CMakeLists.txt
+++ b/libmscgen/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(lex_file ${LEX_FILES})
     FLEX_TARGET(${lex_file}        ${lex_file}.l        ${GENERATED_SRC}/${lex_file}.cpp        COMPILE_FLAGS "${LEX_FLAGS}")
 endforeach()
 
-add_library(mscgen
+add_library(mscgen STATIC
 gd.c
 gd_security.c
 gdfontt.c

--- a/libxml/CMakeLists.txt
+++ b/libxml/CMakeLists.txt
@@ -11,7 +11,7 @@ set_source_files_properties(${GENERATED_SRC}/xml.l.h PROPERTIES GENERATED 1)
 
 FLEX_TARGET(xml xml.l ${GENERATED_SRC}/xml.cpp COMPILE_FLAGS "${LEX_FLAGS}")
 
-add_library(xml
+add_library(xml STATIC
 ${GENERATED_SRC}/xml.cpp
 ${GENERATED_SRC}/xml.l.h
 )


### PR DESCRIPTION
All other libraries have been declared STATIC so better to declare the xml and mscgen libraries also STATIC.