### PR TITLE
issue #8864 Markdown Tables cannot merge cells both horizontally and vertically

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2181,6 +2181,15 @@ int Markdown::writeTableBlock(const char *data,int size)
       {
         continue;
       }
+      if (tableContents[row][c].colSpan)
+      {
+        int cr = c;
+        while ( cr >= 0 && tableContents[row][cr].colSpan)
+        {
+          cr--;
+        };
+        if (cr >= 0 && tableContents[row][cr].cellText == "^") continue;
+      }
       unsigned rowSpan = 1, spanRow = row+1;
       while ((spanRow < tableContents.size()) &&
              (tableContents[spanRow][c].cellText == "^"))


### PR DESCRIPTION
In case we are in a cell with that is a column span cell and the last cell before the cell that is not a column span cell is a a row span cell we also don't have to do anything for this cell.