### PR TITLE
bug_411629 ifdef-ed namespaces generate "endif" namespace (C#)

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6883,6 +6883,18 @@ NONLopt [^\n]*
                                             BEGIN(EndCppQuote);
                                           }
                                         }
+<*>^{B}*"#"                             {
+                                          if (!yyextra->insidePHP)
+                                          {
+                                            yyextra->lastCPPContext = YY_START;
+                                            BEGIN( SkipCPP ) ;
+                                          }
+                                          else
+                                          {
+                                            yyextra->lastCContext = YY_START ;
+                                            BEGIN( SkipCxxComment ) ;
+                                          }
+                                        }
 <*>"#"                                  {
                                           if (!yyextra->insidePHP)
                                             REJECT;


### PR DESCRIPTION
In cpp this behavior can be reproduced when `ENABLE_PREPROCESSING= NO`, in the scanner lines starting with a preprocessor directive should be ignored.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7462021/example.tar.gz)
