### PR TITLE
Adding engine to xml output for plantuml

### DIFF
--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -38,7 +38,7 @@ static void visitCaption(XmlDocVisitor *parent, const DocNodeList &children)
 static void visitPreStart(TextStream &t, const char *cmd, bool doCaption,
                           XmlDocVisitor *parent, const DocNodeList &children,
                           const QCString &name, bool writeType, DocImage::Type type, const QCString &width,
-                          const QCString &height, const QCString &alt = QCString(""), bool inlineImage = FALSE)
+                          const QCString &height, const QCString engine, const QCString &alt = QCString(""), bool inlineImage = FALSE)
 {
   t << "<" << cmd;
   if (writeType)
@@ -65,6 +65,10 @@ static void visitPreStart(TextStream &t, const char *cmd, bool doCaption,
   if (!height.isEmpty())
   {
     t << " height=\"" << convertToXML(height) << "\"";
+  }
+  if (!engine.isEmpty())
+  {
+    t << " engine=\"" << convertToXML(engine) << "\"";
   }
   if (!alt.isEmpty())
   {
@@ -300,17 +304,17 @@ void XmlDocVisitor::visit(DocVerbatim *s)
       m_t << s->text();
       break;
     case DocVerbatim::Dot:
-      visitPreStart(m_t, "dot", s->hasCaption(), this, s->children(), QCString(""), FALSE, DocImage::Html, s->width(), s->height());
+      visitPreStart(m_t, "dot", s->hasCaption(), this, s->children(), QCString(""), FALSE, DocImage::Html, s->width(), s->height(), QCString());
       filter(s->text());
       visitPostEnd(m_t, "dot");
       break;
     case DocVerbatim::Msc:
-      visitPreStart(m_t, "msc", s->hasCaption(), this, s->children(),  QCString(""), FALSE, DocImage::Html, s->width(), s->height());
+      visitPreStart(m_t, "msc", s->hasCaption(), this, s->children(),  QCString(""), FALSE, DocImage::Html, s->width(), s->height(), QCString());
       filter(s->text());
       visitPostEnd(m_t, "msc");
       break;
     case DocVerbatim::PlantUML:
-      visitPreStart(m_t, "plantuml", s->hasCaption(), this, s->children(),  QCString(""), FALSE, DocImage::Html, s->width(), s->height());
+      visitPreStart(m_t, "plantuml", s->hasCaption(), this, s->children(),  QCString(""), FALSE, DocImage::Html, s->width(), s->height(), s->engine());
       filter(s->text());
       visitPostEnd(m_t, "plantuml");
       break;
@@ -945,7 +949,7 @@ void XmlDocVisitor::visitPre(DocImage *img)
                          [](const auto &att) { return att.name=="alt"; });
   QCString altValue = it!=attribs.end() ? it->value : "";
   visitPreStart(m_t, "image", FALSE, this, img->children(), baseName, TRUE,
-                img->type(), img->width(), img->height(),
+                img->type(), img->width(), img->height(), QCString(),
                 altValue, img->isInlineImage());
 
   // copy the image to the output dir
@@ -966,7 +970,7 @@ void XmlDocVisitor::visitPost(DocImage *)
 void XmlDocVisitor::visitPre(DocDotFile *df)
 {
   if (m_hide) return;
-  visitPreStart(m_t, "dotfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
+  visitPreStart(m_t, "dotfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height(), QCString());
 }
 
 void XmlDocVisitor::visitPost(DocDotFile *)
@@ -978,7 +982,7 @@ void XmlDocVisitor::visitPost(DocDotFile *)
 void XmlDocVisitor::visitPre(DocMscFile *df)
 {
   if (m_hide) return;
-  visitPreStart(m_t, "mscfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
+  visitPreStart(m_t, "mscfile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height(), QCString());
 }
 
 void XmlDocVisitor::visitPost(DocMscFile *)
@@ -990,7 +994,7 @@ void XmlDocVisitor::visitPost(DocMscFile *)
 void XmlDocVisitor::visitPre(DocDiaFile *df)
 {
   if (m_hide) return;
-  visitPreStart(m_t, "diafile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height());
+  visitPreStart(m_t, "diafile", FALSE, this, df->children(), df->file(), FALSE, DocImage::Html, df->width(), df->height(), QCString());
 }
 
 void XmlDocVisitor::visitPost(DocDiaFile *)

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -436,9 +436,9 @@
       <xsd:element name="latexonly" type="xsd:string" />
       <xsd:element name="docbookonly" type="xsd:string" />
       <xsd:element name="image" type="docImageType" />
-      <xsd:element name="dot" type="docImageType" />
-      <xsd:element name="msc" type="docImageType" />
-      <xsd:element name="plantuml" type="docImageType" />
+      <xsd:element name="dot" type="docDotMscType" />
+      <xsd:element name="msc" type="docDotMscType" />
+      <xsd:element name="plantuml" type="docPlantumlType" />
       <xsd:element name="anchor" type="docAnchorType" />
       <xsd:element name="formula" type="docFormulaType" />
       <xsd:element name="ref" type="docRefTextType" />
@@ -467,9 +467,9 @@
       <xsd:element name="variablelist" type="docVariableListType" />
       <xsd:element name="table" type="docTableType" />
       <xsd:element name="heading" type="docHeadingType" />
-      <xsd:element name="dotfile" type="docImageType" />
-      <xsd:element name="mscfile" type="docImageType" />
-      <xsd:element name="diafile" type="docImageType" />
+      <xsd:element name="dotfile" type="docImageFileType" />
+      <xsd:element name="mscfile" type="docImageFileType" />
+      <xsd:element name="diafile" type="docImageFileType" />
       <xsd:element name="toclist" type="docTocListType" />
       <xsd:element name="language" type="docLanguageType" />
       <xsd:element name="parameterlist" type="docParamListType" />
@@ -607,6 +607,30 @@
     <xsd:attribute name="alt" type="xsd:string" use="optional"/>
     <xsd:attribute name="inline" type="DoxBool" use="optional"/>
     <xsd:attribute name="caption" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="docDotMscType" mixed="true">
+    <xsd:group ref="docTitleCmdGroup" minOccurs="0" maxOccurs="unbounded" />
+    <xsd:attribute name="name" type="xsd:string" use="optional"/>
+    <xsd:attribute name="width" type="xsd:string" use="optional"/>
+    <xsd:attribute name="height" type="xsd:string" use="optional"/>
+    <xsd:attribute name="caption" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="docImageFileType" mixed="true">
+    <xsd:group ref="docTitleCmdGroup" minOccurs="0" maxOccurs="unbounded" />
+    <xsd:attribute name="name" type="xsd:string" use="optional"/>
+    <xsd:attribute name="width" type="xsd:string" use="optional"/>
+    <xsd:attribute name="height" type="xsd:string" use="optional"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="docPlantumlType" mixed="true">
+    <xsd:group ref="docTitleCmdGroup" minOccurs="0" maxOccurs="unbounded" />
+    <xsd:attribute name="name" type="xsd:string" use="optional"/>
+    <xsd:attribute name="width" type="xsd:string" use="optional"/>
+    <xsd:attribute name="height" type="xsd:string" use="optional"/>
+    <xsd:attribute name="caption" type="xsd:string" use="optional"/>
+    <xsd:attribute name="engine" type="DoxPlantumlEngine" use="optional"/>
   </xsd:complexType>
 
   <xsd:complexType name="docTocItemType" mixed="true">
@@ -918,6 +942,28 @@
       <xsd:enumeration value="docbook" />
       <xsd:enumeration value="rtf" />
       <xsd:enumeration value="xml" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="DoxPlantumlEngine">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="uml"/>
+      <xsd:enumeration value="bpm"/>
+      <xsd:enumeration value="wire"/>
+      <xsd:enumeration value="dot"/>
+      <xsd:enumeration value="ditaa"/>
+      <xsd:enumeration value="salt"/>
+      <xsd:enumeration value="math"/>
+      <xsd:enumeration value="latex"/>
+      <xsd:enumeration value="gantt"/>
+      <xsd:enumeration value="mindmap"/>
+      <xsd:enumeration value="wbs"/>
+      <xsd:enumeration value="yaml"/>
+      <xsd:enumeration value="creole"/>
+      <xsd:enumeration value="json"/>
+      <xsd:enumeration value="flow"/>
+      <xsd:enumeration value="board"/>
+      <xsd:enumeration value="git"/>
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
For the output HTML / LaTeX / RTF / docbook the `\startuml` command has been extended with the "engine". This was omitted with XML
- added engine for `<plantuml>` tag in the XML output
- made some attribute testing rules a bit more precise.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7467287/example.tar.gz)
