### PR TITLE
Warning on empty \cond statement plus extra empty line.

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -883,7 +883,7 @@ SLASHopt [/]*
 <CondLine>\n			   |
 <CondLine>.			   { // forgot section id?
                                      handleCondSectionId(yyscanner," "); // fake section id causing the section to be hidden unconditionally
-				     if (*yytext=='\n') yyextra->lineNr++;
+				     if (*yytext=='\n') { yyextra->lineNr++; copyToOutput(yyscanner,"\n",1);}
   				   }
 <CComment,ReadLine>[\\@][a-z_A-Z][a-z_A-Z0-9]*  { // expand alias without arguments
 				     replaceAliases(yyscanner,QCString(yytext));

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -880,6 +880,7 @@ SLASHopt [/]*
   				     yyextra->condCtx=YY_START;
                                      handleCondSectionId(yyscanner," "); // fake section id causing the section to be hidden unconditionally
                                    }
+<CondLine>\n			   |
 <CondLine>.			   { // forgot section id?
                                      handleCondSectionId(yyscanner," "); // fake section id causing the section to be hidden unconditionally
 				     if (*yytext=='\n') yyextra->lineNr++;
@@ -948,6 +949,9 @@ SLASHopt [/]*
 <*>.                               {
   				     copyToOutput(yyscanner,yytext,(int)yyleng);
                                    }
+  /*
+<*>\n  { fprintf(stderr,"Lex scanner %s (%s) default rule newline for state %s.\n", __FILE__, qPrint(yyextra->fileName),stateToString(YY_START));}
+  */
 %%
 
 static void replaceCommentMarker(yyscan_t yyscanner,const char *s,int len)


### PR DESCRIPTION
When we have a Fortran file like:
```
!> \file

!> \cond
!>
      subroutine test
      end subroutine
!> \endcond
```
We get the warning:
```
.../bb.f90:4: warning: problem evaluating expression '!': Unexpected end of expression
```
But in the console output we also see an empty line like:`
```
Reading .../bb.f90...

.../bb.f90:4: warning: problem evaluating expression '!': Unexpected end of expression
Prepassing fixed form of .../bb.f90
```
This newline can also be observed in C code, when the preprocessing is disabled.
This is due to the fact that during the processing of the `CondLine` the `\n` is not caught properly and thus the default rule kicks in.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7487978/example.tar.gz)
