### PR TITLE
Incorrect handling of JAVA style code statement in preprocessor

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -414,7 +414,7 @@ SLASHopt [/]*
 <CComment,CNComment,ReadLine>"<"{MAILADR}">" { // Mail address, to prevent seeing e.g x@code-factory.org as start of a code block
                                      copyToOutput(yyscanner,yytext,(int)yyleng);
                                    }
-<CComment>"{@code"/[ \t\n]	   {
+<CComment>"{"[ \t]*"@code"/[ \t\n] {
                                      copyToOutput(yyscanner,"@code",5); 
 				     yyextra->lastCommentContext = YY_START;
 				     yyextra->javaBlock=1;

--- a/src/pre.l
+++ b/src/pre.l
@@ -281,6 +281,7 @@ struct preYY_state
   QCString           guardExpr;
   int                curlyCount     = 0;
   bool               nospaces       = false; // add extra spaces during macro expansion
+  int                javaBlock      = 0;
 
   bool               macroExpansion = false; // from the configuration
   bool               expandOnlyPredef = false; // from the configuration
@@ -395,6 +396,7 @@ WSopt [ \t\r]*
 %x      CopyCComment
 %x      SkipVerbatim
 %x      SkipCPPComment
+%x      JavaDocVerbatimCode
 %x      RemoveCComment
 %x      RemoveCPPComment
 %x      Guard
@@ -1247,6 +1249,11 @@ WSopt [ \t\r]*
                                           }
                                           BEGIN(SkipVerbatim);
                                         }
+<SkipCComment>"{"[ \t]*"@code"/[ \t\n]  {
+                                          outputArray(yyscanner,"@code",5);
+                                          yyextra->javaBlock=1;
+                                          BEGIN(JavaDocVerbatimCode);
+                                        }
 <SkipCComment,SkipCPPComment>[\\@][\\@]"cond"[ \t]+ { // escaped @cond
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
@@ -1377,7 +1384,43 @@ WSopt [ \t\r]*
 <SkipVerbatim>{CCE}|{CCS}                       {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
-<SkipCComment,SkipVerbatim>[^*\\@\x06~`\n\/]+ {
+<JavaDocVerbatimCode>"{"                {
+                                          if (yyextra->javaBlock==0)
+                                          {
+                                            REJECT;
+                                          }
+                                          else
+                                          {
+                                            yyextra->javaBlock++;
+                                            outputArray(yyscanner,yytext,(int)yyleng);
+                                          }
+                                        }
+<JavaDocVerbatimCode>"}"                {
+                                          if (yyextra->javaBlock==0)
+                                          {
+                                            REJECT;
+                                          }
+                                          else
+                                          {
+                                            yyextra->javaBlock--;
+                                            if (yyextra->javaBlock==0)
+                                            {
+                                              outputArray(yyscanner," @endcode ",10);
+                                              BEGIN(SkipCComment);
+                                            }
+                                            else
+                                            {
+                                              outputArray(yyscanner,yytext,(int)yyleng);
+                                            }
+                                          }
+                                        }
+<JavaDocVerbatimCode>\n                 { /* new line in verbatim block */
+                                          outputArray(yyscanner,yytext,(int)yyleng);
+                                        }
+<JavaDocVerbatimCode>.                  { /* any other character */
+                                          outputArray(yyscanner,yytext,(int)yyleng);
+                                        }
+<SkipCComment,SkipVerbatim>[^{*\\@\x06~`\n\/]+ {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <SkipCComment,SkipVerbatim>\n           {


### PR DESCRIPTION
When we have a program like:
```
/**
 * {@code
 * fie
 * }
 */
void fie();

/**
 * \cond
 */
U_DEFINE_LOCAL_OPEN_POINTER(LocalUSpoofCheckerPointer, USpoofChecker, uspoof_close);
/** \endcond */
```
and run `doxygen -d preprocessor` we see that the `\cond` part is not removed.
The problem comes from the preprocessor that doesn't recognize `{@code` as a JAVA style code statement that should end at the corresponding `}` and thus we remain in a code section. and thus not handling the `\cond` statement.
In the commentcnv lexer the `{@code` is handled as a special case and this is done in the preprocessor now as well.

The `{@code` has also been brought in line with the other JAVA style commands by allowing white space between `{` and `@`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7490371/example.tar.gz)
