### PR TITLE
issue #8882 Java: Issue with virtual as identifier

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -3750,7 +3750,8 @@ static bool skipLanguageSpecificKeyword(yyscan_t yyscanner,const char *keyword)
     "signed", "sizeof", "static_assert", "static_cast", "struct",
     "template", "thread_local", "typedef", "typeid", "typename",
     "union", "unsigned", "using", "virtual", "wchar_t",
-    "xor", "xor_eq"
+    "xor", "xor_eq",
+    "override"
   };
   bool retval;
   switch (yyextra->lang)

--- a/src/code.l
+++ b/src/code.l
@@ -3737,7 +3737,22 @@ static bool skipLanguageSpecificKeyword(yyscan_t yyscanner,const char *keyword)
     "gcnew", "gcroot", "generic", "get",
     "internal", "null", "pin_ptr", "raise",
     "remove", "self", "set", "transient"};
-  return yyextra->lang==SrcLangExt_Cpp && (non_cpp_keywords.find(keyword) != non_cpp_keywords.end());
+  static std::unordered_set<std::string> non_java_keywords = {
+    "inline", "requires", "virtual"};
+  bool retval;
+  switch (yyextra->lang)
+  {
+    case SrcLangExt_Cpp:
+      retval = (non_cpp_keywords.find(keyword) != non_cpp_keywords.end());
+      break;
+    case SrcLangExt_Java:
+      retval = (non_java_keywords.find(keyword) != non_java_keywords.end());
+      break;
+    default: 
+      retval = false;
+      break;
+  }
+  return retval;
 }
 
 static bool isCastKeyword(const char *keyword)

--- a/src/code.l
+++ b/src/code.l
@@ -3738,7 +3738,20 @@ static bool skipLanguageSpecificKeyword(yyscan_t yyscanner,const char *keyword)
     "internal", "null", "pin_ptr", "raise",
     "remove", "self", "set", "transient"};
   static std::unordered_set<std::string> non_java_keywords = {
-    "inline", "requires", "virtual"};
+    "alignas", "alignof", "and", "and_eq", "asm",
+    "atomic_cancel", "atomic_commit", "atomic_noexcept", "auto", "bitand",
+    "bitor", "bool", "char8_t", "char16_t", "char32_t",
+    "compl", "concept", "consteval", "constexpr", "constinit",
+    "const_cast", "co_await", "co_return", "co_yield", "decltype",
+    "delete", "dynamic_cast", "explicit", "export", "extern",
+    "friend", "inline", "mutable", "namespace", "noexcept",
+    "not", "not_eq", "nullptr", "operator", "or",
+    "or_eq", "reflexpr", "register", "reinterpret_cast", "requires",
+    "signed", "sizeof", "static_assert", "static_cast", "struct",
+    "template", "thread_local", "typedef", "typeid", "typename",
+    "union", "unsigned", "using", "virtual", "wchar_t",
+    "xor", "xor_eq"
+  };
   bool retval;
   switch (yyextra->lang)
   {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1078,7 +1078,8 @@ NONLopt [^\n]*
                                             REJECT;
                                           }
                                         }
-<FindMembers>{B}*"virtual"{BN}+         { yyextra->current->type += " virtual ";
+<FindMembers>{B}*"virtual"{BN}+         { if (yyextra->insideJava) REJECT;
+                                          yyextra->current->type += " virtual ";
                                           yyextra->current->virt = Virtual;
                                           lineCount(yyscanner);
                                         }
@@ -1124,7 +1125,8 @@ NONLopt [^\n]*
                                           }
                                           lineCount(yyscanner);
                                         }
-<FindMembers>{B}*"inline"{BN}+          { yyextra->current->spec|=Entry::Inline;
+<FindMembers>{B}*"inline"{BN}+          { if (yyextra->insideJava) REJECT;
+                                          yyextra->current->spec|=Entry::Inline;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"mutable"{BN}+         { yyextra->current->spec|=Entry::Mutable;
@@ -2103,16 +2105,19 @@ NONLopt [^\n]*
                                           BEGIN(FindMembers);
                                         }
 <FindMembers>"requires"                 { // C++20 requires clause
+                                          if (yyextra->insideJava) REJECT;
                                           yyextra->current->req.resize(0);
                                           yyextra->requiresContext = YY_START;
                                           BEGIN(RequiresClause);
                                         }
 <RequiresClause>"requires"{BN}*/"{"     { // requires requires { ... }
+                                          if (yyextra->insideJava) REJECT;
                                           lineCount(yyscanner) ;
                                           yyextra->current->req+=yytext;
                                           BEGIN( RequiresExpression ) ;
                                         }
 <RequiresClause>"requires"{BN}*"("      { // requires requires(T x) { ... }
+                                          if (yyextra->insideJava) REJECT;
                                           lineCount(yyscanner) ;
                                           yyextra->current->req+=yytext;
                                           yyextra->lastRoundContext=RequiresExpression;
@@ -4839,6 +4844,7 @@ NONLopt [^\n]*
                                           BEGIN(FuncQual);
                                         }
 <TrailingReturn>"requires"{BN}+         {
+                                          if (yyextra->insideJava) REJECT;
                                           yyextra->requiresContext = FuncQual;
                                           yyextra->current->req+=' ';
                                           BEGIN(RequiresClause);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1053,7 +1053,7 @@ NONLopt [^\n]*
                                           yyextra->curlyCount=0;
                                           BEGIN( ReadNSBody );
                                         }
-<FindMembers>{B}*"initonly"{BN}+        {
+<FindMembers>{B}*"initonly"{BN}+        { if (yyextra->insideJava) REJECT;
                                           yyextra->current->type += " initonly ";
                                           if (yyextra->insideCli) yyextra->current->spec |= Entry::Initonly;
                                           lineCount(yyscanner);
@@ -1062,7 +1062,7 @@ NONLopt [^\n]*
                                           yyextra->current->stat = TRUE;
                                           lineCount(yyscanner);
                                         }
-<FindMembers>{B}*"extern"{BN}+          {
+<FindMembers>{B}*"extern"{BN}+          { if (yyextra->insideJava) REJECT;
                                           yyextra->current->stat = FALSE;
                                           yyextra->current->explicitExternal = TRUE;
                                           lineCount(yyscanner);
@@ -1129,13 +1129,16 @@ NONLopt [^\n]*
                                           yyextra->current->spec|=Entry::Inline;
                                           lineCount(yyscanner);
                                         }
-<FindMembers>{B}*"mutable"{BN}+         { yyextra->current->spec|=Entry::Mutable;
+<FindMembers>{B}*"mutable"{BN}+         { if (yyextra->insideJava) REJECT;
+                                          yyextra->current->spec|=Entry::Mutable;
                                           lineCount(yyscanner);
                                         }
-<FindMembers>{B}*"explicit"{BN}+        { yyextra->current->spec|=Entry::Explicit;
+<FindMembers>{B}*"explicit"{BN}+        { if (yyextra->insideJava) REJECT;
+                                          yyextra->current->spec|=Entry::Explicit;
                                           lineCount(yyscanner);
                                         }
-<FindMembers>{B}*"local"{BN}+           { yyextra->current->spec|=Entry::Local;
+<FindMembers>{B}*"local"{BN}+           { if (yyextra->insideJava) REJECT;
+                                          yyextra->current->spec|=Entry::Local;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"@required"{BN}+       { // Objective C 2.0 protocol required section
@@ -1152,7 +1155,7 @@ NONLopt [^\n]*
                                         }
   */
 <FindMembers>{B}*"typename"{BN}+        { lineCount(yyscanner); }
-<FindMembers>{B}*"namespace"{BNopt}/[^a-z_A-Z0-9] {
+<FindMembers>{B}*"namespace"{BNopt}/[^a-z_A-Z0-9] { if (yyextra->insideJava) REJECT;
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::NAMESPACE_SEC;
                                           yyextra->current->type = "namespace" ;
@@ -1358,6 +1361,7 @@ NONLopt [^\n]*
                                           BEGIN( CompoundName );
                                         }
 <FindMembers>{B}*"exception"{BN}+       { // Corba IDL/Slice exception
+                                          if (yyextra->insideJava) REJECT;
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
                                           // preserve UNO IDL, Slice local
@@ -1489,6 +1493,7 @@ NONLopt [^\n]*
                                         }
 <FindMembers>{B}*{TYPEDEFPREFIX}"struct{" |
 <FindMembers>{B}*{TYPEDEFPREFIX}"struct"/{BN}+ {
+                                          if (yyextra->insideJava) REJECT;
                                           QCString decl = yytext;
                                           yyextra->isTypedef=decl.find("typedef")!=-1;
                                           bool isConst=decl.find("const")!=-1;
@@ -1570,6 +1575,7 @@ NONLopt [^\n]*
                                         }
 <FindMembers>{B}*{TYPEDEFPREFIX}"union{" |
 <FindMembers>{B}*{TYPEDEFPREFIX}"union"{BN}+ {
+                                          if (yyextra->insideJava) REJECT;
                                           QCString decl=yytext;
                                           yyextra->isTypedef=decl.find("typedef")!=-1;
                                           bool isConst=decl.find("const")!=-1;
@@ -1633,6 +1639,7 @@ NONLopt [^\n]*
                                           BEGIN( CompoundName ) ;
                                         }
 <FindMembers>{B}*"concept"{BN}+         { // C++20 concept
+                                          if (yyextra->insideJava) REJECT;
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CONCEPT_SEC;
                                           addType(yyscanner);
@@ -1683,6 +1690,7 @@ NONLopt [^\n]*
                                           BEGIN( ReadTempArgs );
                                         }
 <FindMembers>"namespace"{BN}+/{ID}{BN}*"=" { // namespace alias
+                                          if (yyextra->insideJava) REJECT;
                                           lineCount(yyscanner);
                                           BEGIN( NSAliasName );
                                         }
@@ -1773,6 +1781,7 @@ NONLopt [^\n]*
                                           BEGIN(Using);
                                         }
 <FindMembers>"using"{BN}+               {
+                                          if (yyextra->insideJava) REJECT;
                                           yyextra->current->startLine=yyextra->yyLineNr;
                                           yyextra->current->startColumn = yyextra->yyColNr;
                                           lineCount(yyscanner);


### PR DESCRIPTION
Some C++ keywords are not Java keywords and can be used as normal identifiers.
This problem has been solved for `inline`, `requires` and `virtual`.