### PR TITLE
issue #8889 Extra ".html" attached to some url links when linking to external library

### DIFF
--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -460,11 +460,11 @@ void DotNode::writeBox(TextStream &t,
       int anchorPos = m_url.findRev('#');
       if (anchorPos==-1)
       {
-        t << ",URL=\"" << m_url << Doxygen::htmlFileExtension << "\"";
+        t << ",URL=\"" << addHtmlExtensionIfMissing(m_url) << "\"";
       }
       else
       {
-        t << ",URL=\"" << m_url.left(anchorPos) << Doxygen::htmlFileExtension
+        t << ",URL=\"" << addHtmlExtensionIfMissing(m_url.left(anchorPos))
           << m_url.right(m_url.length()-anchorPos) << "\"";
       }
     }

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -336,7 +336,7 @@ static void writeColumn(TextStream &t,const MemberDef *md,bool start)
   if (md)
   {
     t << "href=\"";
-    t << md->getOutputFileBase()<< Doxygen::htmlFileExtension;
+    t << addHtmlExtensionIfMissing(md->getOutputFileBase());
     t << "#" << md->anchor();
     t<<"\" ";
 
@@ -406,7 +406,7 @@ static void writeClassToDot(TextStream &t,ClassDef* cd)
   t << cd->name();
   t << "\" ";
   t << "href=\"";
-  t << cd->getOutputFileBase() << Doxygen::htmlFileExtension;
+  t << addHtmlExtensionIfMissing(cd->getOutputFileBase());
   t << "\" ";
   t << ">";
   t << cd->name();
@@ -1727,7 +1727,7 @@ void VhdlDocGen::writeTagFile(MemberDefMutable *mdef,TextStream &tagFile)
   tagFile << "\">\n";
   tagFile << "      <type>" << convertToXML(mdef->typeString()) << "</type>\n";
   tagFile << "      <name>" << convertToXML(mdef->name()) << "</name>\n";
-  tagFile << "      <anchorfile>" << convertToXML(mdef->getOutputFileBase()) << Doxygen::htmlFileExtension << "</anchorfile>\n";
+  tagFile << "      <anchorfile>" << convertToXML(addHtmlExtensionIfMissing(mdef->getOutputFileBase())) << "</anchorfile>\n";
   tagFile << "      <anchor>" << convertToXML(mdef->anchor()) << "</anchor>\n";
 
   if (VhdlDocGen::isVhdlFunction(mdef))


### PR DESCRIPTION
In case the URL already has an extension present doxygen should not add an extra extension.