### PR TITLE
Add the HTML and XML commands to the index

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2653,7 +2653,7 @@ Commands for visual enhancements
   ... the \a x and \a y coordinates are used to ...
 
   Equivalent to \ref cmde "\\e" and \ref cmdem "\\em".
-  To emphasize multiple words use \<em\>multiple words\</em\>.
+  To emphasize multiple words use \ref htmltag_EM "\<em\>"multiple words\ref htmltag_endEM "\</em\>".
 
 <hr>
 \section cmdarg \\arg { item-description }
@@ -2693,8 +2693,8 @@ Commands for visual enhancements
 
   \addindex \\b
   Displays the argument \<word\> using a bold font.
-  Equivalent to \<b\>word\</b\>.
-  To put multiple words in bold use \<b\>multiple words\</b\>.
+  Equivalent to \ref htmltag_B "\<b\>"word\ref htmltag_endB "\</b\>".
+  To put multiple words in bold use \ref htmltag_B "\<b\>"multiple words\ref htmltag_endB "\</b\>".
 
 <hr>
 \section cmdc \\c <word>
@@ -2702,7 +2702,7 @@ Commands for visual enhancements
   \addindex \\c
   Displays the argument \<word\> using a typewriter font.
   Use this to refer to a word of code.
-  Equivalent to \<tt\>word\</tt\>.
+  Equivalent to \ref htmltag_TT "\<tt\>"word\ref htmltag_endTT "\</tt\>".
 
   \par Example:
   Typing:
@@ -2713,7 +2713,7 @@ Commands for visual enhancements
      ... This function returns \c void and not \c int ...
 
   Equivalent to \ref cmdp "\\p"
-  To have multiple words in typewriter font use \<tt\>multiple words\</tt\>.
+  To have multiple words in typewriter font use \ref htmltag_TT "\<tt\>"multiple words\ref htmltag_endTT "\</tt\>".
 
 <hr>
 \section cmdcode \\code['{'<word>'}']
@@ -3152,7 +3152,7 @@ class Receiver
   ... this is a \e really good example ...
 
   Equivalent to \ref cmda "\\a" and \ref cmdem "\\em".
-  To emphasize multiple words use \<em\>multiple words\</em\>.
+  To emphasize multiple words use \ref htmltag_EM "\<em\>"multiple words\ref htmltag_endEM "\</em\>".
 
 <hr>
 \section cmdem \\em <word>
@@ -3170,7 +3170,7 @@ class Receiver
   ... this is a \em really good example ...
 
   Equivalent to \ref cmda "\\a" and \ref cmde "\\e".
-  To emphasize multiple words use \<em\>multiple words\</em\>.
+  To emphasize multiple words use \ref htmltag_EM "\<em\>"multiple words\ref htmltag_endEM "\</em\>".
 
 <hr>
 \section cmdendcode \\endcode
@@ -3493,7 +3493,7 @@ class Receiver
 \section cmdn \\n
 
   \addindex \\n
-  Forces a new line. Equivalent to \<br\> and inspired by
+  Forces a new line. Equivalent to \ref htmltag_BR "\<br\>" and inspired by
   the \c printf function.
 
 <hr>
@@ -3512,7 +3512,7 @@ class Receiver
   ... the \p x and \p y coordinates are used to ...
 
   Equivalent to \ref cmdc "\\c"
-  To have multiple words in typewriter font use \<tt\>multiple words\</tt\>.
+  To have multiple words in typewriter font use \ref htmltag_TT "\<tt\>"multiple words\ref htmltag_endTT "\</tt\>".
 
 <hr>
 \section cmdrtfonly \\rtfonly

--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -23,100 +23,100 @@ of a HTML tag are passed on to the HTML output only
 (the \c HREF and \c NAME attributes for the \c A tag are the only exception).
 
 <ul>
-<li><tt>\<A HREF="..."\></tt> Starts a hyperlink 
+<li><tt>\anchor htmltag_A_HREF \addindex "\<A HREF=\"...\"\>"\<A HREF="..."\></tt> Starts a hyperlink 
                        (if supported by the output format). 
-<li><tt>\<A ID="..."\></tt> Starts a named anchor 
+<li><tt>\anchor htmltag_A_ID \addindex "\<A ID=\"...\"\>"\<A ID="..."\></tt> Starts a named anchor 
                        (if supported by the output format).
-<li><tt>\<A NAME="..."\></tt> Starts a named anchor 
+<li><tt>\anchor htmltag_A_NAME \addindex "\<A NAME=\"...\"\>"\<A NAME="..."\></tt> Starts a named anchor 
                        (if supported by the output format).
-<li><tt>\</A\></tt>    Ends a link or anchor 
-<li><tt>\<B\></tt>     Starts a piece of text displayed in a bold font.
-<li><tt>\</B\></tt>    Ends a <tt>\<B\></tt> section.
-<li><tt>\<BLOCKQUOTE\></tt> Starts a quotation block.
-<li><tt>\</BLOCKQUOTE\></tt> Ends the quotation block.
-<li><tt>\<BR\></tt>    Forces a line break.
-<li><tt>\<CENTER\></tt> starts a section of centered text.
-<li><tt>\</CENTER\></tt> ends a section of centered text.
-<li><tt>\<CAPTION\></tt> Starts a caption. Use within a table only.
-<li><tt>\</CAPTION\></tt> Ends a caption. Use within a table only.
-<li><tt>\<CODE\></tt>  Starts a piece of text displayed in a typewriter font.
+<li><tt>\anchor htmltag_endA \addindex "\</A\>"\</A\></tt>    Ends a link or anchor 
+<li><tt>\anchor htmltag_B \addindex "\<B\>"\<B\></tt>     Starts a piece of text displayed in a bold font.
+<li><tt>\anchor htmltag_endB \addindex "\</B\>"\</B\></tt>    Ends a \ref htmltag_B "\<B\>" section.
+<li><tt>\anchor htmltag_BLOCKQUOTE \addindex "\<BLOCKQUOTE\>"\<BLOCKQUOTE\></tt> Starts a quotation block.
+<li><tt>\anchor htmltag_endBLOCKQUOTE \addindex "\</BLOCKQUOTE\>"\</BLOCKQUOTE\></tt> Ends the quotation block.
+<li><tt>\anchor htmltag_BR \addindex "\<BR\>"\<BR\></tt>    Forces a line break.
+<li><tt>\anchor htmltag_CENTER \addindex "\<CENTER\>"\<CENTER\></tt> starts a section of centered text.
+<li><tt>\anchor htmltag_endCENTER \addindex "\</CENTER\>"\</CENTER\></tt> ends a section of centered text.
+<li><tt>\anchor htmltag_CAPTION \addindex "\<CAPTION\>"\<CAPTION\></tt> Starts a caption. Use within a table only.
+<li><tt>\anchor htmltag_endCAPTION \addindex "\</CAPTION\>"\</CAPTION\></tt> Ends a caption. Use within a table only.
+<li><tt>\anchor htmltag_CODE \addindex "\<CODE\>"\<CODE\></tt>  Starts a piece of text displayed in a typewriter font.
                        Note that only for C# code, this command is equivalent to 
-                       \ref cmdcode "\\code". 
-<li><tt>\</CODE\></tt> Ends a <tt>\<CODE\></tt> section.
+                       \ref cmdcode "\\code" (see \ref xmltag_code "\<code\>"). 
+<li><tt>\anchor htmltag_endCODE \addindex "\</CODE\>"\</CODE\></tt> Ends a \ref htmltag_CODE "\<CODE\>" section.
                        Note that only for C# code, this command is equivalent to
-                       \ref cmdendcode "\\endcode".
-<li><tt>\<DD\></tt>    Starts an item description.
-<li><tt>\</DD\></tt>   Ends an item description.
-<li><tt>\<DEL\></tt>   Starts a section of deleted text, typically shown strike through text.
-<li><tt>\</DEL\></tt>  Ends a section of deleted text.
-<li><tt>\<DFN\></tt>   Starts a piece of text displayed in a typewriter font.
-<li><tt>\</DFN\></tt>  Ends a <tt>\<DFN\></tt> section.
-<li><tt>\<DIV></tt>    Starts a section with a specific style (HTML only)
-<li><tt>\</DIV></tt>   Ends a section with a specific style (HTML only)
-<li><tt>\<DL\></tt>    Starts a description list.
-<li><tt>\</DL\></tt>   Ends a description list.
-<li><tt>\<DT\></tt>    Starts an item title.
-<li><tt>\</DT\></tt>   Ends an item title.
-<li><tt>\<EM\></tt>    Starts a piece of text displayed in an italic font.
-<li><tt>\</EM\></tt>   Ends a <tt>\<EM\></tt> section.
-<li><tt>\<HR\></tt>    Writes a horizontal ruler.
-<li><tt>\<H1\></tt>    Starts an unnumbered section.
-<li><tt>\</H1\></tt>   Ends an unnumbered section.
-<li><tt>\<H2\></tt>    Starts an unnumbered subsection.
-<li><tt>\</H2\></tt>   Ends an unnumbered subsection.
-<li><tt>\<H3\></tt>    Starts an unnumbered subsubsection.
-<li><tt>\</H3\></tt>   Ends an unnumbered subsubsection.
-<li><tt>\<H4\></tt>    Starts an unnumbered subsubsection.
-<li><tt>\</H4\></tt>   Ends an unnumbered subsubsection.
-<li><tt>\<H5\></tt>    Starts an unnumbered subsubsection.
-<li><tt>\</H5\></tt>   Ends an unnumbered subsubsection.
-<li><tt>\<H6\></tt>    Starts an unnumbered subsubsection.
-<li><tt>\</H6\></tt>   Ends an unnumbered subsubsection.
-<li><tt>\<I\></tt>     Starts a piece of text displayed in an italic font.
-<li><tt>\</I\></tt>    Ends a <tt>\<I\></tt> section.
-<li><tt>\<IMG SRC="..." ...\></tt>   This command is written with its attributes to the HTML output only. The SRC attribute is mandatory.
-<li><tt>\<INS\></tt>   Starts a section of inserted text, typically shown as underlined text.
-<li><tt>\</INS\></tt>  Ends a section of inserted text.
-<li><tt>\<LI\></tt>    Starts a new list item.
-<li><tt>\</LI\></tt>   Ends a list item.
-<li><tt>\<OL\></tt>    Starts a numbered item list.
-<li><tt>\</OL\></tt>   Ends a numbered item list.
-<li><tt>\<P\></tt>     Starts a new paragraph.
-<li><tt>\</P\></tt>    Ends a paragraph.
-<li><tt>\<PRE\></tt>   Starts a preformatted fragment.
-<li><tt>\</PRE\></tt>  Ends a preformatted fragment.
-<li><tt>\<SMALL\></tt> Starts a section of text displayed in a smaller font.
-<li><tt>\</SMALL\></tt> Ends a <tt>\<SMALL\></tt> section.
-<li><tt>\<SPAN></tt>   Starts an inline text fragment with a specific style (HTML only)
-<li><tt>\</SPAN></tt>  Ends an inline text fragment with a specific style (HTML only)
-<li><tt>\<S\></tt>     Starts a section of strike through text.
-<li><tt>\</S\></tt>    Ends a section of strike through text.
-<li><tt>\<STRIKE\></tt> Starts a section of strike through text.
-<li><tt>\</STRIKE\></tt> Ends a section of strike through text.
-<li><tt>\<STRONG\></tt> Starts a section of bold text.
-<li><tt>\</STRONG\></tt> Ends a section of bold text.
-<li><tt>\<SUB\></tt>   Starts a piece of text displayed in subscript.
-<li><tt>\</SUB\></tt>  Ends a <tt>\<SUB\></tt> section.
-<li><tt>\<SUP\></tt>   Starts a piece of text displayed in superscript.
-<li><tt>\</SUP\></tt>  Ends a <tt>\<SUP\></tt> section.
-<li><tt>\<TABLE\></tt> starts a table.
-<li><tt>\</TABLE\></tt> ends a table.
-<li><tt>\<TD\></tt>    Starts a new table data element.
-<li><tt>\</TD\></tt>   Ends a table data element.
-<li><tt>\<TH\></tt>    Starts a new table header.
-<li><tt>\</TH\></tt>   Ends a table header.
-<li><tt>\<TR\></tt>    Starts a new table row.
-<li><tt>\</TR\></tt>   Ends a table row.
-<li><tt>\<TT\></tt>    Starts a piece of text displayed in a typewriter font.
-<li><tt>\</TT\></tt>   Ends a <tt>\<TT\></tt> section.
-<li><tt>\<KBD\></tt>   Starts a piece of text displayed in a typewriter font.
-<li><tt>\</KBD\></tt>  Ends a <tt>\<KBD\></tt> section.
-<li><tt>\<U\></tt> Starts a section of underlined text.
-<li><tt>\</U\></tt> Ends a section of underlined text.
-<li><tt>\<UL\></tt>    Starts an unnumbered item list.
-<li><tt>\</UL\></tt>   Ends an unnumbered item list.
-<li><tt>\<VAR\></tt>   Starts a piece of text displayed in an italic font.
-<li><tt>\</VAR\></tt>  Ends a <tt>\<VAR\></tt> section.
+                       \ref cmdendcode "\\endcode" (see \ref xmltag_code "\<code\>").
+<li><tt>\anchor htmltag_DD \addindex "\<DD\>"\<DD\></tt>    Starts an item description.
+<li><tt>\anchor htmltag_endDD \addindex "\</DD\>"\</DD\></tt>   Ends an item description.
+<li><tt>\anchor htmltag_DEL \addindex "\<DEL\>"\<DEL\></tt>   Starts a section of deleted text, typically shown strike through text.
+<li><tt>\anchor htmltag_endDEL \addindex "\</DEL\>"\</DEL\></tt>  Ends a section of deleted text.
+<li><tt>\anchor htmltag_DFN \addindex "\<DFN\>"\<DFN\></tt>   Starts a piece of text displayed in a typewriter font.
+<li><tt>\anchor htmltag_endDFN \addindex "\</DFN\>"\</DFN\></tt>  Ends a \ref htmltag_DFN "\<DFN\>" section.
+<li><tt>\anchor htmltag_DIV \addindex "\<DIV\>"\<DIV></tt>    Starts a section with a specific style (HTML only)
+<li><tt>\anchor htmltag_endDIV \addindex "\</DIV\>"\</DIV></tt>   Ends a section with a specific style (HTML only)
+<li><tt>\anchor htmltag_DL \addindex "\<DL\>"\<DL\></tt>    Starts a description list.
+<li><tt>\anchor htmltag_endDL \addindex "\</DL\>"\</DL\></tt>   Ends a description list.
+<li><tt>\anchor htmltag_DT \addindex "\<DT\>"\<DT\></tt>    Starts an item title.
+<li><tt>\anchor htmltag_endDT \addindex "\</DT\>"\</DT\></tt>   Ends an item title.
+<li><tt>\anchor htmltag_EM \addindex "\<EM\>"\<EM\></tt>    Starts a piece of text displayed in an italic font.
+<li><tt>\anchor htmltag_endEM \addindex "\</EM\>"\</EM\></tt>   Ends a \ref htmltag_EM "\<EM\>" section.
+<li><tt>\anchor htmltag_HR \addindex "\<HR\>"\<HR\></tt>    Writes a horizontal ruler.
+<li><tt>\anchor htmltag_H1 \addindex "\<H1\>"\<H1\></tt>    Starts an unnumbered section.
+<li><tt>\anchor htmltag_endH1 \addindex "\</H1\>"\</H1\></tt>   Ends an unnumbered section.
+<li><tt>\anchor htmltag_H2 \addindex "\<H2\>"\<H2\></tt>    Starts an unnumbered subsection.
+<li><tt>\anchor htmltag_endH2 \addindex "\</H2\>"\</H2\></tt>   Ends an unnumbered subsection.
+<li><tt>\anchor htmltag_H3 \addindex "\<H3\>"\<H3\></tt>    Starts an unnumbered subsubsection.
+<li><tt>\anchor htmltag_endH3 \addindex "\</H3\>"\</H3\></tt>   Ends an unnumbered subsubsection.
+<li><tt>\anchor htmltag_H4 \addindex "\<H4\>"\<H4\></tt>    Starts an unnumbered subsubsection.
+<li><tt>\anchor htmltag_endH4 \addindex "\</H4\>"\</H4\></tt>   Ends an unnumbered subsubsection.
+<li><tt>\anchor htmltag_H5 \addindex "\<H5\>"\<H5\></tt>    Starts an unnumbered subsubsection.
+<li><tt>\anchor htmltag_endH5 \addindex "\</H5\>"\</H5\></tt>   Ends an unnumbered subsubsection.
+<li><tt>\anchor htmltag_H6 \addindex "\<H6\>"\<H6\></tt>    Starts an unnumbered subsubsection.
+<li><tt>\anchor htmltag_endH6 \addindex "\</H6\>"\</H6\></tt>   Ends an unnumbered subsubsection.
+<li><tt>\anchor htmltag_I \addindex "\<I\>"\<I\></tt>     Starts a piece of text displayed in an italic font.
+<li><tt>\anchor htmltag_endI \addindex "\</I\>"\</I\></tt>    Ends a \ref htmltag_I "\<I\>" section.
+<li><tt>\anchor htmltag_IMG \addindex "\<IMG SRC=\"...\"\>"\<IMG SRC="..." ...\></tt>   This command is written with its attributes to the HTML output only. The SRC attribute is mandatory.
+<li><tt>\anchor htmltag_INS \addindex "\<INS\>"\<INS\></tt>   Starts a section of inserted text, typically shown as underlined text.
+<li><tt>\anchor htmltag_endINS \addindex "\</INS\>"\</INS\></tt>  Ends a section of inserted text.
+<li><tt>\anchor htmltag_LI \addindex "\<LI\>"\<LI\></tt>    Starts a new list item.
+<li><tt>\anchor htmltag_endLI \addindex "\</LI\>"\</LI\></tt>   Ends a list item.
+<li><tt>\anchor htmltag_OL \addindex "\<OL\>"\<OL\></tt>    Starts a numbered item list.
+<li><tt>\anchor htmltag_endOL \addindex "\</OL\>"\</OL\></tt>   Ends a numbered item list.
+<li><tt>\anchor htmltag_P \addindex "\<P\>"\<P\></tt>     Starts a new paragraph.
+<li><tt>\anchor htmltag_endP \addindex "\</P\>"\</P\></tt>    Ends a paragraph.
+<li><tt>\anchor htmltag_PRE \addindex "\<PRE\>"\<PRE\></tt>   Starts a preformatted fragment.
+<li><tt>\anchor htmltag_endPRE \addindex "\</PRE\>"\</PRE\></tt>  Ends a preformatted fragment.
+<li><tt>\anchor htmltag_SMALL \addindex "\<SMALL\>"\<SMALL\></tt> Starts a section of text displayed in a smaller font.
+<li><tt>\anchor htmltag_endSMALL \addindex "\</SMALL\>"\</SMALL\></tt> Ends a \ref htmltag_SMALL "\<SMALL\>" section.
+<li><tt>\anchor htmltag_SPAN \addindex "\<SPAN\>"\<SPAN></tt>   Starts an inline text fragment with a specific style (HTML only)
+<li><tt>\anchor htmltag_endSPAN \addindex "\</SPAN\>"\</SPAN></tt>  Ends an inline text fragment with a specific style (HTML only)
+<li><tt>\anchor htmltag_S \addindex "\<S\>"\<S\></tt>     Starts a section of strike through text.
+<li><tt>\anchor htmltag_endS \addindex "\</S\>"\</S\></tt>    Ends a section of strike through text.
+<li><tt>\anchor htmltag_STRIKE \addindex "\<STRIKE\>"\<STRIKE\></tt> Starts a section of strike through text.
+<li><tt>\anchor htmltag_endSTRIKE \addindex "\</STRIKE\>"\</STRIKE\></tt> Ends a section of strike through text.
+<li><tt>\anchor htmltag_STRONG \addindex "\<STRONG\>"\<STRONG\></tt> Starts a section of bold text.
+<li><tt>\anchor htmltag_endSTRONG \addindex "\</STRONG\>"\</STRONG\></tt> Ends a section of bold text.
+<li><tt>\anchor htmltag_SUB \addindex "\<SUB\>"\<SUB\></tt>   Starts a piece of text displayed in subscript.
+<li><tt>\anchor htmltag_endSUB \addindex "\</SUB\>"\</SUB\></tt>  Ends a \ref htmltag_SUB "\<SUB\>" section.
+<li><tt>\anchor htmltag_SUP \addindex "\<SUP\>"\<SUP\></tt>   Starts a piece of text displayed in superscript.
+<li><tt>\anchor htmltag_endSUP \addindex "\</SUP\>"\</SUP\></tt>  Ends a \ref htmltag_SUP "\<SUP\>" section.
+<li><tt>\anchor htmltag_TABLE \addindex "\<TABLE\>"\<TABLE\></tt> starts a table.
+<li><tt>\anchor htmltag_endTABLE \addindex "\</TABLE\>"\</TABLE\></tt> ends a table.
+<li><tt>\anchor htmltag_TD \addindex "\<TD\>"\<TD\></tt>    Starts a new table data element.
+<li><tt>\anchor htmltag_endTD \addindex "\</TD\>"\</TD\></tt>   Ends a table data element.
+<li><tt>\anchor htmltag_TH \addindex "\<TH\>"\<TH\></tt>    Starts a new table header.
+<li><tt>\anchor htmltag_endTH \addindex "\</TH\>"\</TH\></tt>   Ends a table header.
+<li><tt>\anchor htmltag_TR \addindex "\<TR\>"\<TR\></tt>    Starts a new table row.
+<li><tt>\anchor htmltag_endTR \addindex "\</TR\>"\</TR\></tt>   Ends a table row.
+<li><tt>\anchor htmltag_TT \addindex "\<TT\>"\<TT\></tt>    Starts a piece of text displayed in a typewriter font.
+<li><tt>\anchor htmltag_endTT \addindex "\</TT\>"\</TT\></tt>   Ends a \ref htmltag_TT "\<TT\>" section.
+<li><tt>\anchor htmltag_KBD \addindex "\<KBD\>"\<KBD\></tt>   Starts a piece of text displayed in a typewriter font.
+<li><tt>\anchor htmltag_endKBD \addindex "\</KBD\>"\</KBD\></tt>  Ends a \ref htmltag_KBD "\<KBD\>" section.
+<li><tt>\anchor htmltag_U \addindex "\<U\>"\<U\></tt> Starts a section of underlined text.
+<li><tt>\anchor htmltag_endU \addindex "\</U\>"\</U\></tt> Ends a section of underlined text.
+<li><tt>\anchor htmltag_UL \addindex "\<UL\>"\<UL\></tt>    Starts an unnumbered item list.
+<li><tt>\anchor htmltag_endUL \addindex "\</UL\>"\</UL\></tt>   Ends an unnumbered item list.
+<li><tt>\anchor htmltag_VAR \addindex "\<VAR\>"\<VAR\></tt>   Starts a piece of text displayed in an italic font.
+<li><tt>\anchor htmltag_endVAR \addindex "\</VAR\>"\</VAR\></tt>  Ends a \ref htmltag_VAR "\<VAR\>" section.
 </ul>
 
 The special HTML4 character entities.<br>

--- a/doc/trouble.doc
+++ b/doc/trouble.doc
@@ -34,7 +34,7 @@
     or unions with the same name in your code. It should not crash however,
     rather it should ignore all of the classes with the same name except one.
 <li>Some commands do not work inside the arguments of other commands.
-    Inside a HTML link (i.e. \<a&nbsp;href="..."\>...\</a\>) for instance 
+    Inside a HTML link (i.e. \ref htmltag_A_HREF "\<A HREF=\"...\"\>"...\ref htmltag_endA "\</A\>") for instance 
     other commands (including other HTML commands) do not work!
     The sectioning commands are an important exception. 
 <li>Redundant braces can confuse doxygen in some cases. 

--- a/doc/xmlcmds.doc
+++ b/doc/xmlcmds.doc
@@ -25,52 +25,53 @@ not very precise and a number of the examples given are of poor quality.
 Here is the list of tags supported by doxygen:
 
 <ul>
-<li><tt>\<c\></tt>     Identifies inline text that should be rendered as a 
+<li><tt>\anchor xmltag_c \addindex "\<c\>" \<c\></tt>     Identifies inline text that should be rendered as a 
                        piece of code. Similar to using <tt>\<tt\></tt>text<tt>\</tt\></tt>.
-<li><tt>\<code\></tt>  Set one or more lines of source code or program output.
+<li><tt>\anchor xmltag_code \addindex "\<code\>" <code\></tt>  Set one or more lines of source code or program output.
                        Note that this command behaves like \ref cmdcode "\\code" ... \ref cmdendcode "\\endcode"
                        for C# code, but it behaves like the HTML equivalent
-                       <tt>\<code\>...\</code\></tt> for other languages.
-<li><tt>\<description\></tt> Part of a <tt>\<list\></tt> command, describes an item.
-<li><tt>\<example\></tt> Marks a block of text as an example, ignored by doxygen.
-<li><tt>\<exception cref="member"\></tt> Identifies the exception a 
+                       \ref htmltag_CODE "\<CODE\>"...\ref htmltag_endCODE "\</CODE\>" for other languages.
+<li><tt>\anchor xmltag_description \addindex "\<description\>" \<description\></tt> Part of a \ref xmltag_list "\<list\>" command, describes an item.
+<li><tt>\anchor xmltag_example \addindex "\<example\>" \<example\></tt> Marks a block of text as an example, ignored by doxygen.
+<li><tt>\anchor xmltag_exception \addindex "\<exception\>" \<exception cref="member"\></tt> Identifies the exception a 
                          method can throw.
-<li><tt>\<include\></tt> Can be used to import a piece of XML from an external
+<li><tt>\anchor xmltag_include \addindex "\<include\>" \<include\></tt> Can be used to import a piece of XML from an external
                          file. Ignored by doxygen at the moment.
-<li><tt>\<inheritdoc\></tt> Can be used to insert the documentation of a 
+<li><tt>\anchor xmltag_inheritdoc \addindex "\<inheritdoc\>" \<inheritdoc\></tt> Can be used to insert the documentation of a 
                          member of a base class into the documentation of a 
                          member of a derived class that reimplements it.
-<li><tt>\<item\></tt> List item. Can only be used inside a <tt>\<list\></tt> context.
-<li><tt>\<list type="type"\></tt> Starts a list, supported types are <tt>bullet</tt>
+<li><tt>\anchor xmltag_item \addindex "\<item\>" \<item\></tt> List item. Can only be used inside a \ref xmltag_list "\<list\>" context.
+
+<li><tt>\anchor xmltag_list \addindex "\<list\>" \<list type="type"\></tt> Starts a list, supported types are <tt>bullet</tt>
                          or <tt>number</tt> and <tt>table</tt>. 
                          A list consists of a number of <tt>\<item\></tt> tags.
                          A list of type table, is a two column table which can have
                          a header.
-<li><tt>\<listheader\></tt>   Starts the header of a list of type "table".
-<li><tt>\<para\></tt>    Identifies a paragraph of text.
-<li><tt>\<param name="paramName"\></tt> Marks a piece of text as the documentation
+<li><tt>\anchor xmltag_listheader \addindex "\<listheader\>" \<listheader\></tt>   Starts the header of a list of type "table".
+<li><tt>\anchor xmltag_para \addindex "\<para\>" \<para\></tt>    Identifies a paragraph of text.
+<li><tt>\anchor xmltag_param \addindex "\<param\>" \<param name="paramName"\></tt> Marks a piece of text as the documentation
                          for parameter "paramName". Similar to 
                          using \ref cmdparam "\\param".
-<li><tt>\<paramref name="paramName"\></tt> Refers to a parameter with name
+<li><tt>\anchor xmltag_paramref \addindex "\<paramref\>" \<paramref name="paramName"\></tt> Refers to a parameter with name
                          "paramName". Similar to using \ref cmda "\\a".
-<li><tt>\<permission\></tt> Identifies the security accessibility of a member.
+<li><tt>\anchor xmltag_permission \addindex "\<permission\>" \<permission\></tt> Identifies the security accessibility of a member.
                          Ignored by doxygen.
-<li><tt>\<remarks\></tt> Identifies the detailed description. 
-<li><tt>\<returns\></tt> Marks a piece of text as the return value of a
+<li><tt>\anchor xmltag_remarks \addindex "\<remarks\>" \<remarks\></tt> Identifies the detailed description. 
+<li><tt>\anchor xmltag_returns \addindex "\<returns\>" \<returns\></tt> Marks a piece of text as the return value of a
                          function or method. Similar to using \ref cmdreturn "\\return".
-<li><tt>\<see cref="member"\></tt> Refers to a member. Similar to \ref cmdref "\\ref".
-<li><tt>\<seealso cref="member"\></tt> Starts a "See also" section referring
+<li><tt>\anchor xmltag_see \addindex "\<see\>" \<see cref="member"\></tt> Refers to a member. Similar to \ref cmdref "\\ref".
+<li><tt>\anchor xmltag_seealso \addindex "\<seealso\>" \<seealso cref="member"\></tt> Starts a "See also" section referring
                          to "member". Similar to using \ref cmdsa "\\sa" member.
-<li><tt>\<summary\></tt> Identifies the brief description.
+<li><tt>\anchor xmltag_summary \addindex "\<summary\>" \<summary\></tt> Identifies the brief description.
                          Similar to using \ref cmdbrief "\\brief".
-<li><tt>\<term\></tt>    Part of a <tt>\<list\></tt> command.
-<li><tt>\<typeparam name="paramName"\></tt> Marks a piece of text as the documentation
+<li><tt>\anchor xmltag_term \addindex "\<term\>" \<term\></tt>    Part of a \ref xmltag_list "\<list\>" command.
+<li><tt>\anchor xmltag_typeparam \addindex "\<typeparam\>" \<typeparam name="paramName"\></tt> Marks a piece of text as the documentation
                          for type parameter "paramName". Similar to 
                          using \ref cmdparam "\\param".
-<li><tt>\<typeparamref name="paramName"\></tt> Refers to a parameter with name
+<li>\anchor xmltag_typeparamref \addindex "\<typeparamref\>"<tt>\<typeparamref name="paramName"\></tt> Refers to a parameter with name
                          "paramName". Similar to using \ref cmda "\\a".
-<li><tt>\<value\></tt>   Identifies a property. Ignored by doxygen.
-<li><tt>\<![CDATA[...]]\></tt> The text inside this tag (on the ...) is  handled as normal
+<li><tt>\anchor xmltag_value \addindex "\<value\>" \<value\></tt>   Identifies a property. Ignored by doxygen.
+<li><tt>\anchor xmltag_CDATA \addindex "\<![CDATA[...]]\>" \<![CDATA[...]]\></tt> The text inside this tag (on the ...) is  handled as normal
                          doxygen comment except for the XML special characters `<`, `>` and
                          `&` that are used as if they were escaped.
 </ul>


### PR DESCRIPTION
Add the documented HTML and XML commands to the (LaTeX) index and also create the possibilities for referencing directly to the these items.