### PR TITLE
issue #8528 Markdown links to Markdown pages with explicit page command are broken

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -195,6 +195,12 @@ int Trace::s_indent = 0;
    data[i]=='\\' || \
    data[i]=='@')
 
+enum class ExplicitPage
+{
+  notExplicit,
+  explicitPage,
+  explicitMainPage
+};
 //----------
 
 struct TableCell
@@ -2849,8 +2855,11 @@ QCString Markdown::processBlocks(const QCString &s,const int indent)
   return m_out.get();
 }
 
-/** returns TRUE if input string docs starts with \@page or \@mainpage command */
-static bool isExplicitPage(const QCString &docs)
+/** returns ExplicitPage::explicitPage in case input string docs starts with page command
+ *  returns ExplicitPage::explicitMainPage in case input string docs starts with mainpage comand
+ *  returns ExplicitPage::notExplicit otherwise
+ */
+static ExplicitPage isExplicitPage(const QCString &docs)
 {
   TRACE(docs);
   int i=0;
@@ -2867,12 +2876,20 @@ static bool isExplicitPage(const QCString &docs)
         (qstrncmp(&data[i+1],"page ",5)==0 || qstrncmp(&data[i+1],"mainpage",8)==0)
        )
     {
-      TRACE_RESULT(TRUE);
-      return TRUE;
+      if (qstrncmp(&data[i+1],"page ",5)==0)
+      {
+        TRACE_RESULT(ExplicitPage::explicitPage);
+        return ExplicitPage::explicitPage;
+      }
+      else
+      {
+        TRACE_RESULT(ExplicitPage::explicitMainPage);
+        return ExplicitPage::explicitMainPage;
+      }
     }
   }
-  TRACE_RESULT(FALSE);
-  return FALSE;
+  TRACE_RESULT(ExplicitPage::notExplicit);
+  return ExplicitPage::notExplicit;
 }
 
 QCString Markdown::extractPageTitle(QCString &docs,QCString &id, int &prepend)
@@ -3107,30 +3124,65 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
   QCString mdfileAsMainPage = Config_getString(USE_MDFILE_AS_MAINPAGE);
   bool wasEmpty = id.isEmpty();
   if (wasEmpty) id = markdownFileNameToId(fileName);
-  if (!isExplicitPage(docs))
+  static const reg::Ex re(R"([\\@]page[ \t]*)");
+  static const reg::Ex re0(R"(^[a-z_A-Z\x80-\xFF])"); // from LABELID, see commentscan.l
+  static const reg::Ex re1(R"([a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*)"); // LABELID, see commentscan.l
+  static const reg::Ex re2(R"(\n)");
+  reg::Match match;
+  reg::Match match1;
+  std::string t;
+  std::string t1;
+  switch (isExplicitPage(docs))
   {
-    if (!mdfileAsMainPage.isEmpty() &&
-        (fn==mdfileAsMainPage || // name reference
-         FileInfo(fileName.str()).absFilePath()==
-         FileInfo(mdfileAsMainPage.str()).absFilePath()) // file reference with path
-       )
-    {
-      docs.prepend("@anchor " + id + "\\ilinebr ");
-      docs.prepend("@mainpage "+title+"\\ilinebr ");
-    }
-    else if (id=="mainpage" || id=="index")
-    {
-      if (title.isEmpty()) title = titleFn;
-      docs.prepend("@anchor " + id + "\\ilinebr ");
-      docs.prepend("@mainpage "+title+"\\ilinebr ");
-    }
-    else
-    {
-      if (title.isEmpty()) {title = titleFn;prepend=0;}
-      if (!wasEmpty) docs.prepend("@anchor " +  markdownFileNameToId(fileName) + "\\ilinebr ");
-      docs.prepend("@page "+id+" "+title+"\\ilinebr ");
-    }
-    for (int i = 0; i < prepend; i++) docs.prepend("\n");
+    case ExplicitPage::notExplicit:
+      if (!mdfileAsMainPage.isEmpty() &&
+          (fn==mdfileAsMainPage || // name reference
+           FileInfo(fileName.str()).absFilePath()==
+           FileInfo(mdfileAsMainPage.str()).absFilePath()) // file reference with path
+         )
+      {
+        docs.prepend("@anchor " + id + "\\ilinebr ");
+        docs.prepend("@mainpage "+title+"\\ilinebr ");
+      }
+      else if (id=="mainpage" || id=="index")
+      {
+        if (title.isEmpty()) title = titleFn;
+        docs.prepend("@anchor " + id + "\\ilinebr ");
+        docs.prepend("@mainpage "+title+"\\ilinebr ");
+      }
+      else
+      {
+        if (title.isEmpty()) {title = titleFn;prepend=0;}
+        if (!wasEmpty) docs.prepend("@anchor " +  markdownFileNameToId(fileName) + "\\ilinebr ");
+        docs.prepend("@page "+id+" "+title+"\\ilinebr ");
+      }
+      for (int i = 0; i < prepend; i++) docs.prepend("\n");
+      break;
+    case ExplicitPage::explicitPage:
+      t = docs.str();
+      reg::search(t,match,re);
+      t1 = match.suffix().str();
+
+      // check first character in [a-z_A-Z\x80-\xFF], so we have a potential label
+      if (reg::search(t1,match1,re0))
+      {
+        docs = match.prefix().str();
+        docs += match.str() + markdownFileNameToId(fileName);
+        t = match.suffix().str();
+
+        reg::search(t,match,re1);
+        QCString saveAnchor = match.str();
+        t = match.suffix().str();
+        reg::search(t,match,re2);
+        docs += match.prefix().str();
+        docs += "\\ilinebr @anchor ";
+        docs += saveAnchor;
+        docs += match.str();
+        docs += match.suffix().str();
+      }
+      break;
+    case ExplicitPage::explicitMainPage:
+      break;
   }
   int lineNr=1;
 

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -66,13 +66,6 @@
 #define PRETTY_FUNC __PRETTY_FUNCTION__
 #endif
 
-enum class ExplicitPage
-{
-  notExplicit,
-  explicitPage,
-  explicitMainPage
-};
-
 class Trace
 {
   public:
@@ -141,11 +134,6 @@ class Trace
     {
       m_resultSet = true;
       m_resultValue = b ? "true" : "false";
-    }
-    void setResult(ExplicitPage ep)
-    {
-      m_resultSet = true;
-      m_resultValue = QCString().setNum(static_cast<int>(ep));
     }
     void setResult(int i)
     {
@@ -2860,11 +2848,11 @@ QCString Markdown::processBlocks(const QCString &s,const int indent)
   return m_out.get();
 }
 
-/** returns ExplicitPage::explicitPage in case input string docs starts with page command
- *  returns ExplicitPage::explicitMainPage in case input string docs starts with mainpage comand
- *  returns ExplicitPage::notExplicit otherwise
+/** returns 1 in case input string docs starts with page command
+ *  returns 2 in case input string docs starts with mainpage comand
+ *  returns 0 otherwise
  */
-static ExplicitPage isExplicitPage(const QCString &docs)
+static int isExplicitPage(const QCString &docs)
 {
   TRACE(docs);
   int i=0;
@@ -2883,18 +2871,18 @@ static ExplicitPage isExplicitPage(const QCString &docs)
     {
       if (qstrncmp(&data[i+1],"page ",5)==0)
       {
-        TRACE_RESULT(ExplicitPage::explicitPage);
-        return ExplicitPage::explicitPage;
+        TRACE_RESULT(1);
+        return 1;
       }
       else
       {
-        TRACE_RESULT(ExplicitPage::explicitMainPage);
-        return ExplicitPage::explicitMainPage;
+        TRACE_RESULT(2);
+        return 2;
       }
     }
   }
-  TRACE_RESULT(ExplicitPage::notExplicit);
-  return ExplicitPage::notExplicit;
+  TRACE_RESULT(0);
+  return 0;
 }
 
 QCString Markdown::extractPageTitle(QCString &docs,QCString &id, int &prepend)
@@ -3139,7 +3127,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
   std::string t1;
   switch (isExplicitPage(docs))
   {
-    case ExplicitPage::notExplicit:
+    case 0:
       if (!mdfileAsMainPage.isEmpty() &&
           (fn==mdfileAsMainPage || // name reference
            FileInfo(fileName.str()).absFilePath()==
@@ -3163,7 +3151,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
       }
       for (int i = 0; i < prepend; i++) docs.prepend("\n");
       break;
-    case ExplicitPage::explicitPage:
+    case 1:
       t = docs.str();
       reg::search(t,match,re);
       t1 = match.suffix().str();
@@ -3186,7 +3174,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
         docs += match.suffix().str();
       }
       break;
-    case ExplicitPage::explicitMainPage:
+    case 2:
       break;
   }
   int lineNr=1;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -66,6 +66,13 @@
 #define PRETTY_FUNC __PRETTY_FUNCTION__
 #endif
 
+enum class ExplicitPage
+{
+  notExplicit,
+  explicitPage,
+  explicitMainPage
+};
+
 class Trace
 {
   public:
@@ -135,6 +142,11 @@ class Trace
       m_resultSet = true;
       m_resultValue = b ? "true" : "false";
     }
+    void setResult(ExplicitPage ep)
+    {
+      m_resultSet = true;
+      m_resultValue = QCString().setNum(static_cast<int>(ep));
+    }
     void setResult(int i)
     {
       m_resultSet = true;
@@ -194,13 +206,6 @@ int Trace::s_indent = 0;
   (data[i]=='('  || data[i]=='{' || data[i]=='[' || (data[i]=='<' && data[i+1]!='/') || \
    data[i]=='\\' || \
    data[i]=='@')
-
-enum class ExplicitPage
-{
-  notExplicit,
-  explicitPage,
-  explicitMainPage
-};
 //----------
 
 struct TableCell

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3129,14 +3129,6 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
   QCString mdfileAsMainPage = Config_getString(USE_MDFILE_AS_MAINPAGE);
   bool wasEmpty = id.isEmpty();
   if (wasEmpty) id = markdownFileNameToId(fileName);
-  static const reg::Ex re(R"([\\@]page[ \t]*)");
-  static const reg::Ex re0(R"(^[a-z_A-Z\x80-\xFF])"); // from LABELID, see commentscan.l
-  static const reg::Ex re1(R"([a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*)"); // LABELID, see commentscan.l
-  static const reg::Ex re2(R"(\n)");
-  reg::Match match;
-  reg::Match match1;
-  std::string t;
-  std::string t1;
   switch (isExplicitPage(docs))
   {
     case ExplicitPage::notExplicit:
@@ -3164,26 +3156,36 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
       for (int i = 0; i < prepend; i++) docs.prepend("\n");
       break;
     case ExplicitPage::explicitPage:
-      t = docs.str();
-      reg::search(t,match,re);
-      t1 = match.suffix().str();
-
-      // check first character in [a-z_A-Z\x80-\xFF], so we have a potential label
-      if (reg::search(t1,match1,re0))
       {
-        docs = match.prefix().str();
-        docs += match.str() + markdownFileNameToId(fileName);
-        t = match.suffix().str();
-
-        reg::search(t,match,re1);
-        QCString saveAnchor = match.str();
-        t = match.suffix().str();
-        reg::search(t,match,re2);
-        docs += match.prefix().str();
-        docs += "\\ilinebr @anchor ";
-        docs += saveAnchor;
-        docs += match.str();
-        docs += match.suffix().str();
+        static const reg::Ex re(R"([\\@]page[ \t]*)");
+        static const reg::Ex re0(R"(^[a-z_A-Z\x80-\xFF])"); // from LABELID, see commentscan.l
+        static const reg::Ex re1(R"([a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*)"); // LABELID, see commentscan.l
+        static const reg::Ex re2(R"(\n)");
+        reg::Match match;
+        reg::Match match1;
+        std::string t;
+        std::string t1;
+        t = docs.str();
+        reg::search(t,match,re);
+        t1 = match.suffix().str();
+  
+        // check first character in [a-z_A-Z\x80-\xFF], so we have a potential label
+        if (reg::search(t1,match1,re0))
+        {
+          docs = match.prefix().str();
+          docs += match.str() + markdownFileNameToId(fileName);
+          t = match.suffix().str();
+  
+          reg::search(t,match,re1);
+          QCString saveAnchor = match.str();
+          t = match.suffix().str();
+          reg::search(t,match,re2);
+          docs += match.prefix().str();
+          docs += "\\ilinebr @anchor ";
+          docs += saveAnchor;
+          docs += match.str();
+          docs += match.suffix().str();
+        }
       }
       break;
     case ExplicitPage::explicitMainPage:


### PR DESCRIPTION
In case a  `@page` command is the first line in a markdown file it is used as  "label" but also to construct the name of the output file and hence the regular markdown reference (like `[...](..)`) does not work anymore as here an internal label and filename is used  (`md_...`).
To overcome this problem the `@page <label> (title)` is changed into `@page md_<filename> (title)\ilinebr @anchor <label>`.