### PR TITLE
issue #8898 c#: Inherit documentation from interface property (not working as no docs displayed)

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -3590,6 +3590,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
     TemplateVariant isStatic() const                 { return m_memberDef->isStatic(); }
     TemplateVariant isObjCMethod() const             { return m_memberDef->isObjCMethod(); }
     TemplateVariant isObjCProperty() const           { return m_memberDef->isObjCProperty(); }
+    TemplateVariant isCSharpProperty() const         { return m_memberDef->isCSharpProperty(); }
     TemplateVariant isImplementation() const         { return m_memberDef->isImplementation(); }
     TemplateVariant isSignal() const                 { return m_memberDef->isSignal(); }
     TemplateVariant isSlot() const                   { return m_memberDef->isSlot(); }
@@ -4346,6 +4347,7 @@ const PropertyMap<MemberContext::Private> MemberContext::Private::s_inst {
   {  "isTemplateSpecialization",&Private::isTemplateSpecialization },
   {  "isObjCMethod",        &Private::isObjCMethod },
   {  "isObjCProperty",      &Private::isObjCProperty },
+  {  "isCSharpProperty",    &Private::isCSharpProperty },
   {  "isAnonymous",         &Private::isAnonymous },
   {  "hasParameters",       &Private::hasParameters },
   {  "declType",            &Private::declType },

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7828,7 +7828,7 @@ static void computeMemberRelations()
                    bmd->getLanguage()==SrcLangExt_Python || bmd->getLanguage()==SrcLangExt_Java || bmd->getLanguage()==SrcLangExt_PHP ||
                    bmcd->compoundType()==ClassDef::Interface || bmcd->compoundType()==ClassDef::Protocol
                   ) &&
-                  md->isFunction() &&
+                  (md->isFunction() || md->isCSharpProperty()) &&
                   mcd->isLinkable() &&
                   bmcd->isLinkable() &&
                   mcd->isBaseClass(bmcd,TRUE))

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -163,6 +163,7 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual bool isTemplateSpecialization() const;
     virtual bool isObjCMethod() const;
     virtual bool isObjCProperty() const;
+    virtual bool isCSharpProperty() const;
     virtual bool isConstructor() const;
     virtual bool isDestructor() const;
     virtual bool hasOneLineInitializer() const;
@@ -601,6 +602,8 @@ class MemberDefAliasImpl : public DefinitionAliasMixin<MemberDef>
     { return getMdAlias()->isObjCMethod(); }
     virtual bool isObjCProperty() const
     { return getMdAlias()->isObjCProperty(); }
+    virtual bool isCSharpProperty() const
+    { return getMdAlias()->isCSharpProperty(); }
     virtual bool isConstructor() const
     { return getMdAlias()->isConstructor(); }
     virtual bool isDestructor() const
@@ -4700,6 +4703,12 @@ bool MemberDefImpl::isObjCMethod() const
 bool MemberDefImpl::isObjCProperty() const
 {
   if (getClassDef() && getClassDef()->isObjectiveC() && isProperty()) return TRUE;
+  return FALSE;
+}
+
+bool MemberDefImpl::isCSharpProperty() const
+{
+  if (getClassDef() && getClassDef()->isCSharp() && isProperty()) return TRUE;
   return FALSE;
 }
 

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -172,6 +172,7 @@ class MemberDef : public Definition
     virtual bool isTemplateSpecialization() const = 0;
     virtual bool isObjCMethod() const = 0;
     virtual bool isObjCProperty() const = 0;
+    virtual bool isCSharpProperty() const = 0;
     virtual bool isConstructor() const = 0;
     virtual bool isDestructor() const = 0;
     virtual bool hasOneLineInitializer() const = 0;


### PR DESCRIPTION
See to it that the documentation of a C# property is copied as well.