### PR TITLE
issue #7807 Incorrect handling of triple backticks with specifying language.

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6625,7 +6625,7 @@ NONLopt [^\n]*
                                             REJECT;
                                           }
                                         }
-<DocBlock>[^@*~\/\\\n]+                 { // any character that isn't special
+<DocBlock>[^@*~`\/\\\n]+                { // any character that isn't special
                                           yyextra->docBlock << yytext;
                                         }
 <DocBlock>\n                            { // newline

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6604,7 +6604,9 @@ NONLopt [^\n]*
                                           yyextra->nestedComment=FALSE;
                                           BEGIN(DocCopyBlock);
                                         }
-<DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]*                {
+<DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]*/(".")?[a-zA-Z0-9#_-]+ |
+<DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]*/"{"[^}]+"}" |
+<DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]* {
                                           QCString pat = substitute(yytext,"*"," ");
                                           yyextra->docBlock << pat;
                                           yyextra->docBlockName="```";
@@ -6625,7 +6627,7 @@ NONLopt [^\n]*
                                             REJECT;
                                           }
                                         }
-<DocBlock>[^@*~`\/\\\n]+                { // any character that isn't special
+<DocBlock>[^@*~\/\\\n]+                 { // any character that isn't special
                                           yyextra->docBlock << yytext;
                                         }
 <DocBlock>\n                            { // newline


### PR DESCRIPTION
When having:
~~~
/** \file
 *
 * ```{.c}
 *   // backticks c ext
 *   void fie_b4(void);
 * ```
*/
~~~
the triple backticks with language are handled properly, though when having:
~~~
/** \file

```{.c}
  // backticks c ext
  void fie_b4(void);
```
*/
~~~
this is not the case.

Note: when using triple tildes instead of backticks it does work as well.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7587860/example.tar.gz)
