### PR TITLE
issue #8909 Build error with git head GCC (version 12, Nov 2021)

### DIFF
--- a/src/growbuf.h
+++ b/src/growbuf.h
@@ -1,6 +1,7 @@
 #ifndef GROWBUF_H
 #define GROWBUF_H
 
+#include <utility>
 #include <stdlib.h>
 #include <string.h>
 #include <string>


### PR DESCRIPTION
Added the `include` for `utility`.
(even though GCC 12 is not yet released).