### PR TITLE
issue #8914 Double Square Bracket – somewhere – stop Doxygen

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5383,6 +5383,7 @@ NONLopt [^\n]*
 <SkipString,SkipPHPString>\n            {
                                           lineCount(yyscanner);
                                         }
+<SkipString>"[["                        { }
 <SkipString,SkipPHPString>.             { }
 <CompoundName>":"                       { // for "class : public base {} var;" construct, see bug 608359
                                           unput(':');


### PR DESCRIPTION
Doxygen sees, even in comment, the consecutive double open square brackets as the start of a C++11 attribute.
Defining specific rule for C++ and starting square bracket in a string.