### PR TITLE
Incorrect warnings due to WARN_IF_DOC_ERROR=NO

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -379,7 +379,7 @@ QCString DocParser::findAndCopyImage(const QCString &fileName, DocImage::Type ty
  */
 void DocParser::checkArgumentName()
 {
-  if (!Config_getBool(WARN_IF_DOC_ERROR)) return;
+  if (!(Config_getBool(WARN_IF_DOC_ERROR) || Config_getBool(WARN_IF_INCOMPLETE_DOC))) return;
   if (context.memberDef==0) return; // not a member
   std::string name = context.token->name.str();
   const ArgumentList &al=context.memberDef->isDocsForDefinition() ?


### PR DESCRIPTION
In case we have a simple file like:
```
/// \file

/// \brief void fie
///
/// \param a first arg
/// \param b second arg
/// \param c third arg
void fie0(int a, int b, int c){}
```
and set:
```
WARN_IF_DOC_ERROR=NO
```
we get the warnings:
```
..../aa.h:8: warning: The following parameters of fie0(int a, int b, int c) are not documented:
  parameter 'a'
  parameter 'b'
  parameter 'c'
```

This is due to the new setting `WARN_IF_INCOMPLETE_DOC` (since 1.9.2) and this needs `paramsFound` which is set in `checkArgumentName` but was skipped due to `WARN_IF_DOC_ERROR=NO`.

example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7610330/example.tar.gz)
