### PR TITLE
Double member names in python source code

### DIFF
--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1520,16 +1520,17 @@ static void findMemberLink(yyscan_t yyscanner,
   //    yyextra->currentDefinition?qPrint(yyextra->currentDefinition->name()):"<none>",
   //    yyextra->currentMemberDef?qPrint(yyextra->currentMemberDef->name()):"<none>"
   //    );
+  bool found = false;
   if (yyextra->currentDefinition)
   {
     auto range = Doxygen::symbolMap->find(symName);
     for (auto it = range.first; it!=range.second; ++it)
     {
-      findMemberLink(yyscanner,ol,it->second,symName);
+      if (findMemberLink(yyscanner,ol,it->second,symName)) found = true;
     }
   }
   //printf("sym %s not found\n",&yytext[5]);
-  codify(yyscanner,symName);
+  if (!found) codify(yyscanner,symName);
 }
 
 


### PR DESCRIPTION
When having a simple python program:
```
class preserve_keys(object):
    def __init__(self, dictionary1, *keys):
        self.dictionary = dictionary1
        loc_dictionary = dictionary1
```
doxygen gives as source code:
```
class preserve_keys(object):
    def __init__(self, dictionary1, *keys):
        self.dictionarydictionary = dictionary1
        loc_dictionary = dictionary1
```
note the double `dictionary ` in `self.dictionarydictionary `

This is caused by:
```
Commit: 1c889cca680b79ca55a69b6dfef2f387f120e2d3 [1c889cc]
Date: Thursday, October 22, 2020 8:57:03 AM
Commit Date: Friday, October 23, 2020 7:27:09 PM
Refactoring: modernize Doxygen::symbolMap
```
where the logic structure is not observed properly.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7612117/example.tar.gz)
