### PR TITLE
bug_750666 Usergroup (layout.xml) url="[none]" doesn't work

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4932,7 +4932,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const LayoutNavEntryList &
             QCString url = correctURL(lne->url(),"!"); // add ! to relative URL
             if (!url.isEmpty())
             {
-              if (url=="![none]")
+              if (url=="!") // result of a "[none]" url
               {
                 Doxygen::indexList->addContentsItem(TRUE,lne->title(),QCString(),QCString(),QCString(),FALSE,FALSE);
               }

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -552,7 +552,14 @@ class LayoutParser
       {
         if (!url.isEmpty())
         {
-          baseFile=url;
+          if (url == "[none]")
+          {
+            baseFile = QCString();
+          }
+          else
+          {
+            baseFile=url;
+          }
         }
         else
         {


### PR DESCRIPTION
Handle the `url="[none]"` so that the "landing place" remains the current page.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7625274/example.tar.gz)
