### PR TITLE
issue #8924 Horizontal scroll bar missing in HTML for wide class="dotgraph" objects

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -262,7 +262,7 @@ dl.el {
 }
 
 ul {
-  overflow: hidden; /*Fixed: list item bullets overlap floating elements*/
+  overflow: visible;
 }
 
 #side-nav ul {


### PR DESCRIPTION
Most of the RTL implementation, this looks like a remnant.
(relevant original issue introducing the problem #636, some fixes in #754)