### PR TITLE
Incorrect markdown links.

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -972,10 +972,12 @@ int Markdown::processLink(const char *data,int,int size)
   if (!isImageLink && content.isEmpty()) { TRACE_RESULT(0); return 0; } // no link text
   i++; // skip over ]
 
+  bool whiteSpace = false;
   // skip whitespace
-  while (i<size && data[i]==' ') i++;
+  while (i<size && data[i]==' ') {whiteSpace = true; i++;}
   if (i<size && data[i]=='\n') // one newline allowed here
   {
+    whiteSpace = true;
     i++;
     nl++;
     // skip more whitespace
@@ -983,6 +985,7 @@ int Markdown::processLink(const char *data,int,int size)
   }
   nlTotal += nl;
   nl = 0;
+  if (whiteSpace && i<size && (data[i]=='(' || data[i]=='[')) return 0;
 
   bool explicitTitle=FALSE;
   if (i<size && data[i]=='(') // inline link


### PR DESCRIPTION
When having a space between  the `]` and `(` of a potential markdown link this is not a markdown link.
Example:
```
[is a link](aa.html)
[is not a link] (aa.html)
```

This was found in the plantuml package  where the following shows as a link:
```
[3, 3, 3, 3, 3, 3, 3, 3] (result: A=000, B=001, C=010, ..., H=111)
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7642867/example.tar.gz)
