### PR TITLE
Incorrect C++ comment conversion due to {@code

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -414,7 +414,7 @@ SLASHopt [/]*
 <CComment,CNComment,ReadLine>"<"{MAILADR}">" { // Mail address, to prevent seeing e.g x@code-factory.org as start of a code block
                                      copyToOutput(yyscanner,yytext,(int)yyleng);
                                    }
-<CComment>"{"[ \t]*"@code"/[ \t\n] {
+<CComment,ReadLine>"{"[ \t]*"@code"/[ \t\n] {
                                      copyToOutput(yyscanner,"@code",5); 
 				     yyextra->lastCommentContext = YY_START;
 				     yyextra->javaBlock=1;


### PR DESCRIPTION
When having:
```
/// \file
///
/// a java code section
/// {@code
/// Some text
/// }
/// and more
```
and a default Doxyfile, we get
```
cc.h:8: warning: reached end of file while inside a 'code' block!
The command that should end the block seems to be missing!
```
this is independent of the setting of `ENABLE_PREPROCESSING`.
It is caused as `{@code` is not recognized as a "special" comment  in this case, it is recognized when we are in C-type comment.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7654026/example.tar.gz)
