### PR TITLE
issue #8935 'make docs' fails when building PDF

### DIFF
--- a/doc/manual.sty
+++ b/doc/manual.sty
@@ -45,6 +45,6 @@
   \markright{\thesection\ #1}%
 }
 %
-\usepackage{xpatch}
+\usepackage{regexpatch}
 \xpatchcmd{\part}{plain}{empty}{}{}
 


### PR DESCRIPTION
Looks like the `xpatch` package is not available everywhere, replacing it with `regexpatch` (which is also used in the Czech and Slovak translators)