### PR TITLE
bug_688384 JavaDoc @link does not use code font

### DIFF
--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -60,6 +60,7 @@ CommandMap cmdMap[] =
   { "internal",      CMD_INTERNAL },
   { "invariant",     CMD_INVARIANT },
   { "javalink",      CMD_JAVALINK },
+  { "javalinkplain", CMD_JAVALINK },
   { "latexinclude",  CMD_LATEXINCLUDE },
   { "latexonly",     CMD_LATEXONLY },
   { "li",            CMD_LI },

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -5078,9 +5078,11 @@ void DocPara::handleLink(const QCString &cmdName,bool isJavaLink)
         DocTokenizer::tokToString(tok),qPrint(saveCmdName));
     return;
   }
+  if (saveCmdName == "javalink") m_children.push_back(std::make_unique<DocStyleChange>(m_parser,this,(uint)m_parser.context.nodeStack.size(),DocStyleChange::Code,cmdName,TRUE));
   m_parser.tokenizer.setStatePara();
   DocLink *lnk = new DocLink(m_parser,this,m_parser.context.token->name);
   m_children.push_back(std::unique_ptr<DocLink>(lnk));
+  if (saveCmdName == "javalink") m_children.push_back(std::make_unique<DocStyleChange>(m_parser,this,(uint)m_parser.context.nodeStack.size(),DocStyleChange::Code,cmdName,FALSE));
   QCString leftOver = lnk->parse(isJavaLink);
   if (!leftOver.isEmpty())
   {

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -515,6 +515,10 @@ LINENR {BLANK}*[1-9][0-9]*
                          yyextra->token->indent = computeIndent(text.data(),dotPos);
                          return TK_ENDLIST;
                        }
+<St_Para>"{"{BLANK}*"@linkplain"/{WS}+ {
+                         yyextra->token->name = "javalinkplain";
+                         return TK_COMMAND_AT;
+                       }
 <St_Para>"{"{BLANK}*"@link"/{WS}+ {
                          yyextra->token->name = "javalink";
                          return TK_COMMAND_AT;


### PR DESCRIPTION
When looking at the JavaDoc definition we see:
```
{@link  package.class#member  label}
    Inserts an in-line link with visible text label that points to the documentation for the specified package, class or member name of a referenced class.
```
and
```
{@linkplain  package.class#member  label}
    Identical to {@link}, except the link's label is displayed in plain text than code font.
```

- setting a `{@link ...}` in code font
- implementing `{@linkplain ...}` (JavaDoc @linkplain is not recognized (Origin: bugzilla #688387))

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7675531/example.tar.gz)
