### PR TITLE
bug_772405 *_AUTOBRIEF=YES gobbles end of paragraph from brief

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2143,6 +2143,7 @@ static bool handleMainpage(yyscan_t yyscanner,const QCString &, const StringVect
   {
     yyextra->current->name = "mainpage";
   }
+  setOutput(yyscanner,OutputDoc);
   BEGIN( PageDocArg2 );
   return stop;
 }


### PR DESCRIPTION
A mainpage has no brief description, so all information should directly land in the detailed description section.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7677619/example.tar.gz)
 