### PR TITLE
issue #9857 C# incorrect interpretation of '?'-operators

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6918,7 +6918,7 @@ NONLopt [^\n]*
                                           }
                                         }
 <*>\?                                   {
-                                          if (yyextra->insideCS && (YY_START != SkipRound))
+                                          if (yyextra->insideCS && (YY_START != SkipRound) && (YY_START != CSAccessorDecl))
                                           {
                                             if (yyextra->current->type.isEmpty())
                                             {


### PR DESCRIPTION
Not only should question marks inside round brackets but also inside curly brackets be handled in the same way.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7686362/example.tar.gz)
