### PR TITLE
issue #8956 Section links in markdown mainpage not working

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -227,6 +227,16 @@ In addition doxygen provides a similar way to link a documented entity:
 
     [The link text](@ref MyClass)
 
+in case the first non whitespace character of the reference is a \c # this
+is interpreted as a doxygen link and replaced as a \ref cmdref "\@ref" command:
+
+    [The link text](#MyClass)
+
+will be interpreted as:
+
+    @ref MyClass "The link text"
+
+
 \subsubsection md_reflinks Reference Links
 
 Instead of putting the URL inline, you can also define the link separately
@@ -466,7 +476,7 @@ To link to a section in the same comment block you can use
 
     [Link text](#labelid)
 
-to link to a section in general, doxygen allows you to use \@ref
+to link to a section in general, doxygen allows you to use \ref cmdref "\@ref"
 
     [Link text](@ref labelid)
 

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1208,32 +1208,44 @@ int Markdown::processLink(const char *data,int,int size)
       m_out.addStr(" \"");
       if (explicitTitle && !title.isEmpty())
       {
-        m_out.addStr(title);
+        m_out.addStr(substitute(title,"\"","&quot;"));
       }
       else
       {
-        m_out.addStr(content);
+        m_out.addStr(substitute(content,"\"","&quot;"));
       }
       m_out.addStr("\"");
     }
     else if (link.find('/')!=-1 || link.find('.')!=-1 || link.find('#')!=-1)
     { // file/url link
-      m_out.addStr("<a href=\"");
-      m_out.addStr(link);
-      m_out.addStr("\"");
-      for (int ii = 0; ii < nlTotal; ii++) m_out.addStr("\n");
-      if (!title.isEmpty())
+      if (link.at(0) == '#')
       {
-        m_out.addStr(" title=\"");
-        m_out.addStr(substitute(title.simplifyWhiteSpace(),"\"","&quot;"));
+        m_out.addStr("@ref ");
+        m_out.addStr(link.mid(1));
+        m_out.addStr(" \"");
+        m_out.addStr(substitute(content.simplifyWhiteSpace(),"\"","&quot;"));
         m_out.addStr("\"");
+
       }
-      m_out.addStr(" ");
-      m_out.addStr(externalLinkTarget());
-      m_out.addStr(">");
-      content = content.simplifyWhiteSpace();
-      processInline(content.data(),content.length());
-      m_out.addStr("</a>");
+      else
+      {
+        m_out.addStr("<a href=\"");
+        m_out.addStr(link);
+        m_out.addStr("\"");
+        for (int ii = 0; ii < nlTotal; ii++) m_out.addStr("\n");
+        if (!title.isEmpty())
+        {
+          m_out.addStr(" title=\"");
+          m_out.addStr(substitute(title.simplifyWhiteSpace(),"\"","&quot;"));
+          m_out.addStr("\"");
+        }
+        m_out.addStr(" ");
+        m_out.addStr(externalLinkTarget());
+        m_out.addStr(">");
+        content = substitute(content.simplifyWhiteSpace(),"\"","\\\"");
+        processInline(content.data(),content.length());
+        m_out.addStr("</a>");
+      }
     }
     else // avoid link to e.g. F[x](y)
     {


### PR DESCRIPTION
In case a link to a section starts with a `#` this will be interpreted as wusing a `@ref` command:, so
```
    [The link text](#MyClass)
```
will be interpreted as:
```
    @ref MyClass "The link text"
```

Furthermore double quotes `"` are properly escaped.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7694646/example.tar.gz)
