### PR TITLE
Set currentCmd for `\relates` / `\related` command

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2330,6 +2330,7 @@ static bool handleRelated(yyscan_t yyscanner,const QCString &cmd, const StringVe
         "found multiple \\relates, \\relatesalso or \\memberof commands in a comment block, using last definition");
   }
   yyextra->current->relatesType = Simple;
+  yyextra->currentCmd = cmd;
   BEGIN(RelatesParam1);
   return FALSE;
 }


### PR DESCRIPTION
See to it that for the `\relates` / `\related`  command also the currentCmd is set (used in warnings)