### PR TITLE
bug_365053 Wrong reference to ::classname (in typedef)

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2346,6 +2346,18 @@ NONLopt [^\n]*
                                                 }
                                                 yyextra->current->name=yyextra->current->name.mid(9);
                                               }
+                                              else if (yyextra->current->name.left(8)=="typedef ")
+                                              {
+                                                if (yyextra->current->type.isEmpty())
+                                                {
+                                                  yyextra->current->type="typedef";
+                                                }
+                                                else
+                                                {
+                                                  yyextra->current->type+="typedef ";
+                                                }
+                                                yyextra->current->name=yyextra->current->name.mid(8);
+                                              }
                                             }
                                             QCString tmp=yytext;
                                             if (nameIsOperator(tmp))


### PR DESCRIPTION
This fixes the second problem:
```
class Foo
{
   typedef ::Bar MyBar;
}
```
mentioned in the issue.
Besides the already supported words also the word `typedef` should be supported.

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7718879/example.tar.gz)