### PR TITLE
bug_365053 Wrong reference to ::classname

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1534,7 +1534,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           yyextra->code->codify(yytext);
                                           endFontClass(yyscanner);
                                         }
-<MemberCall2,FuncCall>{ID}(({B}*"<"[^\n\[\](){}<>]*">")?({B}*"::"{B}*{ID})?)* {
+<MemberCall2,FuncCall>("::")?{ID}(({B}*"<"[^\n\[\](){}<>]*">")?({B}*"::"{B}*{ID})?)* {
                                           if (isCastKeyword(yytext))
                                           {
                                             REJECT;

--- a/src/symbolresolver.cpp
+++ b/src/symbolresolver.cpp
@@ -1041,6 +1041,7 @@ const ClassDef *SymbolResolver::resolveClass(const Definition *scope,
       (scope->definitionType()!=Definition::TypeClass &&
        scope->definitionType()!=Definition::TypeNamespace
       ) ||
+      (name.stripWhiteSpace().startsWith("::")) ||
       (scope->getLanguage()==SrcLangExt_Java && QCString(name).find("::")!=-1)
      )
   {
@@ -1048,7 +1049,7 @@ const ClassDef *SymbolResolver::resolveClass(const Definition *scope,
   }
   //fprintf(stderr,"------------ resolveClass(scope=%s,name=%s,mayUnlinkable=%d)\n",
   //    scope?qPrint(scope->name()):"<global>",
-  //    name,
+  //    qPrint(name),
   //    mayBeUnlinkable
   //   );
   const ClassDef *result;
@@ -1070,12 +1071,12 @@ const ClassDef *SymbolResolver::resolveClass(const Definition *scope,
   {
     if (!mayBeHidden || !result->isHidden())
     {
-      //printf("result was %s\n",result?qPrint(result->name()):"<none>");
+      //fprintf(stderr,"result was %s\n",result?qPrint(result->name()):"<none>");
       result=0; // don't link to artificial/hidden classes unless explicitly allowed
     }
   }
   //fprintf(stderr,"ResolvedClass(%s,%s)=%s\n",scope?qPrint(scope->name()):"<global>",
-  //                                  name,result?qPrint(result->name()):"<none>");
+  //                                  qPrint(name),result?qPrint(result->name()):"<none>");
   return result;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -889,12 +889,12 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
     bool keepSpaces,int indentLevel)
 {
   if (text.isEmpty()) return;
-  //printf("linkify='%s'\n",text);
+  //printf("linkify='%s'\n",qPrint(text));
   std::string txtStr=text.str();
   size_t strLen = txtStr.length();
   if (strLen==0) return;
 
-  static const reg::Ex regExp(R"(\a[\w~!\\.:$]*)");
+  static const reg::Ex regExp(R"(:?:?\a[\w~!\\.:$]*)");
   reg::Iterator it(txtStr,regExp);
   reg::Iterator end;
 


### PR DESCRIPTION
Identified few places where the global class prefix (`::`) was not handled.