### PR TITLE
Specifying strings to be excluded from markdown processing

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -668,6 +668,18 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='list' id='MARKDOWN_EXCLUDE' format='string' depends='MARKDOWN_SUPPORT'>
+      <docs>
+<![CDATA[
+ The strings as supplied in the \c MARKDOWN_EXCLUDE tag will be excluded from the
+ markdown processing. It might be necessary to exclude strings from the processing
+ as they are e.g. the name of a structure but start and end with an underscore,
+ meaning that they would by handled by the markdown processor as an italic string.
+ \note The order of the excluded patterns is of importance. When one needs to
+ exclude `_A_` and `__A__` one has to place the `__A__` before `_A_` in the list.
+]]>
+      </docs>
+    </option>
     <option type='int' id='TOC_INCLUDE_HEADINGS' minval='0' maxval='99' defval='5' depends='MARKDOWN_SUPPORT'>
       <docs>
 <![CDATA[


### PR DESCRIPTION
When having code like
```
/** @struct _MODEL_DICT_
 *  @brief This structure contains models.dat info
 *  @var _MODEL_DICT_::s_tech_class
 *  Member 's_tech_class' contains tech_class info
```
we get warnings like:
```
 warning: the name 'MODEL_SMALL_DICT' supplied as the argument of the \class, \struct, \union, or \include command is not an input file
 warning: Member s_tech_class (variable) of struct _MODEL_SMALL_DICT_ is not documented.
```
even though the member is properly documented. This is due to the fact that the `_MODEL_SMALL_DICT_` is in the markdown processing seen as an italic string `MODEL_SMALL_DATA`.

To overcome this problem in a general way an new setting had to be introduces: `MARKDOWN_EXCLUDE`

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7734952/example.tar.gz)

(Found by fossies for the hplip package)
