### PR TITLE
Unmatched tt tag.

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -658,6 +658,10 @@ LINENR {BLANK}*[1-9][0-9]*
                          yyextra->token->name = yytext;
                          return TK_LNKWORD;
                         }
+<St_Para>{LNKWORD1}/"<tt>" { // prevent <tt> html tag to be parsed as template arguments
+                         yyextra->token->name = yytext;
+                         return TK_LNKWORD;
+                       }
 <St_Para>{LNKWORD1}/"<br>"           | // prevent <br> html tag to be parsed as template arguments
 <St_Para>{LNKWORD1}                  |
 <St_Para>{LNKWORD1}{FUNCARG}         |


### PR DESCRIPTION
When having the
```
- \\cite  cgal:k-dat-96 \cite  cgal:k-dat-96
```
with bib entry:
```
@incollection{ cgal:k-dat-96
  ,author       = "Keffer, T."
  ,title        = "The Design and Architecture of {T}ools.h{\tt ++}"
  ,booktitle    = "{C{\tt ++}}~Gems"
  ,publisher    = "SIGS publications"
  ,editor       = "Lippman, S."
  ,year         = "1996"
  ,pages        = "43--57"
  ,update       = "98.01 schirra"
}
```
we get the warning:
```
citelist:6: warning: found </tt> tag without matching <tt>
```
this is due to the fact that `{T}ools.h{\tt ++}`  is translated into `Tools.h<tt>++</tt>.` where an attempt is made for a template match of `Tools.h<tt>`

so we have to make an exception for `<tt>` analogous to `<br>`

Unfortunately we have to split the rule as otherwise we get the complication warning:
```
doctokenizer.l:662: warning, dangerous trailing context
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7741209/example.tar.gz)

(Found when running some CGAL tests)
