### PR TITLE
Incorrect citations for entries with double dash and for cross references

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -24,6 +24,7 @@
 #include "debug.h"
 #include "fileinfo.h"
 #include "dir.h"
+#include "markdown.h"
 
 #include <map>
 #include <string>
@@ -135,7 +136,7 @@ void CitationManager::insertCrossReferencesForBibFile(const QCString &bibFile)
     {
       // assumption entry like: "@book { name," or "@book { name" (spaces optional)
       int j = line.find('{');
-      // when no {, go hunting for it
+      // when no '{', go hunting for it
       while (j==-1 && getline(f,lineStr))
       {
         line = lineStr;
@@ -143,7 +144,7 @@ void CitationManager::insertCrossReferencesForBibFile(const QCString &bibFile)
       }
       // search for the name
       citeName = "";
-      if (!f.eof() && j!=-1) // to prevent something like "@manual ," and no { found
+      if (!f.eof() && j!=-1) // to prevent something like "@manual ," and no '{' found
       {
         int k = line.find(',',j);
         j++;
@@ -304,7 +305,7 @@ void CitationManager::generatePage()
       if      (line.find("<!-- BEGIN BIBLIOGRAPHY")!=-1) insideBib=TRUE;
       else if (line.find("<!-- END BIBLIOGRAPH")!=-1)    insideBib=FALSE;
       // determine text to use at the location of the @cite command
-      if (insideBib && (i=line.find("name=\"CITEREF_"))!=-1)
+      if (insideBib && ((i=line.find("name=\"CITEREF_"))!=-1 || (i=line.find("href=\"#CITEREF_"))!=-1))
       {
         int j=line.find("\">[");
         int k=line.find("]</a>");
@@ -315,7 +316,7 @@ void CitationManager::generatePage()
           uint uk=(uint)k;
           QCString label = line.mid(ui+14,uj-ui-14);
           QCString number = line.mid(uj+2,uk-uj-1);
-          label = substitute(substitute(label,"&ndash;","--"),"&mdash;","---");
+          label = undoMarkdown(label);
           line = line.left(ui+14) + label + line.right(line.length()-uj);
           auto it = p->entries.find(label.str());
           //printf("label='%s' number='%s' => %p\n",qPrint(label),qPrint(number),it->second.get());

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -58,6 +58,7 @@ typedef yyguts_t *yyscan_t;
 #include "section.h"
 #include "util.h"
 #include "reflist.h"
+#include "markdown.h"
 
 #define USE_STATE2STRING 0
 
@@ -488,8 +489,8 @@ FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+@&#]
 FILE      ({FILESCHAR}*{FILEECHAR}+("."{FILESCHAR}*{FILEECHAR}+)*)|("\""[^\n\"]*"\"")
 ID        [$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
-CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
-CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]*
+CITESCHAR [&;a-z_A-Z0-9\x80-\xFF\-\?]
+CITEECHAR [&;a-z_A-Z0-9\x80-\xFF\-\+:\/\?]*
 CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*"\""
 SCOPEID   {ID}({ID}*{BN}*"::"{BN}*)*({ID}?)
 SCOPENAME "$"?(({ID}?{BN}*("::"|"."){BN}*)*)((~{BN}*)?{ID})
@@ -1919,7 +1920,7 @@ STopt  [^\n@\\]*
 
 <CiteLabel>{CITEID}                     { // found argument
                                           addCite(yyscanner);
-                                          addOutput(yyscanner,yytext);
+                                          //addOutput(yyscanner,yytext); // will be done in addCite
                                           BEGIN(Comment);
                                         }
 <CiteLabel>{DOCNL}                      { // missing argument
@@ -3100,6 +3101,8 @@ static void addCite(yyscan_t yyscanner)
     name=yytext+1;
     name=name.left((int)yyleng-2);
   }
+  name = undoMarkdown(name);
+  addOutput(yyscanner,name.data()); 
   CitationManager::instance().insert(name);
 }
 

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3107,6 +3107,15 @@ QCString markdownFileNameToId(const QCString &fileName)
   return res;
 }
 
+QCString undoMarkdown(const QCString &name)
+{
+  static bool markdownSupport = Config_getBool(MARKDOWN_SUPPORT);
+  if (!markdownSupport) return name;
+  QCString localName = substitute(name,"&ndash;","--");
+  localName = substitute(localName,"&mdash;","---");
+  return localName;
+}
+
 //---------------------------------------------------------------------------
 
 struct MarkdownOutlineParser::Private

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -28,6 +28,9 @@ class Entry;
 //QCString processMarkdown(const QCString &fileName,const int lineNr,Entry *e,const QCString &s);
 QCString markdownFileNameToId(const QCString &fileName);
 
+/* undo part of the markdown settings e.g.g for the \cite command */
+QCString undoMarkdown(const QCString &name);
+
 /// Helper class to process markdown formatted text
 class Markdown
 {

--- a/templates/html/bib2xhtml.pl
+++ b/templates/html/bib2xhtml.pl
@@ -57,7 +57,9 @@ sub html_ent {
 	s/\?\`/&iquest;/g;
 	s/\!\`/&iexcl;/g;
 	s/\-\-\-/&mdash;/g;
-	s/([^\!])\-\-([^\>])/$1&ndash;$2/g;
+        s/([^\!])\-\-([^\>])/$1&ndash;$2/g;
+        s/(CITEREF_[^\!])&ndash;([^\>])/$1--$2/g;
+        s/(CITEREF_[^\!])&mdash;([^\>])/$1---$2/g;
 	s/\\([aA]lpha)\b/&$1;/g;
 	s/\\([bB]eta)\b/&$1;/g;
 	s/\\([gG]amma)\b/&$1;/g;

--- a/templates/html/doxygen.bst
+++ b/templates/html/doxygen.bst
@@ -556,7 +556,7 @@ FUNCTION {format.article.crossref}
 	  warning$
 	  ""
 	}
-        { "<cite>" * journal * "</cite>" * }
+        { journal * }
       if$
     }
     { key * }
@@ -600,7 +600,7 @@ FUNCTION {format.book.crossref}
 	      crossref * warning$
 	      "" *
 	    }
-            { "<cite>" * series * "</cite>" * }
+            { series * }
 	  if$
 	}
 	{ key * }
@@ -623,7 +623,7 @@ FUNCTION {format.incoll.inproc.crossref}
 	      crossref * warning$
 	      ""
 	    }
-            { "<cite>" * booktitle * "</cite>" * }
+            { booktitle * }
 	  if$
 	}
         { key * }


### PR DESCRIPTION
When having a simple citation problem like:
```
/** \mainpage
- \\cite s--92 \cite s--92
- \\cite csos-frcms-95 \cite csos-frcms-95
*/
```
with the bib entries (a bit strange here but it is because of the example):
```
@phdthesis{s--92
, author =      "M. F. Sanner"
, title =       "??"
, school =      "UHA"
, address =     "France"
, year =        1992
, keywords =    "doctoral thesis"
, update =      "98.03 bibrelex"
}
@inproceedings{csos-frcms-95
, author =      "Michel F. Sanner and Arthur J. Olson and Jean-Claude Spehner"
, title =       "Fast and Robust Computation of Molecular Surfaces,"
, booktitle =   "Proc. 11th Annu. ACM Sympos. Comput. Geom."
, year =        1995
, pages =       "C60--C70"
, keywords =    "molecules, biology, visualization"
, crossref =    "s--92"
, update =      "98.03 bibrelex, 95.09 mitchell"
}
```
and the settings:
```
CITE_BIB_FILES  = mybib.bib
QUIET = YES
OUTPUT_DIRECTORY = docs
```
we get the warning like:
```
aa.h:2: warning: \cite command to 's' does not have an associated number
```

This is due to the fact that the `--` has been converted to `&ndash;`  in the cite IDs and the detection of the cite IDs was not prepared for this.
Also the output of the cross-references would contain the unknown / by doxygen not supported `<cite>` tag.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7745749/example.tar.gz)

(Found by doing some tests on CGAL citations).
