### PR TITLE
Fix inline check of markdown images

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1142,8 +1142,8 @@ int Markdown::processLink(const char *data,int offset,int size)
     // if there is non-whitespace before the ![ within the scope of two new lines, the image
     // is considered inlined, i.e. the image is not preceded by an empty line
     int numNLsNeeded=2;
-    int pos = offset-1;
-    while (pos>=0 && numNLsNeeded>0)
+    int pos = -1;
+    while (pos>=-offset && numNLsNeeded>0)
     {
       if (data[pos]=='\n') numNLsNeeded--;
       else if (data[pos]!=' ') // found non-whitespace, stop searching


### PR DESCRIPTION
Fixing the updated content of https://github.com/doxygen/doxygen/pull/8953 in https://github.com/doxygen/doxygen/commit/5bb622158e33aac19d23068c08f434aaced60b4c.

Offset is the offset in the original array but not the index in data[]