### PR TITLE
bug_693776 @copydoc not working properly

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1946,7 +1946,7 @@ STopt  [^\n@\\]*
 
 <CopyDoc><<EOF>>                        {
                                           setOutput(yyscanner,OutputDoc);
-                                          addOutput(yyscanner," \\copydetails ");
+                                          addOutput(yyscanner," \\ilinebr\\ilinebr\\copydetails ");
                                           addOutput(yyscanner,yyextra->copyDocArg);
                                           addOutput(yyscanner,"\n");
                                           BEGIN(Comment);
@@ -1956,7 +1956,7 @@ STopt  [^\n@\\]*
                                           if (yyextra->braceCount==0)
                                           {
                                             setOutput(yyscanner,OutputDoc);
-                                            addOutput(yyscanner," \\copydetails ");
+                                            addOutput(yyscanner," \\ilinebr\\ilinebr\\copydetails ");
                                             addOutput(yyscanner,yyextra->copyDocArg);
                                             addOutput(yyscanner,"\n");
                                             BEGIN(Comment);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -308,15 +308,7 @@ static void addRelatedPage(Entry *root)
     if (!g.groupname.isEmpty() && (gd=Doxygen::groupLinkedMap->find(g.groupname))) break;
   }
   //printf("---> addRelatedPage() %s gd=%p\n",qPrint(root->name),gd);
-  QCString doc;
-  if (root->brief.isEmpty())
-  {
-    doc=root->doc+root->inbodyDocs;
-  }
-  else
-  {
-    doc=root->brief+"\n\n"+root->doc+root->inbodyDocs;
-  }
+  QCString doc=root->doc+root->inbodyDocs;
 
   PageDef *pd = addRelatedPage(root->name,root->args,doc,
       root->docFile,
@@ -9363,6 +9355,7 @@ static void generateExampleDocs()
                          pd->docLine(),                            // startLine
                          pd.get(),                                 // context
                          0,                                        // memberDef
+                         (pd->briefDescription().isEmpty()?"":pd->briefDescription()+"\n\n")+
                          pd->documentation()+"\n\n\\include"+lineNoOptStr+" "+pd->name(), // docs
                          TRUE,                                     // index words
                          TRUE,                                     // is example

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -292,7 +292,7 @@ void PageDefImpl::writeDocumentation(OutputList &ol)
 void PageDefImpl::writePageDocumentation(OutputList &ol) const
 {
   ol.startTextBlock();
-  QCString docStr = documentation()+inbodyDocumentation();
+  QCString docStr = (briefDescription().isEmpty()?"":briefDescription()+"\n\n")+documentation()+inbodyDocumentation();
   if (hasBriefDescription() && !SectionManager::instance().find(name()))
   {
     ol.pushGeneratorState();

--- a/testing/043/mypage.xml
+++ b/testing/043/mypage.xml
@@ -36,7 +36,6 @@
       <para>Page brief description. </para>
     </briefdescription>
     <detaileddescription>
-      <para>Page brief description.</para>
       <para>Text at page level. See <ref refid="mypage_1mysect" kindref="member">Section Title.</ref> for more. </para>
       <sect1 id="mypage_1mysect">
         <title>Section Title.</title>


### PR DESCRIPTION
The visible problems is
- repeating the brief description in the detailed description resulting in the situation when using `\copydoc` that the brief is shown twice  and that it is directly concatenated

Solution:
- doxygen.cpp don't copy  brief description into the detailed description
- doxygen.cpp pagedef.cpp for the pages explicitly concatenate now the brief description so it is on the page as well.
- commentscan.l properly separate brief and details as if they were directly used.
- xmlgen.cpp output was incorrect as it also had the page brief description doubled

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7774486/example.tar.gz)
