### PR TITLE
Include qualified names in `<memberdef>`s in XML output

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -568,12 +568,6 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
      << "_1" << md->anchor() << "\" kind=\"" << memType << "\"><name>"
      << convertToXML(md->name()) << "</name></member>\n";
 
-  QCString scopeName;
-  if (md->getClassDef())
-    scopeName=md->getClassDef()->name();
-  else if (md->getNamespaceDef())
-    scopeName=md->getNamespaceDef()->name();
-
   t << "      <memberdef kind=\"";
   //enum { define_t,variable_t,typedef_t,enum_t,function_t } xmlType = function_t;
   t << memType << "\" id=\"";
@@ -820,6 +814,7 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
   }
 
   t << "        <name>" << convertToXML(md->name()) << "</name>\n";
+  t << "        <qualifiedname>" << convertToXML(md->qualifiedName()) << "</qualifiedname>\n";
 
   if (md->memberType() == MemberType_Property)
   {


### PR DESCRIPTION
Today, Doxygen models a number of C++ entities as members - functions, enums, typedefs, variables, etc. In the Doxygen XML output, these things are represented by `<memberdef>`s, which have a child `<name>` tag that has a local unqualified name for the entity. There is no way for us to get the fully qualified name of the entity. The closest we have (for some entities) is a "definition" (e.g. signature in the case of a function) from which a qualified name could theoretically be parsed, but doing so would be challenging (I've tried).

This is a big pain for those consuming the Doxygen XML output. This is impacting github.com/nvidia/thrust and github.com/nvidia/cub - we use github.com/matusnovak/doxybook2 to render our docs, which itself uses the Doxygen XML output.

When outputting a `<memberdef>`, I'd like to add a `<qualifiedname>` tag with qualified name of the thing in addition to the existing `<name>` tag.

Note that for things like classes, structs, and namespaces, only one name is output, and it's the fully qualified one.

I haven't included any tests or documentation for this PR because I'm unfamiliar with your test and documentation setup. If someone can give me some pointers on how to add tests and documentation I'd be happy to do that.