### PR TITLE
Coverity: side_effect_free: Calling countLines(yyscanner) is only useful for its return value, which is ignored.

### DIFF
--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1655,7 +1655,6 @@ void VHDLCodeParser::parseCode(CodeOutputInterface &od,
     VhdlDocGen::init();
     yyextra->lexInit=true;
   }
-  /*int iLine=*/countLines(yyscanner);
   vhdlcodeYYrestart( 0, yyscanner );
   BEGIN( Bases );
   vhdlcodeYYlex(yyscanner);


### PR DESCRIPTION
Removed call. Looks indeed that the call is now side-effects free, in the past there was the setting:
```
    yyextra->needsTermination=true;
```
in it, removed with:
```
Commit: 5ff3742e9dfdc98d8f0adc0ab0181b40fc8772c4 [5ff3742]
Date: Saturday, December 25, 2021 1:45:26 PM
Implemented a different solution

The various code parsers now have `insideCodeLine` boolean state variable that replaces
the `needsTermination` and keeps track if the parser in inside a line or not.
This information is now passe between lexcode.l and code.l to make sure the start
and end codelines stay balanced.
```