### PR TITLE
Consistent messages regarding enabling settings for VHDL

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2003,40 +2003,38 @@ void Config::checkAndCorrect(bool quiet, const bool check)
 
   //------------------------
   // some default settings for vhdl
-  if (Config_getBool(OPTIMIZE_OUTPUT_VHDL) &&
-      (Config_getBool(INLINE_INHERITED_MEMB) ||
-       Config_getBool(INHERIT_DOCS) ||
-       !Config_getBool(HIDE_SCOPE_NAMES) ||
-       !Config_getBool(EXTRACT_PRIVATE) ||
-       !Config_getBool(EXTRACT_PACKAGE)
-      )
-     )
+  if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
   {
-    bool b1 = Config_getBool(INLINE_INHERITED_MEMB);
-    bool b2 = Config_getBool(INHERIT_DOCS);
-    bool b3 = Config_getBool(HIDE_SCOPE_NAMES);
-    bool b4 = Config_getBool(EXTRACT_PRIVATE);
-    bool b5 = Config_getBool(SKIP_FUNCTION_MACROS);
-    bool b6 = Config_getBool(EXTRACT_PACKAGE);
-    const char *s1,*s2,*s3,*s4,*s5,*s6;
-    if (b1)  s1="  INLINE_INHERITED_MEMB  = NO (was YES)\n"; else s1="";
-    if (b2)  s2="  INHERIT_DOCS           = NO (was YES)\n"; else s2="";
-    if (!b3) s3="  HIDE_SCOPE_NAMES       = YES (was NO)\n"; else s3="";
-    if (!b4) s4="  EXTRACT_PRIVATE        = YES (was NO)\n"; else s4="";
-    if (b5)  s5="  ENABLE_PREPROCESSING   = NO (was YES)\n"; else s5="";
-    if (!b6) s6="  EXTRACT_PACKAGE        = YES (was NO)\n"; else s6="";
-
-
-    warn_uncond("enabling OPTIMIZE_OUTPUT_VHDL assumes the following settings:\n"
-               "%s%s%s%s%s%s",s1,s2,s3,s4,s5,s6
-              );
-
-    Config_updateBool(INLINE_INHERITED_MEMB, FALSE);
-    Config_updateBool(INHERIT_DOCS,          FALSE);
-    Config_updateBool(HIDE_SCOPE_NAMES,      TRUE);
-    Config_updateBool(EXTRACT_PRIVATE,       TRUE);
-    Config_updateBool(ENABLE_PREPROCESSING,  FALSE);
-    Config_updateBool(EXTRACT_PACKAGE,       TRUE);
+    if (Config_getBool(INLINE_INHERITED_MEMB))
+    {
+      err("When enabling OPTIMIZE_OUTPUT_VHDL the INLINE_INHERITED_MEMB should be disabled. I'll do it for you.\n");
+      Config_updateBool(INLINE_INHERITED_MEMB,FALSE);
+    }
+    if (Config_getBool(INHERIT_DOCS))
+    {
+      err("When enabling OPTIMIZE_OUTPUT_VHDL the INHERIT_DOCS should be disabled. I'll do it for you.\n");
+      Config_updateBool(INHERIT_DOCS,FALSE);
+    }
+    if (!Config_getBool(HIDE_SCOPE_NAMES))
+    {
+      err("When enabling OPTIMIZE_OUTPUT_VHDL the HIDE_SCOPE_NAMES should be enabled. I'll do it for you.\n");
+      Config_updateBool(HIDE_SCOPE_NAMES,TRUE);
+    }
+    if (!Config_getBool(EXTRACT_PRIVATE))
+    {
+      err("When enabling OPTIMIZE_OUTPUT_VHDL the EXTRACT_PRIVATE should be enabled. I'll do it for you.\n");
+      Config_updateBool(EXTRACT_PRIVATE,TRUE);
+    }
+    if (!Config_getBool(EXTRACT_PACKAGE))
+    {
+      err("When enabling OPTIMIZE_OUTPUT_VHDL the EXTRACT_PACKAGE should be enabled. I'll do it for you.\n");
+      Config_updateBool(EXTRACT_PACKAGE,TRUE);
+    }
+    if (Config_getBool(ENABLE_PREPROCESSING))
+    {
+      err("When enabling OPTIMIZE_OUTPUT_VHDL the ENABLE_PREPROCESSING should be disabled. I'll do it for you.\n");
+      Config_updateBool(ENABLE_PREPROCESSING,FALSE);
+    }
   }
 
   if (!checkFileName(Config_getString(GENERATE_TAGFILE),"GENERATE_TAGFILE"))


### PR DESCRIPTION
- making messages about automatic settings consistent with what has been done with GENERATE_HTMLHELP
- correcting the `ENABLE_PREPROCESSING` / `SKIP_FUNCTION_MACROS` settings, preprocessing does not make sense for VHDL (and as already disabled but based on an incorrect test)