### PR TITLE
Make email obfuscation optional

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3912,6 +3912,14 @@ This setting is not only used for dot files but also for msc temporary files.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='OBFUSCATE_EMAILS' defval='1'>
+      <docs>
+<![CDATA[
+If the \c OBFUSCATE_EMAILS tag is set to \c YES, doxygen will
+obfuscate email addresses.
+]]>
+      </docs>
+    </option>
     <option type='obsolete' orgtype='bool' id='USE_WINDOWS_ENCODING'/>
     <option type='obsolete' orgtype='bool' id='DETAILS_AT_TOP'/>
     <option type='obsolete' orgtype='string' id='QTHELP_FILE'/>

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -353,23 +353,30 @@ void HtmlDocVisitor::visit(DocEmoji *s)
 
 void HtmlDocVisitor::writeObfuscatedMailAddress(const QCString &url)
 {
-  m_t << "<a href=\"#\" onclick=\"location.href='mai'+'lto:'";
-  if (!url.isEmpty())
+  if (!Config_getBool(OBFUSCATE_EMAILS))
   {
-    const char *p = url.data();
-    uint size=3;
-    while (*p)
-    {
-      m_t << "+'";
-      for (uint j=0;j<size && *p;j++)
-      {
-        p = writeUTF8Char(m_t,p);
-      }
-      m_t << "'";
-      if (size==3) size=2; else size=3;
-    }
+    m_t << "<a href=\"mailto:" << url << "\">";
   }
-  m_t << "; return false;\">";
+  else
+  {
+    m_t << "<a href=\"#\" onclick=\"location.href='mai'+'lto:'";
+    if (!url.isEmpty())
+    {
+      const char *p = url.data();
+      uint size=3;
+      while (*p)
+      {
+        m_t << "+'";
+        for (uint j=0;j<size && *p;j++)
+        {
+          p = writeUTF8Char(m_t,p);
+        }
+        m_t << "'";
+        if (size==3) size=2; else size=3;
+      }
+    }
+    m_t << "; return false;\">";
+  }
 }
 
 void HtmlDocVisitor::visit(DocURL *u)
@@ -380,17 +387,24 @@ void HtmlDocVisitor::visit(DocURL *u)
     QCString url = u->url();
     // obfuscate the mail address link
     writeObfuscatedMailAddress(url);
-    const char *p = url.data();
-    // also obfuscate the address as shown on the web page
-    uint size=5;
-    while (*p)
+    if (!Config_getBool(OBFUSCATE_EMAILS))
     {
-      for (uint j=0;j<size && *p;j++)
+      m_t << url;
+    }
+    else
+    {
+      const char *p = url.data();
+      // also obfuscate the address as shown on the web page
+      uint size=5;
+      while (*p)
       {
-        p = writeUTF8Char(m_t,p);
+        for (uint j=0;j<size && *p;j++)
+        {
+          p = writeUTF8Char(m_t,p);
+        }
+        if (*p) m_t << "<span style=\"display: none;\">.nosp@m.</span>";
+        if (size==5) size=4; else size=5;
       }
-      if (*p) m_t << "<span style=\"display: none;\">.nosp@m.</span>";
-      if (size==5) size=4; else size=5;
     }
     m_t << "</a>";
   }


### PR DESCRIPTION
I've noticed that my email is obfuscated in Doxygen output, and that's definitely not that I want. There was no option to disable this behavior and I've added one. The default behavior is unchanged, but specifying `OBFUSCATE_EMAILS = False` in Doxyfile disables obfuscation.

Here's an example case:
```
README.md: Dmitry Marakasov <amdmi3@amdmi3.ru>
Doxyfile1: USE_MDFILE_AS_MAINPAGE = README.md
Doxyfile2: USE_MDFILE_AS_MAINPAGE = README.md
Doxyfile2: OBFUSCATE_EMAILS = False
```

Diff for generated `html/index.html` with `Doxyfile1` and `Doxyfile2`:
```patch
--- html/index.html	2021-12-29 17:03:55.598158000 +0300
+++ html/index.html	2021-12-29 17:03:59.660321000 +0300
@@ -65,7 +65,7 @@
   <div class="headertitle"><div class="title">My Project </div></div>
 </div><!--header-->
 <div class="contents">
-<div class="textblock"><p ><a class="anchor" id="md_README"></a> Dmitry Marakasov <a href="#" onclick="location.href='mai'+'lto:'+'amd'+'mi'+'3@a'+'md'+'mi3'+'.r'+'u'amdmi<span style="display: none;">.nosp@m.</span>3@am<span style="display: none;">.nosp@m.</span>dmi3.<span style="display: none;">.nosp@m.</span>ru</a> </p>
+<div class="textblock"><p ><a class="anchor" id="md_README"></a> Dmitry Marakasov <a href="mailto:amdmi3@amdmi3.ru">amdmi3@amdmi3.ru</a> </p>
 </div></div><!-- PageDoc -->
 </div><!-- contents -->
 <!-- start footer part -->
```