### PR TITLE
Redefinition of VHDL specifiers

### DIFF
--- a/src/classdef.h
+++ b/src/classdef.h
@@ -360,6 +360,8 @@ class ClassDef : public Definition
 
     virtual QCString requiresClause() const = 0;
 
+    virtual Spec getClassSpecifier() const = 0;
+
     //-----------------------------------------------------------------------------------
     // --- count members ----
     //-----------------------------------------------------------------------------------
@@ -396,7 +398,7 @@ class ClassDefMutable : public DefinitionMutable, public ClassDef
     virtual void setIsStatic(bool b) = 0;
     virtual void setCompoundType(CompoundType t) = 0;
     virtual void setClassName(const QCString &name) = 0;
-    virtual void setClassSpecifier(uint64 spec) = 0;
+    virtual void setClassSpecifier(Spec spec) = 0;
     virtual void setTemplateArguments(const ArgumentList &al) = 0;
     virtual void setTemplateBaseClassNames(const TemplateNameMap &templateNames) = 0;
     virtual void setTemplateMaster(const ClassDef *tm) = 0;

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2024,9 +2024,7 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     adjustBoolSetting(depOption,"INLINE_INHERITED_MEMB",false);
     adjustBoolSetting(depOption,"INHERIT_DOCS",         false);
     adjustBoolSetting(depOption,"HIDE_SCOPE_NAMES",     true );
-    adjustBoolSetting(depOption,"EXTRACT_PRIVATE",      true );
     adjustBoolSetting(depOption,"ENABLE_PREPROCESSING", false);
-    adjustBoolSetting(depOption,"EXTRACT_PACKAGE",      true );
   }
 
   if (!checkFileName(Config_getString(GENERATE_TAGFILE),"GENERATE_TAGFILE"))

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -5002,9 +5002,9 @@ class ClassListContext::Private : public GenericNodeListContext
     {
       for (const auto &cd : classLinkedMap)
       {
+        Spec spec=cd->getClassSpecifier();
         if (cd->getLanguage()==SrcLangExt_VHDL &&
-            ((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKAGECLASS ||
-             (VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKBODYCLASS)
+            ((spec&SpecifierPackage)!= 0 || (spec&SpecifierPackage_body)!= 0)
            ) // no architecture
         {
           continue;
@@ -5075,9 +5075,9 @@ class ClassIndexContext::Private
       {
         for (const auto &cd : *Doxygen::classLinkedMap)
         {
+          Spec spec=cd->getClassSpecifier();
           if (cd->getLanguage()==SrcLangExt_VHDL &&
-              ((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKAGECLASS ||
-               (VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKBODYCLASS)
+              ((spec&SpecifierPackage)!= 0 || (spec&SpecifierPackage_body)!= 0)
              ) // no architecture
           {
             continue;
@@ -5731,8 +5731,8 @@ class NestingContext::Private : public GenericNodeListContext
     {
       if (cd->getLanguage()==SrcLangExt_VHDL)
       {
-        if ((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKAGECLASS ||
-            (VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKBODYCLASS
+        Spec spec=cd->getClassSpecifier();
+        if ((spec&SpecifierPackage)!= 0 || (spec&SpecifierPackage_body)!= 0
            )// no architecture
         {
           return;
@@ -5893,7 +5893,8 @@ class NestingContext::Private : public GenericNodeListContext
       for (const auto &bcd : bcl)
       {
         const ClassDef *cd=bcd.classDef;
-        if (cd->getLanguage()==SrcLangExt_VHDL && (VhdlDocGen::VhdlClasses)cd->protection()!=VhdlDocGen::ENTITYCLASS)
+        Spec spec=cd->getClassSpecifier();
+        if (cd->getLanguage()==SrcLangExt_VHDL && (spec&SpecifierEntity)==0)
         {
           continue;
         }
@@ -5923,7 +5924,8 @@ class NestingContext::Private : public GenericNodeListContext
         bool b;
         if (cd->getLanguage()==SrcLangExt_VHDL)
         {
-          if ((VhdlDocGen::VhdlClasses)cd->protection()!=VhdlDocGen::ENTITYCLASS)
+          Spec spec=cd->getClassSpecifier();
+          if ((spec&SpecifierEntity)==0)
           {
             continue;
           }

--- a/src/dotgfxhierarchytable.cpp
+++ b/src/dotgfxhierarchytable.cpp
@@ -181,9 +181,8 @@ void DotGfxHierarchyTable::addClassList(const ClassLinkedMap &cl,ClassDefSet &vi
   for (const auto &cd : cl)
   {
     //printf("Trying %s subClasses=%d\n",qPrint(cd->name()),cd->subClasses()->count());
-    if (cd->getLanguage()==SrcLangExt_VHDL &&
-      (VhdlDocGen::VhdlClasses)cd->protection()!=VhdlDocGen::ENTITYCLASS
-      )
+    Spec spec=cd->getClassSpecifier();
+    if (cd->getLanguage()==SrcLangExt_VHDL && (spec&SpecifierEntity)==0)
     {
       continue;
     }

--- a/src/entry.h
+++ b/src/entry.h
@@ -118,73 +118,6 @@ class Entry
       EXAMPLE_LINENO_SEC     = 0x1B000000,
     };
 
-    // class specifiers (add new items to the end)
-    static const uint64 Template        = (1ULL<<0);
-    static const uint64 Generic         = (1ULL<<1);
-    static const uint64 Ref             = (1ULL<<2);
-    static const uint64 Value           = (1ULL<<3);
-    static const uint64 Interface       = (1ULL<<4);
-    static const uint64 Struct          = (1ULL<<5);
-    static const uint64 Union           = (1ULL<<6);
-    static const uint64 Exception       = (1ULL<<7);
-    static const uint64 Protocol        = (1ULL<<8);
-    static const uint64 Category        = (1ULL<<9);
-    static const uint64 SealedClass     = (1ULL<<10);
-    static const uint64 AbstractClass   = (1ULL<<11);
-    static const uint64 Enum            = (1ULL<<12); // for Java-style enums
-    static const uint64 Service         = (1ULL<<13); // UNO IDL
-    static const uint64 Singleton       = (1ULL<<14); // UNO IDL
-    static const uint64 ForwardDecl     = (1ULL<<15); // forward declared template classes
-    static const uint64 Local           = (1ULL<<16); // for Slice types
-
-    // member specifiers (add new items to the beginning)
-    static const uint64 EnumStruct      = (1ULL<<18);
-    static const uint64 ConstExpr       = (1ULL<<19); // C++11 constexpr
-    static const uint64 PrivateGettable     = (1ULL<<20); // C# private getter
-    static const uint64 ProtectedGettable   = (1ULL<<21); // C# protected getter
-    static const uint64 PrivateSettable     = (1ULL<<22); // C# private setter
-    static const uint64 ProtectedSettable   = (1ULL<<23); // C# protected setter
-    static const uint64 Inline          = (1ULL<<24);
-    static const uint64 Explicit        = (1ULL<<25);
-    static const uint64 Mutable         = (1ULL<<26);
-    static const uint64 Settable        = (1ULL<<27);
-    static const uint64 Gettable        = (1ULL<<28);
-    static const uint64 Readable        = (1ULL<<29);
-    static const uint64 Writable        = (1ULL<<30);
-    static const uint64 Final           = (1ULL<<31);
-    static const uint64 Abstract        = (1ULL<<32);
-    static const uint64 Addable         = (1ULL<<33);
-    static const uint64 Removable       = (1ULL<<34);
-    static const uint64 Raisable        = (1ULL<<35);
-    static const uint64 Override        = (1ULL<<36);
-    static const uint64 New             = (1ULL<<37);
-    static const uint64 Sealed          = (1ULL<<38);
-    static const uint64 Initonly        = (1ULL<<39);
-    static const uint64 Optional        = (1ULL<<40);
-    static const uint64 Required        = (1ULL<<41);
-    static const uint64 NonAtomic       = (1ULL<<42);
-    static const uint64 Copy            = (1ULL<<43);
-    static const uint64 Retain          = (1ULL<<44);
-    static const uint64 Assign          = (1ULL<<45);
-    static const uint64 Strong          = (1ULL<<46);
-    static const uint64 Weak            = (1ULL<<47);
-    static const uint64 Unretained      = (1ULL<<48);
-    static const uint64 Alias           = (1ULL<<49);
-    static const uint64 ConstExp        = (1ULL<<50);
-    static const uint64 Default         = (1ULL<<51);
-    static const uint64 Delete          = (1ULL<<52);
-    static const uint64 NoExcept        = (1ULL<<53);
-    static const uint64 Attribute       = (1ULL<<54); // UNO IDL attribute
-    static const uint64 Property        = (1ULL<<55); // UNO IDL property
-    static const uint64 Readonly        = (1ULL<<56); // on UNO IDL attribute or property
-    static const uint64 Bound           = (1ULL<<57); // on UNO IDL attribute or property
-    static const uint64 Constrained     = (1ULL<<58); // on UNO IDL property
-    static const uint64 Transient       = (1ULL<<59); // on UNO IDL property
-    static const uint64 MaybeVoid       = (1ULL<<60); // on UNO IDL property
-    static const uint64 MaybeDefault    = (1ULL<<61); // on UNO IDL property
-    static const uint64 MaybeAmbiguous  = (1ULL<<62); // on UNO IDL property
-    static const uint64 Published       = (1ULL<<63); // UNO IDL keyword
-
     enum GroupDocType
     {
       GROUPDOC_NORMAL,        //!< defgroup
@@ -245,7 +178,7 @@ class Entry
     // content
     Protection protection;    //!< class protection
     MethodTypes mtype;        //!< signal, slot, (dcop) method, or property?
-    uint64 spec;              //!< class/member specifiers
+    Spec spec;                //!< class/member specifiers
     int  initLines;           //!< define/variable initializer lines to show
     bool stat;                //!< static ?
     bool explicitExternal;    //!< explicitly defined as external?
@@ -290,7 +223,7 @@ class Entry
     QCString	fileName;     //!< file this entry was extracted from
     int		startLine;    //!< start line of entry in the source
     int		startColumn;  //!< start column of entry in the source
-    RefItemVector sli; //!< special lists (test/todo/bug/deprecated/..) this entry is in
+    RefItemVector sli;        //!< special lists (test/todo/bug/deprecated/..) this entry is in
     SrcLangExt  lang;         //!< programming language in which this entry was found
     bool        hidden;       //!< does this represent an entity that is hidden from the output
     bool        artificial;   //!< Artificially introduced item

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -657,7 +657,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 {BS}"::"{BS}                            {}
 
 abstract                                {
-                                          yyextra->current->spec |= Entry::AbstractClass;
+                                          yyextra->current->spec |= SpecifierAbstractClass;
                                         }
 extends{ARGS}                           {
                                           QCString basename = extractFromParens(yytext).lower();
@@ -676,7 +676,7 @@ private                                 {
                                         }
 {ID}                                    { /* type name found */
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec |= Entry::Struct;
+                                          yyextra->current->spec |= SpecifierStruct;
                                           yyextra->current->name = yytext;
                                           yyextra->current->fileName = yyextra->fileName;
                                           yyextra->current->bodyLine  = yyextra->lineNr;
@@ -701,7 +701,7 @@ private                                 {
                                           yyextra->current->type = QCString(yytext).simplifyWhiteSpace();
                                         }
 ^{BS}final                              {
-                                          yyextra->current->spec |= Entry::Final;
+                                          yyextra->current->spec |= SpecifierFinal;
                                           yyextra->current->type = QCString(yytext).simplifyWhiteSpace();
                                         }
 ^{BS}generic                            {
@@ -1077,7 +1077,7 @@ private                                 {
                                           yyextra->typeProtection = yyextra->defaultProtection;
                                           yyextra->typeMode = true;
 
-                                          yyextra->current->spec |= Entry::Struct;
+                                          yyextra->current->spec |= SpecifierStruct;
                                           yyextra->current->name.resize(0);
                                           yyextra->current->args.resize(0);
                                           yyextra->current->name.sprintf("@%d",yyextra->anonCount++);
@@ -2392,7 +2392,7 @@ static void addInterface(yyscan_t yyscanner,QCString name, InterfaceType type)
   }
 
   yyextra->current->section = Entry::CLASS_SEC; // was Entry::INTERFACE_SEC;
-  yyextra->current->spec = Entry::Interface;
+  yyextra->current->spec = SpecifierInterface;
   yyextra->current->name = name;
 
   switch (type)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -430,7 +430,8 @@ static void writeClassTreeToOutput(OutputList &ol,const BaseClassList &bcl,int l
   for (const auto &bcd : bcl)
   {
     ClassDef *cd=bcd.classDef;
-    if (cd->getLanguage()==SrcLangExt_VHDL && (VhdlDocGen::VhdlClasses)cd->protection()!=VhdlDocGen::ENTITYCLASS)
+    Spec spec=cd->getClassSpecifier();
+    if (cd->getLanguage()==SrcLangExt_VHDL && (spec&SpecifierEntity)==0)
     {
       continue;
     }
@@ -792,7 +793,8 @@ static void writeClassTreeForList(OutputList &ol,const ClassLinkedMap &cl,bool &
     bool b;
     if (cd->getLanguage()==SrcLangExt_VHDL)
     {
-      if ((VhdlDocGen::VhdlClasses)cd->protection()!=VhdlDocGen::ENTITYCLASS)
+      Spec spec=cd->getClassSpecifier();
+      if ((spec&SpecifierEntity)==0)
       {
         continue;
       }
@@ -1527,13 +1529,12 @@ static void writeClassTree(const ListType &cl,FTVHelp *ftv,bool addToIndex,bool 
     ClassDefMutable *cdm = toClassDefMutable(cd);
     if (cdm && cd->getLanguage()==SrcLangExt_VHDL)
     {
-      if ((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKAGECLASS ||
-          (VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKBODYCLASS
-         )// no architecture
+      Spec spec=cd->getClassSpecifier();
+      if ((spec&SpecifierPackage)!= 0 || (spec&SpecifierPackage_body)!= 0)// no architecture
       {
         continue;
       }
-      if ((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::ARCHITECTURECLASS)
+      if (cd->getLanguage()==SrcLangExt_VHDL && (spec&SpecifierArchitecture)==0)
       {
         QCString n=cd->name();
         cdm->setClassName(n);
@@ -1947,9 +1948,9 @@ static void writeAnnotatedClassList(OutputList &ol,ClassDef::CompoundType ct)
 
   for (const auto &cd : *Doxygen::classLinkedMap)
   {
+    Spec spec=cd->getClassSpecifier();
     if (cd->getLanguage()==SrcLangExt_VHDL &&
-        ((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKAGECLASS ||
-         (VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::PACKBODYCLASS)
+        ((spec&SpecifierPackage)!= 0 || (spec&SpecifierPackage_body)!= 0)
        ) // no architecture
     {
       continue;
@@ -1977,8 +1978,8 @@ static void writeAnnotatedClassList(OutputList &ol,ClassDef::CompoundType ct)
       ol.startIndexKey();
       if (cd->getLanguage()==SrcLangExt_VHDL)
       {
-        QCString prot= VhdlDocGen::getProtectionName((VhdlDocGen::VhdlClasses)cd->protection());
-        ol.docify(prot);
+        QCString specName= VhdlDocGen::getSpecifierName(spec);
+        ol.docify(specName);
         ol.writeString(" ");
       }
       ol.writeObjectLink(QCString(),cd->getOutputFileBase(),cd->anchor(),cd->displayName());
@@ -2079,7 +2080,8 @@ static void writeAlphabeticalClassList(OutputList &ol, ClassDef::CompoundType ct
       continue;
     if (cd->isLinkableInProject() && cd->templateMaster()==0)
     {
-      if (cd->getLanguage()==SrcLangExt_VHDL && !((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::ENTITYCLASS ))// no architecture
+      Spec spec=cd->getClassSpecifier();
+      if (cd->getLanguage()==SrcLangExt_VHDL && (spec&SpecifierEntity)==0)
         continue;
 
       // get the first UTF8 character (after the part that should be ignored)
@@ -2116,7 +2118,8 @@ static void writeAlphabeticalClassList(OutputList &ol, ClassDef::CompoundType ct
   {
     if (sliceOpt && cd->compoundType() != ct)
       continue;
-    if (cd->getLanguage()==SrcLangExt_VHDL && !((VhdlDocGen::VhdlClasses)cd->protection()==VhdlDocGen::ENTITYCLASS ))// no architecture
+    Spec spec=cd->getClassSpecifier();
+    if (cd->getLanguage()==SrcLangExt_VHDL && (spec&SpecifierEntity)==0)
       continue;
 
     if (cd->isLinkableInProject() && cd->templateMaster()==0)

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -831,7 +831,7 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                   } },
   { "class/memberdecl/nestedclasses",             { startCb(&LayoutParser::startSectionEntry,LayoutDocEntry::ClassNestedClasses,
                                                             []() { return compileOptions(/*default*/        theTranslator->trCompounds(),
-                                                                                         SrcLangExt_VHDL,   theTranslator->trVhdlType(VhdlDocGen::ENTITY,FALSE),
+                                                                                         SrcLangExt_VHDL,   theTranslator->trVhdlType(SpecifierEntity,FALSE),
                                                                                          SrcLangExt_Fortran,theTranslator->trDataTypes()); }),
                                                     endCb()
                                                   } },
@@ -1076,7 +1076,7 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                   } },
   { "namespace/memberdecl/classes",               { startCb(&LayoutParser::startSectionEntry,LayoutDocEntry::NamespaceClasses,
                                                             []() { return compileOptions(/* default */      theTranslator->trCompounds(),
-                                                                           SrcLangExt_VHDL,   theTranslator->trVhdlType(VhdlDocGen::ENTITY,FALSE),
+                                                                           SrcLangExt_VHDL,   theTranslator->trVhdlType(SpecifierEntity,FALSE),
                                                                            SrcLangExt_Fortran,theTranslator->trDataTypes()); }),
                                                     endCb()
                                                   } },
@@ -1199,7 +1199,7 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                   } },
   { "file/memberdecl/classes",                    { startCb(&LayoutParser::startSectionEntry,LayoutDocEntry::FileClasses,
                                                             []() { return compileOptions(/* default */      theTranslator->trCompounds(),
-                                                                                         SrcLangExt_VHDL,   theTranslator->trVhdlType(VhdlDocGen::ENTITY,FALSE),
+                                                                                         SrcLangExt_VHDL,   theTranslator->trVhdlType(SpecifierEntity,FALSE),
                                                                                          SrcLangExt_Fortran,theTranslator->trDataTypes()); }),
                                                     endCb()
                                                   } },
@@ -1325,7 +1325,7 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
 
   { "group/memberdecl/classes",                   { startCb(&LayoutParser::startSectionEntry, LayoutDocEntry::GroupClasses,
                                                             []() { return compileOptions(/* default */       theTranslator->trCompounds(),
-                                                                                         SrcLangExt_VHDL,    theTranslator->trVhdlType(VhdlDocGen::ENTITY,FALSE),
+                                                                                         SrcLangExt_VHDL,    theTranslator->trVhdlType(SpecifierEntity,FALSE),
                                                                                          SrcLangExt_Fortran, theTranslator->trDataTypes()); }),
                                                     endCb()
                                                   } },

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -74,7 +74,7 @@ class MemberDef : public Definition
     virtual QCString extraTypeChars() const = 0;
     virtual const QCString &initializer() const = 0;
     virtual int initializerLines() const = 0;
-    virtual uint64 getMemberSpecifiers() const = 0;
+    virtual Spec getMemberSpecifiers() const = 0;
     virtual const MemberList *getSectionList(const Definition *container) const = 0;
     virtual QCString    displayDefinition() const = 0;
 
@@ -308,8 +308,8 @@ class MemberDefMutable : public DefinitionMutable, public MemberDef
     virtual void setFileDef(const FileDef *fd) = 0;
     virtual void setAnchor() = 0;
     virtual void setProtection(Protection p) = 0;
-    virtual void setMemberSpecifiers(uint64 s) = 0;
-    virtual void mergeMemberSpecifiers(uint64 s) = 0;
+    virtual void setMemberSpecifiers(Spec s) = 0;
+    virtual void mergeMemberSpecifiers(Spec s) = 0;
     virtual void setInitializer(const QCString &i) = 0;
     virtual void setBitfields(const QCString &s) = 0;
     virtual void setMaxInitLines(int lines) = 0;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -961,7 +961,7 @@ NONLopt [^\n]*
                                           else if (qstrncmp(yytext,"@property",9)==0) // ObjC 2.0 property
                                           {
                                             yyextra->current->mtype = yyextra->mtype = Property;
-                                            yyextra->current->spec|=Entry::Readable | Entry::Writable | Entry::Assign;
+                                            yyextra->current->spec|=SpecifierReadable | SpecifierWritable | SpecifierAssign;
                                             yyextra->current->protection = Public ;
                                             unput('(');
                                             BEGIN( ObjCPropAttr );
@@ -978,34 +978,34 @@ NONLopt [^\n]*
                                           yyextra->current->write = yytext+7;
                                         }
 <ObjCPropAttr>"readonly"                {
-                                          yyextra->current->spec&=~Entry::Writable;
+                                          yyextra->current->spec&=~SpecifierWritable;
                                         }
 <ObjCPropAttr>"readwrite"               { // default
                                         }
 <ObjCPropAttr>"assign"                  { // default
                                         }
 <ObjCPropAttr>"unsafe_unretained"       {
-                                          yyextra->current->spec&=~Entry::Assign;
-                                          yyextra->current->spec|=Entry::Unretained;
+                                          yyextra->current->spec&=~SpecifierAssign;
+                                          yyextra->current->spec|=SpecifierUnretained;
                                         }
 <ObjCPropAttr>"retain"                  {
-                                          yyextra->current->spec&=~Entry::Assign;
-                                          yyextra->current->spec|=Entry::Retain;
+                                          yyextra->current->spec&=~SpecifierAssign;
+                                          yyextra->current->spec|=SpecifierRetain;
                                         }
 <ObjCPropAttr>"copy"                    {
-                                          yyextra->current->spec&=~Entry::Assign;
-                                          yyextra->current->spec|=Entry::Copy;
+                                          yyextra->current->spec&=~SpecifierAssign;
+                                          yyextra->current->spec|=SpecifierCopy;
                                         }
 <ObjCPropAttr>"weak"                    {
-                                          yyextra->current->spec&=~Entry::Assign;
-                                          yyextra->current->spec|=Entry::Weak;
+                                          yyextra->current->spec&=~SpecifierAssign;
+                                          yyextra->current->spec|=SpecifierWeak;
                                         }
 <ObjCPropAttr>"strong"                  {
-                                          yyextra->current->spec&=~Entry::Assign;
-                                          yyextra->current->spec|=Entry::Strong;
+                                          yyextra->current->spec&=~SpecifierAssign;
+                                          yyextra->current->spec|=SpecifierStrong;
                                         }
 <ObjCPropAttr>"nonatomic"               {
-                                          yyextra->current->spec|=Entry::NonAtomic;
+                                          yyextra->current->spec|=SpecifierNonAtomic;
                                         }
 <ObjCPropAttr>")"                       {
                                           BEGIN(FindMembers);
@@ -1028,7 +1028,7 @@ NONLopt [^\n]*
                                           else if (qstrcmp(yytext,"@property")==0) // ObjC 2.0 property
                                           {
                                             yyextra->current->mtype = yyextra->mtype = Property;
-                                            yyextra->current->spec|=Entry::Writable | Entry::Readable;
+                                            yyextra->current->spec|=SpecifierWritable | SpecifierReadable;
                                             yyextra->current->protection = Public ;
                                           }
                                           else if (qstrcmp(yytext,"@synthesize")==0)
@@ -1075,7 +1075,7 @@ NONLopt [^\n]*
                                         }
 <FindMembers>{B}*"initonly"{BN}+        { if (yyextra->insideJava) REJECT;
                                           yyextra->current->type += " initonly ";
-                                          if (yyextra->insideCli) yyextra->current->spec |= Entry::Initonly;
+                                          if (yyextra->insideCli) yyextra->current->spec |= SpecifierInitonly;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"static"{BN}+          { yyextra->current->type += " static ";
@@ -1106,7 +1106,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"constexpr"{BN}+       {
                                           if (yyextra->insideCpp)
                                           {
-                                            yyextra->current->spec |= Entry::ConstExpr;
+                                            yyextra->current->spec |= SpecifierConstExpr;
                                           }
                                           REJECT;
                                         }
@@ -1114,7 +1114,7 @@ NONLopt [^\n]*
                                           if (yyextra->insideIDL)
                                           {
                                             lineCount(yyscanner);
-                                            yyextra->current->spec |= Entry::Published;
+                                            yyextra->current->spec |= SpecifierPublished;
                                           }
                                           else
                                           {
@@ -1131,37 +1131,37 @@ NONLopt [^\n]*
                                             }
                                             else
                                             {
-                                              yyextra->current->spec|=Entry::Abstract;
+                                              yyextra->current->spec|=SpecifierAbstract;
                                             }
                                           }
                                           else
                                           {
-                                            yyextra->current->spec|=Entry::Abstract;
+                                            yyextra->current->spec|=SpecifierAbstract;
                                           }
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"inline"{BN}+          { if (yyextra->insideJava) REJECT;
-                                          yyextra->current->spec|=Entry::Inline;
+                                          yyextra->current->spec|=SpecifierInline;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"mutable"{BN}+         { if (yyextra->insideJava) REJECT;
-                                          yyextra->current->spec|=Entry::Mutable;
+                                          yyextra->current->spec|=SpecifierMutable;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"explicit"{BN}+        { if (yyextra->insideJava) REJECT;
-                                          yyextra->current->spec|=Entry::Explicit;
+                                          yyextra->current->spec|=SpecifierExplicit;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"local"{BN}+           { if (yyextra->insideJava) REJECT;
-                                          yyextra->current->spec|=Entry::Local;
+                                          yyextra->current->spec|=SpecifierLocal;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"@required"{BN}+       { // Objective C 2.0 protocol required section
-                                          yyextra->current->spec=(yyextra->current->spec & ~Entry::Optional) | Entry::Required;
+                                          yyextra->current->spec=(yyextra->current->spec & ~SpecifierOptional) | SpecifierRequired;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"@optional"{BN}+       {  // Objective C 2.0 protocol optional section
-                                          yyextra->current->spec=(yyextra->current->spec & ~Entry::Required) | Entry::Optional;
+                                          yyextra->current->spec=(yyextra->current->spec & ~SpecifierRequired) | SpecifierOptional;
                                           lineCount(yyscanner);
                                         }
   /*
@@ -1260,9 +1260,9 @@ NONLopt [^\n]*
                                           {
                                             yyextra->isTypedef=FALSE;
                                             yyextra->current->section = Entry::CLASS_SEC;
-                                            yyextra->current->spec = Entry::Service |
+                                            yyextra->current->spec = SpecifierService |
                                               // preserve UNO IDL [optional] or published
-                                              (yyextra->current->spec & (Entry::Optional|Entry::Published));
+                                              (yyextra->current->spec & (SpecifierOptional|SpecifierPublished));
                                             addType(yyscanner);
                                             yyextra->current->type += " service " ;
                                             yyextra->current->fileName  = yyextra->fileName;
@@ -1283,8 +1283,8 @@ NONLopt [^\n]*
                                           {
                                             yyextra->isTypedef=FALSE;
                                             yyextra->current->section = Entry::CLASS_SEC;
-                                            yyextra->current->spec = Entry::Singleton |
-                                              (yyextra->current->spec & Entry::Published); // preserve
+                                            yyextra->current->spec = SpecifierSingleton |
+                                              (yyextra->current->spec & SpecifierPublished); // preserve
                                             addType(yyscanner);
                                             yyextra->current->type += " singleton " ;
                                             yyextra->current->fileName  = yyextra->fileName;
@@ -1305,9 +1305,9 @@ NONLopt [^\n]*
                                           {
                                             yyextra->isTypedef=FALSE;
                                             yyextra->current->section = Entry::CLASS_SEC;
-                                            yyextra->current->spec = Entry::Interface |
+                                            yyextra->current->spec = SpecifierInterface |
                                                 // preserve UNO IDL [optional], published, Slice local
-                                                (yyextra->current->spec & (Entry::Optional|Entry::Published|Entry::Local));
+                                                (yyextra->current->spec & (SpecifierOptional|SpecifierPublished|SpecifierLocal));
                                             addType(yyscanner);
                                             yyextra->current->type += " interface" ;
                                             yyextra->current->fileName  = yyextra->fileName;
@@ -1342,7 +1342,7 @@ NONLopt [^\n]*
                                           lineCount(yyscanner);
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec = Entry::Interface;
+                                          yyextra->current->spec = SpecifierInterface;
                                           if (!yyextra->insideJava)
                                           {
                                             yyextra->language = yyextra->current->lang = SrcLangExt_ObjC;
@@ -1362,7 +1362,7 @@ NONLopt [^\n]*
                                           lineCount(yyscanner);
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec = Entry::Protocol;
+                                          yyextra->current->spec = SpecifierProtocol;
                                           yyextra->language = yyextra->current->lang = SrcLangExt_ObjC;
                                           yyextra->insideObjC = TRUE;
                                           yyextra->current->protection = yyextra->protection = Public ;
@@ -1380,9 +1380,9 @@ NONLopt [^\n]*
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
                                           // preserve UNO IDL, Slice local
-                                          yyextra->current->spec    = Entry::Exception |
-                                            (yyextra->current->spec & Entry::Published) |
-                                            (yyextra->current->spec & Entry::Local);
+                                          yyextra->current->spec    = SpecifierException |
+                                            (yyextra->current->spec & SpecifierPublished) |
+                                            (yyextra->current->spec & SpecifierLocal);
                                           addType(yyscanner);
                                           yyextra->current->type += " exception" ;
                                           yyextra->current->fileName  = yyextra->fileName;
@@ -1402,15 +1402,15 @@ NONLopt [^\n]*
                                           bool isVolatile=decl.find("volatile")!=-1;
                                           yyextra->current->section = Entry::CLASS_SEC;
                                           addType(yyscanner);
-                                          uint64 spec = yyextra->current->spec;
-                                          if (yyextra->insidePHP && yyextra->current->spec&Entry::Abstract)
+                                          Spec spec = yyextra->current->spec;
+                                          if (yyextra->insidePHP && yyextra->current->spec&SpecifierAbstract)
                                           {
                                             // convert Abstract to AbstractClass
-                                            yyextra->current->spec=(yyextra->current->spec&~Entry::Abstract)|Entry::AbstractClass;
+                                            yyextra->current->spec=(yyextra->current->spec&~SpecifierAbstract)|SpecifierAbstractClass;
                                           }
-                                          if (yyextra->insideSlice && spec&Entry::Local)
+                                          if (yyextra->insideSlice && spec&SpecifierLocal)
                                           {
-                                            yyextra->current->spec|=Entry::Local;
+                                            yyextra->current->spec|=SpecifierLocal;
                                           }
                                           if (isConst)
                                           {
@@ -1439,7 +1439,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"value class"{BN}+     {
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec = Entry::Value;
+                                          yyextra->current->spec = SpecifierValue;
                                           addType(yyscanner);
                                           yyextra->current->type += " value class" ;
                                           yyextra->current->fileName  = yyextra->fileName;
@@ -1455,7 +1455,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"ref class"{BN}+       {
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec = Entry::Ref;
+                                          yyextra->current->spec = SpecifierRef;
                                           addType(yyscanner);
                                           yyextra->current->type += " ref class" ;
                                           yyextra->current->fileName  = yyextra->fileName;
@@ -1471,7 +1471,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"interface class"{BN}+ {
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec = Entry::Interface;
+                                          yyextra->current->spec = SpecifierInterface;
                                           addType(yyscanner);
                                           yyextra->current->type += " interface class" ;
                                           yyextra->current->fileName  = yyextra->fileName;
@@ -1515,10 +1515,10 @@ NONLopt [^\n]*
                                           bool isVolatile=decl.find("volatile")!=-1;
                                           yyextra->current->section = Entry::CLASS_SEC ;
                                           // preserve UNO IDL & Inline attributes, Slice local
-                                          yyextra->current->spec    = Entry::Struct |
-                                            (yyextra->current->spec & Entry::Published) |
-                                            (yyextra->current->spec & Entry::Inline) |
-                                            (yyextra->current->spec & Entry::Local);
+                                          yyextra->current->spec    = SpecifierStruct |
+                                            (yyextra->current->spec & SpecifierPublished) |
+                                            (yyextra->current->spec & SpecifierInline) |
+                                            (yyextra->current->spec & SpecifierLocal);
                                           // bug 582676: can be a struct nested in an interface so keep yyextra->insideObjC state
                                           //yyextra->current->objc    = yyextra->insideObjC = FALSE;
                                           addType(yyscanner);
@@ -1544,7 +1544,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"value struct"{BN}+     {
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec    = Entry::Struct | Entry::Value;
+                                          yyextra->current->spec    = SpecifierStruct | SpecifierValue;
                                           addType(yyscanner);
                                           yyextra->current->type += " value struct" ;
                                           yyextra->current->fileName  = yyextra->fileName;
@@ -1560,7 +1560,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"ref struct"{BN}+     {
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec    = Entry::Struct | Entry::Ref;
+                                          yyextra->current->spec    = SpecifierStruct | SpecifierRef;
                                           addType(yyscanner);
                                           yyextra->current->type += " ref struct" ;
                                           yyextra->current->fileName  = yyextra->fileName;
@@ -1576,7 +1576,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"interface struct"{BN}+ {
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec    = Entry::Struct | Entry::Interface;
+                                          yyextra->current->spec    = SpecifierStruct | SpecifierInterface;
                                           addType(yyscanner);
                                           yyextra->current->type += " interface struct";
                                           yyextra->current->fileName  = yyextra->fileName;
@@ -1596,7 +1596,7 @@ NONLopt [^\n]*
                                           bool isConst=decl.find("const")!=-1;
                                           bool isVolatile=decl.find("volatile")!=-1;
                                           yyextra->current->section = Entry::CLASS_SEC;
-                                          yyextra->current->spec    = Entry::Union;
+                                          yyextra->current->spec    = SpecifierUnion;
                                           // bug 582676: can be a struct nested in an interface so keep yyextra->insideObjC state
                                           //yyextra->current->objc    = yyextra->insideObjC = FALSE;
                                           addType(yyscanner);
@@ -1627,7 +1627,7 @@ NONLopt [^\n]*
                                           if (yyextra->insideJava)
                                           {
                                             yyextra->current->section = Entry::CLASS_SEC;
-                                            yyextra->current->spec    = Entry::Enum;
+                                            yyextra->current->spec    = SpecifierEnum;
                                           }
                                           else
                                           {
@@ -1637,12 +1637,12 @@ NONLopt [^\n]*
                                           yyextra->current->type += " enum";
                                           if (isStrongEnum)
                                           {
-                                            yyextra->current->spec |= Entry::Strong;
+                                            yyextra->current->spec |= SpecifierStrong;
                                           }
                                           if (isEnumSytruct)
                                           {
-                                            yyextra->current->spec |= Entry::Strong;
-                                            yyextra->current->spec |= Entry::EnumStruct;
+                                            yyextra->current->spec |= SpecifierStrong;
+                                            yyextra->current->spec |= SpecifierEnumStruct;
                                           }
                                           yyextra->current->fileName  = yyextra->fileName;
                                           yyextra->current->startLine = yyextra->yyLineNr;
@@ -1695,7 +1695,7 @@ NONLopt [^\n]*
 <FindMembers>("template"|"generic")({BN}*)"<"/[>]?      {  // generic is a C++/CLI extension
                                           lineCount(yyscanner);
                                           ArgumentList al;
-                                          //yyextra->current->spec |= (yytext[0]=='g') ? Entry::Generic : Entry::Template;
+                                          //yyextra->current->spec |= (yytext[0]=='g') ? SpecifierGeneric : SpecifierTemplate;
                                           yyextra->current->tArgLists.push_back(al);
                                           yyextra->currentArgumentList = &yyextra->current->tArgLists.back();
                                           yyextra->templateStr="<";
@@ -1841,7 +1841,7 @@ NONLopt [^\n]*
                                           yyextra->previous->name=yyextra->previous->name.stripWhiteSpace();
                                           yyextra->previous->bodyLine = yyextra->yyLineNr;
                                           yyextra->previous->bodyColumn = yyextra->yyColNr;
-                                          yyextra->previous->spec |= Entry::Alias;
+                                          yyextra->previous->spec |= SpecifierAlias;
                                           BEGIN(FindMembers);
                                         }
 <UsingAlias>";"{BN}*{DCOMM}"<" {
@@ -2096,11 +2096,11 @@ NONLopt [^\n]*
                                           yyextra->current->name=yytext;
                                         }
 <QtPropType,QtPropAttr>{B}+"READ"{B}+   {
-                                          yyextra->current->spec |= Entry::Readable;
+                                          yyextra->current->spec |= SpecifierReadable;
                                           BEGIN(QtPropRead);
                                         }
 <QtPropType,QtPropAttr>{B}+"WRITE"{B}+  {
-                                          yyextra->current->spec |= Entry::Writable;
+                                          yyextra->current->spec |= SpecifierWritable;
                                           BEGIN(QtPropWrite);
                                         }
 <QtPropType,QtPropAttr>{B}+"MEMBER"{B}+{ID}     | // member property => not supported yet
@@ -2805,7 +2805,7 @@ NONLopt [^\n]*
                                           yyextra->lastInitializerContext = YY_START;
                                           yyextra->initBracketCount=0;
                                           yyextra->current->mtype = yyextra->mtype = Property;
-                                          yyextra->current->spec |= Entry::Gettable;
+                                          yyextra->current->spec |= SpecifierGettable;
                                           BEGIN(ReadInitializerPtr);
                                         }
 <FindMembers>"="                        { // in PHP code this could also be due to "<?="
@@ -2850,7 +2850,7 @@ NONLopt [^\n]*
                                         }
 <ReadInitializer,ReadInitializerPtr>[;,] {
                                           //printf(">> initializer '%s' <<\n",qPrint(yyextra->current->initializer));
-                                          if (*yytext==';' && (yyextra->current_root->spec&Entry::Enum))
+                                          if (*yytext==';' && (yyextra->current_root->spec&SpecifierEnum))
                                           {
                                             yyextra->current->fileName   = yyextra->fileName;
                                             yyextra->current->startLine  = yyextra->yyLineNr;
@@ -3518,8 +3518,8 @@ NONLopt [^\n]*
                                                  yyextra->current->mtype == Property)
                                             { // we are yyextra->inside the properties section of a dispinterface
                                               yyextra->odlProp = true;
-                                              yyextra->current->spec |= Entry::Gettable;
-                                              yyextra->current->spec |= Entry::Settable;
+                                              yyextra->current->spec |= SpecifierGettable;
+                                              yyextra->current->spec |= SpecifierSettable;
                                             }
 
                                             BEGIN( IDLAttribute );
@@ -3592,54 +3592,54 @@ NONLopt [^\n]*
                                           {
                                             yyextra->current->mtype = Property;
                                           }
-                                          yyextra->current->spec |= Entry::Settable;
+                                          yyextra->current->spec |= SpecifierSettable;
                                         }
 <IDLAttribute>"propget"                 {
                                           if (Config_getBool(IDL_PROPERTY_SUPPORT))
                                           {
                                             yyextra->current->mtype = Property;
                                           }
-                                          yyextra->current->spec |= Entry::Gettable;
+                                          yyextra->current->spec |= SpecifierGettable;
                                         }
 <IDLAttribute>"property" { // UNO IDL property
-                                          yyextra->current->spec |= Entry::Property;
+                                          yyextra->current->spec |= SpecifierProperty;
                                         }
 <IDLAttribute>"attribute" { // UNO IDL attribute
-                                          yyextra->current->spec |= Entry::Attribute;
+                                          yyextra->current->spec |= SpecifierAttribute;
                                         }
 <IDLAttribute>"optional" { // on UNO IDL interface/service/attribute/property
-                           yyextra->current->spec |= Entry::Optional;
+                           yyextra->current->spec |= SpecifierOptional;
                          }
 <IDLAttribute>"readonly" { // on UNO IDL attribute or property
                                           if (Config_getBool(IDL_PROPERTY_SUPPORT) && yyextra->odlProp)
                                           {
-                                            yyextra->current->spec ^= Entry::Settable;
+                                            yyextra->current->spec ^= SpecifierSettable;
                                           }
                                           else
                                           {
-                                            yyextra->current->spec |= Entry::Readonly;
+                                            yyextra->current->spec |= SpecifierReadonly;
                                           }
                                         }
 <IDLAttribute>"bound" { // on UNO IDL attribute or property
-                                          yyextra->current->spec |= Entry::Bound;
+                                          yyextra->current->spec |= SpecifierBound;
                                         }
 <IDLAttribute>"removable" { // on UNO IDL property
-                                          yyextra->current->spec |= Entry::Removable;
+                                          yyextra->current->spec |= SpecifierRemovable;
                                         }
 <IDLAttribute>"constrained" { // on UNO IDL property
-                                          yyextra->current->spec |= Entry::Constrained;
+                                          yyextra->current->spec |= SpecifierConstrained;
                                         }
 <IDLAttribute>"transient" { // on UNO IDL property
-                                          yyextra->current->spec |= Entry::Transient;
+                                          yyextra->current->spec |= SpecifierTransient;
                                         }
 <IDLAttribute>"maybevoid" { // on UNO IDL property
-                                          yyextra->current->spec |= Entry::MaybeVoid;
+                                          yyextra->current->spec |= SpecifierMaybeVoid;
                                         }
 <IDLAttribute>"maybedefault" { // on UNO IDL property
-                                          yyextra->current->spec |= Entry::MaybeDefault;
+                                          yyextra->current->spec |= SpecifierMaybeDefault;
                                         }
 <IDLAttribute>"maybeambiguous" { // on UNO IDL property
-                                          yyextra->current->spec |= Entry::MaybeAmbiguous;
+                                          yyextra->current->spec |= SpecifierMaybeAmbiguous;
                                         }
 <IDLAttribute>.                         {
                                         }
@@ -3783,7 +3783,7 @@ NONLopt [^\n]*
                                               yyextra->current->fileName   = yyextra->fileName;
                                               yyextra->current->startLine  = yyextra->yyLineNr;
                                               yyextra->current->startColumn = yyextra->yyColNr;
-                                              if (!(yyextra->current_root->spec&Entry::Enum))
+                                              if (!(yyextra->current_root->spec&SpecifierEnum))
                                               {
                                                 yyextra->current->type       = "@"; // enum marker
                                               }
@@ -3810,7 +3810,7 @@ NONLopt [^\n]*
                                             yyextra->current->fileName   = yyextra->fileName;
                                             yyextra->current->startLine  = yyextra->yyLineNr;
                                             yyextra->current->startColumn = yyextra->yyColNr;
-                                            if (!(yyextra->current_root->spec&Entry::Enum))
+                                            if (!(yyextra->current_root->spec&SpecifierEnum))
                                             {
                                               yyextra->current->type       = "@"; // enum marker
                                             }
@@ -3819,7 +3819,7 @@ NONLopt [^\n]*
                                             yyextra->current->section    = Entry::VARIABLE_SEC;
                                             // add to the scope of the enum
                                             if (!yyextra->insideCS && !yyextra->insideJava &&
-                                                !(yyextra->current_root->spec&Entry::Strong))
+                                                !(yyextra->current_root->spec&SpecifierStrong))
                                                 // for C# and Java 1.5+ enum values always have to be explicitly qualified,
                                                 // same for C++11 style enums (enum class Name {})
                                             {
@@ -3973,7 +3973,7 @@ NONLopt [^\n]*
                                             }
                                             else
                                             {
-                                              if ((yyextra->current->section == Entry::ENUM_SEC) || (yyextra->current->spec&Entry::Enum))
+                                              if ((yyextra->current->section == Entry::ENUM_SEC) || (yyextra->current->spec&SpecifierEnum))
                                               {
                                                 yyextra->current->program << ','; // add field terminator
                                               }
@@ -3984,7 +3984,7 @@ NONLopt [^\n]*
                                               yyextra->current->name = yyextra->current->name.stripWhiteSpace();
                                               //printf("adding '%s' '%s' '%s' brief=%s yyextra->insideObjC=%d %x\n",qPrint(yyextra->current->type),qPrint(yyextra->current->name),qPrint(yyextra->current->args),qPrint(yyextra->current->brief),yyextra->insideObjC,yyextra->current->section);
                                               if (yyextra->insideObjC &&
-                                                  ((yyextra->current->spec&Entry::Interface) || (yyextra->current->spec==Entry::Category))
+                                                  ((yyextra->current->spec&SpecifierInterface)!=0 || (yyextra->current->spec&SpecifierCategory)!=0)
                                                  ) // method definition follows
                                               {
                                                 BEGIN( ReadBodyIntf ) ;
@@ -3995,7 +3995,7 @@ NONLopt [^\n]*
                                                 yyextra->current_root->moveToSubEntryAndKeep( yyextra->current ) ;
                                                 yyextra->current = std::make_shared<Entry>(*yyextra->current);
                                                 if (yyextra->current->section==Entry::NAMESPACE_SEC ||
-                                                    (yyextra->current->spec==Entry::Interface) ||
+                                                    (yyextra->current->spec&SpecifierInterface)!=0 ||
                                                     yyextra->insideJava || yyextra->insidePHP || yyextra->insideCS || yyextra->insideD || yyextra->insideJS ||
                                                     yyextra->insideSlice
                                                    )
@@ -4047,7 +4047,7 @@ NONLopt [^\n]*
                                           yyextra->current->type.prepend(yytext);
                                         }
 <TypedefName>{ID}                       {
-                                          if ((yyextra->current->section == Entry::ENUM_SEC) || (yyextra->current->spec&Entry::Enum))
+                                          if ((yyextra->current->section == Entry::ENUM_SEC) || (yyextra->current->spec&SpecifierEnum))
                                           {
                                             yyextra->current->program << ","; // add field terminator
                                           }
@@ -4067,7 +4067,7 @@ NONLopt [^\n]*
                                         }
 <TypedefName>";"                        { /* typedef of anonymous type */
                                           yyextra->current->name.sprintf("@%d",anonCount++);
-                                          if ((yyextra->current->section == Entry::ENUM_SEC) || (yyextra->current->spec&Entry::Enum))
+                                          if ((yyextra->current->section == Entry::ENUM_SEC) || (yyextra->current->spec&SpecifierEnum))
                                           {
                                             yyextra->current->program << ','; // add field terminator
                                           }
@@ -4096,11 +4096,11 @@ NONLopt [^\n]*
                                           // handle *pName in: typedef { ... } name, *pName;
                                           if (yyextra->firstTypedefEntry)
                                           {
-                                            if (yyextra->firstTypedefEntry->spec&Entry::Struct)
+                                            if ((yyextra->firstTypedefEntry->spec&SpecifierStruct)!=0)
                                             {
                                               yyextra->msType.prepend("struct "+yyextra->firstTypedefEntry->name);
                                             }
-                                            else if (yyextra->firstTypedefEntry->spec&Entry::Union)
+                                            else if ((yyextra->firstTypedefEntry->spec&SpecifierUnion)!=0)
                                             {
                                               yyextra->msType.prepend("union "+yyextra->firstTypedefEntry->name);
                                             }
@@ -4158,7 +4158,7 @@ NONLopt [^\n]*
                                             // -> omit typedef and use S_t as the struct name
                                             if (typedefHidesStruct &&
                                                 yyextra->isTypedef &&
-                                                ((yyextra->current->spec&(Entry::Struct|Entry::Union)) ||
+                                                ((yyextra->current->spec&(SpecifierStruct|SpecifierUnion))!=0 ||
                                                  yyextra->current->section==Entry::ENUM_SEC )&&
                                                 yyextra->msType.stripWhiteSpace().isEmpty() &&
                                                 yyextra->memspecEntry)
@@ -4184,7 +4184,7 @@ NONLopt [^\n]*
                                               }
                                               if (typedefHidesStruct &&
                                                   yyextra->isTypedef &&
-                                                  (yyextra->current->spec&(Entry::Struct|Entry::Union)) &&
+                                                  (yyextra->current->spec&(SpecifierStruct|SpecifierUnion)) &&
                                                   yyextra->memspecEntry
                                                  ) // case 1: use S_t as type for pS_t in "typedef struct _S {} S_t, *pS_t;"
                                               {
@@ -4821,24 +4821,24 @@ NONLopt [^\n]*
                                         }
 <FuncQual,TrailingReturn>{BN}*"override"{BN}*          { // C++11 overridden virtual member function
                                           lineCount(yyscanner) ;
-                                          yyextra->current->spec |= Entry::Override;
+                                          yyextra->current->spec |= SpecifierOverride;
                                           yyextra->current->args += " override ";
                                           BEGIN(FuncQual);
                                         }
 <FuncQual,TrailingReturn>{BN}*"final"{BN}*             { // C++11 final method
                                           lineCount(yyscanner) ;
-                                          yyextra->current->spec |= Entry::Final;
+                                          yyextra->current->spec |= SpecifierFinal;
                                           yyextra->current->args += " final ";
                                           BEGIN(FuncQual);
                                         }
 <FuncQual>{BN}*"sealed"{BN}*            { // sealed member function
                                           lineCount(yyscanner) ;
-                                          yyextra->current->spec |= Entry::Sealed;
+                                          yyextra->current->spec |= SpecifierSealed;
                                           yyextra->current->args += " sealed ";
                                         }
 <FuncQual>{BN}*"new"{BN}*               { // new member function
                                           lineCount(yyscanner) ;
-                                          yyextra->current->spec |= Entry::New;
+                                          yyextra->current->spec |= SpecifierNew;
                                           yyextra->current->args += " new ";
                                         }
 <FuncQual>{BN}*"const"{BN}*             { // const member function
@@ -4854,12 +4854,12 @@ NONLopt [^\n]*
 <FuncQual>{BN}*"noexcept"{BN}*          { // noexcept qualifier
                                           lineCount(yyscanner) ;
                                           yyextra->current->args += " noexcept ";
-                                          yyextra->current->spec |= Entry::NoExcept;
+                                          yyextra->current->spec |= SpecifierNoExcept;
                                         }
 <FuncQual>{BN}*"noexcept"{BN}*"("       { // noexcept expression
                                           lineCount(yyscanner) ;
                                           yyextra->current->args += " noexcept(";
-                                          yyextra->current->spec |= Entry::NoExcept;
+                                          yyextra->current->spec |= SpecifierNoExcept;
                                           yyextra->lastRoundContext=FuncQual;
                                           yyextra->pCopyRoundString=&yyextra->current->args;
                                           yyextra->roundCount=0;
@@ -4884,14 +4884,14 @@ NONLopt [^\n]*
 <FuncQual,TrailingReturn>{BN}*"="{BN}*"delete"{BN}*     { // C++11 explicitly delete member
                                           lineCount(yyscanner);
                                           yyextra->current->args += " = delete";
-                                          yyextra->current->spec |= Entry::Delete;
+                                          yyextra->current->spec |= SpecifierDelete;
                                           yyextra->current->argList.setIsDeleted(TRUE);
                                           BEGIN(FuncQual);
                                         }
 <FuncQual,TrailingReturn>{BN}*"="{BN}*"default"{BN}*     { // C++11 explicitly defaulted constructor/assignment operator
                                           lineCount(yyscanner);
                                           yyextra->current->args += " = default";
-                                          yyextra->current->spec |= Entry::Default;
+                                          yyextra->current->spec |= SpecifierDefault;
                                           BEGIN(FuncQual);
                                         }
 <FuncQual>{BN}*"->"{BN}*                {
@@ -5172,11 +5172,11 @@ NONLopt [^\n]*
                                           {
                                             if (findAndRemoveWord(yyextra->current->type,"final"))
                                             {
-                                              yyextra->current->spec |= Entry::Final;
+                                              yyextra->current->spec |= SpecifierFinal;
                                             }
                                             if (findAndRemoveWord(yyextra->current->type,"abstract"))
                                             {
-                                              yyextra->current->spec |= Entry::Abstract;
+                                              yyextra->current->spec |= SpecifierAbstract;
                                             }
                                           }
                                           if ( yyextra->insidePHP && !containsWord(yyextra->current->type,"function"))
@@ -5203,9 +5203,9 @@ NONLopt [^\n]*
                                             yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
                                             initEntry(yyscanner);
                                             // Objective C 2.0: Required/Optional section
-                                            if (yyextra->previous->spec & (Entry::Optional | Entry::Required))
+                                            if ((yyextra->previous->spec & (SpecifierOptional | SpecifierRequired))!=0)
                                             {
-                                              yyextra->current->spec |= yyextra->previous->spec & (Entry::Optional|Entry::Required);
+                                              yyextra->current->spec |= yyextra->previous->spec & (SpecifierOptional|SpecifierRequired);
                                             }
                                             yyextra->lastCurlyContext = FindMembers;
                                             if ( *yytext == ',' )
@@ -5220,7 +5220,7 @@ NONLopt [^\n]*
                                             {
                                               if ( !yyextra->insidePHP && (yyextra->current_root->section & Entry::COMPOUND_MASK) )
                                               {
-                                                yyextra->previous->spec |= Entry::Inline;
+                                                yyextra->previous->spec |= SpecifierInline;
                                               }
                                               //addToBody(yytext);
                                               yyextra->curlyCount=0;
@@ -5467,8 +5467,8 @@ NONLopt [^\n]*
                                           BEGIN( FindMembers ) ;
                                         }
 <Bases>";"                      {
-                                          if (yyextra->insideIDL && (yyextra->current->spec & (Entry::Singleton |
-                                                                             Entry::Service)))
+                                          if (yyextra->insideIDL && (yyextra->current->spec & (SpecifierSingleton |
+                                                                             SpecifierService)))
                                           {
                                             // in UNO IDL a service or singleton may be defined
                                             // completely like this: "service Foo : XFoo;"
@@ -5500,7 +5500,7 @@ NONLopt [^\n]*
 <CompoundName>{SCOPENAME}/{BN}*"<"      {
                                           yyextra->sharpCount = 0;
                                           yyextra->current->name = yytext ;
-                                          if (yyextra->current->spec & Entry::Protocol)
+                                          if ((yyextra->current->spec & SpecifierProtocol)!=0)
                                           {
                                             yyextra->current->name+="-p";
                                           }
@@ -5524,7 +5524,7 @@ NONLopt [^\n]*
 <CSGeneric>"<"                          {
                                           ArgumentList al;
                                           // check bug 612858 before enabling the next line
-                                          //yyextra->current->spec |= Entry::Template;
+                                          //yyextra->current->spec |= SpecifierTemplate;
                                           yyextra->current->tArgLists.push_back(al);
                                           yyextra->currentArgumentList = &yyextra->current->tArgLists.back();
                                           yyextra->templateStr="<";
@@ -5545,7 +5545,7 @@ NONLopt [^\n]*
                                           if (yyextra->roundCount==0 && --yyextra->sharpCount<=0)
                                           {
                                             yyextra->current->name = removeRedundantWhiteSpace(yyextra->current->name);
-                                            if (yyextra->current->spec & Entry::Protocol)
+                                            if ((yyextra->current->spec & SpecifierProtocol)!=0)
                                             { // Objective-C protocol
                                               unput('{'); // fake start of body
                                               BEGIN( ClassVar );
@@ -5577,16 +5577,16 @@ NONLopt [^\n]*
                                             {
                                               prependScope(yyscanner);
                                             }
-                                            yyextra->current->spec|=Entry::ForwardDecl;
+                                            yyextra->current->spec|=SpecifierForwardDecl;
                                             yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
                                           }
                                           else if (yyextra->insideIDL &&
-                                                   (((yyextra->current_root->spec & (Entry::Interface |
-                                                                            Entry::Service)) &&
-                                                     (yyextra->current->spec & Entry::Interface)) ||
-                                                    ((yyextra->current_root->spec & (Entry::Service |
-                                                                            Entry::Singleton)) &&
-                                                     (yyextra->current->spec & Entry::Service))))
+                                                   (((yyextra->current_root->spec & (SpecifierInterface |
+                                                                            SpecifierService)) &&
+                                                     (yyextra->current->spec & SpecifierInterface)) ||
+                                                    ((yyextra->current_root->spec & (SpecifierService |
+                                                                            SpecifierSingleton)) &&
+                                                     (yyextra->current->spec & SpecifierService))))
                                           {
                                             // interface yyextra->inside of UNO IDL service or interface
                                             // service yyextra->inside of UNO IDL service or singleton
@@ -5594,11 +5594,11 @@ NONLopt [^\n]*
                                             // so do not throw it away...
                                             yyextra->current->name = yytext;
                                             yyextra->current->name=yyextra->current->name.left(yyextra->current->name.length()-1).stripWhiteSpace();
-                                            yyextra->current->section = (yyextra->current->spec & Entry::Interface)
+                                            yyextra->current->section = (yyextra->current->spec & SpecifierInterface)!=0
                                                 ? Entry::EXPORTED_INTERFACE_SEC
                                                 : Entry::INCLUDED_SERVICE_SEC;
 //                                          yyextra->current->section = Entry::MEMBERDOC_SEC;
-                                            yyextra->current->spec &= ~(Entry::Interface|Entry::Service); // FIXME: horrible: Interface == Gettable, so need to clear it - actually we're mixing values from different enums in this case... granted only Optional and Interface are actually valid in this context but urgh...
+                                            yyextra->current->spec &= ~(SpecifierInterface|SpecifierService); // FIXME: horrible: Interface == Gettable, so need to clear it - actually we're mixing values from different enums in this case... granted only Optional and Interface are actually valid in this context but urgh...
                                             yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
                                           }
 
@@ -5626,7 +5626,7 @@ NONLopt [^\n]*
                                           }
                                           else
                                           {
-                                            if (yyextra->current->spec & Entry::Protocol)
+                                            if ((yyextra->current->spec & SpecifierProtocol)!=0)
                                             {
                                               yyextra->current->name += "-p";
                                             }
@@ -5669,11 +5669,11 @@ NONLopt [^\n]*
                                             yyextra->current->id = yyextra->clangParser->lookup(yyextra->yyLineNr,yytext);
                                           }
                                           lineCount(yyscanner);
-                                          if (yyextra->current->spec & Entry::Protocol)
+                                          if ((yyextra->current->spec & SpecifierProtocol)!=0)
                                           {
                                             yyextra->current->name += "-p";
                                           }
-                                          if ((yyextra->current->spec & Entry::Protocol) ||
+                                          if ((yyextra->current->spec & SpecifierProtocol) ||
                                               yyextra->current->section == Entry::OBJCIMPL_SEC)
                                           {
                                             unput('{'); // fake start of body
@@ -5720,9 +5720,9 @@ NONLopt [^\n]*
                                           if (yyextra->insideCli)
                                           {
                                             if (yytext[0]=='s') // sealed
-                                              yyextra->current->spec |= Entry::SealedClass;
+                                              yyextra->current->spec |= SpecifierSealedClass;
                                             else // abstract
-                                              yyextra->current->spec |= Entry::AbstractClass;
+                                              yyextra->current->spec |= SpecifierAbstractClass;
                                             BEGIN( ClassVar );
                                           }
                                           else
@@ -5761,15 +5761,15 @@ NONLopt [^\n]*
                                           }
                                           else if (yyextra->insideCli &&  qstrcmp(yytext,"abstract")==0)
                                           {
-                                            yyextra->current->spec|=Entry::Abstract;
+                                            yyextra->current->spec|=SpecifierAbstract;
                                           }
                                           else if (yyextra->insideCli &&  qstrcmp(yytext,"sealed")==0)
                                           {
-                                            yyextra->current->spec|=Entry::Sealed;
+                                            yyextra->current->spec|=SpecifierSealed;
                                           }
                                           else if (qstrcmp(yytext,"final")==0)
                                           {
-                                            yyextra->current->spec|=Entry::Final;
+                                            yyextra->current->spec|=SpecifierFinal;
                                           }
                                           else
                                           {
@@ -5793,7 +5793,7 @@ NONLopt [^\n]*
                                             yyextra->current->name+='(';
                                             //if (yyextra->current->section!=Entry::OBJCIMPL_SEC)
                                             //{
-                                              yyextra->current->spec|=Entry::Category;
+                                              yyextra->current->spec|=SpecifierCategory;
                                             //}
                                             BEGIN( ClassCategory );
                                           }
@@ -5871,7 +5871,7 @@ NONLopt [^\n]*
                                         }
 <ClassCategory>")"                      {
                                           yyextra->current->name+=')';
-                                          if ((yyextra->current->section & Entry::Protocol) ||
+                                          if ((yyextra->current->spec & SpecifierProtocol)!=0 ||
                                               yyextra->current->section == Entry::OBJCIMPL_SEC)
                                           {
                                             unput('{'); // fake start of body
@@ -5899,10 +5899,10 @@ NONLopt [^\n]*
                                           else
                                           {
                                             yyextra->current->type.resize(0);
-                                            if ((yyextra->current->spec & Entry::Interface) ||
-                                                (yyextra->current->spec & Entry::Struct)    ||
-                                                (yyextra->current->spec & Entry::Ref)       ||
-                                                (yyextra->current->spec & Entry::Value)     ||
+                                            if ((yyextra->current->spec & SpecifierInterface) ||
+                                                (yyextra->current->spec & SpecifierStruct)    ||
+                                                (yyextra->current->spec & SpecifierRef)       ||
+                                                (yyextra->current->spec & SpecifierValue)     ||
                                                 yyextra->insidePHP || yyextra->insideCS || yyextra->insideD || yyextra->insideObjC || yyextra->insideIDL
                                                )
                                               yyextra->baseProt=Public;
@@ -5995,8 +5995,8 @@ NONLopt [^\n]*
                                           }
                                           yyextra->curlyCount=0;
                                           if (yyextra->current_root && // not a nested struct yyextra->inside an @interface section
-                                              !(yyextra->current_root->spec & Entry::Interface) &&
-                                              ((yyextra->current->spec & (Entry::Interface | Entry::Protocol | Entry::Category) ||
+                                              !(yyextra->current_root->spec & SpecifierInterface) &&
+                                              ((yyextra->current->spec & (SpecifierInterface | SpecifierProtocol | SpecifierCategory) ||
                                                 yyextra->current->section==Entry::OBJCIMPL_SEC)
                                               ) &&
                                               yyextra->insideObjC
@@ -6189,7 +6189,7 @@ NONLopt [^\n]*
                                               BaseInfo(yyextra->baseName,yyextra->baseProt,yyextra->baseVirt)
                                             );
                                           }
-                                          if ((yyextra->current->spec & (Entry::Interface|Entry::Struct)) ||
+                                          if ((yyextra->current->spec & (SpecifierInterface|SpecifierStruct)) ||
                                               yyextra->insideJava || yyextra->insidePHP || yyextra->insideCS ||
                                               yyextra->insideD || yyextra->insideObjC || yyextra->insideIDL || yyextra->insideSlice)
                                           {
@@ -6434,7 +6434,7 @@ NONLopt [^\n]*
                                             yyextra->curlyCount=0;
                                             BEGIN( CSAccessorDecl );
                                           }
-                                          else if (yyextra->insideIDL && (yyextra->current->spec & Entry::Attribute))
+                                          else if (yyextra->insideIDL && (yyextra->current->spec & SpecifierAttribute))
                                           {
                                             // UNO IDL: attributes may have setter and getter
                                             // exception specifications
@@ -6506,15 +6506,15 @@ NONLopt [^\n]*
                                             BEGIN(FindMembers);
                                           }
                                         }
-<CSAccessorDecl>"private "{BN}*"set"    { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::PrivateSettable;   }
-<CSAccessorDecl>"protected "{BN}*"set"  { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::ProtectedSettable; }
-<CSAccessorDecl>"private "{BN}*"get"    { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::PrivateGettable;         }
-<CSAccessorDecl>"protected "{BN}*"get"  { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::ProtectedGettable; }
-<CSAccessorDecl>"set"                   { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::Settable;  }
-<CSAccessorDecl>"get"                   { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::Gettable;  }
-<CSAccessorDecl>"add"                   { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::Addable;   }
-<CSAccessorDecl>"remove"                { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::Removable; }
-<CSAccessorDecl>"raise"                 { if (yyextra->curlyCount==0) yyextra->current->spec |= Entry::Raisable;  }
+<CSAccessorDecl>"private "{BN}*"set"    { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierPrivateSettable;   }
+<CSAccessorDecl>"protected "{BN}*"set"  { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierProtectedSettable; }
+<CSAccessorDecl>"private "{BN}*"get"    { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierPrivateGettable;         }
+<CSAccessorDecl>"protected "{BN}*"get"  { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierProtectedGettable; }
+<CSAccessorDecl>"set"                   { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierSettable;  }
+<CSAccessorDecl>"get"                   { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierGettable;  }
+<CSAccessorDecl>"add"                   { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierAddable;   }
+<CSAccessorDecl>"remove"                { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierRemovable; }
+<CSAccessorDecl>"raise"                 { if (yyextra->curlyCount==0) yyextra->current->spec |= SpecifierRaisable;  }
 <CSAccessorDecl>"\""                    { BEGIN(CSString);}
 <CSAccessorDecl>"."                     {}
 <CSAccessorDecl>\n                      { lineCount(yyscanner); }
@@ -6527,7 +6527,7 @@ NONLopt [^\n]*
  /* ---- Slice-specific rules ------ */
 
 <SliceSequence>{SCOPENAME}              {
-                                          if (yyextra->current->spec&Entry::Local)
+                                          if ((yyextra->current->spec&SpecifierLocal)!=0)
                                           {
                                             yyextra->current->type = "local ";
                                           }
@@ -6556,7 +6556,7 @@ NONLopt [^\n]*
 
 <SliceDictionary>{SCOPENAME}{BN}*","{BN}*{SCOPENAME} {
                                           lineCount(yyscanner);
-                                          if (yyextra->current->spec&Entry::Local)
+                                          if ((yyextra->current->spec&SpecifierLocal)!=0)
                                           {
                                             yyextra->current->type = "local ";
                                           }
@@ -7068,7 +7068,7 @@ static void initEntry(yyscan_t yyscanner)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (yyextra->insideJava)
   {
-    yyextra->protection = (yyextra->current_root->spec & (Entry::Interface|Entry::Enum)) ?  Public : Package;
+    yyextra->protection = (yyextra->current_root->spec & (SpecifierInterface|SpecifierEnum))!=0 ?  Public : Package;
   }
   yyextra->current->protection = yyextra->protection ;
   yyextra->current->mtype      = yyextra->mtype;
@@ -7540,7 +7540,7 @@ static void parseCompounds(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
       yyextra->programStr = ce->program.str();
       yyextra->inputString = yyextra->programStr.data();
       yyextra->inputPosition = 0;
-      if (ce->section==Entry::ENUM_SEC || (ce->spec&Entry::Enum))
+      if (ce->section==Entry::ENUM_SEC || (ce->spec&SpecifierEnum))
         BEGIN( FindFields ) ;
       else
         BEGIN( FindMembers ) ;
@@ -7557,7 +7557,7 @@ static void parseCompounds(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
 
       // deep copy group list from parent (see bug 727732)
       bool autoGroupNested = Config_getBool(GROUP_NESTED_COMPOUNDS);
-      if (autoGroupNested && !rt->groups.empty() && ce->section!=Entry::ENUM_SEC && !(ce->spec&Entry::Enum))
+      if (autoGroupNested && !rt->groups.empty() && ce->section!=Entry::ENUM_SEC && !(ce->spec&SpecifierEnum))
       {
         ce->groups = rt->groups;
       }
@@ -7572,9 +7572,9 @@ static void parseCompounds(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
         }
         else if (yyextra->insideJava)
         {
-          yyextra->current->protection = yyextra->protection = (ce->spec & (Entry::Interface|Entry::Enum)) ?  Public : Package;
+          yyextra->current->protection = yyextra->protection = (ce->spec & (SpecifierInterface|SpecifierEnum))!=0 ?  Public : Package;
         }
-        else if (ce->spec&(Entry::Interface | Entry::Ref | Entry::Value | Entry::Struct | Entry::Union))
+        else if ((ce->spec&(SpecifierInterface | SpecifierRef | SpecifierValue | SpecifierStruct | SpecifierUnion))!=0)
         {
           if (ce->lang==SrcLangExt_ObjC)
           {

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -1200,7 +1200,7 @@ void TagFileParser::buildMemberList(const std::shared_ptr<Entry> &ce,const std::
     }
     if (tmi.enumValues.size()>0)
     {
-      me->spec |= Entry::Strong;
+      me->spec |= SpecifierStrong;
       for (const auto &evi : tmi.enumValues)
       {
         std::shared_ptr<Entry> ev = std::make_shared<Entry>();
@@ -1318,15 +1318,15 @@ void TagFileParser::buildLists(const std::shared_ptr<Entry> &root)
       switch (tci->kind)
       {
         case TagClassInfo::Kind::Class:     break;
-        case TagClassInfo::Kind::Struct:    ce->spec = Entry::Struct;    break;
-        case TagClassInfo::Kind::Union:     ce->spec = Entry::Union;     break;
-        case TagClassInfo::Kind::Interface: ce->spec = Entry::Interface; break;
-        case TagClassInfo::Kind::Enum:      ce->spec = Entry::Enum;      break;
-        case TagClassInfo::Kind::Exception: ce->spec = Entry::Exception; break;
-        case TagClassInfo::Kind::Protocol:  ce->spec = Entry::Protocol;  break;
-        case TagClassInfo::Kind::Category:  ce->spec = Entry::Category;  break;
-        case TagClassInfo::Kind::Service:   ce->spec = Entry::Service;   break;
-        case TagClassInfo::Kind::Singleton: ce->spec = Entry::Singleton; break;
+        case TagClassInfo::Kind::Struct:    ce->spec = SpecifierStruct;    break;
+        case TagClassInfo::Kind::Union:     ce->spec = SpecifierUnion;     break;
+        case TagClassInfo::Kind::Interface: ce->spec = SpecifierInterface; break;
+        case TagClassInfo::Kind::Enum:      ce->spec = SpecifierEnum;      break;
+        case TagClassInfo::Kind::Exception: ce->spec = SpecifierException; break;
+        case TagClassInfo::Kind::Protocol:  ce->spec = SpecifierProtocol;  break;
+        case TagClassInfo::Kind::Category:  ce->spec = SpecifierCategory;  break;
+        case TagClassInfo::Kind::Service:   ce->spec = SpecifierService;   break;
+        case TagClassInfo::Kind::Singleton: ce->spec = SpecifierSingleton; break;
         case TagClassInfo::Kind::None:      // should never happen, means not properly initialized
                                       assert(tci->kind != TagClassInfo::Kind::None);
                                       break;

--- a/src/translator.h
+++ b/src/translator.h
@@ -618,7 +618,7 @@ class Translator
     virtual QCString trDesignUnitIndex() = 0;
     virtual QCString trDesignUnits() = 0;
     virtual QCString trFunctionAndProc() = 0;
-    virtual QCString trVhdlType(uint64 type,bool single) = 0;
+    virtual QCString trVhdlType(Spec type,bool single) = 0;
     virtual QCString trCustomReference(const QCString &name) = 0;
 
     virtual QCString trConstants() = 0;

--- a/src/translator_adapter.h
+++ b/src/translator_adapter.h
@@ -106,7 +106,7 @@ class TranslatorAdapter_1_8_15 : public TranslatorAdapter_1_8_19
     virtual QCString trFunctionAndProc()
     { return english.trFunctionAndProc(); }
 
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     { return english.trVhdlType(type,single); }
 
     virtual QCString trCustomReference(const QCString &name)

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -2121,90 +2121,141 @@ class TranslatorBrazilian : public Translator
     virtual QCString trFunctionAndProc()
     { return "Funções/Procedimentos/Processos"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Biblioteca";
           else        return "Bibliotecas";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Pacote";
           else        return "Pacotes";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Sinal";
           else        return "Sinais";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Componente";
           else        return "Componentes";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Constante";
           else        return "Constantes";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entidade";
           else        return "Entidades";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Tipo";
           else        return "Tipos";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Subtipo";
           else        return "Subtipos";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Função";
           else        return "Funções";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Registro";
           else        return "Registros";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procedimento";
           else        return "Procedimentos";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Arquitetura";
           else        return "Arquiteturas";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Atributo";
           else        return "Atributos";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Processo";
           else        return "Processos";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Porta";
           else        return "Portas";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "cláusula de uso";
           else        return "cláusulas de uso";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Generico";
           else        return "Genericos";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Corpo do Pacote";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Unidades";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Variável Compartilhada";
           else        return "Variáveis Compartilhadas";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Arquivo";
           else        return "Arquivos";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Grupo";
           else        return "Grupos";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
             if (single) return "Instância";
             else        return "Instâncias";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Apelido";
           else        return "Apelidos";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Configuração";
           else        return "Configurações";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Outros"; // Is this correct for VHDL?
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Restrições";
-        default:
+        }
+        else
           return "Classe";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return "Referência de " + QCString(name); }

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -1944,68 +1944,119 @@ class TranslatorChinese : public Translator
     virtual QCString trFunctionAndProc()
     { return "函数/调用过程/进程语句"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           return "库";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           return "包";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           return "信号";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           return "元件";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           return "常量";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           return "实体";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           return "类型";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           return "子类型";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           return "函数";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           return "记录";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           return "过程";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           return "结构体";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           return "属性";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           return "进程语句";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           return "端口";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "使用语句";
           else        return "使用语句";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           return "类属";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "包体";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "单元";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           return "共享变量";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           return "文件";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           return "组";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           return "实例化";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           return "别名";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           return " 配置";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "混合运算";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "约束";
-        default:
+        }
+        else
           return "类";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return QCString(name)+" 引用"; }

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -2115,90 +2115,141 @@ class TranslatorCzech : public Translator
     virtual QCString trFunctionAndProc()
     { return "Funkce/Procedury/Procesy"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Knihovna";
           else        return "Knihovny";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Balík";
           else        return "Balíky";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Signál";
           else        return "Signály";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Komponenta";
           else        return "Komponenty";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Konstanta";
           else        return "Konstanty";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entita";
           else        return "Entity";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Typ";
           else        return "Typy";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Subtyp";
           else        return "Subtypy";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Funkce";
           else        return "Funkce";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Záznam";
           else        return "Záznamy";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procedura";
           else        return "Procedury";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Architektura";
           else        return "Architektury";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Atribut";
           else        return "Atributy";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Proces";
           else        return "Procesy";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Brána";
           else        return "Brány";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "Klauzule use";
           else        return "Klauzule use";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Generický parametr";
           else        return "Generické parametry";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Tělo balíku";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Fyzikální jednotky";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Sdílená proměnná";
           else        return "Sdílené proměnné";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Soubor";
           else        return "Soubory";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Skupina";
           else        return "Skupiny";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Vložená instance";
           else        return "Vložené instance";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Alias";
           else        return "Aliasy";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Konfigurace";
           else        return "Konfigurace";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Ostatní";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Omezení (constraints)";
-        default:
+        }
+        else
           return "Třída";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return "Dokumentace pro "+QCString(name); }

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -2168,90 +2168,141 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     virtual QCString trFunctionAndProc()
     { return "Funktionen/Prozeduren/Prozesse"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Bibliothek";
           else        return "Bibliotheken";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Paket";
           else        return "Pakete";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Signal";
           else        return "Signale";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Komponente";
           else        return "Komponenten";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Konstante";
           else        return "Konstanten";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entwurfseinheit";
           else        return "Entwurfseinheiten";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Typ";
           else        return "Typen";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Subtyp";
           else        return "Subtypen";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Funktion";
           else        return "Funktionen";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Datenstruktur";
           else        return "Datenstrukturen";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Prozedur";
           else        return "Prozeduren";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Architektur";
           else        return "Architekturen";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Attribut";
           else        return "Attribute";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Prozess";
           else        return "Prozesse";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Schnittstelle";
           else        return "Schnittstellen";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "Use Klausel";
           else        return "Use Klauseln";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Parameter";
           else        return "Parameter";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Paketkörper";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Einheiten";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Geteilte Variable";
           else        return "Geteilte Variablen";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Datei";
           else        return "Dateien";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Gruppe";
           else        return "Gruppen";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Instanziierung";
           else        return "Instanziierungen";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Alias";
           else        return "Aliase";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Konfiguration";
           else        return "Konfigurationen";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Verschiedenes";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Constraints";
-        default:
+        }
+        else
           return "Klasse";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return QCString(name)+"-Referenz"; }

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -2035,90 +2035,141 @@ class TranslatorEnglish : public Translator
     virtual QCString trFunctionAndProc()
     { return "Functions/Procedures/Processes"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Library";
           else        return "Libraries";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Package";
           else        return "Packages";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Signal";
           else        return "Signals";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Component";
           else        return "Components";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Constant";
           else        return "Constants";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entity";
           else        return "Entities";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Type";
           else        return "Types";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Subtype";
           else        return "Subtypes";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Function";
           else        return "Functions";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Record";
           else        return "Records";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procedure";
           else        return "Procedures";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Architecture";
           else        return "Architectures";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Attribute";
           else        return "Attributes";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Process";
           else        return "Processes";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Port";
           else        return "Ports";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "use clause";
           else        return "Use Clauses";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Generic";
           else        return "Generics";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Package Body";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Units";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Shared Variable";
           else        return "Shared Variables";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "File";
           else        return "Files";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Group";
           else        return "Groups";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Instantiation";
           else        return "Instantiations";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Alias";
           else        return "Aliases";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Configuration";
           else        return "Configurations";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Miscellaneous";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Constraints";
-        default:
+        }
+        else
           return "Class";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return QCString(name)+" Reference"; }

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -2087,90 +2087,141 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
     virtual QCString trFunctionAndProc()
     { return "Funciones/Procedimientos/Procesos"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Libreria";
           else        return "Librerias";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Paquete";
           else        return "Paquetes";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Señal";
           else        return "Señales";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Componente";
           else        return "Componentes";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Constante";
           else        return "Constantes";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entidad";
           else        return "Entidades";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Tipo";
           else        return "Tipos";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Subtipo";
           else        return "Subtipos";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Función";
           else        return "Funciones";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Registro";
           else        return "Registros";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procedimiento";
           else        return "Procedimientos";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Arquitectura";
           else        return "Arquitecturas";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Atributo";
           else        return "Atributos";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Proceso";
           else        return "Procesos";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Puerto";
           else        return "Puertos";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "cláusula de uso";
           else        return "Cláusulas de uso";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Genérico";
           else        return "Genéricos";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Cuerpo del paquete";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Unidades";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Variable Compartida";
           else        return "Variable Compartidas";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Fichero";
           else        return "Ficheros";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Grupo";
           else        return "Grupos";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Instanciación";
           else        return "Instanciaciones";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Alias";
           else        return "Aliases";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Configuración";
           else        return "Configuraciones";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Varios";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Restricciones";
-        default:
+        }
+        else
           return "Clase";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return "Referencia"+QCString(name); }

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -2092,90 +2092,141 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
     virtual QCString trFunctionAndProc()
     { return "Fonctions/Procédures/Processes"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Librairie";
           else        return "Librairies";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Paquetage";
           else        return "Paquetages";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Signal";
           else        return "Signaux";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Composant";
           else        return "Composants";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Constante";
           else        return "Constantes";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entité";
           else        return "Entités";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Type";
           else        return "Types";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Sous-type";
           else        return "Sous-types";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Fonction";
           else        return "Fonctions";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Enregistrement";
           else        return "Enregistrements";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procédure";
           else        return "Procédures";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Architecture";
           else        return "Architectures";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Attribut";
           else        return "Attributs";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Process";
           else        return "Processes";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Port";
           else        return "Ports";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "Clause d'utilisation";
           else        return "Clauses d'utilisation";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Generique";
           else        return "Generiques";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Corps du paquetage";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Unités";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Variable partagée";
           else        return "Variables partagées";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Fichier";
           else        return "Fichiers";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Groupe";
           else        return "Groupes";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Instanciation";
           else        return "Instanciations";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Alias";
           else        return "Alias";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Configuration";
           else        return "Configurations";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Divers";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Contraintes";
-        default:
+        }
+        else
           return "Classe";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return QCString("Référence ") + QCString(name); }

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -2035,90 +2035,141 @@ class TranslatorGreek : public Translator
     virtual QCString trFunctionAndProc()
     { return "Συναρτήσεις/Διαδικασίες/Διεργασίες"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Βιβλιοθήκη";
           else        return "Βιβλιοθήκες";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Πακέτο";
           else        return "Πακέτα";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Σήμα";
           else        return "Σήματα";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Εξάρτημα";
           else        return "Εξαρτήματα";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Σταθερά";
           else        return "Σταθερές";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Οντότητα";
           else        return "Οντότητες";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Τύπος";
           else        return "Τύποι";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Υποτύπος";
           else        return "Υποτύποι";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Συνάρτηση";
           else        return "Συναρτήσεις";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Εγγραφή";
           else        return "Εγγραφές";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Διαδικασία";
           else        return "Διαδικασίες";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Αρχιτεκτονική";
           else        return "Αρχιτεκτονικές";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Ιδιότητα";
           else        return "Ιδιότητες";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Διεργασία";
           else        return "Διεργασίες";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Πόρτα";
           else        return "Πόρτες";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "χρήση διάταξης";
           else        return "Χρήση Διατάξεων";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Γενίκευση";
           else        return "Γενικεύσεις";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Σώμα Πακέτου";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Μονάδες";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Κοινόχρηστη Μεταβλητή";
           else        return "Κοινόχρηστες Μεταβλητές";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Αρχείο";
           else        return "Αρχεία";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Ομάδα";
           else        return "Ομάδες";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Ενσάρκωση";
           else        return "Ενσαρκώσεις";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Συνώνυμο";
           else        return "Συνώνυμα";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Ρύθμιση";
           else        return "Ρυθμίσεις";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Διάφορα";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Εξαναγκασμοί";
-        default:
+        }
+        else
           return "Κλάση";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return QCString("Τεκμηρίωση ")+name; }

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -1628,90 +1628,141 @@ class TranslatorDutch : public Translator
     virtual QCString trFunctionAndProc()
     { return "Functies/Procedures/Processen"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Bibliotheek";
           else        return "Bibliotheken";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Package";
           else        return "Packages";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Signal";
           else        return "Signals";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Bestanddeel";
           else        return "Bestanddelen";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Konstante";
           else        return "Konstanten";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entiteit";
           else        return "Entiteiten";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Type";
           else        return "Types";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Ondertype";
           else        return "Ondertypes";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Funktie";
           else        return "Funkties";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Record";
           else        return "Records";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procedure";
           else        return "Procedures";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Architectuur";
           else        return "Architecturen";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Attribuut";
           else        return "Attributen";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Proces";
           else        return "Processen";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Poort";
           else        return "Porten";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "gebruiks clausule";
           else        return "Gebruiks Clausules";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Algemeen";
           else        return "Algemene";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Package Body";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Eenheden";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Gedeelde Variable";
           else        return "Gedeelde Variablen";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Bestand";
           else        return "Bestanden";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Groep";
           else        return "Groepen";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Instanti&euml;ring";
           else        return "Instanti&euml;ringen";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Alias";
           else        return "Aliases";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Configuratie";
           else        return "Configuraties";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Diverse";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Limiteringen";
-        default:
+        }
+        else
           return "Klasse";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return QCString(name)+" Referentie"; }

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -2059,90 +2059,141 @@ class TranslatorPortuguese : public Translator
     virtual QCString trFunctionAndProc()
     { return "Funções/Procedimentos/Processos"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           if (single) return "Biblioteca";
           else        return "Bibliotecas";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           if (single) return "Pacote";
           else        return "Pacotes";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Sinal";
           else        return "Sinais";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Componente";
           else        return "Componentes";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Constante";
           else        return "Constantes";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entidade";
           else        return "Entidades";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Tipo";
           else        return "Tipos";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Subtipo";
           else        return "Subtipos";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Função";
           else        return "Funções";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Registro";
           else        return "Registros";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procedimento";
           else        return "Procedimentos";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Arquitetura";
           else        return "Arquiteturas";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           if (single) return "Atributo";
           else        return "Atributos";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Processo";
           else        return "Processos";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Porta";
           else        return "Portas";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "cláusula de uso";
           else        return "cláusulas de uso";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Generico";
           else        return "Genericos";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Corpo do Pacote";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Unidades";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Variável Compartilhada";
           else        return "Variáveis Compartilhadas";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Ficheiro";
           else        return "Ficheiros";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Grupo";
           else        return "Grupos";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Instância";
           else        return "Instâncias";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           if (single) return "Apelido";
           else        return "Apelidos";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Configuração";
           else        return "Configurações";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Outros"; // Is this correct for VHDL?
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Restrições";
-        default:
+        }
+        else
           return "Classe";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return "Referência de " + QCString(name); }

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -2131,86 +2131,137 @@ class TranslatorSwedish : public Translator
     virtual QCString trFunctionAndProc()
     { return "Funktioner/Procedurer/Processer"; }
     /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
+    virtual QCString trVhdlType(Spec type,bool single)
     {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
+        if ((SpecifierLibrary&type)!=0)
+        {
           return "Biblotek";
-        case VhdlDocGen::PACKAGE:
+        }
+        else if ((SpecifierPackage&type)!=0)
+        {
           return "Paket";
-        case VhdlDocGen::SIGNAL:
+        }
+        else if ((SpecifierSignal&type)!=0)
+        {
           if (single) return "Signal";
           else        return "Signaler";
-        case VhdlDocGen::COMPONENT:
+        }
+        else if ((SpecifierComponent&type)!=0)
+        {
           if (single) return "Komponent";
           else        return "Komponenter";
-        case VhdlDocGen::CONSTANT:
+        }
+        else if ((SpecifierConstant&type)!=0)
+        {
           if (single) return "Konstant";
           else        return "Konstanter";
-        case VhdlDocGen::ENTITY:
+        }
+        else if ((SpecifierEntity&type)!=0)
+        {
           if (single) return "Entitet";
           else        return "Entiteter";
-        case VhdlDocGen::TYPE:
+        }
+        else if ((SpecifierType&type)!=0)
+        {
           if (single) return "Typ";
           else        return "Typer";
-        case VhdlDocGen::SUBTYPE:
+        }
+        else if ((SpecifierSubtype&type)!=0)
+        {
           if (single) return "Undertyp";
           else        return "Undertyper";
-        case VhdlDocGen::FUNCTION:
+        }
+        else if ((SpecifierFunction&type)!=0)
+        {
           if (single) return "Funktion";
           else        return "Funktioner";
-        case VhdlDocGen::RECORD:
+        }
+        else if ((SpecifierRecord&type)!=0)
+        {
           if (single) return "Post";
           else        return "Poster";
-        case VhdlDocGen::PROCEDURE:
+        }
+        else if ((SpecifierProcedure&type)!=0)
+        {
           if (single) return "Procedur";
           else        return "Procedurer";
-        case VhdlDocGen::ARCHITECTURE:
+        }
+        else if ((SpecifierArchitecture&type)!=0)
+        {
           if (single) return "Arkitektur";
           else        return "Arkitekturer";
-        case VhdlDocGen::ATTRIBUTE:
+        }
+        else if ((SpecifierAttributeVhdl&type)!=0)
+        {
           return "Attribut";
-        case VhdlDocGen::PROCESS:
+        }
+        else if ((SpecifierProcess&type)!=0)
+        {
           if (single) return "Process";
           else        return "Processer";
-        case VhdlDocGen::PORT:
+        }
+        else if ((SpecifierPort&type)!=0)
+        {
           if (single) return "Port";
           else        return "Portar";
-        case VhdlDocGen::USE:
+        }
+        else if ((SpecifierUse&type)!=0)
+        {
           if (single) return "use clause";
           else        return "Use Clauses";
-        case VhdlDocGen::GENERIC:
+        }
+        else if ((SpecifierGenericVhdl&type)!=0)
+        {
           if (single) return "Generisk";
           else        return "Generiska";
-        case VhdlDocGen::PACKAGE_BODY:
+        }
+        else if ((SpecifierPackage_body&type)!=0)
+        {
           return "Paketinehåll";
-        case VhdlDocGen::UNITS:
+        }
+        else if ((SpecifierUnits&type)!=0)
+        {
           return "Enheter";
-        case VhdlDocGen::SHAREDVARIABLE:
+        }
+        else if ((SpecifierSharedvariable&type)!=0)
+        {
           if (single) return "Delad Variabel";
           else        return "Delade Variabler";
-        case VhdlDocGen::VFILE:
+        }
+        else if ((SpecifierVfile&type)!=0)
+        {
           if (single) return "Fil";
           else        return "Filer";
-        case VhdlDocGen::GROUP:
+        }
+        else if ((SpecifierGroup&type)!=0)
+        {
           if (single) return "Grupp";
           else        return "Grupper";
-        case VhdlDocGen::INSTANTIATION:
+        }
+        else if ((SpecifierInstantiation&type)!=0)
+        {
           if (single) return "Instantiation";
           else        return "Instantiations";
-        case VhdlDocGen::ALIAS:
+        }
+        else if ((SpecifierAliasVhdl&type)!=0)
+        {
           return "Alias";
-        case VhdlDocGen::CONFIG:
+        }
+        else if ((SpecifierConfig&type)!=0)
+        {
           if (single) return "Konfiguration";
           else        return "Konfigurationer";
-        case VhdlDocGen::MISCELLANEOUS:
+        }
+        else if ((SpecifierMiscellaneous&type)!=0)
+        {
           return "Diverse";
-        case VhdlDocGen::UCF_CONST:
+        }
+        else if ((SpecifierUcf_const&type)!=0)
+        {
           return "Begränsningar";
-        default:
+        }
+        else
           return "Klass";
-      }
     }
     virtual QCString trCustomReference(const QCString &name)
     { return QCString(name)+"referens"; }

--- a/src/types.h
+++ b/src/types.h
@@ -60,6 +60,135 @@ enum SrcLangExt
   SrcLangExt_Lex      = 0x80000
 };
 
+/** This struct is used to store the class specifiers */
+struct Spec
+{
+  Spec() : spec(0), specExt(0) {}
+  Spec(uint64 n, uint64 e = 0) : spec(n), specExt(e) {}
+
+  bool operator==(Spec rhs) const { return rhs.spec == spec && rhs.specExt == specExt;}
+
+  bool operator!=(Spec rhs) const { return !(rhs==*this);}
+  friend bool operator!=(const int lhs, const Spec& rhs) { return !(rhs==lhs);}
+
+  bool operator&&(const Spec& rhs) { return (*this!=0) && (rhs!=0);}
+  friend bool operator&&(const bool lhs, const Spec& rhs) { return lhs && (rhs!=0);}
+
+  bool operator||(const Spec& rhs) { return (*this!=0) || (rhs!=0);}
+  friend bool operator||(const bool lhs, const Spec& rhs) { return lhs || (rhs!=0);}
+
+  bool operator!() { return !(spec!=0 || specExt!=0);}
+
+  Spec operator~() const { return Spec(~spec,~specExt);}
+
+  Spec operator&(Spec rhs) const { return Spec(rhs.spec & spec, rhs.specExt & specExt);}
+  Spec operator&=(const Spec rhs) { spec &= rhs.spec; specExt &= rhs.specExt; return *this;}
+
+  Spec operator|(Spec rhs) const { return Spec(rhs.spec | spec, rhs.specExt | specExt);}
+  Spec operator|=(const Spec rhs) { spec |= rhs.spec; specExt |= rhs.specExt; return *this;}
+
+  Spec operator^(Spec rhs) const { return Spec(rhs.spec ^ spec, rhs.specExt ^ specExt);}
+  Spec operator^=(const Spec rhs) { spec ^= rhs.spec; specExt ^= rhs.specExt; return *this;}
+
+  uint64 spec;
+  uint64 specExt;
+};
+// class specifiers (add new items to the end)
+static const Spec SpecifierTemplate        = (1ULL<<0);
+static const Spec SpecifierGeneric         = (1ULL<<1);
+static const Spec SpecifierRef             = (1ULL<<2);
+static const Spec SpecifierValue           = (1ULL<<3);
+static const Spec SpecifierInterface       = (1ULL<<4);
+static const Spec SpecifierStruct          = (1ULL<<5);
+static const Spec SpecifierUnion           = (1ULL<<6);
+static const Spec SpecifierException       = (1ULL<<7);
+static const Spec SpecifierProtocol        = (1ULL<<8);
+static const Spec SpecifierCategory        = (1ULL<<9);
+static const Spec SpecifierSealedClass     = (1ULL<<10);
+static const Spec SpecifierAbstractClass   = (1ULL<<11);
+static const Spec SpecifierEnum            = (1ULL<<12); // for Java-style enums
+static const Spec SpecifierService         = (1ULL<<13); // UNO IDL
+static const Spec SpecifierSingleton       = (1ULL<<14); // UNO IDL
+static const Spec SpecifierForwardDecl     = (1ULL<<15); // forward declared template classes
+static const Spec SpecifierLocal           = (1ULL<<16); // for Slice types
+
+// member specifiers (add new items to the beginning)
+static const Spec SpecifierEnumStruct      = (1ULL<<18);
+static const Spec SpecifierConstExpr       = (1ULL<<19); // C++11 constexpr
+static const Spec SpecifierPrivateGettable     = (1ULL<<20); // C# private getter
+static const Spec SpecifierProtectedGettable   = (1ULL<<21); // C# protected getter
+static const Spec SpecifierPrivateSettable     = (1ULL<<22); // C# private setter
+static const Spec SpecifierProtectedSettable   = (1ULL<<23); // C# protected setter
+static const Spec SpecifierInline          = (1ULL<<24);
+static const Spec SpecifierExplicit        = (1ULL<<25);
+static const Spec SpecifierMutable         = (1ULL<<26);
+static const Spec SpecifierSettable        = (1ULL<<27);
+static const Spec SpecifierGettable        = (1ULL<<28);
+static const Spec SpecifierReadable        = (1ULL<<29);
+static const Spec SpecifierWritable        = (1ULL<<30);
+static const Spec SpecifierFinal           = (1ULL<<31);
+static const Spec SpecifierAbstract        = (1ULL<<32);
+static const Spec SpecifierAddable         = (1ULL<<33);
+static const Spec SpecifierRemovable       = (1ULL<<34);
+static const Spec SpecifierRaisable        = (1ULL<<35);
+static const Spec SpecifierOverride        = (1ULL<<36);
+static const Spec SpecifierNew             = (1ULL<<37);
+static const Spec SpecifierSealed          = (1ULL<<38);
+static const Spec SpecifierInitonly        = (1ULL<<39);
+static const Spec SpecifierOptional        = (1ULL<<40);
+static const Spec SpecifierRequired        = (1ULL<<41);
+static const Spec SpecifierNonAtomic       = (1ULL<<42);
+static const Spec SpecifierCopy            = (1ULL<<43);
+static const Spec SpecifierRetain          = (1ULL<<44);
+static const Spec SpecifierAssign          = (1ULL<<45);
+static const Spec SpecifierStrong          = (1ULL<<46);
+static const Spec SpecifierWeak            = (1ULL<<47);
+static const Spec SpecifierUnretained      = (1ULL<<48);
+static const Spec SpecifierAlias           = (1ULL<<49);
+static const Spec SpecifierConstExp        = (1ULL<<50);
+static const Spec SpecifierDefault         = (1ULL<<51);
+static const Spec SpecifierDelete          = (1ULL<<52);
+static const Spec SpecifierNoExcept        = (1ULL<<53);
+static const Spec SpecifierAttribute       = (1ULL<<54); // UNO IDL attribute
+static const Spec SpecifierProperty        = (1ULL<<55); // UNO IDL property
+static const Spec SpecifierReadonly        = (1ULL<<56); // on UNO IDL attribute or property
+static const Spec SpecifierBound           = (1ULL<<57); // on UNO IDL attribute or property
+static const Spec SpecifierConstrained     = (1ULL<<58); // on UNO IDL property
+static const Spec SpecifierTransient       = (1ULL<<59); // on UNO IDL property
+static const Spec SpecifierMaybeVoid       = (1ULL<<60); // on UNO IDL property
+static const Spec SpecifierMaybeDefault    = (1ULL<<61); // on UNO IDL property
+static const Spec SpecifierMaybeAmbiguous  = (1ULL<<62); // on UNO IDL property
+static const Spec SpecifierPublished       = (1ULL<<63); // UNO IDL keyword
+
+// VHDL specifiers
+static const Spec SpecifierLibrary         = Spec(0,1ULL<< 1);
+static const Spec SpecifierEntity          = Spec(0,1ULL<< 2);
+static const Spec SpecifierPackage_body    = Spec(0,1ULL<< 3);
+static const Spec SpecifierArchitecture    = Spec(0,1ULL<< 4);
+static const Spec SpecifierPackage         = Spec(0,1ULL<< 5);
+static const Spec SpecifierAttributeVhdl       = Spec(0,1ULL<< 6);
+static const Spec SpecifierSignal          = Spec(0,1ULL<< 7);
+static const Spec SpecifierComponent       = Spec(0,1ULL<< 8);
+static const Spec SpecifierConstant        = Spec(0,1ULL<< 9);
+static const Spec SpecifierType            = Spec(0,1ULL<<10);
+static const Spec SpecifierSubtype         = Spec(0,1ULL<<11);
+static const Spec SpecifierFunction        = Spec(0,1ULL<<12);
+static const Spec SpecifierRecord          = Spec(0,1ULL<<13);
+static const Spec SpecifierProcedure       = Spec(0,1ULL<<14);
+static const Spec SpecifierUse             = Spec(0,1ULL<<15);
+static const Spec SpecifierProcess         = Spec(0,1ULL<<16);
+static const Spec SpecifierPort            = Spec(0,1ULL<<17);
+static const Spec SpecifierUnits           = Spec(0,1ULL<<18);
+static const Spec SpecifierGenericVhdl         = Spec(0,1ULL<<19);
+static const Spec SpecifierInstantiation   = Spec(0,1ULL<<20);
+static const Spec SpecifierGroup           = Spec(0,1ULL<<21);
+static const Spec SpecifierVfile           = Spec(0,1ULL<<22);
+static const Spec SpecifierSharedvariable  = Spec(0,1ULL<<23);
+static const Spec SpecifierConfig          = Spec(0,1ULL<<24);
+static const Spec SpecifierAliasVhdl           = Spec(0,1ULL<<25);
+static const Spec SpecifierMiscellaneous   = Spec(0,1ULL<<26);
+static const Spec SpecifierUcf_const       = Spec(0,1ULL<<27);
+
 /** Grouping info */
 struct Grouping
 {

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1305,7 +1305,7 @@ static void generateMemLink(yyscan_t yyscanner,CodeOutputInterface &ol,QCString 
   const MemberDef *md=VhdlDocGen::findMember(className,memberName);
   ClassDef *po=VhdlDocGen::getClass(className);
 
-  if (md==0 && po && (VhdlDocGen::VhdlClasses)po->protection()==VhdlDocGen::PACKBODYCLASS)
+  if (md==0 && po && ((po->getClassSpecifier()&SpecifierPackage)!= 0))
   {
     QCString temp=className;//.stripPrefix("_");
     temp.stripPrefix("_");

--- a/src/vhdldocgen.h
+++ b/src/vhdldocgen.h
@@ -68,46 +68,6 @@ struct VhdlConfNode
 class VhdlDocGen
 {
   public:
-
-    enum VhdlClasses       // Overlays: Protection
-    {
-      ENTITYCLASS,         // Overlays: Public
-      PACKBODYCLASS,       // Overlays: Protected
-      ARCHITECTURECLASS,   // Overlays: Private
-      PACKAGECLASS         // Overlays: Package
-    };
-
-    enum VhdlKeyWords
-    {
-      LIBRARY=1,
-      ENTITY,
-      PACKAGE_BODY,
-      ARCHITECTURE,
-      PACKAGE,
-      ATTRIBUTE,
-      SIGNAL,
-      COMPONENT,
-      CONSTANT,
-      TYPE,
-      SUBTYPE,
-      FUNCTION,
-      RECORD,
-      PROCEDURE,
-      USE,
-      PROCESS,
-      PORT,
-      UNITS,
-      GENERIC,
-      INSTANTIATION,
-      GROUP,
-      VFILE,
-      SHAREDVARIABLE,
-      CONFIG,
-      ALIAS,
-      MISCELLANEOUS,
-      UCF_CONST
-    };
-
     VhdlDocGen();
     virtual ~VhdlDocGen();
     static void init();
@@ -194,11 +154,11 @@ class VhdlDocGen
 
     static void writePlainVHDLDeclarations(const MemberList* ml,OutputList &ol,
         const ClassDef *cd,const NamespaceDef *nd,const FileDef *fd,const GroupDef *gd,
-        uint64_t specifier);
+        Spec specifier);
 
     static void writeVHDLDeclarations(const MemberList* ml,OutputList &ol,
         const ClassDef *cd,const NamespaceDef *nd,const FileDef *fd,const GroupDef *gd,
-        const QCString &title,const QCString &subtitle,bool showEnumValues,int type);
+        const QCString &title,const QCString &subtitle,bool showEnumValues,Spec type);
 
     static bool writeClassType(const ClassDef *,OutputList &ol ,QCString & cname);
 
@@ -208,7 +168,7 @@ class VhdlDocGen
 
     static QCString getClassName(const ClassDef*);
     static bool isNumber(const std::string& s);
-    static QCString getProtectionName(int prot);
+    static QCString getSpecifierName(Spec spec);
 
     static void parseUCF(const char*  input,Entry* entity,const QCString &f,bool vendor);
 
@@ -235,10 +195,10 @@ class VhdlDocGen
 
     static  bool isVhdlClass (const Entry *cu)
     {
-      return cu->spec==VhdlDocGen::ENTITY       ||
-             cu->spec==VhdlDocGen::PACKAGE      ||
-             cu->spec==VhdlDocGen::ARCHITECTURE ||
-             cu->spec==VhdlDocGen::PACKAGE_BODY;
+      return (cu->spec&SpecifierEntity)!=0       ||
+             (cu->spec&SpecifierPackage)!=0      ||
+             (cu->spec&SpecifierArchitecture)!=0 ||
+             (cu->spec&SpecifierPackage_body)!=0;
     }
 
   static void resetCodeVhdlParserState();

--- a/src/vhdljjparser.h
+++ b/src/vhdljjparser.h
@@ -47,8 +47,8 @@ class VHDLOutlineParser : public OutlineParserInterface
     void lineCount();
     void addProto(const char *s1,const char *s2,const char *s3,const char *s4,const char *s5,const char *s6);
     //void addConfigureNode(const char* a,const char*b, bool,bool isLeaf,bool inlineConf);
-    void createFunction(const char *impure,uint64 spec,const char *fname);
-    void addVhdlType(const char *n,int startLine,int section, uint64 spec,const char* args,const char* type,Protection prot);
+    void createFunction(const char *impure,Spec spec,const char *fname);
+    void addVhdlType(const char *n,int startLine,int section, Spec spec,const char* args,const char* type,Protection prot);
     void addCompInst(const char *n, const char* instName, const char* comp,int iLine);
     void handleCommentBlock(const QCString &doc,bool brief);
     void handleFlowComment(const char*);

--- a/vhdlparser/VhdlParser.cc
+++ b/vhdlparser/VhdlParser.cc
@@ -306,7 +306,7 @@ s+=s1;
     if (!hasError) {
     jj_consume_token(SEMI_T);
     }
-outlineParser()->addVhdlType(s2.data(),outlineParser()->getLine(ALIAS_T),Entry::VARIABLE_SEC,VhdlDocGen::ALIAS,0,s.data(),Public);
+outlineParser()->addVhdlType(s2.data(),outlineParser()->getLine(ALIAS_T),Entry::VARIABLE_SEC,SpecifierAliasVhdl,0,s.data(),Public);
 
  return s2+" "+s+";";
 assert(false);
@@ -401,7 +401,7 @@ QCString t=s1+"::"+s;
     m_sharedState->genLabels.resize(0);
     outlineParser()->pushLabel(m_sharedState->genLabels,s1);
     m_sharedState->lastCompound=m_sharedState->current;
-    outlineParser()->addVhdlType(t.data(),outlineParser()->getLine(ARCHITECTURE_T),Entry::CLASS_SEC,VhdlDocGen::ARCHITECTURE,0,0,Private);
+    outlineParser()->addVhdlType(t.data(),outlineParser()->getLine(ARCHITECTURE_T),Entry::CLASS_SEC,SpecifierArchitecture,0,0,Public);
     }
     if (!hasError) {
     try {
@@ -701,7 +701,7 @@ QCString VhdlParser::attribute_declaration() {QCString s,s1;
     if (!hasError) {
     jj_consume_token(SEMI_T);
     }
-outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,VhdlDocGen::ATTRIBUTE,0,s1.data(),Public);
+outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,SpecifierAttributeVhdl,0,s1.data(),Public);
     return " attribute "+s+":"+s1+";";
 assert(false);
 }
@@ -820,7 +820,7 @@ QCString VhdlParser::attribute_specification() {QCString s,s1,s2;
     jj_consume_token(SEMI_T);
     }
 QCString t= s1+" is "+s2;
-   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,VhdlDocGen::ATTRIBUTE,0,t.data(),Public);
+   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,SpecifierAttributeVhdl,0,t.data(),Public);
    return " attribute "+s+" of "+s1+ " is "+s2+";";
 assert(false);
 }
@@ -1632,7 +1632,7 @@ void VhdlParser::component_declaration() {QCString s;
     }
     }
     if (!hasError) {
-m_sharedState->currP=VhdlDocGen::COMPONENT;
+m_sharedState->currP=SpecifierComponent;
     }
     if (!hasError) {
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1661,7 +1661,7 @@ m_sharedState->currP=VhdlDocGen::COMPONENT;
     }
     }
     if (!hasError) {
-outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(COMPONENT_T),Entry::VARIABLE_SEC,VhdlDocGen::COMPONENT,0,0,Public);
+outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(COMPONENT_T),Entry::VARIABLE_SEC,SpecifierComponent,0,0,Public);
      m_sharedState->currP=0;
     }
     if (!hasError) {
@@ -2059,7 +2059,7 @@ void VhdlParser::configuration_declaration() {QCString s,s1;
     }
     if (!hasError) {
 m_sharedState->confName=s+"::"+s1;
-  outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONFIGURATION_T),Entry::VARIABLE_SEC,VhdlDocGen::CONFIG,"configuration",s1.data(),Public);
+  outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONFIGURATION_T),Entry::VARIABLE_SEC,SpecifierConfig,"configuration",s1.data(),Public);
     }
     if (!hasError) {
     configuration_declarative_part();
@@ -2230,7 +2230,7 @@ QCString VhdlParser::constant_declaration() {QCString s,s1,s2;Token *t=0;
 if(t)
       s2.prepend(":=");
      QCString it=s1+s2;
-     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONSTANT_T),Entry::VARIABLE_SEC,VhdlDocGen::CONSTANT,0,it.data(),Public);
+     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONSTANT_T),Entry::VARIABLE_SEC,SpecifierConstant,0,it.data(),Public);
      it.prepend("constant ");
      return it;
 assert(false);
@@ -2610,7 +2610,7 @@ auto ql = split(rec_name.str(),",");
       outlineParser()->addVhdlType(
           name.c_str(),outlineParser()->getLine(),
           Entry::VARIABLE_SEC,
-          VhdlDocGen::RECORD,0,
+          SpecifierRecord,0,
           s1.data(),
           Public);
     }
@@ -2925,7 +2925,7 @@ void VhdlParser::entity_declaration() {QCString s;
     if (!hasError) {
 m_sharedState->lastEntity=m_sharedState->current;
                 m_sharedState->lastCompound=0;
-                outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ENTITY_T),Entry::CLASS_SEC,VhdlDocGen::ENTITY,0,0,Public);
+                outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ENTITY_T),Entry::CLASS_SEC,SpecifierEntity,0,0,Public);
     }
     if (!hasError) {
     entity_header();
@@ -3181,7 +3181,7 @@ void VhdlParser::entity_header() {
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case GENERIC_T:{
       if (!hasError) {
-m_sharedState->currP=VhdlDocGen::GENERIC;m_sharedState->parse_sec=GEN_SEC;
+m_sharedState->currP=SpecifierGenericVhdl;m_sharedState->parse_sec=GEN_SEC;
       }
       if (!hasError) {
       generic_clause();
@@ -3197,7 +3197,7 @@ m_sharedState->currP=VhdlDocGen::GENERIC;m_sharedState->parse_sec=GEN_SEC;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case PORT_T:{
       if (!hasError) {
-m_sharedState->currP=VhdlDocGen::PORT;
+m_sharedState->currP=SpecifierPort;
       }
       if (!hasError) {
       port_clause();
@@ -3760,7 +3760,7 @@ QCString VhdlParser::file_declaration() {QCString s,s1,s2,s3;
     jj_consume_token(SEMI_T);
     }
 QCString t1=s2+" "+s3;
-   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::VFILE,0,t1.data(),Public);
+   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierVfile,0,t1.data(),Public);
    return " file "+s+":"+s2+" "+s3+";";
 assert(false);
 }
@@ -3925,7 +3925,7 @@ QCString VhdlParser::full_type_declaration() {std::shared_ptr<Entry> tmpEntry;QC
     }
     if (!hasError) {
 tmpEntry=m_sharedState->current;
-    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::RECORD,0,0,Public);
+    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierRecord,0,0,Public);
     }
     if (!hasError) {
     s2 = type_definition();
@@ -3935,16 +3935,16 @@ tmpEntry=m_sharedState->current;
     }
 if (s2.contains("#")) {
       VhdlDocGen::deleteAllChars(s2,'#');
-      tmpEntry->spec=VhdlDocGen::RECORD;
+      tmpEntry->spec=SpecifierRecord;
       tmpEntry->type=s2.data();
     }
     else if (s2.contains("%")) {
       VhdlDocGen::deleteAllChars(s2,'%');
-      tmpEntry->spec=VhdlDocGen::UNITS;
+      tmpEntry->spec=SpecifierUnits;
       tmpEntry->type=s2.data();
      }
     else {
-      tmpEntry->spec=VhdlDocGen::TYPE;
+      tmpEntry->spec=SpecifierType;
       tmpEntry->type=s2.data();
     }
 
@@ -4789,7 +4789,7 @@ QCString VhdlParser::interface_file_declaration() {QCString s,s1;
     if (!hasError) {
     s1 = subtype_indication();
     }
-outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::VFILE,0,s1.data(),Public);
+outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierVfile,0,s1.data(),Public);
     return QCString(" file "+s+":"+s1);
 assert(false);
 }
@@ -4938,16 +4938,16 @@ if(tok)
         s3+=":=";
 
       QCString it=s+":"+s1+" "+s2+" "+s3+" "+s4;
-      if (m_sharedState->currP!=VhdlDocGen::COMPONENT)
+      if ((m_sharedState->currP&SpecifierComponent)==0)
       {
-        if (m_sharedState->currP==VhdlDocGen::FUNCTION || m_sharedState->currP==VhdlDocGen::PROCEDURE)
+        if ((m_sharedState->currP&SpecifierFunction)!=0 || (m_sharedState->currP&SpecifierProcedure)!=0)
         {
           outlineParser()->addProto(s5.data(),s.data(),s1.data(),s2.data(),s3.data(),s4.data());
         }
         else
         {
           QCString i=s2+s3+s4;
-          if (m_sharedState->currP==VhdlDocGen::GENERIC && m_sharedState->param_sec==0)
+          if ((m_sharedState->currP&SpecifierGenericVhdl)!=0 && m_sharedState->param_sec==0)
             outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,m_sharedState->currP,i.data(),s1.data(),Public);
           else if(m_sharedState->parse_sec != GEN_SEC)
             outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,m_sharedState->currP,i.data(),s1.data(),Public);
@@ -5023,7 +5023,7 @@ QCString VhdlParser::library_clause() {QCString s;
     }
 if ( m_sharedState->parse_sec==0 && Config_getBool(SHOW_INCLUDE_FILES) )
                    {
-                           outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::LIBRARY,s.data(),"_library_",Public);
+                           outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierLibrary,0,"_library_",Public);
                    }
                    QCString s1="library "+s;
                    return s1;
@@ -5876,7 +5876,7 @@ void VhdlParser::package_body() {QCString s;
     if (!hasError) {
 m_sharedState->lastCompound=m_sharedState->current;
                         s.prepend("_");
-                        outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::CLASS_SEC,VhdlDocGen::PACKAGE_BODY,0,0,Protected);
+                        outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::CLASS_SEC,SpecifierPackage_body,0,0,Public);
     }
     if (!hasError) {
     package_body_declarative_part();
@@ -6081,13 +6081,13 @@ void VhdlParser::package_declaration() {QCString s;
 m_sharedState->lastCompound=m_sharedState->current;
                           std::shared_ptr<Entry> clone=std::make_shared<Entry>(*m_sharedState->current);
                           clone->section=Entry::NAMESPACE_SEC;
-                          clone->spec=VhdlDocGen::PACKAGE;
+                          clone->spec=SpecifierPackage;
                           clone->name=s;
                           clone->startLine=outlineParser()->getLine(PACKAGE_T);
                           clone->bodyLine=outlineParser()->getLine(PACKAGE_T);
                           clone->protection=Package;
                           m_sharedState->current_root->moveToSubEntryAndKeep(clone);
-                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::CLASS_SEC,VhdlDocGen::PACKAGE,0,0,Package);
+                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::CLASS_SEC,SpecifierPackage,0,0,Public);
     }
     if (!hasError) {
     package_header();
@@ -6380,7 +6380,7 @@ QCString VhdlParser::physical_type_definition() {QCString s,s1,s2;Token *t=0;
     jj_consume_token(SEMI_T);
     }
     if (!hasError) {
-outlineParser()->addVhdlType(s.data(),t->beginLine,Entry::VARIABLE_SEC,VhdlDocGen::UNITS,0,0,Public);
+outlineParser()->addVhdlType(s.data(),t->beginLine,Entry::VARIABLE_SEC,SpecifierUnits,0,0,Public);
     }
     if (!hasError) {
     while (!hasError) {
@@ -6863,7 +6863,7 @@ void VhdlParser::process_statement() {QCString s,s1,s2;Token *tok=0;Token *tok1=
     tok1 = jj_consume_token(PROCESS_T);
     }
     if (!hasError) {
-m_sharedState->currP=VhdlDocGen::PROCESS;
+m_sharedState->currP=SpecifierProcess;
     m_sharedState->current->startLine=tok1->beginLine;
     m_sharedState->current->bodyLine=tok1->beginLine;
     }
@@ -6962,7 +6962,7 @@ if(s.isEmpty())
           m_sharedState->currP=0;
           if(tok)
             s1=tok->image;
-          outlineParser()->createFunction(m_sharedState->currName.data(),VhdlDocGen::PROCESS,s1.data());
+          outlineParser()->createFunction(m_sharedState->currName.data(),SpecifierProcess,s1.data());
           outlineParser()->createFlow();
           m_sharedState->currName="";
           outlineParser()->newEntry();
@@ -7494,7 +7494,7 @@ QCString VhdlParser::secondary_unit_declaration() {QCString s,s1;Token *t1=0;
     if (!hasError) {
     jj_consume_token(SEMI_T);
     }
-outlineParser()->addVhdlType(s.data(),t1->beginLine,Entry::VARIABLE_SEC,VhdlDocGen::UNITS,0,s1.data(),Public);
+outlineParser()->addVhdlType(s.data(),t1->beginLine,Entry::VARIABLE_SEC,SpecifierUnits,0,s1.data(),Public);
    return s+"="+s1;
 assert(false);
 }
@@ -8039,7 +8039,7 @@ void VhdlParser::signal_declaration() {Token* tok=0;QCString s,s1,s2,s3,s4;
 if(tok)
       s3.prepend(":=");
      s4=s1+s2+s3;
-     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::SIGNAL,0,s4.data(),Public);
+     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierSignal,0,s4.data(),Public);
 }
 
 
@@ -8609,7 +8609,7 @@ void VhdlParser::subprogram_specification() {QCString s;Token *tok=0;Token *t;
       s = designator();
       }
       if (!hasError) {
-m_sharedState->currP=VhdlDocGen::PROCEDURE;
+m_sharedState->currP=SpecifierProcedure;
    outlineParser()->createFunction(s.data(),m_sharedState->currP,0);
    m_sharedState->tempEntry=m_sharedState->current;
    m_sharedState->current->startLine=outlineParser()->getLine(PROCEDURE_T);
@@ -8707,7 +8707,7 @@ outlineParser()->newEntry();
       s = designator();
       }
       if (!hasError) {
-m_sharedState->currP=VhdlDocGen::FUNCTION;
+m_sharedState->currP=SpecifierFunction;
    if(tok)
      outlineParser()->createFunction(tok->image.c_str(),m_sharedState->currP,s.data());
    else
@@ -8816,7 +8816,7 @@ QCString VhdlParser::subtype_declaration() {QCString s,s1;
     if (!hasError) {
     jj_consume_token(SEMI_T);
     }
-outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::SUBTYPE,0,s1.data(),Public);
+outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierSubtype,0,s1.data(),Public);
   return " subtype "+s+" is "+s1+";";
 assert(false);
 }
@@ -9219,8 +9219,8 @@ auto ql1=split(s.str(),",");
                          outlineParser()->addVhdlType(it.c_str(),
                                                       outlineParser()->getLine(),
                                                       Entry::VARIABLE_SEC,
-                                                      VhdlDocGen::USE,
-                                                      it.c_str(),
+                                                      SpecifierUse,
+                                                      0,
                                                       "_use_",Public);
                        }
                      }
@@ -9333,7 +9333,7 @@ QCString VhdlParser::variable_declaration() {Token *tok=0;Token *t1=0;QCString s
     if (!hasError) {
     jj_consume_token(SEMI_T);
     }
-int spec;
+Spec spec;
   if(t1)
     s2.prepend(":=");
   QCString val=" variable "+s+":"+s1+s2+";";
@@ -9342,10 +9342,10 @@ int spec;
   {
     it.prepend(" shared ");
     val.prepend(" shared");
-    spec=VhdlDocGen::SHAREDVARIABLE;
+    spec=SpecifierSharedvariable;
   }
   else
-    spec=VhdlDocGen::SHAREDVARIABLE;
+    spec=SpecifierSharedvariable;
 
   if(t1)
   {
@@ -9904,7 +9904,7 @@ m_sharedState->parse_sec=CONTEXT_SEC;
     jj_consume_token(SEMI_T);
     }
 m_sharedState->parse_sec=0;
-                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(LIBRARY_T),Entry::VARIABLE_SEC,VhdlDocGen::LIBRARY,"context",s1.data(),Public);
+                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(LIBRARY_T),Entry::VARIABLE_SEC,SpecifierLibrary,"context",s1.data(),Public);
 }
 
 
@@ -9982,7 +9982,7 @@ void VhdlParser::package_instantiation_declaration() {QCString s,s1,s2;
     jj_consume_token(SEMI_T);
     }
 QCString q=" is new "+s1+s2;
-      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::VARIABLE_SEC,VhdlDocGen::INSTANTIATION,"package",q.data(),Public);
+      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::VARIABLE_SEC,SpecifierInstantiation,"package",q.data(),Public);
 }
 
 
@@ -10057,7 +10057,7 @@ QCString VhdlParser::subprogram_instantiation_declaration() {QCString s,s1,s2;
     jj_consume_token(SEMI_T);
     }
 QCString q= " is new "+s1+s2;
-      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(FUNCTION_T),Entry::VARIABLE_SEC,VhdlDocGen::INSTANTIATION,"function ",q.data(),Public);
+      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(FUNCTION_T),Entry::VARIABLE_SEC,SpecifierInstantiation,"function ",q.data(),Public);
     return q;
 assert(false);
 }
@@ -11323,7 +11323,7 @@ QCString q;
      int b=outlineParser()->getLine(PROCEDURE_T);
 
      if (a>b) b=a;
-     outlineParser()->addVhdlType(m_sharedState->current->name.data(),b,Entry::VARIABLE_SEC,VhdlDocGen::GENERIC,ss.data(),0,Public);
+     outlineParser()->addVhdlType(m_sharedState->current->name.data(),b,Entry::VARIABLE_SEC,SpecifierGenericVhdl,ss.data(),0,Public);
    }
    m_sharedState->currP=0;return QCString();
 assert(false);

--- a/vhdlparser/VhdlParser.h
+++ b/vhdlparser/VhdlParser.h
@@ -8597,7 +8597,7 @@ struct SharedState
   QCString lab;
   int param_sec = 0;
   int parse_sec = 0;
-  int currP = 0;
+  Spec currP = 0;
 };
 
 VHDLOutlineParser *m_outlineParser;

--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -43,7 +43,7 @@ struct SharedState
   QCString lab;
   int param_sec = 0;
   int parse_sec = 0;
-  int currP = 0;
+  Spec currP = 0;
 };
 
 VHDLOutlineParser *m_outlineParser;
@@ -402,7 +402,7 @@ QCString alias_declaration() :  {QCString s,s1,s2;}
  <IS_T> { s+=" is "; } s1=name() {s+=s1;} [s1=signature() {s+=s1;}]
  <SEMI_T>
 {
- outlineParser()->addVhdlType(s2.data(),outlineParser()->getLine(ALIAS_T),Entry::VARIABLE_SEC,VhdlDocGen::ALIAS,0,s.data(),Public);
+ outlineParser()->addVhdlType(s2.data(),outlineParser()->getLine(ALIAS_T),Entry::VARIABLE_SEC,SpecifierAliasVhdl,0,s.data(),Public);
 
  return s2+" "+s+";";
 }
@@ -431,7 +431,7 @@ void architecture_body() : {QCString s,s1;}
     m_sharedState->genLabels.resize(0);
     outlineParser()->pushLabel(m_sharedState->genLabels,s1);
     m_sharedState->lastCompound=m_sharedState->current;
-    outlineParser()->addVhdlType(t.data(),outlineParser()->getLine(ARCHITECTURE_T),Entry::CLASS_SEC,VhdlDocGen::ARCHITECTURE,0,0,Private);
+    outlineParser()->addVhdlType(t.data(),outlineParser()->getLine(ARCHITECTURE_T),Entry::CLASS_SEC,SpecifierArchitecture,0,0,Public);
   }
   try
   {
@@ -503,7 +503,7 @@ QCString attribute_declaration() : {QCString s,s1;}
 {
  <ATTRIBUTE_T> s=identifier() <COLON_T> s1=type_mark() <SEMI_T>
   {
-    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,VhdlDocGen::ATTRIBUTE,0,s1.data(),Public);
+    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,SpecifierAttributeVhdl,0,s1.data(),Public);
     return " attribute "+s+":"+s1+";";
   }
  }
@@ -525,7 +525,7 @@ QCString attribute_specification():  {QCString s,s1,s2;}
   <ATTRIBUTE_T> s=attribute_designator() <OF_T> s1=entity_specification() <IS_T> s2=expression() <SEMI_T>
   {
    QCString t= s1+" is "+s2;
-   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,VhdlDocGen::ATTRIBUTE,0,t.data(),Public);
+   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ATTRIBUTE_T),Entry::VARIABLE_SEC,SpecifierAttributeVhdl,0,t.data(),Public);
    return " attribute "+s+" of "+s1+ " is "+s2+";";
   }
 }
@@ -712,11 +712,11 @@ void component_configuration () :{}
 void component_declaration() :  {QCString s;}
 {
  <COMPONENT_T> s=identifier() [ <IS_T> ]
-   { m_sharedState->currP=VhdlDocGen::COMPONENT; }
+   { m_sharedState->currP=SpecifierComponent; }
   [ generic_clause() ]
   [ port_clause() ]
    {
-     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(COMPONENT_T),Entry::VARIABLE_SEC,VhdlDocGen::COMPONENT,0,0,Public);
+     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(COMPONENT_T),Entry::VARIABLE_SEC,SpecifierComponent,0,0,Public);
      m_sharedState->currP=0;
   }
   <END_T> <COMPONENT_T> [ identifier() ] <SEMI_T>
@@ -838,7 +838,7 @@ void configuration_declaration() :  {QCString s,s1;}
   {
 
   m_sharedState->confName=s+"::"+s1;
-  outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONFIGURATION_T),Entry::VARIABLE_SEC,VhdlDocGen::CONFIG,"configuration",s1.data(),Public);
+  outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONFIGURATION_T),Entry::VARIABLE_SEC,SpecifierConfig,"configuration",s1.data(),Public);
   }
     configuration_declarative_part()
     block_configuration()
@@ -878,7 +878,7 @@ QCString constant_declaration() :  {QCString s,s1,s2;Token *t=0;}
      if(t)
       s2.prepend(":=");
      QCString it=s1+s2;
-     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONSTANT_T),Entry::VARIABLE_SEC,VhdlDocGen::CONSTANT,0,it.data(),Public);
+     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(CONSTANT_T),Entry::VARIABLE_SEC,SpecifierConstant,0,it.data(),Public);
      it.prepend("constant ");
      return it;
     }
@@ -989,7 +989,7 @@ QCString element_declaration() :  {QCString rec_name,s1,s2;}
       outlineParser()->addVhdlType(
           name.c_str(),outlineParser()->getLine(),
           Entry::VARIABLE_SEC,
-          VhdlDocGen::RECORD,0,
+          SpecifierRecord,0,
           s1.data(),
           Public);
     }
@@ -1044,7 +1044,7 @@ void entity_declaration() :  {QCString s;}
              {
                 m_sharedState->lastEntity=m_sharedState->current;
                 m_sharedState->lastCompound=0;
-                outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ENTITY_T),Entry::CLASS_SEC,VhdlDocGen::ENTITY,0,0,Public);
+                outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(ENTITY_T),Entry::CLASS_SEC,SpecifierEntity,0,0,Public);
                }
         entity_header()
         entity_declarative_part ()
@@ -1095,8 +1095,8 @@ s=entity_tag() [ s1=signature() ] { return s+s1;}
 
 void entity_header() : {}
 {
- [  { m_sharedState->currP=VhdlDocGen::GENERIC;m_sharedState->parse_sec=GEN_SEC; } generic_clause()]
- [ { m_sharedState->currP=VhdlDocGen::PORT; } port_clause()]
+ [  { m_sharedState->currP=SpecifierGenericVhdl;m_sharedState->parse_sec=GEN_SEC; } generic_clause()]
+ [ { m_sharedState->currP=SpecifierPort; } port_clause()]
 }
 
 QCString entity_name_list() :  {QCString s,s1,s2;}
@@ -1198,7 +1198,7 @@ QCString file_declaration() :  {QCString s,s1,s2,s3;}
  <FILE_T> s=identifier_list() <COLON_T> s2=subtype_indication() [ s3=file_open_information() ] <SEMI_T>
    {
    QCString t1=s2+" "+s3;
-   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::VFILE,0,t1.data(),Public);
+   outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierVfile,0,t1.data(),Public);
    return " file "+s+":"+s2+" "+s3+";";
    }
  }
@@ -1245,7 +1245,7 @@ QCString full_type_declaration() :  { std::shared_ptr<Entry> tmpEntry;QCString s
   <TYPE_T> s=identifier() <IS_T>
   {
     tmpEntry=m_sharedState->current;
-    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::RECORD,0,0,Public);
+    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierRecord,0,0,Public);
   }
  
   s2=type_definition()
@@ -1254,16 +1254,16 @@ QCString full_type_declaration() :  { std::shared_ptr<Entry> tmpEntry;QCString s
   {
      if (s2.contains("#")) {
       VhdlDocGen::deleteAllChars(s2,'#');
-      tmpEntry->spec=VhdlDocGen::RECORD;
+      tmpEntry->spec=SpecifierRecord;
       tmpEntry->type=s2.data();
     }
     else if (s2.contains("%")) {
       VhdlDocGen::deleteAllChars(s2,'%');
-      tmpEntry->spec=VhdlDocGen::UNITS;
+      tmpEntry->spec=SpecifierUnits;
       tmpEntry->type=s2.data();
      }
     else {
-      tmpEntry->spec=VhdlDocGen::TYPE;
+      tmpEntry->spec=SpecifierType;
       tmpEntry->type=s2.data();
     }
    
@@ -1465,7 +1465,7 @@ QCString interface_file_declaration() : {QCString s,s1;}
 {
   <FILE_T> s=identifier_list() <COLON_T> s1=subtype_indication()
   {
-    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::VFILE,0,s1.data(),Public);
+    outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierVfile,0,s1.data(),Public);
     return QCString(" file "+s+":"+s1);
   }
 }
@@ -1493,16 +1493,16 @@ QCString interface_variable_declaration() :  {Token *tok=0;Token *tok1=0;Token *
         s3+=":=";
 
       QCString it=s+":"+s1+" "+s2+" "+s3+" "+s4;
-      if (m_sharedState->currP!=VhdlDocGen::COMPONENT)
+      if ((m_sharedState->currP&SpecifierComponent)==0)
       {
-        if (m_sharedState->currP==VhdlDocGen::FUNCTION || m_sharedState->currP==VhdlDocGen::PROCEDURE)
+        if ((m_sharedState->currP&SpecifierFunction)!=0 || (m_sharedState->currP&SpecifierProcedure)!=0)
         {
           outlineParser()->addProto(s5.data(),s.data(),s1.data(),s2.data(),s3.data(),s4.data());
         }
         else
         {
           QCString i=s2+s3+s4;
-          if (m_sharedState->currP==VhdlDocGen::GENERIC && m_sharedState->param_sec==0)
+          if ((m_sharedState->currP&SpecifierGenericVhdl)!=0 && m_sharedState->param_sec==0)
             outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,m_sharedState->currP,i.data(),s1.data(),Public);
           else if(m_sharedState->parse_sec != GEN_SEC)
             outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,m_sharedState->currP,i.data(),s1.data(),Public);
@@ -1543,7 +1543,7 @@ QCString library_clause() :  {QCString s;}
  {
                if ( m_sharedState->parse_sec==0 && Config_getBool(SHOW_INCLUDE_FILES) )
                    {
-                           outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::LIBRARY,s.data(),"_library_",Public);
+                           outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierLibrary,0,"_library_",Public);
                    }
                    QCString s1="library "+s;
                    return s1;
@@ -1731,7 +1731,7 @@ void package_body() :  {QCString s;}
  {
                         m_sharedState->lastCompound=m_sharedState->current;
                         s.prepend("_");
-                        outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::CLASS_SEC,VhdlDocGen::PACKAGE_BODY,0,0,Protected);
+                        outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::CLASS_SEC,SpecifierPackage_body,0,0,Public);
                       }
  package_body_declarative_part()
 
@@ -1774,13 +1774,13 @@ void package_declaration():  {QCString s;}
                           m_sharedState->lastCompound=m_sharedState->current;
                           std::shared_ptr<Entry> clone=std::make_shared<Entry>(*m_sharedState->current);
                           clone->section=Entry::NAMESPACE_SEC;
-                          clone->spec=VhdlDocGen::PACKAGE;
+                          clone->spec=SpecifierPackage;
                           clone->name=s;
                           clone->startLine=outlineParser()->getLine(PACKAGE_T);
                           clone->bodyLine=outlineParser()->getLine(PACKAGE_T);
                           clone->protection=Package;
                           m_sharedState->current_root->moveToSubEntryAndKeep(clone);
-                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::CLASS_SEC,VhdlDocGen::PACKAGE,0,0,Package);
+                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::CLASS_SEC,SpecifierPackage,0,0,Public);
                           }
     package_header()  
     package_declarative_part()
@@ -1840,7 +1840,7 @@ QCString physical_literal() :  {QCString s,s1;}
 QCString physical_type_definition() : {QCString s,s1,s2;Token *t=0;}
 {
         t=<UNITS_T>
-            s=identifier()<SEMI_T> { outlineParser()->addVhdlType(s.data(),t->beginLine,Entry::VARIABLE_SEC,VhdlDocGen::UNITS,0,0,Public);}
+            s=identifier()<SEMI_T> { outlineParser()->addVhdlType(s.data(),t->beginLine,Entry::VARIABLE_SEC,SpecifierUnits,0,0,Public);}
             (
              s1=secondary_unit_declaration()
             )*
@@ -1951,7 +1951,7 @@ void process_statement() : {QCString s,s1,s2;Token *tok=0;Token *tok1=0;}
 [ s=identifier() <COLON_T> ]
 [ <POSTPONED_T> ] tok1=<PROCESS_T>
  {
-	m_sharedState->currP=VhdlDocGen::PROCESS;
+	m_sharedState->currP=SpecifierProcess;
     m_sharedState->current->startLine=tok1->beginLine;
     m_sharedState->current->bodyLine=tok1->beginLine;
  }
@@ -1979,7 +1979,7 @@ void process_statement() : {QCString s,s1,s2;Token *tok=0;Token *tok1=0;}
           m_sharedState->currP=0;
           if(tok)
             s1=tok->image;
-          outlineParser()->createFunction(m_sharedState->currName.data(),VhdlDocGen::PROCESS,s1.data());
+          outlineParser()->createFunction(m_sharedState->currName.data(),SpecifierProcess,s1.data());
           outlineParser()->createFlow();
           m_sharedState->currName="";
           outlineParser()->newEntry();
@@ -2085,7 +2085,7 @@ QCString secondary_unit_declaration() :  {QCString s,s1;Token *t1=0;}
 {
 s=identifier() t1=<EQU_T> s1=physical_literal() <SEMI_T>
 {
-   outlineParser()->addVhdlType(s.data(),t1->beginLine,Entry::VARIABLE_SEC,VhdlDocGen::UNITS,0,s1.data(),Public);  
+   outlineParser()->addVhdlType(s.data(),t1->beginLine,Entry::VARIABLE_SEC,SpecifierUnits,0,s1.data(),Public);  
    return s+"="+s1; }
 }
 
@@ -2219,7 +2219,7 @@ void signal_declaration() :  { Token* tok=0;QCString s,s1,s2,s3,s4;}
      if(tok)
       s3.prepend(":=");
      s4=s1+s2+s3;
-     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::SIGNAL,0,s4.data(),Public);
+     outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierSignal,0,s4.data(),Public);
      }
 }
 QCString signal_kind() :  {}
@@ -2339,7 +2339,7 @@ void subprogram_specification() : {QCString s;Token *tok=0;Token *t;}
 {
  <PROCEDURE_T> s=designator()
  {
-   m_sharedState->currP=VhdlDocGen::PROCEDURE;
+   m_sharedState->currP=SpecifierProcedure;
    outlineParser()->createFunction(s.data(),m_sharedState->currP,0);
    m_sharedState->tempEntry=m_sharedState->current;
    m_sharedState->current->startLine=outlineParser()->getLine(PROCEDURE_T);
@@ -2353,7 +2353,7 @@ void subprogram_specification() : {QCString s;Token *tok=0;Token *t;}
  |
  [ (tok=<PURE_T> | tok=<IMPURE_T>) ] t=<FUNCTION_T> s=designator()
  {
-   m_sharedState->currP=VhdlDocGen::FUNCTION;
+   m_sharedState->currP=SpecifierFunction;
    if(tok)
      outlineParser()->createFunction(tok->image.c_str(),m_sharedState->currP,s.data());
    else
@@ -2380,7 +2380,7 @@ QCString subtype_declaration() :  {QCString s,s1;}
 {
 <SUBTYPE_T> s=identifier() <IS_T> s1=subtype_indication() <SEMI_T>
 {
-  outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,VhdlDocGen::SUBTYPE,0,s1.data(),Public);
+  outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(),Entry::VARIABLE_SEC,SpecifierSubtype,0,s1.data(),Public);
   return " subtype "+s+" is "+s1+";";
 }
 }
@@ -2477,8 +2477,8 @@ QCString unconstraint_array_definition() :  {QCString s,s1,s2,s3;}
                          outlineParser()->addVhdlType(it.c_str(),
                                                       outlineParser()->getLine(),
                                                       Entry::VARIABLE_SEC,
-                                                      VhdlDocGen::USE,
-                                                      it.c_str(),
+                                                      SpecifierUse,
+                                                      0,
                                                       "_use_",Public);
                        }
                      }
@@ -2503,7 +2503,7 @@ QCString variable_declaration() :  {Token *tok=0;Token *t1=0;QCString s,s1,s2;}
 [ t1=<VARASSIGN_T> s2=expression() ] <SEMI_T>
 
 {
-  int spec;
+  Spec spec;
   if(t1)
     s2.prepend(":=");
   QCString val=" variable "+s+":"+s1+s2+";";
@@ -2512,10 +2512,10 @@ QCString variable_declaration() :  {Token *tok=0;Token *t1=0;QCString s,s1,s2;}
   {
     it.prepend(" shared ");
     val.prepend(" shared");
-    spec=VhdlDocGen::SHAREDVARIABLE;
+    spec=SpecifierSharedvariable;
   }
   else
-    spec=VhdlDocGen::SHAREDVARIABLE;
+    spec=SpecifierSharedvariable;
 
   if(t1)
   {
@@ -2632,7 +2632,7 @@ void context_declaration(): {QCString s,s1;}
  <CONTEXT_T> s=identifier() <IS_T> { m_sharedState->parse_sec=CONTEXT_SEC; }  (s1=libustcont_stats())* <END_T> [ <CONTEXT_T> ][identifier()] <SEMI_T>
                         {
                           m_sharedState->parse_sec=0;
-                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(LIBRARY_T),Entry::VARIABLE_SEC,VhdlDocGen::LIBRARY,"context",s1.data(),Public);
+                          outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(LIBRARY_T),Entry::VARIABLE_SEC,SpecifierLibrary,"context",s1.data(),Public);
                         }
 }
 
@@ -2648,7 +2648,7 @@ QCString libustcont_stats(): {QCString s;}
  <PACKAGE_T> s=identifier() <IS_T>  <NEW_T> s1=name() s2=signature() [gen_assoc_list()] <SEMI_T>
     {
       QCString q=" is new "+s1+s2;
-      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::VARIABLE_SEC,VhdlDocGen::INSTANTIATION,"package",q.data(),Public);
+      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(PACKAGE_T),Entry::VARIABLE_SEC,SpecifierInstantiation,"package",q.data(),Public);
     }
 }
 
@@ -2666,7 +2666,7 @@ QCString subprogram_instantiation_declaration():{QCString s,s1,s2;}
  <FUNCTION_T>  s=identifier() <IS_T> <NEW_T> s1=name()  s2=signature() [gen_assoc_list()] <SEMI_T>
     {
      QCString q= " is new "+s1+s2;
-      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(FUNCTION_T),Entry::VARIABLE_SEC,VhdlDocGen::INSTANTIATION,"function ",q.data(),Public);
+      outlineParser()->addVhdlType(s.data(),outlineParser()->getLine(FUNCTION_T),Entry::VARIABLE_SEC,SpecifierInstantiation,"function ",q.data(),Public);
     return q;
     }
 }
@@ -2923,7 +2923,7 @@ QCString ifunc():{QCString s,s1,s2,s3;Token *t=0;Token *t1=0;Token *t2=0;}
      int b=outlineParser()->getLine(PROCEDURE_T);
 
      if (a>b) b=a;
-     outlineParser()->addVhdlType(m_sharedState->current->name.data(),b,Entry::VARIABLE_SEC,VhdlDocGen::GENERIC,ss.data(),0,Public);
+     outlineParser()->addVhdlType(m_sharedState->current->name.data(),b,Entry::VARIABLE_SEC,SpecifierGenericVhdl,ss.data(),0,Public);
    }
    m_sharedState->currP=0;return QCString();
  }


### PR DESCRIPTION
Based on the simple VHDL code line:
```
library ieee;
```
we got the warning:
```
warning: Member ieeeieee (variable) of class filter_pkg is not documented.
```
note the double "ieee" and as "type" variable instead of library.

This problem lead to a "small" redesign of the specifiers definition into a `struct Spec`  (see `types.h`) as the specifiers were misused by VHDL and the current uint64 had no space to store all values anymore and a rename of the different Values (like `Entry::Published` into `SpecifierPublished` and `VhdlDocGen::RECORD` into `SpecifierRecord`, all names so that no name classes with `enum`s occurred).

The actual change for the double "ieee"  was done in the vhdlparser.jj (setting the args field to the empty field for library / use)
The problem regarding the usage of `variable` instead of `library` is corrected in memberdef.cpp (wrong name used for testing).

For VHDL Entity, Architecture, Package and PackageBody with a class definition the protection field was misused (leading to a strange occurrence of a +2 as the protection and e.g. VhdlDocGen::EntityClass and also the old VhdlDocGen::Entity were off by 2), this has been properly corrected by directly using the specifier.
Also the automatic setting of `EXTRACT_PRIVATE` and `EXTRACT_PACKAGE` for VHDL output are now no longer needed (which could also give strange effects, especially in multi language projects i.e. not really wanted output).

Furthermore a number of "simple" changes were necessary to overcome problems with `if` conditions etc.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7792512/example.tar.gz)
