### PR TITLE
Make email obfuscation CSP friendly

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -402,7 +402,7 @@ void HtmlDocVisitor::visit(DocURL *u)
         {
           p = writeUTF8Char(m_t,p);
         }
-        if (*p) m_t << "<span style=\"display: none;\">.nosp@m.</span>";
+        if (*p) m_t << "<span class=\"obfuscator\">.nosp@m.</span>";
         if (size==5) size=4; else size=5;
       }
     }

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1527,6 +1527,10 @@ span.emoji {
          */
 }
 
+span.obfuscator {
+  display: none;
+}
+
 .PageDocRTL-title div.toc li.level1 {
   margin-left: 0 !important;
   margin-right: 0;


### PR DESCRIPTION
Obfuscation makes email addresses harder to harvest by inserting into them HTML elements which are supposed to be invisible in the rendered HTML (display: none). The style is specified inline, and inline styles may be prohibited by content-security-policy HTTP header, breaking the markup if generated html is served from the server which sets such header. So move the style to CSS and refer to it via `class` in HTML code to fix this.

For content served from a server which sets CSP header, here's how the current doxygen genereted HTML look:
![2021-12-30-143020_maim](https://user-images.githubusercontent.com/474217/147749627-20b9fec5-2468-4c45-883c-8b77cb128959.png)
After the fix:
![2021-12-30-143110_maim](https://user-images.githubusercontent.com/474217/147749639-5a7a5c30-fdd5-48a5-bd33-4605d799420b.png)
