### PR TITLE
Wrong line counting in VHDL code with 2008 type comment

### DIFF
--- a/vhdlparser/VhdlParserTokenManager.cc
+++ b/vhdlparser/VhdlParserTokenManager.cc
@@ -3521,6 +3521,7 @@ void  VhdlParserTokenManager::SkipLexicalActions(Token *matchedToken){
          image.append(input_stream->GetSuffix(jjimageLen + (lengthOfMatch = jjmatchedPos + 1)));
    {
      QCString q = filter2008VhdlComment(image.data());
+     parser->outlineParser()->lineCount(image.data());
      parser->outlineParser()->handleCommentBlock(QCString(q),TRUE);image.clear();
    }
          break;

--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -128,6 +128,7 @@ SKIP :
   {
    {
      QCString q = filter2008VhdlComment(image.data());
+     parser->outlineParser()->lineCount(image.data());
      parser->outlineParser()->handleCommentBlock(QCString(q),TRUE);image.clear();
    }
   }


### PR DESCRIPTION
When having in VHDL the comment of type 2008 i.e. like:
```
/*!\file
 * \brief This file is generated with Matlab. It contains ROM with filter coefficients and supporting package*/
```
the line references are incorrect by the number of returns in the comment, due to the missing call to the line counting.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7793343/example.tar.gz)
