### PR TITLE
Missing <VERSION> in description of doxyparse

### DIFF
--- a/addon/doxyparse/README.md
+++ b/addon/doxyparse/README.md
@@ -36,8 +36,8 @@ Academic publications citing Doxyparse:
 * update debian/changelog, commit, push
 * create git tag, push to github analizo/doxyparse
 * build on amd64 and i386 archs, upload tar.gz to github
-  * tar -zcf doxyparse_<VERSION>_amd64.tar.gz -C bin/ doxyparse
-  * tar -zcf doxyparse_<VERSION>_i386.tar.gz -C bin/ doxyparse
+  * `tar -zcf doxyparse_<VERSION>_amd64.tar.gz -C bin/ doxyparse`
+  * `tar -zcf doxyparse_<VERSION>_i386.tar.gz -C bin/ doxyparse`
 * build debian packages for amd64 and i386, update analizo.org repository
     * (see analizo.github.io/README.md file for updating repository instructions)
     * upload the deb files to github release tag also


### PR DESCRIPTION
As the word `<VERSION>` is an, unknown, HTML tag it is not shown on e.g. github, making it part of a code sections makes it visible (other sections with commands are also shown as code sections).