### PR TITLE
issue #8355 Doxywizard 1.9.x doesn't start up properly

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -756,7 +756,7 @@ void Expert::loadSettings(QSettings *s)
   {
     i.next();
     QVariant var = s->value(SA("config/")+i.key());
-    if (i.value())
+    if (i.value() && var.isValid())
     {
       //printf("Loading key %s: type=%d value='%s'\n",qPrintable(i.key()),var.type(),qPrintable(var.toString()));
       i.value()->value() = var;


### PR DESCRIPTION
The problem here was that the "wizard/loadsetting" key in the registry is set (Using a set of settings defined by the user as a "default" set of settings) in an older version and that some of the keys didn't yet exist in that version but were required in the current version.
So we have to test whether or not the setting is valid and not a default "QVariant" is returned (as this will not have methods required by doxygen ./ there is no value and thus no update necessary and the current value can remain.

Note that the test contains of 2 parts:
- var.isDefault() i.e. whether or not the setting is present in the user "default" settings
- i.value() the name of the setting is known but not compiled into the current executable (e.g the SQLITE3 settings of the CLAN settings)

In the past this was, apparently, not necessary (or never noticed / reported).