### PR TITLE
Bug 690999 - Add project name to xml output

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1211,7 +1211,7 @@ class DoxygenType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, version=None, lang=None, compounddef=None, gds_collector_=None, **kwargs_):
+    def __init__(self, version=None, lang=None, project=None, compounddef=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -1221,6 +1221,11 @@ class DoxygenType(GeneratedsSuper):
         self.version_nsprefix_ = None
         self.lang = _cast(None, lang)
         self.lang_nsprefix_ = None
+        if project is None:
+            self.project = []
+        else:
+            self.project = project
+        self.project_nsprefix_ = None
         if compounddef is None:
             self.compounddef = []
         else:
@@ -1241,6 +1246,16 @@ class DoxygenType(GeneratedsSuper):
         return self.ns_prefix_
     def set_ns_prefix_(self, ns_prefix):
         self.ns_prefix_ = ns_prefix
+    def get_project(self):
+        return self.project
+    def set_project(self, project):
+        self.project = project
+    def add_project(self, value):
+        self.project.append(value)
+    def insert_project_at(self, index, value):
+        self.project.insert(index, value)
+    def replace_project_at(self, index, value):
+        self.project[index] = value
     def get_compounddef(self):
         return self.compounddef
     def set_compounddef(self, compounddef):
@@ -1272,6 +1287,7 @@ class DoxygenType(GeneratedsSuper):
     validate_DoxVersionNumber_patterns_ = [['^(\\d+\\.\\d+.*)$']]
     def hasContent_(self):
         if (
+            self.project or
             self.compounddef
         ):
             return True
@@ -1312,6 +1328,9 @@ class DoxygenType(GeneratedsSuper):
             eol_ = '\n'
         else:
             eol_ = ''
+        for project_ in self.project:
+            namespaceprefix_ = self.project_nsprefix_ + ':' if (UseCapturedNS_ and self.project_nsprefix_) else ''
+            project_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='project', pretty_print=pretty_print)
         for compounddef_ in self.compounddef:
             namespaceprefix_ = self.compounddef_nsprefix_ + ':' if (UseCapturedNS_ and self.compounddef_nsprefix_) else ''
             compounddef_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='compounddef', pretty_print=pretty_print)
@@ -1337,12 +1356,163 @@ class DoxygenType(GeneratedsSuper):
             already_processed.add('lang')
             self.lang = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'compounddef':
+        if nodeName_ == 'project':
+            obj_ = ProjectType.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.project.append(obj_)
+            obj_.original_tagname_ = 'project'
+        elif nodeName_ == 'compounddef':
             obj_ = compounddefType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
             self.compounddef.append(obj_)
             obj_.original_tagname_ = 'compounddef'
 # end class DoxygenType
+
+
+class ProjectType(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    subclass = None
+    superclass = None
+    def __init__(self, projectname=None, projectnumber=None, projectbrief=None, projectlogo=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.projectname = projectname
+        self.projectname_nsprefix_ = None
+        self.projectnumber = projectnumber
+        self.projectnumber_nsprefix_ = None
+        self.projectbrief = projectbrief
+        self.projectbrief_nsprefix_ = None
+        self.projectlogo = projectlogo
+        self.projectlogo_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, ProjectType)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if ProjectType.subclass:
+            return ProjectType.subclass(*args_, **kwargs_)
+        else:
+            return ProjectType(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_ns_prefix_(self):
+        return self.ns_prefix_
+    def set_ns_prefix_(self, ns_prefix):
+        self.ns_prefix_ = ns_prefix
+    def get_projectname(self):
+        return self.projectname
+    def set_projectname(self, projectname):
+        self.projectname = projectname
+    def get_projectnumber(self):
+        return self.projectnumber
+    def set_projectnumber(self, projectnumber):
+        self.projectnumber = projectnumber
+    def get_projectbrief(self):
+        return self.projectbrief
+    def set_projectbrief(self, projectbrief):
+        self.projectbrief = projectbrief
+    def get_projectlogo(self):
+        return self.projectlogo
+    def set_projectlogo(self, projectlogo):
+        self.projectlogo = projectlogo
+    def hasContent_(self):
+        if (
+            self.projectname is not None or
+            self.projectnumber is not None or
+            self.projectbrief is not None or
+            self.projectlogo is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ProjectType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('ProjectType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'ProjectType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ProjectType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='ProjectType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='ProjectType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ProjectType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.projectname is not None:
+            namespaceprefix_ = self.projectname_nsprefix_ + ':' if (UseCapturedNS_ and self.projectname_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectname>%s</%sprojectname>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectname), input_name='projectname')), namespaceprefix_ , eol_))
+        if self.projectnumber is not None:
+            namespaceprefix_ = self.projectnumber_nsprefix_ + ':' if (UseCapturedNS_ and self.projectnumber_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectnumber>%s</%sprojectnumber>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectnumber), input_name='projectnumber')), namespaceprefix_ , eol_))
+        if self.projectbrief is not None:
+            namespaceprefix_ = self.projectbrief_nsprefix_ + ':' if (UseCapturedNS_ and self.projectbrief_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectbrief>%s</%sprojectbrief>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectbrief), input_name='projectbrief')), namespaceprefix_ , eol_))
+        if self.projectlogo is not None:
+            namespaceprefix_ = self.projectlogo_nsprefix_ + ':' if (UseCapturedNS_ and self.projectlogo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectlogo>%s</%sprojectlogo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectlogo), input_name='projectlogo')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'projectname':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectname')
+            value_ = self.gds_validate_string(value_, node, 'projectname')
+            self.projectname = value_
+            self.projectname_nsprefix_ = child_.prefix
+        elif nodeName_ == 'projectnumber':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectnumber')
+            value_ = self.gds_validate_string(value_, node, 'projectnumber')
+            self.projectnumber = value_
+            self.projectnumber_nsprefix_ = child_.prefix
+        elif nodeName_ == 'projectbrief':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectbrief')
+            value_ = self.gds_validate_string(value_, node, 'projectbrief')
+            self.projectbrief = value_
+            self.projectbrief_nsprefix_ = child_.prefix
+        elif nodeName_ == 'projectlogo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectlogo')
+            value_ = self.gds_validate_string(value_, node, 'projectlogo')
+            self.projectlogo = value_
+            self.projectlogo_nsprefix_ = child_.prefix
+# end class ProjectType
 
 
 class compounddefType(GeneratedsSuper):
@@ -26553,6 +26723,7 @@ NamespaceToDefMappings_ = {'http://www.w3.org/XML/1998/namespace': []}
 
 __all__ = [
     "DoxygenType",
+    "ProjectType",
     "argsstring",
     "array",
     "attributes",

--- a/addon/doxmlparser/doxmlparser/index.py
+++ b/addon/doxmlparser/doxmlparser/index.py
@@ -1007,7 +1007,7 @@ class DoxygenType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, version=None, lang=None, compound=None, gds_collector_=None, **kwargs_):
+    def __init__(self, version=None, lang=None, project=None, compound=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -1017,6 +1017,8 @@ class DoxygenType(GeneratedsSuper):
         self.version_nsprefix_ = None
         self.lang = _cast(None, lang)
         self.lang_nsprefix_ = None
+        self.project = project
+        self.project_nsprefix_ = None
         if compound is None:
             self.compound = []
         else:
@@ -1037,6 +1039,10 @@ class DoxygenType(GeneratedsSuper):
         return self.ns_prefix_
     def set_ns_prefix_(self, ns_prefix):
         self.ns_prefix_ = ns_prefix
+    def get_project(self):
+        return self.project
+    def set_project(self, project):
+        self.project = project
     def get_compound(self):
         return self.compound
     def set_compound(self, compound):
@@ -1057,6 +1063,7 @@ class DoxygenType(GeneratedsSuper):
         self.lang = lang
     def hasContent_(self):
         if (
+            self.project is not None or
             self.compound
         ):
             return True
@@ -1097,6 +1104,9 @@ class DoxygenType(GeneratedsSuper):
             eol_ = '\n'
         else:
             eol_ = ''
+        if self.project is not None:
+            namespaceprefix_ = self.project_nsprefix_ + ':' if (UseCapturedNS_ and self.project_nsprefix_) else ''
+            self.project.export(outfile, level, namespaceprefix_, namespacedef_='', name_='project', pretty_print=pretty_print)
         for compound_ in self.compound:
             namespaceprefix_ = self.compound_nsprefix_ + ':' if (UseCapturedNS_ and self.compound_nsprefix_) else ''
             compound_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='compound', pretty_print=pretty_print)
@@ -1121,12 +1131,163 @@ class DoxygenType(GeneratedsSuper):
             already_processed.add('lang')
             self.lang = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'compound':
+        if nodeName_ == 'project':
+            obj_ = ProjectType.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.project = obj_
+            obj_.original_tagname_ = 'project'
+        elif nodeName_ == 'compound':
             obj_ = CompoundType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
             self.compound.append(obj_)
             obj_.original_tagname_ = 'compound'
 # end class DoxygenType
+
+
+class ProjectType(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    subclass = None
+    superclass = None
+    def __init__(self, projectname=None, projectnumber=None, projectbrief=None, projectlogo=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.projectname = projectname
+        self.projectname_nsprefix_ = None
+        self.projectnumber = projectnumber
+        self.projectnumber_nsprefix_ = None
+        self.projectbrief = projectbrief
+        self.projectbrief_nsprefix_ = None
+        self.projectlogo = projectlogo
+        self.projectlogo_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, ProjectType)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if ProjectType.subclass:
+            return ProjectType.subclass(*args_, **kwargs_)
+        else:
+            return ProjectType(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_ns_prefix_(self):
+        return self.ns_prefix_
+    def set_ns_prefix_(self, ns_prefix):
+        self.ns_prefix_ = ns_prefix
+    def get_projectname(self):
+        return self.projectname
+    def set_projectname(self, projectname):
+        self.projectname = projectname
+    def get_projectnumber(self):
+        return self.projectnumber
+    def set_projectnumber(self, projectnumber):
+        self.projectnumber = projectnumber
+    def get_projectbrief(self):
+        return self.projectbrief
+    def set_projectbrief(self, projectbrief):
+        self.projectbrief = projectbrief
+    def get_projectlogo(self):
+        return self.projectlogo
+    def set_projectlogo(self, projectlogo):
+        self.projectlogo = projectlogo
+    def hasContent_(self):
+        if (
+            self.projectname is not None or
+            self.projectnumber is not None or
+            self.projectbrief is not None or
+            self.projectlogo is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ProjectType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('ProjectType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'ProjectType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='ProjectType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='ProjectType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='ProjectType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='ProjectType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.projectname is not None:
+            namespaceprefix_ = self.projectname_nsprefix_ + ':' if (UseCapturedNS_ and self.projectname_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectname>%s</%sprojectname>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectname), input_name='projectname')), namespaceprefix_ , eol_))
+        if self.projectnumber is not None:
+            namespaceprefix_ = self.projectnumber_nsprefix_ + ':' if (UseCapturedNS_ and self.projectnumber_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectnumber>%s</%sprojectnumber>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectnumber), input_name='projectnumber')), namespaceprefix_ , eol_))
+        if self.projectbrief is not None:
+            namespaceprefix_ = self.projectbrief_nsprefix_ + ':' if (UseCapturedNS_ and self.projectbrief_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectbrief>%s</%sprojectbrief>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectbrief), input_name='projectbrief')), namespaceprefix_ , eol_))
+        if self.projectlogo is not None:
+            namespaceprefix_ = self.projectlogo_nsprefix_ + ':' if (UseCapturedNS_ and self.projectlogo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sprojectlogo>%s</%sprojectlogo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.projectlogo), input_name='projectlogo')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'projectname':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectname')
+            value_ = self.gds_validate_string(value_, node, 'projectname')
+            self.projectname = value_
+            self.projectname_nsprefix_ = child_.prefix
+        elif nodeName_ == 'projectnumber':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectnumber')
+            value_ = self.gds_validate_string(value_, node, 'projectnumber')
+            self.projectnumber = value_
+            self.projectnumber_nsprefix_ = child_.prefix
+        elif nodeName_ == 'projectbrief':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectbrief')
+            value_ = self.gds_validate_string(value_, node, 'projectbrief')
+            self.projectbrief = value_
+            self.projectbrief_nsprefix_ = child_.prefix
+        elif nodeName_ == 'projectlogo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'projectlogo')
+            value_ = self.gds_validate_string(value_, node, 'projectlogo')
+            self.projectlogo = value_
+            self.projectlogo_nsprefix_ = child_.prefix
+# end class ProjectType
 
 
 class CompoundType(GeneratedsSuper):
@@ -1618,5 +1779,6 @@ NamespaceToDefMappings_ = {'http://www.w3.org/XML/1998/namespace': []}
 __all__ = [
     "CompoundType",
     "DoxygenType",
-    "MemberType"
+    "MemberType",
+    "ProjectType"
 ]

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -12219,6 +12219,7 @@ void generateOutput()
   bool generateMan   = Config_getBool(GENERATE_MAN);
   bool generateRtf   = Config_getBool(GENERATE_RTF);
   bool generateDocbook = Config_getBool(GENERATE_DOCBOOK);
+  bool generateXml   = Config_getBool(GENERATE_XML);
 
 
   g_outputList = new OutputList;
@@ -12318,6 +12319,10 @@ void generateOutput()
   {
     copyLogo(Config_getString(RTF_OUTPUT));
   }
+  if (generateXml)
+  {
+    copyLogo(Config_getString(XML_OUTPUT));
+  }
 
   const FormulaManager &fm = FormulaManager::instance();
   if (fm.hasFormulas() && generateHtml
@@ -12400,7 +12405,7 @@ void generateOutput()
   writeTagFile();
   g_s.end();
 
-  if (Config_getBool(GENERATE_XML))
+  if (generateXml)
   {
     g_s.begin("Generating XML output...\n");
     Doxygen::generatingXmlOutput=TRUE;

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -8,10 +8,20 @@
 
   <xsd:complexType name="DoxygenType">
     <xsd:sequence maxOccurs="unbounded">
-      <xsd:element name="compounddef" type="compounddefType" minOccurs="0" />
+      <xsd:element name="project" type="ProjectType"/>
+      <xsd:element name="compounddef" type="compounddefType" maxOccurs="unbounded" minOccurs="0" />
     </xsd:sequence>
     <xsd:attribute name="version" type="DoxVersionNumber" use="required" />
     <xsd:attribute ref="xml:lang" use="required"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="ProjectType">
+    <xsd:sequence>
+    <xsd:element name="projectname" type="xsd:string"/>
+    <xsd:element name="projectnumber" type="xsd:string"/>
+    <xsd:element name="projectbrief" type="xsd:string"/>
+    <xsd:element name="projectlogo" type="xsd:string"/>
+    </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="compounddefType">

--- a/templates/xml/index.xsd
+++ b/templates/xml/index.xsd
@@ -6,10 +6,20 @@
 
   <xsd:complexType name="DoxygenType">
     <xsd:sequence>
+      <xsd:element name="project" type="ProjectType"/>
       <xsd:element name="compound" type="CompoundType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="version" type="xsd:string" use="required"/>
     <xsd:attribute ref="xml:lang" use="required"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="ProjectType">
+    <xsd:sequence>
+    <xsd:element name="projectname" type="xsd:string"/>
+    <xsd:element name="projectnumber" type="xsd:string"/>
+    <xsd:element name="projectbrief" type="xsd:string"/>
+    <xsd:element name="projectlogo" type="xsd:string"/>
+    </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="CompoundType">

--- a/testing/001/indexpage.xml
+++ b/testing/001/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/002/indexpage.xml
+++ b/testing/002/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/003/indexpage.xml
+++ b/testing/003/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/004/indexpage.xml
+++ b/testing/004/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/005/indexpage.xml
+++ b/testing/005/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/006/indexpage.xml
+++ b/testing/006/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/007/indexpage.xml
+++ b/testing/007/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/008/008__brief_8c.xml
+++ b/testing/008/008__brief_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="008__brief_8c" kind="file" language="C++">
     <compoundname>008_brief.c</compoundname>
     <briefdescription>

--- a/testing/009/bug.xml
+++ b/testing/009/bug.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="bug" kind="page">
     <compoundname>bug</compoundname>
     <title>Bug List</title>

--- a/testing/009/class_bug.xml
+++ b/testing/009/class_bug.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_bug" kind="class" language="C++" prot="public">
     <compoundname>Bug</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_deprecated.xml
+++ b/testing/009/class_deprecated.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_deprecated" kind="class" language="C++" prot="public">
     <compoundname>Deprecated</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_reminder.xml
+++ b/testing/009/class_reminder.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_reminder" kind="class" language="C++" prot="public">
     <compoundname>Reminder</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_test.xml
+++ b/testing/009/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" language="C++" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/class_todo.xml
+++ b/testing/009/class_todo.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_todo" kind="class" language="C++" prot="public">
     <compoundname>Todo</compoundname>
     <sectiondef kind="public-func">

--- a/testing/009/deprecated.xml
+++ b/testing/009/deprecated.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="deprecated" kind="page">
     <compoundname>deprecated</compoundname>
     <title>Deprecated List</title>

--- a/testing/009/reminders.xml
+++ b/testing/009/reminders.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="reminders" kind="page">
     <compoundname>reminders</compoundname>
     <title>Reminders</title>

--- a/testing/009/test.xml
+++ b/testing/009/test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="test" kind="page">
     <compoundname>test</compoundname>
     <title>Test List</title>

--- a/testing/009/todo.xml
+++ b/testing/009/todo.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="todo" kind="page">
     <compoundname>todo</compoundname>
     <title>Todo List</title>

--- a/testing/010/indexpage.xml
+++ b/testing/010/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/011/category_integer_07_arithmetic_08.xml
+++ b/testing/011/category_integer_07_arithmetic_08.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="category_integer_07_arithmetic_08" kind="category" language="Objective-C" prot="public">
     <compoundname>Integer(Arithmetic)</compoundname>
     <sectiondef kind="public-func">

--- a/testing/011/interface_integer.xml
+++ b/testing/011/interface_integer.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="interface_integer" kind="class" language="Objective-C" prot="public">
     <compoundname>Integer</compoundname>
     <basecompoundref prot="public" virt="non-virtual">Object</basecompoundref>

--- a/testing/012/citelist.xml
+++ b/testing/012/citelist.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="citelist" kind="page">
     <compoundname>citelist</compoundname>
     <title>Bibliography</title>

--- a/testing/012/indexpage.xml
+++ b/testing/012/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/013/class_t1.xml
+++ b/testing/013/class_t1.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t1" kind="class" language="C++" prot="public">
     <compoundname>T1</compoundname>
     <includes refid="013__class_8h" local="yes">inc/013_class.h</includes>

--- a/testing/013/class_t2.xml
+++ b/testing/013/class_t2.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t2" kind="class" language="C++" prot="public">
     <compoundname>T2</compoundname>
     <includes refid="013__class_8h" local="no">013_class.h</includes>

--- a/testing/013/class_t3.xml
+++ b/testing/013/class_t3.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t3" kind="class" language="C++" prot="public">
     <compoundname>T3</compoundname>
     <includes refid="013__class_8h" local="no">013_class.h</includes>

--- a/testing/013/class_t4.xml
+++ b/testing/013/class_t4.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_t4" kind="class" language="C++" prot="public">
     <compoundname>T4</compoundname>
     <includes refid="013__class_8h" local="yes">inc/013_class.h</includes>

--- a/testing/014/indexpage.xml
+++ b/testing/014/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/015/015__cond_8c.xml
+++ b/testing/015/015__cond_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="015__cond_8c" kind="file" language="C++">
     <compoundname>015_cond.c</compoundname>
     <sectiondef kind="func">

--- a/testing/016/016__copydoc_8c.xml
+++ b/testing/016/016__copydoc_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="016__copydoc_8c" kind="file" language="C++">
     <compoundname>016_copydoc.c</compoundname>
     <sectiondef kind="func">

--- a/testing/017/indexpage.xml
+++ b/testing/017/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/018/018__def_8c.xml
+++ b/testing/018/018__def_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="018__def_8c" kind="file" language="C++">
     <compoundname>018_def.c</compoundname>
     <sectiondef kind="define">

--- a/testing/019/group___a.xml
+++ b/testing/019/group___a.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="group___a" kind="group">
     <compoundname>A</compoundname>
     <title>A</title>

--- a/testing/019/group___b.xml
+++ b/testing/019/group___b.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="group___b" kind="group">
     <compoundname>B</compoundname>
     <title>B</title>

--- a/testing/019/group___c.xml
+++ b/testing/019/group___c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="group___c" kind="group">
     <compoundname>C</compoundname>
     <title>C</title>

--- a/testing/019/group___d.xml
+++ b/testing/019/group___d.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="group___d" kind="group">
     <compoundname>D</compoundname>
     <title>D</title>

--- a/testing/019/group__g1.xml
+++ b/testing/019/group__g1.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="group__g1" kind="group">
     <compoundname>g1</compoundname>
     <title>First Group</title>

--- a/testing/019/group__g2.xml
+++ b/testing/019/group__g2.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="group__g2" kind="group">
     <compoundname>g2</compoundname>
     <title>Second Group</title>

--- a/testing/019/group__g3.xml
+++ b/testing/019/group__g3.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="group__g3" kind="group">
     <compoundname>g3</compoundname>
     <title>Third Group</title>

--- a/testing/020/indexpage.xml
+++ b/testing/020/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/021/indexpage.xml
+++ b/testing/021/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/022/indexpage.xml
+++ b/testing/022/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/023/indexpage.xml
+++ b/testing/023/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/024/indexpage.xml
+++ b/testing/024/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/025/class_test.xml
+++ b/testing/025/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" language="C++" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/025/example_test_8cpp-example.xml
+++ b/testing/025/example_test_8cpp-example.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="example_test_8cpp-example" kind="example">
     <compoundname>example_test.cpp</compoundname>
     <briefdescription>

--- a/testing/026/class_test.xml
+++ b/testing/026/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" language="C++" prot="public">
     <compoundname>Test</compoundname>
     <templateparamlist>

--- a/testing/027/struct_car.xml
+++ b/testing/027/struct_car.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_car" kind="struct" language="C++" prot="public">
     <compoundname>Car</compoundname>
     <basecompoundref refid="struct_vehicle" prot="public" virt="non-virtual">Vehicle</basecompoundref>

--- a/testing/027/struct_object.xml
+++ b/testing/027/struct_object.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_object" kind="struct" language="C++" prot="public">
     <compoundname>Object</compoundname>
     <derivedcompoundref refid="struct_vehicle" prot="public" virt="non-virtual">Vehicle</derivedcompoundref>

--- a/testing/027/struct_truck.xml
+++ b/testing/027/struct_truck.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_truck" kind="struct" language="C++" prot="public">
     <compoundname>Truck</compoundname>
     <basecompoundref refid="struct_vehicle" prot="public" virt="non-virtual">Vehicle</basecompoundref>

--- a/testing/027/struct_vehicle.xml
+++ b/testing/027/struct_vehicle.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_vehicle" kind="struct" language="C++" prot="public">
     <compoundname>Vehicle</compoundname>
     <basecompoundref refid="struct_object" prot="public" virt="non-virtual">Object</basecompoundref>

--- a/testing/028/indexpage.xml
+++ b/testing/028/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/029/029__hideinit_8c.xml
+++ b/testing/029/029__hideinit_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="029__hideinit_8c" kind="file" language="C++">
     <compoundname>029_hideinit.c</compoundname>
     <sectiondef kind="var">

--- a/testing/030/indexpage.xml
+++ b/testing/030/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/031/indexpage.xml
+++ b/testing/031/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/032/indexpage.xml
+++ b/testing/032/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/033/indexpage.xml
+++ b/testing/033/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/034/indexpage.xml
+++ b/testing/034/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/035/035__invariant_8c.xml
+++ b/testing/035/035__invariant_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="035__invariant_8c" kind="file" language="C++">
     <compoundname>035_invariant.c</compoundname>
     <sectiondef kind="func">

--- a/testing/036/036__link_8c.xml
+++ b/testing/036/036__link_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="036__link_8c" kind="file" language="C++">
     <compoundname>036_link.c</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/037/037__msc_8cpp.xml
+++ b/testing/037/037__msc_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="037__msc_8cpp" kind="file" language="C++">
     <compoundname>037_msc.cpp</compoundname>
     <innerclass refid="class_sender" prot="public">Sender</innerclass>

--- a/testing/037/class_receiver.xml
+++ b/testing/037/class_receiver.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_receiver" kind="class" language="C++" prot="public">
     <compoundname>Receiver</compoundname>
     <sectiondef kind="public-func">

--- a/testing/037/class_sender.xml
+++ b/testing/037/class_sender.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_sender" kind="class" language="C++" prot="public">
     <compoundname>Sender</compoundname>
     <sectiondef kind="public-func">

--- a/testing/038/indexpage.xml
+++ b/testing/038/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/039/class_test.xml
+++ b/testing/039/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" language="C++" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="user-defined">

--- a/testing/040/namespace_n_s.xml
+++ b/testing/040/namespace_n_s.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespace_n_s" kind="namespace" language="C++">
     <compoundname>NS</compoundname>
     <briefdescription>

--- a/testing/041/class_test.xml
+++ b/testing/041/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" language="C++" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/042/namespaceorg_1_1doxygen_1_1_test.xml
+++ b/testing/042/namespaceorg_1_1doxygen_1_1_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespaceorg_1_1doxygen_1_1_test" kind="namespace" language="Java">
     <compoundname>org::doxygen::Test</compoundname>
     <briefdescription>

--- a/testing/043/another.xml
+++ b/testing/043/another.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="another" kind="page">
     <compoundname>another</compoundname>
     <title>Another Page</title>

--- a/testing/043/mypage.xml
+++ b/testing/043/mypage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="mypage" kind="page">
     <compoundname>mypage</compoundname>
     <title>Page Title</title>

--- a/testing/044/struct_s.xml
+++ b/testing/044/struct_s.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_s" kind="struct" language="C++" prot="public">
     <compoundname>S</compoundname>
     <includes refid="044__section_8h" local="no">044_section.h</includes>

--- a/testing/045/indexpage.xml
+++ b/testing/045/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/046/046__related_8cpp.xml
+++ b/testing/046/046__related_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="046__related_8cpp" kind="file" language="C++">
     <compoundname>046_related.cpp</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/046/class_test.xml
+++ b/testing/046/class_test.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_test" kind="class" language="C++" prot="public">
     <compoundname>Test</compoundname>
     <sectiondef kind="public-func">

--- a/testing/047/047__return_8cpp.xml
+++ b/testing/047/047__return_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="047__return_8cpp" kind="file" language="C++">
     <compoundname>047_return.cpp</compoundname>
     <sectiondef kind="func">

--- a/testing/048/048__showinit_8c.xml
+++ b/testing/048/048__showinit_8c.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="048__showinit_8c" kind="file" language="C++">
     <compoundname>048_showinit.c</compoundname>
     <sectiondef kind="var">

--- a/testing/049/indexpage.xml
+++ b/testing/049/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/050/indexpage.xml
+++ b/testing/050/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/051/indexpage.xml
+++ b/testing/051/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/052/indexpage.xml
+++ b/testing/052/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/053/indexpage.xml
+++ b/testing/053/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="nl">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/054/054__parblock_8cpp.xml
+++ b/testing/054/054__parblock_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="054__parblock_8cpp" kind="file" language="C++">
     <compoundname>054_parblock.cpp</compoundname>
     <sectiondef kind="func">

--- a/testing/055/md_055_markdown.xml
+++ b/testing/055/md_055_markdown.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="md_055_markdown" kind="page">
     <compoundname>md_055_markdown</compoundname>
     <title>055_markdown</title>

--- a/testing/056/indexpage.xml
+++ b/testing/056/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/057/namespacelibrary.xml
+++ b/testing/057/namespacelibrary.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespacelibrary" kind="namespace" language="C++">
     <compoundname>library</compoundname>
     <innerclass refid="classlibrary_1_1v2_1_1foo" prot="public">library::foo</innerclass>

--- a/testing/057/namespacelibrary_1_1v1.xml
+++ b/testing/057/namespacelibrary_1_1v1.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespacelibrary_1_1v1" kind="namespace" language="C++">
     <compoundname>library::v1</compoundname>
     <innerclass refid="classlibrary_1_1v1_1_1foo" prot="public">library::v1::foo</innerclass>

--- a/testing/057/namespacelibrary_1_1v2.xml
+++ b/testing/057/namespacelibrary_1_1v2.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespacelibrary_1_1v2" kind="namespace" inline="yes" language="C++">
     <compoundname>library::v2</compoundname>
     <innerclass refid="classlibrary_1_1v2_1_1foo" prot="public">library::v2::foo</innerclass>

--- a/testing/058/class_class.xml
+++ b/testing/058/class_class.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_class" kind="class" language="C++" prot="public">
     <compoundname>Class</compoundname>
     <sectiondef kind="public-type">

--- a/testing/058/classns2_1_1_class.xml
+++ b/testing/058/classns2_1_1_class.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="classns2_1_1_class" kind="class" language="C++" prot="public">
     <compoundname>ns2::Class</compoundname>
     <sectiondef kind="public-type">

--- a/testing/058/classns_1_1_class.xml
+++ b/testing/058/classns_1_1_class.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="classns_1_1_class" kind="class" language="C++" prot="public">
     <compoundname>ns::Class</compoundname>
     <sectiondef kind="public-type">

--- a/testing/059/struct_n_1_1allocator__traits.xml
+++ b/testing/059/struct_n_1_1allocator__traits.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_n_1_1allocator__traits" kind="struct" language="C++" prot="public">
     <compoundname>N::allocator_traits</compoundname>
     <templateparamlist>

--- a/testing/064/struct_foo.xml
+++ b/testing/064/struct_foo.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_foo" kind="struct" language="C++" prot="public">
     <compoundname>Foo</compoundname>
     <sectiondef kind="public-func">

--- a/testing/065/indexpage.xml
+++ b/testing/065/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="ja">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>My Project</title>

--- a/testing/066/class_class1.xml
+++ b/testing/066/class_class1.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_class1" kind="class" language="C#" prot="public">
     <compoundname>Class1</compoundname>
     <sectiondef kind="property">

--- a/testing/067/067__link__varargs_8cpp.xml
+++ b/testing/067/067__link__varargs_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="067__link__varargs_8cpp" kind="file" language="C++">
     <compoundname>067_link_varargs.cpp</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/068/068__ref__varargs_8cpp.xml
+++ b/testing/068/068__ref__varargs_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="068__ref__varargs_8cpp" kind="file" language="C++">
     <compoundname>068_ref_varargs.cpp</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/069/069__link__variadic__template_8cpp.xml
+++ b/testing/069/069__link__variadic__template_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="069__link__variadic__template_8cpp" kind="file" language="C++">
     <compoundname>069_link_variadic_template.cpp</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/070/070__ref__variadic__template_8cpp.xml
+++ b/testing/070/070__ref__variadic__template_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="070__ref__variadic__template_8cpp" kind="file" language="C++">
     <compoundname>070_ref_variadic_template.cpp</compoundname>
     <innerclass refid="class_test" prot="public">Test</innerclass>

--- a/testing/071/namespace_a_namespace_1_1_0d0.xml
+++ b/testing/071/namespace_a_namespace_1_1_0d0.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespace_a_namespace_1_1_0d0" kind="namespace" language="C++">
     <compoundname>ANamespace::@0</compoundname>
     <sectiondef kind="enum">

--- a/testing/072/072__using_8cpp.xml
+++ b/testing/072/072__using_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="072__using_8cpp" kind="file" language="C++">
     <compoundname>072_using.cpp</compoundname>
     <sectiondef kind="typedef">

--- a/testing/073/073__typed__enum_8cpp.xml
+++ b/testing/073/073__typed__enum_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="073__typed__enum_8cpp" kind="file" language="C++">
     <compoundname>073_typed_enum.cpp</compoundname>
     <sectiondef kind="enum">

--- a/testing/074/namespacens.xml
+++ b/testing/074/namespacens.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespacens" kind="namespace" language="C++">
     <compoundname>ns</compoundname>
     <sectiondef kind="func">

--- a/testing/074/struct_foo.xml
+++ b/testing/074/struct_foo.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_foo" kind="struct" language="C++" prot="public">
     <compoundname>Foo</compoundname>
     <sectiondef kind="public-func">

--- a/testing/075/struct_foo.xml
+++ b/testing/075/struct_foo.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="struct_foo" kind="struct" language="C++" prot="public">
     <compoundname>Foo</compoundname>
     <sectiondef kind="public-func">

--- a/testing/076/indexpage.xml
+++ b/testing/076/indexpage.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="indexpage" kind="page">
     <compoundname>index</compoundname>
     <title>Emoji test</title>

--- a/testing/077/077__no__xml__namespace__members__in__file__scope_8h.xml
+++ b/testing/077/077__no__xml__namespace__members__in__file__scope_8h.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="077__no__xml__namespace__members__in__file__scope_8h" kind="file" language="C++">
     <compoundname>077_no_xml_namespace_members_in_file_scope.h</compoundname>
     <innernamespace refid="namespace_namespace">Namespace</innernamespace>

--- a/testing/078/078__xml__namespace__members__in__file__scope_8h.xml
+++ b/testing/078/078__xml__namespace__members__in__file__scope_8h.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="078__xml__namespace__members__in__file__scope_8h" kind="file" language="C++">
     <compoundname>078_xml_namespace_members_in_file_scope.h</compoundname>
     <innernamespace refid="namespace_namespace">Namespace</innernamespace>

--- a/testing/079/empty.xml
+++ b/testing/079/empty.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="empty" kind="page">
     <compoundname>empty</compoundname>
     <title>An empty page</title>

--- a/testing/079/levels.xml
+++ b/testing/079/levels.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="levels" kind="page">
     <compoundname>levels</compoundname>
     <title>A page with two-level TOC</title>

--- a/testing/080/class_interface.xml
+++ b/testing/080/class_interface.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="class_interface" kind="class" language="C++" prot="public" abstract="yes">
     <compoundname>Interface</compoundname>
     <sectiondef kind="public-func">

--- a/testing/081/081__brief__lists_8h.xml
+++ b/testing/081/081__brief__lists_8h.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="081__brief__lists_8h" kind="file" language="C++">
     <compoundname>081_brief_lists.h</compoundname>
     <sectiondef kind="func">

--- a/testing/082/namespace_n.xml
+++ b/testing/082/namespace_n.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespace_n" kind="namespace" language="C++">
     <compoundname>N</compoundname>
     <sectiondef kind="var">

--- a/testing/083/namespace_n.xml
+++ b/testing/083/namespace_n.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="namespace_n" kind="namespace" language="C++">
     <compoundname>N</compoundname>
     <sectiondef kind="var">

--- a/testing/084/084__markdown__pre_8f90.xml
+++ b/testing/084/084__markdown__pre_8f90.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="084__markdown__pre_8f90" kind="file" language="Fortran">
     <compoundname>084_markdown_pre.f90</compoundname>
     <sectiondef kind="func">

--- a/testing/085/085__tooltip_8cpp.xml
+++ b/testing/085/085__tooltip_8cpp.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="085__tooltip_8cpp" kind="file" language="C++">
     <compoundname>085_tooltip.cpp</compoundname>
     <sectiondef kind="define">

--- a/testing/086/086__style__tags_8h.xml
+++ b/testing/086/086__style__tags_8h.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <project>
+    <projectname>My Project</projectname>
+    <projectnumber/>
+    <projectbrief/>
+    <projectlogo/>
+  </project>
   <compounddef id="086__style__tags_8h" kind="file" language="C++">
     <compoundname>086_style_tags.h</compoundname>
     <briefdescription>


### PR DESCRIPTION
Adding the project* elements to the the xml output.
- doxygen.cpp
   copy logo in case of xml generation

- index.xsd
- compound.xsd
  Adjusting xsd file for new project elements

- xmlgen.cpp
  Added function to add project output and called it at the relevant places.
  Adjusted written xslt file to place the project only once in the result and be able to validate the result file against the general compound.xsd
  small layout correction for codeline

- testing
  Adjusted test output to new project elements