### PR TITLE
Trace statement in markdown.cpp

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -105,7 +105,7 @@ class Trace
           }
         }
         data_s[j++]=0;
-        fprintf(IOSTREAM,"> %s data=[%s…]\n",qPrint(func),data_s);
+        fprintf(IOSTREAM,"> %s data=[%s...]\n",qPrint(func),data_s);
         s_indent++;
       }
     }


### PR DESCRIPTION
When we run the markdown processor with tracing on Windows we see a.o.
```
class QCString __thiscall Markdown::detab(const class QCString &,int &) data=[    \\page ExamplePagÔÇª]
```
so some "strange: characters at the end., due to a hard coded ellipse. Expected would be something like:
```
class QCString __thiscall Markdown::detab(const class QCString &,int &) data=[    \\page ExamplePag...]
```