### PR TITLE
Add for the xml output also xml to the markdown image representation.

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1489,6 +1489,7 @@ int Markdown::processLink(const char *data,int offset,int size)
       writeMarkdownImage("latex",   isImageInline, explicitTitle, title, content, link, attributes, fd);
       writeMarkdownImage("rtf",     isImageInline, explicitTitle, title, content, link, attributes, fd);
       writeMarkdownImage("docbook", isImageInline, explicitTitle, title, content, link, attributes, fd);
+      writeMarkdownImage("xml",     isImageInline, explicitTitle, title, content, link, attributes, fd);
     }
     else
     {


### PR DESCRIPTION
In pull request #8859 the possibility for `xml` was added to the `\image` command, it was omitted with the markdown representation (`![..](...)`) this has been corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7828374/example.tar.gz)
