### PR TITLE
issue #9007 Using DOT_PATH with a symlink for dot does not always work

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3787,7 +3787,7 @@ UML notation for the relationships.
 ]]>
       </docs>
     </option>
-    <option type='string' id='DOT_PATH' format='dir' defval='' depends='HAVE_DOT'>
+    <option type='string' id='DOT_PATH' format='filedir' defval='' depends='HAVE_DOT'>
       <docs>
 <![CDATA[
  The \c DOT_PATH tag can be used to specify the path where the \c dot tool can be found.

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1856,30 +1856,28 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   if (!dotPath.isEmpty())
   {
     FileInfo fi(dotPath.str());
-    if (fi.exists() && fi.isFile()) // user specified path + exec
+    if (!(fi.exists() && fi.isFile()) )// not an existing user specified path + exec
     {
-      dotPath=fi.dirPath(TRUE)+"/";
-    }
-    else
-    {
-      QCString dotExe = dotPath+"/dot"+Portable::commandExtension();
-      FileInfo dp(dotExe.str());
+      dotPath = dotPath+"/dot"+Portable::commandExtension();
+      FileInfo dp(dotPath.str());
       if (!dp.exists() || !dp.isFile())
       {
-        warn_uncond("the dot tool could not be found at %s\n",qPrint(dotPath));
-        dotPath="";
-      }
-      else
-      {
-        dotPath=dp.dirPath(TRUE)+"/";
+        warn_uncond("the dot tool could not be found as '%s'\n",qPrint(dotPath));
+        dotPath = "dot";
+        dotPath += Portable::commandExtension();
       }
     }
 #if defined(_WIN32) // convert slashes
     uint i=0,l=dotPath.length();
     for (i=0;i<l;i++) if (dotPath.at(i)=='/') dotPath.at(i)='\\';
 #endif
-    Config_updateString(DOT_PATH,dotPath);
   }
+  else
+  {
+    dotPath = "dot";
+    dotPath += Portable::commandExtension();
+  }
+  Config_updateString(DOT_PATH,dotPath);
 
   //------------------------
   // check plantuml path

--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -141,7 +141,7 @@ bool DotRunner::readBoundingBox(const QCString &fileName,int *width,int *height,
 DotRunner::DotRunner(const QCString& absDotName, const QCString& md5Hash)
   : m_file(absDotName)
   , m_md5Hash(md5Hash)
-  , m_dotExe(Config_getString(DOT_PATH)+"dot")
+  , m_dotExe(Config_getString(DOT_PATH))
   , m_cleanUp(Config_getBool(DOT_CLEANUP))
 {
 }

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -178,8 +178,6 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
   {
     pumlArgs += "-graphvizdot \"";
     pumlArgs += dotPath;
-    pumlArgs += "dot";
-    pumlArgs += Portable::commandExtension();
     pumlArgs += "\" ";
   }
   switch (format)

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -165,7 +165,7 @@ static void createSVG()
 
     QCString vlargs="-Tsvg \""+ov+"\" "+dir ;
 
-    if (Portable::system(Config_getString(DOT_PATH) + "dot",vlargs)!=0)
+    if (Portable::system(Config_getString(DOT_PATH),vlargs)!=0)
     {
       err("could not create dot file");
     }
@@ -3398,7 +3398,7 @@ void FlowChart::createSVG()
 
   QCString vlargs="-Tsvg \""+ov+"\" "+dir ;
 
-  if (Portable::system(Config_getString(DOT_PATH) + "dot",vlargs)!=0)
+  if (Portable::system(Config_getString(DOT_PATH),vlargs)!=0)
   {
     err("could not create dot file");
   }


### PR DESCRIPTION
Adjusted checking mechanism and resulting dotPath.
The name of the executable is now only used in configimpl.l