### PR TITLE
Combine function of rtf gives wrong results.

### DIFF
--- a/src/textstream.h
+++ b/src/textstream.h
@@ -97,6 +97,12 @@ class TextStream final
       m_buffer+=c;
       return static_cast<TextStream&>(*this);
     }
+    /** Adds an unsigned character to the stream */
+    TextStream &operator<<( unsigned char c)
+    {
+      m_buffer+=c;
+      return static_cast<TextStream&>(*this);
+    }
 
     /** Adds an unsigned character string to the stream */
     TextStream &operator<<( unsigned char *s)


### PR DESCRIPTION
Regression on:
```
Commit: d9bc62b9316f5da492f3f19d22e818489a9f634c [d9bc62b]
Date: Tuesday, January 4, 2022 4:12:07 PM
Refactoring: replace old style casts (part 2)
```
an unsigned char was handled as if it is an unsigned integer and not as a character type, giving the wrong results in the combine process of RTF.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7830486/example.tar.gz)
