### PR TITLE
Bugfix for issue #1311 (Prevent problems with spaces in paths in Windows popen)

### DIFF
--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -447,10 +447,16 @@ bool Portable::fileSystemIsCaseSensitive()
 
 FILE * Portable::popen(const QCString &name,const QCString &type)
 {
-  #if defined(_MSC_VER) || defined(__BORLANDC__)
-  return ::_popen(name.data(),type.data());
+  #if defined(_WIN32)
+  QCString newname = "\"" + name + "\"";
   #else
-  return ::popen(name.data(),type.data());
+  QCString newname = name;
+  #endif
+
+  #if defined(_MSC_VER) || defined(__BORLANDC__)
+  return ::_popen(newname.data(),type.data());
+  #else
+  return ::popen(newname.data(),type.data());
   #endif
 }
 


### PR DESCRIPTION
Yet to check if it breaks anything, but doesn't look like it does at the moment.

Recommendation to add quotes taken from here:
https://www.reddit.com/r/learnpython/comments/ml2h7v/cprogram_is_not_recognized_as_an_internal_or/