### PR TITLE
issue #9007 Using DOT_PATH with a symlink for dot does not always work (plantuml)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -92,6 +92,11 @@ namespace Config
 
   /*! Clean up any data */
   void deinit();
+
+  /*! Signal whether or not the DOT_PATH is explicitly set. plantuml needs either a full or
+   * relative path to the dot executable
+   */
+  bool getPlantumlDotPathSet();
 }
 
 #endif

--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -583,6 +583,20 @@ class ConfigImpl
       return substitute(result,"\r","");
     }
 
+    /*! Signal whether or not the DOT_PATH is explicitly set. plantuml needs either a full or
+     * relative path to the dot executable
+     */
+    bool getPlantumlDotPathSet()
+    {
+      return m_plantumlDotPathSet;
+    }
+
+    /*! setter function for m_plantumlDotPathSet */
+    void setPlantumlDotPathSet(bool f)
+    {
+      m_plantumlDotPathSet = f;
+    }
+
   protected:
 
     ConfigImpl()
@@ -604,6 +618,7 @@ class ConfigImpl
     QCString m_userComment;
     bool m_initialized;
     QCString m_header;
+    bool m_plantumlDotPathSet = false;
 };
 
 #endif

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1853,6 +1853,7 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   //------------------------
   // check dot path
   QCString dotPath = Config_getString(DOT_PATH);
+  bool plantumlDotPathSet = true;
   if (!dotPath.isEmpty())
   {
     FileInfo fi(dotPath.str());
@@ -1863,6 +1864,7 @@ void Config::checkAndCorrect(bool quiet, const bool check)
       if (!dp.exists() || !dp.isFile())
       {
         warn_uncond("the dot tool could not be found as '%s'\n",qPrint(dotPath));
+        plantumlDotPathSet = false;
         dotPath = "dot";
         dotPath += Portable::commandExtension();
       }
@@ -1874,10 +1876,12 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   }
   else
   {
+    plantumlDotPathSet = false;
     dotPath = "dot";
     dotPath += Portable::commandExtension();
   }
   Config_updateString(DOT_PATH,dotPath);
+  ConfigImpl::instance()->setPlantumlDotPathSet(plantumlDotPathSet);
 
   //------------------------
   // check plantuml path
@@ -2100,6 +2104,11 @@ void Config::compareDoxyfile(TextStream &t)
 void Config::writeXMLDoxyfile(TextStream &t)
 {
   ConfigImpl::instance()->writeXMLDoxyfile(t);
+}
+
+bool Config::getPlantumlDotPathSet()
+{
+  return ConfigImpl::instance()->getPlantumlDotPathSet();
 }
 
 bool Config::parse(const QCString &fileName,bool update)

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -174,7 +174,7 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
     pumlArgs += plantumlConfigFile;
     pumlArgs += "\" ";
   }
-  if (Config_getBool(HAVE_DOT) && !dotPath.isEmpty())
+  if (Config_getBool(HAVE_DOT) && Config::getPlantumlDotPathSet() && !dotPath.isEmpty())
   {
     pumlArgs += "-graphvizdot \"";
     pumlArgs += dotPath;


### PR DESCRIPTION
Regression as mentioned in https://github.com/doxygen/doxygen/issues/9007#issuecomment-1007651759
The `-graphvizdot` cannot just contain the name of an executable somewhere in the path but needs a relative or full path.
So just when having no explicit `DOT_PATH` set just setting the command `dot` won't work as plantuml won't resolve the path.