### PR TITLE
The image of the `\image` command is placed in the wrong directory in XML mode

### DIFF
--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -986,7 +986,7 @@ void XmlDocVisitor::visitPre(DocImage *img)
   bool ambig;
   if (url.isEmpty() && (fd=findFileDef(Doxygen::imageNameLinkedMap,img->name(),ambig)))
   {
-    copyFile(fd->absFilePath(),Config_getString(XML_OUTPUT)+"/"+baseName);
+    copyFile(fd->absFilePath(),Config_getString(XML_OUTPUT)+"/"+img->name());
   }
 }
 


### PR DESCRIPTION
In case `CREATE_SUBDIRS=YES` the image is not placed in the `xml` directory but in the grandfather directory of the `xml` directory.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7841560/example.tar.gz)
