### PR TITLE
bug 711041 Undocumented "enum" values in TOC of qhp files causes tag-mismatch and corrupt TOC

### DIFF
--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -38,7 +38,7 @@ static QCString makeFileName(const QCString & withoutExtension)
     }
     else // add specified HTML extension
     {
-      addHtmlExtensionIfMissing(result);
+      result = addHtmlExtensionIfMissing(result);
     }
   }
   return result;


### PR DESCRIPTION
The result of the `addHtmlExtensionIfMissing` was not caught and thus remained `result` unchanged so there was no extension.

(the original problem of the incorrect number of closing tags was already corrected).