### PR TITLE
issue #9028 DoxyVerb environment should terminate the previous paragraph before changing paragraph formatting

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -151,6 +151,7 @@
 
 % Used by @verbatim ... @endverbatim
 \newenvironment{DoxyVerb}{%
+  \par%
   \footnotesize%
   \verbatim%
 }{%


### PR DESCRIPTION
In case of a verbatim section the previous paragraph was not properly closed and at that moment the `\footnotesize` hits the previous paragraph.

Note: it is independent of the setting of `COMPACT_LATEX`