### PR TITLE
Incorrect doxygen help information

### DIFF
--- a/doc/doxygen.1
+++ b/doc/doxygen.1
@@ -23,7 +23,7 @@ doxygen [configName]
 .IP
 doxygen -l [layoutFileName]
 .IP
-In case layoutFileName is omitted layoutFileName.xml will be used as filename.
+In case layoutFileName is omitted DoxygenLayout.xml will be used as filename.
 If - is used for layoutFileName doxygen will write to standard output.
 .TP
 5) Use doxygen to generate a template style sheet file for RTF, HTML or Latex.

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10618,7 +10618,7 @@ static void usage(const QCString &name,const QCString &versionString)
   msg("4) Use doxygen to generate a template file controlling the layout of the\n");
   msg("   generated documentation:\n");
   msg("    %s -l [layoutFileName]\n\n",qPrint(name));
-  msg("    In case layoutFileName is omitted layoutFileName.xml will be used as filename.\n");
+  msg("    In case layoutFileName is omitted DoxygenLayout.xml will be used as filename.\n");
   msg("    If - is used for layoutFileName doxygen will write to standard output.\n\n");
   msg("5) Use doxygen to generate a template style sheet file for RTF, HTML or Latex.\n");
   msg("    RTF:        %s -w rtf styleSheetFile\n",qPrint(name));


### PR DESCRIPTION
The `doxygen --help` states:
```
4) Use doxygen to generate a template file controlling the layout of the
   generated documentation:
    D:\Programs\Doxygen\fork\doxygen\build_windows_nmake_v2017\bin\doxygen.exe -l [layoutFileName]

    In case layoutFileName is omitted layoutFileName.xml will be used as filename.
```
the last line is incorrect, this has to be:
```
     In case layoutFileName is omitted DoxygenLayout.xml will be used as filename.
```