### PR TITLE
bug_711041 Undocumented "enum" values in TOC of qhp files causes tag-mismatch and corrupt TOC.

### DIFF
--- a/src/docsets.h
+++ b/src/docsets.h
@@ -48,6 +48,7 @@ class DocSets  : public IndexIntf
                          bool addToNavIndex,
                          const Definition *def
                         );
+    void closeContentsItem() {}
     void addIndexItem(const Definition *context,const MemberDef *md,
                       const QCString &sectionAnchor,const QCString &title);
     void addIndexFile(const QCString &name);

--- a/src/eclipsehelp.h
+++ b/src/eclipsehelp.h
@@ -51,6 +51,7 @@ class EclipseHelp : public IndexIntf
     virtual void addContentsItem(bool isDir, const QCString &name, const QCString &ref,
                                  const QCString &file, const QCString &anchor,bool separateIndex,bool addToNavIndex,
                                  const Definition *def);
+    virtual void closeContentsItem() {}
     virtual void addIndexItem(const Definition *context,const MemberDef *md,
                               const QCString &sectionAnchor,const QCString &title);
     virtual void addIndexFile(const QCString &name);

--- a/src/ftvhelp.h
+++ b/src/ftvhelp.h
@@ -50,6 +50,7 @@ class FTVHelp : public IndexIntf
                          bool separateIndex,
                          bool addToNavIndex,
                          const Definition *def);
+    void closeContentsItem() {}
     void addIndexItem(const Definition *,const MemberDef *,const QCString &,const QCString &) {}
     void addIndexFile(const QCString &) {}
     void addImageFile(const QCString &) {}

--- a/src/htmlhelp.h
+++ b/src/htmlhelp.h
@@ -73,6 +73,7 @@ class HtmlHelp  : public IndexIntf
                          bool separateIndex,
                          bool addToNavIndex,
                          const Definition *def);
+    void closeContentsItem() {}
     void addIndexItem(const Definition *context,const MemberDef *md,
                       const QCString &sectionAnchor, const QCString &title);
     void addIndexFile(const QCString &name);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3834,6 +3834,10 @@ static void writeGroupTreeNode(OutputList &ol, const GroupDef *gd, int level, FT
               }
               Doxygen::indexList->decContentsDepth();
             }
+            if (md->isVisible() && !md->isAnonymous())
+            {
+              Doxygen::indexList->closeContentsItem();
+            }
           }
         }
       }

--- a/src/index.h
+++ b/src/index.h
@@ -40,6 +40,7 @@ class IndexIntf
     virtual void addContentsItem(bool isDir, const QCString &name, const QCString &ref,
                                  const QCString &file, const QCString &anchor, bool separateIndex,
                                  bool addToNavIndex,const Definition *def) = 0;
+    virtual void closeContentsItem() = 0;
     virtual void addIndexItem(const Definition *context,const MemberDef *md,
                               const QCString &sectionAnchor,const QCString &title) = 0;
     virtual void addIndexFile(const QCString &name) = 0;
@@ -98,6 +99,8 @@ class IndexList : public IndexIntf
                          const QCString &file, const QCString &anchor,bool separateIndex=FALSE,bool addToNavIndex=FALSE,
                          const Definition *def=0)
     { if (m_enabled) foreach(&IndexIntf::addContentsItem,isDir,name,ref,file,anchor,separateIndex,addToNavIndex,def); }
+    void closeContentsItem()
+    { if (m_enabled) foreach(&IndexIntf::closeContentsItem); }
     void addIndexItem(const Definition *context,const MemberDef *md,const QCString &sectionAnchor=QCString(),const QCString &title=QCString())
     { if (m_enabled) foreach(&IndexIntf::addIndexItem,context,md,sectionAnchor,title); }
     void addIndexFile(const QCString &name)

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3540,9 +3540,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
           docs = docs.left(labelStartPos)+                     // part before label
                  newLabel+                                     // new label
                  docs.mid(labelEndPos,lineLen-labelEndPos-1)+  // part between orgLabel and \n
-                 "\\ilinebr @ianchor "+orgLabel+               // add original anchor
-                 docs.mid(labelEndPos,lineLen-labelEndPos-1)+  // part between orgLabel and \n
-                 "\n"+
+                 "\\ilinebr ianchor "+orgLabel+"\n"+           // add original anchor
                  docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3540,7 +3540,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
           docs = docs.left(labelStartPos)+                     // part before label
                  newLabel+                                     // new label
                  docs.mid(labelEndPos,lineLen-labelEndPos-1)+  // part between orgLabel and \n
-                 "\\ilinebr ianchor "+orgLabel+"\n"+           // add original anchor
+                 "\\ilinebr @anchor "+orgLabel+"\n"+           // add original anchor
                  docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3540,7 +3540,9 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
           docs = docs.left(labelStartPos)+                     // part before label
                  newLabel+                                     // new label
                  docs.mid(labelEndPos,lineLen-labelEndPos-1)+  // part between orgLabel and \n
-                 "\\ilinebr @anchor "+orgLabel+"\n"+           // add original anchor
+                 "\\ilinebr @ianchor "+orgLabel+               // add original anchor
+                 docs.mid(labelEndPos,lineLen-labelEndPos-1)+  // part between orgLabel and \n
+                 "\n"+
                  docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -193,6 +193,12 @@ void Qhp::decContentsDepth()
   m_sectionLevel--;
 }
 
+void Qhp::closeContentsItem()
+{
+    handlePrevSection();
+    m_toc.close("section");
+    m_openCount--;
+}
 void Qhp::addContentsItem(bool /*isDir*/, const QCString & name,
                           const QCString & /*ref*/, const QCString & file,
                           const QCString &anchor, bool /* separateIndex */,
@@ -205,7 +211,7 @@ void Qhp::addContentsItem(bool /*isDir*/, const QCString & name,
   QCString f = file;
   if (!f.isEmpty() && f.at(0)=='^') return; // absolute URL not supported
 
-  int diff = m_prevSectionLevel - m_sectionLevel;
+  int diff = m_prevSectionLevel - m_sectionLevel - 1;
 
   handlePrevSection();
   setPrevSection(name, f, anchor, m_sectionLevel);
@@ -310,13 +316,8 @@ void Qhp::handlePrevSection()
   </toc>
   */
 
-  if (m_prevSectionTitle.isNull())
-  {
-    m_prevSectionTitle=" "; // should not happen...
-  }
-
   // We skip "Main Page" as our extra root is pointing to that
-  if (!((m_prevSectionLevel==1) && (m_prevSectionTitle==getFullProjectName())))
+  if (!((m_prevSectionLevel==1) && (m_prevSectionTitle==getFullProjectName())) && !m_prevSectionTitle.isNull())
   {
     QCString finalRef = makeRef(m_prevSectionBaseName, m_prevSectionAnchor);
 

--- a/src/qhp.h
+++ b/src/qhp.h
@@ -37,6 +37,7 @@ class Qhp : public IndexIntf
                          const Definition *def);
     void addIndexItem(const Definition *context, const MemberDef *md,
                       const QCString &sectionAnchor, const QCString &title);
+    void closeContentsItem();
     void addIndexFile(const QCString & name);
     void addImageFile(const QCString & name);
     void addStyleSheetFile(const QCString & name);

--- a/templates/general/layout_default.xml
+++ b/templates/general/layout_default.xml
@@ -13,29 +13,29 @@
     </tab>
     <tab type="interfaces" visible="yes" title="">
       <tab type="interfacelist" visible="yes" title="" intro=""/>
-      <tab type="interfaceindex" visible="$ALPHABETICAL_INDEX" title=""/> 
+      <tab type="interfaceindex" visible="$ALPHABETICAL_INDEX" title=""/>
       <tab type="interfacehierarchy" visible="yes" title="" intro=""/>
     </tab>
     <tab type="classes" visible="yes" title="">
       <tab type="classlist" visible="yes" title="" intro=""/>
-      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/> 
+      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/>
       <tab type="hierarchy" visible="yes" title="" intro=""/>
       <tab type="classmembers" visible="yes" title="" intro=""/>
     </tab>
     <tab type="structs" visible="yes" title="">
       <tab type="structlist" visible="yes" title="" intro=""/>
-      <tab type="structindex" visible="$ALPHABETICAL_INDEX" title=""/> 
+      <tab type="structindex" visible="$ALPHABETICAL_INDEX" title=""/>
     </tab>
     <tab type="exceptions" visible="yes" title="">
       <tab type="exceptionlist" visible="yes" title="" intro=""/>
-      <tab type="exceptionindex" visible="$ALPHABETICAL_INDEX" title=""/> 
+      <tab type="exceptionindex" visible="$ALPHABETICAL_INDEX" title=""/>
       <tab type="exceptionhierarchy" visible="yes" title="" intro=""/>
     </tab>
     <tab type="files" visible="yes" title="">
       <tab type="filelist" visible="yes" title="" intro=""/>
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="examples" visible="yes" title="" intro=""/>  
+    <tab type="examples" visible="yes" title="" intro=""/>
   </navindex>
 
   <!-- Layout definition for a class page -->


### PR DESCRIPTION
The problem regarding the extra `</section>` in the case of a `user` section in the doxyfile could be solved by means of better calculating the "diff", though this lead to bad index sequences in the qhp navtree.
To solve the bad tree entries, for the enum values, a function `closeContentsItem` is introduced.
(in `layout_default.xml` some white space at the end of the line is removed.)