### PR TITLE
issue_9027 SEARCHDATA_FILE (searchdata.xml) keyword elements blank

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -12203,6 +12203,7 @@ void parseInput()
   combineUsingRelations();
   g_s.end();
 
+  initSearchIndexer();
   g_s.begin("Adding members to index pages...\n");
   addMembersToIndex();
   addToIndices();
@@ -12246,8 +12247,6 @@ void generateOutput()
     dumpSymbolMap();
     exit(0);
   }
-
-  initSearchIndexer();
 
   bool generateHtml  = Config_getBool(GENERATE_HTML);
   bool generateLatex = Config_getBool(GENERATE_LATEX);


### PR DESCRIPTION
the search database was initialized at the wrong moment, so a number of items didn't land in it.
