### PR TITLE
Correct reference text of a page reference

### DIFF
--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -153,6 +153,7 @@ CommandMap cmdMap[] =
   { "iline",         CMD_ILINE },
   { "iliteral",      CMD_ILITERAL },
   { "endiliteral",   CMD_ENDILITERAL },
+  { "ianchor",       CMD_IANCHOR },
   { 0,               0 },
 };
 

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -145,6 +145,7 @@ enum CommandType
   CMD_ILINE        = 116,
   CMD_ILITERAL     = 117,
   CMD_ENDILITERAL  = 118,
+  CMD_IANCHOR      = 119,
 };
 
 enum HtmlTagType

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -171,6 +171,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "addindex",        { &handleAddIndex,         CommandSpacing::Invisible }},
   { "addtogroup",      { &handleAddToGroup,       CommandSpacing::Invisible }},
   { "anchor",          { &handleAnchor,           CommandSpacing::Invisible }},
+  { "ianchor",         { &handleAnchor,           CommandSpacing::Invisible }},
   { "arg",             { 0,                       CommandSpacing::Block     }},
   { "attention",       { 0,                       CommandSpacing::Block     }},
   { "author",          { 0,                       CommandSpacing::Block     }},
@@ -386,6 +387,9 @@ struct commentscanYY_state
 
   bool             needNewEntry = FALSE;
 
+  QCString         anchorLabel;
+  QCString         anchorText;
+
   QCString         sectionLabel;
   QCString         sectionTitle;
   int              sectionLevel = 0;
@@ -442,7 +446,7 @@ static QCString addFormula(yyscan_t yyscanner);
 static void checkFormula(yyscan_t yyscanner);
 static void addSection(yyscan_t yyscanner);
 static inline void setOutput(yyscan_t yyscanner,OutputContext ctx);
-static void addAnchor(yyscan_t yyscanner,const QCString &anchor);
+static void addAnchor(yyscan_t yyscanner,const QCString &anchor, QCString title = QCString());
 static inline void addOutput(yyscan_t yyscanner,const char *s);
 static inline void addOutput(yyscan_t yyscanner,const QCString &s);
 static inline void addOutput(yyscan_t yyscanner,char c);
@@ -509,11 +513,11 @@ TMPLSPEC  "<"{BN}*[^>]+{BN}*">"
 MAILADDR  ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a-z_A-Z0-9\x80-\xff\-]+)+[a-z_A-Z0-9\x80-\xff\-]+
 RCSTAG    "$"{ID}":"[^\n$]+"$"
 
-  // C start comment 
+  // C start comment
 CCS   "/\*"
   // C end comment
 CCE   "*\/"
-  // Cpp comment 
+  // Cpp comment
 CPPC  "/\/"
 
   // end of section title with asterisk
@@ -563,6 +567,8 @@ STopt  [^\n@\\]*
 %x      ReadFormulaRound
 %x      ReadFormulaLong
 %x      AnchorLabel
+%x      IAnchorLabel
+%x      IAnchorText
 %x      HtmlComment
 %x      SkipLang
 %x      CiteLabel
@@ -1495,12 +1501,21 @@ STopt  [^\n@\\]*
 
   /* ----- handle arguments of the anchor command ------- */
 
-<AnchorLabel>{LABELID}                  { // found argument
-                                          addAnchor(yyscanner,QCString(yytext));
+<AnchorLabel,IAnchorLabel>{LABELID}     { // found argument
                                           addOutput(yyscanner,yytext);
-                                          BEGIN( Comment );
+                                          if (YY_START == IAnchorLabel)
+                                          {
+                                            yyextra->anchorLabel = yytext;
+                                            yyextra->anchorText = "";
+                                            BEGIN( IAnchorText );
+                                          }
+                                          else
+                                          {
+                                            addAnchor(yyscanner,QCString(yytext));
+                                            BEGIN( Comment );
+                                          }
                                         }
-<AnchorLabel>{DOCNL}                    { // missing argument
+<AnchorLabel,IAnchorLabel>{DOCNL}       { // missing argument
                                           warn(yyextra->fileName,yyextra->lineNr,
                                               "\\anchor command has no label"
                                               );
@@ -1508,13 +1523,23 @@ STopt  [^\n@\\]*
                                           addOutput(yyscanner,'\n');
                                           BEGIN( Comment );
                                         }
-<AnchorLabel>.                          { // invalid character for anchor label
+<AnchorLabel,IAnchorLabel>.             { // invalid character for anchor label
                                           warn(yyextra->fileName,yyextra->lineNr,
                                               "Invalid or missing anchor label"
                                               );
                                           BEGIN(Comment);
                                         }
 
+<IAnchorText>{DOCNL}                    { // end of text
+                                          addAnchor(yyscanner,yyextra->anchorLabel, yyextra->anchorText.stripWhiteSpace());
+                                          unput_string(yytext,yyleng);
+                                          BEGIN(Comment);
+                                        }
+
+<IAnchorText>.                          { // text
+                                          addOutput(yyscanner,yytext);
+                                          yyextra->anchorText += *yytext;
+                                        }
 
   /* ----- handle arguments of the preformatted block commands ------- */
 
@@ -2472,11 +2497,18 @@ static bool handleSubpage(yyscan_t yyscanner,const QCString &s, const StringVect
   return FALSE;
 }
 
-static bool handleAnchor(yyscan_t yyscanner,const QCString &s, const StringVector &)
+static bool handleAnchor(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  addOutput(yyscanner,"@"+s+" ");
-  BEGIN(AnchorLabel);
+  addOutput(yyscanner,"@anchor ");
+  if (cmd == "anchor")
+  {
+    BEGIN(AnchorLabel);
+  }
+  else
+  {
+    BEGIN(IAnchorLabel);
+  }
   return FALSE;
 }
 
@@ -3329,7 +3361,7 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
 }
 
 
-static void addAnchor(yyscan_t yyscanner,const QCString &anchor)
+static void addAnchor(yyscan_t yyscanner,const QCString &anchor, QCString title)
 {
   std::unique_lock<std::mutex> lock(g_sectionMutex);
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
@@ -3339,7 +3371,7 @@ static void addAnchor(yyscan_t yyscanner,const QCString &anchor)
   {
     if (!si->ref().isEmpty()) // we are from a tag file
     {
-      si = sm.replace(anchor,yyextra->fileName,yyextra->lineNr,QCString(),SectionType::Anchor,0);
+      si = sm.replace(anchor,yyextra->fileName,yyextra->lineNr,title,SectionType::Anchor,0);
       yyextra->current->anchors.push_back(si);
     }
     else if (si->lineNr() != -1)
@@ -3356,7 +3388,7 @@ static void addAnchor(yyscan_t yyscanner,const QCString &anchor)
   }
   else
   {
-    si = sm.add(anchor,yyextra->fileName,yyextra->lineNr,QCString(),SectionType::Anchor,0);
+    si = sm.add(anchor,yyextra->fileName,yyextra->lineNr,title,SectionType::Anchor,0);
     yyextra->current->anchors.push_back(si);
   }
 }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2678,7 +2678,7 @@ void Markdown::writeOneLineHeaderOrRuler(const char *data,int size)
     {
       if (!id.isEmpty())
       {
-        m_out.addStr("\\anchor "+id+"\\ilinebr ");
+        m_out.addStr("\\ianchor "+id+" "+header+"\\ilinebr ");
       }
       hTag.sprintf("h%d",level);
       m_out.addStr("<"+hTag+">");
@@ -3507,13 +3507,13 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
            FileInfo(mdfileAsMainPage.str()).absFilePath()) // file reference with path
          )
       {
-        docs.prepend("@anchor " + id + "\\ilinebr ");
+        docs.prepend("@ianchor " + id + " " + title + "\\ilinebr ");
         docs.prepend("@mainpage "+title+"\\ilinebr ");
       }
       else if (id=="mainpage" || id=="index")
       {
         if (title.isEmpty()) title = titleFn;
-        docs.prepend("@anchor " + id + "\\ilinebr ");
+        docs.prepend("@ianchor " + id + " " + title + "\\ilinebr ");
         docs.prepend("@mainpage "+title+"\\ilinebr ");
       }
       else
@@ -3540,7 +3540,9 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
           docs = docs.left(labelStartPos)+                     // part before label
                  newLabel+                                     // new label
                  docs.mid(labelEndPos,lineLen-labelEndPos-1)+  // part between orgLabel and \n
-                 "\\ilinebr @anchor "+orgLabel+"\n"+           // add original anchor
+                 "\\ilinebr @ianchor "+orgLabel+" "+           // add original anchor
+                 docs.mid(labelEndPos,lineLen-labelEndPos-1)+  // part between orgLabel and \n
+                 "\n"+
                  docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }


### PR DESCRIPTION
During the initial check for #9023 it was discovered that the patch  "issue #8528 Markdown links to Markdown pages with explicit page command are broken"  (i.e. #8896) changed the behavior of the text in the links (the link name was shown instead of the text of the link).
To overcome this problem a new internal only command `\ianchor` had to be introduced which also can contain the text of the link (for consistency reasons it is not possible to add an extra argument to the `\anchor` command.