### PR TITLE
Close open brackets.

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1824,7 +1824,7 @@ table.DocNodeLTR {
    margin-left: 0;
 }
 
-code.JavaDocCode
+code.JavaDocCode {
   direction:ltr;
 }
 


### PR DESCRIPTION
The CSS block was open because it needed to be closed with an opening bracket `{`.