### PR TITLE
Spelling error in Dutch translation

### DIFF
--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -845,7 +845,7 @@ class TranslatorDutch : public Translator
      */
     virtual QCString trClass(bool first_capital, bool singular)
     {
-      QCString result((first_capital ? "Klasse" : "klass"));
+      QCString result((first_capital ? "Klasse" : "klasse"));
       if (!singular)  result+="n";
       return result;
     }


### PR DESCRIPTION
In the lowercase spelling the last `e` was missing.