### PR TITLE
issue #9054 Feature Request: Doxywizard: Customize Doxyfile Line Endings

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -333,6 +333,7 @@ void MainWindow::saveConfig(const QString &fileName)
     return;
   }
   QTextStream t(&f);
+  t.device()->setTextModeEnabled(false);
   m_expert->writeConfig(t,false,false);
   updateConfigFileName(fileName);
   m_modified = false;


### PR DESCRIPTION
Doxygen will always write out the doxygen settings file with `\n` line endings.
The doxywizard was writing (on Windows) the doxygen settings file with `\r\n`m, by default a stream is, apparently opened in Text mode so:
```
When reading, the end-of-line terminators are translated to '\n'. When writing, the end-of-line terminators are translated to the local encoding, for example '\r\n' for Win32.
```

For consistency between doxygen and doxywizard we also write out the settings file with just `\n` line endings in the doxywizard now.