### PR TITLE
Incorrect line number in warning message

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3537,7 +3537,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
           docs = docs.left(match[1].position())+               // part before label
                  newLabel+                                     // new label
                  match[2].str()+                               // part between orgLabel and \n
-                 "\\ilinebr @anchor "+orgLabel+"\n"+           // add original anchor
+                 "\\ilinebr @anchor "+orgLabel+                // add original anchor
                  docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }


### PR DESCRIPTION
When having e.g.:
```
# Unit tests Requirements
\page test_requirements Unit tests Requirements
Extended \line_3
```
we get the warning:
```
test.md:4: warning: Found unknown command '\line_3'
```
when running `doxygen -d markdown` we see:
```

\page md_test Unit tests Requirements\ilinebr @anchor test_requirements

Extended \line_3
```
so an extra `\n` before the word `Extended` due to the fact that an explicit `\n` was written but it was also still included in the "remainder"

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7914424/example.tar.gz)
