### PR TITLE
Reference to non existing anchor with "More..."

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2470,7 +2470,19 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
         ol.pushGeneratorState();
         ol.disableAllBut(OutputGenerator::Html);
         ol.docify(" ");
-        ol.startTextLink(getOutputFileBase(),anchor());
+        MemberDefMutable *annMemb = NULL;
+        if (!isAnonymous()) // hide anonymous stuff
+        {
+          annMemb = toMemberDefMutable(m_impl->annMemb);
+        }
+        if (annMemb)
+        {
+          ol.startTextLink(annMemb->getOutputFileBase(),annMemb->anchor());
+        }
+        else
+        {
+          ol.startTextLink(getOutputFileBase(),anchor());
+        }
         ol.parseText(theTranslator->trMore());
         ol.endTextLink();
         ol.popGeneratorState();


### PR DESCRIPTION
When having an anonymous struct, the `More ...` in the detailed description points to a non existing page and anchor. We can see this with e.g.:
```
/// \file

class test {
 public:
    struct {
        double s2_time;  //!< \brief brief time in secs
                         //!< \details details time in secs
    } s2_temp;
};
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7920648/example.tar.gz)


the correction is analogous to the correction for writing the name.