### PR TITLE
issue #9058 Strip leading spaces in QHP file

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -46,7 +46,8 @@ static std::map< std::string, Debug::DebugMask > s_labels =
   { "plantuml",          Debug::Plantuml          },
   { "fortranfixed2free", Debug::FortranFixed2Free },
   { "cite",              Debug::Cite              },
-  { "rtf",               Debug::Rtf               }
+  { "rtf",               Debug::Rtf               },
+  { "qhp",               Debug::Qhp               },
 };
 
 //------------------------------------------------------------------------

--- a/src/debug.h
+++ b/src/debug.h
@@ -41,7 +41,8 @@ class Debug
                      FortranFixed2Free = 0x00008000,
                      Cite         = 0x00010000,
                      NoLineNo     = 0x00020000,
-                     Rtf          = 0x00040000
+                     Rtf          = 0x00040000,
+                     Qhp          = 0x00080000,
                    };
     static void print(DebugMask mask,int prio,const char *fmt,...);
 

--- a/src/qhpxmlwriter.cpp
+++ b/src/qhpxmlwriter.cpp
@@ -17,10 +17,12 @@
 #include "qhpxmlwriter.h"
 #include "util.h"
 #include "qcstring.h"
+#include "debug.h"
 
 QhpXmlWriter::QhpXmlWriter()
-    : m_indentLevel(0), m_curLineIndented(false), m_compress(false)
+    : m_indentLevel(0), m_curLineIndented(false)
 {
+  m_compress = !Debug::isFlagSet(Debug::Qhp);
 }
 
 QhpXmlWriter::~QhpXmlWriter()
@@ -94,9 +96,12 @@ void QhpXmlWriter::indent()
   {
     return;
   }
-  for (int i = 0; i < m_indentLevel; i++)
+  if (!m_compress)
   {
-    m_backend << "  ";
+    for (int i = 0; i < m_indentLevel; i++)
+    {
+      m_backend << "  ";
+    }
   }
   m_curLineIndented = true;
 }


### PR DESCRIPTION
As the `qhp` file is meant for processing by tools, not for humans to read.
To get a better readable form (indentation and line endings) one has to supply the option `-d qhp` to the doxygen command.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7920794/example.tar.gz)
