### PR TITLE
#issue 9058 Indentation on enum in QHP file

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -331,6 +331,7 @@ static void writeMemberToIndex(const Definition *def,const MemberDef *md,bool ad
       Doxygen::indexList->decContentsDepth();
     }
   }
+  Doxygen::indexList->closeContentsItem();
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
In patch #9032 the function `closeContentItem` was introduced, but a call to this routine was necessary at another place where an enum was used as well.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7920979/example.tar.gz)
