### PR TITLE
Warnings Windows 64-bit compilation

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -3559,7 +3559,7 @@ void Preprocessor::processFile(const QCString &fileName,BufStr &input,BufStr &ou
 #endif
 
   printlex(yy_flex_debug, TRUE, __FILE__, qPrint(fileName));
-  uint orgOffset=output.curPos();
+  size_t orgOffset=output.curPos();
   //printf("##########################\n%s\n####################\n",
   //    qPrint(input));
 

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -878,7 +878,7 @@ QCString filter2008VhdlComment(const char *s)
     }
   }
   // special attention in case */ at end of last line
-  int len = growBuf.getPos();
+  size_t len = growBuf.getPos();
   if (growBuf.at(len-1) == '/' && growBuf.at(len-2) == '*')
   {
     len -= 2;


### PR DESCRIPTION
On Windows 64-bit compilation we get warnings like:
```
pre.l(3563): warning C4267: 'initializing': conversion from 'size_t' to 'uint', possible loss of data
```