### PR TITLE
Issue #9075 .html Extension Removed from Tag File URLs

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5285,7 +5285,7 @@ bool checkExtension(const QCString &fName, const QCString &ext)
 QCString addHtmlExtensionIfMissing(const QCString &fName)
 {
   if (fName.isEmpty()) return fName;
-  if (fName.find('.')==-1) // no extension
+  if (stripPath(fName).find('.')==-1) // no extension
   {
     return QCString(fName)+Doxygen::htmlFileExtension;
   }


### PR DESCRIPTION
The problem encountered is due to the `.` in the directory part of  the tag file name entries like:
```
<filename>java.base/java/lang/Object.html</filename>
```
during the processing doxygen strips the extension when it matches the extension of the current project (`HTML_FILE_EXTENSION`), later on doxygen attempts to check whether there is an extension present and when not to add the current extension.
The check is performed on `java.base/java/lang/Object` and here an extension is "found" (`.base/java/lang/Object`), doxygen should here only consider the file name part.

A bit a smaller example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7941281/example.tar.gz)
