### PR TITLE
issue #9074 Menubar Links not Parsed Correctly

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5119,6 +5119,7 @@ static bool renderQuickLinksAsJs(std::ostream &t,LayoutNavEntry *root,bool first
         if (!firstChild) t << ",\n";
         firstChild=FALSE;
         QCString url = entry->url();
+        if (isURL(url)) url = "^" + url;
         t << "{text:\"" << convertToJSString(entry->title()) << "\",url:\""
           << convertToJSString(url) << "\"";
         bool hasChildren=FALSE;

--- a/templates/html/menu.js
+++ b/templates/html/menu.js
@@ -28,7 +28,15 @@ function initMenu(relPath,searchEnabled,serverSide,searchPage,search) {
     if ('children' in data) {
       result+='<ul>';
       for (var i in data.children) {
-        result+='<li><a href="'+relPath+data.children[i].url+'">'+
+        var url;
+        var link;
+        link = data.children[i].url;
+        if (link.substring(0,1)=='^') {
+          url = link.substring(1);
+        } else {
+          url = relPath+link;
+        }
+        result+='<li><a href="'+url+'">'+
                                 data.children[i].text+'</a>'+
                                 makeTree(data.children[i],relPath)+'</li>';
       }


### PR DESCRIPTION
The handling in the navtree was done in such a way that absolute links were prepended with a `^`, in the menus this was not done, this has been corrected.

A bit a smaller example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7942627/example.tar.gz)

In case of `CREATE_SUBDIRS = YES`, on the, original, page:  `html/d8/d6b/classcls__frst.html` you will see (incorrect):

![sub_wrong](https://user-images.githubusercontent.com/5223533/151184115-509be86b-bf4f-4425-8894-5f03e26a7b22.jpg)

In case of `CREATE_SUBDIRS = NO`, on the, original, page `html/classcls__frst.html`:

![nosub_ok](https://user-images.githubusercontent.com/5223533/151184178-c44a5670-d52f-45e9-821d-7e688c775dea.jpg)

in the corrected case you will see in both cases something like in the last image.

