### PR TITLE
issue #9070 Doxygen is not showing all called functions in graph plot

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -292,6 +292,7 @@ struct preYY_state
   QCString           blockName;
   int                condCtx        = 0;
   bool               skip           = false;
+  bool               insideIDL      = false;
   bool               insideCS       = false; // C# has simpler preprocessor
   bool               insideFtn      = false;
   bool               isSource       = false;
@@ -415,6 +416,7 @@ WSopt [ \t\r]*
 %x      CondLineC
 %x      CondLineCpp
 %x      SkipCond
+%x      IDLquote
 
 %%
 
@@ -434,6 +436,32 @@ WSopt [ \t\r]*
                                           if (getLanguageFromFileName(yyextra->fileName)!=SrcLangExt_Lex) REJECT
                                           outputArray(yyscanner,yytext,yyleng);
                                           BEGIN(LexCopyLine);
+                                        }
+<Start>^{Bopt}"cpp_quote"{Bopt}"("{Bopt}\" {
+                                          if (yyextra->insideIDL)
+                                          {
+                                            BEGIN(IDLquote);
+                                          }
+                                          else
+                                          {
+                                            REJECT;
+                                          }
+                                        }
+<IDLquote>"\\\\"                        {
+                                          outputArray(yyscanner,"\\",1);
+                                        }
+<IDLquote>"\\\""                        {
+                                          outputArray(yyscanner,"\"",1);
+                                        }
+<IDLquote>"\""{Bopt}")"                 {
+                                          BEGIN(Start);
+                                        }
+<IDLquote>\n                            {
+                                          outputChar(yyscanner,'\n');
+                                          yyextra->yyLineNr++;
+                                        }
+<IDLquote>.                             {
+                                          outputArray(yyscanner,yytext,yyleng);
                                         }
 <Start>^{Bopt}/[^#]                     {
                                           outputArray(yyscanner,yytext,yyleng);
@@ -1764,7 +1792,7 @@ WSopt [ \t\r]*
                                         }
 <*>{CCS}/{CCE}                          |
 <*>{CCS}[*!]?                           {
-                                          if (YY_START==SkipVerbatim || YY_START==SkipCond)
+                                          if (YY_START==SkipVerbatim || YY_START==SkipCond || YY_START==IDLquote)
                                           {
                                             REJECT;
                                           }
@@ -1786,7 +1814,7 @@ WSopt [ \t\r]*
                                           }
                                         }
 <*>{CPPC}[/!]?                          {
-                                          if (YY_START==SkipVerbatim || YY_START==SkipCond || getLanguageFromFileName(yyextra->fileName)==SrcLangExt_Fortran)
+                                          if (YY_START==SkipVerbatim || YY_START==SkipCond || getLanguageFromFileName(yyextra->fileName)==SrcLangExt_Fortran || YY_START==IDLquote)
                                           {
                                             REJECT;
                                           }
@@ -1844,6 +1872,7 @@ static void setFileName(yyscan_t yyscanner,const QCString &name)
   //printf("setFileName(%s) state->fileName=%s state->yyFileDef=%p\n",
   //    name,qPrint(state->fileName),state->yyFileDef);
   if (state->yyFileDef && state->yyFileDef->isReference()) state->yyFileDef=0;
+  state->insideIDL = getLanguageFromFileName(state->fileName)==SrcLangExt_IDL;
   state->insideCS = getLanguageFromFileName(state->fileName)==SrcLangExt_CSharp;
   state->insideFtn = getLanguageFromFileName(state->fileName)==SrcLangExt_Fortran;
   state->isSource = guessSection(state->fileName);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5038,6 +5038,16 @@ NONLopt [^\n]*
                                           BEGIN(FuncQual);
                                         }
 <OldStyleArgs>.                         { yyextra->current->args += *yytext; }
+<FuncQual,FuncRound,FuncFunc>\"         {
+                                          if (yyextra->insideIDL && yyextra->insideCppQuote)
+                                          {
+                                            BEGIN(EndCppQuote);
+                                          }
+                                          else
+                                          {
+                                            yyextra->current->args += *yytext;
+                                          }
+                                        }
 <FuncQual,FuncRound,FuncFunc>.          { yyextra->current->args += *yytext; }
 <FuncQual>{BN}*"try:"                   |
 <FuncQual>{BN}*"try"{BN}+               { /* try-function-block */
@@ -6963,6 +6973,11 @@ NONLopt [^\n]*
                                           {
                                             BEGIN(EndCppQuote);
                                           }
+                                          else if (yyextra->insidePHP)
+                                          {
+                                            yyextra->lastStringContext=YY_START;
+                                            BEGIN(SkipString);
+                                          }
                                         }
 <*>^{B}*"#"                             {
                                           if (!yyextra->insidePHP)
@@ -6987,13 +7002,6 @@ NONLopt [^\n]*
                                           {
                                             yyextra->lastStringContext=YY_START;
                                             BEGIN(SkipPHPString);
-                                          }
-                                        }
-<*>\"                                   {
-                                          if (yyextra->insidePHP)
-                                          {
-                                            yyextra->lastStringContext=YY_START;
-                                            BEGIN(SkipString);
                                           }
                                         }
 <*>\?                                   {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3489,6 +3489,8 @@ NONLopt [^\n]*
                                           {
                                             yyextra->mtype = Method;
                                             yyextra->virt = Normal;
+                                            yyextra->current->bodyLine = -1;
+                                            yyextra->current->bodyColumn = 1;
                                             yyextra->current->groups.clear();
                                             initEntry(yyscanner);
                                           }


### PR DESCRIPTION
The end of an IDL cpp_quote was not properly caught (the rule `<*>\"` was expected to be used (Note: later on a rule dedicated to PHP was present but could / should not be reached, joined these 2 as well).
For the state `DefineEnd` there was already a separate rule, adding one for functions as well (until now the rule with `.` kicked in).