### PR TITLE
bug_644899 New diagram implementing environment

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3097,8 +3097,7 @@ static QCString addFormula(yyscan_t yyscanner)
   std::unique_lock<std::mutex> lock(g_formulaMutex);
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   QCString formLabel;
-  QCString fText=yyextra->formulaText.simplifyWhiteSpace();
-  int id = FormulaManager::instance().addFormula(fText.str());
+  int id = FormulaManager::instance().addFormula(yyextra->formulaText.str());
   formLabel.sprintf("\\_form#%d",id);
   for (int i=0;i<yyextra->formulaNewLines;i++) formLabel+="@_fakenl"; // add fake newlines to
                                                          // keep the warnings

--- a/testing/028/indexpage.xml
+++ b/testing/028/indexpage.xml
@@ -6,7 +6,12 @@
     <briefdescription>
     </briefdescription>
     <detaileddescription>
-      <para>Here are some formulas:<orderedlist><listitem><para>The distance between <formula id="0">$(x_1,y_1)$</formula> and <formula id="1">$(x_2,y_2)$</formula> is <formula id="2">$\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}$</formula>.</para></listitem><listitem><para>Unnumbered formula: <formula id="3">\[ |I_2|=\left| \int_{0}^T \psi(t) \left\{ u(a,t)- \int_{\gamma(t)}^a \frac{d\theta}{k(\theta,t)} \int_{a}^\theta c(\xi)u_t(\xi,t)\,d\xi \right\} dt \right| \]</formula></para></listitem><listitem><para>Formula in different environment <formula id="4">\begin{eqnarray*} g &amp;=&amp; \frac{Gm_2}{r^2} \\ &amp;=&amp; \frac{(6.673 \times 10^{-11}\,\mbox{m}^3\,\mbox{kg}^{-1}\, \mbox{s}^{-2})(5.9736 \times 10^{24}\,\mbox{kg})}{(6371.01\,\mbox{km})^2} \\ &amp;=&amp; 9.82066032\,\mbox{m/s}^2 \end{eqnarray*}</formula> </para></listitem></orderedlist>
+      <para>Here are some formulas:<orderedlist><listitem><para>The distance between <formula id="0">$(x_1,y_1)$</formula> and <formula id="1">$(x_2,y_2)$</formula> is <formula id="2">$\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}$</formula>.</para></listitem><listitem><para>Unnumbered formula: <formula id="3">\[ |I_2|=\left| \int_{0}^T \psi(t) \left\{ u(a,t)- \int_{\gamma(t)}^a 
+       \frac{d\theta}{k(\theta,t)} \int_{a}^\theta c(\xi)u_t(\xi,t)\,d\xi \right\} dt \right| \]</formula></para></listitem><listitem><para>Formula in different environment <formula id="4">\begin{eqnarray*} g &amp;=&amp; \frac{Gm_2}{r^2} \\ 
+                   &amp;=&amp; \frac{(6.673 \times 10^{-11}\,\mbox{m}^3\,\mbox{kg}^{-1}\,
+                       \mbox{s}^{-2})(5.9736 \times 10^{24}\,\mbox{kg})}{(6371.01\,\mbox{km})^2} \\ 
+                       &amp;=&amp; 9.82066032\,\mbox{m/s}^2
+ \end{eqnarray*}</formula> </para></listitem></orderedlist>
 </para>
     </detaileddescription>
     <location file="028_formula.c"/>


### PR DESCRIPTION
In principle this should already be possible by means of defining the relevant `EXTRA_PACKAGES` and embedding the LaTeX code in the right environment.
Due to the `simpliftWhiteSpace` though embedded `\n` were stripped as well so the entire LaTeX code was seen as one line and when having comment signs (`%`) in it, the rest of the line was not handled by LaTeX.
The formulas are a more verbatim type of so has to be used "as is".

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7972027/example.tar.gz)
