### PR TITLE
Incorrect check on a list item.

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -6826,7 +6826,7 @@ reparsetoken:
         break;
       case TK_ENDLIST:
         DBG(("Found end of list inside of paragraph at line %d\n",m_parser.tokenizer.getLineNr()));
-        if (dynamic_cast<DocAutoList*>(parent()))
+        if (dynamic_cast<DocAutoListItem*>(parent()))
         {
           DocAutoList *al = dynamic_cast<DocAutoList*>(parent()->parent());
           if (al && al->indent()>=m_parser.context.token->indent)


### PR DESCRIPTION
When having the example from the manual:
```
/** \file
 *
 * Text before the list
 * - list item 1
 *   - sub item 1
 *     - sub sub item 1
 *     - sub sub item 2
 *     .
 *     The dot above ends the sub sub item list.
 *
 *     More text for the first sub item
 *   .
 *   The dot above ends the first sub item.
 *
 *   More text for the first list item
 *   - sub item 2
 *   - sub item 3
 * - list item 2
 * .
 * More text in the same paragraph.
 *
 * More text in a new paragraph.
 */
```
the handling of the dots (`.`) is incorrect.
This problem is a regression due to:
```
Commit: fcadb697534eef370f563d89f04ad32cd9ba5b97 [fcadb69]
Date: Saturday, January 15, 2022 2:47:46 PM

Replaced DocNode::kind() by dynamic_cast checks
```
The problem is that a  a `Kind_AutoListItem` was translated to `if (dynamic_cast<DocAutoList*>(parent()))` instead of `if (dynamic_cast<DocAutoListItem*>(parent()))`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/7977701/example.tar.gz)
