### PR TITLE
Removing obsolete functions

### DIFF
--- a/doc/translator.py
+++ b/doc/translator.py
@@ -875,8 +875,13 @@ class Transl:
                             assert False
 
                         assert(uniPrototype not in self.prototypeDic)
-                        # Insert new dictionary item.
-                        self.prototypeDic[uniPrototype] = prototype
+                        # Insert new dictionary item, unless they have a default in translator.h
+                        if (not (prototype=="virtual QCString latexDocumentPost()" or
+                                 prototype=="virtual QCString latexDocumentPre()" or
+                                 prototype=="virtual QCString latexCommandName()" or
+                                 prototype=="virtual QCString latexFont()" or
+                                 prototype=="virtual QCString latexFontenc()")):
+                          self.prototypeDic[uniPrototype] = prototype
                         status = 2      # body consumed
                         methodId = None # outside of any method
                 elif tokenId == 'lcurly':

--- a/src/translator.h
+++ b/src/translator.h
@@ -104,7 +104,6 @@ class Translator
     virtual QCString trClassHierarchy() = 0;
     virtual QCString trCompoundList() = 0;
     virtual QCString trFileList() = 0;
-    //virtual QCString trHeaderFiles() = 0;
     virtual QCString trCompoundMembers() = 0;
     virtual QCString trFileMembers() = 0;
     virtual QCString trRelatedPages() = 0;
@@ -115,11 +114,9 @@ class Translator
     virtual QCString trCompoundListDescription() = 0;
     virtual QCString trCompoundMembersDescription(bool extractAll) = 0;
     virtual QCString trFileMembersDescription(bool extractAll) = 0;
-    //virtual QCString trHeaderFilesDescription() = 0;
     virtual QCString trExamplesDescription() = 0;
     virtual QCString trRelatedPagesDescription() = 0;
     virtual QCString trModulesDescription() = 0;
-    //virtual QCString trNoDescriptionAvailable() = 0;
 
     // index titles (the project name is prepended for these)
 
@@ -135,26 +132,21 @@ class Translator
     virtual QCString trPageDocumentation() = 0;
     virtual QCString trReferenceManual() = 0;
     virtual QCString trDefines() = 0;
-    //virtual QCString trFuncProtos() = 0;
     virtual QCString trTypedefs() = 0;
     virtual QCString trEnumerations() = 0;
     virtual QCString trFunctions() = 0;
     virtual QCString trVariables() = 0;
     virtual QCString trEnumerationValues() = 0;
     virtual QCString trDefineDocumentation() = 0;
-    //virtual QCString trFunctionPrototypeDocumentation() = 0;
     virtual QCString trTypedefDocumentation() = 0;
     virtual QCString trEnumerationTypeDocumentation() = 0;
     virtual QCString trFunctionDocumentation() = 0;
     virtual QCString trVariableDocumentation() = 0;
     virtual QCString trCompounds() = 0;
     virtual QCString trGeneratedAt(const QCString &date,const QCString &projName) = 0;
-    //virtual QCString trWrittenBy() = 0;
     virtual QCString trClassDiagram(const QCString &clName) = 0;
     virtual QCString trForInternalUseOnly() = 0;
-    //virtual QCString trReimplementedForInternalReasons() = 0;
     virtual QCString trWarning() = 0;
-    //virtual QCString trBugsAndLimitations() = 0;
     virtual QCString trVersion() = 0;
     virtual QCString trDate() = 0;
     virtual QCString trReturns() = 0;
@@ -234,7 +226,6 @@ class Translator
 // new since 0.49-991003
 //////////////////////////////////////////////////////////////////////////
 
-    //virtual QCString trSources() = 0;
     virtual QCString trDefinedAtLineInSourceFile() = 0;
     virtual QCString trDefinedInSourceFile() = 0;
 
@@ -328,13 +319,11 @@ class Translator
 // new since 1.2.4
 //////////////////////////////////////////////////////////////////////////
 
-    //virtual QCString trInterfaces() = 0;
     virtual QCString trClasses() = 0;
     virtual QCString trPackage(const QCString &name) = 0;
     virtual QCString trPackageList() = 0;
     virtual QCString trPackageListDescription() = 0;
     virtual QCString trPackages() = 0;
-    //virtual QCString trPackageDocumentation() = 0;
     virtual QCString trDefineValue() = 0;
 
 //////////////////////////////////////////////////////////////////////////
@@ -415,7 +404,6 @@ class Translator
     virtual QCString trGroup(bool first_capital, bool singular) = 0;
     virtual QCString trPage(bool first_capital, bool singular) = 0;
     virtual QCString trMember(bool first_capital, bool singular) = 0;
-    //virtual QCString trField(bool first_capital, bool singular) = 0;
     virtual QCString trGlobal(bool first_capital, bool singular) = 0;
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -181,10 +181,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     virtual QCString trFileList()
     { return "قائمة الملفات"; }
 
-    /*! This is put above each page as a link to the list of all verbatim headers */
-    virtual QCString trHeaderFiles()
-    { return "الملفات الرأسية"; }
-
     /*! This is put above each page as a link to all members of compounds. */
     virtual QCString trCompoundMembers()
     {
@@ -318,10 +314,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
       return result;
     }
 
-    /*! This is an introduction to the page with the list of all header files. */
-    virtual QCString trHeaderFilesDescription()
-    { return "Here are the header files that make up the API:"; }
-
     /*! This is an introduction to the page with the list of all examples */
     virtual QCString trExamplesDescription()
     { return "هذه قائمة بكل الأمثلة:"; }
@@ -333,14 +325,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     /*! This is an introduction to the page with the list of class/file groups */
     virtual QCString trModulesDescription()
     { return "هذه قائمة بكل المكونات:"; }
-
-    /*! This sentences is used in the annotated class/file lists if no brief
-     * description is given.
-     */
-    virtual QCString trNoDescriptionAvailable()
-    { return "لا يوجد وصف متاح"; }
-
-    // index titles (the project name is prepended for these)
 
 
     /*! This is used in HTML as the title of index.html. */
@@ -531,17 +515,9 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     virtual QCString trForInternalUseOnly()
     { return "للاستخدام الداخلي فقط."; }
 
-    /*! this text is generated when the \\reimp command is used. */
-    virtual QCString trReimplementedForInternalReasons()
-    { return "Reimplemented for internal reasons; the API is not affected."; }
-
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
     { return "تنبيه"; }
-
-    /*! this text is generated when the \\bug command is used. */
-    virtual QCString trBugsAndLimitations()
-    { return "Bugs and limitations"; }
 
     /*! this text is generated when the \\version command is used. */
     virtual QCString trVersion()
@@ -813,10 +789,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
 // new since 0.49-991003
 //////////////////////////////////////////////////////////////////////////
 
-    virtual QCString trSources()
-    {
-      return "مصادر";
-    }
     virtual QCString trDefinedAtLineInSourceFile()
     {
       return "Definition at line @0 of file @1.";
@@ -1150,11 +1122,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     {
       return "حزم";
     }
-    /*! Used as a chapter title for Latex & RTF output */
-    virtual QCString trPackageDocumentation()
-    {
-      return "توثيق الحزم";
-    }
     /*! Text shown before a multi-line define */
     virtual QCString trDefineValue()
     {
@@ -1288,17 +1255,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     {
       QCString result("عضو");
       if (!singular)  result="أعضاء";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trField(bool /*first_capital*/, bool singular)
-    {
-      QCString result("حقل");
-      if (!singular)  result="حقول";
       return result;
     }
 

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -1941,15 +1941,6 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     {
       return "Dokumentaro de la Metodo";
     }
-
-    /*! Used as the title of the design overview picture created for the
-     *  VHDL output.
-     */
-    virtual QCString trDesignOverview()
-    {
-      return "Fasona Superrigardo";
-    }
-
 };
 
 #endif

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -1944,15 +1944,6 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     {
       return "Metožu dokumentācija";
     }
-
-    /*! Used as the title of the design overview picture created for the
-     *  VHDL output.
-     */
-    virtual QCString trDesignOverview()
-    {
-      return "Dizaina pārskats";
-    }
-
 };
 
 #endif

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -190,10 +190,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     virtual QCString trFileList()
     { return "Fil-liste"; }
 
-    /*! This is put above each page as a link to the list of all verbatim headers */
-    virtual QCString trHeaderFiles()
-    { return "Header-filer"; }
-
     /*! This is put above each page as a link to all members of compounds. */
     virtual QCString trCompoundMembers()
     {
@@ -329,10 +325,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
       return result;
     }
 
-    /*! This is an introduction to the page with the list of all header files. */
-    virtual QCString trHeaderFilesDescription()
-    { return "Her er alle header-filene som utgjør API'et:"; }
-
     /*! This is an introduction to the page with the list of all examples */
     virtual QCString trExamplesDescription()
     { return "Her er en liste over alle eksemplene:"; }
@@ -344,12 +336,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     /*! This is an introduction to the page with the list of class/file groups */
     virtual QCString trModulesDescription()
     { return "Her er en liste over alle moduler:"; }
-
-    /*! This sentences is used in the annotated class/file lists if no brief
-     * description is given.
-     */
-    virtual QCString trNoDescriptionAvailable()
-    { return "Ingen beskrivelse tilgjengelig"; }
 
     // index titles (the project name is prepended for these)
 
@@ -542,17 +528,9 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     virtual QCString trForInternalUseOnly()
     { return "Kun for intern bruk."; }
 
-    /*! this text is generated when the \\reimp command is used. */
-    virtual QCString trReimplementedForInternalReasons()
-    { return "Reimplementert av interne grunner; API er ikke påvirket."; }
-
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
     { return "Advarsel"; }
-
-    /*! this text is generated when the \\bug command is used. */
-    virtual QCString trBugsAndLimitations()
-    { return "Feil og begrensninger"; }
 
     /*! this text is generated when the \\version command is used. */
     virtual QCString trVersion()
@@ -824,10 +802,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
 // new since 0.49-991003
 //////////////////////////////////////////////////////////////////////////
 
-    virtual QCString trSources()
-    {
-      return "Kilder";
-    }
     virtual QCString trDefinedAtLineInSourceFile()
     {
       return "Definisjon på linje @0 i filen @1.";
@@ -1155,11 +1129,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     {
       return "Pakker";
     }
-    /*! Used as a chapter title for Latex & RTF output */
-    virtual QCString trPackageDocumentation()
-    {
-      return "Pakke-dokumentasjon";
-    }
     /*! Text shown before a multi-line define */
     virtual QCString trDefineValue()
     {
@@ -1293,17 +1262,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     {
       QCString result((first_capital ? "Medlem" : "medlem"));
       if (!singular)  result+="mer";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trField(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Felt" : "felt"));
-      if (!singular)  result+="";
       return result;
     }
 

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -169,10 +169,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     QCString trFileList()
     { return "Lista plików"; }
 
-    /*! This is put above each page as a link to the list of all verbatim headers */
-    QCString trHeaderFiles()
-    { return "Pliki nagłówkowe"; }
-
     /*! This is put above each page as a link to all members of compounds. */
     QCString trCompoundMembers()
     {
@@ -308,10 +304,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
       return result;
     }
 
-    /*! This is an introduction to the page with the list of all header files. */
-    QCString trHeaderFilesDescription()
-    { return "Tutaj znajdują się pliki nagłówkowe tworzące API:"; }
-
     /*! This is an introduction to the page with the list of all examples */
     QCString trExamplesDescription()
     { return "Tutaj znajduje się lista wszystkich przykładów:"; }
@@ -323,12 +315,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     /*! This is an introduction to the page with the list of class/file groups */
     QCString trModulesDescription()
     { return "Tutaj znajduje się lista wszystkich grup:"; }
-
-    /*! This sentences is used in the annotated class/file lists if no brief
-     * description is given.
-     */
-    QCString trNoDescriptionAvailable()
-    { return "Brak opisu"; }
 
     // index titles (the project name is prepended for these)
 
@@ -515,17 +501,9 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     QCString trForInternalUseOnly()
     { return "Tylko do użytku wewnętrznego."; }
 
-    /*! this text is generated when the \\reimp command is used. */
-    QCString trReimplementedForInternalReasons()
-    { return "Reimplementowana z wewnętrzych przyczyn; nie dotyczy API."; }
-
     /*! this text is generated when the \\warning command is used. */
     QCString trWarning()
     { return "Ostrzeżenie"; }
-
-    /*! this text is generated when the \\bug command is used. */
-    QCString trBugsAndLimitations()
-    { return "Błędy i ograniczenia"; }
 
     /*! this text is generated when the \\version command is used. */
     QCString trVersion()
@@ -796,10 +774,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
 // new since 0.49-991003
 //////////////////////////////////////////////////////////////////////////
 
-    QCString trSources()
-    {
-      return "Źródła";
-    }
     QCString trDefinedAtLineInSourceFile()
     {
       return "Definicja w linii @0 pliku @1.";
@@ -1129,11 +1103,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     {
       return "Pakiety";
     }
-    /*! Used as a chapter title for Latex & RTF output */
-    virtual QCString trPackageDocumentation()
-    {
-      return "Dokumentacja Pakietu";
-    }
     /*! Text shown before a multi-line define */
     virtual QCString trDefineValue()
     {
@@ -1241,17 +1210,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     {
       QCString result((first_capital ? "Składow" : "składow"));
       result+=(singular ? "a" : "e");
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trField(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Pol" : "pol"));
-      result+=(singular ? "e" : "a");
       return result;
     }
 

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -84,8 +84,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     { return "kratek opis razredov"; }
     QCString trFileList()
     { return "seznam datotek"; }
-/*     QCString trHeaderFiles() */
-/*     { return "'Header' datoteka"; } */
     QCString trCompoundMembers()
     { return "metode in atributi"; }
     QCString trFileMembers()
@@ -128,17 +126,12 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
       else result+="s povezavami na datoteke v katerih se nahajajo:";
       return result;
     }
-/*     QCString trHeaderFilesDescription() */
-/*     { return "Seznam header datotek, ki tvorijo aplikacijski vmesnik (API) :"; } */
     QCString trExamplesDescription()
     { return "Seznam primerov :"; }
     QCString trRelatedPagesDescription()
     { return "Seznam strani z dodatnimi opisi:"; }
     QCString trModulesDescription()
     { return "Seznam modulov:"; }
-/*     QCString trNoDescriptionAvailable() */
-/*     { return "Opis ni dostopen"; } */
-
     QCString trDocumentation()
     { return "Dokumentacija"; }
     QCString trModuleIndex()
@@ -199,14 +192,8 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     }
     QCString trForInternalUseOnly()
     { return "Samo za interno uporabo."; }
-/*     QCString trReimplementedForInternalReasons() */
-/*     { return "Ponovno implementirano zaradi internih razlogov. " */
-/*              "Nima vpliva na API.";  */
-/*     } */
     QCString trWarning()
     { return "Opozorilo"; }
-/*     QCString trBugsAndLimitations() */
-/*     { return "Napake in omejtive"; } */
     QCString trVersion()
     { return "Verzija"; }
     QCString trDate()
@@ -445,10 +432,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
 // new since 0.49-991106
 //////////////////////////////////////////////////////////////////////////
 
-/*     QCString trSources() */
-/*     { */
-/*       return "Izvorne datoteke"; */
-/*     } */
     QCString trDefinedAtLineInSourceFile()
     {
       return "Definirano v @0 vrstici datoteke @1.";
@@ -784,11 +767,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     {
       return "JAVA paketi";
     }
-    /*! Used as a chapter title for Latex & RTF output */
-/*     virtual QCString trPackageDocumentation() */
-/*     { */
-/*       return "Opisi JAVA paketov"; */
-/*     } */
     /*! Text shown before a multi-line define */
     virtual QCString trDefineValue()
     {
@@ -925,18 +903,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
       if (!singular)  result+="i";
       return result;
     }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-/*     virtual QCString trField(bool first_capital, bool singular) */
-/*     {  */
-/*       QCString result((first_capital ? "Polj" : "polj")); */
-/*       if (!singular)  result+="a"; */
-/*       else result += "e"; */
-/*       return result;  */
-/*     } */
 
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -1723,59 +1723,11 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
       return "Ograničenja tipova";
     }
 
-//////////////////////////////////////////////////////////////////////////
-// following methods have no corresponding entry in translator_en.h
-//////////////////////////////////////////////////////////////////////////
-
-//      /*! This is put above each page as a link to the list of all verbatim headers */
-//     virtual QCString trHeaderFiles()
-//     { return "Zaglavlja"; }
-//
-//     /*! This is an introduction to the page with the list of all header files. */
-//     virtual QCString trHeaderFilesDescription()
-//     { return "Zaglavlja koje izgraduju API:"; }
-//
-//     /*! This sentences is used in the annotated class/file lists if no brief
-//      * description is given.
-//      */
-//     virtual QCString trNoDescriptionAvailable()
-//     { return "Opis nije dostupan"; }
-//
-//     /*! this text is generated when the \\reimp command is used. */
-//     virtual QCString trReimplementedForInternalReasons()
-//     { return decode("Preuradeno zbog unutrasnjih razloga; Nema uticaja na API." ); }
-//
-//     /*! this text is generated when the \\bug command is used. */
-//     virtual QCString trBugsAndLimitations()
-//     { return "Greske i ogranicenja"; }
-//
-//     virtual QCString trSources()
-//     {
-//       return decode("Izvorne datoteke" );
-//     }
-//
-//     /*! Used for Java interfaces in the summary section of Java packages */
-//     virtual QCString trInterfaces()
-//     {
-//       return "Interfejsi";  //!< Radna okruzenja. Ali to je dve reci.
-//     }
-//
-//     /*! Used as a chapter title for Latex & RTF output */
-//     virtual QCString trPackageDocumentation()
-//     {
-//       return "Dokumentacija paketa";
-//     }
-//
-//     /*! This is used for translation of the word that will possibly
-//      *  be followed by a single name or by a list of names
-//      *  of the category.
-//      */
-//     virtual QCString trField(bool first_capital, bool singular)
-//     {
-//       QCString result((first_capital ? "Polj" : "polj"));
-//       result+= (singular ? "e" : "a");
-//       return result;
-//     }
+    /*! Used for Java interfaces in the summary section of Java packages */
+    virtual QCString trInterfaces()
+    {
+      return "Interfejsi";  //!< Radna okruzenja. Ali to je dve reci.
+    }
 
 };
 

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -1908,15 +1908,6 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     {
       return "Документація метода";
     }
-
-    /*! Used as the title of the design overview picture created for the
-     *  VHDL output.
-     */
-    virtual QCString trDesignOverview()
-    {
-      return "Огляд дизайну проекту";
-    }
-
 };
 
 #endif


### PR DESCRIPTION
In the translator_report.txt we find quite a few obsolete functions
- Corrected marking of obsolete functions for functions that have a default implementation and thus are not obsolete
- Removing obsolete functions