### PR TITLE
Maintenance on translator functions

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1619,8 +1619,6 @@ void HtmlDocVisitor::visitPost(DocHtmlCaption *)
 void HtmlDocVisitor::visitPre(DocInternal *)
 {
   if (m_hide) return;
-  //forceEndParagraph(i);
-  //m_t << "<p><b>" << theTranslator->trForInternalUseOnly() << "</b></p>\n";
 }
 
 void HtmlDocVisitor::visitPost(DocInternal *)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4490,8 +4490,6 @@ static void writeIndex(OutputList &ol)
   }
   if (documentedPages>0)
   {
-    //ol.parseText(projPrefix+theTranslator->trPageDocumentation());
-    //ol.endIndexSection(isPageDocumentation);
     bool first=Doxygen::mainPage==0;
     for (const auto &pd : *Doxygen::pageLinkedMap)
     {

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1477,15 +1477,11 @@ void LatexDocVisitor::visitPost(DocHtmlCell *c)
 void LatexDocVisitor::visitPre(DocInternal *)
 {
   if (m_hide) return;
-  //m_t << "\\begin{DoxyInternal}{";
-  //filter(theTranslator->trForInternalUseOnly());
-  //m_t << "}\n";
 }
 
 void LatexDocVisitor::visitPost(DocInternal *)
 {
   if (m_hide) return;
-  //m_t << "\\end{DoxyInternal}\n";
 }
 
 void LatexDocVisitor::visitPre(DocHRef *href)

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -745,10 +745,6 @@ void LatexGenerator::startIndexSection(IndexSections is)
       if (compactLatex) m_t << "\\doxysection"; else m_t << "\\chapter";
       m_t << "{"; //Introduction}\n"
       break;
-    //case isPackageIndex:
-    //  if (compactLatex) m_t << "\\doxysection"; else m_t << "\\chapter";
-    //  m_t << "{"; //Package Index}\n"
-    //  break;
     case isModuleIndex:
       if (compactLatex) m_t << "\\doxysection"; else m_t << "\\chapter";
       m_t << "{"; //Module Index}\n"

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -466,13 +466,6 @@ class LayoutParser
           theTranslator->trFileMembersDescription(extractAll),
           "globals"
         },
-        //{ "dirs",
-        //  LayoutNavEntry::Dirs,
-        //  theTranslator->trDirectories(),
-        //  QCString(),
-        //  theTranslator->trDirDescription(),
-        //  "dirs"
-        //},
         { "examples",
           LayoutNavEntry::Examples,
           theTranslator->trExamples(),

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -843,19 +843,11 @@ void ManDocVisitor::visitPost(DocHtmlCell *)
 void ManDocVisitor::visitPre(DocInternal *)
 {
   if (m_hide) return;
-  //if (!m_firstCol) m_t << "\n";
-  //m_t << ".PP\n";
-  //m_t << "\\fB" << theTranslator->trForInternalUseOnly() << "\\fP\n";
-  //m_t << ".RS 4\n";
 }
 
 void ManDocVisitor::visitPost(DocInternal *)
 {
   if (m_hide) return;
-  //if (!m_firstCol) m_t << "\n";
-  //m_t << ".RE\n";
-  //m_t << ".PP\n";
-  //m_firstCol=TRUE;
 }
 
 void ManDocVisitor::visitPre(DocHRef *)

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1169,25 +1169,11 @@ void RTFDocVisitor::visitPost(DocHtmlCell *)
 void RTFDocVisitor::visitPre(DocInternal *)
 {
   if (m_hide) return;
-  //DBG_RTF("{\\comment RTFDocVisitor::visitPre(DocInternal)}\n");
-  //m_t << "{"; // start desc
-  //m_t << "{\\b "; // start bold
-  //m_t << theTranslator->trForInternalUseOnly();
-  //m_t << "}"; // end bold
-  //m_t << "\\par\n";
-  //incIndentLevel();
-  //m_t << rtf_Style_Reset << getStyle("DescContinue");
-  //m_lastIsPara=FALSE;
 }
 
 void RTFDocVisitor::visitPost(DocInternal *)
 {
   if (m_hide) return;
-  //DBG_RTF("{\\comment RTFDocVisitor::visitPost(DocInternal)}\n");
-  //m_t << "\\par";
-  //decIndentLevel();
-  //m_t << "}"; // end desc
-  //m_lastIsPara=TRUE;
 }
 
 void RTFDocVisitor::visitPre(DocHRef *href)

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -431,10 +431,6 @@ void RTFGenerator::startIndexSection(IndexSections is)
       //Introduction
       beginRTFChapter();
       break;
-    //case isPackageIndex:
-    //  //Package Index
-    //  beginRTFChapter();
-    //  break;
     case isModuleIndex:
       //Module Index
       beginRTFChapter();
@@ -694,11 +690,6 @@ void RTFGenerator::endIndexSection(IndexSections is)
       m_t << "index";
       m_t << ".rtf\" \\\\*MERGEFORMAT}{\\fldrslt includedstuff}}\n";
       break;
-    //case isPackageIndex:
-    //  m_t << "\\par " << rtf_Style_Reset << "\n";
-    //  m_t << "{\\tc \\v " << theTranslator->trPackageList() << "}\n";
-    //  m_t << "{\\field\\fldedit{\\*\\fldinst INCLUDETEXT \"packages.rtf\" \\\\*MERGEFORMAT}{\\fldrslt includedstuff}}\n";
-    //  break;
     case isModuleIndex:
       m_t << "\\par " << rtf_Style_Reset << "\n";
       m_t << "{\\tc \\v " << theTranslator->trModuleIndex() << "}\n";
@@ -929,23 +920,6 @@ void RTFGenerator::endIndexSection(IndexSections is)
       }
       break;
     case isPageDocumentation:
-      {
-//#error "fix me in the same way as the latex index..."
-        //m_t << "{\\tc \\v " << theTranslator->trPageDocumentation() << "}\n";
-        //m_t << "}\n";
-        //bool first=TRUE;
-        //for (const auto *pd : Doxygen::pageLinkedMap)
-        //{
-        //  if (!pd->getGroupDef() && !pd->isReference())
-        //  {
-        //    if (first) m_t << "\\par " << rtf_Style_Reset << "\n";
-        //    m_t << "{\\field\\fldedit{\\*\\fldinst INCLUDETEXT \"";
-        //    m_t << pd->getOutputFileBase();
-        //    m_t << ".rtf\" \\\\*MERGEFORMAT}{\\fldrslt includedstuff}}\n";
-        //    first=FALSE;
-        //  }
-        //}
-      }
       break;
     case isPageDocumentation2:
       {

--- a/src/translator.h
+++ b/src/translator.h
@@ -129,7 +129,6 @@ class Translator
     virtual QCString trClassDocumentation() = 0;
     virtual QCString trFileDocumentation() = 0;
     virtual QCString trExampleDocumentation() = 0;
-    virtual QCString trPageDocumentation() = 0;
     virtual QCString trReferenceManual() = 0;
     virtual QCString trDefines() = 0;
     virtual QCString trTypedefs() = 0;
@@ -145,7 +144,6 @@ class Translator
     virtual QCString trCompounds() = 0;
     virtual QCString trGeneratedAt(const QCString &date,const QCString &projName) = 0;
     virtual QCString trClassDiagram(const QCString &clName) = 0;
-    virtual QCString trForInternalUseOnly() = 0;
     virtual QCString trWarning() = 0;
     virtual QCString trVersion() = 0;
     virtual QCString trDate() = 0;
@@ -212,7 +210,6 @@ class Translator
 
     virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
                                           bool single) = 0;
-    //virtual QCString trAlphabeticalList() = 0;
 
 //////////////////////////////////////////////////////////////////////////
 // new since 0.49-990901
@@ -303,12 +300,6 @@ class Translator
     virtual QCString trTestList() = 0;
 
 //////////////////////////////////////////////////////////////////////////
-// new since 1.2.1
-//////////////////////////////////////////////////////////////////////////
-
-    //virtual QCString trDCOPMethods() = 0;
-
-//////////////////////////////////////////////////////////////////////////
 // new since 1.2.2
 //////////////////////////////////////////////////////////////////////////
 
@@ -321,7 +312,6 @@ class Translator
 
     virtual QCString trClasses() = 0;
     virtual QCString trPackage(const QCString &name) = 0;
-    virtual QCString trPackageList() = 0;
     virtual QCString trPackageListDescription() = 0;
     virtual QCString trPackages() = 0;
     virtual QCString trDefineValue() = 0;
@@ -465,7 +455,6 @@ class Translator
 // new since 1.3.3
 //////////////////////////////////////////////////////////////////////////
 
-    //virtual QCString trSearchForIndex() = 0;
     virtual QCString trSearchResultsTitle() = 0;
     virtual QCString trSearchResults(int numDocuments) = 0;
     virtual QCString trSearchMatches() = 0;
@@ -483,7 +472,6 @@ class Translator
     virtual QCString trDirIndex() = 0;
     virtual QCString trDirDocumentation() = 0;
     virtual QCString trDirectories() = 0;
-    virtual QCString trDirDescription() = 0;
     virtual QCString trDirReference(const QCString &dirName) = 0;
     virtual QCString trDir(bool first_capital, bool singular) = 0;
 
@@ -544,7 +532,6 @@ class Translator
 // new since 1.6.3
 //////////////////////////////////////////////////////////////////////////
 
-    //virtual QCString trDirDependency(const QCString &name) = 0;
     virtual QCString trFileIn(const QCString &name) = 0;
     virtual QCString trIncludesFileIn(const QCString &name) = 0;
     virtual QCString trDateTime(int year,int month,int day,int dayOfWeek,

--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -342,6 +342,10 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
       {
         return "Տվյալների կառուցվածքներ";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Դասեր";
@@ -359,12 +363,6 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
      */
     virtual QCString trExampleDocumentation()
     { return "Օրինակներ"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Էջեր"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -470,10 +468,6 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
     {
       return clName+QCString(" -ի ժառանգման գծագիրը.");
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Միայն ներքին օգտագործման համար"; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1078,11 +1072,6 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
     {
       return "Փաթեթ "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Փաթեթների ցուցակ";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1434,14 +1423,6 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
      */
     virtual QCString trDirectories()
     { return "Ֆայլադրաններ"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Այս ֆայլադարանների հիերարխիան կարգավորված է կոպտորեն, "
-			"բայց ոչ ամբողջապես, այբբենական կարգով.";
-	}
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -379,6 +379,10 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
       {
         return "فهرس هيكل البيانات";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "فهرس الفئة";
@@ -396,12 +400,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
      */
     virtual QCString trExampleDocumentation()
     { return "توثيق الأمثلة"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "توثيق الصفحات"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -510,10 +508,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     {
       return "Inheritance diagram for "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "للاستخدام الداخلي فقط."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1107,11 +1101,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     {
       return "حزمة "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "قائمة الحزم";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1485,14 +1474,6 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
      */
     virtual QCString trDirectories()
     { return "الأدلة"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "هذا الشكل الهرمي للأدلة تم ترتيبه أبجديا بصورة تقريبية، "
-	"وليس ترتيبا أبجديا كاملا:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -426,12 +426,6 @@ class TranslatorBulgarian : public Translator
     virtual QCString trExampleDocumentation()
     { return "Примери Документация"; }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Свързани страници Документация"; }
-
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
     { return "Помощно ръководство"; }
@@ -533,10 +527,6 @@ class TranslatorBulgarian : public Translator
     {
       return (QCString)"Диаграма на наследяване за "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Само за вътрешно ползване."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1128,11 +1118,6 @@ class TranslatorBulgarian : public Translator
     {
       return (QCString)"Пакет "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Пакети Списък";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1506,14 +1491,6 @@ class TranslatorBulgarian : public Translator
      */
     virtual QCString trDirectories()
     { return "Директории"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Тази йерархия на директориите е сортирана, "
-             "но не изцяло, по азбучен ред:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -420,6 +420,10 @@ class TranslatorBrazilian : public Translator
       {
         return "Estruturas";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Classes";
@@ -437,12 +441,6 @@ class TranslatorBrazilian : public Translator
      */
     virtual QCString trExampleDocumentation()
     { return "Exemplos"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Documentação Relacionada"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -545,10 +543,6 @@ class TranslatorBrazilian : public Translator
     {
       return "Diagrama de hierarquia para "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Apenas para uso interno."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1177,11 +1171,6 @@ class TranslatorBrazilian : public Translator
     {
       return "Pacote "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Lista de Pacotes";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1559,12 +1548,6 @@ class TranslatorBrazilian : public Translator
      */
     virtual QCString trDirectories()
     { return "Diretórios"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Esta Hierarquia de Diretórios está parcialmente ordenada (ordem alfabética)"; }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.
@@ -2349,7 +2332,7 @@ class TranslatorBrazilian : public Translator
 	virtual QCString trDesignUnitDocumentation()
 	{
 	    return "Documentação da Unidade de Projeto";
-    }
+        }
 
 
 	//////////////////////////////////////////////////////////////////////////

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -392,6 +392,10 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
       {
         return "Documentació de les Estructures de Dades";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Documentació de les Classes";
@@ -409,12 +413,6 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     virtual QCString trExampleDocumentation()
     { return "Documentació dels Exemples"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Documentació de les Pàgines"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -517,10 +515,6 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
     {
       return "Diagrama d'Herència per a "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Tan sols per a ús intern."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1106,11 +1100,6 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
     {
       return "Paquet "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Llista de Paquets";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1484,14 +1473,6 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     virtual QCString trDirectories()
     { return "Directoris"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Aquesta jerarquia de directoris està ordenada toscament, "
-             "però no completa, de forma alfabètica:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -329,6 +329,10 @@ class TranslatorChinese : public Translator
       {
         return "结构体说明";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else {
         return "类说明";
       }
@@ -339,9 +343,6 @@ class TranslatorChinese : public Translator
 
     virtual QCString trExampleDocumentation()
     { return "示例说明"; }
-
-    virtual QCString trPageDocumentation()
-    { return "页面说明"; }
 
     virtual QCString trReferenceManual()
     { return "参考手册"; }
@@ -402,9 +403,6 @@ class TranslatorChinese : public Translator
     {
       return "类" CN_SPC+clName+CN_SPC "继承关系图:";
     }
-
-     virtual QCString trForInternalUseOnly()
-    { return "仅限内部使用."; }
 
      virtual QCString trWarning()
     { return "警告"; }
@@ -1010,11 +1008,6 @@ class TranslatorChinese : public Translator
       return "包" CN_SPC+name;
     }
 
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "包列表";
-    }
 
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
@@ -1429,14 +1422,6 @@ class TranslatorChinese : public Translator
      */
     virtual QCString trDirectories()
     { return "目录"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    {
-      return "此继承关系列表按字典顺序粗略的排序:" CN_SPC;
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -462,12 +462,6 @@ class TranslatorCzech : public Translator
     virtual QCString trExampleDocumentation()
     { return "Dokumentace příkladů"; }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Dokumentace souvisejících stránek"; }
-
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
     { return "Referenční příručka"; }
@@ -569,10 +563,6 @@ class TranslatorCzech : public Translator
     {
       return QCString("Diagram dědičnosti pro třídu ") + clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Pouze pro vnitřní použití."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1185,11 +1175,6 @@ class TranslatorCzech : public Translator
     {
       return QCString("Balík ") + name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Seznam balíků";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1570,15 +1555,6 @@ class TranslatorCzech : public Translator
      */
     virtual QCString trDirectories()
     { return "Adresáře"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    {
-        return "Následující hierarchie adresářů je zhruba, "
-                      "ale ne úplně, řazena podle abecedy:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -26,8 +26,6 @@
 //
 //   2001/03/23 Jens Seidel (jensseidel@users.sourceforge.net)
 //    - fixed typos
-//    - changed trPageDocumentation() "Seitenbeschreibung" to
-//      "Zusätzliche Informationen"
 //    - removed old trGeneratedFrom()
 //    - changed "/*!" to "/*" (documentation is inherited from translator_en.h
 //      (INHERIT_DOCS = YES), there's no need to make changes twice)
@@ -509,12 +507,6 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     virtual QCString trExampleDocumentation()
     { return "Dokumentation der Beispiele"; }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Zusätzliche Informationen"; }
-
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
     { return "Nachschlagewerk"; }
@@ -616,10 +608,6 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     {
       return "Klassendiagramm für "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Nur für den internen Gebrauch."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1259,11 +1247,6 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
       return "Paket "+name;
     }
 
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Paketliste";
-    }
 
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
@@ -1626,14 +1609,6 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "Verzeichnisse"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Diese Verzeichnishierarchie ist -mit Einschränkungen- "
-         "alphabetisch sortiert:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -398,9 +398,16 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
      */
     virtual QCString trClassDocumentation()
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C)) {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
         return "Datastruktur-documentation";
-      } else {
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
+      else
+      {
         return "Klasse-dokumentation";
       }
     }
@@ -416,12 +423,6 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
      */
     virtual QCString trExampleDocumentation()
     { return "Eksempel-dokumentation"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Side-dokumentation"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -527,10 +528,6 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     {
       return "Stamtræ for "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Kun til intern brug."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1084,11 +1081,6 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     {
       return "Pakke "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Pakkeoversigt";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1406,14 +1398,6 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
      */
     virtual QCString trDirectories()
     { return "Kataloger"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Denne katalogstruktur er sorteret næsten - "
-             "men ikke nødvendigvis helt - alfabetisk:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -421,12 +421,6 @@ class TranslatorEnglish : public Translator
     virtual QCString trExampleDocumentation()
     { return "Example Documentation"; }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Page Documentation"; }
-
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
     { return "Reference Manual"; }
@@ -528,10 +522,6 @@ class TranslatorEnglish : public Translator
     {
       return "Inheritance diagram for "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "For internal use only."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1122,11 +1112,6 @@ class TranslatorEnglish : public Translator
     {
       return "Package "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Package List";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1500,14 +1485,6 @@ class TranslatorEnglish : public Translator
      */
     virtual QCString trDirectories()
     { return "Directories"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "This directory hierarchy is sorted roughly, "
-             "but not completely, alphabetically:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -393,6 +393,10 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
       {
         return "Datumstruktura Dokumentado";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Klasa Dokumentado";
@@ -410,12 +414,6 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     virtual QCString trExampleDocumentation()
     { return "Ekzempla Dokumentado"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Paĝa Dokumentado"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -518,10 +516,6 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     {
       return "Heredada diagramo por "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Nur por ena uzado."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1109,11 +1103,6 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     {
       return "Pakaĵo "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Pakaĵa Listo";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1487,14 +1476,6 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     virtual QCString trDirectories()
     { return "Dosierujoj"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Tiu ĉi dosieruja hierarkio estas plimalpli, "
-             "sed ne tute, ordigita alfabete:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -383,6 +383,10 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
       {
         return "Documentación de las estructuras de datos";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Documentación de las clases";
@@ -400,12 +404,6 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "Documentación de ejemplos"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Documentación de páginas"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -508,10 +506,6 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
     {
       return "Diagrama de herencias de "+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Sólo para uso interno."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1145,11 +1139,6 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
       return "Paquetes "+name;
     }
 
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Lista de Paquetes ";
-    }
 
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
@@ -1535,14 +1524,6 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "Directorios"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "La jeraquía de este directorio está ordenada"
-              " alfabéticamente, de manera aproximada:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -384,6 +384,10 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
       {
         return "مستندات ساختار داده ها";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "مستندات کلاس ها";
@@ -401,12 +405,6 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
      */
     virtual QCString trExampleDocumentation()
     { return "مستندات مثال"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "مستندات صفحه"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -515,10 +513,6 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
     {
       return ""+clName+" نمودار وراثت برای  :";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return ".فقط برای استعمال داخلی"; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1103,11 +1097,6 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
     {
       return "Package "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "لیست بسته ها";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1481,13 +1470,6 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
      */
     virtual QCString trDirectories()
     { return "شاخه ها"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "در ذيل ساختار شاخه ها و دايرکتوری ها را نسبتا مرتب شده می بينيد :";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -89,17 +89,6 @@ positiiviset kommentit otetaan ilolla vastaan.
 class TranslatorFinnish : public TranslatorAdapter_1_6_0
 {
   public:
-    /*! This method is used to generate a warning message to signal
-     *  the user that the translation of his/her language of choice
-     *  needs updating.
-     */
-    /*virtual QCString updateNeededMessage()
-    {
-      return "The Finnish translator is really obsolete.\n"
-             "It was not updated since version 1.0.0.  As a result,\n"
-             "some sentences may appear in English.\n\n";
-    }*/
-
     // --- Language control methods -------------------
 
     /*! Used for identification of the language. The identification
@@ -453,6 +442,10 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
       {
         return "Tietueiden dokumentaatio"; // "Data Structure Documentation"
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Luokkien dokumentaatio"; // "Class Documentation"
@@ -470,12 +463,6 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     virtual QCString trExampleDocumentation()
     { return "Esimerkkien dokumentaatio"; } // "Example Documentation"
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Sivujen dokumentaatio"; } // "Page Documentation"
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -582,10 +569,6 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
     {
       return "Luokan "+clName+" luokkakaavio"; // "Inheritance diagram for "
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Vain sisäiseen käyttöön."; } // "For internal use only."
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1225,11 +1208,6 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
     {
       return "Paketti "+name; // "Package "
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Pakettilista"; // "Package List"
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1603,15 +1581,6 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     virtual QCString trDirectories()
     { return "Hakemistot"; } // "Directories"
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Tämä hakemistohierarkia on järjestetty aakkosellisesti tasoittain:";
-             //This directory hierarchy is sorted roughly, "
-             // "but not completely, alphabetically:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -457,6 +457,10 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
       {
         return "Documentation des structures de données";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Documentation des classes";
@@ -474,12 +478,6 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "Documentation des exemples"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Documentation des pages associées"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -582,10 +580,6 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
     {
       return "Graphe d'héritage de "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Pour un usage interne uniquement."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1178,11 +1172,6 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
     {
       return "Paquetage "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Liste des paquetages";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1557,14 +1546,6 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "Répertoires"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Cette hiérarchie de répertoire est triée approximativement, "
-             "mais pas complètement, par ordre alphabétique :";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -395,6 +395,10 @@ class TranslatorGreek : public Translator
       {
         return "Τεκμηρίωση Δομών Δεδομένων";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Τεκμηρίωση Κλάσεων";
@@ -412,12 +416,6 @@ class TranslatorGreek : public Translator
      */
     virtual QCString trExampleDocumentation()
     { return "Τεκμηρίωση Παραδειγμάτων"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Τεκμηρίωση Σελίδων"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -520,10 +518,6 @@ class TranslatorGreek : public Translator
     {
       return "Διάγραμμα κληρονομικότητας για την "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Μόνο για εσωτερική χρήση."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1114,11 +1108,6 @@ class TranslatorGreek : public Translator
     {
       return "Πακέτο "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Λίστα Πακέτων";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1502,14 +1491,6 @@ class TranslatorGreek : public Translator
      */
     virtual QCString trDirectories()
     { return "Κατάλογοι"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    {
-			return "Η ιεραρχία καταλόγων ταξινομήθηκε αλφαβητικά, αλλά όχι πολύ αυστηρά:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -234,30 +234,32 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
       }
       else
       {
-		return "Skupno kazalo ";
+	return "Skupno kazalo ";
       }
-	}
+    }
     QCString trFileIndex()
     { return "Kazalo datoteka"; }
     QCString trModuleDocumentation()
     { return "Dokumentacija modula"; }
     QCString trClassDocumentation()
     {
-		if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-		{
-			return "Dokumentacija struktura podataka";
-		}
-		else
-		{
-			return "Dokumentacija klasa";
-		}
-	}
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Dokumentacija struktura podataka";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+        return trDesignUnitDocumentation();
+      }
+      else
+      {
+        return "Dokumentacija klasa";
+      }
+    }
     QCString trFileDocumentation()
     { return "Dokumentacija datoteka"; }
     QCString trExampleDocumentation()
     { return "Dokumentacija primjera"; }
-    QCString trPageDocumentation()
-    { return "Dokumentacija vezane stranice"; }
     QCString trReferenceManual()
     { return "Priručnik"; }
 
@@ -296,8 +298,6 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     {
       return QCString("Dijagram klasa za ")+clName;
     }
-    QCString trForInternalUseOnly()
-    { return "Isključivo za internu uporabu."; }
     QCString trWarning()
     { return "Upozorenje"; }
     QCString trVersion()
@@ -828,11 +828,6 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     {
       return "Paket "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Lista paketa";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1184,12 +1179,6 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     virtual QCString trDirectories()
     { return "Direktoriji"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Stablo direktorija sortirano abecednim redom:"; }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -418,6 +418,10 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
       {
         return "Adatszerkezetek dokumentációja";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Osztályok dokumentációja";
@@ -435,12 +439,6 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "Példák dokumentációja"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Kapcsolódó dokumentációk"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -543,10 +541,6 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
     {
       return QCString("A")+zed(clName[0])+clName+" osztály származási diagramja:";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "CSAK BELSŐ HASZNÁLATRA!"; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1135,11 +1129,6 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
     {
       return name+" csomag";
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Csomaglista";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1514,14 +1503,6 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "Könyvtárak"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Majdnem (de nem teljesen) betűrendbe szedett "
-             "könyvtárhierarchia:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -374,6 +374,10 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
       {
         return "Dokumentasi Struktur Data";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Dokumentasi Kelas";
@@ -391,12 +395,6 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     virtual QCString trExampleDocumentation()
     { return "Dokumentasi Contoh"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Dokumentasi Halaman"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -499,10 +497,6 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     {
       return "Diagram hierarki kelas untuk "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Hanya untuk digunakan secara internal."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1090,11 +1084,6 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     {
       return "Paket "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Daftar Paket";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1468,13 +1457,6 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     virtual QCString trDirectories()
     { return "Daftar Direktori"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Struktur direktori ini diurutkan hampir berdasarkan abjad:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -424,12 +424,6 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     QCString trExampleDocumentation()
     { return "Documentazione degli esempi"; }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    QCString trPageDocumentation()
-    { return "Documentazione delle pagine tra loro collegate "; }
-
     /*! This is used in LaTeX as the title of the document */
     QCString trReferenceManual()
     { return "Manuale di riferimento"; }
@@ -531,10 +525,6 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     {
       return "Diagramma delle classi per "+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    QCString trForInternalUseOnly()
-    { return "Solo per uso interno."; }
 
     /*! this text is generated when the \\warning command is used. */
     QCString trWarning()
@@ -1121,11 +1111,6 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     {
       return "Package "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Lista dei package";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1471,14 +1456,6 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "Directory"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Questa gerarchia di directory è approssimativamente, "
-        "ma non completamente, ordinata in ordine alfabetico:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -424,6 +424,10 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
       {
         return "データ構造詳解";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "クラス詳解";
@@ -441,12 +445,6 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "各例詳解"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "ページ詳解"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -547,10 +545,6 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     {
       return clName+" の継承関係図";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "内部処理用です。"; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1132,11 +1126,6 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     {
       return name+" パッケージ";
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "パッケージ一覧";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1495,14 +1484,6 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "ディレクトリ"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "このディレクトリ一覧はおおまかにはソートされていますが、"
-             "完全にアルファベット順でソートされてはいません。";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -417,6 +417,10 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
       {
         return "데이터 구조 문서화";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "클래스 문서화";
@@ -434,12 +438,6 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "예제 문서화"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "페이지 문서화"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -542,10 +540,6 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     {
       return clName+"에 대한 상속 다이어그램 : ";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "내부적적으로만 사용하기 위해."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1128,11 +1122,6 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     {
       return name+" 패키지";
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "패키지 목록";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1506,13 +1495,6 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "디렉토리"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "이 디렉토리 목록은 완전하진 않지만, (대략적으로) 알파벳순으로 정렬되어있습니다.:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -382,6 +382,10 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
       {
         return "Duomenų Struktūros Dokumentacija";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Klasės Dokumentacija";
@@ -399,12 +403,6 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     virtual QCString trExampleDocumentation()
     { return "Pavyzdžio Dokumentacija"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Puslapio Dokumentacija"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -507,10 +505,6 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
     {
       return "Paveldimumo diagrama "+clName+":"; /*FIXME*/
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Tiktai vidiniam naudojimui."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1098,11 +1092,6 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
     {
       return "Paketas "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Paketo Sąrašas";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1481,13 +1470,6 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     virtual QCString trDirectories()
     { return "Direktorijos"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Ši direktorjų strūktūra grubiai surikiuota abėcėlės tvarka:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -397,6 +397,10 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
       {
         return "Datu struktūras dokomentācija";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Klases dokumentācija";
@@ -414,12 +418,6 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     virtual QCString trExampleDocumentation()
     { return "Piemēri"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Lapas dokumentācija"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -522,10 +520,6 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     {
       return "Mantojamības diagramma klasei "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Tikai iekšējai lietošanai."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1115,11 +1109,6 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     {
       return "Pakotne "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Pakotņu saraksts";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1493,14 +1482,6 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     virtual QCString trDirectories()
     { return "Direktorijas"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Šī direktoriju hierarhija ir aptuveni, "
-             "bet ne pilnībā, alfabēta secībā:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -377,6 +377,10 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
       {
         return "Документација на Структури";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Документација на Класи";
@@ -394,12 +398,6 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     virtual QCString trExampleDocumentation()
     { return "Документаија на Примери"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Документација на Страници"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -502,10 +500,6 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
     {
       return "Диаграм на наследување за "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Само за интерна употреба."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1093,11 +1087,6 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
     {
       return "Пакет "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Список на Пакети";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1471,12 +1460,6 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     virtual QCString trDirectories()
     { return "Именици"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Ова стебло на именици е приближно азбучно подреден:";}
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -166,13 +166,24 @@ class TranslatorDutch : public Translator
     QCString trModuleDocumentation()
     { return "Module Documentatie"; }
     QCString trClassDocumentation()
-    { return "Klassen Documentatie"; }
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Klassen Documentatie";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
+      else
+      {
+        return "Klassen Documentatie";
+      }
+    }
     QCString trFileDocumentation()
     { return "Bestand Documentatie"; }
     QCString trExampleDocumentation()
     { return "Documentatie van voorbeelden"; }
-    QCString trPageDocumentation()
-    { return "Documentatie van gerelateerde pagina's"; }
     QCString trReferenceManual()
     { return "Naslagwerk"; }
 
@@ -213,8 +224,6 @@ class TranslatorDutch : public Translator
     {
       return "Klasse diagram voor "+clName;
     }
-    QCString trForInternalUseOnly()
-    { return "Alleen voor intern gebruik."; }
     QCString trWarning()
     { return "Waarschuwing"; }
     QCString trVersion()
@@ -754,11 +763,6 @@ class TranslatorDutch : public Translator
     {
       return "Package "+name;
     }
-    /*! Title of the package index page */
-    QCString trPackageList()
-    {
-      return "Package Lijst";
-    }
     /*! The description of the package index page */
     QCString trPackageListDescription()
     {
@@ -1126,14 +1130,6 @@ class TranslatorDutch : public Translator
      */
     virtual QCString trDirectories()
     { return "Folders"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Deze folder hi&euml;rarchie is min of meer alfabetisch "
-             "gesorteerd:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -392,6 +392,10 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
       {
         return "Datastrukturdokumentasjon";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Klassedokumentasjon";
@@ -409,12 +413,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     virtual QCString trExampleDocumentation()
     { return "Eksempeldokumentasjon"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Sidedokumentasjon"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -523,10 +521,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     {
       return "Arvediagram for "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Kun for intern bruk."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1114,11 +1108,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     {
       return "Package "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Pakke-liste";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1492,14 +1481,6 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     virtual QCString trDirectories()
     { return "Kataloger"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Denne katalogen er grovsortert alfabetisk "
-             "(ikke nødvendigvis korrekt).";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -371,6 +371,10 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
       {
         return "Dokumentacja struktur danych";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Dokumentacja klas";
@@ -388,12 +392,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
      */
     QCString trExampleDocumentation()
     { return "Dokumentacja przykładów"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    QCString trPageDocumentation()
-    { return "Dokumentacja stron"; }
 
     /*! This is used in LaTeX as the title of the document */
     QCString trReferenceManual()
@@ -496,10 +494,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     {
       return "Diagram dziedziczenia dla "+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    QCString trForInternalUseOnly()
-    { return "Tylko do użytku wewnętrznego."; }
 
     /*! this text is generated when the \\warning command is used. */
     QCString trWarning()
@@ -1088,11 +1082,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     {
       return "Pakiet "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Lista Pakietów";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1443,14 +1432,6 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     virtual QCString trDirectories()
     { return "Katalogi"; }
 
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    {
-      return "Ta struktura katalogów posortowana jest z grubsza, "
-             "choć nie całkowicie, alfabetycznie:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -409,7 +409,20 @@ class TranslatorPortuguese : public Translator
      *  the documentation of all classes, structs and unions.
      */
     QCString trClassDocumentation()
-    { return "Documentação da classe"; }
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Documentação da estruturas de dados";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
+      else
+      {
+        return "Documentação da classe";
+      }
+    }
 
     /*! This is used in LaTeX as the title of the chapter containing
      *  the documentation of all files.
@@ -422,12 +435,6 @@ class TranslatorPortuguese : public Translator
      */
     QCString trExampleDocumentation()
     { return "Documentação do exemplo"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    QCString trPageDocumentation()
-    { return "Documentação da página"; }
 
     /*! This is used in LaTeX as the title of the document */
     QCString trReferenceManual()
@@ -530,10 +537,6 @@ class TranslatorPortuguese : public Translator
     {
       return "Diagrama de heranças da classe "+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    QCString trForInternalUseOnly()
-    { return "Apenas para uso interno."; }
 
     /*! this text is generated when the \\warning command is used. */
     QCString trWarning()
@@ -1119,11 +1122,6 @@ class TranslatorPortuguese : public Translator
     {
       return "Pacote "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Lista de pacotes";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1497,12 +1495,6 @@ class TranslatorPortuguese : public Translator
      */
     virtual QCString trDirectories()
     { return "Diretórios"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Esta Hierarquia de Diretórios está parcialmente ordenada (ordem alfabética)"; }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -402,6 +402,10 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
       {
         return "Documentaţia Structurilor de Date";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Documentaţia Claselor";
@@ -420,12 +424,6 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "Documentaţia Exemplelor"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Documentaţii înrudite"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -529,10 +527,6 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
     {
       return "Diagrama de relaţii pentru "+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Doar pentru uz intern."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1119,11 +1113,6 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
     {
       return "Pachet "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Lista Pachetelor";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1497,14 +1486,6 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
       */
      virtual QCString trDirectories()
      { return "Directoare"; }
-
-     /*! This returns a sentences that introduces the directory hierarchy.
-      *  and the fact that it is sorted alphabetically per level
-      */
-     virtual QCString trDirDescription()
-     { return "Această ierarhie de directoare este sortată în general, "
-              "dar nu complet, în ordine alfabetică:";
-     }
 
      /*! This returns the title of a directory page. The name of the
       *  directory is passed via \a dirName.

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -339,6 +339,10 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
       {
         return "Структуры данных";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Классы";
@@ -356,12 +360,6 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "Примеры"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Тематические описания"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -469,10 +467,6 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
     {
       return QCString("Граф наследования:")+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Только для внутреннего использования"; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1093,11 +1087,6 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
     {
       return QCString("Пакет ")+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Полный список пакетов ";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1449,12 +1438,6 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "Алфавитный указатель директорий"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Дерево директорий"; }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -395,6 +395,10 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
       {
         return "Документација структуре";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Документација класе";
@@ -412,12 +416,6 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     virtual QCString trExampleDocumentation()
     { return "Документација примера"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Документација странице"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -520,10 +518,6 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     {
       return "Дијаграм наслеђивања за "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Само за унутрашњу употребу."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1129,11 +1123,6 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     {
       return "Пакет "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Списак пакета";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1519,14 +1508,6 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     virtual QCString trDirectories()
     { return "Директоријуми"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Ова хијерархија директоријума је уређена "
-             "приближно по абецеди:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -150,8 +150,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     { return "Opis datoteke"; }
     QCString trExampleDocumentation()
     { return "Opis primera"; }
-    QCString trPageDocumentation()
-    { return "Opis povezanih strani"; }
     QCString trReferenceManual()
     { return "Priročnik"; }
 
@@ -190,8 +188,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     {
       return "Diagram razredov za "+clName;
     }
-    QCString trForInternalUseOnly()
-    { return "Samo za interno uporabo."; }
     QCString trWarning()
     { return "Opozorilo"; }
     QCString trVersion()
@@ -752,11 +748,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     {
       return "JAVA paket "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Seznam JAVA paketov";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1133,13 +1124,6 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     virtual QCString trDirectories()
     { return "Imeniki"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Imeniška hierarhija je urejena v glavnem, toda ne popolnoma, po abecedi, ";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -384,12 +384,6 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     virtual QCString trExampleDocumentation()
     { return "Dokumentácia príkladov"; }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *	the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Dokumentácia súvisiacich stránok"; }
-
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
     { return "Referenčná príručka"; }
@@ -491,10 +485,6 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     {
       return "Diagram dedičnosti pre triedu "+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Iba pre interné použitie."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1094,11 +1084,6 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     {
       return "Balík "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Zoznam balíkov";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1449,15 +1434,6 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "Adresáre"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    {
-        return "Následujúca hierarchia adresárov je zhruba, "
-                      "ale nie úplne, zoradená podľa abecedy:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -375,6 +375,10 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
       {
         return "Dokumentacija stuktura/unija";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Dokumentacija klasa";
@@ -392,12 +396,6 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     virtual QCString trExampleDocumentation()
     { return "Dokumentacija primera"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Dokumentacija stranice"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -500,10 +498,6 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
     {
       return QCString("Dijagram nasleđivanja za klasu ") + clName + ":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Samo za unutrašnju upotrebu."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1091,11 +1085,6 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
     {
       return "Paket "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Spisak paketa";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1470,12 +1459,6 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     virtual QCString trDirectories()
     { return "Direktorijumi"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Hijerarhija direktorijuma uređena približno po abecedi:"; }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -500,6 +500,10 @@ class TranslatorSwedish : public Translator
       {
         return "Dokumentation över datastrukturer";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Klassdokumentation";
@@ -517,12 +521,6 @@ class TranslatorSwedish : public Translator
      */
     virtual QCString trExampleDocumentation()
     { return "Exempeldokumentation"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Sid-dokumentation"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -625,10 +623,6 @@ class TranslatorSwedish : public Translator
     {
       return "Klassdiagram för "+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Endast för internt bruk."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1227,11 +1221,6 @@ class TranslatorSwedish : public Translator
     {
       return "Paket "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Paketlista";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1593,14 +1582,6 @@ class TranslatorSwedish : public Translator
      */
     virtual QCString trDirectories()
     { return "Kataloger"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Den här katalogen är grovt sorterad, "
-             "men inte helt, i alfabetisk ordning:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -386,6 +386,10 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
       {
         return "Veri Yapıları Dokümantasyonu";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Sınıf Dokümantasyonu";
@@ -403,12 +407,6 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     virtual QCString trExampleDocumentation()
     { return "Örnek Dokümantasyonu"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Sayfa Dokümantasyonu"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -511,10 +509,6 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     {
       return clName+" için kalıtım şeması:";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "İç kullanıma ayrılmıştır."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1103,11 +1097,6 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     {
       return "Paket "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Paket Listesi";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1481,14 +1470,6 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     virtual QCString trDirectories()
     { return "Dizinler"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Bu dizin hiyerarşisi tamamen olmasa da yaklaşık "
-             "olarak alfabetik sıraya konulmuştur:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_tw.h
+++ b/src/translator_tw.h
@@ -399,6 +399,10 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
       {
         return "資料結構說明文件";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "類別說明文件";
@@ -416,12 +420,6 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
      */
     virtual QCString trExampleDocumentation()
     { return "範例說明文件"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "頁面說明文件"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -530,10 +528,6 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
     {
       return "類別"+clName+"的繼承圖:";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "僅供內部使用."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1121,11 +1115,6 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
     {
       return "Package "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Package列表";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1484,13 +1473,6 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
      */
     virtual QCString trDirectories()
     { return "目錄"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "這個目錄階層經過簡略的字母排序: ";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -334,6 +334,10 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
       {
         return  "Структури даних" ;
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return  "Класи" ;
@@ -351,12 +355,6 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     virtual QCString trExampleDocumentation()
     { return "Приклади"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Документація по темі"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -464,10 +462,6 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     {
       return QCString("Схема успадкувань для ")+clName;
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Тільки для внутрішнього користування"; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1082,11 +1076,6 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     {
       return QCString("Пакет ")+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Повний список пакетів";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1443,14 +1432,6 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     virtual QCString trDirectories()
     { return "Каталоги"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Дерево каталогів впорядковано наближено "
-	     "до алфавіту:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -411,6 +411,10 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
       {
         return "Thông tin về cấu trúc cơ sở dữ liệu";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Thông tin về Class";
@@ -428,12 +432,6 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     virtual QCString trExampleDocumentation()
     { return "Thông tin về các ví dụ"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Trang Thông tin"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -536,10 +534,6 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     {
       return "Sơ đồ kế thừa cho "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Chỉ cho sử dụng nội bộ."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1126,11 +1120,6 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     {
       return "Gói "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Danh sách gói";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1504,14 +1493,6 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     virtual QCString trDirectories()
     { return "Các thư mục"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Thư mục đã được sắp xếp theo al-pha-bê, "
-             "nhưng chưa đầy đủ:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -374,6 +374,10 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
       {
         return "Data Strukture Dokumentasie";
       }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
       else
       {
         return "Klas Dokumentasie";
@@ -391,12 +395,6 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     virtual QCString trExampleDocumentation()
     { return "Voorbeeld Dokumentasie"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all related pages.
-     */
-    virtual QCString trPageDocumentation()
-    { return "Bladsy Dokumentasie"; }
 
     /*! This is used in LaTeX as the title of the document */
     virtual QCString trReferenceManual()
@@ -499,10 +497,6 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
     {
       return "Afleidings diagram vir "+clName+":";
     }
-
-    /*! this text is generated when the \\internal command is used. */
-    virtual QCString trForInternalUseOnly()
-    { return "Slegs vir interne gebruik."; }
 
     /*! this text is generated when the \\warning command is used. */
     virtual QCString trWarning()
@@ -1091,11 +1085,6 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
     {
       return "Pakket "+name;
     }
-    /*! Title of the package index page */
-    virtual QCString trPackageList()
-    {
-      return "Pakket Lys";
-    }
     /*! The description of the package index page */
     virtual QCString trPackageListDescription()
     {
@@ -1469,14 +1458,6 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     virtual QCString trDirectories()
     { return "Directories"; }
-
-    /*! This returns a sentences that introduces the directory hierarchy.
-     *  and the fact that it is sorted alphabetically per level
-     */
-    virtual QCString trDirDescription()
-    { return "Hierdie directory hiërargie is min of meer alfabeties "
-             "gesorteer:";
-    }
 
     /*! This returns the title of a directory page. The name of the
      *  directory is passed via \a dirName.

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -320,12 +320,6 @@
   \end{DoxyDesc}%
 }
 
-% Used by @internal
-\newenvironment{DoxyInternal}[1]{%
-  \paragraph*{#1}%
-}{%
-}
-
 % Used by @par and @paragraph
 \newenvironment{DoxyParagraph}[1]{%
   \begin{DoxyDesc}{#1}%


### PR DESCRIPTION
Removing unused translator functions and adjusting the usage of a.o. `trDesignUnitDocumentation();` in `trClassDocumentation()`