### PR TITLE
HTMLHELP warning on using svg as image format for graphs

### DIFF
--- a/src/dotcallgraph.cpp
+++ b/src/dotcallgraph.cpp
@@ -189,6 +189,8 @@ QCString DotCallGraph::writeGraph(
         const QCString &relPath,bool generateImageMap,
         int graphId)
 {
+  m_doNotAddImageToIndex = textFormat!=EOF_Html;
+
   return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
 }
 

--- a/src/dotgroupcollaboration.cpp
+++ b/src/dotgroupcollaboration.cpp
@@ -244,7 +244,7 @@ QCString DotGroupCollaboration::writeGraph( TextStream &t,
   const QCString &path, const QCString &fileName, const QCString &relPath,
   bool generateImageMap,int graphId)
 {
-  m_doNotAddImageToIndex = TRUE;
+  m_doNotAddImageToIndex = textFormat!=EOF_Html;
 
   return DotGraph::writeGraph(t, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
 }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1288,10 +1288,18 @@ void HtmlGenerator::writeStyleInfo(int part)
     }
 
     Doxygen::indexList->addStyleSheetFile("jquery.js");
+
     Doxygen::indexList->addStyleSheetFile("dynsections.js");
+
     if (Config_getBool(INTERACTIVE_SVG))
     {
       Doxygen::indexList->addStyleSheetFile("svgpan.js");
+    }
+
+    if (!Config_getBool(DISABLE_INDEX) && Config_getBool(HTML_DYNAMIC_MENUS))
+    {
+      Doxygen::indexList->addStyleSheetFile("menu.js");
+      Doxygen::indexList->addStyleSheetFile("menudata.js");
     }
   }
 }

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -320,6 +320,7 @@ class HtmlHelp::Private
     int dc = 0;
     StringSet indexFiles;
     StringSet imageFiles;
+    StringSet styleFiles;
     HtmlHelpRecoder recoder;
     HtmlHelpIndex index;
 };
@@ -557,6 +558,10 @@ void HtmlHelp::Private::createProjectFile()
     {
       t << s.c_str() << "\n";
     }
+    for (auto &s : styleFiles)
+    {
+      t << s.c_str() << "\n";
+    }
     t.close();
   }
   else
@@ -715,6 +720,11 @@ void HtmlHelp::addIndexItem(const Definition *context,const MemberDef *md,
     QCString level1  = !word.isEmpty() ? word : context->name();
     p->index.addItem(level1,QCString(),context->getOutputFileBase(),sectionAnchor,TRUE,FALSE);
   }
+}
+
+void HtmlHelp::addStyleSheetFile(const QCString &fileName)
+{
+  p->styleFiles.insert(fileName.str());
 }
 
 void HtmlHelp::addImageFile(const QCString &fileName)

--- a/src/htmlhelp.h
+++ b/src/htmlhelp.h
@@ -78,7 +78,7 @@ class HtmlHelp  : public IndexIntf
                       const QCString &sectionAnchor, const QCString &title);
     void addIndexFile(const QCString &name);
     void addImageFile(const QCString &);
-    void addStyleSheetFile(const QCString &) {}
+    void addStyleSheetFile(const QCString &);
     static QCString getLanguageString();
 
   private:


### PR DESCRIPTION
In the chm file, when having (interactive) SVG as format for the dot graphs we miss the `svgpan.js`. All used style sheets are added to the chm file.
This gives a warning like:
![image](https://user-images.githubusercontent.com/5223533/152641764-f8e2dee4-fccb-4ffc-a140-6d41fa22c15a.png)

When the `GENERATE_LATEX=YES` also the generated pdf files were added to the list of files, giving warnings (only files generated for the HTML version are relevant here).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8007989/example.tar.gz)
