### PR TITLE
Correcting default settings when running HTMLHELP

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1817,6 +1817,8 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     const char *depOption = "GENERATE_HTMLHELP";
     adjustBoolSetting(  depOption, "GENERATE_TREEVIEW",   false  );
     adjustBoolSetting(  depOption, "SEARCHENGINE",        false  );
+    adjustBoolSetting(  depOption, "HTML_DYNAMIC_MENUS",  false  );
+    adjustBoolSetting(  depOption, "HTML_DYNAMIC_SECTIONS",false  );
     adjustStringSetting(depOption, "HTML_FILE_EXTENSION", ".html");
   }
 


### PR DESCRIPTION
Due to the fact that HTMLHELP is very old it doesn't understand `jquery.js` properly due to the dynamic menus and sections and will throw an error.
We disable these now for HTMLHELP.