### PR TITLE
Fix build with MinGW and Ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,7 @@ if (CMAKE_SYSTEM MATCHES "Darwin")
 endif()
 
 if (WIN32)
-    if ((NOT CMAKE_GENERATOR MATCHES "MinGW Makefiles") AND 
-        (NOT CMAKE_GENERATOR MATCHES "MSYS Makefiles") AND
-        (NOT CMAKE_GENERATOR MATCHES "Unix Makefiles"))
+    if (MSVC)
         if (NOT ICONV_DIR)
           set(ICONV_DIR "${PROJECT_SOURCE_DIR}/winbuild")
         endif()


### PR DESCRIPTION
I don't think there should be a check on the generator but on the
compiler, because my gcc complains rightfully:
c++.exe: warning: /bigobj: linker input file unused because linking not done
c++.exe: error: /bigobj: linker input file not found: No such file or directory

And this in turn failed the configuration:
-- Performing Test ICONV_COMPILES - Failed