### PR TITLE
Missing part of output due to wrong emoji command

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -4972,14 +4972,16 @@ void DocPara::handleEmoji()
   tok=m_parser.tokenizer.lex();
   if (tok==0)
   {
-    warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command %s\n", qPrint("emoji"));
+    warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"no emoji name given or unexpected end of comment block while parsing the "
+        "argument of command %s", qPrint("emoji"));
+    m_parser.tokenizer.setStatePara();
     return;
   }
   else if (tok!=TK_WORD)
   {
     warn_doc_error(m_parser.context.fileName,m_parser.tokenizer.getLineNr(),"unexpected token %s as the argument of %s",
         DocTokenizer::tokToString(tok),qPrint("emoji"));
+    m_parser.tokenizer.setStatePara();
     return;
   }
   m_children.push_back(

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1234,6 +1234,7 @@ LINENR {BLANK}*[1-9][0-9]*
                          return TK_WORD;
                        }
 <St_Emoji>.            {
+                         unput(*yytext);
                          return 0;
                        }
 <St_Iline>{LINENR}/[\n\.]     |


### PR DESCRIPTION
In case we have an emoji without an name specified like:
```
/// \file
///
/// \include aa.h

/// \brief function
/// \details details
///
/// \emoji ; no emoji name specified but this text is not shown either
void fie2(int a);
```
we get a warning (correct) but also all the information after it is omitted.

- the tokenizer should put the character that it didn't handle
- the docparser should put the state back to a "normal" input state.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8049568/example.tar.gz)
