### PR TITLE
issue #9110 MULTILINE_CPP_IS_BRIEF breaks multi-line latex formulas

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -576,14 +576,21 @@ SLASHopt [/]*
 <Verbatim>^[ \t]*{CPPC}[/!]          {
   				     if (yyextra->blockName=="dot" || yyextra->blockName=="msc" || yyextra->blockName=="uml" || yyextra->blockName.at(0)=='f')
 				     {
-				       // see bug 487871, strip /// from dot images and formulas.
-                                       int l=0;
-                                       while (yytext[l]==' ' || yytext[l]=='\t')
+                                       if (yyextra->mlBrief)
                                        {
-                                         l++;
+                                         copyToOutput(yyscanner,yytext,yyleng);
                                        }
-                                       copyToOutput(yyscanner,yytext,l);
-				       copyToOutput(yyscanner,"   ",3);
+                                       else
+                                       {
+				         // see bug 487871, strip /// from dot images and formulas.
+                                         int l=0;
+                                         while (yytext[l]==' ' || yytext[l]=='\t')
+                                         {
+                                           l++;
+                                         }
+                                         copyToOutput(yyscanner,yytext,l);
+				         copyToOutput(yyscanner,"   ",3);
+				       }
 				     }
 				     else // even slashes are verbatim (e.g. \verbatim, \code)
 				     {


### PR DESCRIPTION
In normal case the multiline `///` comments are replaced by comment blocks of type `/** ... */` an in here the extra `*` on a line are problematic with some commands. In case of `MULTILINE_CPP_IS_BRIEF=YES` this comment conversion is not done but in e.g. formulas the `///` was still stripped. This should not be the case.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8050465/example.tar.gz)
