### PR TITLE
Small corrections for Bulgarian language

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -339,6 +339,7 @@ HtmlHelp::~HtmlHelp()
 }
 
 /* language codes for Html help
+   0x402 Bulgarian
    0x405 Czech
    0x406 Danish
    0x413 Dutch
@@ -403,6 +404,7 @@ static StringUnorderedMap s_languageDict =
   { "polish",      "0x415 Polish"                    },
   { "portuguese",  "0x816 Portuguese(Portugal)"      },
   { "brazilian",   "0x416 Portuguese(Brazil)"        },
+  { "bulgarian",   "0x402 bulgarian"                 },
   { "russian",     "0x419 Russian"                   },
   { "spanish",     "0x40A Spanish(Traditional Sort)" },
   { "swedish",     "0x41D Swedish"                   },

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -76,7 +76,7 @@ class TranslatorBulgarian : public Translator
      */
     virtual QCString latexLanguageSupportCommand()
     {
-      return "";
+    { return "\\usepackage[T2A]{fontenc}\n\\usepackage[bulgarian]{babel}\n"; }
     }
 
     virtual QCString trISOLang()
@@ -1156,8 +1156,8 @@ class TranslatorBulgarian : public Translator
     /*! Used as ansicpg for RTF file
      *
      * The following table shows the correlation of Charset name, Charset Value and
-     * <pre>
      * Codepage number:
+     * <pre>
      * Charset Name       Charset Value(hex)  Codepage number
      * ------------------------------------------------------
      * DEFAULT_CHARSET           1 (x01)
@@ -1180,7 +1180,7 @@ class TranslatorBulgarian : public Translator
      */
     virtual QCString trRTFansicp()
     {
-      return "1252";
+      return "1251";
     }
 
 
@@ -1189,7 +1189,7 @@ class TranslatorBulgarian : public Translator
      */
     virtual QCString trRTFCharSet()
     {
-      return "222";
+      return "204";
     }
 
     /*! Used as header RTF general index */


### PR DESCRIPTION
Small corrections for the generation of output of the Bulgarian language:
- latex set right translation library
- RTF set right code page and character set
- htmlhelp set correct language code