### PR TITLE
Uniform retrieval of language code by means of translator unit

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -998,7 +998,7 @@ class TranslateContext::Private
     }
     TemplateVariant langString() const
     {
-      return HtmlHelp::getLanguageString();
+      return theTranslator->getLanguageString();
     }
     TemplateVariant code() const
     {

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -338,106 +338,6 @@ HtmlHelp::~HtmlHelp()
 {
 }
 
-/* language codes for Html help
-   0x402 Bulgarian
-   0x405 Czech
-   0x406 Danish
-   0x413 Dutch
-   0xC09 English (Australia)
-   0x809 English (Britain)
-   0x1009 English (Canada)
-   0x1809 English (Ireland)
-   0x1409 English (New Zealand)
-   0x1C09 English (South Africa)
-   0x409 English (United States)
-   0x40B Finnish
-   0x40C French
-   0x407 German
-   0x408 Greece
-   0x40E Hungarian
-   0x410 Italian
-   0x814 Norwegian
-   0x415 Polish
-   0x816 Portuguese(Portugal)
-   0x416 Portuguese(Brazil)
-   0x419 Russian
-   0x80A Spanish(Mexico)
-   0xC0A Spanish(Modern Sort)
-   0x40A Spanish(Traditional Sort)
-   0x41D Swedish
-   0x41F Turkey
-   0x411 Japanese
-   0x412 Korean
-   0x804 Chinese (PRC)
-   0x404 Chinese (Taiwan)
-
-   New LCIDs:
-   0x421 Indonesian
-   0x41A Croatian
-   0x418 Romanian
-   0x424 Slovenian
-   0x41B Slovak
-   0x422 Ukrainian
-   0x81A Serbian (Serbia, Latin)
-   0x403 Catalan
-   0x426 Latvian
-   0x427 Lithuanian
-   0x436 Afrikaans
-   0x42A Vietnamese
-   0x429 Persian (Iran)
-   0xC01 Arabic (Egypt) - I don't know which version of arabic is used inside translator_ar.h ,
-   so I have chosen Egypt at random
-
-*/
-static StringUnorderedMap s_languageDict =
-{
-  { "czech",       "0x405 Czech"                     },
-  { "danish",      "0x406 Danish"                    },
-  { "dutch",       "0x413 Dutch"                     },
-  { "finnish",     "0x40B Finnish"                   },
-  { "french",      "0x40C French"                    },
-  { "german",      "0x407 German"                    },
-  { "greek",       "0x408 Greece"                    },
-  { "hungarian",   "0x40E Hungarian"                 },
-  { "italian",     "0x410 Italian"                   },
-  { "norwegian",   "0x814 Norwegian"                 },
-  { "polish",      "0x415 Polish"                    },
-  { "portuguese",  "0x816 Portuguese(Portugal)"      },
-  { "brazilian",   "0x416 Portuguese(Brazil)"        },
-  { "bulgarian",   "0x402 bulgarian"                 },
-  { "russian",     "0x419 Russian"                   },
-  { "spanish",     "0x40A Spanish(Traditional Sort)" },
-  { "swedish",     "0x41D Swedish"                   },
-  { "turkish",     "0x41F Turkey"                    },
-  { "japanese",    "0x411 Japanese"                  },
-  { "japanese-en", "0x411 Japanese"                  },
-  { "korean",      "0x412 Korean"                    },
-  { "korean-en",   "0x412 Korean"                    },
-  { "chinese",     "0x804 Chinese (PRC)"             },
-  { "chinese-traditional", "0x404 Chinese (Taiwan)"  },
-  { "indonesian",  "0x421 Indonesian"                },
-  { "croatian",    "0x41A Croatian"                  },
-  { "romanian",    "0x418 Romanian"                  },
-  { "slovene",     "0x424 Slovenian"                 },
-  { "slovak",      "0x41B Slovak"                    },
-  { "ukrainian",   "0x422 Ukrainian"                 },
-  { "serbian",     "0x81A Serbian (Serbia, Latin)"   },
-  { "catalan",     "0x403 Catalan"                   },
-  { "lithuanian",  "0x427 Lithuanian"                },
-  { "afrikaans",   "0x436 Afrikaans"                 },
-  { "vietnamese",  "0x42A Vietnamese"                },
-  { "persian",     "0x429 Persian (Iran)"            },
-  { "arabic",      "0xC01 Arabic (Egypt)"            },
-  { "latvian",     "0x426 Latvian"                   },
-  { "macedonian",  "0x042f Macedonian (Former Yugoslav Republic of Macedonia)" },
-  { "armenian",    "0x42b Armenian"                  },
-  //Code for Esperanto should be as shown below but the htmlhelp compiler 1.3 does not support this
-  // (and no newer version is available).
-  //So do a fallback to the default language (see getLanguageString())
-  //{ "esperanto",   "0x48f Esperanto" },
-  { "serbian-cyrillic", "0xC1A Serbian (Serbia, Cyrillic)" }
-};
-
 /*! This will create a contents file (index.hhc) and a index file (index.hhk)
  *  and write the header of those files.
  *  It also creates a project file (index.hhp)
@@ -479,23 +379,6 @@ void HtmlHelp::initialize()
 
 }
 
-
-QCString HtmlHelp::getLanguageString()
-{
-  if (!theTranslator->idLanguage().isEmpty())
-  {
-    auto it = s_languageDict.find(theTranslator->idLanguage().str());
-    if (it!=s_languageDict.end())
-    {
-      return QCString(it->second);
-    }
-  }
-  // default language
-  return "0x409 English (United States)";
-}
-
-
-
 void HtmlHelp::Private::createProjectFile()
 {
   /* Write the project file */
@@ -521,7 +404,7 @@ void HtmlHelp::Private::createProjectFile()
     t << "Default Window=main\n"
          "Default topic=" << indexName << "\n";
     if (hhkPresent) t << "Index file=index.hhk\n";
-    t << "Language=" << getLanguageString() << "\n";
+    t << "Language=" << theTranslator->getLanguageString() << "\n";
     if (Config_getBool(BINARY_TOC)) t << "Binary TOC=YES\n";
     if (Config_getBool(GENERATE_CHI)) t << "Create CHI file=YES\n";
     t << "Title=" << recoder.recode(Config_getString(PROJECT_NAME)) << "\n\n";

--- a/src/htmlhelp.h
+++ b/src/htmlhelp.h
@@ -79,7 +79,6 @@ class HtmlHelp  : public IndexIntf
     void addIndexFile(const QCString &name);
     void addImageFile(const QCString &);
     void addStyleSheetFile(const QCString &);
-    static QCString getLanguageString();
 
   private:
     class Private;

--- a/src/translator.h
+++ b/src/translator.h
@@ -79,6 +79,68 @@ class Translator
     }
     virtual QCString trISOLang() = 0;
 
+    /** language codes for Html help
+       0x402 Bulgarian
+       0x405 Czech
+       0x406 Danish
+       0x413 Dutch
+       0xC09 English (Australia)
+       0x809 English (Britain)
+       0x1009 English (Canada)
+       0x1809 English (Ireland)
+       0x1409 English (New Zealand)
+       0x1C09 English (South Africa)
+       0x409 English (United States)
+       0x40B Finnish
+       0x40C French
+       0x407 German
+       0x408 Greece
+       0x40E Hungarian
+       0x410 Italian
+       0x814 Norwegian
+       0x415 Polish
+       0x816 Portuguese(Portugal)
+       0x416 Portuguese(Brazil)
+       0x419 Russian
+       0x80A Spanish(Mexico)
+       0xC0A Spanish(Modern Sort)
+       0x40A Spanish(Traditional Sort)
+       0x41D Swedish
+       0x41F Turkey
+       0x411 Japanese
+       0x412 Korean
+       0x804 Chinese (PRC)
+       0x404 Chinese (Taiwan)
+
+       New LCIDs:
+       0x421 Indonesian
+       0x41A Croatian
+       0x418 Romanian
+       0x424 Slovenian
+       0x41B Slovak
+       0x422 Ukrainian
+       0x81A Serbian (Serbia, Latin)
+       0x403 Catalan
+       0x426 Latvian
+       0x427 Lithuanian
+       0x436 Afrikaans
+       0x42A Vietnamese
+       0x429 Persian (Iran)
+       0xC01 Arabic (Egypt) - I don't know which version of arabic is used inside translator_ar.h ,
+       so I have chosen Egypt at random
+
+      Code for Esperanto should be as shown below but the htmlhelp compiler 1.3 does not support this
+      (and no newer version is available).
+      0x48f Esperanto
+      So do a fallback to the default language
+      0x409 English (United States)
+
+
+      0xC1A Serbian (Serbia, Cyrillic)
+
+    */
+    virtual QCString getLanguageString() = 0;
+
     // --- Language translation methods -------------------
 
     virtual QCString trRelatedFunctions() = 0;

--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -37,6 +37,10 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
     }
     virtual QCString trISOLang()
     { return "hy"; }
+    virtual QCString getLanguageString()
+    {
+      return "0x42b Armenian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -70,6 +70,10 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
 
     virtual QCString trISOLang()
     { return "ar-EG"; }
+    virtual QCString getLanguageString()
+    {
+      return "0xC01 Arabic (Egypt)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -83,6 +83,10 @@ class TranslatorBulgarian : public Translator
     {
       return "bg";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x402 bulgarian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -94,6 +94,10 @@ class TranslatorBrazilian : public Translator
     {
       return "pt-BR";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x416 Portuguese(Brazil)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -79,6 +79,10 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
     {
       return "ca";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x403 Catalan";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -59,6 +59,10 @@ class TranslatorChinese : public Translator
     {
       return "zh";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x804 Chinese (PRC)";
+    }
     virtual QCString latexFontenc()
     {
       return "";

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -111,6 +111,10 @@ class TranslatorCzech : public Translator
     {
       return "cs";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x405 Czech";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -168,6 +168,10 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     {
       return "de";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x407 German";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -123,6 +123,10 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     {
       return "da";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x406 Danish";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -79,6 +79,10 @@ class TranslatorEnglish : public Translator
       return "en-US";
     }
 
+    virtual QCString getLanguageString()
+    {
+      return "0x409 English (United States)";
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -81,6 +81,11 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
       return "eo";
     }
 
+    // using fallback see translator.h
+    virtual QCString getLanguageString()
+    {
+      return "0x409 English (United States)";
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -72,6 +72,10 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
     {
       return "es";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x40A Spanish(Traditional Sort)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -96,6 +96,10 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
       return "fa";
     }
 
+    virtual QCString getLanguageString()
+    {
+      return "0x429 Persian (Iran)";
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -123,6 +123,10 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
     {
       return "fi";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x40B Finnish";
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -139,6 +139,10 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
     {
       return "fr";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x40C French";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -1196,6 +1196,10 @@ class TranslatorGreek : public Translator
     {
       return "Ευρετήριο";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x408 Greece";
+    }
 
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -94,6 +94,10 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     { return "\\usepackage[croatian]{babel}\n"; }
     QCString trISOLang()
     { return "hr"; }
+    virtual QCString getLanguageString()
+    {
+      return "0x41A Croatian";
+    }
     QCString trRelatedFunctions()
     { return "Povezane funkcije"; }
     QCString trRelatedSubscript()

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -104,6 +104,10 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
     {
       return "hu";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x40E Hungarian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -62,6 +62,10 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     {
       return "id";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x421 Indonesian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -116,6 +116,10 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     {
       return "it";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x410 Italian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_je.h
+++ b/src/translator_je.h
@@ -67,6 +67,10 @@ class TranslatorJapaneseEn : public TranslatorEnglish
     {
       return "ja";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x411 Japanese";
+    }
 };
 
 #endif

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -83,6 +83,10 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     {
       return "ja";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x411 Japanese";
+    }
     virtual QCString latexFontenc()
     {
       return "";

--- a/src/translator_ke.h
+++ b/src/translator_ke.h
@@ -64,6 +64,10 @@ class TranslatorKoreanEn : public TranslatorEnglish
     {
       return "ko";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x412 Korean";
+    }
 };
 
 #endif

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -102,6 +102,10 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     {
       return "ko";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x412 Korean";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -69,6 +69,10 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
     {
       return "lt";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x427 Lithuanian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -84,6 +84,10 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     {
       return "lv";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x426 Latvian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -69,6 +69,10 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
     {
       return "mk";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x042f Macedonian (Former Yugoslav Republic of Macedonia)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -38,6 +38,10 @@ class TranslatorDutch : public Translator
     { return "\\usepackage[dutch]{babel}\n"; }
     QCString trISOLang()
     { return "nl"; }
+    virtual QCString getLanguageString()
+    {
+      return "0x413 Dutch";
+    }
     QCString trRelatedFunctions()
     { return "Gerelateerde functies"; }
     QCString trRelatedSubscript()

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -79,6 +79,10 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     {
       return "nn";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x814 Norwegian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -58,6 +58,10 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     {
       return "pl";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x415 Polish";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -104,6 +104,10 @@ class TranslatorPortuguese : public Translator
     {
       return "pt";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x816 Portuguese(Portugal)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -78,6 +78,10 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
     {
       return "ro";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x418 Romanian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -39,6 +39,10 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
 
     virtual QCString trISOLang()
     { return "ru"; }
+    virtual QCString getLanguageString()
+    {
+      return "0x419 Russian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -82,6 +82,10 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     {
       return "sr-Cyrl";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0xC1A Serbian (Serbia, Cyrillic)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -38,6 +38,10 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     { return "\\usepackage[slovene]{babel}\n"; }
     QCString trISOLang()
     { return "sl"; }
+    virtual QCString getLanguageString()
+    {
+      return "0x424 Slovenian";
+    }
     QCString trRelatedFunctions()
     { return "Povezane funkcije"; }
     QCString trRelatedSubscript()

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -53,6 +53,10 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     {
       return "sk";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x41B Slovak";
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -62,6 +62,10 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
     {
       return "sr-Latn";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x81A Serbian (Serbia, Latin)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -186,6 +186,10 @@ class TranslatorSwedish : public Translator
     {
       return "sv";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x41D Swedish";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -77,6 +77,10 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     {
       return "tr";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x41F Turkey";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_tw.h
+++ b/src/translator_tw.h
@@ -90,6 +90,10 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
     {
       return "zh-Hant";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x404 Chinese (Taiwan)";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -35,6 +35,10 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     {
       return "uk";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x422 Ukrainian";
+    }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -99,6 +99,10 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     {
       return "vi";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x42A Vietnamese";
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -63,6 +63,10 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
     {
       return "af";
     }
+    virtual QCString getLanguageString()
+    {
+      return "0x436 Afrikaans";
+    }
 
     // --- Language translation methods -------------------
 


### PR DESCRIPTION
Making the retrieval of the language code for HTML uniform with other formats, i.e. moving it into the translator classes instead of a separate entity in the HtmlHelp.
(so there are not multiple files to change when adding a language).