### PR TITLE
issue #9118 Java: argument annotation remains in xml output

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -950,7 +950,7 @@ NONLopt [^\n]*
 <FindMembers>{BN}{1,80}                 {
                                           lineCount(yyscanner);
                                         }
-<FindMembers>"@"({ID}".")*{ID}{BN}*"("  {
+<FindMembers,ReadFuncArgType>"@"({ID}".")*{ID}{BN}*"("  {
                                           if (yyextra->insideJava) // Java annotation
                                           {
                                             lineCount(yyscanner);
@@ -958,7 +958,7 @@ NONLopt [^\n]*
                                             yyextra->roundCount=0;
                                             BEGIN( SkipRound );
                                           }
-                                          else if (qstrncmp(yytext,"@property",9)==0) // ObjC 2.0 property
+                                          else if ((YY_START == FindMembers) && qstrncmp(yytext,"@property",9)==0) // ObjC 2.0 property
                                           {
                                             yyextra->current->mtype = yyextra->mtype = Property;
                                             yyextra->current->spec|=Entry::Readable | Entry::Writable | Entry::Assign;


### PR DESCRIPTION
Annotations were already skipped in Java code but not in function arguments, this has been corrected.