### PR TITLE
issue #9124 Latex: Does not properly compile when PROJECT_BRIEF contains commas

### DIFF
--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -172,8 +172,8 @@
       linkcolor=blue,%
       citecolor=blue,%
       unicode,%
-      pdftitle=$projectname,%
-      pdfsubject=$projectbrief%
+      pdftitle={$projectname},%
+      pdfsubject={$projectbrief}%
     }
 
 %%END PDF_HYPERLINKS


### PR DESCRIPTION
The options in the LaTeX `\hypersetup command are separated by commas, but the `pdftitle` and the `pdfsubject` are just texts that can contain commas as well and as such should be placed in a LaTeX block `{..}`