### PR TITLE
Line numbers not shown in gray in source code

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -489,7 +489,7 @@ std::string ClangTUParser::lookup(uint line,const char *symbol)
 void ClangTUParser::writeLineNumber(CodeOutputInterface &ol,const FileDef *fd,uint line,bool writeLineAnchor)
 {
   const Definition *d = fd ? fd->getSourceDefinition(line) : 0;
-  if (d && d->isLinkable())
+  if (d && fd->isLinkable())
   {
     p->currentLine=line;
     const MemberDef *md = fd->getSourceMember(line);


### PR DESCRIPTION
In case we use the CLANG_ASSISTED parser the line numbers are not shown in (darker) gray for the lines that can be referenced.
(found due to evaluating some fixes for #9073 / #8784)