### PR TITLE
issue #9127 Doxywizard truncates standard input passed to doxygen process.

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -578,6 +578,7 @@ void MainWindow::runDoxygen()
     }
     QTextStream t(m_runProcess);
     m_expert->writeConfig(t,false,false);
+    t.flush();
     m_runProcess->closeWriteChannel();
 
     if (m_runProcess->state() == QProcess::NotRunning)


### PR DESCRIPTION
The documentation of `void QProcess::closeWriteChannel()` stated:
> Schedules the write channel of QProcess to be closed. The channel will close once all data has been written to the process. After calling this function, any attempts to write to the process will fail.
>
> Closing the write channel is necessary for programs that read input data until the channel has been closed. For example, the program "more" is used to display text data in a console on both Unix and Windows. But it will not display the text data until QProcess's write channel has been closed

This was interpreted as that the buffer would have been flushed but as we use:
```
    QTextStream t(m_runProcess);
    m_expert->writeConfig(t,false,false);
```
the `QTextStream` does some buffering of its own and this is not detected by the `closeWriteChannel()` hence  we need to `flush` the QTextStream by hand as well.