### PR TITLE
issue #9144 problem with matching function when using namespace

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5951,7 +5951,8 @@ static void addMemberFunction(const Entry *root,
               root->protection,root->stat,root->virt,spec,relates);
           return;
         }
-        if (md->argsString()==argListToString(root->argList,FALSE,FALSE))
+        if (argListToString(*(stringToArgumentList(SrcLangExt_Cpp, md->argsString()).get()),FALSE,FALSE) ==
+            argListToString(root->argList,FALSE,FALSE))
         { // exact argument list match -> remember
           ucd = ecd = ccd;
           umd = emd = cmd;


### PR DESCRIPTION
During the checking whether argument lists are the same, the match should in both cases not contain the default values.