### PR TITLE
issue #9145 ALIASES in Python docstrings with ''' are not expanded.

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -97,6 +97,7 @@ struct commentcnvYY_state
   bool     lastEscaped = FALSE;
   int      lastBlockContext= 0;
   bool     pythonDocString = FALSE;
+  QCString pythonDocTriple;
   int      nestingCount= 0;
 
   bool     vhdl = FALSE; // for VHDL old style --! comment
@@ -205,6 +206,7 @@ SLASHopt [/]*
 <Scan>[,= ;\t]                      { /* eat , so we have a nice separator in long initialization lines */ 
                                        copyToOutput(yyscanner,yytext,(int)yyleng);
                                     }
+<Scan>"'''"!                        |
 <Scan>"\"\"\""!                     { /* start of python long comment */
                                      if (yyextra->lang!=SrcLangExt_Python)
 				     {
@@ -213,6 +215,7 @@ SLASHopt [/]*
 				     else
 				     {
                                        yyextra->pythonDocString = TRUE;
+                                       yyextra->pythonDocTriple = yytext;
                                        yyextra->nestingCount=1;
                                        clearCommentStack(yyscanner); /*  to be on the save side */
                                        copyToOutput(yyscanner,yytext,(int)yyleng);
@@ -636,12 +639,13 @@ SLASHopt [/]*
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
 
-<CComment,CNComment>[^ `~<\\!@*\n{\"\/]*     { /* anything that is not a '*' or command */ 
+<CComment,CNComment>[^ `~<\\!@*\n{'\"\/]*     { /* anything that is not a '*' or command */ 
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
-<CComment,CNComment>"*"+[^*\/\\@\n{\"]*      { /* stars without slashes */
+<CComment,CNComment>"*"+[^*\/\\@\n{'\"]*      { /* stars without slashes */
                                      copyToOutput(yyscanner,yytext,(int)yyleng); 
                                    }
+<CComment>"'''"                    |
 <CComment>"\"\"\""                 { /* end of Python docstring */
                                      if (yyextra->lang!=SrcLangExt_Python)
 				     {
@@ -649,10 +653,17 @@ SLASHopt [/]*
 				     }
 				     else
 				     {
-                                       yyextra->nestingCount--;
-                                       yyextra->pythonDocString = FALSE;
-				       copyToOutput(yyscanner,yytext,(int)yyleng);
-				       BEGIN(Scan);
+                                       if (yyextra->pythonDocTriple[0] == yytext[0])
+                                       {
+                                         yyextra->nestingCount--;
+                                         yyextra->pythonDocString = FALSE;
+				         copyToOutput(yyscanner,yytext,(int)yyleng);
+				         BEGIN(Scan);
+				       }
+                                       else
+                                       {
+				         copyToOutput(yyscanner,yytext,(int)yyleng);
+                                       }
 				     }
   				   }
 <CComment,CNComment>\n                       { /* new line in comment */


### PR DESCRIPTION
When handling `"""!` also the `'''!` should be handled in, internal, comment conversion