### PR TITLE
issue #9143 warning file-line format in Possible candidates

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1373,6 +1373,25 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
  Optionally the format may contain
  <code>$version</code>, which will be replaced by the version of the file (if it could
  be obtained via \ref cfg_file_version_filter "FILE_VERSION_FILTER")
+
+ \sa \ref cfg_warn_line_format "WARN_LINE_FORMAT"
+]]>
+      </docs>
+    </option>
+    <option type='string' id='WARN_LINE_FORMAT' format='string' defval='at line $line of file $file'>
+      <docs>
+<![CDATA[
+ In the `$text` part of the \ref cfg_warn_format "WARN_FORMAT" command it is
+ possible that a reference to a more specific place is given.  To make it easier
+ to jump to this place (outside of doxygen) the user can define its own
+ "cut" / "paste" string.
+
+ Example:
+ \verbatim
+  WARN_LINE_FORMAT = "'vi $file +$line'"
+ \endverbatim
+
+ \sa \ref cfg_warn_format "WARN_FORMAT"
 ]]>
       </docs>
     </option>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5473,8 +5473,7 @@ static bool findGlobalMember(const Entry *root,
         {
           warnMsg+=" '";
           warnMsg+=substitute(md->declaration(),"%","%%");
-          warnMsg+="' at line "+QCString().setNum(md->getDefLine())+
-                   " of file "+md->getDefFileName()+"\n";
+          warnMsg+="' " + warn_line(md->getDefFileName(),md->getDefLine());
         }
       }
       warn(root->fileName,root->startLine, "%s", qPrint(warnMsg));
@@ -6036,8 +6035,7 @@ static void addMemberFunction(const Entry *root,
           warnMsg+=md->argsString();
           if (noMatchCount>1)
           {
-            warnMsg+="' at line "+QCString().setNum(md->getDefLine()) +
-              " of file "+md->getDefFileName();
+            warnMsg+="' " + warn_line(md->getDefFileName(),md->getDefLine());
           }
           else
             warnMsg += "'";
@@ -9158,9 +9156,9 @@ static void computePageRelations(Entry *root)
         PageDef *subPd = Doxygen::pageLinkedMap->find(bi.name);
         if (pd==subPd)
         {
-         term("page defined at line %d of file %s with label %s is a direct "
+         term("page defined %s with label %s is a direct "
              "subpage of itself! Please remove this cyclic dependency.\n",
-              pd->docLine(),qPrint(pd->docFile()),qPrint(pd->name()));
+              qPrint(warn_line(pd->docFile(),pd->docLine())),qPrint(pd->name()));
         }
         else if (subPd)
         {
@@ -9183,9 +9181,9 @@ static void checkPageRelations()
     {
       if (ppd==pd.get())
       {
-        term("page defined at line %d of file %s with label %s is a subpage "
-            "of itself! Please remove this cyclic dependency.\n",
-            pd->docLine(),qPrint(pd->docFile()),qPrint(pd->name()));
+        term("page defined %s with label %s is a subpage "
+             "of itself! Please remove this cyclic dependency.\n",
+              qPrint(warn_line(pd->docFile(),pd->docLine())),qPrint(pd->name()));
       }
       ppd=ppd->getOuterScope();
     }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -24,6 +24,7 @@
 
 // globals
 static QCString        g_warnFormat;
+static QCString        g_warnLineFormat;
 static const char *    g_warningStr = "warning: ";
 static const char *    g_errorStr = "error: ";
 static FILE *          g_warnFile = stderr;
@@ -34,6 +35,7 @@ static std::mutex      g_mutex;
 void initWarningFormat()
 {
   g_warnFormat = Config_getString(WARN_FORMAT);
+  g_warnLineFormat = Config_getString(WARN_LINE_FORMAT);
   QCString logFile = Config_getString(WARN_LOGFILE);
 
   if (!logFile.isEmpty())
@@ -159,6 +161,18 @@ static void do_warn(bool enabled, const QCString &file, int line, const char *pr
   va_end(argsCopy);
 }
 
+QCString warn_line(const QCString &file,int line)
+{
+  QCString fileSubst = file.isEmpty() ? "<unknown>" : file;
+  QCString lineSubst; lineSubst.setNum(line);
+  return  substitute(
+            substitute(
+              g_warnLineFormat,
+              "$file",fileSubst
+            ),
+            "$line",lineSubst
+          );
+}
 void warn(const QCString &file,int line,const char *fmt, ...)
 {
   va_list args;

--- a/src/message.h
+++ b/src/message.h
@@ -36,6 +36,7 @@ extern void warn_uncond(const char *fmt, ...) PRINTFLIKE(1, 2);
 extern void err(const char *fmt, ...) PRINTFLIKE(1, 2);
 extern void err_full(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void term(const char *fmt, ...) PRINTFLIKE(1, 2);
+extern QCString warn_line(const QCString &file,int line);
 void initWarningFormat();
 void warn_flush();
 extern void finishWarnExit();


### PR DESCRIPTION
Defining the possibility for the user to specify  its own file/line string in the explaining part of warnings