### PR TITLE
Better handling of of *. in C++ ///  comments

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -842,11 +842,11 @@ SLASHopt [/]*
                                                                   //   static void handleCondSectionId
 				     BEGIN(Scan); 
                                    }
-<ReadLine>{CCS}"*"                    {
-				     copyToOutput(yyscanner,"/&zwj;**",8);
+<ReadLine>{CCS}"*"                 {
+				     copyToOutput(yyscanner,"/&doxyzwj;**",12);
 				   }
-<ReadLine>{CCE}                     {
-				     copyToOutput(yyscanner,"*&zwj;/",7);
+<ReadLine>{CCE}                    {
+				     copyToOutput(yyscanner,"*&doxyzwj;/",11);
 				   }
 <ReadLine>"*"                      {
 				     copyToOutput(yyscanner,yytext,(int)yyleng);

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -399,7 +399,9 @@ class DocSymbol : public DocNode
                    /* doxygen commands mapped */
                    Sym_BSlash, Sym_At, Sym_Less, Sym_Greater, Sym_Amp,
                    Sym_Dollar, Sym_Hash, Sym_DoubleColon, Sym_Percent, Sym_Pipe,
-                   Sym_Quot, Sym_Minus, Sym_Plus, Sym_Dot, Sym_Colon, Sym_Equal
+                   Sym_Quot, Sym_Minus, Sym_Plus, Sym_Dot, Sym_Colon, Sym_Equal,
+                   /* doxygen internal symbol */
+                   Sym_doxyzwj
                  };
     enum PerlType { Perl_unknown = 0, Perl_string, Perl_char, Perl_symbol, Perl_umlaut,
                     Perl_acute, Perl_grave, Perl_circ, Perl_slash, Perl_tilde,

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -691,6 +691,7 @@ LINENR {BLANK}*[1-9][0-9]*
                            yyextra->token->name = &yytext[1];
                          else
                            yyextra->token->name = yytext;
+                         yyextra->token->name = substitute(yyextra->token->name,"&doxyzwj;","");
                          return TK_WORD;
                        }
 <St_Text>({ID}".")+{ID} {

--- a/src/htmlentity.cpp
+++ b/src/htmlentity.cpp
@@ -316,7 +316,8 @@ static struct htmlEntityInfo
   { SYM(Plus),     "+",            "+",          "+",                    "+",             "+",                      "+",      "+",           { "+",          DocSymbol::Perl_char    }},
   { SYM(Dot),      ".",            ".",          ".",                    ".",             ".",                      ".",      ".",           { ".",          DocSymbol::Perl_char    }},
   { SYM(Colon),    ":",            ":",          ":",                    ":",             ":",                      ":",      ":",           { ":",          DocSymbol::Perl_char    }},
-  { SYM(Equal),    "=",            "=",          "=",                    "=",             "=",                      "=",      "=",           { "=",          DocSymbol::Perl_char    }}
+  { SYM(Equal),    "=",            "=",          "=",                    "=",             "=",                      "=",      "=",           { "=",          DocSymbol::Perl_char    }},
+  { SYM(doxyzwj),  "",             "",           "",                     "",              "",                       NULL,     "",            { NULL,         DocSymbol::Perl_unknown }},
 };
 
 static const int g_numHtmlEntities = static_cast<int>(sizeof(g_htmlEntities)/ sizeof(*g_htmlEntities));


### PR DESCRIPTION
In case we have a cpp comment like:
```
///     double "somepath/bin*/exename[.ext]", the resulting
///
```
this results in the (HTML) output like:
```
double "somepath/bin*&zwj;/exename[.ext]", the resulting
```
as the `*/` has bee converted in the comment conversion to `*&zwj;/` which is done due to the conversion of the `///` type comment to `/*` type comment.
In the string this is later seen as a literal `&zwj;` that should remain.

To overcome the problem the replacement is done with a new doxygen internal entity `&doxyzwj;` that is filtered out again later on.