### PR TITLE
INCLUDE_PATH is not recursive

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3401,6 +3401,9 @@ If set to \c NO, doxygen will warn if an a database file is already found and no
  The \c INCLUDE_PATH tag can be used to specify one or more directories that
  contain include files that are not input files but should be processed by
  the preprocessor.
+
+ Note that the \c INCLUDE_PATH is not recursive, so the setting of \ref cfg_recursive "RECURSIVE" 
+ has no effect here.
 ]]>
       </docs>
     </option>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11421,7 +11421,7 @@ void searchInputFiles()
                         &exclPatterns,                 // exclPatList
                         0,                             // resultList
                         0,                             // resultSet
-                        alwaysRecursive,               // recursive
+                        false,                         // INCLUDE_PATH isn't recursive
                         TRUE,                          // errorIfNotExist
                         &killSet);                     // killSet
   }


### PR DESCRIPTION
The `INCLUDE_PATH` is not recursive.
- correcting retrieval code
- making a note in the documentation