### PR TITLE
Reinstate warnings about stale translations

### DIFF
--- a/src/language.cpp
+++ b/src/language.cpp
@@ -301,4 +301,7 @@ void setTranslator(OUTPUT_LANGUAGE_t langName)
 #endif
 #endif
   }
+
+  QCString msg = theTranslator->updateNeededMessage();
+  if (!msg.isEmpty()) warn_uncond("%s", qPrint(msg));
 }

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -303,5 +303,5 @@ void setTranslator(OUTPUT_LANGUAGE_t langName)
   }
 
   QCString msg = theTranslator->updateNeededMessage();
-  if (!msg.isEmpty()) warn_uncond("%s", qPrint(msg));
+  if (!msg.isEmpty()) ::msg("%s", qPrint(msg));
 }


### PR DESCRIPTION
While replacing string comparisons with enums in commit
a0fb56e0560d657d6fde8ade9e74624c9412eb4d, the warning about stale
translations was also removed:

    The selected output language "foo" has not been updated since
    release x.y.z.  As a result some sentences may appear in English.

Reinstate the warning as that is useful and unrelated to the original
focus of the removing commit.