### PR TITLE
issue #9159 Doxygen produces ugly empty space in LaTeX and PDF output because of hypertargets

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -837,7 +837,7 @@ DB_GEN_C
 }
 void DocbookGenerator::startDoxyAnchor(const QCString &fName,const QCString &,
                                  const QCString &anchor,const QCString &,
-                                 const QCString &)
+                                 const QCString &,const bool)
 {
 DB_GEN_C
   if (!m_inListItem[m_levelListItem] && !m_descTable && !m_simpleTable)

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -258,7 +258,7 @@ class DocbookGenerator : public OutputGenerator
     void endMemberDoc(bool);
     void startDoxyAnchor(const QCString &fName,const QCString &manName,
                          const QCString &anchor,const QCString &name,
-                         const QCString &args);
+                         const QCString &args,const bool);
     void endDoxyAnchor(const QCString &fileName,const QCString &anchor);
     void writeLatexSpacing(){DB_GEN_EMPTY}
     void writeStartAnnoItem(const QCString &,const QCString &,

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1306,7 +1306,7 @@ void HtmlGenerator::writeStyleInfo(int part)
 
 void HtmlGenerator::startDoxyAnchor(const QCString &,const QCString &,
                                     const QCString &anchor, const QCString &,
-                                    const QCString &)
+                                    const QCString &,const bool)
 {
   m_t << "<a id=\"" << anchor << "\" name=\"" << anchor << "\"></a>";
 }

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -230,7 +230,7 @@ class HtmlGenerator : public OutputGenerator
     void endMemberDoc(bool);
     void startDoxyAnchor(const QCString &fName,const QCString &manName,
                          const QCString &anchor,const QCString &name,
-                         const QCString &args);
+                         const QCString &args,const bool);
     void endDoxyAnchor(const QCString &fName,const QCString &anchor);
     void writeLatexSpacing() {}
     void writeStartAnnoItem(const QCString &type,const QCString &file,

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1459,11 +1459,11 @@ void LatexGenerator::endMemberDoc(bool)
 
 void LatexGenerator::startDoxyAnchor(const QCString &fName,const QCString &,
                                      const QCString &anchor, const QCString &,
-                                     const QCString &)
+                                     const QCString &, const bool boxed)
 {
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   bool usePDFLatex   = Config_getBool(USE_PDFLATEX);
-  m_t << "\\mbox{";
+  if (boxed) m_t << "\\mbox{";
   if (usePDFLatex && pdfHyperlinks)
   {
     m_t << "\\Hypertarget{";
@@ -1474,7 +1474,14 @@ void LatexGenerator::startDoxyAnchor(const QCString &fName,const QCString &,
   m_t << "\\label{";
   if (!fName.isEmpty()) m_t << stripPath(fName);
   if (!anchor.isEmpty()) m_t << "_" << anchor;
-  m_t << "}} \n";
+  if (boxed)
+  {
+    m_t << "}} \n";
+  }
+  else
+  {
+    m_t << "} \n";
+  }
 }
 
 void LatexGenerator::endDoxyAnchor(const QCString &fName,const QCString &anchor)

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -220,7 +220,7 @@ class LatexGenerator : public OutputGenerator
     void lineBreak(const QCString &style=QCString());
     void startMemberDoc(const QCString &,const QCString &,const QCString &,const QCString &,int,int,bool);
     void endMemberDoc(bool);
-    void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &);
+    void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &,const bool);
     void endDoxyAnchor(const QCString &,const QCString &);
     void writeChar(char c);
     void writeLatexSpacing() { m_t << "\\hspace{0.3cm}"; }

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -422,7 +422,7 @@ void ManGenerator::startMemberDoc(const QCString &,const QCString &,const QCStri
 
 void ManGenerator::startDoxyAnchor(const QCString &,const QCString &manName,
                                    const QCString &, const QCString &name,
-                                   const QCString &)
+                                   const QCString &,const bool)
 {
     // something to be done?
     if( !Config_getBool(MAN_LINKS) )

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -141,7 +141,7 @@ class ManGenerator : public OutputGenerator
     void writeChar(char c);
     void startMemberDoc(const QCString &,const QCString &,const QCString &,const QCString &,int,int,bool);
     void endMemberDoc(bool);
-    void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &);
+    void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &,const bool);
     void endDoxyAnchor(const QCString &,const QCString &) {}
     void writeLatexSpacing() {}
     void writeStartAnnoItem(const QCString &type,const QCString &file,

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3373,7 +3373,7 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
   }
   else // not an enum value or anonymous compound
   {
-    ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs);
+    ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs,false);
     ol.startMemberDoc(ciname,name(),memAnchor,title,memCount,memTotal,showInline);
 
     if (!m_impl->metaData.isEmpty() && getLanguage()==SrcLangExt_Slice)

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -426,7 +426,7 @@ class OutputGenerator : public BaseOutputDocInterface
     virtual void endMemberDoc(bool) = 0;
     virtual void startDoxyAnchor(const QCString &fName,const QCString &manName,
                                  const QCString &anchor,const QCString &name,
-                                 const QCString &args) = 0;
+                                 const QCString &args,const bool boxed = true) = 0;
     virtual void endDoxyAnchor(const QCString &fileName,const QCString &anchor) = 0;
     virtual void writeLatexSpacing() = 0;
     virtual void writeStartAnnoItem(const QCString &type,const QCString &file,

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -263,8 +263,8 @@ class OutputList : public OutputDocInterface
     { forall(&OutputGenerator::endMemberDoc,hasArgs); }
     void startDoxyAnchor(const QCString &fName,const QCString &manName,
                          const QCString &anchor, const QCString &name,
-                         const QCString &args)
-    { forall(&OutputGenerator::startDoxyAnchor,fName,manName,anchor,name,args); }
+                         const QCString &args,const bool boxed = true)
+    { forall(&OutputGenerator::startDoxyAnchor,fName,manName,anchor,name,args,boxed); }
     void endDoxyAnchor(const QCString &fn,const QCString &anchor)
     { forall(&OutputGenerator::endDoxyAnchor,fn,anchor); }
     void writeLatexSpacing()

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1425,7 +1425,7 @@ void RTFGenerator::endMemberDoc(bool)
 
 void RTFGenerator::startDoxyAnchor(const QCString &,const QCString &,
                                    const QCString &,const QCString &,
-                                   const QCString &
+                                   const QCString &,const bool
                                   )
 {
   DBG_RTF(m_t << "{\\comment startDoxyAnchor}\n")

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -141,7 +141,7 @@ class RTFGenerator : public OutputGenerator
     void lineBreak(const QCString &style=QCString());
     void startMemberDoc(const QCString &,const QCString &,const QCString &,const QCString &,int,int,bool);
     void endMemberDoc(bool);
-    void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &);
+    void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &,const bool);
     void endDoxyAnchor(const QCString &,const QCString &);
     void writeChar(char c);
     void writeLatexSpacing() {};//{ m_t << "\\hspace{0.3cm}"; }


### PR DESCRIPTION
The fix as done for issue #6093
```
Commit: d571efb062fbe17d7257f3971e3db6c9cba833d0 [d571efb]
Date: Sunday, October 23, 2016 1:15:37 PM
```
introduced this side effect, this has been corrected.