### PR TITLE
Moving punctuation dependency to translator

### DIFF
--- a/doc/translator.py
+++ b/doc/translator.py
@@ -880,7 +880,8 @@ class Transl:
                                  prototype=="virtual QCString latexDocumentPre()" or
                                  prototype=="virtual QCString latexCommandName()" or
                                  prototype=="virtual QCString latexFont()" or
-                                 prototype=="virtual QCString latexFontenc()")):
+                                 prototype=="virtual QCString latexFontenc()" or
+                                 prototype=="virtual bool needsPunctuation()")):
                           self.prototypeDic[uniPrototype] = prototype
                         status = 2      # body consumed
                         methodId = None # outside of any method

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -488,10 +488,7 @@ void DefinitionImpl::setDocumentation(const QCString &d,const QCString &docFile,
 
 void DefinitionImpl::_setBriefDescription(const QCString &b,const QCString &briefFile,int briefLine)
 {
-  static OUTPUT_LANGUAGE_t outputLanguage = Config_getEnum(OUTPUT_LANGUAGE);
-  static bool needsDot = outputLanguage!=OUTPUT_LANGUAGE_t::Japanese &&
-                         outputLanguage!=OUTPUT_LANGUAGE_t::Chinese &&
-                         outputLanguage!=OUTPUT_LANGUAGE_t::Korean;
+  const bool needsDot = theTranslator->needsPunctuation();
   QCString brief = b;
   brief = brief.stripWhiteSpace();
   brief = stripLeadingAndTrailingEmptyLines(brief,briefLine);

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -488,22 +488,24 @@ void DefinitionImpl::setDocumentation(const QCString &d,const QCString &docFile,
 
 void DefinitionImpl::_setBriefDescription(const QCString &b,const QCString &briefFile,int briefLine)
 {
-  const bool needsDot = theTranslator->needsPunctuation();
   QCString brief = b;
   brief = brief.stripWhiteSpace();
   brief = stripLeadingAndTrailingEmptyLines(brief,briefLine);
   brief = brief.stripWhiteSpace();
   if (brief.isEmpty()) return;
   uint bl = brief.length();
-  if (bl>0 && needsDot) // add punctuation if needed
+  if (bl>0)
   {
-    int c = brief.at(bl-1);
-    switch(c)
+    if (!theTranslator || theTranslator->needsPunctuation()) // add punctuation if needed
     {
-      case '.': case '!': case '?': case '>': case ':': case ')': break;
-      default:
-        if (isUTF8CharUpperCase(brief.str(),0) && !lastUTF8CharIsMultibyte(brief.str())) brief+='.';
-        break;
+      int c = brief.at(bl-1);
+      switch(c)
+      {
+        case '.': case '!': case '?': case '>': case ':': case ')': break;
+        default:
+          if (isUTF8CharUpperCase(brief.str(),0) && !lastUTF8CharIsMultibyte(brief.str())) brief+='.';
+          break;
+      }
     }
   }
 

--- a/src/translator.h
+++ b/src/translator.h
@@ -143,7 +143,7 @@ class Translator
     virtual QCString getLanguageString() = 0;
 
     /** add punctuation at the end of a brief description when needed and supported by the language */
-    virtual const inline bool needsPunctuation() {return true;}
+    virtual inline bool needsPunctuation() {return true;}
 
     // --- Language translation methods -------------------
 

--- a/src/translator.h
+++ b/src/translator.h
@@ -142,6 +142,9 @@ class Translator
     */
     virtual QCString getLanguageString() = 0;
 
+    /** add punctuation at the end of a brief description when needed and supported by the language */
+    virtual const inline bool needsPunctuation() {return true;}
+
     // --- Language translation methods -------------------
 
     virtual QCString trRelatedFunctions() = 0;

--- a/src/translator.h
+++ b/src/translator.h
@@ -142,8 +142,10 @@ class Translator
     */
     virtual QCString getLanguageString() = 0;
 
-    /** add punctuation at the end of a brief description when needed and supported by the language */
-    virtual inline bool needsPunctuation() {return true;}
+    /**
+     * add punctuation at the end of a brief description when needed and supported by the language
+    */
+    virtual bool needsPunctuation() { return true; }
 
     // --- Language translation methods -------------------
 

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -75,6 +75,10 @@ class TranslatorChinese : public Translator
     {
       return "\\end{CJK}\n";
     }
+    virtual const inline bool needsPunctuation()
+    {
+      return false;
+    }
 
     /*! used in the compound documentation before a list of related functions.
      */

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -75,7 +75,7 @@ class TranslatorChinese : public Translator
     {
       return "\\end{CJK}\n";
     }
-    virtual inline bool needsPunctuation()
+    virtual bool needsPunctuation()
     {
       return false;
     }

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -75,7 +75,7 @@ class TranslatorChinese : public Translator
     {
       return "\\end{CJK}\n";
     }
-    virtual const inline bool needsPunctuation()
+    virtual inline bool needsPunctuation()
     {
       return false;
     }

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -99,7 +99,7 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     {
       return "\\end{CJK}\n";
     }
-    virtual const inline bool needsPunctuation()
+    virtual inline bool needsPunctuation()
     {
       return false;
     }

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -99,7 +99,7 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     {
       return "\\end{CJK}\n";
     }
-    virtual inline bool needsPunctuation()
+    virtual bool needsPunctuation()
     {
       return false;
     }

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -99,6 +99,10 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     {
       return "\\end{CJK}\n";
     }
+    virtual const inline bool needsPunctuation()
+    {
+      return false;
+    }
 
     /*! used in the compound documentation before a list of related functions. */
     virtual QCString trRelatedFunctions()

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -102,7 +102,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     {
       return "0x412 Korean";
     }
-    virtual inline bool needsPunctuation()
+    virtual bool needsPunctuation()
     {
       return false;
     }

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -102,7 +102,10 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     {
       return "0x412 Korean";
     }
-
+    virtual const inline bool needsPunctuation()
+    {
+      return false;
+    }
     // --- Language translation methods -------------------
 
     /*! used in the compound documentation before a list of related functions. */

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -102,7 +102,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     {
       return "0x412 Korean";
     }
-    virtual const inline bool needsPunctuation()
+    virtual inline bool needsPunctuation()
     {
       return false;
     }


### PR DESCRIPTION
Moving a dependency of the used `OUTPUT_LANGUAGE` into the respective translators.