### PR TITLE
issue #9158 Python: Two classes in one file, second class documentation block copied into its class method block

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1800,6 +1800,7 @@ static void parseCompounds(yyscan_t yyscanner,std::shared_ptr<Entry> rt)
       pyscannerYYrestart( 0, yyscanner );
       if (ce->section&Entry::COMPOUND_MASK)
       {
+        yyextra->specialBlock = false;
         yyextra->current_root = ce;
         BEGIN( Search );
       }


### PR DESCRIPTION
When starting a new class  (or other compound) the `specialBlock` flag should be reset