### PR TITLE
Don't interpret */ in "verbatim" blocks

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1544,22 +1544,10 @@ STopt  [^\n@\\]*
                                           addOutput(yyscanner,'\n');
                                         }
 <FormatBlock>{CCS}                       { // start of a C-comment
-                                          if (!(yyextra->blockName=="code" || yyextra->blockName=="verbatim" || yyextra->blockName=="iliteral")) yyextra->commentCount++;
                                           addOutput(yyscanner,yytext);
                                         }
 <FormatBlock>{CCE}                       { // end of a C-comment
                                           addOutput(yyscanner,yytext);
-                                          if (!(yyextra->blockName=="code" || yyextra->blockName=="verbatim" || yyextra->blockName=="iliteral"))
-                                          {
-                                            yyextra->commentCount--;
-                                            if (yyextra->commentCount<0)
-                                            {
-                                              QCString endTag = "end"+yyextra->blockName;
-                                              if (yyextra->blockName=="startuml") endTag="enduml";
-                                              warn(yyextra->fileName,yyextra->lineNr,
-                                                 "found */ without matching /* while inside a \\%s block! Perhaps a missing \\%s?\n",qPrint(yyextra->blockName),qPrint(endTag));
-                                            }
-                                          }
                                         }
 <FormatBlock>.                          {
                                           addOutput(yyscanner,*yytext);


### PR DESCRIPTION
When having:
```
/// \verbatim
/// verbatim bare somepath/bin*/exename[.ext], the resulting
/// \endverbatim
/// \htmlonly
/// htmlonly bare somepath/bin*/exename[.ext], the resulting<br>
/// \endhtmlonly
```

the "end of  comment" `*/` is ignored in the `\verbatim` block but not in the `\htmlonly` block and resulting in warnings like:
```
warning: found */ without matching /* while inside a \htmlonly block! Perhaps a missing \endhtmlonly?
```
The `*/` should not only be ignored in `\verbatim` blocks but in all "verbatim" blocks.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8161574/example.tar.gz)
