### PR TITLE
Recognize type= as variable in Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -639,6 +639,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 
  /*------- type definition  -------------------------------------------------------------------------------*/
 
+<ModuleBody>^{BS}type{BS}"="            {}
 <Start,ModuleBody>^{BS}type/[^a-z0-9_]  {
                                           if (YY_START == Start)
                                           {


### PR DESCRIPTION
Recognize a construct like `type=` as a variable with assignment and not as start of  a type definition
The given warning is of the type:
```
warning: Found 'END' instead of 'END TYPE'
```
for a construct like
```
      type = 6
```

Found by Fossies for the rlab package