### PR TITLE
Issue #9171 XML output for dot file uses relative path in 1.9.3

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -21479,6 +21479,8 @@ class docDotMscType(GeneratedsSuper):
 
 
 class docImageFileType(GeneratedsSuper):
+    """The mentioned file will be located in the directory as specified by
+    XML_OUTPUT"""
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -626,7 +626,11 @@
 
   <xsd:complexType name="docImageFileType" mixed="true">
     <xsd:group ref="docTitleCmdGroup" minOccurs="0" maxOccurs="unbounded" />
-    <xsd:attribute name="name" type="xsd:string" use="optional"/>
+    <xsd:attribute name="name" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation>The mentioned file will be located in the directory as specified by XML_OUTPUT</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
     <xsd:attribute name="width" type="xsd:string" use="optional"/>
     <xsd:attribute name="height" type="xsd:string" use="optional"/>
   </xsd:complexType>


### PR DESCRIPTION
Documenting in the xsd source file where the mentioned file will be placed.