### PR TITLE
Replace static Config_Get... by just Config_get...

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -44,7 +44,7 @@ enum class DetectedLang { Cpp, ObjC, ObjCpp };
 
 static QCString detab(const QCString &s)
 {
-  static int tabSize = Config_getInt(TAB_SIZE);
+  int tabSize = Config_getInt(TAB_SIZE);
   GrowBuf out;
   int size = s.length();
   const char *data = s.data();
@@ -324,7 +324,7 @@ void ClangTUParser::parse()
 ClangTUParser::~ClangTUParser()
 {
   //printf("ClangTUParser::~ClangTUParser() this=%p\n",this);
-  static bool clangAssistedParsing = Config_getBool(CLANG_ASSISTED_PARSING);
+  bool clangAssistedParsing = Config_getBool(CLANG_ASSISTED_PARSING);
   if (!clangAssistedParsing) return;
   if (p->tu)
   {
@@ -383,7 +383,7 @@ std::string ClangTUParser::lookup(uint line,const char *symbol)
   //printf("ClangParser::lookup(%d,%s)\n",line,symbol);
   std::string result;
   if (symbol==0) return result;
-  static bool clangAssistedParsing = Config_getBool(CLANG_ASSISTED_PARSING);
+  bool clangAssistedParsing = Config_getBool(CLANG_ASSISTED_PARSING);
   if (!clangAssistedParsing) return result;
 
   auto getCurrentTokenLine = [=]() -> uint
@@ -574,7 +574,7 @@ void ClangTUParser::writeMultiLineCodeLink(CodeOutputInterface &ol,
                   const Definition *d,
                   const char *text)
 {
-  static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
+  bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
   p->tooltipManager.addTooltip(ol,d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -55,7 +55,7 @@
 static QCString makeQualifiedNameWithTemplateParameters(const ClassDef *cd,
     const ArgumentLists *actualParams,uint *actualParamIndex)
 {
-  //static bool optimizeOutputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
+  //bool optimizeOutputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
   bool hideScopeNames = Config_getBool(HIDE_SCOPE_NAMES);
   //printf("qualifiedNameWithTemplateParameters() localName=%s\n",qPrint(localName()));
   QCString scName;
@@ -106,9 +106,9 @@ static QCString makeQualifiedNameWithTemplateParameters(const ClassDef *cd,
 
 static QCString makeDisplayName(const ClassDef *cd,bool includeScope)
 {
-  //static bool optimizeOutputForJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
+  //bool optimizeOutputForJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
   SrcLangExt lang = cd->getLanguage();
-  //static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  //bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
   QCString n;
   if (lang==SrcLangExt_VHDL)
   {
@@ -821,7 +821,7 @@ void ClassDefImpl::insertSubClass(ClassDef *cd,Protection p,
                                 Specifier s,const QCString &t)
 {
   //printf("*** insert sub class %s into %s\n",qPrint(cd->name()),qPrint(name()));
-  static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+  bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
   if (!extractPrivate && cd->protection()==Private) return;
   m_impl->inheritedBy.push_back(BaseClassDef(cd,QCString(),p,s,t));
   m_impl->isSimple = FALSE;
@@ -1385,7 +1385,7 @@ void ClassDefImpl::writeBriefDescription(OutputList &ol,bool exampleFlag) const
 
 void ClassDefImpl::writeDetailedDocumentationBody(OutputList &ol) const
 {
-  static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
+  bool repeatBrief = Config_getBool(REPEAT_BRIEF);
 
   ol.startTextBlock();
 
@@ -1435,8 +1435,8 @@ void ClassDefImpl::writeDetailedDocumentationBody(OutputList &ol) const
 
 bool ClassDefImpl::hasDetailedDescription() const
 {
-  static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
-  static bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
+  bool repeatBrief = Config_getBool(REPEAT_BRIEF);
+  bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
   return ((!briefDescription().isEmpty() && repeatBrief) ||
           !documentation().isEmpty() ||
           (sourceBrowser && getStartBodyLine()!=-1 && getBodyDef()));
@@ -1605,8 +1605,8 @@ int ClassDefImpl::countInheritanceNodes() const
 
 void ClassDefImpl::writeInheritanceGraph(OutputList &ol) const
 {
-  static bool haveDot    = Config_getBool(HAVE_DOT);
-  static auto classGraph = Config_getEnum(CLASS_GRAPH);
+  bool haveDot    = Config_getBool(HAVE_DOT);
+  auto classGraph = Config_getEnum(CLASS_GRAPH);
 
   if (classGraph == CLASS_GRAPH_t::NO) return;
   // count direct inheritance relations
@@ -1996,7 +1996,7 @@ void ClassDefImpl::startMemberDeclarations(OutputList &ol) const
 void ClassDefImpl::endMemberDeclarations(OutputList &ol) const
 {
   //printf("%s: ClassDefImpl::endMemberDeclarations()\n",qPrint(name()));
-  static bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
+  bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
   if (!inlineInheritedMembers && countAdditionalInheritedMembers()>0)
   {
     ol.startMemberHeader("inherited");
@@ -2309,9 +2309,9 @@ void ClassDefImpl::writeMoreLink(OutputList &ol,const QCString &anchor) const
 {
   // TODO: clean up this mess by moving it to
   // the output generators...
-  static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
-  static bool rtfHyperlinks = Config_getBool(RTF_HYPERLINKS);
-  static bool usePDFLatex   = Config_getBool(USE_PDFLATEX);
+  bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+  bool rtfHyperlinks = Config_getBool(RTF_HYPERLINKS);
+  bool usePDFLatex   = Config_getBool(USE_PDFLATEX);
 
   // HTML only
   ol.pushGeneratorState();
@@ -2351,9 +2351,9 @@ void ClassDefImpl::writeMoreLink(OutputList &ol,const QCString &anchor) const
 
 bool ClassDefImpl::visibleInParentsDeclList() const
 {
-  static bool extractPrivate      = Config_getBool(EXTRACT_PRIVATE);
-  static bool hideUndocClasses = Config_getBool(HIDE_UNDOC_CLASSES);
-  static bool extractLocalClasses = Config_getBool(EXTRACT_LOCAL_CLASSES);
+  bool extractPrivate      = Config_getBool(EXTRACT_PRIVATE);
+  bool hideUndocClasses = Config_getBool(HIDE_UNDOC_CLASSES);
+  bool extractLocalClasses = Config_getBool(EXTRACT_LOCAL_CLASSES);
   bool linkable = isLinkable();
   return (!isAnonymous() && !isExtension() &&
           (protection()!=::Private || extractPrivate) &&
@@ -2363,9 +2363,9 @@ bool ClassDefImpl::visibleInParentsDeclList() const
 
 void ClassDefImpl::writeDeclarationLink(OutputList &ol,bool &found,const QCString &header,bool localNames) const
 {
-  //static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-  //static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-  static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  //bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  //bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   SrcLangExt lang = getLanguage();
   if (visibleInParentsDeclList())
   {
@@ -2690,10 +2690,10 @@ QCString ClassDefImpl::title() const
 // write all documentation for this class
 void ClassDefImpl::writeDocumentation(OutputList &ol) const
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
-  //static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-  //static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-  static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  //bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  //bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   QCString pageTitle = title();
 
   HighlightedItem hli;
@@ -2768,7 +2768,7 @@ void ClassDefImpl::writeMemberPages(OutputList &ol) const
 
 void ClassDefImpl::writeQuickMemberLinks(OutputList &ol,const MemberDef *currentMd) const
 {
-  static bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
+  bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
 
   ol.writeString("      <div class=\"navtab\">\n");
   ol.writeString("        <table>\n");
@@ -2836,10 +2836,10 @@ void ClassDefImpl::writeDocumentationForInnerClasses(OutputList &ol) const
 // write the list of all (inherited) members for this class
 void ClassDefImpl::writeMemberList(OutputList &ol) const
 {
-  static bool cOpt    = Config_getBool(OPTIMIZE_OUTPUT_FOR_C);
-  //static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool cOpt    = Config_getBool(OPTIMIZE_OUTPUT_FOR_C);
+  //bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   if (m_impl->allMemberNameInfoLinkedMap.empty() || cOpt) return;
   // only for HTML
   ol.pushGeneratorState();
@@ -3133,7 +3133,7 @@ bool ClassDefImpl::hasExamples() const
 void ClassDefImpl::addTypeConstraint(const QCString &typeConstraint,const QCString &type)
 {
   //printf("addTypeConstraint(%s,%s)\n",qPrint(type),qPrint(typeConstraint));
-  static bool hideUndocRelation = Config_getBool(HIDE_UNDOC_RELATIONS);
+  bool hideUndocRelation = Config_getBool(HIDE_UNDOC_RELATIONS);
   if (typeConstraint.isEmpty() || type.isEmpty()) return;
   SymbolResolver resolver(getFileDef());
   ClassDefMutable *cd = resolver.resolveClassMutable(this,typeConstraint);
@@ -3296,9 +3296,9 @@ void ClassDefImpl::writeDeclaration(OutputList &ol,const MemberDef *md,bool inGr
 /*! a link to this class is possible within this project */
 bool ClassDefImpl::isLinkableInProject() const
 {
-  static bool extractLocal   = Config_getBool(EXTRACT_LOCAL_CLASSES);
-  static bool extractStatic  = Config_getBool(EXTRACT_STATIC);
-  static bool hideUndoc      = Config_getBool(HIDE_UNDOC_CLASSES);
+  bool extractLocal   = Config_getBool(EXTRACT_LOCAL_CLASSES);
+  bool extractStatic  = Config_getBool(EXTRACT_STATIC);
+  bool hideUndoc      = Config_getBool(HIDE_UNDOC_CLASSES);
   if (m_impl->templateMaster)
   {
     return m_impl->templateMaster->isLinkableInProject();
@@ -3418,16 +3418,16 @@ void ClassDefImpl::mergeMembers()
 {
   if (m_impl->membersMerged) return;
 
-  //static bool optimizeOutputForJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
-  //static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  //bool optimizeOutputForJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
+  //bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
   SrcLangExt lang = getLanguage();
   QCString sep=getLanguageSpecificSeparator(lang,TRUE);
   uint sepLen = sep.length();
 
   m_impl->membersMerged=TRUE;
   //printf("  mergeMembers for %s\n",qPrint(name()));
-  static bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
-  static bool extractPrivate         = Config_getBool(EXTRACT_PRIVATE);
+  bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
+  bool extractPrivate         = Config_getBool(EXTRACT_PRIVATE);
   for (const auto &bcd : baseClasses())
   {
     ClassDefMutable *bClass=toClassDefMutable(bcd.classDef);
@@ -3649,7 +3649,7 @@ void ClassDefImpl::mergeCategory(ClassDef *cat)
   ClassDefMutable *category = toClassDefMutable(cat);
   if (category)
   {
-    static bool extractLocalMethods = Config_getBool(EXTRACT_LOCAL_METHODS);
+    bool extractLocalMethods = Config_getBool(EXTRACT_LOCAL_METHODS);
     bool makePrivate = category->isLocal();
     // in case extract local methods is not enabled we don't add the methods
     // of the category in case it is defined in the .m file.
@@ -3762,8 +3762,8 @@ void ClassDefImpl::mergeCategory(ClassDef *cat)
 void ClassDefImpl::addUsedClass(ClassDef *cd,const QCString &accessName,
                Protection prot)
 {
-  static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
-  static bool umlLook = Config_getBool(UML_LOOK);
+  bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+  bool umlLook = Config_getBool(UML_LOOK);
   if (prot==Private && !extractPrivate) return;
   //printf("%s::addUsedClass(%s,%s)\n",qPrint(name()),qPrint(cd->name()),accessName);
 
@@ -3794,8 +3794,8 @@ void ClassDefImpl::addUsedClass(ClassDef *cd,const QCString &accessName,
 void ClassDefImpl::addUsedByClass(ClassDef *cd,const QCString &accessName,
                Protection prot)
 {
-  static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
-  static bool umlLook = Config_getBool(UML_LOOK);
+  bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+  bool umlLook = Config_getBool(UML_LOOK);
   if (prot==Private && !extractPrivate) return;
   //printf("%s::addUsedByClass(%s,%s)\n",qPrint(name()),qPrint(cd->name()),accessName);
   //
@@ -3860,8 +3860,8 @@ QCString ClassDefImpl::compoundTypeString() const
 
 QCString ClassDefImpl::getOutputFileBase() const
 {
-  static bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
-  static bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
+  bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
+  bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
   if (!Doxygen::generatingXmlOutput)
   {
     Definition *scope=0;
@@ -4192,8 +4192,8 @@ MemberList *ClassDefImpl::getMemberList(MemberListType lt) const
 
 void ClassDefImpl::addMemberToList(MemberListType lt,const MemberDef *md,bool isBrief)
 {
-  static bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
-  static bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
+  bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
+  bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
   const auto &ml = m_impl->memberLists.get(lt,MemberListContainer::Class);
   ml->setNeedsSorting((isBrief && sortBriefDocs) || (!isBrief && sortMemberDocs));
   ml->push_back(md);
@@ -4253,7 +4253,7 @@ int ClassDefImpl::countMemberDeclarations(MemberListType lt,const ClassDef *inhe
         if (lt2!=-1) count+=mg->countGroupedInheritedMembers(static_cast<MemberListType>(lt2));
       }
     }
-    static bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
+    bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
     if (!inlineInheritedMembers) // show inherited members as separate lists
     {
       count+=countInheritedDecMembers(lt,inheritedFrom,invert,showAlways,visitedClasses);
@@ -4499,7 +4499,7 @@ void ClassDefImpl::writeMemberDeclarations(OutputList &ol,ClassDefSet &visitedCl
       //printf("  writeDeclaration type=%d count=%d\n",lt2,ml2->numDecMembers());
       ml2->writeDeclarations(ol,this,0,0,0,tt,st,FALSE,showInline,inheritedFrom,lt);
     }
-    static bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
+    bool inlineInheritedMembers = Config_getBool(INLINE_INHERITED_MEMB);
     if (!inlineInheritedMembers) // show inherited members as separate lists
     {
       writeInheritedMemberDeclarations(ol,visitedClasses,lt,lt2,title,
@@ -4808,8 +4808,8 @@ QCString ClassDefImpl::anchor() const
 
 bool ClassDefImpl::isEmbeddedInOuterScope() const
 {
-  static bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
-  static bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
+  bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
+  bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
 
   Definition *container = getOuterScope();
 

--- a/src/classlist.cpp
+++ b/src/classlist.cpp
@@ -53,7 +53,7 @@ bool ClassLinkedRefMap::declVisible(const ClassDef::CompoundType *filter) const
 void ClassLinkedRefMap::writeDeclaration(OutputList &ol,const ClassDef::CompoundType *filter,
                                       const QCString &header,bool localNames) const
 {
-  static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+  bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
   bool found=FALSE;
   for (const auto &cd : *this)
   {
@@ -73,10 +73,10 @@ void ClassLinkedRefMap::writeDeclaration(OutputList &ol,const ClassDef::Compound
 
 void ClassLinkedRefMap::writeDocumentation(OutputList &ol,const Definition * container) const
 {
-  static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
 
-  static bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
-  static bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
+  bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
+  bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
   if (!inlineGroupedClasses && !inlineSimpleClasses) return;
 
   bool found=FALSE;

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1011,7 +1011,7 @@ static void replaceCommentMarker(yyscan_t yyscanner,const char *s,int len)
 static inline int computeIndent(const char *s)
 {
   int col=0;
-  static int tabSize=Config_getInt(TAB_SIZE);
+  int tabSize=Config_getInt(TAB_SIZE);
   const char *p=s;
   char c;
   while ((c=*p++))

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -426,7 +426,7 @@ void ConceptDefImpl::writeDefinition(OutputList &ol,const QCString &title) const
 
 void ConceptDefImpl::writeDetailedDescription(OutputList &ol,const QCString &title) const
 {
-  static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
+  bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   if (hasDetailedDescription())
   {
     ol.pushGeneratorState();
@@ -485,7 +485,7 @@ void ConceptDefImpl::writeAuthorSection(OutputList &ol) const
 
 void ConceptDefImpl::writeDocumentation(OutputList &ol)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   QCString pageTitle = theTranslator->trConceptReference(displayName());
   startFile(ol,getOutputFileBase(),name(),pageTitle,HLI_ConceptVisible,!generateTreeView);
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -705,12 +705,12 @@ class TranslateContext::Private
     }
     TemplateVariant fileMembersDescription() const
     {
-      static bool extractAll = Config_getBool(EXTRACT_ALL);
+      bool extractAll = Config_getBool(EXTRACT_ALL);
       return theTranslator->trFileMembersDescription(extractAll);
     }
     TemplateVariant namespaceMembersDescription() const
     {
-      static bool extractAll = Config_getBool(EXTRACT_ALL);
+      bool extractAll = Config_getBool(EXTRACT_ALL);
       return theTranslator->trNamespaceMemberDescription(extractAll);
     }
     TemplateVariant classHierarchyDescription() const
@@ -727,8 +727,8 @@ class TranslateContext::Private
     }
     TemplateVariant classMembersDescription() const
     {
-      static bool extractAll = Config_getBool(EXTRACT_ALL);
-      static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+      bool extractAll = Config_getBool(EXTRACT_ALL);
+      bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
       if (fortranOpt)
       {
         return theTranslator->trCompoundMembersDescriptionFortran(extractAll);
@@ -912,15 +912,15 @@ class TranslateContext::Private
     }
     TemplateVariant functions() const
     {
-      static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-      static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+      bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       return fortranOpt ? theTranslator->trSubprograms()     :
              vhdlOpt    ? theTranslator->trFunctionAndProc() :
                           theTranslator->trFunctions();
     }
     TemplateVariant variables() const
     {
-      static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+      bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
       return sliceOpt ? theTranslator->trConstants() : theTranslator->trVariables();
     }
     TemplateVariant typedefs() const
@@ -1308,7 +1308,7 @@ static TemplateVariant parseCode(const Definition *d,const QCString &scopeName,c
 
 static TemplateVariant parseCode(const FileDef *fd,const QCString &relPath)
 {
-  static bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
+  bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
   auto intf = Doxygen::parserManager->getCodeParser(fd->getDefFileExtension());
   intf->resetCodeParserState();
   TextStream t;
@@ -1471,7 +1471,7 @@ class DefinitionContext
 
     QCString relPathAsString() const
     {
-      static bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
+      bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
       return createSubdirs ? QCString("../../") : QCString("");
     }
     virtual TemplateVariant relPath() const     { return relPathAsString(); }
@@ -1790,8 +1790,8 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
     TemplateVariant hasInheritanceDiagram() const
     {
       bool result=FALSE;
-      static bool haveDot    = Config_getBool(HAVE_DOT);
-      static auto classGraph = Config_getEnum(CLASS_GRAPH);
+      bool haveDot    = Config_getBool(HAVE_DOT);
+      auto classGraph = Config_getEnum(CLASS_GRAPH);
       bool classGraphEnabled = classGraph==CLASS_GRAPH_t::YES || classGraph==CLASS_GRAPH_t::GRAPH;
 
       if (haveDot && classGraphEnabled)
@@ -1808,8 +1808,8 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
     TemplateVariant inheritanceDiagram() const
     {
       TextStream t;
-      static bool haveDot    = Config_getBool(HAVE_DOT);
-      static auto classGraph = Config_getEnum(CLASS_GRAPH);
+      bool haveDot    = Config_getBool(HAVE_DOT);
+      auto classGraph = Config_getEnum(CLASS_GRAPH);
       bool classGraphEnabled = classGraph==CLASS_GRAPH_t::YES || classGraph==CLASS_GRAPH_t::GRAPH;
 
       if (haveDot && classGraphEnabled)
@@ -1896,12 +1896,12 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
     }
     TemplateVariant hasCollaborationDiagram() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       return haveDot && !getCollaborationGraph()->isTrivial();
     }
     TemplateVariant collaborationDiagram() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       TextStream t;
       if (haveDot)
       {
@@ -2526,7 +2526,7 @@ class NamespaceContext::Private : public DefinitionContext<NamespaceContext::Pri
   private:
     TemplateVariant createClasses() const
     {
-      static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+      bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
       TemplateVariantList classList;
       classList.reserve(m_namespaceDef->getClasses().size());
       for (const auto &cd : m_namespaceDef->getClasses())
@@ -2601,7 +2601,7 @@ class NamespaceContext::Private : public DefinitionContext<NamespaceContext::Pri
     }
     TemplateVariant createVariables() const
     {
-      static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+      bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
       return createMemberList(MemberListType_decVarMembers, sliceOpt ? theTranslator->trConstants() :
                                                                        theTranslator->trVariables());
     }
@@ -2629,7 +2629,7 @@ class NamespaceContext::Private : public DefinitionContext<NamespaceContext::Pri
     }
     TemplateVariant createDetailedVariables() const
     {
-      static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+      bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
       return createMemberList(MemberListType_docVarMembers, sliceOpt ? theTranslator->trConstantDocumentation() :
                                                                        theTranslator->trVariableDocumentation());
     }
@@ -2779,13 +2779,13 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
 
     TemplateVariant hasIncludeGraph() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       DotInclDepGraphPtr incGraph = getIncludeGraph();
       return (haveDot && !incGraph->isTooBig() && !incGraph->isTrivial());
     }
     TemplateVariant includeGraph() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       TextStream t;
       if (haveDot)
       {
@@ -2821,13 +2821,13 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
     }
     TemplateVariant hasIncludedByGraph() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       DotInclDepGraphPtr incGraph = getIncludedByGraph();
       return (haveDot && !incGraph->isTooBig() && !incGraph->isTrivial());
     }
     TemplateVariant includedByGraph() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       TextStream t;
       if (haveDot)
       {
@@ -2958,7 +2958,7 @@ class FileContext::Private : public DefinitionContext<FileContext::Private>
     }
     TemplateVariant createVariables() const
     {
-      static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+      bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
       return createMemberList(MemberListType_decVarMembers, sliceOpt ? theTranslator->trConstants() :
                                                                        theTranslator->trVariables());
     }
@@ -3134,8 +3134,8 @@ class DirContext::Private : public DefinitionContext<DirContext::Private>
     TemplateVariant hasDirGraph() const
     {
       bool result=FALSE;
-      static bool haveDot  = Config_getBool(HAVE_DOT);
-      static bool dirGraph = Config_getBool(DIRECTORY_GRAPH);
+      bool haveDot  = Config_getBool(HAVE_DOT);
+      bool dirGraph = Config_getBool(DIRECTORY_GRAPH);
       if (haveDot && dirGraph)
       {
         DotDirDepsPtr graph = getDirDepsGraph();
@@ -3146,8 +3146,8 @@ class DirContext::Private : public DefinitionContext<DirContext::Private>
     TemplateVariant dirGraph() const
     {
       TextStream t;
-      static bool haveDot  = Config_getBool(HAVE_DOT);
-      static bool dirGraph = Config_getBool(DIRECTORY_GRAPH);
+      bool haveDot  = Config_getBool(HAVE_DOT);
+      bool dirGraph = Config_getBool(DIRECTORY_GRAPH);
       if (haveDot && dirGraph)
       {
         DotDirDepsPtr graph = getDirDepsGraph();
@@ -3489,7 +3489,7 @@ class TextGeneratorLatex : public TextGeneratorIntf
                    const QCString &anchor,const QCString &text
                   ) const
     {
-      static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+      bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
       if (ref.isEmpty() && pdfHyperlinks)
       {
         m_ts << "\\mbox{\\hyperlink{";
@@ -3720,7 +3720,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
     }
     TemplateVariant hasCallGraph() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       if (m_memberDef->hasCallGraph() && haveDot &&
           (m_memberDef->isFunction() || m_memberDef->isSlot() || m_memberDef->isSignal()))
       {
@@ -3778,7 +3778,7 @@ class MemberContext::Private : public DefinitionContext<MemberContext::Private>
     }
     TemplateVariant hasCallerGraph() const
     {
-      static bool haveDot = Config_getBool(HAVE_DOT);
+      bool haveDot = Config_getBool(HAVE_DOT);
       if (m_memberDef->hasCallerGraph() && haveDot &&
           (m_memberDef->isFunction() || m_memberDef->isSlot() || m_memberDef->isSignal()))
       {
@@ -4584,8 +4584,8 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
     TemplateVariant hasGroupGraph() const
     {
       bool result=FALSE;
-      static bool haveDot     = Config_getBool(HAVE_DOT);
-      static bool groupGraphs = Config_getBool(GROUP_GRAPHS);
+      bool haveDot     = Config_getBool(HAVE_DOT);
+      bool groupGraphs = Config_getBool(GROUP_GRAPHS);
       if (haveDot && groupGraphs)
       {
         DotGroupCollaborationPtr graph = getGroupGraph();
@@ -4596,8 +4596,8 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
     TemplateVariant groupGraph() const
     {
       TextStream t;
-      static bool haveDot     = Config_getBool(HAVE_DOT);
-      static bool groupGraphs = Config_getBool(GROUP_GRAPHS);
+      bool haveDot     = Config_getBool(HAVE_DOT);
+      bool groupGraphs = Config_getBool(GROUP_GRAPHS);
       if (haveDot && groupGraphs)
       {
         DotGroupCollaborationPtr graph = getGroupGraph();
@@ -4760,7 +4760,7 @@ class ModuleContext::Private : public DefinitionContext<ModuleContext::Private>
     }
     TemplateVariant createVariables() const
     {
-      static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+      bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
       return createMemberList(MemberListType_decVarMembers, sliceOpt ? theTranslator->trConstants() :
                                                                        theTranslator->trVariables());
     }
@@ -5353,7 +5353,7 @@ class NestingNodeContext::Private
     }
     QCString relPathAsString() const
     {
-      static bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
+      bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
       return createSubdirs ? QCString("../../") : QCString("");
     }
 
@@ -7028,7 +7028,7 @@ class NavPathElemContext::Private
     }
     QCString relPathAsString() const
     {
-      static bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
+      bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
       return createSubdirs ? QCString("../../") : QCString("");
     }
   private:
@@ -7411,8 +7411,8 @@ class InheritanceGraphContext::Private
     TemplateVariant createGraph() const
     {
       TextStream t;
-      static bool haveDot            = Config_getBool(HAVE_DOT);
-      static bool graphicalHierarchy = Config_getBool(GRAPHICAL_HIERARCHY);
+      bool haveDot            = Config_getBool(HAVE_DOT);
+      bool graphicalHierarchy = Config_getBool(GRAPHICAL_HIERARCHY);
       if (haveDot && graphicalHierarchy)
       {
         m_hierarchy->createGraph(m_node,t,
@@ -7718,7 +7718,7 @@ class AllMembersListContext::Private : public GenericNodeListContext
   public:
     Private(const MemberNameInfoLinkedMap &ml)
     {
-      static bool hideUndocMembers = Config_getBool(HIDE_UNDOC_MEMBERS);
+      bool hideUndocMembers = Config_getBool(HIDE_UNDOC_MEMBERS);
       for (auto &mni : ml)
       {
         for (auto &mi : *mni)

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -587,7 +587,7 @@ class FilterCache
     FilterCache() : m_endPos(0) { }
     bool getFileContents(const QCString &fileName,BufStr &str)
     {
-      static bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
+      bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
       QCString filter = getFileFilter(fileName,TRUE);
       bool usePipe = !filter.isEmpty() && filterSourceFiles;
       FILE *f=0;
@@ -719,7 +719,7 @@ bool readCodeFragment(const QCString &fileName,
                       int &startLine,int &endLine,QCString &result)
 {
   //printf("readCodeFragment(%s,startLine=%d,endLine=%d)\n",fileName,startLine,endLine);
-  static bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
+  bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
   QCString filter = getFileFilter(fileName,TRUE);
   bool usePipe = !filter.isEmpty() && filterSourceFiles;
   int tabSize = Config_getInt(TAB_SIZE);
@@ -859,7 +859,7 @@ QCString DefinitionImpl::getSourceFileBase() const
 {
   ASSERT(m_impl->def->definitionType()!=Definition::TypeFile); // file overloads this method
   QCString fn;
-  static bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
+  bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
   if (sourceBrowser &&
       m_impl->body && m_impl->body->startLine!=-1 && m_impl->body->fileDef)
   {
@@ -962,7 +962,7 @@ bool DefinitionImpl::hasSources() const
 /*! Write code of this definition into the documentation */
 void DefinitionImpl::writeInlineCode(OutputList &ol,const QCString &scopeName) const
 {
-  static bool inlineSources = Config_getBool(INLINE_SOURCES);
+  bool inlineSources = Config_getBool(INLINE_SOURCES);
   ol.pushGeneratorState();
   //printf("Source Fragment %s: %d-%d bodyDef=%p\n",qPrint(name()),
   //        m_startBodyLine,m_endBodyLine,m_bodyDef);
@@ -1027,14 +1027,14 @@ void DefinitionImpl::_writeSourceRefList(OutputList &ol,const QCString &scopeNam
     const QCString &text,const std::unordered_map<std::string,const MemberDef *> &membersMap,
     bool /*funcOnly*/) const
 {
-  static bool sourceBrowser   = Config_getBool(SOURCE_BROWSER);
-  static bool refLinkSource   = Config_getBool(REFERENCES_LINK_SOURCE);
   if (!membersMap.empty())
   {
     auto members = refMapToVector(membersMap);
 
     auto replaceFunc = [this,&members,scopeName,&ol](size_t entryIndex)
     {
+      bool sourceBrowser   = Config_getBool(SOURCE_BROWSER);
+      bool refLinkSource   = Config_getBool(REFERENCES_LINK_SOURCE);
       const MemberDef *md=members[entryIndex];
       if (md)
       {
@@ -1113,8 +1113,8 @@ bool DefinitionImpl::hasSourceRefs() const
 
 bool DefinitionImpl::hasDocumentation() const
 {
-  static bool extractAll    = Config_getBool(EXTRACT_ALL);
-  //static bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
+  bool extractAll    = Config_getBool(EXTRACT_ALL);
+  //bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
   bool hasDocs =
          (m_impl->details    && !m_impl->details->doc.isEmpty())    || // has detailed docs
          (m_impl->brief      && !m_impl->brief->doc.isEmpty())      || // has brief description
@@ -1848,7 +1848,7 @@ QCString DefinitionImpl::_symbolName() const
 
 bool DefinitionImpl::hasBriefDescription() const
 {
-  static bool briefMemberDesc = Config_getBool(BRIEF_MEMBER_DESC);
+  bool briefMemberDesc = Config_getBool(BRIEF_MEMBER_DESC);
   return !briefDescription().isEmpty() && briefMemberDesc;
 }
 

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -464,7 +464,7 @@ QCString DirDefImpl::shortTitle() const
 
 bool DirDefImpl::hasDetailedDescription() const
 {
-  static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
+  bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   return (!briefDescription().isEmpty() && repeatBrief) || !documentation().isEmpty();
 }
 
@@ -507,7 +507,7 @@ void DirDefImpl::writeTagFile(TextStream &tagFile)
 
 void DirDefImpl::writeDocumentation(OutputList &ol)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   ol.pushGeneratorState();
 
   QCString title=theTranslator->trDirReference(m_dispName);
@@ -881,7 +881,7 @@ static void writePartialFilePath(OutputList &ol,const DirDef *root,const FileDef
 
 void DirRelation::writeDocumentation(OutputList &ol)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   ol.pushGeneratorState();
   ol.disableAllBut(OutputGenerator::Html);
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -423,7 +423,7 @@ DB_VIS_C
       break;
     case DocVerbatim::PlantUML:
       {
-        static QCString docbookOutput = Config_getString(DOCBOOK_OUTPUT);
+        QCString docbookOutput = Config_getString(DOCBOOK_OUTPUT);
         QCString baseName = PlantumlManager::instance().writePlantUMLSource(docbookOutput,s->exampleFile(),s->text(),PlantumlManager::PUML_BITMAP,s->engine(),s->srcFile(),s->srcLine());
         QCString shortName = baseName;
         int i;

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -696,7 +696,7 @@ bool DocParser::findDocsForMemberOrCompound(const QCString &commandName,
   // for symbols we need to normalize the separator, so A#B, or A\B, or A.B becomes A::B
   cmdArg = substitute(cmdArg,"#","::");
   cmdArg = substitute(cmdArg,"\\","::");
-  static bool extractAnonNs = Config_getBool(EXTRACT_ANON_NSPACES);
+  bool extractAnonNs = Config_getBool(EXTRACT_ANON_NSPACES);
   if (extractAnonNs &&
       cmdArg.startsWith("anonymous_namespace{")
       )
@@ -1044,7 +1044,7 @@ void DocParser::handleUnclosedStyleCommands()
 void DocParser::handleLinkedWord(DocNode *parent,DocNodeList &children,bool ignoreAutoLinkFlag)
 {
   QCString name = linkToText(SrcLangExt_Unknown,context.token->name,TRUE);
-  static bool autolinkSupport = Config_getBool(AUTOLINK_SUPPORT);
+  bool autolinkSupport = Config_getBool(AUTOLINK_SUPPORT);
   if (!autolinkSupport && !ignoreAutoLinkFlag) // no autolinking -> add as normal word
   {
     children.push_back(std::make_unique<DocWord>(*this,parent,name));
@@ -5725,7 +5725,7 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       break;
     case CMD_STARTUML:
       {
-        static QCString jarPath = Config_getString(PLANTUML_JAR_PATH);
+        QCString jarPath = Config_getString(PLANTUML_JAR_PATH);
         m_parser.tokenizer.setStatePlantUMLOpt();
         retval = m_parser.tokenizer.lex();
 

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -177,7 +177,7 @@ static int computeIndent(const char *str,size_t length)
   if (str==0 || length==std::string::npos) return 0;
   size_t i;
   int indent=0;
-  static int tabSize=Config_getInt(TAB_SIZE);
+  int tabSize=Config_getInt(TAB_SIZE);
   for (i=0;i<length;i++)
   {
     if (str[i]=='\t')

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -62,9 +62,9 @@ typedef std::vector< std::pair< std::unique_ptr<DirRelation>, bool> > DirRelatio
 /** Returns a DOT color name according to the directory depth. */
 static QCString getDirectoryBackgroundColor(int depthIndex)
 {
-  static int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
-  static int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
-  static int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
+  int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
+  int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
+  int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
   assert(depthIndex>=0 && depthIndex<=Config_getInt(DIR_GRAPH_MAX_DEPTH));
   float fraction = static_cast<float>(depthIndex)/static_cast<float>(Config_getInt(DIR_GRAPH_MAX_DEPTH));
   const char hex[] = "0123456789abcdef";

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -131,7 +131,7 @@ static void writeBoxMemberList(TextStream &t,
     }
 
     int count=0;
-    static auto dotUmlDetails = Config_getEnum(DOT_UML_DETAILS);
+    auto dotUmlDetails = Config_getEnum(DOT_UML_DETAILS);
     for (const auto &mma : *ml)
     {
       if (mma->getClassDef() == scope &&
@@ -408,7 +408,7 @@ void DotNode::writeBox(TextStream &t,
 
     //printf("DotNode::writeBox for %s\n",qPrint(m_classDef->name()));
     t << "{" << convertLabel(m_label) << "\\n";
-    static auto dotUmlDetails = Config_getEnum(DOT_UML_DETAILS);
+    auto dotUmlDetails = Config_getEnum(DOT_UML_DETAILS);
     if (dotUmlDetails!=DOT_UML_DETAILS_t::NONE)
     {
       t << "|";

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1452,7 +1452,7 @@ static void resolveClassNestingRelations()
 
 void distributeClassGroupRelations()
 {
-  //static bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
+  //bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
   //if (!inlineGroupedClasses) return;
   //printf("** distributeClassGroupRelations()\n");
 
@@ -2790,7 +2790,7 @@ done:
 
 static void addVariable(const Entry *root,int isFuncPtr=-1)
 {
-    static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+    bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
 
     Debug::print(Debug::Variables,0,
                   "VARIABLE_SEC: \n"
@@ -2947,7 +2947,7 @@ static void addVariable(const Entry *root,int isFuncPtr=-1)
       //int anonyScopes = 0;
       //bool added=FALSE;
 
-      static bool inlineSimpleStructs = Config_getBool(INLINE_SIMPLE_STRUCTS);
+      bool inlineSimpleStructs = Config_getBool(INLINE_SIMPLE_STRUCTS);
       if (si!=-1 && !inlineSimpleStructs) // anonymous scope or type
       {
         QCString pScope;
@@ -5970,7 +5970,7 @@ static void addMemberFunction(const Entry *root,
         candidates++;
       }
     }
-    static bool strictProtoMatching = Config_getBool(STRICT_PROTO_MATCHING);
+    bool strictProtoMatching = Config_getBool(STRICT_PROTO_MATCHING);
     if (!strictProtoMatching)
     {
       if (candidates==1 && ucd && umd)
@@ -8970,7 +8970,7 @@ static void findDefineDocumentation(Entry *root)
     }
     else if (!root->doc.isEmpty() || !root->brief.isEmpty()) // define not found
     {
-      static bool preEnabled = Config_getBool(ENABLE_PREPROCESSING);
+      bool preEnabled = Config_getBool(ENABLE_PREPROCESSING);
       if (preEnabled)
       {
         warn(root->fileName,root->startLine,
@@ -9503,7 +9503,7 @@ static void generateNamespaceConceptDocs(const ConceptLinkedRefMap &conceptList)
 
 static void generateNamespaceDocs()
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
 
   //writeNamespaceIndex(*g_outputList);
 
@@ -12291,8 +12291,8 @@ void generateOutput()
   g_outputList->writeStyleInfo(0); // write first part
   g_s.end();
 
-  static bool searchEngine      = Config_getBool(SEARCHENGINE);
-  static bool serverBasedSearch = Config_getBool(SERVER_BASED_SEARCH);
+  bool searchEngine      = Config_getBool(SEARCHENGINE);
+  bool serverBasedSearch = Config_getBool(SERVER_BASED_SEARCH);
 
   g_s.begin("Generating search indices...\n");
   if (searchEngine && !serverBasedSearch && (generateHtml || g_useOutputTemplate))

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -305,8 +305,8 @@ void FileDefImpl::findSectionsInDocumentation()
 
 bool FileDefImpl::hasDetailedDescription() const
 {
-  static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
-  static bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
+  bool repeatBrief = Config_getBool(REPEAT_BRIEF);
+  bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
   return ((!briefDescription().isEmpty() && repeatBrief) ||
           !documentation().stripWhiteSpace().isEmpty() || // avail empty section
           (sourceBrowser && getStartBodyLine()!=-1 && getBodyDef())
@@ -814,7 +814,7 @@ void FileDefImpl::writeSummaryLinks(OutputList &ol) const
 */
 void FileDefImpl::writeDocumentation(OutputList &ol)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   //funcList->countDecMembers();
 
   //QCString fn = name();
@@ -1023,7 +1023,7 @@ void FileDefImpl::writeMemberPages(OutputList &ol)
 
 void FileDefImpl::writeQuickMemberLinks(OutputList &ol,const MemberDef *currentMd) const
 {
-  static bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
+  bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
 
   ol.writeString("      <div class=\"navtab\">\n");
   ol.writeString("        <table>\n");
@@ -1169,7 +1169,7 @@ void FileDefImpl::writeSourceFooter(OutputList &ol)
 
 void FileDefImpl::parseSource(ClangTUParser *clangParser)
 {
-  static bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
+  bool filterSourceFiles = Config_getBool(FILTER_SOURCE_FILES);
   DevNullCodeDocInterface devNullIntf;
 #if USE_LIBCLANG
   if (Doxygen::clangAssistedParsing && clangParser &&
@@ -1444,8 +1444,8 @@ bool FileDefImpl::isIncluded(const QCString &name) const
 
 bool FileDefImpl::generateSourceFile() const
 {
-  static bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
-  static bool verbatimHeaders = Config_getBool(VERBATIM_HEADERS);
+  bool sourceBrowser = Config_getBool(SOURCE_BROWSER);
+  bool verbatimHeaders = Config_getBool(VERBATIM_HEADERS);
   return !isReference() &&
          (sourceBrowser ||
            (verbatimHeaders && guessSection(name())==Entry::HEADER_SEC)
@@ -1578,8 +1578,8 @@ QCString FileDefImpl::includeName() const
 
 void FileDefImpl::addMemberToList(MemberListType lt,MemberDef *md)
 {
-  static bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
-  static bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
+  bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
+  bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
   const auto &ml = m_memberLists.get(lt,MemberListContainer::File);
   ml->setNeedsSorting(
        ((ml->listType()&MemberListType_declarationLists) && sortBriefDocs) ||
@@ -1648,7 +1648,7 @@ MemberList *FileDefImpl::getMemberList(MemberListType lt) const
 
 void FileDefImpl::writeMemberDeclarations(OutputList &ol,MemberListType lt,const QCString &title)
 {
-  static bool optVhdl = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool optVhdl = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
   MemberList * ml = getMemberList(lt);
   if (ml)
   {
@@ -1672,7 +1672,7 @@ void FileDefImpl::writeMemberDocumentation(OutputList &ol,MemberListType lt,cons
 
 bool FileDefImpl::isLinkableInProject() const
 {
-  static bool showFiles = Config_getBool(SHOW_FILES);
+  bool showFiles = Config_getBool(SHOW_FILES);
   return hasDocumentation() && !isReference() && (showFiles || isLinkableViaGroup());
 }
 

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1029,7 +1029,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
                   Definition *d,const QCString &text)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
+  bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
   yyextra->tooltipManager.addTooltip(ol,d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();

--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -563,7 +563,7 @@ static QCString convertFileId2Var(const QCString &fileId)
 static bool generateJSTree(NavIndexEntryList &navIndex,TextStream &t,
                            const std::vector<FTVNode*> &nl,int level,bool &first)
 {
-  static QCString htmlOutput = Config_getString(HTML_OUTPUT);
+  QCString htmlOutput = Config_getString(HTML_OUTPUT);
   QCString indentStr;
   indentStr.fill(' ',level*2);
   bool found=FALSE;

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -236,7 +236,7 @@ void GroupDefImpl::findSectionsInDocumentation()
 
 void GroupDefImpl::addFile(const FileDef *def)
 {
-  static bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
+  bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
   if (def->isHidden()) return;
   updateLanguage(def);
   if (sortBriefDocs)
@@ -1100,7 +1100,7 @@ void GroupDefImpl::writeSummaryLinks(OutputList &ol) const
 
 void GroupDefImpl::writeDocumentation(OutputList &ol)
 {
-  //static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  //bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   ol.pushGeneratorState();
   startFile(ol,getOutputFileBase(),name(),m_title,HLI_Modules);
 
@@ -1274,7 +1274,7 @@ void GroupDefImpl::writeMemberPages(OutputList &ol)
 
 void GroupDefImpl::writeQuickMemberLinks(OutputList &ol,const MemberDef *currentMd) const
 {
-  static bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
+  bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
 
   ol.writeString("      <div class=\"navtab\">\n");
   ol.writeString("        <table>\n");
@@ -1576,8 +1576,8 @@ void GroupDefImpl::addListReferences()
 
 void GroupDefImpl::addMemberToList(MemberListType lt,const MemberDef *md)
 {
-  static bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
-  static bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
+  bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
+  bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
   const auto &ml = m_memberLists.get(lt,MemberListContainer::Group);
   ml->setNeedsSorting(
       ((ml->listType()&MemberListType_declarationLists) && sortBriefDocs) ||
@@ -1691,7 +1691,7 @@ MemberList *GroupDefImpl::getMemberList(MemberListType lt) const
 
 void GroupDefImpl::writeMemberDeclarations(OutputList &ol,MemberListType lt,const QCString &title)
 {
-  static bool optimizeVhdl = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool optimizeVhdl = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
 
   MemberList * ml = getMemberList(lt);
   if (optimizeVhdl && ml)
@@ -1747,7 +1747,7 @@ void GroupDefImpl::updateLanguage(const Definition *d)
 
 bool GroupDefImpl::hasDetailedDescription() const
 {
-  static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
+  bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   return ((!briefDescription().isEmpty() && repeatBrief) ||
          !documentation().isEmpty() ||
          !inbodyDocumentation().isEmpty()) &&

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -672,7 +672,7 @@ void HtmlDocVisitor::visit(DocVerbatim *s)
     case DocVerbatim::PlantUML:
       {
         forceEndParagraph(s);
-        static QCString htmlOutput = Config_getString(HTML_OUTPUT);
+        QCString htmlOutput = Config_getString(HTML_OUTPUT);
         QCString imgExt = getDotImageExtension();
         PlantumlManager::OutputFormat format = PlantumlManager::PUML_BITMAP;	// default : PUML_BITMAP
         if (imgExt=="svg")
@@ -2332,7 +2332,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   {
     baseName=baseName.left(i);
   }
-  static QCString outDir = Config_getString(HTML_OUTPUT);
+  QCString outDir = Config_getString(HTML_OUTPUT);
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")
   {

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -526,7 +526,7 @@ void HtmlHelp::addContentsItem(bool isDir,
                                bool /* addToNavIndex */,
                                const Definition * /* def */)
 {
-  static bool binaryTOC = Config_getBool(BINARY_TOC);
+  bool binaryTOC = Config_getBool(BINARY_TOC);
   // If we're using a binary toc then folders cannot have links.
   // Tried this and I didn't see any problems, when not using
   // the resetting of file and anchor the TOC works better
@@ -580,7 +580,7 @@ void HtmlHelp::addIndexItem(const Definition *context,const MemberDef *md,
 {
   if (md)
   {
-    static bool separateMemberPages = Config_getBool(SEPARATE_MEMBER_PAGES);
+    bool separateMemberPages = Config_getBool(SEPARATE_MEMBER_PAGES);
     if (context==0) // global member
     {
       if (md->getGroupDef())

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -208,9 +208,9 @@ static Color palette3[] =
 
 Image::Image(uint w,uint h)
 {
-  static int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
-  static int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
-  static int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
+  int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
+  int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
+  int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
 
   double red1,green1,blue1;
   double red2,green2,blue2;
@@ -381,7 +381,7 @@ void Image::fillRect(uint x,uint y,uint width,uint height,uchar colIndex,uint ma
 
 bool Image::save(const QCString &fileName,int mode)
 {
-  static bool useTransparency = Config_getBool(FORMULA_TRANSPARENT);
+  bool useTransparency = Config_getBool(FORMULA_TRANSPARENT);
   uchar* buffer;
   size_t bufferSize;
   LodePNG_Encoder encoder;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -86,7 +86,7 @@ static void countRelatedPages(int &docPages,int &indexPages);
 
 void countDataStructures()
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   annotatedClasses           = countAnnotatedClasses(&annotatedClassesPrinted, ClassDef::Class); // "classes" + "annotated"
   hierarchyClasses           = countClassHierarchy(ClassDef::Class);     // "hierarchy"
   // "interfaces" + "annotated"
@@ -236,7 +236,7 @@ void startFile(OutputList &ol,const QCString &name,const QCString &manName,
                const QCString &title,HighlightedItem hli,bool additionalIndices,
                const QCString &altSidebarName)
 {
-  static bool disableIndex     = Config_getBool(DISABLE_INDEX);
+  bool disableIndex     = Config_getBool(DISABLE_INDEX);
   ol.startFile(name,manName,title);
   ol.startQuickIndices();
   if (!disableIndex)
@@ -254,7 +254,7 @@ void startFile(OutputList &ol,const QCString &name,const QCString &manName,
 void endFile(OutputList &ol,bool skipNavIndex,bool skipEndContents,
              const QCString &navPath)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   ol.pushGeneratorState();
   ol.disableAllBut(OutputGenerator::Html);
   if (!skipNavIndex)
@@ -273,7 +273,7 @@ void endFile(OutputList &ol,bool skipNavIndex,bool skipEndContents,
 
 void endFileWithNavPath(const Definition *d,OutputList &ol)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   QCString navPath;
   if (generateTreeView)
   {
@@ -394,7 +394,7 @@ void addMembersToIndex(T *def,LayoutDocManager::LayoutPart part,
         {
           if (cd->isLinkable() && (cd->partOfGroups().empty() || def->definitionType()==Definition::TypeGroup))
           {
-            static bool inlineSimpleStructs = Config_getBool(INLINE_SIMPLE_STRUCTS);
+            bool inlineSimpleStructs = Config_getBool(INLINE_SIMPLE_STRUCTS);
             bool isNestedClass = def->definitionType()==Definition::TypeClass;
             addMembersToIndex(cd,LayoutDocManager::Class,cd->displayName(lde->kind()==LayoutDocEntry::FileClasses),cd->anchor(),
                               addToIndex && (isNestedClass || (cd->isSimple() && inlineSimpleStructs)),
@@ -586,7 +586,7 @@ static void writeDirTreeNode(OutputList &ol, const DirDef *dd, int level, FTVHel
     return;
   }
 
-  static bool tocExpand = TRUE; //Config_getBool(TOC_EXPAND);
+  bool tocExpand = TRUE; //Config_getBool(TOC_EXPAND);
   bool isDir = !dd->subDirs().empty() ||  // there are subdirs
                (tocExpand &&              // or toc expand and
                 !dd->getFiles().empty()   // there are files
@@ -631,7 +631,7 @@ static void writeDirTreeNode(OutputList &ol, const DirDef *dd, int level, FTVHel
   {
     for (const auto &fd : dd->getFiles())
     {
-      //static bool allExternals = Config_getBool(ALLEXTERNALS);
+      //bool allExternals = Config_getBool(ALLEXTERNALS);
       //if ((allExternals && fd->isLinkable()) || fd->isLinkableInProject())
       //{
       //  fileCount++;
@@ -687,7 +687,7 @@ static void writeDirTreeNode(OutputList &ol, const DirDef *dd, int level, FTVHel
     {
       for (const auto &fd : dd->getFiles())
       {
-        //static bool allExternals = Config_getBool(ALLEXTERNALS);
+        //bool allExternals = Config_getBool(ALLEXTERNALS);
         //if ((allExternals && fd->isLinkable()) || fd->isLinkableInProject())
         bool doc,src;
         doc = fileVisibleInIndex(fd,src);
@@ -784,7 +784,7 @@ static void writeDirHierarchy(OutputList &ol, FTVHelp* ftv,bool addToIndex)
 static void writeClassTreeForList(OutputList &ol,const ClassLinkedMap &cl,bool &started,FTVHelp* ftv,bool addToIndex,
                                   ClassDef::CompoundType ct,ClassDefSet &visitedClasses)
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   for (const auto &cd : cl)
   {
     //printf("class %s hasVisibleRoot=%d isVisibleInHierarchy=%d\n",
@@ -909,7 +909,7 @@ static void writeClassHierarchy(OutputList &ol, FTVHelp* ftv,bool addToIndex,Cla
 
 static int countClassesInTreeList(const ClassLinkedMap &cl, ClassDef::CompoundType ct)
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   int count=0;
   for (const auto &cd : cl)
   {
@@ -1523,7 +1523,7 @@ template<>             const ClassDef *get_pointer(const ClassLinkedRefMap::Ptr 
 template<class ListType>
 static void writeClassTree(const ListType &cl,FTVHelp *ftv,bool addToIndex,bool globalOnly,ClassDef::CompoundType ct)
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   for (const auto &cdi : cl)
   {
     const ClassDef *cd = get_pointer(cdi);
@@ -1727,7 +1727,7 @@ static void writeClassTreeInsideNamespace(const NamespaceLinkedRefMap &nsLinkedM
 static void writeClassTreeInsideNamespaceElement(const NamespaceDef *nd,FTVHelp *ftv,
                                bool rootOnly,bool addToIndex,ClassDef::CompoundType ct)
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   if (!nd->isAnonymous() &&
       (!rootOnly || nd->getOuterScope()==Doxygen::globalScope))
   {
@@ -1923,7 +1923,7 @@ static void writeNamespaceIndex(OutputList &ol)
 
 static int countAnnotatedClasses(int *cp, ClassDef::CompoundType ct)
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   int count=0;
   int countPrinted=0;
   for (const auto &cd : *Doxygen::classLinkedMap)
@@ -1952,7 +1952,7 @@ static void writeAnnotatedClassList(OutputList &ol,ClassDef::CompoundType ct)
   //bool addToIndex = lne==0 || lne->visible();
   bool first=TRUE;
 
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
 
   for (const auto &cd : *Doxygen::classLinkedMap)
   {
@@ -2076,7 +2076,7 @@ using UsedIndexLetters = std::set<std::string>;
 // write an alphabetical index of all class with a header for each letter
 static void writeAlphabeticalClassList(OutputList &ol, ClassDef::CompoundType ct, int annotatedCount)
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
 
   // What starting letters are used
   UsedIndexLetters indexLettersUsed;
@@ -2663,7 +2663,7 @@ void initClassMemberIndices()
 
 void addClassMemberNameToIndex(const MemberDef *md)
 {
-  static bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
+  bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
   const ClassDef *cd=0;
 
   if (md->isLinkableInProject() &&
@@ -2945,8 +2945,8 @@ struct CmhlInfo
 
 static const CmhlInfo *getCmhlInfo(size_t hl)
 {
-  static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-  static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
   static CmhlInfo cmhlInfo[] =
   {
     CmhlInfo("functions",     theTranslator->trAll()),
@@ -2969,7 +2969,7 @@ static void writeClassMemberIndexFiltered(OutputList &ol, ClassMemberHighlight h
 {
   if (documentedClassMembers[hl]==0) return;
 
-  static bool disableIndex     = Config_getBool(DISABLE_INDEX);
+  bool disableIndex     = Config_getBool(DISABLE_INDEX);
 
   bool multiPageIndex=FALSE;
   if (documentedClassMembers[hl]>MAX_ITEMS_BEFORE_MULTIPAGE_INDEX)
@@ -3122,9 +3122,9 @@ struct FmhlInfo
 
 static const FmhlInfo *getFmhlInfo(size_t hl)
 {
-  static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-  static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-  static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   static FmhlInfo fmhlInfo[] =
   {
     FmhlInfo("globals",     theTranslator->trAll()),
@@ -3147,7 +3147,7 @@ static void writeFileMemberIndexFiltered(OutputList &ol, FileMemberHighlight hl)
 {
   if (documentedFileMembers[hl]==0) return;
 
-  static bool disableIndex     = Config_getBool(DISABLE_INDEX);
+  bool disableIndex     = Config_getBool(DISABLE_INDEX);
 
   bool multiPageIndex=FALSE;
   if (documentedFileMembers[hl]>MAX_ITEMS_BEFORE_MULTIPAGE_INDEX)
@@ -3293,9 +3293,9 @@ struct NmhlInfo
 
 static const NmhlInfo *getNmhlInfo(size_t hl)
 {
-  static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-  static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-  static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   static NmhlInfo nmhlInfo[] =
   {
     NmhlInfo("namespacemembers",     theTranslator->trAll()),
@@ -3320,7 +3320,7 @@ static void writeNamespaceMemberIndexFiltered(OutputList &ol,
 {
   if (documentedNamespaceMembers[hl]==0) return;
 
-  static bool disableIndex     = Config_getBool(DISABLE_INDEX);
+  bool disableIndex     = Config_getBool(DISABLE_INDEX);
 
 
   bool multiPageIndex=FALSE;
@@ -3544,7 +3544,7 @@ static void countRelatedPages(int &docPages,int &indexPages)
 
 static bool mainPageHasOwnTitle()
 {
-  static QCString projectName = Config_getString(PROJECT_NAME);
+  QCString projectName = Config_getString(PROJECT_NAME);
   QCString title;
   if (Doxygen::mainPage)
   {
@@ -4309,9 +4309,9 @@ static void writeUserGroupStubPage(OutputList &ol,LayoutNavEntry *lne)
 
 static void writeIndex(OutputList &ol)
 {
-  static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-  static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-  static QCString projectName = Config_getString(PROJECT_NAME);
+  bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  QCString projectName = Config_getString(PROJECT_NAME);
   // save old generator state
   ol.pushGeneratorState();
 
@@ -4702,7 +4702,7 @@ static std::vector<bool> indexWritten;
 
 static void writeIndexHierarchyEntries(OutputList &ol,const LayoutNavEntryList &entries)
 {
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   for (const auto &lne : entries)
   {
     LayoutNavEntry::Kind kind = lne->kind();
@@ -4736,7 +4736,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const LayoutNavEntryList &
           break;
         case LayoutNavEntry::Namespaces:
           {
-            static bool showNamespaces = Config_getBool(SHOW_NAMESPACES);
+            bool showNamespaces = Config_getBool(SHOW_NAMESPACES);
             if (showNamespaces)
             {
               if (documentedNamespaces>0 && addToIndex)
@@ -4755,7 +4755,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const LayoutNavEntryList &
           break;
         case LayoutNavEntry::NamespaceList:
           {
-            static bool showNamespaces = Config_getBool(SHOW_NAMESPACES);
+            bool showNamespaces = Config_getBool(SHOW_NAMESPACES);
             if (showNamespaces)
             {
               msg("Generating namespace index...\n");
@@ -4998,8 +4998,8 @@ static void writeIndexHierarchyEntries(OutputList &ol,const LayoutNavEntryList &
 
 static bool quickLinkVisible(LayoutNavEntry::Kind kind)
 {
-  static bool showNamespaces = Config_getBool(SHOW_NAMESPACES);
-  static bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+  bool showNamespaces = Config_getBool(SHOW_NAMESPACES);
+  bool sliceOpt = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
   switch (kind)
   {
     case LayoutNavEntry::MainPage:           return TRUE;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -46,7 +46,7 @@ static const char *secLabels[maxLevels] =
 
 static const char *getSectionName(int level)
 {
-  static bool compactLatex = Config_getBool(COMPACT_LATEX);
+  bool compactLatex = Config_getBool(COMPACT_LATEX);
   int l = level;
   if (compactLatex) l++;
   if (Doxygen::insideMainPage) l--;
@@ -1220,7 +1220,7 @@ void LatexDocVisitor::visitPre(DocHtmlTable *t)
   if (t->hasCaption())
   {
     DocHtmlCaption *c = t->caption();
-    static bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
+    bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
     if (!c->file().isEmpty() && pdfHyperLinks)
     {
       m_t << "\\hypertarget{" << stripPath(c->file()) << "_" << c->anchor()
@@ -1846,7 +1846,7 @@ void LatexDocVisitor::visitPost(DocParamList *pl)
 
 void LatexDocVisitor::visitPre(DocXRefItem *x)
 {
-  static bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+  bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   if (m_hide) return;
   if (x->title().isEmpty()) return;
   incIndentLevel();
@@ -1949,7 +1949,7 @@ void LatexDocVisitor::filter(const QCString &str, const bool retainNewLine)
 
 void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable)
 {
-  static bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
+  bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
   if (ref.isEmpty() && pdfHyperLinks) // internal PDF link
   {
     if (refToTable)
@@ -1982,7 +1982,7 @@ void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const Q
 void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable)
 {
   m_t << "}";
-  static bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
+  bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
   if (ref.isEmpty() && !pdfHyperLinks)
   {
     m_t << "{";

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -267,13 +267,13 @@ class LayoutParser
 
     void startNavEntry(const XMLHandlers::Attributes &attrib)
     {
-      static bool javaOpt    = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
-      static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
-      static bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-      static bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
-      static bool hasGraphicalHierarchy = Config_getBool(HAVE_DOT) &&
+      bool javaOpt    = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
+      bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+      bool vhdlOpt    = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool sliceOpt   = Config_getBool(OPTIMIZE_OUTPUT_SLICE);
+      bool hasGraphicalHierarchy = Config_getBool(HAVE_DOT) &&
                                           Config_getBool(GRAPHICAL_HIERARCHY);
-      static bool extractAll = Config_getBool(EXTRACT_ALL);
+      bool extractAll = Config_getBool(EXTRACT_ALL);
       static struct NavEntryMap
       {
         const char *typeStr;       // type attribute name in the XML file

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1519,8 +1519,8 @@ bool MemberDefImpl::hasExamples() const
 
 QCString MemberDefImpl::getOutputFileBase() const
 {
-  static bool separateMemberPages = Config_getBool(SEPARATE_MEMBER_PAGES);
-  static bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
+  bool separateMemberPages = Config_getBool(SEPARATE_MEMBER_PAGES);
+  bool inlineSimpleClasses = Config_getBool(INLINE_SIMPLE_STRUCTS);
   QCString baseName;
 
   //printf("Member: %s: templateMaster=%p group=%p classDef=%p nspace=%p fileDef=%p\n",
@@ -1640,8 +1640,8 @@ QCString MemberDefImpl::anchor() const
 
 void MemberDefImpl::_computeLinkableInProject()
 {
-  static bool extractStatic  = Config_getBool(EXTRACT_STATIC);
-  static bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
+  bool extractStatic  = Config_getBool(EXTRACT_STATIC);
+  bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
   m_isLinkableCached = 2; // linkable
   //printf("MemberDefImpl::isLinkableInProject(name=%s)\n",qPrint(name()));
   if (isHidden())
@@ -1774,7 +1774,7 @@ void MemberDefImpl::writeLink(OutputList &ol,
                       bool onlyText) const
 {
   SrcLangExt lang = getLanguage();
-  static bool hideScopeNames     = Config_getBool(HIDE_SCOPE_NAMES);
+  bool hideScopeNames     = Config_getBool(HIDE_SCOPE_NAMES);
   QCString sep = getLanguageSpecificSeparator(lang,TRUE);
   QCString n = name();
   const ClassDef *classDef = getClassDef();
@@ -1883,12 +1883,12 @@ ClassDef *MemberDefImpl::getClassDefOfAnonymousType() const
  */
 bool MemberDefImpl::isBriefSectionVisible() const
 {
-  static bool extractStatic       = Config_getBool(EXTRACT_STATIC);
-  static bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
-  static bool hideUndocMembers    = Config_getBool(HIDE_UNDOC_MEMBERS);
-  static bool briefMemberDesc     = Config_getBool(BRIEF_MEMBER_DESC);
-  static bool repeatBrief         = Config_getBool(REPEAT_BRIEF);
-  static bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
+  bool extractStatic       = Config_getBool(EXTRACT_STATIC);
+  bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
+  bool hideUndocMembers    = Config_getBool(HIDE_UNDOC_MEMBERS);
+  bool briefMemberDesc     = Config_getBool(BRIEF_MEMBER_DESC);
+  bool repeatBrief         = Config_getBool(REPEAT_BRIEF);
+  bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
 
   //printf("Member %s grpId=%d docs=%s file=%s args=%s\n",
   //    qPrint(name()),
@@ -2266,9 +2266,9 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
   // *** write name
   if (!isAnonymous()) // hide anonymous stuff
   {
-    static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
-    static bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
-    static bool extractStatic  = Config_getBool(EXTRACT_STATIC);
+    bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+    bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
+    bool extractStatic  = Config_getBool(EXTRACT_STATIC);
     MemberDefMutable *annMemb = toMemberDefMutable(m_impl->annMemb);
     //printf("Member name=`%s gd=%p md->groupDef=%p inGroup=%d isLinkable()=%d hasDocumentation=%d\n",qPrint(name()),gd,getGroupDef(),inGroup,isLinkable(),hasDocumentation());
     if (!name().isEmpty() && // name valid
@@ -2496,14 +2496,14 @@ bool MemberDefImpl::hasDetailedDescription() const
   //printf(">hasDetailedDescription(cached=%d)\n",m_impl->hasDetailedDescriptionCached);
   if (!m_impl->hasDetailedDescriptionCached)
   {
-    static bool extractAll            = Config_getBool(EXTRACT_ALL);
-    static bool alwaysDetailedSec     = Config_getBool(ALWAYS_DETAILED_SEC);
-    static bool repeatBrief           = Config_getBool(REPEAT_BRIEF);
-    static bool briefMemberDesc       = Config_getBool(BRIEF_MEMBER_DESC);
-    static bool hideUndocMembers      = Config_getBool(HIDE_UNDOC_MEMBERS);
-    static bool extractStatic         = Config_getBool(EXTRACT_STATIC);
-    static bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
-    static bool inlineSources         = Config_getBool(INLINE_SOURCES);
+    bool extractAll            = Config_getBool(EXTRACT_ALL);
+    bool alwaysDetailedSec     = Config_getBool(ALWAYS_DETAILED_SEC);
+    bool repeatBrief           = Config_getBool(REPEAT_BRIEF);
+    bool briefMemberDesc       = Config_getBool(BRIEF_MEMBER_DESC);
+    bool hideUndocMembers      = Config_getBool(HIDE_UNDOC_MEMBERS);
+    bool extractStatic         = Config_getBool(EXTRACT_STATIC);
+    bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
+    bool inlineSources         = Config_getBool(INLINE_SOURCES);
 
     // the member has detailed documentation because the user added some comments
     bool docFilter =
@@ -2597,9 +2597,9 @@ bool MemberDefImpl::hasDetailedDescription() const
 
 bool MemberDefImpl::isDetailedSectionVisible(MemberListContainer container) const
 {
-  static bool separateMemPages = Config_getBool(SEPARATE_MEMBER_PAGES);
-  static bool inlineSimpleStructs = Config_getBool(INLINE_SIMPLE_STRUCTS);
-  static bool hideUndocMembers = Config_getBool(HIDE_UNDOC_MEMBERS);
+  bool separateMemPages = Config_getBool(SEPARATE_MEMBER_PAGES);
+  bool inlineSimpleStructs = Config_getBool(INLINE_SIMPLE_STRUCTS);
+  bool hideUndocMembers = Config_getBool(HIDE_UNDOC_MEMBERS);
   bool groupFilter = getGroupDef()==0 || container==MemberListContainer::Group || separateMemPages;
   bool fileFilter  = getNamespaceDef()==0 || !getNamespaceDef()->isLinkable() || container!=MemberListContainer::File;
   bool simpleFilter = (hasBriefDescription() || !hideUndocMembers) && inlineSimpleStructs &&
@@ -2616,7 +2616,7 @@ bool MemberDefImpl::isDetailedSectionVisible(MemberListContainer container) cons
 StringVector MemberDefImpl::getLabels(const Definition *container) const
 {
   StringVector sl;
-  static bool inlineInfo = Config_getBool(INLINE_INFO);
+  bool inlineInfo = Config_getBool(INLINE_INFO);
 
   Specifier lvirt=virtualness();
   if ((!isObjCMethod() || isOptional() || isRequired()) &&
@@ -2636,7 +2636,7 @@ StringVector MemberDefImpl::getLabels(const Definition *container) const
     //ol.docify(" [");
     SrcLangExt lang = getLanguage();
     bool optVhdl = lang==SrcLangExt_VHDL;
-    static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+    bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
     if (optVhdl)
     {
       sl.push_back(theTranslator->trVhdlType(getMemberSpecifiers(),TRUE).str());
@@ -3153,7 +3153,7 @@ void MemberDefImpl::_writeGroupInclude(OutputList &ol,bool inGroup) const
 {
   // only write out the include file if this is not part of a class or file
   // definition
-  static bool showGroupedMembInc = Config_getBool(SHOW_GROUPED_MEMB_INC);
+  bool showGroupedMembInc = Config_getBool(SHOW_GROUPED_MEMB_INC);
   const FileDef *fd = getFileDef();
   QCString nm;
   if (fd) nm = getFileDef()->docName();
@@ -3875,7 +3875,7 @@ void MemberDefImpl::warnIfUndocumented() const
     t="group", d=gd;
   else
     t="file", d=fd;
-  static bool extractAll = Config_getBool(EXTRACT_ALL);
+  bool extractAll = Config_getBool(EXTRACT_ALL);
 
   //printf("%s:warnIfUndoc: hasUserDocs=%d isFriendClass=%d protection=%d isRef=%d isDel=%d\n",
   //    qPrint(name()),
@@ -4237,10 +4237,10 @@ void MemberDefImpl::setInitializer(const QCString &initializer)
 
 void MemberDefImpl::addListReference(Definition *)
 {
-  static bool optimizeOutputForC = Config_getBool(OPTIMIZE_OUTPUT_FOR_C);
-  //static bool hideScopeNames     = Config_getBool(HIDE_SCOPE_NAMES);
-  //static bool optimizeOutputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
-  //static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  bool optimizeOutputForC = Config_getBool(OPTIMIZE_OUTPUT_FOR_C);
+  //bool hideScopeNames     = Config_getBool(HIDE_SCOPE_NAMES);
+  //bool optimizeOutputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
+  //bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
   SrcLangExt lang = getLanguage();
   if (!isLinkableInProject()) return;
   QCString memLabel;
@@ -5990,7 +5990,7 @@ const ArgumentList &MemberDefImpl::typeConstraints() const
 
 bool MemberDefImpl::isFriendToHide() const
 {
-  static bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
+  bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
   bool isFriendToHide = hideFriendCompounds &&
      (m_impl->type=="friend class"  ||
       m_impl->type=="friend struct" ||

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -531,7 +531,7 @@ void MemberList::writeDeclarations(OutputList &ol,
   (void)showEnumValues; // unused
 
   //printf("----- writeDeclaration() this=%p ---- inheritedFrom=%p\n",this,inheritedFrom);
-  static bool optimizeVhdl = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+  bool optimizeVhdl = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
   QCString inheritId;
 
   const Definition *ctx = cd;
@@ -749,7 +749,7 @@ void MemberList::writeSimpleDocumentation(OutputList &ol,
 void MemberList::writeDocumentationPage(OutputList &ol,
                      const QCString &scopeName, const DefinitionMutable *container) const
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
 
   struct OverloadInfo
   {

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -468,7 +468,7 @@ void NamespaceDefImpl::insertMember(MemberDef *md)
     //printf("%s::m_allMembersDict->append(%s)\n",qPrint(name()),qPrint(md->localName()));
     m_allMembers.add(md->localName(),md);
     //::addNamespaceMemberNameToIndex(md);
-    //static bool sortBriefDocs=Config_getBool(SORT_BRIEF_DOCS);
+    //bool sortBriefDocs=Config_getBool(SORT_BRIEF_DOCS);
     switch(md->memberType())
     {
       case MemberType_Variable:
@@ -549,7 +549,7 @@ void NamespaceDefImpl::computeAnchors()
 
 bool NamespaceDefImpl::hasDetailedDescription() const
 {
-  static bool repeatBrief = Config_getBool(REPEAT_BRIEF);
+  bool repeatBrief = Config_getBool(REPEAT_BRIEF);
   return ((!briefDescription().isEmpty() && repeatBrief) ||
           !documentation().isEmpty());
 }
@@ -922,9 +922,9 @@ void NamespaceDefImpl::writeConceptsToTagFile(TextStream &tagFile)
 
 void NamespaceDefImpl::writeDocumentation(OutputList &ol)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
-  //static bool outputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
-  //static bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  //bool outputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
+  //bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
 
   QCString pageTitle = title();
   startFile(ol,getOutputFileBase(),name(),pageTitle,HLI_NamespaceVisible,!generateTreeView);
@@ -1105,7 +1105,7 @@ void NamespaceDefImpl::writeMemberPages(OutputList &ol)
 
 void NamespaceDefImpl::writeQuickMemberLinks(OutputList &ol,const MemberDef *currentMd) const
 {
-  static bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
+  bool createSubDirs=Config_getBool(CREATE_SUBDIRS);
 
   ol.writeString("      <div class=\"navtab\">\n");
   ol.writeString("        <table>\n");
@@ -1363,8 +1363,8 @@ void NamespaceLinkedRefMap::writeDeclaration(OutputList &ol,const QCString &titl
 
 void NamespaceDefImpl::addMemberToList(MemberListType lt,MemberDef *md)
 {
-  static bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
-  static bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
+  bool sortBriefDocs = Config_getBool(SORT_BRIEF_DOCS);
+  bool sortMemberDocs = Config_getBool(SORT_MEMBER_DOCS);
   const auto &ml = m_memberLists.get(lt,MemberListContainer::Namespace);
   ml->setNeedsSorting(
       ((ml->listType()&MemberListType_declarationLists) && sortBriefDocs) ||
@@ -1438,7 +1438,7 @@ bool NamespaceDefImpl::isLinkableInProject() const
 {
   int i = name().findRev("::");
   if (i==-1) i=0; else i+=2;
-  static bool extractAnonNs = Config_getBool(EXTRACT_ANON_NSPACES);
+  bool extractAnonNs = Config_getBool(EXTRACT_ANON_NSPACES);
   if (extractAnonNs &&                             // extract anonymous ns
       name().mid(i,20)=="anonymous_namespace{"     // correct prefix
      )                                             // not disabled by config

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -170,7 +170,7 @@ void PageDefImpl::writeTagFile(TextStream &tagFile)
 
 void PageDefImpl::writeDocumentation(OutputList &ol)
 {
-  static bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
+  bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
 
   //outputList->disable(OutputGenerator::Man);
   QCString pageName,manPageName;
@@ -352,7 +352,7 @@ void PageDefImpl::writePageDocumentation(OutputList &ol) const
 
 bool PageDefImpl::visibleInIndex() const
 {
-  static bool externalPages = Config_getBool(EXTERNAL_PAGES);
+  bool externalPages = Config_getBool(EXTERNAL_PAGES);
   return // not part of a group
          !getGroupDef() &&
          // not an externally defined page

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -340,7 +340,7 @@ void Qhp::addIndexItem(const Definition *context,const MemberDef *md,
 
   if (md) // member
   {
-    static bool separateMemberPages = Config_getBool(SEPARATE_MEMBER_PAGES);
+    bool separateMemberPages = Config_getBool(SEPARATE_MEMBER_PAGES);
     if (context==0) // global member
     {
       if (md->getGroupDef())

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -418,7 +418,7 @@ void RTFDocVisitor::visit(DocVerbatim *s)
       break;
     case DocVerbatim::PlantUML:
       {
-        static QCString rtfOutput = Config_getString(RTF_OUTPUT);
+        QCString rtfOutput = Config_getString(RTF_OUTPUT);
         QCString baseName = PlantumlManager::instance().writePlantUMLSource(
                        rtfOutput,s->exampleFile(),s->text(),PlantumlManager::PUML_BITMAP,
                        s->engine(),s->srcFile(),s->srcLine());

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -279,7 +279,7 @@ void RTFGenerator::beginRTFDocument()
   m_t << "{\\widctlpar\\adjustright \\fs20\\cgrid \\snext0 Normal;}\n";
 
   // set the paper dimensions according to PAPER_TYPE
-  static auto paperType = Config_getEnum(PAPER_TYPE);
+  auto paperType = Config_getEnum(PAPER_TYPE);
   m_t << "{";
   switch (paperType)
   {

--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -470,7 +470,7 @@ static QCString definitionToName(const Definition *ctx)
 
 void SearchIndexExternal::setCurrentDoc(const Definition *ctx,const QCString &anchor,bool isSourceFile)
 {
-  static QCString extId = stripPath(Config_getString(EXTERNAL_SEARCH_ID));
+  QCString extId = stripPath(Config_getString(EXTERNAL_SEARCH_ID));
   QCString baseName = isSourceFile ? (toFileDef(ctx))->getSourceFileBase() : ctx->getOutputFileBase();
   QCString url = addHtmlExtensionIfMissing(baseName);
   if (!anchor.isEmpty()) url+=QCString("#")+anchor;
@@ -630,7 +630,7 @@ static std::array<SearchIndexInfo,NUM_SEARCH_INDICES> g_searchIndexInfo =
 
 static void addMemberToSearchIndex(const MemberDef *md)
 {
-  static bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
+  bool hideFriendCompounds = Config_getBool(HIDE_FRIEND_COMPOUNDS);
   bool isLinkable = md->isLinkable();
   const ClassDef *cd=0;
   const NamespaceDef *nd=0;
@@ -1024,7 +1024,7 @@ void writeJavaScriptSearchIndex()
           }
           ti << "',";
 
-          static bool extLinksInWindow = Config_getBool(EXT_LINKS_IN_WINDOW);
+          bool extLinksInWindow = Config_getBool(EXT_LINKS_IN_WINDOW);
           if (!extLinksInWindow || d->getReference().isEmpty())
           {
             ti << "1,";
@@ -1241,9 +1241,9 @@ const std::array<SearchIndexInfo,NUM_SEARCH_INDICES> &getSearchIndices()
 
 void initSearchIndexer()
 {
-  static bool searchEngine      = Config_getBool(SEARCHENGINE);
-  static bool serverBasedSearch = Config_getBool(SERVER_BASED_SEARCH);
-  static bool externalSearch    = Config_getBool(EXTERNAL_SEARCH);
+  bool searchEngine      = Config_getBool(SEARCHENGINE);
+  bool serverBasedSearch = Config_getBool(SERVER_BASED_SEARCH);
+  bool externalSearch    = Config_getBool(EXTERNAL_SEARCH);
   if (searchEngine && serverBasedSearch)
   {
     if (externalSearch) // external tools produce search index and engine

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -766,7 +766,7 @@ class TranslatorBulgarian : public Translator
     virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
         bool single)
     { // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result=(QCString)"Документация за ";
       switch(compType)
       {

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -808,7 +808,7 @@ class TranslatorBrazilian : public Translator
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result="A documentação para ";
       if (compType == ClassDef::Protocol)
       {

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -856,7 +856,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
         bool single)
     { // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result="Die Dokumentation für diese";
       switch(compType)
       {

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -760,7 +760,7 @@ class TranslatorEnglish : public Translator
     virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
         bool single)
     { // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result="The documentation for this ";
       switch(compType)
       {

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -754,7 +754,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result="La documentación para est";
       switch(compType)
       {

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -820,7 +820,7 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       bool feminine = true;
       QCString result="La documentation de ";
       switch(compType)

--- a/src/translator_hi.h
+++ b/src/translator_hi.h
@@ -815,7 +815,7 @@ class TranslatorHindi : public Translator
         bool single)
     {
       // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result;
       switch (compType)
       {

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -427,7 +427,7 @@ class TranslatorDutch : public Translator
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result="De documentatie voor ";
       switch(compType)
       {

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -779,7 +779,7 @@ class TranslatorPortuguese : public Translator
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result="A documentação para ";
       switch(compType)
       {

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -869,7 +869,7 @@ class TranslatorSwedish : public Translator
         bool single)
     { // here s is one of " Class", " Struct" or " Union"
       // single is true implies a single file
-      static bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
       QCString result="Dokumentationen för ";
       switch(compType)
       {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1355,7 +1355,7 @@ QCString getFileFilter(const QCString &name,bool isSourceCode)
 QCString transcodeCharacterStringToUTF8(const QCString &input)
 {
   bool error=FALSE;
-  static QCString inputEncoding = Config_getString(INPUT_ENCODING);
+  QCString inputEncoding = Config_getString(INPUT_ENCODING);
   const char *outputEncoding = "UTF-8";
   if (inputEncoding.isEmpty() || qstricmp(inputEncoding,outputEncoding)==0) return input;
   int inputSize=input.length();
@@ -2947,7 +2947,7 @@ bool resolveRef(/* in */  const QCString &scName,
 
 QCString linkToText(SrcLangExt lang,const QCString &link,bool isFileName)
 {
-  //static bool optimizeOutputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
+  //bool optimizeOutputJava = Config_getBool(OPTIMIZE_OUTPUT_JAVA);
   QCString result=link;
   if (!result.isEmpty())
   {
@@ -3609,8 +3609,8 @@ static int g_usedNamesCount=1;
 QCString convertNameToFile(const QCString &name,bool allowDots,bool allowUnderscore)
 {
   if (name.isEmpty()) return name;
-  static bool shortNames = Config_getBool(SHORT_NAMES);
-  static bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
+  bool shortNames = Config_getBool(SHORT_NAMES);
+  bool createSubdirs = Config_getBool(CREATE_SUBDIRS);
   QCString result;
   if (shortNames) // use short names only
   {
@@ -6334,7 +6334,7 @@ bool patternMatch(const FileInfo &fi,const StringVector &patList)
 
 QCString externalLinkTarget(const bool parent)
 {
-  static bool extLinksInWindow = Config_getBool(EXT_LINKS_IN_WINDOW);
+  bool extLinksInWindow = Config_getBool(EXT_LINKS_IN_WINDOW);
   if (extLinksInWindow)
     return "target=\"_blank\" ";
   else if (parent)
@@ -6374,9 +6374,9 @@ QCString externalRef(const QCString &relPath,const QCString &ref,bool href)
  */
 void writeColoredImgData(const QCString &dir,ColoredImgDataItem data[])
 {
-  static int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
-  static int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
-  static int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
+  int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
+  int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
+  int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
   while (data->name)
   {
     QCString fileName = dir+"/"+data->name;
@@ -6404,9 +6404,9 @@ QCString replaceColorMarkers(const QCString &str)
   static const reg::Ex re(R"(##[0-9A-Fa-f][0-9A-Fa-f])");
   reg::Iterator it(s,re);
   reg::Iterator end;
-  static int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
-  static int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
-  static int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
+  int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
+  int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
+  int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
   size_t sl=s.length();
   size_t p=0;
   for (; it!=end ; ++it)
@@ -6596,8 +6596,8 @@ QCString correctURL(const QCString &url,const QCString &relPath)
 
 bool protectionLevelVisible(Protection prot)
 {
-  static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
-  static bool extractPackage = Config_getBool(EXTRACT_PACKAGE);
+  bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+  bool extractPackage = Config_getBool(EXTRACT_PACKAGE);
 
   return (prot!=Private && prot!=Package)  ||
          (prot==Private && extractPrivate) ||
@@ -6617,7 +6617,7 @@ QCString stripIndentation(const QCString &s)
   int indent=0;
   int minIndent=1000000; // "infinite"
   bool searchIndent=TRUE;
-  static int tabSize=Config_getInt(TAB_SIZE);
+  int tabSize=Config_getInt(TAB_SIZE);
   while ((c=*p++))
   {
     if      (c=='\t') indent+=tabSize - (indent%tabSize);
@@ -6723,7 +6723,7 @@ void stripIndentation(QCString &doc,const int indentationLevel)
 
 bool fileVisibleInIndex(const FileDef *fd,bool &genSourceFile)
 {
-  static bool allExternals = Config_getBool(ALLEXTERNALS);
+  bool allExternals = Config_getBool(ALLEXTERNALS);
   bool isDocFile = fd->isDocumentationFile();
   genSourceFile = !isDocFile && fd->generateSourceFile();
   return ( ((allExternals && fd->isLinkable()) ||
@@ -6867,7 +6867,7 @@ void convertProtectionLevel(
                    int *outListType2
                   )
 {
-  static bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
+  bool extractPrivate = Config_getBool(EXTRACT_PRIVATE);
   // default representing 1-1 mapping
   *outListType1=inListType;
   *outListType2=-1;
@@ -7125,7 +7125,7 @@ bool recognizeFixedForm(const QCString &contents, FortranFormat format)
 
   if (format == FortranFormat_Fixed) return TRUE;
   if (format == FortranFormat_Free)  return FALSE;
-  static int tabSize=Config_getInt(TAB_SIZE);
+  int tabSize=Config_getInt(TAB_SIZE);
 
   for (int i=0;;i++)
   {

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1237,7 +1237,7 @@ static void writeMultiLineCodeLink(yyscan_t yyscanner,CodeOutputInterface &ol,
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (text.isEmpty()) return;
-  static bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
+  bool sourceTooltips = Config_getBool(SOURCE_TOOLTIPS);
   yyextra->tooltipManager.addTooltip(ol,d);
   QCString ref  = d->getReference();
   QCString file = d->getOutputFileBase();

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -707,7 +707,7 @@ void VHDLOutlineParser::mapLibPackage( Entry* root)
 
 bool VHDLOutlineParser::addLibUseClause(const QCString &type)
 {
-  static bool showIEEESTD=Config_getBool(FORCE_LOCAL_INCLUDES);
+  bool showIEEESTD=Config_getBool(FORCE_LOCAL_INCLUDES);
 
   if (showIEEESTD) // all standard packages and libraries will not be shown
   {

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -123,7 +123,7 @@ inline void writeXMLCodeString(TextStream &t,const QCString &str, int &col)
     {
       case '\t':
       {
-        static int tabSize = Config_getInt(TAB_SIZE);
+        int tabSize = Config_getInt(TAB_SIZE);
 	int spacesToNextTabStop = tabSize - (col%tabSize);
 	col+=spacesToNextTabStop;
 	while (spacesToNextTabStop--) t << "<sp/>";
@@ -500,7 +500,7 @@ static void stripQualifiers(QCString &typeStr)
 
 static QCString classOutputFileBase(const ClassDef *cd)
 {
-  //static bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
+  //bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
   //if (inlineGroupedClasses && cd->partOfGroups()!=0)
   return cd->getOutputFileBase();
   //else
@@ -509,7 +509,7 @@ static QCString classOutputFileBase(const ClassDef *cd)
 
 static QCString memberOutputFileBase(const MemberDef *md)
 {
-  //static bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
+  //bool inlineGroupedClasses = Config_getBool(INLINE_GROUPED_CLASSES);
   //if (inlineGroupedClasses && md->getClassDef() && md->getClassDef()->partOfGroups()!=0)
   //  return md->getClassDef()->getXmlOutputFileBase();
   //else


### PR DESCRIPTION
In the past the `Config...` functions did a string lookup and the `static` usage was for speed optimization purposes but nowadays this is not necessary anymore as the "lookup" is done through direct lookup in a `struct`. The `static` is counterproductive as this gives extra thread safe locks.