### PR TITLE
Detecting end of body in python

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -197,7 +197,7 @@ SHORTSTRINGITEM   ({SHORTSTRINGCHAR}|{ESCAPESEQ})
 SHORTSTRINGCHAR   [^\\\n"]
 STRINGLITERAL     {STRINGPREFIX}?( {SHORTSTRING} | {LONGSTRING})
 STRINGPREFIX      ("r"|"u"|"ur"|"R"|"U"|"UR"|"Ur"|"uR")
-FLOWKW            ("or"|"and"|"is"|"not"|"print"|"for"|"in"|"if"|"try"|"except"|"yield"|"raise"|"break"|"continue"|"pass"|"if"|"return"|"while"|"elif"|"else"|"finally")
+FLOWKW            ("or"|"and"|"is"|"not"|"print"|"for"|"in"|"try"|"except"|"yield"|"raise"|"break"|"continue"|"pass"|"if"|"return"|"while"|"elif"|"else"|"finally")
 POUNDCOMMENT      "#"[^#\n][^\n]*
 SCRIPTCOMMENT      "#!".*
 
@@ -548,7 +548,7 @@ STARTDOCSYMS      "##"
 }
 
 <FunctionBody>{
-    \n{B}/{IDENTIFIER}{BB}  {
+    \n{B}/{IDENTIFIER}[^{LETTER}{DIGIT}_]  {
                         DBG_CTX((stderr,"indent %d<=%d\n",computeIndent(&yytext[1]),yyextra->indent));
                         if (computeIndent(&yytext[1])<=yyextra->indent)
                         {


### PR DESCRIPTION
When having:
```
def parsexmlstring0():
    return element

try:
    from generatedsnamespaces
except ModulenotfoundExp_ :
    GenerateDSNamespaceDefs_ = 0

def parsexmlstring1():
    return element

if (true):
    from generatedsnamespaces
else:
    GenerateDSNamespaceDefs_ = 1
```

we see that in the inline sources also the lines with the `try` and `from`. The line with `if` is not shown.
Similar exercises with showing of e.g `print(42)` or `x=42`.

The cause of the problem is that only words followed by a blank were recognized and not words with other characters.

**old output**
![image](https://user-images.githubusercontent.com/5223533/156919807-ffbb44c0-1307-4f4e-8832-3e5e8888cd04.png)

**New output**
![image](https://user-images.githubusercontent.com/5223533/156919820-6b58928e-35c9-4870-94a9-e5e77e548ca0.png)


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8192376/example.tar.gz)
