### PR TITLE
issue #9187 doxygen -x_noenv option to not expand environment variables

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -262,7 +262,8 @@ In case one has to communicate through e.g. a forum the configuration settings t
 are different from the standard doxygen configuration file settings one can run the
 doxygen command: with the `-x` option and the name of the configuration file (default
 is `Doxyfile`). The output will be a list of the not default settings (in `Doxyfile`
-format).
+format). Alternatively also `-x_noenv` is possible which is identical to the `-x`
+option but withour replacing the environment variables.
 
 \htmlonly
 Return to the <a href="index.html">index</a>.

--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -263,7 +263,7 @@ are different from the standard doxygen configuration file settings one can run 
 doxygen command: with the `-x` option and the name of the configuration file (default
 is `Doxyfile`). The output will be a list of the not default settings (in `Doxyfile`
 format). Alternatively also `-x_noenv` is possible which is identical to the `-x`
-option but withour replacing the environment variables.
+option but without replacing the environment variables.
 
 \htmlonly
 Return to the <a href="index.html">index</a>.

--- a/doc/doxygen.1
+++ b/doc/doxygen.1
@@ -47,6 +47,11 @@ If - is used for extensionsFile doxygen will write to standard output.
 .IP
 doxygen \fB\-x\fR [configFile]
 .TP
+   Use doxygen to compare the used configuration file with the template configuration file
+   without replacing the environment variables
+.IP
+doxygen \fB\-x\fR [configFile]
+.TP
 8) Use doxygen to show a list of built-in emojis.
 .IP
 doxygen \fB\-f\fR emoji outputFileName

--- a/doc/doxygen.1
+++ b/doc/doxygen.1
@@ -50,7 +50,7 @@ doxygen \fB\-x\fR [configFile]
    Use doxygen to compare the used configuration file with the template configuration file
    without replacing the environment variables
 .IP
-doxygen \fB\-x\fR [configFile]
+doxygen \fB\-x_noenv\fR [configFile]
 .TP
 8) Use doxygen to show a list of built-in emojis.
 .IP

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,7 @@
 //#endif
 //! @}
 
+enum class DoxyfileSettings { Full, Compressed, CompressedNoEnv };
 class TextStream;
 
 /** \brief Public function to deal with the configuration file. */
@@ -60,7 +61,7 @@ namespace Config
   /*! Writes a the differences between the current configuration and the
    *  template configuration to stream \a t.
    */
-  void compareDoxyfile(TextStream &t);
+  void compareDoxyfile(TextStream &t, DoxyfileSettings diffList);
 
   /*! Writes a the used settings of the current configuration as XML format
    *  to stream \a t.
@@ -76,10 +77,10 @@ namespace Config
   /*! Post processed the parsed data. Replaces raw string values by the actual values.
    *  and replaces environment variables.
    *  \param clearHeaderAndFooter set to TRUE when writing header and footer templates.
-   *  \param compare signals if we in Doxyfile compare (`-x`) mode are or not. Influences
-   *  setting of the default value.
+   *  \param compare signals if we in Doxyfile compare (`-x` or `-x_noenv`) mode are or not.
+   *   Influences setting of the default value and replacement of environment variables.
    */
-  void postProcess(bool clearHeaderAndFooter, bool compare = FALSE);
+  void postProcess(bool clearHeaderAndFooter, DoxyfileSettings compare = DoxyfileSettings::Full);
 
   /*! Check the validity of the parsed options and correct or warn the user where needed.
    * \param quiet setting for the QUIET option (can have been overruled by means of a command line option)

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2063,9 +2063,9 @@ void Config::writeTemplate(TextStream &t,bool shortList,bool update)
   ConfigImpl::instance()->writeTemplate(t,shortList,update);
 }
 
-void Config::compareDoxyfile(TextStream &t)
+void Config::compareDoxyfile(TextStream &t,DoxyfileSettings diffList)
 {
-  postProcess(FALSE, TRUE);
+  postProcess(FALSE, diffList);
   ConfigImpl::instance()->compareDoxyfile(t);
 }
 
@@ -2087,10 +2087,10 @@ bool Config::parse(const QCString &fileName,bool update)
   return parseRes;
 }
 
-void Config::postProcess(bool clearHeaderAndFooter, bool compare)
+void Config::postProcess(bool clearHeaderAndFooter, DoxyfileSettings diffList)
 {
-  ConfigImpl::instance()->substituteEnvironmentVars();
-  if (!compare)ConfigImpl::instance()->emptyValueToDefault();
+  if (diffList != DoxyfileSettings::CompressedNoEnv) ConfigImpl::instance()->substituteEnvironmentVars();
+  if (diffList == DoxyfileSettings::Full)ConfigImpl::instance()->emptyValueToDefault();
   ConfigImpl::instance()->convertStrToVal();
 
   // avoid bootstrapping issues when the g_config file already


### PR DESCRIPTION
Adding the possibility to retain the environment variables (`$(...)`) in the doxyfile when looking for differences with the default settings.