### PR TITLE
Extended support for language specified in markdown fenced code blocks

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -459,6 +459,25 @@ Another way to denote fenced code blocks is to use 3 or more backticks (```):
     also a fenced code block
     ```
 
+For the image formats `dot`, `msc` and `plantuml` the fenced block will be shown as 
+an image provided the image format is enabled (see \ref cfg_have_dot "HAVE_DOT" and
+\ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH"), otherwise it is shown as plain code.
+
+Example:
+~~~~~~{.unparsed}
+```plantuml
+Alice -> Bob
+```
+~~~~~~
+or
+~~~~~~{.unparsed}
+```plantuml
+@startuml
+Alice -> Bob
+@enduml
+```
+~~~~~~
+
 \subsection md_header_id Header Id Attributes
 
 Standard Markdown has no support for labeling headers, which

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2970,10 +2970,41 @@ QCString Markdown::processQuotations(const QCString &s,int refIndent)
     {
       if (isFencedCodeBlock(data+pi,size-pi,currentIndent,lang,blockStart,blockEnd,blockOffset))
       {
-        if (lang=="plantuml")
+        if (lang=="plantuml" && !Config_getString(PLANTUML_JAR_PATH).isEmpty())
         {
           int cmdStart = pi+blockStart+1;
-          processSpecialCommand(data+cmdStart,cmdStart,size-cmdStart);
+          // using pl and pl1 so we don't remove any newlines (line counting)
+          QCString pl = QCString(data+cmdStart).left(blockEnd-blockStart-1);
+          QCString pl1 = pl.left(blockEnd-blockStart-1).stripWhiteSpace();
+          if (!pl1.startsWith("@startuml") && !pl1.startsWith("\\startuml"))
+          {
+            pl = "@startuml\\ilinebr " + pl + " @enduml";
+          }
+          processSpecialCommand(pl.data(),0,pl.length());
+        }
+        else if (lang=="dot" && Config_getBool(HAVE_DOT))
+        {
+          int cmdStart = pi+blockStart+1;
+          // using pl and pl1 so we don't remove any newlines (line counting)
+          QCString pl = QCString(data+cmdStart).left(blockEnd-blockStart-1);
+          QCString pl1 = pl.left(blockEnd-blockStart-1).stripWhiteSpace();
+          if (!pl1.startsWith("@dot") && !pl1.startsWith("\\dot"))
+          {
+            pl = "@dot\\ilinebr " + pl + " @enddot";
+          }
+          processSpecialCommand(pl.data(),0,pl.length());
+        }
+        else if (lang=="msc") // msc is build in
+        {
+          int cmdStart = pi+blockStart+1;
+          // using pl and pl1 so we don't remove any newlines (line counting)
+          QCString pl = QCString(data+cmdStart).left(blockEnd-blockStart-1);
+          QCString pl1 = pl.left(blockEnd-blockStart-1).stripWhiteSpace();
+          if (!pl1.startsWith("@msc") && !pl1.startsWith("\\msc"))
+          {
+            pl = "@msc\\ilinebr " + pl + " @endmsc";
+          }
+          processSpecialCommand(pl.data(),0,pl.length());
         }
         else
         {


### PR DESCRIPTION
Extended support for image formats to be rendered in markdown fenced code blocks (see also #9196, #7543):
- plantuml
  - render as image in case plantuml support is enabled otherwise just as plain code
  - add plantuml commands in case they are missing.
- dot, msc added analogous to plantuml

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8232065/example.tar.gz)
