### PR TITLE
Incorrect warning regarding array types in function definition

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1173,7 +1173,7 @@ QCString argListToString(const ArgumentList &al,bool useCanonicalType,bool showD
     }
     if (!a.name.isEmpty() || !a.array.isEmpty())
     {
-      result+= type1+" "+a.name+type2+a.array;
+      result+= type1+" "+a.name+type2+(useCanonicalType && !a.canType.isEmpty()?"":a.array);
     }
     else
     {


### PR DESCRIPTION
When having (`windows32.h`):
```
#ifndef EASY32_H
#define EASY32_H

class StatusBar
{
  public :
        StatusBar (StandardWindow &w, int id);
        StatusBar (double *f, int id);
};

#endif
```
and (`windows32.cpp`):
```
#include "windows.h"

StatusBar::StatusBar (StandardWindow &w, int id)
{ }

StatusBar::StatusBar (double f[], int id)
{}
```
we get the warning:
```
.../windows32.cpp:6: warning: no matching class member found for
  StatusBar::StatusBar(double[] f[], int id)
Possible candidates:
  'StatusBar::StatusBar(StandardWindow &w, int id)'
  'StatusBar::StatusBar(double *f, int id)'
```
which is reasonable as `*f`  is different from `f[]` (maybe  not in the implementation, but in its appearance / intention), but the messages should not say:
```
  StatusBar::StatusBar(double[] f[], int id)
```
but
```
  StatusBar::StatusBar(double[] f, int id)
```
or
```
  StatusBar::StatusBar(double f[], int id)
```
problem here  is that the canonical type should be used, but this also should imply that the array description should not be used.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8233223/example.tar.gz)

(Found by Fossies for the EulerSource package)
