### PR TITLE
Better translation for trPackageMembers

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -676,7 +676,7 @@ class TranslateContext::Private
     {
       if (m_javaOpt || m_vhdlOpt)
       {
-        return theTranslator->trPackageMembers();
+        return theTranslator->trPackageFunctions();
       }
       else if (m_fortranOpt || m_sliceOpt)
       {
@@ -2091,11 +2091,11 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
     }
     TemplateVariant createPackageMethods() const
     {
-      return createMemberList(MemberListType_pacMethods,theTranslator->trPackageMembers());
+      return createMemberList(MemberListType_pacMethods,theTranslator->trPackageFunctions());
     }
     TemplateVariant createPackageStaticMethods() const
     {
-      return createMemberList(MemberListType_pacStaticMethods,theTranslator->trStaticPackageMembers());
+      return createMemberList(MemberListType_pacStaticMethods,theTranslator->trStaticPackageFunctions());
     }
     TemplateVariant createPackageAttributes() const
     {
@@ -2248,8 +2248,8 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
       ctx->addMemberList(m_classDef,MemberListType_proAttribs,theTranslator->trProtectedAttribs());
       ctx->addMemberList(m_classDef,MemberListType_proStaticAttribs,theTranslator->trStaticProtectedAttribs());
       ctx->addMemberList(m_classDef,MemberListType_pacTypes,theTranslator->trPackageTypes());
-      ctx->addMemberList(m_classDef,MemberListType_pacMethods,theTranslator->trPackageMembers());
-      ctx->addMemberList(m_classDef,MemberListType_pacStaticMethods,theTranslator->trStaticPackageMembers());
+      ctx->addMemberList(m_classDef,MemberListType_pacMethods,theTranslator->trPackageFunctions());
+      ctx->addMemberList(m_classDef,MemberListType_pacStaticMethods,theTranslator->trStaticPackageFunctions());
       ctx->addMemberList(m_classDef,MemberListType_pacAttribs,theTranslator->trPackageAttribs());
       ctx->addMemberList(m_classDef,MemberListType_pacStaticAttribs,theTranslator->trStaticPackageAttribs());
       ctx->addMemberList(m_classDef,MemberListType_properties,theTranslator->trProperties());

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -890,11 +890,11 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                     endCb()
                                                   } },
   { "class/memberdecl/packagemethods",            { startCb(&LayoutParser::startMemberDeclEntry, MemberListType_pacMethods,
-                                                            []() { return compileOptions(theTranslator->trPackageMembers()); }),
+                                                            []() { return compileOptions(theTranslator->trPackageFunctions()); }),
                                                     endCb()
                                                   } },
   { "class/memberdecl/packagestaticmethods",      { startCb(&LayoutParser::startMemberDeclEntry, MemberListType_pacStaticMethods,
-                                                            []() { return compileOptions(theTranslator->trStaticPackageMembers()); }),
+                                                            []() { return compileOptions(theTranslator->trStaticPackageFunctions()); }),
                                                     endCb()
                                                   } },
   { "class/memberdecl/packageattributes",         { startCb(&LayoutParser::startMemberDeclEntry, MemberListType_pacAttribs,

--- a/src/translator.h
+++ b/src/translator.h
@@ -507,8 +507,9 @@ class Translator
 //////////////////////////////////////////////////////////////////////////
 
     virtual QCString trPackageTypes() = 0;
+    virtual QCString trPackageFunctions() = 0;
     virtual QCString trPackageMembers() = 0;
-    virtual QCString trStaticPackageMembers() = 0;
+    virtual QCString trStaticPackageFunctions() = 0;
     virtual QCString trPackageAttribs() = 0;
     virtual QCString trStaticPackageAttribs() = 0;
 

--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -1309,14 +1309,18 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Փաթեթի ֆունկցիաներ";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Փաթեթի անդամներ";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Փաթեթի ստատիկ ֆունկցիաներ";
     }

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -1356,14 +1356,18 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "دوال الحزمة";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "أعضاء الحزمة";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "دوال ساكنة للحزمة";
     }

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -1377,14 +1377,18 @@ class TranslatorBulgarian : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Функции с област на видимост пакет";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Членове с област на видимост пакет";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Статични функции с област на видимост пакет";
     }

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -1434,14 +1434,18 @@ class TranslatorBrazilian : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funções do Pacote";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membros do Pacote";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Funções Estáticas do Pacote";
     }

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -1359,14 +1359,18 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funcions de Paquet";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membres de Paquet";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Funcions Estàtiques de Paquet";
     }

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -1303,15 +1303,19 @@ class TranslatorChinese : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "包函数";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "包成员";
     }
 
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "静态包函数";
     }

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -1440,14 +1440,18 @@ class TranslatorCzech : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funkce v balíku";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Členy v balíku";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statické funkce v balíku";
     }

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -1492,15 +1492,19 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Paketfunktionen";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Paketelemente";
     }
 
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statische Paketfunktionen";
     }

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -1300,9 +1300,11 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     /* Java: Entities with package scope... */
     virtual QCString trPackageTypes()
     { return "Typer med pakke-scope"; }
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     { return "Metoder med pakke-scope"; }
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trPackageMembers()
+    { return "Medlemmer med pakke-scope"; }
+    virtual QCString trStaticPackageFunctions()
     { return "Statiske metoder med pakke-scope"; }
     virtual QCString trPackageAttribs()
     { return "Attributter med pakke-scope"; }

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -1371,14 +1371,18 @@ class TranslatorEnglish : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Package Functions";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Package Members";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Static Package Functions";
     }

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -1363,14 +1363,18 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Pakaĵaj Funkcioj";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Pakaĵaj Membroj";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statikaj Pakaĵaj Funkcioj";
     }

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -1404,15 +1404,19 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funciones del 'package'";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Miembros del 'package'";
     }
 
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Funciones estáticas del 'package'";
     }

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -1356,14 +1356,18 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "توابع بسته ها";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "عضوها بسته ها";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Static Package Functions";
     }

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -1467,14 +1467,18 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Paketin funktiot"; // "Package Functions"
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Paketin jäsenet"; // "Package Members"
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Paketin staattiset funktiot"; // "Static Package Functions"
     }

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -1432,14 +1432,18 @@ class TranslatorFrench : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Fonctions de paquetage";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membres de paquetage";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Fonctions statiques de paquetage";
     }

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -1377,14 +1377,18 @@ class TranslatorGreek : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Συναρτήσεις Πακέτου";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Μέλη Πακέτου";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Στατικές Συναρτήσεις Πακέτου";
     }

--- a/src/translator_hi.h
+++ b/src/translator_hi.h
@@ -1359,13 +1359,15 @@ class TranslatorHindi : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     { return "संकुल फलनगण"; }
+    virtual QCString trPackageMembers()
+    { return "संकुल सदस्यगण"; }
 
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     { return "अचल संकुल फलनगण"; }
 
     /*! Used as a heading for a list of Java class variables with package

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -1059,14 +1059,18 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funkcije u paketu";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "članovi u paketu";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statičke funkcije u paketu";
     }

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -1389,14 +1389,18 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Csomag függvények";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Csomag tagok";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statikus csomag függvények";
     }

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -1343,14 +1343,18 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Daftar Fungsi Paket";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Anggota-anggota Paket";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Daftar Fungsi Statis Paket";
     }

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -33,7 +33,7 @@
  *  2006/10: made class to derive directly from Translator class (reported in Petr Prikryl October 9 translator report)
  *  2006/06: updated translation of new items used since version 1.4.6
  *  2006/05: translated new items used since version 1.4.6
- *           corrected typo in trPackageMembers method
+ *           corrected typo in trPackageFunction method
  *  2005/03: translated new items used since version 1.4.1
  *           removed unused methods listed in Petr Prikryl February 28 translator report
  *  2004/09: translated new items used since version 1.3.9
@@ -1342,14 +1342,18 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funzioni con visibilità di package";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membri con visibilità di package";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Funzioni statiche con visibilità di package";
     }

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -1374,14 +1374,19 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "関数";
     }
+    virtual QCString trPackageMembers()
+    {
+      return "パッケージ内のメンバ";
+    }
+
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "静的関数";
     }

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -1380,14 +1380,18 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "패키지 함수";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "패키지 멤버들";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "정적 패키지 함수";
     }

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -1357,14 +1357,18 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Paketo Funkcijos";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Paketo Nariai";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statinės Paketo Funkcijos";
     }

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -1368,14 +1368,18 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Pakas funkcijas";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Pakas elementi";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statiskās pakas funkcijas";
     }

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -1346,14 +1346,18 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Функции во Пакетот";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Членови во Пакетот";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Статични Функции во Пакетот";
     }

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -1016,14 +1016,18 @@ class TranslatorDutch : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Package Functies";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Package Members";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statische Package Functies";
     }

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -1367,14 +1367,18 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Pakkefunksjoner";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Pakkemedlemmer";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statiske Pakkefunksjoner";
     }

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -1311,14 +1311,18 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funkcje pakietu";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Składowe pakietu";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statyczne funkcje pakietu";
     }

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -1381,14 +1381,18 @@ class TranslatorPortuguese : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funções do Pacote";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membros do Pacote";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Funções Estáticas do Pacote";
     }

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -1372,14 +1372,18 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funcţii în pachet";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membrii în pachet";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Funcţii statice în pachet";
     }

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -1324,14 +1324,18 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Функции с областью видимости пакета";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Члены с областью видимости пакета";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Статические функции с областью видимости пакета";
     }

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -1382,14 +1382,18 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Функције пакета";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Чланови пакета";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Статичке функције пакета";
     }

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -1003,14 +1003,18 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funkcije paketa";   /* don't know the context */
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Elemente paketa";   /* don't know the context */
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statične funkcije paketa";
     }

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -1318,14 +1318,18 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funkcie v balíku";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Členy v balíku";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statické funkcie v balíku";
     }

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -1345,14 +1345,18 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Funkcije u paketu";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Članovi u paketu";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statičke funkcije u paketu";  // Zajednicke funkcije u paketu
     }

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -1468,14 +1468,18 @@ class TranslatorSwedish : public Translator
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Paketfunktioner";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Paketmedlemmar";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statiska paketfunktioner";
     }

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -1356,14 +1356,18 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     /*! Used as a heading for a list of Java class fonksiyonlar with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Paket Fonksiyonlar";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Paket Üyeler";
     }
     /*! Used as a heading for a list of static Java class fonksiyonlar with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Static Pakat Fonksiyonları";
     }

--- a/src/translator_tw.h
+++ b/src/translator_tw.h
@@ -1359,14 +1359,18 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Package 函數列表";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Package 成員列表";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "靜態 Package 函數列表";
     }

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -1315,15 +1315,19 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Функції пакетів";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Елементи пакетів";
     }
 
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Статичні функцію пакетів";
     }

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -1379,14 +1379,18 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Các hàm Package";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Members Package";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Các hàm Static Package";
     }

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -1344,14 +1344,18 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
     /*! Used as a heading for a list of Java class functions with package
      * scope.
      */
-    virtual QCString trPackageMembers()
+    virtual QCString trPackageFunctions()
     {
       return "Pakket Funksies";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Pakket Lede";
     }
     /*! Used as a heading for a list of static Java class functions with
      *  package scope.
      */
-    virtual QCString trStaticPackageMembers()
+    virtual QCString trStaticPackageFunctions()
     {
       return "Statiese Pakket Funksies";
     }


### PR DESCRIPTION
- renaming original trPackageMembers to trPackageFunctions
- renaming trStaticPackageMembers to trStaticPackageFunctions
- introducing new function trPackageMembers with best / educated guess for the translation.

(based on comment with #9192 / #9197)