### PR TITLE
Global enum incorporates values from an enum class

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7372,20 +7372,26 @@ static void addEnumValuesToEnums(const Entry *root)
                       //    qPrint(fmd->name()),qPrint(fmd->getOuterScope()->name()));
                       if (nd && !nd->isAnonymous())
                       {
-                        const NamespaceDef *fnd=fmd->getNamespaceDef();
-                        if (fnd==nd) // enum value is inside a namespace
+                        if (!fmd->isStrongEnumValue()) // only non strong enum values can be globally added
                         {
-                          md->insertEnumField(fmd);
-                          fmd->setEnumScope(md);
+                          const NamespaceDef *fnd=fmd->getNamespaceDef();
+                          if (fnd==nd) // enum value is inside a namespace
+                          {
+                            md->insertEnumField(fmd);
+                            fmd->setEnumScope(md);
+                          }
                         }
                       }
                       else if (isGlobal)
                       {
-                        const FileDef *ffd=fmd->getFileDef();
-                        if (ffd==fd) // enum value has file scope
+                        if (!fmd->isStrongEnumValue()) // only non strong enum values can be globally added
                         {
-                          md->insertEnumField(fmd);
-                          fmd->setEnumScope(md);
+                          const FileDef *ffd=fmd->getFileDef();
+                          if (ffd==fd) // enum value has file scope
+                          {
+                            md->insertEnumField(fmd);
+                            fmd->setEnumScope(md);
+                          }
                         }
                       }
                       else if (isRelated && cd) // reparent enum value to
@@ -7400,13 +7406,16 @@ static void addEnumValuesToEnums(const Entry *root)
                       }
                       else
                       {
-                        const ClassDef *fcd=fmd->getClassDef();
-                        if (fcd==cd) // enum value is inside a class
+                        if (!fmd->isStrongEnumValue()) // only non strong enum values can be globally added
                         {
-                          //printf("Inserting enum field %s in enum scope %s\n",
-                          //    qPrint(fmd->name()),qPrint(md->name()));
-                          md->insertEnumField(fmd); // add field def to list
-                          fmd->setEnumScope(md);    // cross ref with enum name
+                          const ClassDef *fcd=fmd->getClassDef();
+                          if (fcd==cd) // enum value is inside a class
+                          {
+                            //printf("Inserting enum field %s in enum scope %s\n",
+                            //    qPrint(fmd->name()),qPrint(md->name()));
+                            md->insertEnumField(fmd); // add field def to list
+                            fmd->setEnumScope(md);    // cross ref with enum name
+                          }
                         }
                       }
                     }


### PR DESCRIPTION
When having:
```
/// the class enum
enum class F1 {
  /*! first */
  FFAST = 1
};

/// the enum
enum F3
{
  /// third
  FFAST = 103
};
```

we see in the output (a.o.):
```
enum   F3 { FFAST = 103 , FFAST = 1 }
```
so in the global enum the `FFAST` from the class enum is incorporated as well (based on the name).
When having first the `F3` enum followed by the `F1` enum the results are OK.

Adding of an enum value to the global enum should only take place when we have an enum value that is not from an `enum class`.

(In the CGAL original the `enum`s were embedded in a namespace).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8288308/example.tar.gz)