### PR TITLE
Don't create anchor for \name command

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -7782,7 +7782,6 @@ class MemberGroupInfoContext::Private
     TemplateVariant members() const              { return m_members.get(this); }
     TemplateVariant groupTitle() const           { return m_memberGroup->header(); }
     TemplateVariant groupSubtitle() const        { return ""; }
-    TemplateVariant groupAnchor() const          { return m_memberGroup->anchor(); }
     TemplateVariant memberGroups() const         { return m_memberGroups.get(this); }
     TemplateVariant docs() const                 { return m_docs.get(this); }
     TemplateVariant inherited() const            { return FALSE; }
@@ -7819,7 +7818,6 @@ const PropertyMap<MemberGroupInfoContext::Private> MemberGroupInfoContext::Priva
   {  "members",      &Private::members },
   {  "title",        &Private::groupTitle },
   {  "subtitle",     &Private::groupSubtitle },
-  {  "anchor",       &Private::groupAnchor },
   {  "memberGroups", &Private::memberGroups },
   {  "docs",         &Private::docs },
   {  "inherited",    &Private::inherited }

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -723,8 +723,7 @@ void FileDefImpl::writeMemberGroups(OutputList &ol)
   /* write user defined member groups */
   for (const auto &mg : m_memberGroups)
   {
-    if ((!mg->allMembersInSameSection() || !m_subGrouping)
-        && mg->header()!="[NOHEADER]")
+    if (!mg->allMembersInSameSection() || !m_subGrouping)
     {
       mg->writeDeclarations(ol,0,0,this,0);
     }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -213,7 +213,6 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual MemberDef *fromAnonymousMember() const;
     virtual bool hasCallGraph() const;
     virtual bool hasCallerGraph() const;
-    virtual bool visibleMemberGroup(bool hideNoHeader) const;
     virtual bool hasReferencesRelation() const;
     virtual bool hasReferencedByRelation() const;
     virtual const MemberDef *templateMaster() const;
@@ -698,8 +697,6 @@ class MemberDefAliasImpl : public DefinitionAliasMixin<MemberDef>
     { return getMdAlias()->hasCallGraph(); }
     virtual bool hasCallerGraph() const
     { return getMdAlias()->hasCallerGraph(); }
-    virtual bool visibleMemberGroup(bool hideNoHeader) const
-    { return getMdAlias()->visibleMemberGroup(hideNoHeader); }
     virtual bool hasReferencesRelation() const
     { return getMdAlias()->hasReferencesRelation(); }
     virtual bool hasReferencedByRelation() const
@@ -4084,12 +4081,6 @@ bool MemberDefImpl::hasDocumentation() const
 void MemberDefImpl::setMemberGroup(MemberGroup *grp)
 {
   m_impl->memberGroup = grp;
-}
-
-bool MemberDefImpl::visibleMemberGroup(bool hideNoHeader) const
-{
-  return m_impl->memberGroup!=0 &&
-          (!hideNoHeader || m_impl->memberGroup->header()!="[NOHEADER]");
 }
 
 QCString MemberDefImpl::getScopeString() const

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -235,7 +235,6 @@ class MemberDef : public Definition
     // callgraph related members
     virtual bool hasCallGraph() const = 0;
     virtual bool hasCallerGraph() const = 0;
-    virtual bool visibleMemberGroup(bool hideNoHeader) const = 0;
     // referenced related members
     virtual bool hasReferencesRelation() const = 0;
     virtual bool hasReferencedByRelation() const = 0;

--- a/src/membergroup.cpp
+++ b/src/membergroup.cpp
@@ -95,7 +95,6 @@ void MemberGroup::writeDeclarations(OutputList &ol,
 {
   //printf("MemberGroup::writeDeclarations() %s\n",qPrint(grpHeader));
   QCString ldoc = doc;
-  if (!ldoc.isEmpty()) ldoc.prepend("<a name=\""+anchor()+"\" id=\""+anchor()+"\"></a>");
   memberList->writeDeclarations(ol,cd,nd,fd,gd,grpHeader,ldoc,FALSE,showInline);
 }
 
@@ -255,29 +254,9 @@ int MemberGroup::numDocEnumValues() const
   return memberList->numDocEnumValues();
 }
 
-QCString MemberGroup::anchor() const
-{
-  uchar md5_sig[16];
-  char sigStr[33];
-  QCString locHeader = grpHeader;
-  if (locHeader.isEmpty()) locHeader="[NOHEADER]";
-  MD5Buffer(locHeader.data(),locHeader.length(),md5_sig);
-  MD5SigToString(md5_sig,sigStr);
-  return QCString("amgrp")+sigStr;
-}
-
 void MemberGroup::addListReferences(Definition *def)
 {
   memberList->addListReferences(def);
-  if (def)
-  {
-    QCString name = def->getOutputFileBase()+"#"+anchor();
-    addRefItem(m_xrefListItems,
-        name,
-        theTranslator->trGroup(TRUE,TRUE),
-        name,
-        grpHeader,QCString(),def);
-  }
 }
 
 void MemberGroup::findSectionsInDocumentation(const Definition *d)

--- a/src/membergroup.h
+++ b/src/membergroup.h
@@ -83,7 +83,6 @@ class MemberGroup
     void addListReferences(Definition *d);
     void setRefItems(const RefItemVector &sli);
     const MemberList &members() const { return *memberList.get(); }
-    QCString anchor() const;
 
     QCString docFile() const { return m_docFile; }
     int docLine() const { return m_docLine; }

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -614,7 +614,7 @@ void MemberList::writeDeclarations(OutputList &ol,
     //printf("memberGroupList=%p\n",memberGroupList);
     for (const auto &mg : m_memberGroupRefList)
     {
-      bool hasHeader=!mg->header().isEmpty() && mg->header()!="[NOHEADER]";
+      bool hasHeader=!mg->header().isEmpty();
       if (inheritId.isEmpty())
       {
         //printf("mg->header=%s hasHeader=%d\n",qPrint(mg->header()),hasHeader);

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -791,8 +791,7 @@ void NamespaceDefImpl::writeMemberGroups(OutputList &ol)
   /* write user defined member groups */
   for (const auto &mg : m_memberGroups)
   {
-    if ((!mg->allMembersInSameSection() || !m_subGrouping)
-        && mg->header()!="[NOHEADER]")
+    if (!mg->allMembersInSameSection() || !m_subGrouping)
     {
       mg->writeDeclarations(ol,0,this,0,0);
     }

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2123,7 +2123,7 @@ void VhdlDocGen::writeVHDLDeclarations(const MemberList* ml,OutputList &ol,
     if (membersHaveSpecificType(&mg->members(),type))
     {
       //printf("mg->header=%s\n",qPrint(mg->header()));
-      bool hasHeader=mg->header()!="[NOHEADER]";
+      bool hasHeader=!mg->header().isEmpty();
       ol.startMemberGroupHeader(hasHeader);
       if (hasHeader)
       {


### PR DESCRIPTION
Do not create an anchor for a `\name` command,  the same `\name` can be used multiple times in the same file / documentation block (most notably the `\name` without a text) leading to multiple anchors with the same values.
Furthermore the anchor is internally generated by doxygen, so the user has no, natural, way to reference it.

The function `visibleMembergGroup` is not used anywhere, so obsolete and thus removed.

This pull request make the pull requests #6676 and #8238 obsolete.