### PR TITLE
issue #9217 Can't load MathJax 3 extensions

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -461,8 +461,22 @@ static QCString substituteHtmlKeywords(const QCString &str,
          const StringVector &mathJaxExtensions = Config_getList(MATHJAX_EXTENSIONS);
          if (!mathJaxExtensions.empty() || !g_latex_macro.isEmpty())
          {
-           mathJaxJs+= ",\n"
-                       "  tex: {\n"
+           mathJaxJs+= ",\n";
+           if (!mathJaxExtensions.empty())
+           {
+             bool first = true;
+             mathJaxJs+= "  loader: {\n"
+                         "    load: [";
+             for (const auto &s : mathJaxExtensions)
+             {
+               if (!first) mathJaxJs+= ",";
+               mathJaxJs+= "'[tex]/"+QCString(s.c_str())+"'";
+               first = false;
+             }
+             mathJaxJs+= "]\n"
+                         "  },\n";
+           }
+           mathJaxJs+= "  tex: {\n"
                        "    macros: {";
            if (!g_latex_macro.isEmpty())
            {

--- a/templates/html/htmlbase.tpl
+++ b/templates/html/htmlbase.tpl
@@ -51,6 +51,11 @@ window.MathJax = {
     ignoreHtmlClass: 'tex2jax_ignore',
     processHtmlClass: 'tex2jax_process'
   },
+{% if config.MATHJAX_EXTENSIONS %}
+  loader: {
+    load: [{% for ext in config.MATHJAX_EXTENSIONS %},'{{ ext }}'{% endfor %}]
+  },
+{% endif %}{# MATHJAX_EXTENSIONS #}
   tex: {
 {% if doxygen.mathJaxMacros %}
     macros: { {{ doxygen.mathJaxMacros|raw }} },


### PR DESCRIPTION
Specified loader for the extension as well.
(looks like for e.g. `ams` it is not necessary but no negative influence seen when explicitly loading).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8323501/example.tar.gz)
