### PR TITLE
issue #9190 DOC: Mention -x switch in the "Support" page

### DIFF
--- a/doc/doxygen_usage.doc
+++ b/doc/doxygen_usage.doc
@@ -102,7 +102,7 @@ doxygen -w rtf rtfstyle.cfg
      used in combination with the \c -u option, to add or strip the
      documentation from an existing configuration file.
      To get a minimal configuration file use the \c -x or \-x_noenv option to
-     show only the defferences from the default doxygen configuration file.
+     show only the differences from the default doxygen configuration file.
      Please use the \c -s or \c -x or \c -x_noenv option if you send me a
      configuration file as part of a bug report or post an issue on GitHub!
      (see also: \ref bug_reports "How to report a bug")

--- a/doc/doxygen_usage.doc
+++ b/doc/doxygen_usage.doc
@@ -101,8 +101,11 @@ doxygen -w rtf rtfstyle.cfg
      file then you can use the optional \c -s option. This can use be
      used in combination with the \c -u option, to add or strip the
      documentation from an existing configuration file.
-     Please use the \c -s option if you send me a configuration file 
-     as part of a bug report!
+     To get a minimal configuration file use the \c -x or \-x_noenv option to
+     show only the defferences from the default doxygen configuration file.
+     Please use the \c -s or \c -x or \c -x_noenv option if you send me a
+     configuration file as part of a bug report or post an issue on GitHub!
+     (see also: \ref bug_reports "How to report a bug")
 <li> To make doxygen read/write to standard input/output instead of from/to 
      a file, use \c - for the file name.
 </ul>

--- a/doc/perlmod.doc
+++ b/doc/perlmod.doc
@@ -20,7 +20,7 @@ useful output, as shown by the Perl Module-based \LaTeX generator.
 <p>Please report any bugs or problems you find in the Perl Module 
 backend or the Perl Module-based \LaTeX generator to the 
 <a href="https://github.com/doxygen/doxygen/issues">doxygen issue tracker</a>.
-Suggestions are welcome as well.
+Suggestions are welcome as well (see also: \ref bug_reports "How to report a bug").
 
 \section using_perlmod_fmt Usage
 

--- a/doc/trouble.doc
+++ b/doc/trouble.doc
@@ -115,7 +115,10 @@ always try to include the following information in your bug report:
 - It is usually a good idea to send along the configuration file as well, 
   but please use doxygen with the <code>-s</code> flag while generating it
   to keep it small (use <code>doxygen -s -u [configName]</code> to strip
-  the comments from an existing configuration file). 
+  the comments from an existing configuration file. Better even to use the
+  <code>-x</code> or the <code>-x_noenv</code> flag on the used <code>[configName]</code> to
+  get the differences between the used settings and the doxygen default settings, so
+  <code>doxygen -x [configName]</code>). 
 - The easiest (and often the only) way for me to fix bugs is if you can 
   attach a small example demonstrating the problem you have to the bug report, so I can
   reproduce it on my machine. Please make sure the example is valid

--- a/src/config.xml
+++ b/src/config.xml
@@ -88,6 +88,17 @@ For lists, items can also be appended using:
       TAG += value [value, ...]
 \endverbatim
 Values that contain spaces should be placed between quotes (\" \").
+<br>
+Note:<br>
+Use doxygen to compare the used configuration file with the template configuration file:
+\verbatim
+      doxygen -x [configFile]
+\endverbatim
+Use doxygen to compare the used configuration file with the template configuration file
+without replacing the environment variables>
+\verbatim
+      doxygen -x_noenv [configFile]
+\endverbatim
 ]]>
     </docs>
   </header>


### PR DESCRIPTION
Adding some information regarding the `-x` and `-x_noenv` to the configuration file and the documentation