### PR TITLE
bug_445536 Select folder for STRIP_FROM_PATH

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -423,7 +423,7 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
-    <option type='list' id='STRIP_FROM_PATH' format='string' depends='FULL_PATH_NAMES'>
+    <option type='list' id='STRIP_FROM_PATH' format='dir' depends='FULL_PATH_NAMES'>
       <docs>
 <![CDATA[
  The \c STRIP_FROM_PATH tag
@@ -438,7 +438,7 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
-    <option type='list' id='STRIP_FROM_INC_PATH' format='string'>
+    <option type='list' id='STRIP_FROM_INC_PATH' format='dir'>
       <docs>
 <![CDATA[
  The \c STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of


### PR DESCRIPTION
Added the possibility to select a directory in the doxywizard GUI for `STRIP_FROM_PATH` and `STRIP_FROM_INC_PATH` (analogous to the possibilities for e.g `DOTFILE_DIRS`)