### PR TITLE
issue #9229 Crash with Segmentation fault in ClassDefImpl::mergeMembers

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -1040,7 +1040,7 @@ void VhdlDocGen::parseFuncProto(const QCString &text,QCString& name,QCString& re
 
 QCString VhdlDocGen::getIndexWord(const QCString &c,int index)
 {
-  static const reg::Ex reg(R"([\s|])");
+  static const reg::Ex reg(R"([\s:|])");
   auto ql=split(c.str(),reg);
 
   if (index < static_cast<int>(ql.size()))


### PR DESCRIPTION
Incorrect translation of regular expression:
```
  static const std::regex reg("[[:space:]:|]",std::regex::optimize);
```
to
```
  static const reg::Ex reg(R"([\s|])");
```
this should have been:
```
  static const reg::Ex reg(R"([\s:|])");
```