### PR TITLE
issue #9234 NUM_PROC_THREADS not being honored when processing input

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1808,6 +1808,13 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     checkList(Config_getList(EXTRA_SEARCH_MAPPINGS),"EXTRA_SEARCH_MAPPING",TRUE,TRUE);
   }
 
+  int numThreads = Config_getInt(NUM_PROC_THREADS);
+  if (numThreads==0)
+  {
+     numThreads = static_cast<int>(std::thread::hardware_concurrency());
+     Config_updateInt(NUM_PROC_THREADS,numThreads);
+  }
+
   //------------------------
 
   // check for settings that are inconsistent with having GENERATE_HTMLHELP enabled

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8069,10 +8069,6 @@ static void generateFileSources()
 #endif
     {
       std::size_t numThreads = static_cast<std::size_t>(Config_getInt(NUM_PROC_THREADS));
-      if (numThreads==0)
-      {
-        numThreads = std::thread::hardware_concurrency();
-      }
       if (numThreads>1)
       {
         msg("Generating code files using %zu threads.\n",numThreads);
@@ -8151,10 +8147,6 @@ static void generateFileDocs()
   if (!Doxygen::inputNameLinkedMap->empty())
   {
     std::size_t numThreads = static_cast<std::size_t>(Config_getInt(NUM_PROC_THREADS));
-    if (numThreads==0)
-    {
-      numThreads = std::thread::hardware_concurrency();
-    }
     if (numThreads>1) // multi threaded processing
     {
       struct DocContext
@@ -8439,10 +8431,6 @@ static void countMembers()
 static void generateDocsForClassList(const std::vector<ClassDefMutable*> &classList)
 {
   std::size_t numThreads = static_cast<std::size_t>(Config_getInt(NUM_PROC_THREADS));
-  if (numThreads==0)
-  {
-    numThreads = std::thread::hardware_concurrency();
-  }
   if (numThreads>1) // multi threaded processing
   {
     struct DocContext
@@ -9417,10 +9405,6 @@ static void generateGroupDocs()
 static void generateNamespaceClassDocs(const ClassLinkedRefMap &classList)
 {
   std::size_t numThreads = static_cast<std::size_t>(Config_getInt(NUM_PROC_THREADS));
-  if (numThreads==0)
-  {
-    numThreads = std::thread::hardware_concurrency();
-  }
   if (numThreads>1) // multi threaded processing
   {
     struct DocContext
@@ -9970,10 +9954,6 @@ static void parseFilesMultiThreading(const std::shared_ptr<Entry> &root)
     std::mutex processedFilesLock;
     // process source files (and their include dependencies)
     std::size_t numThreads = static_cast<std::size_t>(Config_getInt(NUM_PROC_THREADS));
-    if (numThreads==0)
-    {
-      numThreads = std::thread::hardware_concurrency();
-    }
     msg("Processing input using %zu threads.\n",numThreads);
     ThreadPool threadPool(numThreads);
     using FutureType = std::vector< std::shared_ptr<Entry> >;
@@ -10076,7 +10056,7 @@ static void parseFilesMultiThreading(const std::shared_ptr<Entry> &root)
   else // normal processing
 #endif
   {
-    std::size_t numThreads = std::thread::hardware_concurrency();
+    std::size_t numThreads = static_cast<std::size_t>(Config_getInt(NUM_PROC_THREADS));
     msg("Processing input using %zu threads.\n",numThreads);
     ThreadPool threadPool(numThreads);
     using FutureType = std::shared_ptr<Entry>;


### PR DESCRIPTION
In the proposed pull request #9235 the correct solution was given for the specific place.
To overcome the problem to have to have the correction code at each place where `NUM_PROC_THREADS` is used the code is moved to a central place.