### PR TITLE
issue #9185 tag file entry without filename

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -777,7 +777,7 @@ ClassDefImpl::ClassDefImpl(
     bool isSymbol,bool isJavaEnum)
  : DefinitionMixin(defFileName,defLine,defColumn,removeRedundantWhiteSpace(nm),0,0,isSymbol)
 {
-  setReference(lref);
+  setReference(lref,fName);
   m_impl = new ClassDefImpl::IMPL;
   m_impl->compType = ct;
   m_impl->isJavaEnum = isJavaEnum;
@@ -3324,7 +3324,7 @@ bool ClassDefImpl::isLinkable() const
   }
   else
   {
-    return isReference() || isLinkableInProject();
+    return (isReference() && !isInValidTagReference()) || isLinkableInProject();
   }
 }
 

--- a/src/classdef.h
+++ b/src/classdef.h
@@ -135,6 +135,9 @@ class ClassDef : public Definition
     /** Returns TRUE if this class is imported via a tag file */
     virtual bool isReference() const = 0;
 
+    /*! Returns TRUE if this definition is imported via a tag file and no filename is given there. */
+    virtual bool isInValidTagReference() const = 0;
+
     /** Returns TRUE if this is a local class definition, see EXTRACT_LOCAL_CLASSES */
     virtual bool isLocal() const = 0;
 

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -167,7 +167,7 @@ ConceptDefImpl::ConceptDefImpl(const QCString &fileName,int startLine,int startC
   {
     m_fileName = convertNameToFile(QCString("concept")+name);
   }
-  setReference(tagRef);
+  setReference(tagRef,tagFile);
 }
 
 ConceptDefImpl::~ConceptDefImpl()
@@ -220,7 +220,7 @@ bool ConceptDefImpl::isLinkableInProject() const
 
 bool ConceptDefImpl::isLinkable() const
 {
-  return isLinkableInProject() || isReference();
+  return isLinkableInProject() || (isReference() && !isInValidTagReference());
 }
 
 void ConceptDefImpl::setIncludeFile(FileDef *fd,const QCString &incName,bool local,bool force)

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -64,7 +64,8 @@ class DefinitionImpl::IMPL
     QCString localName;      // local (unqualified) name of the definition
                              // in the future m_name should become m_localName
     QCString qualifiedName;
-    QCString ref;   // reference to external documentation
+    QCString ref;            // reference to external documentation
+    QCString refDocuFile;    // reference to file part of the external documentation
 
     bool hidden = FALSE;
     bool isArtificial = FALSE;
@@ -1715,6 +1716,11 @@ bool DefinitionImpl::isReference() const
   return !m_impl->ref.isEmpty();
 }
 
+bool DefinitionImpl::isInValidTagReference() const
+{
+  return !m_impl->ref.isEmpty() && m_impl->refDocuFile.isEmpty();
+}
+
 int DefinitionImpl::getStartDefLine() const
 {
   return m_impl->body ? m_impl->body->defLine : -1;
@@ -1805,9 +1811,10 @@ void DefinitionImpl::mergeReferencedBy(const Definition *other)
 }
 
 
-void DefinitionImpl::setReference(const QCString &r)
+void DefinitionImpl::setReference(const QCString &r, const QCString &f)
 {
   m_impl->ref=r;
+  m_impl->refDocuFile=f;
 }
 
 SrcLangExt DefinitionImpl::getLanguage() const

--- a/src/definition.h
+++ b/src/definition.h
@@ -234,6 +234,9 @@ class Definition
     /*! Returns TRUE if this definition is imported via a tag file. */
     virtual bool isReference() const = 0;
 
+    /*! Returns TRUE if this definition is imported via a tag file and no filename is given there. */
+    virtual bool isInValidTagReference() const = 0;
+
     /*! Convenience method to return a resolved external link */
     virtual QCString externalReference(const QCString &relPath) const = 0;
 
@@ -333,7 +336,7 @@ class DefinitionMutable
     virtual void setInbodyDocumentation(const QCString &d,const QCString &docFile,int docLine) = 0;
 
     /*! Sets the tag file id via which this definition was imported. */
-    virtual void setReference(const QCString &r) = 0;
+    virtual void setReference(const QCString &r, const QCString &f) = 0;
 
     // source references
     virtual void setBodySegment(int defLine, int bls,int ble) = 0;

--- a/src/definitionimpl.h
+++ b/src/definitionimpl.h
@@ -62,6 +62,7 @@ class DefinitionImpl
     bool isArtificial() const;
     QCString getReference() const;
     bool isReference() const;
+    bool isInValidTagReference() const;
     QCString externalReference(const QCString &relPath) const;
     int getStartDefLine() const;
     int getStartBodyLine() const;
@@ -86,7 +87,7 @@ class DefinitionImpl
     void setDocumentation(const QCString &d,const QCString &docFile,int docLine,bool stripWhiteSpace=TRUE);
     void setBriefDescription(const QCString &b,const QCString &briefFile,int briefLine);
     void setInbodyDocumentation(const QCString &d,const QCString &docFile,int docLine);
-    void setReference(const QCString &r);
+    void setReference(const QCString &r, const QCString &f);
     void addSectionsToDefinition(const std::vector<const SectionInfo*> &anchorList);
     void setBodySegment(int defLine,int bls,int ble);
     void setBodyDef(const FileDef *fd);
@@ -181,6 +182,7 @@ class DefinitionMixin : public Base
     virtual bool isArtificial() const { return m_impl.isArtificial(); }
     virtual QCString getReference() const { return m_impl.getReference(); }
     virtual bool isReference() const { return m_impl.isReference(); }
+    virtual bool isInValidTagReference() const { return m_impl.isInValidTagReference(); }
     virtual QCString externalReference(const QCString &relPath) const { return m_impl.externalReference(relPath); }
     virtual int getStartDefLine() const { return m_impl.getStartDefLine(); }
     virtual int getStartBodyLine() const { return m_impl.getStartBodyLine(); }
@@ -211,8 +213,8 @@ class DefinitionMixin : public Base
     { m_impl.setBriefDescription(brief,briefFile,briefLine); }
     virtual void setInbodyDocumentation(const QCString &doc,const QCString &docFile,int docLine)
     { m_impl.setInbodyDocumentation(doc,docFile,docLine); }
-    virtual void setReference(const QCString &r)
-    { m_impl.setReference(r); }
+    virtual void setReference(const QCString &r, const QCString &f)
+    { m_impl.setReference(r,f); }
     virtual void addSectionsToDefinition(const std::vector<const SectionInfo*> &anchorList)
     { m_impl.addSectionsToDefinition(anchorList); }
     virtual void setBodySegment(int defLine,int bls,int ble)
@@ -381,6 +383,8 @@ class DefinitionAliasMixin : public Base
     { return m_alias->getReference(); }
     virtual bool isReference() const
     { return m_alias->isReference(); }
+    virtual bool isInValidTagReference() const
+    { return m_alias->isInValidTagReference(); }
     virtual QCString externalReference(const QCString &relPath) const
     { return m_alias->externalReference(relPath); }
     virtual int getStartDefLine() const

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -146,7 +146,7 @@ bool DirDefImpl::isLinkableInProject() const
 
 bool DirDefImpl::isLinkable() const
 {
-  return isReference() || isLinkableInProject();
+  return (isReference() && !isInValidTagReference()) || isLinkableInProject();
 }
 
 void DirDefImpl::addSubDir(DirDef *subdir)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -370,7 +370,7 @@ static void buildGroupListFiltered(const Entry *root,bool additional, bool inclu
           gd = Doxygen::groupLinkedMap->add(root->name,
                std::unique_ptr<GroupDef>(
                   createGroupDef(root->fileName,root->startLine,root->name,root->type,root->tagInfo()->fileName)));
-          gd->setReference(root->tagInfo()->tagName);
+          gd->setReference(root->tagInfo()->tagName,root->tagInfo()->fileName);
         }
         else
         {
@@ -1712,7 +1712,7 @@ static void buildNamespaceList(const Entry *root)
             // and also in a project file, then remove
             // the tag file reference
           {
-            nd->setReference("");
+            nd->setReference("","");
             nd->setFileName(fullName);
           }
           nd->setMetaData(root->metaData);

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -80,7 +80,7 @@ class FileDefImpl : public DefinitionMixin<FileDef>
     virtual QCString getPath() const { return m_path; }
     virtual QCString getVersion() const { return m_fileVersion; }
     virtual bool isLinkableInProject() const;
-    virtual bool isLinkable() const { return isLinkableInProject() || isReference(); }
+    virtual bool isLinkable() const { return isLinkableInProject() || (isReference() && !isInValidTagReference()); }
     virtual bool isIncluded(const QCString &name) const;
     virtual PackageDef *packageDef() const { return m_package; }
     virtual DirDef *getDirDef() const      { return m_dir; }
@@ -233,7 +233,7 @@ FileDefImpl::FileDefImpl(const QCString &p,const QCString &nm,
   m_path=p;
   m_filePath=m_path+nm;
   m_fileName=nm;
-  setReference(lref);
+  setReference(lref,dn);
   setDiskName(!dn.isEmpty() ? dn : nm);
   m_package           = 0;
   m_isSource          = guessSection(nm)==Entry::SOURCE_SEC;

--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -306,7 +306,15 @@ void FTVHelp::generateLink(TextStream &t,FTVNode *n)
   bool setTarget = FALSE;
   if (n->file.isEmpty()) // no link
   {
-    t << "<b>" << convertToHtml(n->name) << "</b>";
+    if (!n->ref.isEmpty())
+    {
+      t << convertToHtml(n->name);
+      t << "&#160;[external]";
+    }
+    else
+    {
+      t << "<b>" << convertToHtml(n->name) << "</b>";
+    }
   }
   else // link into other frame
   {

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1732,7 +1732,7 @@ bool GroupDefImpl::isLinkableInProject() const
 
 bool GroupDefImpl::isLinkable() const
 {
-  return hasUserDocumentation();
+  return hasUserDocumentation() || (isReference() && !isInValidTagReference());
 }
 
 // let the "programming language" for a group depend on what is inserted into it.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -501,13 +501,19 @@ static void writeClassTreeToOutput(OutputList &ol,const BaseClassList &bcl,int l
         ol.startIndexItem(QCString(),QCString());
         ol.parseText(cd->name());
         ol.endIndexItem(QCString(),QCString());
+        if (cd->isReference())
+        {
+          ol.startTypewriter();
+          ol.docify(" [external]");
+          ol.endTypewriter();
+        }
         if (addToIndex)
         {
           Doxygen::indexList->addContentsItem(hasChildren,cd->displayName(),QCString(),QCString(),QCString());
         }
         if (ftv)
         {
-          ftv->addContentsItem(hasChildren,cd->displayName(),QCString(),QCString(),QCString(),FALSE,FALSE,cd);
+          ftv->addContentsItem(hasChildren,cd->displayName(),cd->isReference()?"[external]":QCString(),QCString(),QCString(),FALSE,FALSE,cd);
         }
       }
       if (hasChildren)
@@ -855,13 +861,19 @@ static void writeClassTreeForList(OutputList &ol,const ClassLinkedMap &cl,bool &
           ol.startIndexItem(QCString(),QCString());
           ol.parseText(cd->displayName());
           ol.endIndexItem(QCString(),QCString());
+          if (cd->isReference())
+          {
+            ol.startTypewriter();
+            ol.docify(" [external]");
+            ol.endTypewriter();
+          }
           if (addToIndex)
           {
             Doxygen::indexList->addContentsItem(hasChildren,cd->displayName(),QCString(),QCString(),QCString(),FALSE,FALSE);
           }
           if (ftv)
           {
-            ftv->addContentsItem(hasChildren,cd->displayName(),QCString(),QCString(),QCString(),FALSE,FALSE,cd.get());
+            ftv->addContentsItem(hasChildren,cd->displayName(),cd->isReference()?"[external]":QCString(),QCString(),QCString(),FALSE,FALSE,cd.get());
           }
         }
         if (cd->getLanguage()==SrcLangExt_VHDL && hasChildren)

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1759,7 +1759,7 @@ bool MemberDefImpl::isLinkable() const
   }
   else
   {
-    return isLinkableInProject() || isReference();
+    return isLinkableInProject() || (isReference() && !isInValidTagReference());
   }
 }
 
@@ -4752,7 +4752,7 @@ void MemberDefImpl::setTagInfo(const TagInfo *ti)
   {
     //printf("%s: Setting tag name=%s anchor=%s\n",qPrint(name()),qPrint(ti->tagName),qPrint(ti->anchor));
     m_impl->anc=ti->anchor;
-    setReference(ti->tagName);
+    setReference(ti->tagName,ti->fileName);
     m_impl->explicitOutputFileBase = stripExtension(ti->fileName);
   }
 }

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -271,6 +271,8 @@ class MemberDef : public Definition
     virtual QCString briefDescription(bool abbr=FALSE) const = 0;
     virtual QCString fieldType() const = 0;
     virtual bool isReference() const = 0;
+    virtual bool isInValidTagReference() const = 0;
+
 
     virtual QCString getDeclFileName() const = 0;
     virtual int getDeclLine() const = 0;

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -274,7 +274,7 @@ NamespaceDefImpl::NamespaceDefImpl(const QCString &df,int dl,int dc,
   {
     setFileName(name);
   }
-  setReference(lref);
+  setReference(lref,fName);
   m_inline=FALSE;
   m_subGrouping=Config_getBool(SUBGROUPING);
   if (type=="module")
@@ -1454,7 +1454,7 @@ bool NamespaceDefImpl::isLinkableInProject() const
 
 bool NamespaceDefImpl::isLinkable() const
 {
-  return isLinkableInProject() || isReference();
+  return isLinkableInProject() || (isReference() && !isInValidTagReference());
 }
 
 const MemberDef * NamespaceDefImpl::getMemberByName(const QCString &n) const

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -39,7 +39,7 @@ class PageDefImpl : public DefinitionMixin<PageDef>
     virtual DefType definitionType() const { return TypePage; }
     virtual CodeSymbolType codeSymbolType() const { return CodeSymbolType::Default; }
     virtual bool isLinkableInProject() const { return /*hasDocumentation() &&*/ !isReference(); }
-    virtual bool isLinkable() const { return isLinkableInProject() || isReference(); }
+    virtual bool isLinkable() const { return isLinkableInProject() || (isReference() && !isInValidTagReference()); }
     virtual QCString getOutputFileBase() const;
     virtual QCString anchor() const { return QCString(); }
     virtual void findSectionsInDocumentation();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4823,7 +4823,7 @@ PageDef *addRelatedPage(const QCString &name,const QCString &ptitle,
 
     if (tagInfo)
     {
-      pd->setReference(tagInfo->tagName);
+      pd->setReference(tagInfo->tagName,tagInfo->fileName);
       pd->setFileName(tagInfo->fileName);
     }
 


### PR DESCRIPTION
In case the the `filename` isn't mentioned in the tag file show the item but don't link to it (but still mention it as external at the appropriate places).
For this the original `filename` has te be "recorded" as later on the filename to be used might be overwritten.