### PR TITLE
issue #9251 HTML extensions stripped from DOT SVG links with tagfiles

### DIFF
--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -471,15 +471,27 @@ void DotNode::writeBox(TextStream &t,
     }
     if (!m_url.isEmpty())
     {
-      int anchorPos = m_url.findRev('#');
-      if (anchorPos==-1)
+      int tagPos = m_url.findRev('$');
+      QCString noTagURL;
+      if (tagPos==-1)
       {
-        t << ",URL=\"" << addHtmlExtensionIfMissing(m_url) << "\"";
+        t << ",URL=\"";
+        QCString noTagURL = m_url;
       }
       else
       {
-        t << ",URL=\"" << addHtmlExtensionIfMissing(m_url.left(anchorPos))
-          << m_url.right(m_url.length()-anchorPos) << "\"";
+        t << ",URL=\"" << m_url.left(tagPos);
+        noTagURL = m_url.right(m_url.length()-tagPos);
+      }
+      int anchorPos = noTagURL.findRev('#');
+      if (anchorPos==-1)
+      {
+        t << addHtmlExtensionIfMissing(noTagURL) << "\"";
+      }
+      else
+      {
+        t << addHtmlExtensionIfMissing(noTagURL.left(anchorPos))
+          << noTagURL.right(noTagURL.length()-anchorPos) << "\"";
       }
     }
   }


### PR DESCRIPTION
In an URL like: `ext_1/external.tag$classext__1_1_1_external_sub_c` the extension is seen like `tag$classext__1_1_1_external_sub_c` as the function searches the entire string for the last `.` instead of looking in the part after the `$`.
This is a special case for dot images.