### PR TITLE
issue #9254 Missing first word of page in case of existing \page command in markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3568,7 +3568,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
           docs = docs.left(match[1].position())+               // part before label
                  newLabel+                                     // new label
                  match[2].str()+                               // part between orgLabel and \n
-                 "\\ilinebr @anchor "+orgLabel+                // add original anchor
+                 "\\ilinebr @anchor "+orgLabel+"\n"+           // add original anchor plus \n of above
                  docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }


### PR DESCRIPTION
When a `\page` command was present in markdown the first word on the next line was added to the anchor instead shown a text.
This is a spin-off of #9254