### PR TITLE
bug 783768 QCH files: classes & their constructors get conflicting keyword handling

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -591,9 +591,10 @@ void HtmlHelp::addIndexItem(const Definition *context,const MemberDef *md,
     if (context==0) return; // should not happen
 
     QCString cfname  = md->getOutputFileBase();
+    QCString argStr  = md->argsString();
     QCString cfiname = context->getOutputFileBase();
     QCString level1  = context->name();
-    QCString level2  = md->name();
+    QCString level2  = md->name() + argStr;
     QCString contRef = separateMemberPages ? cfname : cfiname;
     QCString memRef  = cfname;
     QCString anchor  = !sectionAnchor.isEmpty() ? sectionAnchor : md->anchor();

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -350,6 +350,7 @@ void Qhp::addIndexItem(const Definition *context,const MemberDef *md,
     }
     if (context==0) return; // should not happen
     QCString cfname  = md->getOutputFileBase();
+    QCString argStr  = md->argsString();
     QCString cfiname = context->getOutputFileBase();
     QCString level1  = context->name();
     QCString level2  = !word.isEmpty() ? word : md->name();
@@ -361,8 +362,8 @@ void Qhp::addIndexItem(const Definition *context,const MemberDef *md,
     ref = makeRef(contRef, anchor);
     QCString id = level1+"::"+level2;
     writeIndent(p->index,3);
-    p->index << "<keyword name=\"" << convertToXML(level2) << "\""
-                          " id=\"" << convertToXML(id) << "\""
+    p->index << "<keyword name=\"" << convertToXML(level2 + argStr) << "\""
+                          " id=\"" << convertToXML(id + "_" + anchor) << "\""
                          " ref=\"" << convertToXML(ref) << "\"/>\n";
   }
   else if (context) // container
@@ -373,7 +374,7 @@ void Qhp::addIndexItem(const Definition *context,const MemberDef *md,
     QCString ref = makeRef(contRef,sectionAnchor);
     writeIndent(p->index,3);
     p->index << "<keyword name=\"" << convertToXML(level1) << "\""
-             <<           " id=\"" << convertToXML(level1) << "\""
+             <<           " id=\"" << convertToXML(level1 +"_" + sectionAnchor) << "\""
              <<          " ref=\"" << convertToXML(ref) << "\"/>\n";
   }
 }


### PR DESCRIPTION
The problem in not only present in the Qt help (qhp / qch) but also in the HTML Help (chm).
All items with the same name are put onto one heap. For the index this is corrected by adding the function signatures, analogous to the javascript search functionality of doxygen.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8428593/example.tar.gz)
