### PR TITLE
issue #9257 Build Error regarding vhdlparser

### DIFF
--- a/vhdlparser/CMakeLists.txt
+++ b/vhdlparser/CMakeLists.txt
@@ -19,13 +19,27 @@ if (JAVACC_FOUND)
         message(STATUS "  Doxygen requires at least JavaCC version 7.0.5 (installed: ${JAVACC_VERSION})")
 	message(STATUS "  Fall back to JavaCC not installed, using existing files.")
     else()
-
-    add_custom_command(
-        COMMAND ${JAVACC_EXECUTABLE} ${JAVACC_FLAGS} -OUTPUT_DIRECTORY=${PROJECT_SOURCE_DIR}/vhdlparser ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj
-        DEPENDS ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj
-        OUTPUT ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.cc ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.h ${PROJECT_SOURCE_DIR}/vhdlparser/ErrorHandler.h ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.cc ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.h ${PROJECT_SOURCE_DIR}/vhdlparser/Token.cc ${PROJECT_SOURCE_DIR}/vhdlparser/Token.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenManager.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.cc ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserConstants.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.h
-    )
-
+        if (JAVACC_VERSION VERSION_LESS 7.0.6)
+          add_custom_command(OUTPUT ${GENERATED_SRC}/vhdlparser.jj
+              COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_SOURCE_DIR}/vhdlparser/Token.h
+              COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_SOURCE_DIR}/vhdlparser/Token.cc
+              COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj ${GENERATED_SRC}/vhdlparser.jj
+              DEPENDS ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj
+        )
+        else()
+          add_custom_command(
+              COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_SOURCE_DIR}/vhdlparser/Token.h
+              COMMAND ${CMAKE_COMMAND} -E remove ${PROJECT_SOURCE_DIR}/vhdlparser/Token.cc
+              COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/vhdlparser/vhdljj_adj.py ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj ${GENERATED_SRC}/vhdlparser.jj
+              DEPENDS ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj ${PROJECT_SOURCE_DIR}/vhdlparser/vhdljj_adj.py
+              OUTPUT  ${GENERATED_SRC}/vhdlparser.jj
+          )
+        endif()
+        add_custom_command(
+            COMMAND ${JAVACC_EXECUTABLE} ${JAVACC_FLAGS} -OUTPUT_DIRECTORY=${PROJECT_SOURCE_DIR}/vhdlparser ${GENERATED_SRC}/vhdlparser.jj
+            DEPENDS ${GENERATED_SRC}/vhdlparser.jj
+            OUTPUT ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.cc ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.h ${PROJECT_SOURCE_DIR}/vhdlparser/ErrorHandler.h ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.cc ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.h ${PROJECT_SOURCE_DIR}/vhdlparser/Token.cc ${PROJECT_SOURCE_DIR}/vhdlparser/Token.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenManager.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.cc ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserConstants.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.h
+        )
     endif()
 endif()
 

--- a/vhdlparser/vhdljj_adj.py
+++ b/vhdlparser/vhdljj_adj.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+# python script to adjust vhdlparser.jj for javaCC versions > 7.0.5
+#
+# Copyright (C) 1997-2021 by Dimitri van Heesch.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation under the terms of the GNU General Public License is hereby
+# granted. No representations are made about the suitability of this software
+# for any purpose. It is provided "as is" without express or implied warranty.
+# See the GNU General Public License for more details.
+#
+# Documents produced by Doxygen are derivative works derived from the
+# input used in their production; they are not affected by this license.
+
+import sys
+
+def main():
+    inputFile = open(sys.argv[1], 'r')
+    outputFile = open(sys.argv[2], 'w')
+    for line in inputFile:
+        outputFile.write(line.replace("_INCLUDES","_INCLUDE"))
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
JavaCC introduced an incompatibility in the version 7.0.6:
> C++ generation: renaming the option PARSER_INCLUDES by PARSER_INCLUDE
> C++ generation: renaming the option TOKEN_MANAGER_INCLUDES by TOKEN_MANAGER_INCLUDE

which influences the vhdlparser.jj options section