### PR TITLE
Problem compiling under Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,11 @@ if (WIN32)
 endif()
 if (CMAKE_SYSTEM_NAME MATCHES "CYGWIN")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og")
+
+   if (CMAKE_BUILD_TYPE STREQUAL  "")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O1")
+   endif()
 endif()
 
 if(POLICY CMP0063)


### PR DESCRIPTION
When we create an executable under Cygwin based on `CMAKE_BUILD_TYPE=debug` or in case `CMAKE_BUILD_TYPE` is not se we get errors like:
```
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/as: CMakeFiles/doxymain.dir/context.cpp.o: section .pdata$_ZNSt8_Rb_treeISsSt4pairIKSsMN15ArgumentContext7PrivateEKF15TemplateVariantvEESt10_Select1stIS7_ESt4lessISsESaIS7_EE12_M_rightmostEv: string table overflow at offset 10000088
```
this happens for `concept.cpp` and `docparser.cpp`.
In the past we already added `-Wa,-,big-obj` for similar issues but this was not sufficient anymore.