### PR TITLE
bug_698167 HIDE_SCOPE_NAMES does not hide namespace scope for functions within it

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3431,6 +3431,7 @@ static void addGlobalFunction(const Entry *root,const QCString &rname,const QCSt
     scope+=sep;
   }
 
+  if (Config_getBool(HIDE_SCOPE_NAMES)) scope = "";
   QCString def;
   //QCString optArgs = root->argList.empty() ? QCString() : root->args;
   if (!root->type.isEmpty())


### PR DESCRIPTION
Analogous as for classes in `addMethodToClass` don't use the scope in case of `HIDE_SCOPE_NAMES` (here we do it by resetting the `scope`).