### PR TITLE
issue #9276 File-Line is omitted when suggesting possible candidates depending on noMatchCount

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -6036,13 +6036,7 @@ static void addMemberFunction(const Entry *root,
           if (!qScope.isEmpty())
             warnMsg+=qScope+"::"+md->name();
           warnMsg+=md->argsString();
-          if (noMatchCount>1)
-          {
-            warnMsg+="' " + warn_line(md->getDefFileName(),md->getDefLine());
-          }
-          else
-            warnMsg += "'";
-
+          warnMsg+="' " + warn_line(md->getDefFileName(),md->getDefLine());
           warnMsg+='\n';
         }
       }


### PR DESCRIPTION
There is no reason why to make the File-Line depending on the `noMatchCount`.