### PR TITLE
Code generation optimizations

### DIFF
--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -160,7 +160,7 @@ void DotRunner::addJob(const QCString &format, const QCString &output,
     return;
   }
   auto args = QCString("-T") + format + " -o \"" + output + "\"";
-  m_jobs.emplace_back(format.str(), output, args, srcFile, srcLine);
+  m_jobs.emplace_back(format, output, args, srcFile, srcLine);
 }
 
 QCString getBaseNameOfOutput(const QCString &output)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7721,7 +7721,7 @@ static void addToIndices()
   {
     if (pd->isLinkableInProject())
     {
-      Doxygen::indexList->addIndexItem(pd.get(),0,QCString(),filterTitle(pd->title().str()));
+      Doxygen::indexList->addIndexItem(pd.get(),0,QCString(),filterTitle(pd->title()));
     }
   }
 

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -84,8 +84,8 @@ class FileDefImpl : public DefinitionMixin<FileDef>
     virtual bool isIncluded(const QCString &name) const;
     virtual PackageDef *packageDef() const { return m_package; }
     virtual DirDef *getDirDef() const      { return m_dir; }
-    virtual LinkedRefMap<const NamespaceDef> getUsedNamespaces() const;
-    virtual LinkedRefMap<const ClassDef> getUsedClasses() const  { return m_usingDeclList; }
+    virtual const LinkedRefMap<const NamespaceDef> &getUsedNamespaces() const;
+    virtual const LinkedRefMap<const ClassDef> &getUsedClasses() const  { return m_usingDeclList; }
     virtual const IncludeInfoList &includeFileList() const    { return m_includeList; }
     virtual const IncludeInfoList &includedByFileList() const { return m_includedByList; }
     virtual void getAllIncludeFilesRecursively(StringVector &incFiles) const;
@@ -1354,7 +1354,7 @@ void FileDefImpl::addUsingDirective(const NamespaceDef *nd)
   //printf("%p: FileDefImpl::addUsingDirective: %s:%d\n",this,qPrint(name()),usingDirList->count());
 }
 
-LinkedRefMap<const NamespaceDef> FileDefImpl::getUsedNamespaces() const
+const LinkedRefMap<const NamespaceDef> &FileDefImpl::getUsedNamespaces() const
 {
   //printf("%p: FileDefImpl::getUsedNamespace: %s:%d\n",this,qPrint(name()),usingDirList?usingDirList->count():0);
   return m_usingDirList;

--- a/src/filedef.h
+++ b/src/filedef.h
@@ -122,8 +122,8 @@ class FileDef : public DefinitionMutable, public Definition
 
     virtual PackageDef *packageDef() const = 0;
     virtual DirDef *getDirDef() const = 0;
-    virtual LinkedRefMap<const NamespaceDef> getUsedNamespaces() const = 0;
-    virtual LinkedRefMap<const ClassDef> getUsedClasses() const = 0;
+    virtual const LinkedRefMap<const NamespaceDef> &getUsedNamespaces() const = 0;
+    virtual const LinkedRefMap<const ClassDef> &getUsedClasses() const = 0;
     virtual const IncludeInfoList &includeFileList() const = 0;
     virtual const IncludeInfoList &includedByFileList() const = 0;
     virtual void getAllIncludeFilesRecursively(StringVector &incFiles) const = 0;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3497,7 +3497,7 @@ static void writeExampleIndex(OutputList &ol)
       ol.writeObjectLink(QCString(),n,QCString(),pd->title());
       if (addToIndex)
       {
-        Doxygen::indexList->addContentsItem(FALSE,filterTitle(pd->title().str()),pd->getReference(),n,QCString(),FALSE,TRUE);
+        Doxygen::indexList->addContentsItem(FALSE,filterTitle(pd->title()),pd->getReference(),n,QCString(),FALSE,TRUE);
       }
     }
     else
@@ -3548,7 +3548,7 @@ static bool mainPageHasOwnTitle()
   QCString title;
   if (Doxygen::mainPage)
   {
-    title = filterTitle(Doxygen::mainPage->title().str());
+    title = filterTitle(Doxygen::mainPage->title());
   }
   return !projectName.isEmpty() && mainPageHasTitle() && qstricmp(title,projectName)!=0;
 }
@@ -3570,7 +3570,7 @@ static void writePages(const PageDef *pd,FTVHelp *ftv)
     if (pd->title().isEmpty())
       pageTitle=pd->name();
     else
-      pageTitle=filterTitle(pd->title().str());
+      pageTitle=filterTitle(pd->title());
 
     if (ftv)
     {
@@ -4336,7 +4336,7 @@ static void writeIndex(OutputList &ol)
   }
   else if (Doxygen::mainPage)
   {
-    title = filterTitle(Doxygen::mainPage->title().str());
+    title = filterTitle(Doxygen::mainPage->title());
   }
 
   QCString indexName="index";

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -75,9 +75,9 @@ class NamespaceDefImpl : public DefinitionMixin<NamespaceDefMutable>
     virtual void countMembers();
     virtual int  numDocMembers() const;
     virtual void addUsingDirective(const NamespaceDef *nd);
-    virtual LinkedRefMap<const NamespaceDef> getUsedNamespaces() const { return m_usingDirList; }
+    virtual const LinkedRefMap<const NamespaceDef> &getUsedNamespaces() const { return m_usingDirList; }
     virtual void addUsingDeclaration(const ClassDef *cd);
-    virtual LinkedRefMap<const ClassDef> getUsedClasses() const { return m_usingDeclList; }
+    virtual const LinkedRefMap<const ClassDef> &getUsedClasses() const { return m_usingDeclList; }
     virtual void combineUsingRelations(NamespaceDefSet &visitedNamespace);
     virtual QCString displayName(bool=TRUE) const;
     virtual QCString localName() const;
@@ -190,9 +190,9 @@ class NamespaceDefAliasImpl : public DefinitionAliasMixin<NamespaceDef>
     { return getNSAlias()->anchor(); }
     virtual int numDocMembers() const
     { return getNSAlias()->numDocMembers(); }
-    virtual LinkedRefMap<const NamespaceDef> getUsedNamespaces() const
+    virtual const LinkedRefMap<const NamespaceDef> &getUsedNamespaces() const
     { return getNSAlias()->getUsedNamespaces(); }
-    virtual LinkedRefMap<const ClassDef> getUsedClasses() const
+    virtual const LinkedRefMap<const ClassDef> &getUsedClasses() const
     { return getNSAlias()->getUsedClasses(); }
     virtual QCString displayName(bool b=TRUE) const
     { return makeDisplayName(this,b); }

--- a/src/namespacedef.h
+++ b/src/namespacedef.h
@@ -60,8 +60,8 @@ class NamespaceDef : public Definition
     virtual QCString getOutputFileBase() const = 0;
     virtual QCString anchor() const = 0;
     virtual int numDocMembers() const = 0;
-    virtual LinkedRefMap<const NamespaceDef> getUsedNamespaces() const = 0;
-    virtual LinkedRefMap<const ClassDef> getUsedClasses() const = 0;
+    virtual const LinkedRefMap<const NamespaceDef> &getUsedNamespaces() const = 0;
+    virtual const LinkedRefMap<const ClassDef> &getUsedClasses() const = 0;
     virtual QCString displayName(bool=TRUE) const = 0;
     virtual QCString localName() const = 0;
     virtual bool isConstantGroup() const = 0;

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -2049,7 +2049,7 @@ void PerlModGenerator::generatePerlModForPage(PageDef *pd)
 
   const SectionInfo *si = SectionManager::instance().find(pd->name());
   if (si)
-    m_output.addFieldQuotedString("title4", filterTitle(si->title().str()));
+    m_output.addFieldQuotedString("title4", filterTitle(si->title()));
 
   addPerlModDocBlock(m_output,"detailed",pd->docFile(),pd->docLine(),0,0,pd->documentation());
   m_output.closeHash();

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -117,7 +117,7 @@ class QCString
 
     explicit QCString( const std::string &s ) : m_rep(s) {}
 
-    QCString( std::string &&s) { m_rep = std::move(s); }
+    QCString( std::string &&s) : m_rep(std::move(s)) {}
 
     /** creates a string with room for size characters
      *  @param[in] size the number of character to allocate (also counting the 0-terminator!)

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -465,7 +465,7 @@ class QCString
     }
 #endif
 
-    std::string str() const
+    const std::string &str() const
     {
       return m_rep;
     }
@@ -530,7 +530,7 @@ class QCString
  *****************************************************************************/
 
 inline bool operator==( const QCString &s1, const QCString &s2 )
-{ return qstrcmp(s1.data(),s2.data()) == 0; }
+{ return s1.str() == s2.str(); }
 
 inline bool operator==( const QCString &s1, const char *s2 )
 { return qstrcmp(s1.data(),s2) == 0; }
@@ -539,7 +539,7 @@ inline bool operator==( const char *s1, const QCString &s2 )
 { return qstrcmp(s1,s2.data()) == 0; }
 
 inline bool operator!=( const QCString &s1, const QCString &s2 )
-{ return qstrcmp(s1.data(),s2.data()) != 0; }
+{ return s1.str() != s2.str(); }
 
 inline bool operator!=( const QCString &s1, const char *s2 )
 { return qstrcmp(s1.data(),s2) != 0; }

--- a/src/symbolmap.h
+++ b/src/symbolmap.h
@@ -44,7 +44,7 @@ class SymbolMap
     //! Remove a symbol \a def from the map that was stored under key \a name
     void remove(const QCString &name,Ptr def)
     {
-      auto range = find(name.str());
+      auto range = find(name);
       for (auto it=range.first; it!=range.second; )
       {
         if (it->second==def) it = m_map.erase(it); else ++it;

--- a/src/symbolresolver.cpp
+++ b/src/symbolresolver.cpp
@@ -853,10 +853,8 @@ bool SymbolResolver::Private::accessibleViaUsingNamespace(StringUnorderedSet &vi
     if (item->getLanguage()==SrcLangExt_Cpp)
     {
       QCString key=und->qualifiedName();
-      if (!und->getUsedNamespaces().empty() && visited.find(key.str())==visited.end())
+      if (!und->getUsedNamespaces().empty() && visited.insert(key.str()).second)
       {
-        visited.insert(key.str());
-
         if (accessibleViaUsingNamespace(visited,und->getUsedNamespaces(),item,explicitScopePart,level+1))
         {
           //printf("%d ] found it via recursion\n",level);

--- a/src/symbolresolver.cpp
+++ b/src/symbolresolver.cpp
@@ -144,7 +144,7 @@ struct SymbolResolver::Private
 
     const Definition *followPath(const Definition *start,const QCString &path);
 
-    const Definition *endOfPathIsUsedClass(LinkedRefMap<const ClassDef> cl,const QCString &localName);
+    const Definition *endOfPathIsUsedClass(const LinkedRefMap<const ClassDef> &cl,const QCString &localName);
 
     bool accessibleViaUsingNamespace(StringUnorderedSet &visited,
                                      const LinkedRefMap<const NamespaceDef> &nl,
@@ -821,7 +821,7 @@ const Definition *SymbolResolver::Private::followPath(const Definition *start,co
   return current; // path could be followed
 }
 
-const Definition *SymbolResolver::Private::endOfPathIsUsedClass(LinkedRefMap<const ClassDef> cl,const QCString &localName)
+const Definition *SymbolResolver::Private::endOfPathIsUsedClass(const LinkedRefMap<const ClassDef> &cl,const QCString &localName)
 {
   for (const auto &cd : cl)
   {

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -1794,7 +1794,7 @@ static void generateXMLForPage(PageDef *pd,TextStream &ti,bool isExample)
     QCString title;
     if (mainPageHasTitle())
     {
-      title = filterTitle(convertCharEntitiesToUTF8(Doxygen::mainPage->title()).str());
+      title = filterTitle(convertCharEntitiesToUTF8(Doxygen::mainPage->title()));
     }
     else
     {
@@ -1808,7 +1808,7 @@ static void generateXMLForPage(PageDef *pd,TextStream &ti,bool isExample)
     const SectionInfo *si = SectionManager::instance().find(pd->name());
     if (si)
     {
-      t << "    <title>" << convertToXML(filterTitle(convertCharEntitiesToUTF8(si->title()).str()))
+      t << "    <title>" << convertToXML(filterTitle(convertCharEntitiesToUTF8(si->title())))
         << "</title>\n";
     }
   }


### PR DESCRIPTION
After #9266 I did some profiling of doxygen generation of our C++ codebase. Based on that I have done a few optimizations that bring a 9x speedup, from ~49 minutes down to just over 5 minutes.

The most important change was the first commit, which using `const& for LinkedRefMap` instead of copies.

Note that the commit "Used hash data structures for SymbolMap" seems to cause the regression test `027_extends.c` to fail, not sure if this is an issue?