### PR TITLE
issue #9284 Clicking external link within search results with EXT_LINKS_IN_WINDOW=YES opens the link in the search results box

### DIFF
--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -466,6 +466,7 @@ void writeJavaScriptSearchIndex()
         // searchData[x][1][y+1] = info for child y
         // searchData[x][1][y+1][0] = url
         // searchData[x][1][y+1][1] = 1 => target="_parent"
+        // searchData[x][1][y+1][1] = 0 => target="_blank"
         // searchData[x][1][y+1][2] = scope
 
         ti << "[\n";

--- a/templates/html/search.js
+++ b/templates/html/search.js
@@ -745,6 +745,10 @@ function createResults()
       {
        srLink.setAttribute('target','_parent');
       }
+      else
+      {
+       srLink.setAttribute('target','_blank');
+      }
       var srScope = document.createElement('span');
       setClassAttr(srScope,'SRScope');
       srScope.innerHTML = searchData[e][1][1][2];
@@ -766,6 +770,10 @@ function createResults()
         if (searchData[e][1][c+1][1])
         {
          srChild.setAttribute('target','_parent');
+        }
+        else
+        {
+         srChild.setAttribute('target','_blank');
         }
         srChild.innerHTML = searchData[e][1][c+1][2];
         srChildren.appendChild(srChild);


### PR DESCRIPTION
Analogous to the normal page handling (see `util.cpp`, function `externalLinkTarget`) in case of `EXT_LINKS_IN_WINDOW` is set switch relevant search output to new window.