### PR TITLE
Remove retrieval of the process count for tests

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -336,9 +336,6 @@ jobs:
     - name: Run tests (Linux / MacOS)
       shell: cmake -P {0}
       run: |
-        include(ProcessorCount)
-        ProcessorCount(N)
-
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
 
         execute_process(
@@ -353,9 +350,6 @@ jobs:
     - name: Run tests (Windows)
       shell: cmake -P {0}
       run: |
-        include(ProcessorCount)
-        ProcessorCount(N)
-
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
 
         execute_process(


### PR DESCRIPTION
Although it is possible to run the tests in parallel (`TEST_FLAGS="--pool {N}"`) this option is not used, so no retrieval necessary.