### PR TITLE
Error when generating documentation with formulas a second time

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -75,10 +75,25 @@ void FormulaManager::readFormulas(const QCString &dir,bool doCompare)
   {
     uint formulaCount=0;
     msg("Reading formula repository...\n");
+    std::string readLine;
     std::string line;
-    int lineNr=1;
-    while (getline(f,line))
+    std::string prefix("\\_form#");
+    int lineNr;
+    int nextLineNr=1;
+    bool hasNextLine = getline(f,readLine) ? true : false;
+    while (hasNextLine)
     {
+      line = readLine;
+      lineNr = nextLineNr;
+
+      // look ahead a bit because a formula can be spread over several lines
+      while (hasNextLine = getline(f,readLine) ? true : false)
+      {
+        nextLineNr+=1;
+        if (!readLine.compare(0, prefix.size(), prefix)) break;
+        line += "\n" + readLine;
+      }
+
       // format: \_form#<digits>=<digits>x<digits>:formula
       size_t hi=line.find('#');
       size_t ei=line.find('=');
@@ -117,7 +132,6 @@ void FormulaManager::readFormulas(const QCString &dir,bool doCompare)
           p->storeDisplaySize(id,w,h);
         }
       }
-      lineNr++;
     }
     if (doCompare && formulaCount!=p->formulas.size())
     {


### PR DESCRIPTION
With the pull request #9088 the embedded `\n` are left in the formula and as formulas now can span multiple lines some lookahead is necessary.

The problem shows when doing a documentation run multiple times and a formula spans multiple lines (and MathJax isn't used). The problem surfaced when generating the doxygen manual (due to changes)  a second time.