### PR TITLE
Enhancing xref possibilities

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1146,43 +1146,102 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
-    <option type='bool' id='GENERATE_TODOLIST' defval='1'>
+    <option type='enum' id='GENERATE_TODOLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_TODOLIST tag can be used to enable (\c YES) or
  disable (\c NO) the todo list. This list is created by
- putting \ref cmdtodo "\\todo" commands in the documentation.
+ putting \ref cmdtodo "\\todo" commands in the documentation. In case
+ \c GENERATE_TODOLIST is set to `ITEM` the \ref cmdtodo "\\todo" commands
+ are only visible with the item they are defined with, in case
+ \c GENERATE_TODOLIST is set to `PAGE` the \ref cmdtodo "\\todo" commands
+ are only visible on the page with an overview of all \ref cmdtodo "\\todo"
+ commands used.
 ]]>
       </docs>
+      <value name="NO" />
+      <value name="YES" />
+      <value name="ITEM" />
+      <value name="PAGE" />
     </option>
-    <option type='bool' id='GENERATE_TESTLIST' defval='1'>
+    <option type='enum' id='GENERATE_TESTLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_TESTLIST tag can be used to enable (\c YES) or
  disable (\c NO) the test list. This list is created by
- putting \ref cmdtest "\\test" commands in the documentation.
+ putting \ref cmdtest "\\test" commands in the documentation. In case
+ \c GENERATE_TESTLIST is set to `ITEM` the \ref cmdtest "\\test" commands
+ are only visible with the item they are defined with, in case
+ \c GENERATE_TESTLIST is set to `PAGE` the \ref cmdtest "\\test" commands
+ are only visible on the page with an overview of all \ref cmdtest "\\test"
+ commands used.
 ]]>
       </docs>
+      <value name="NO" />
+      <value name="YES" />
+      <value name="ITEM" />
+      <value name="PAGE" />
     </option>
-    <option type='bool' id='GENERATE_BUGLIST' defval='1'>
+    <option type='enum' id='GENERATE_BUGLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_BUGLIST tag can be used to enable (\c YES) or
  disable (\c NO) the bug list. This list is created by
- putting \ref cmdbug "\\bug" commands in the documentation.
+ putting \ref cmdbug "\\bug" commands in the documentation. In case
+ \c GENERATE_BUGLIST is set to `ITEM` the \ref cmdbug "\\bug" commands
+ are only visible with the item they are defined with, in case
+ \c GENERATE_BUGLIST is set to `PAGE` the \ref cmdbug "\\bug" commands
+ are only visible on the page with an overview of all \ref cmdbug "\\bug"
+ commands used.
 ]]>
       </docs>
+      <value name="NO" />
+      <value name="YES" />
+      <value name="ITEM" />
+      <value name="PAGE" />
     </option>
-    <option type='bool' id='GENERATE_DEPRECATEDLIST' defval='1'>
+    <option type='enum' id='GENERATE_DEPRECATEDLIST' defval='YES'>
       <docs>
 <![CDATA[
  The \c GENERATE_DEPRECATEDLIST tag can be used to enable (\c YES) or
  disable (\c NO) the deprecated list. This list is created by
- putting \ref cmddeprecated "\\deprecated"
- commands in the documentation.
+ putting \ref cmddeprecated "\\deprecated" commands in the documentation. In case
+ \c GENERATE_DEPRECATEDIST is set to `ITEM` the \ref cmddeprecated "\\deprecated" commands
+ are only visible with the item they are defined with, in case
+ \c GENERATE_DEPRECATEDIST is set to `PAGE` the \ref cmddeprecated "\\deprecated" commands
+ are only visible on the page with an overview of all \ref cmddeprecated "\\deprecated"
+ commands used.
+]]>
+      </docs>
+      <value name="NO" />
+      <value name="YES" />
+      <value name="ITEM" />
+      <value name="PAGE" />
+    </option>
+    <option type='list' id='GENERATE_XREFLIST' format='string'>
+      <docs>
+<![CDATA[
+ The \c GENERATE_XREFLIST tag can be used to enable or disable the specified set of
+ user defined \ref cmdxrefitem "\\xrefiten" commands. The functionality is similar as
+ for the \ref cmdtodo "\\todo", \ref cmdtest "\\test", \ref cmdbug "\\bug" and
+ \ref cmddeprecated "\\deprecated" commands. Each part has the syntax:
+ `<key>[=<value>]`, where `<key>` is the identifier as specified with the 
+ \ref cmdxrefitem "\\xrefiten" command and `<value>` is `NO`, `YES`, `ITEM` or `PAGE`.
+ In case `<value>` is set to `ITEM` the specified \ref cmdxrefitem "\\xrefiten" `<key>` commands
+ are only visible with the item they are defined with, in case `<value>` is set to `PAGE` the
+ \ref cmdxrefitem "\\xrefiten" `<key>` commands are only visible on the page with an overview of all
+ \ref cmdxrefitem "\\xrefiten" `<key>` commands used. In case `<value>` is set to `NO`, the
+ \ref cmdxrefitem "\\xrefiten" `<key>` command is omitted and in case `<value>` is set to `YES`
+ the \ref cmdxrefitem "\\xrefiten" `<key>` commands are shown at the overview page and with the item
+ they are specified with.
+ In case the `<value>` is not specified the value `YES` is used.<br>
+ In case `YES`, `NO`, `ITEM` or `PAGE` is used as item in the \c GENERATE_XREFLIST this value is used
+ as default for the \ref cmdxrefitem "\\xrefiten" `<key>` commands that are not defined.<br>
+ In case for a \ref cmdxrefitem "\\xrefiten" `<key>` nothing is specified the default `YES` is used.
 ]]>
       </docs>
     </option>
+
     <option type='list' id='ENABLED_SECTIONS' format='string'>
       <docs>
 <![CDATA[
@@ -3445,7 +3504,7 @@ If set to \c NO, doxygen will warn if an a database file is already found and no
  contain include files that are not input files but should be processed by
  the preprocessor.
 
- Note that the \c INCLUDE_PATH is not recursive, so the setting of \ref cfg_recursive "RECURSIVE" 
+ Note that the \c INCLUDE_PATH is not recursive, so the setting of \ref cfg_recursive "RECURSIVE"
  has no effect here.
 ]]>
       </docs>

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -41,6 +41,7 @@
 #include "fileinfo.h"
 #include "dir.h"
 #include "textstream.h"
+#include "reflist.h"
 
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
@@ -1525,36 +1526,44 @@ void Config::init()
   ConfigImpl::instance()->init();
 }
 
+static [[maybe_unused]] bool checkListItem(const char *inp,const char *name, bool equalRequired,bool valueRequired)
+{
+  QCString item=inp;
+  item=item.stripWhiteSpace();
+  int i=item.find('=');
+  if (i==-1 && equalRequired)
+  {
+    err("Illegal format for option %s, no equal sign ('=') specified for item '%s'\n",name,qPrint(item));
+    return false;
+  }
+  if (i!=-1)
+  {
+    QCString myName=item.left(i).stripWhiteSpace();
+    if (myName.isEmpty())
+    {
+      err("Illegal format for option %s, no name specified for item '%s'\n",name,qPrint(item));
+      return false;
+    }
+    else if (valueRequired)
+    {
+      QCString myValue=item.right(item.length()-i-1).stripWhiteSpace();
+      if (myValue.isEmpty())
+      {
+        err("Illegal format for option %s, no value specified for item '%s'\n",name,qPrint(item));
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 static void checkList(const StringVector &list,const char *name, bool equalRequired,bool valueRequired)
 {
   for (const auto &s: list)
   {
-    QCString item=s.c_str();
-    item=item.stripWhiteSpace();
-    int i=item.find('=');
-    if (i==-1 && equalRequired)
-    {
-      err("Illegal format for option %s, no equal sign ('=') specified for item '%s'\n",name,qPrint(item));
-    }
-    if (i!=-1)
-    {
-      QCString myName=item.left(i).stripWhiteSpace();
-      if (myName.isEmpty())
-      {
-        err("Illegal format for option %s, no name specified for item '%s'\n",name,qPrint(item));
-      }
-      else if (valueRequired)
-      {
-        QCString myValue=item.right(item.length()-i-1).stripWhiteSpace();
-        if (myValue.isEmpty())
-        {
-          err("Illegal format for option %s, no value specified for item '%s'\n",name,qPrint(item));
-        }
-      }
-    }
+    checkListItem(s.c_str(), name, equalRequired,valueRequired);
   }
 }
-
 static void adjustBoolSetting(const char *depOption, const char *optionName,bool expectedValue)
 {
   // lookup option by name
@@ -2033,6 +2042,39 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   }
 #endif
 
+  //------------------------
+  // check & correct GENERATE_XREFLIST
+  StringVector generateXreflist = Config_getList(GENERATE_XREFLIST);
+  StringVector newGenerateXreflist;
+  for (const auto &s: generateXreflist)
+  {
+    if (checkListItem(s.c_str(),"GENERATE_XREFLIST",FALSE,FALSE))
+    {
+      // valid syntax, lets check the values
+      std::string p = s;
+      size_t ei=s.find('=');
+      if (ei!=std::string::npos)
+      {
+        std::string refName = s.substr(0,ei); // part before =
+        std::string refVal  = s.substr(ei+1); // part after =
+
+        Generate_XrefList_t sCode = GENERATE_XREFLIST_str2enum(refVal.c_str());
+        if (sCode == Generate_XrefList_t::UNKNOWN)
+        {
+          warn_uncond("Changing 'GENERATE_XREFLIST option to 'YES' for '%s' because supplied value '%s' is unknown.\n",
+          qPrint(refName),qPrint(refVal));
+          p = refName + "=YES";
+        }
+      }
+      newGenerateXreflist.push_back(p);
+    }
+  }
+  if (newGenerateXreflist.empty()) // by default use "YES"
+  {
+    std::string p = "YES";
+    newGenerateXreflist.push_back(p);
+  }
+  Config_updateList(GENERATE_XREFLIST,newGenerateXreflist);
 }
 
 void Config::updateObsolete()

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -462,7 +462,7 @@ DocXRefItem::DocXRefItem(DocParser *parser,DocNodeVariant *parent,int id,const Q
 bool DocXRefItem::parse(DocNodeVariant *thisVariant)
 {
   RefList *refList = RefListManager::instance().find(m_key);
-  if (refList && refList->isEnabled())
+  if (refList && refList->isEnabled(Generate_Xref_t::ITEM))
   {
     RefItem *item = refList->find(m_id);
     ASSERT(item!=0);
@@ -471,6 +471,11 @@ bool DocXRefItem::parse(DocNodeVariant *thisVariant)
       if (parser()->context.memberDef && parser()->context.memberDef->name().at(0)=='@')
       {
         m_file   = "@";  // can't cross reference anonymous enum
+        m_anchor = "@";
+      }
+      else if (!refList->isEnabled(Generate_Xref_t::PAGE))
+      {
+        m_file   = "@";  // can't cross reference to page as the page does not exist
         m_anchor = "@";
       }
       else

--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -43,18 +43,51 @@ RefItem *RefList::find(int itemId)
   return it!=m_lookup.end() ? it->second : nullptr;
 }
 
-bool RefList::isEnabled() const
+bool RefList::isEnabled(const Generate_Xref_t inp) const
 {
-  if      (m_listName=="todo"       && !Config_getBool(GENERATE_TODOLIST))       return false;
-  else if (m_listName=="test"       && !Config_getBool(GENERATE_TESTLIST))       return false;
-  else if (m_listName=="bug"        && !Config_getBool(GENERATE_BUGLIST))        return false;
-  else if (m_listName=="deprecated" && !Config_getBool(GENERATE_DEPRECATEDLIST)) return false;
+  if      (m_listName=="todo"      ) return compareXrefEnabled(Config_getEnum(GENERATE_TODOLIST), inp);
+  else if (m_listName=="test"      ) return compareXrefEnabled(Config_getEnum(GENERATE_TESTLIST), inp);
+  else if (m_listName=="bug"       ) return compareXrefEnabled(Config_getEnum(GENERATE_BUGLIST), inp);
+  else if (m_listName=="deprecated") return compareXrefEnabled(Config_getEnum(GENERATE_DEPRECATEDLIST), inp);
+  else
+  {
+    const StringVector &generateXrefList = Config_getList(GENERATE_XREFLIST);
+    Generate_XrefList_t defaultXref = GENERATE_XREFLIST_str2enum("YES");
+    for (const auto &p : generateXrefList)
+    {
+      Generate_XrefList_t pCode = GENERATE_XREFLIST_str2enum(p.c_str());
+      if (pCode != Generate_XrefList_t::UNKNOWN) defaultXref = pCode;
+    }
+    for (const auto &s : generateXrefList)
+    {
+      size_t ei=s.find('=');
+      if (ei!=std::string::npos)
+      {
+        std::string refName = s.substr(0,ei); // part before =
+        std::string refVal  = s.substr(ei+1); // part after =
+
+        if (m_listName == refName.c_str())
+        {
+          // value is correct as it is corrected properly in configimpl.l
+          Generate_XrefList_t pCode = GENERATE_XREFLIST_str2enum(refVal.c_str());
+          return compareXrefEnabled(pCode,inp);
+        }
+      }
+      else if (m_listName == s.c_str())
+      {
+        Generate_XrefList_t pCode = GENERATE_XREFLIST_str2enum("YES");
+        return compareXrefEnabled(pCode,inp);
+      }
+    }
+    // not found, so use the default
+    return compareXrefEnabled(defaultXref,inp);
+  }
   return true;
 }
 
 void RefList::generatePage()
 {
-  if (!isEnabled()) return;
+  if (!isEnabled(Generate_Xref_t::PAGE)) return;
 
   std::sort(m_entries.begin(),m_entries.end(),
             [](std::unique_ptr<RefItem> &left,std::unique_ptr<RefItem> &right)

--- a/src/reflist.h
+++ b/src/reflist.h
@@ -26,6 +26,40 @@
 class Definition;
 class RefList;
 
+enum class Generate_Xref_t
+{
+  NO   = 0x0,
+  ITEM = 0x1,
+  PAGE = 0x2,
+  YES  = ITEM | PAGE,
+};
+inline bool operator&(const Generate_Xref_t inp1, const Generate_Xref_t inp2)
+{
+    return static_cast<int>(inp1) & static_cast<int>(inp2);
+}
+
+enum class Generate_XrefList_t
+{
+  UNKNOWN   = -1,
+  NO   = 0x0,
+  ITEM = 0x1,
+  PAGE = 0x2,
+  YES  = ITEM | PAGE,
+};
+inline Generate_XrefList_t GENERATE_XREFLIST_str2enum(const QCString &s)
+{
+  QCString lc = s.lower();
+  static const std::unordered_map<std::string,Generate_XrefList_t> map =
+  {
+    { "no", Generate_XrefList_t::NO },
+    { "yes", Generate_XrefList_t::YES },
+    { "item", Generate_XrefList_t::ITEM },
+    { "page", Generate_XrefList_t::PAGE },
+  };
+  auto it = map.find(lc.str());
+  return it!=map.end() ? it->second : Generate_XrefList_t::UNKNOWN;
+}
+
 /** This struct represents an item in the list of references. */
 class RefItem
 {
@@ -84,7 +118,7 @@ class RefList
      *  @param secTitle String representing the title of the section.
      */
     RefList(const QCString &listName, const QCString &pageTitle, const QCString &secTitle);
-    bool isEnabled() const;
+    bool isEnabled(const Generate_Xref_t inp) const;
 
     /*! Adds a new item to the list.
      *  @returns A unique id for this item.
@@ -103,6 +137,16 @@ class RefList
     QCString sectionTitle() const  { return m_secTitle;  }
 
     void generatePage();
+
+    template<typename T>
+    bool compareXrefEnabled(const T s, const Generate_Xref_t inp) const
+    {
+      if (s == T::YES)  return Generate_Xref_t::YES & inp;
+      if (s == T::NO)   return Generate_Xref_t::NO & inp;
+      if (s == T::ITEM) return Generate_Xref_t::ITEM & inp;
+      if (s == T::PAGE) return Generate_Xref_t::PAGE & inp;
+      return false;
+    }
 
   private:
     int m_id = 0;


### PR DESCRIPTION
Enhancing the xref possibilities so the output for the commands `\todo`, `\test`, `\bug`, `\deprecated` and `\xrefitem` is more flexible:
- introducing the enum values `YES`, `NO`,`ITEM` and `PAGE` for the commands `\todo`, `\test`, `\bug` and `\deprecated` to steer the output
- introducing the setting `GENERATE_XREFLIST` so the output for each `\xreflist` can be steered (until now the information was always shown for all items).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8572292/example.tar.gz)

I think this will be useful for CGAL.
