### PR TITLE
issue #9298 Segfault in Fortran parser (heap use after free)

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1523,7 +1523,7 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   {
     endCodeLine(yyscanner);
   }
-  if (fileDef!=0 && isExampleBlock && yyextra->sourceFileDef)
+  if (!fileDef && isExampleBlock && yyextra->sourceFileDef)
   {
     // delete the temporary file definition used for this example
     delete yyextra->sourceFileDef;

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -1523,7 +1523,7 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   {
     endCodeLine(yyscanner);
   }
-  if (isExampleBlock && yyextra->sourceFileDef)
+  if (fileDef!=0 && isExampleBlock && yyextra->sourceFileDef)
   {
     // delete the temporary file definition used for this example
     delete yyextra->sourceFileDef;


### PR DESCRIPTION
Precondition for the setting of the `sourceFileDef` is that the `fileDef` wasn't used as `sourceFileDef`.
(check with e.g. code.l / pycode.l)