### PR TITLE
Correcting README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Doxygen
 Doxygen is the de facto standard tool for generating documentation from
 annotated C++ sources, but it also supports other popular programming
 languages such as C, Objective-C, C#, PHP, Java, Python, IDL
-(Corba, Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL,
-and to some extent D.
+(Corba, Microsoft, and UNO/OpenOffice flavors), Fortran,
+and to some extent D. Doxygen also supports the hardware description language VHDL.
 
 Doxygen can help you in three ways:
 


### PR DESCRIPTION
The current description of Doxygen implies that VHDL is a "programming language", which is not correct. VHDL is a hardware description language (HDL), and HDLs should never be thought of as programming languages since they are totally different concepts. You might be interested to correct the same mistake on the project website as well.