### PR TITLE
Making Windows executable large address aware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if (WIN32)
         set(CMAKE_REQUIRED_DEFINITIONS "-DLIBICONV_STATIC")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # needed for language.cpp on 64bit
         add_definitions(-DLIBICONV_STATIC -D_CRT_SECURE_NO_WARNINGS)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
     endif()
     if (CMAKE_GENERATOR MATCHES "NMake Makefiles")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")


### PR DESCRIPTION
In some cases the (not supported!) 32-bit Windows executables stop to work due to exceeding of the memory limit that can be addressed by the executable.
This can be overcome by setting the `/LARGEADDRESSAWARE` flag.
With the 64-bit Windows executable this flag is already automatically set see also: https://docs.microsoft.com/en-us/cpp/build/reference/largeaddressaware-handle-large-addresses?view=msvc-170).