### PR TITLE
Compilation warnings

### DIFF
--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -42,6 +42,7 @@
 
 #define MAX_INCLUDE_DEPTH 10
 
+#define USE_STATE2STRING 0
 
 /* -----------------------------------------------------------------
  *
@@ -374,6 +375,9 @@ static void readIncludeFile(const QString &incName)
   }
 }
 
+#if USE_STATE2STRING
+static const char *stateToString(int state);
+#endif
 
 %}
 
@@ -832,4 +836,6 @@ void writeStringValue(QTextStream &t,TextCodecAdapter *codec,const QString &s)
     }
   }
 }
+#if USE_STATE2STRING
 #include "config_doxyw.l.h"
+#endif

--- a/libmscgen/mscgen_lexer.l
+++ b/libmscgen/mscgen_lexer.l
@@ -33,6 +33,9 @@
 #include "mscgen_safe.h"
 #include "mscgen_lexer.h"
 #include "mscgen_language.h"  /* Token definitions from Yacc/Bison */
+
+#define USE_STATE2STRING 0
+
 /* Counter for error reporting */
 static unsigned long  lex_linenum = 1;
 static char          *lex_line = NULL;
@@ -42,6 +45,10 @@ static Boolean        lex_utf8 = FALSE;
 static void newline(const char *text, unsigned int n);
 static char *trimQstring(char *s);
 static const char *stateToString(int state);
+
+#if USE_STATE2STRING
+static const char *stateToString(int state);
+#endif
 %}
 
 /* Not used, so prevent compiler warning */
@@ -241,5 +248,7 @@ void lex_resetparser()
   lex_utf8 = FALSE;
 }
 
+#if USE_STATE2STRING
 #include "mscgen_lexer.l.h"
+#endif
 /* END OF FILE */


### PR DESCRIPTION
Protecting the `stateToString` parts by means of a `define` (like done in other lexers).