### PR TITLE
fold long template params

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1316,7 +1316,8 @@ void ClassDefImpl::writeTemplateSpec(OutputList &ol,const Definition *d,
       {
         Argument a = *it;
         if (al.size()>2) {
-          ol.docify("\n    ");
+          ol.lineBreak();
+          ol.writeNonBreakableSpace(4);
         }
         linkifyText(TextGeneratorOLImpl(ol), // out
           d,                       // scope

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1315,6 +1315,9 @@ void ClassDefImpl::writeTemplateSpec(OutputList &ol,const Definition *d,
       while (it!=al.end())
       {
         Argument a = *it;
+        if (al.size()>2) {
+          ol.docify("\n    ");
+        }
         linkifyText(TextGeneratorOLImpl(ol), // out
           d,                       // scope
           getFileDef(),            // fileScope

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2179,8 +2179,7 @@ void HtmlGenerator::addIndexItem(const QCString &,const QCString &)
 
 void HtmlGenerator::writeNonBreakableSpace(int n)
 {
-  int i;
-  for (i=0;i<n;i++)
+  for (int i=0;i<n;i++)
   {
     m_t << "&#160;";
   }

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1688,7 +1688,7 @@ void LatexGenerator::endMemberDescription()
 }
 
 
-void LatexGenerator::writeNonBreakableSpace(int)
+void LatexGenerator::writeNonBreakableSpace(int n)
 {
   //printf("writeNonBreakableSpace()\n");
   if (m_insideTabbing)
@@ -1697,7 +1697,12 @@ void LatexGenerator::writeNonBreakableSpace(int)
   }
   else
   {
-    m_t << "~";
+    m_t << "$";
+    for (int i=0;i<n;i++)
+    {
+      m_t << "~";
+    }
+    m_t << "$";
   }
 }
 

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1735,9 +1735,12 @@ void RTFGenerator::endCodeFragment(const QCString &)
   m_omitParagraph = TRUE;
 }
 
-void RTFGenerator::writeNonBreakableSpace(int)
+void RTFGenerator::writeNonBreakableSpace(int n)
 {
-  m_t << "\\~ ";
+  for (int i=0;i<n;i++)
+  {
+    m_t << "\\~ ";
+  }
 }
 
 


### PR DESCRIPTION
Fold template params in separate lines if number of template params is greater than 2.
For example: Class with more than 2 template parameters that have parameters in separate lines have better readability. https://nvlabs.github.io/cub/classcub_1_1_arg_index_input_iterator.html