### PR TITLE
issue #9319 Doc build fails with cairo 1.17.6

### DIFF
--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -123,12 +123,15 @@ bool DotRunner::readBoundingBox(const QCString &fileName,int *width,int *height,
      if (p) // found PageBoundingBox or /MediaBox string
      {
        int x,y;
+       double w,h;
        fclose(f);
-       if (sscanf(p+bblen,"%d %d %d %d",&x,&y,width,height)!=4)
+       if (sscanf(p+bblen,"%d %d %lf %lf",&x,&y,&w,&h)!=4)
        {
          //printf("readBoundingBox sscanf fail\n");
          return FALSE;
        }
+       *width = static_cast<int>(ceil(w));
+       *height = static_cast<int>(ceil(h));
        return TRUE;
      }
   }

--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -14,6 +14,7 @@
 */
 
 #include <cassert>
+#include <cmath>
 
 #include "dotrunner.h"
 #include "util.h"
@@ -130,8 +131,8 @@ bool DotRunner::readBoundingBox(const QCString &fileName,int *width,int *height,
          //printf("readBoundingBox sscanf fail\n");
          return FALSE;
        }
-       *width = static_cast<int>(ceil(w));
-       *height = static_cast<int>(ceil(h));
+       *width = static_cast<int>(std::ceil(w));
+       *height = static_cast<int>(std::ceil(h));
        return TRUE;
      }
   }


### PR DESCRIPTION
The `\MediaBox` field is written as:
```
"   /MediaBox [ 0 0 %f %f ]
```
bur read with
```
sscanf(p+bblen,"%d %d %d %d",&x,&y,width,height)
```
this has been corrected.