### PR TITLE
Friendly message on incorrect input

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -211,6 +211,7 @@ static void addLocalVar(yyscan_t yyscanner,const QCString &varName);
 static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName,
                                  const UseMap &useMap);
 static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static inline void pop_state(yyscan_t yyscanner);
 
 
 //-------------------------------------------------------------------
@@ -376,7 +377,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Use,UseOnly,Import>"\n"                {
                                           unput(*yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <*>"import"{BS}/"\n"                    |
@@ -437,7 +438,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                             yyextra->currentModule = yyextra->currentModule.lower();
                                           }
                                           generateLink(yyscanner,*yyextra->code,yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <ClassName>({ACCESS_SPEC}|ABSTRACT|EXTENDS)/[,:( ] { //| variable declaration
                                           startFontClass(yyscanner,"keyword");
@@ -445,7 +446,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           endFontClass(yyscanner);
                                         }
 <ClassName>\n                           { // interface may be without name
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_REJECT;
                                         }
 <Start>^{BS}"end"({BS_}"enum").*        {
@@ -486,7 +487,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Subprog,Subprogend>"\n"                { codifyLines(yyscanner,yytext);
                                           yyextra->contLineNr++;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface")?{BS}     {  // Fortran subroutine or function ends
@@ -500,7 +501,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <Subprogend>{ID}/{BS}(\n|!|;)           {
                                           generateLink(yyscanner,*yyextra->code,yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Start>"end"{BS}("block"{BS}"data"|{SUBPROG}|"module"|"program"|"enum"|"type"|"interface"){BS}/(\n|!|;) {  // Fortran subroutine or function ends
                                           //cout << "===> end function " << yytext << endl;
@@ -572,7 +573,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <DeclarationBinding>{ID}                { // Type bound procedure link
                                           generateLink(yyscanner,*yyextra->code, yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Declaration>[(]                        { // start of array or type / class specification
                                           yyextra->bracketCount++;
@@ -597,7 +598,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->contLineNr++;
                                           codifyLines(yyscanner,yytext);
                                           yyextra->bracketCount = 0;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 <Declaration,DeclarationBinding>"\n"    { // end declaration line (?)
@@ -614,7 +615,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           if (!(yyextra->hasContLine && yyextra->hasContLine[yyextra->contLineNr - 1]))
                                           {
                                             yyextra->isExternal = false;
-                                            yy_pop_state(yyscanner);
+                                            pop_state(yyscanner);
                                           }
                                           YY_FTN_RESET
                                         }
@@ -632,7 +633,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           yyextra->insideBody=TRUE;
                                           generateLink(yyscanner,*yyextra->code, yytext);
                                           yyextra->insideBody=FALSE;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Start>{ID}{BS}/"("                     { // function call
                                           if (yyextra->isFixedForm && yy_my_start == 6)
@@ -708,7 +709,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           }
                                           unput(*yytext);
                                           yyextra->contLineNr--;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           YY_FTN_RESET
                                         }
 
@@ -775,7 +776,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           startFontClass(yyscanner,"stringliteral");
                                           codifyLines(yyscanner,yyextra->str);
                                           endFontClass(yyscanner);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <String>.                               {yyextra->str+=yytext;}
 
@@ -1538,6 +1539,14 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   printlex(yy_flex_debug, FALSE, __FILE__, fileDef ? qPrint(fileDef->fileName()): NULL);
 }
 
+static inline void pop_state(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if ( yyg->yy_start_stack_ptr <= 0 )
+    warn(yyextra->fileName,yyextra->yyLineNr,"Unexpected statement '%s'",yytext );
+  else
+    yy_pop_state(yyscanner);
+}
 //---------------------------------------------------------
 
 #if USE_STATE2STRING

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -225,6 +225,7 @@ static void addSubprogram(yyscan_t yyscanner,const QCString &text);
 static void addInterface(yyscan_t yyscanner,QCString name, InterfaceType type);
 static Argument *getParameter(yyscan_t yyscanner,const QCString &name);
 static void scanner_abort(yyscan_t yyscanner);
+static inline void pop_state(yyscan_t yyscanner);
 
 static void startScope(yyscan_t yyscanner,Entry *scope);
 static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot=FALSE);
@@ -248,6 +249,8 @@ static inline const char *getLexerFILE() {return __FILE__;}
 #include "doxygen_lex.h"
 #define YY_USER_ACTION yyextra->colNr+=(int)yyleng;
 #define INVALID_ENTRY ((Entry*)0x8)
+
+
 //-----------------------------------------------------------------------------
 
 %}
@@ -372,7 +375,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                                //printf("BUFFER:%s\n", (const char*)yyextra->inputStringPrepass);
                                                pushBuffer(yyscanner,yyextra->inputStringPrepass);
                                                yyextra->colNr = 0;
-                                               yy_pop_state(yyscanner);
+                                               pop_state(yyscanner);
                                              }
                                              else
                                              { // simple line
@@ -413,7 +416,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                           {
                                             yyextra->initializer+=yytext;
                                           }
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <String>.                               { if (yy_top_state(yyscanner) == Initialization ||
                                               yy_top_state(yyscanner) == ArrayInitializer)
@@ -452,7 +455,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                             DBG_CTX((stderr,"start comment %d\n",yyextra->lineNr));
                                            }
                                         }
-<StrIgnore>.?/\n                        { yy_pop_state(yyscanner); // comment ends with endline character
+<StrIgnore>.?/\n                        { pop_state(yyscanner); // comment ends with endline character
                                           DBG_CTX((stderr,"end comment %d %s\n",yyextra->lineNr,qPrint(yyextra->debugStr)));
                                         } // comment line ends
 <StrIgnore>.                            { yyextra->debugStr+=yytext; }
@@ -476,7 +479,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                           yyextra->current->section=Entry::USINGDIR_SEC;
                                           yyextra->current_root->moveToSubEntryAndRefresh(yyextra->current);
                                           yyextra->current->lang = SrcLangExt_Fortran;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Use>{ID}/,                             {
                                           yyextra->useModuleName=yytext;
@@ -496,7 +499,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
 <Use,UseOnly>"\n"                       {
                                           yyextra->colNr -= 1;
                                           unput(*yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 
  /* INTERFACE definitions */
@@ -537,7 +540,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                             yyterminate();
                                           }
                                           yyextra->ifType = IF_NONE;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <InterfaceBody>module{BS}procedure      { yy_push_state(YY_START,yyscanner);
                                           BEGIN(ModuleProcedure);
@@ -555,7 +558,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                         }
 <ModuleProcedure>"\n"                   { yyextra->colNr -= 1;
                                           unput(*yytext);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <InterfaceBody>.                        {}
 
@@ -593,7 +596,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                           //if (!endScope(yyscanner,yyextra->current_root))
                                           //  yyterminate();
                                           yyextra->defaultProtection = Public;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 <Start,ModuleBody,ModuleBodyContains>"end"({BS}(module|program)({BS_}{ID})?)?{BS}/(\n|!|;) { // end module
                                           resolveModuleProcedures(yyscanner,yyextra->current_root);
@@ -610,7 +613,7 @@ SCOPENAME ({ID}{BS}"::"{BS})*
                                             }
                                             else
                                             {
-                                              yy_pop_state(yyscanner); // cannot pop artrificial entry
+                                              pop_state(yyscanner); // cannot pop artrificial entry
                                             }
                                           }
                                           else
@@ -745,7 +748,7 @@ private                                 {
                                             yyterminate();
                                           }
                                           yyextra->typeMode = false;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 ^{BS}"end"{BS}/(\n|!|;) { /* incorrect end type definition */
                                           warn(yyextra->fileName,yyextra->lineNr, "Found 'END' instead of 'END TYPE'");
@@ -755,7 +758,7 @@ private                                 {
                                             yyterminate();
                                           }
                                           yyextra->typeMode = false;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 }
 
@@ -780,7 +783,7 @@ private                                 {
                                            }
                                            yyextra->subrCurrent.pop_back();
                                            yyextra->vtype = V_IGNORE;
-                                           yy_pop_state(yyscanner) ;
+                                           pop_state(yyscanner) ;
                                         }
 <BlockData>{
 {ID}                                    {
@@ -992,12 +995,12 @@ private                                 {
                                           BEGIN(Initialization);
                                         }
 <Variable>"\n"                          { yyextra->currentModifiers = SymbolModifiers();
-                                          yy_pop_state(yyscanner); // end variable declaration list
+                                          pop_state(yyscanner); // end variable declaration list
                                           newLine(yyscanner);
                                           yyextra->docBlock.resize(0);
                                         }
 <Variable>";".*"\n"                     { yyextra->currentModifiers = SymbolModifiers();
-                                          yy_pop_state(yyscanner); // end variable declaration list
+                                          pop_state(yyscanner); // end variable declaration list
                                           yyextra->docBlock.resize(0);
                                           yyextra->inputStringSemi = " \n"+QCString(yytext+1);
                                           yyextra->lineNr--;
@@ -1036,7 +1039,7 @@ private                                 {
 <Initialization>{COMMA}                 { if (yyextra->initializerScope == 0)
                                           {
                                             updateVariablePrepassComment(yyscanner,yyextra->colNr-(int)yyleng, yyextra->colNr);
-                                            yy_pop_state(yyscanner); // end initialization
+                                            pop_state(yyscanner); // end initialization
                                             if (yyextra->last_enum)
                                             {
                                               yyextra->last_enum->initializer.str(yyextra->initializer.str());
@@ -1052,7 +1055,7 @@ private                                 {
                                           }
                                         }
 <Initialization>"\n"|"!"                { //|
-                                          yy_pop_state(yyscanner); // end initialization
+                                          pop_state(yyscanner); // end initialization
                                           if (yyextra->last_enum)
                                           {
                                             yyextra->last_enum->initializer.str(yyextra->initializer.str());
@@ -1105,7 +1108,7 @@ private                                 {
                                             yyterminate();
                                           }
                                           yyextra->typeMode = false;
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
  /*------ fortran subroutine/function handling ------------------------------------------------------------*/
  /*       Start is initial condition                                                                       */
@@ -1273,7 +1276,7 @@ private                                 {
                                           {
                                             subrHandleCommentBlockResult(yyscanner,yyextra->docBlock,TRUE);
                                           }
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                           yyextra->docBlock.resize(0);
                                         }
 
@@ -1301,7 +1304,7 @@ private                                 {
                                           yyextra->colNr -= 1;
                                           unput(*yytext);
                                           handleCommentBlock(yyscanner,yyextra->docBlock,TRUE);
-                                          yy_pop_state(yyscanner);
+                                          pop_state(yyscanner);
                                         }
 
  /*-----Prototype parsing -------------------------------------------------------------------------*/
@@ -2822,6 +2825,14 @@ static void scanner_abort(yyscan_t yyscanner)
   //exit(-1);
 }
 
+static inline void pop_state(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if ( yyg->yy_start_stack_ptr <= 0 )
+    warn(yyextra->fileName,yyextra->lineNr,"Unexpected statement '%s'",yytext );
+  else
+    yy_pop_state(yyscanner);
+}
 //----------------------------------------------------------------------------
 
 #include "fortranscanner.l.h"

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -148,6 +148,7 @@ static void findMemberLink(yyscan_t yyscanner, CodeOutputInterface &ol,
                            const QCString &symName);
 static void adjustScopesAndSuites(yyscan_t yyscanner,unsigned indentLength);
 static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static inline void pop_state(yyscan_t yyscanner);
 
 #if 0 // TODO: call me to store local variables and get better syntax highlighting, see code.l
 static void addVariable(yyscan_t yyscanner, QCString type, QCString name);
@@ -780,7 +781,7 @@ TARGET            ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBU
                                         endFontClass(yyscanner);
                                       }
                                       unput(*yytext);
-                                      yy_pop_state(yyscanner);
+                                      pop_state(yyscanner);
                                     }
 <*>{POUNDCOMMENT}.*                 {
                                       if (YY_START==SingleQuoteString ||
@@ -1662,6 +1663,15 @@ void PythonCodeParser::parseCode(CodeOutputInterface &codeOutIntf,
   // write the tooltips
   yyextra->tooltipManager.writeTooltips(codeOutIntf);
   printlex(yy_flex_debug, FALSE, __FILE__, fileDef ? qPrint(fileDef->fileName()): NULL);
+}
+
+static inline void pop_state(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if ( yyg->yy_start_stack_ptr <= 0 )
+    warn(yyextra->fileName,yyextra->yyLineNr,"Unexpected statement '%s'",yytext );
+  else
+    yy_pop_state(yyscanner);
 }
 
 #if USE_STATE2STRING


### PR DESCRIPTION
When having an invalid source file it is possible that one gets the message:
```
start-condition stack underflow
    lexical analyzer: .../src/fortranscanner.l (for: .../end.f)
```
and that doxygen terminates due to the fact that the `yy_pop_state` function in the lexer contains:
```
        if ( --yyg->yy_start_stack_ptr < 0 )
                YY_FATAL_ERROR( "start-condition stack underflow" );
```
it is more friendly  when a normal doxygen warning would be issued like:
```
.../end.f:16: warning: Unexpected statement 'end program                  main'
```
this has been implemented by means of the function `pop_state` for the lexers that use `yy_pop_state`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8652001/example.tar.gz)
Example was taken from the llvm-project test suite.
Of course doxygen expects valid code but sometimes a file slips in that is not valid and this would terminate doxygen (now it is of course rubish in -> rubish out) 
