### PR TITLE
Warning about non closed (nested) comment

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -663,6 +663,10 @@ SLASHopt [/]*
 				       BEGIN(Scan);
 				     }
                                    }
+<CComment,CNComment>"/""/"+/"*/"   { /* we are already in C-comment so not a start of a nested comment but 
+                                      * just the end of the comment (the end part is handled later). */
+                                     copyToOutput(yyscanner,yytext,(int)yyleng);
+                                   }
 <CComment,CNComment>"/"+"*"                  { /* nested C comment */
                                      if (yyextra->lang==SrcLangExt_Python ||
                                          yyextra->lang==SrcLangExt_Markdown)


### PR DESCRIPTION
Having code like:
```
#include <stdio.h>

int main1(int argc, char **argv)
{
  printf("before \n");
  /*
  printf("in \n");
  // */
  printf("last \n");
}
```
results in a warning like:
```
aa.cpp:11: warning: Reached end of file while still inside a (nested) comment. Nesting level 2 (probable line reference: 8, 6)
```
as doxygen supports the (non standard) nested comments, though here we have no nested comment as is well signaled by the `/` after the `*`.
The code is also valid Cpp code.

We now explicitly exclude  code like `//*/` from being a start comment.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8660329/example.tar.gz)

(Found by Fossies in sockperf package)
