### PR TITLE
Implementation of lineBreak and nonBreakingSpace in docbook

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -761,12 +761,12 @@ DB_GEN_C
 void DocbookGenerator::writeNonBreakableSpace(int n)
 {
 DB_GEN_C
-  for (int i=0;i<n;i++) m_t << " ";
+  for (int i=0;i<n;i++) m_t << "&#160;";
 }
 void DocbookGenerator::lineBreak(const QCString &)
 {
 DB_GEN_C
-  m_t << "\n";
+  m_t << "<?linebreak?>";
 }
 void DocbookGenerator::startTypewriter()
 {

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -245,7 +245,7 @@ void DocbookDocVisitor::operator()(const DocLineBreak &)
 {
 DB_VIS_C
   if (m_hide) return;
-  m_t << "\n<literallayout>&#160;&#xa;</literallayout>\n";
+  m_t << "<?linebreak?>";
   // gives nicer results but gives problems as it is not allowed in <pare> and also problems with dblatex
   // m_t << "\n" << "<sbr/>\n";
 }


### PR DESCRIPTION
In the docbook it is hard to see and implement a lineBreak or a nonBreakingSpace.

The advise from the documentation for the nonBreakingSpace is to use either `&#xA0;` or `&nbsp;` (see: http://www.sagehill.net/docbookxsl/SpecialChars.html) and as we used as replacement for the HTML `&nbsp;` already `&#xA0;` it is used here as well.

The advise from the documentation for the lineBreak is to use either `<literallayout >` or to use <`?linebreak?>` (see: http://www.sagehill.net/docbookxsl/LineBreaks.html) where the `<literallayout>`  is not suitable in all cases..
The `<?linebreak?>` gives the user of the docbook more flexibility as:

> You can create an XML processing instruction to indicate a line break, and add a stylesheet customization to enact it. A template like the following can be added to a customization layer:
>
> ```
>   <xsl:template match="processing-instruction('linebreak')">
>     <fo:block/>
>   </xsl:template>
> ```

This method is now also implemented for the replacement of the `<br>` tag.