### PR TITLE
issue #9016 Support collapsible sections in markdown

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -9396,7 +9396,7 @@ class docTitleType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -9472,11 +9472,6 @@ class docTitleType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -9722,16 +9717,6 @@ class docTitleType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -9910,7 +9895,6 @@ class docTitleType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -10008,9 +9992,6 @@ class docTitleType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -10223,16 +10204,6 @@ class docTitleType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -10394,7 +10365,7 @@ class docParaType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, hruler=None, preformatted=None, programlisting=None, verbatim=None, javadocliteral=None, javadoccode=None, indexentry=None, orderedlist=None, itemizedlist=None, simplesect=None, title=None, variablelist=None, table=None, heading=None, dotfile=None, mscfile=None, diafile=None, toclist=None, language=None, parameterlist=None, xrefsect=None, copydoc=None, blockquote=None, parblock=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, hruler=None, preformatted=None, programlisting=None, verbatim=None, javadocliteral=None, javadoccode=None, indexentry=None, orderedlist=None, itemizedlist=None, simplesect=None, title=None, variablelist=None, table=None, heading=None, dotfile=None, mscfile=None, diafile=None, toclist=None, language=None, parameterlist=None, xrefsect=None, copydoc=None, details=None, blockquote=None, parblock=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -10470,11 +10441,6 @@ class docParaType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -10665,6 +10631,11 @@ class docParaType(GeneratedsSuper):
         else:
             self.copydoc = copydoc
         self.copydoc_nsprefix_ = None
+        if details is None:
+            self.details = []
+        else:
+            self.details = details
+        self.details_nsprefix_ = None
         if blockquote is None:
             self.blockquote = []
         else:
@@ -10840,16 +10811,6 @@ class docParaType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -11230,6 +11191,16 @@ class docParaType(GeneratedsSuper):
         self.copydoc.insert(index, value)
     def replace_copydoc_at(self, index, value):
         self.copydoc[index] = value
+    def get_details(self):
+        return self.details
+    def set_details(self, details):
+        self.details = details
+    def add_details(self, value):
+        self.details.append(value)
+    def insert_details_at(self, index, value):
+        self.details.insert(index, value)
+    def replace_details_at(self, index, value):
+        self.details[index] = value
     def get_blockquote(self):
         return self.blockquote
     def set_blockquote(self, blockquote):
@@ -11268,7 +11239,6 @@ class docParaType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -11307,6 +11277,7 @@ class docParaType(GeneratedsSuper):
             self.parameterlist or
             self.xrefsect or
             self.copydoc or
+            self.details or
             self.blockquote or
             self.parblock or
             (1 if type(self.valueOf_) in [int,float] else self.valueOf_) or
@@ -11390,9 +11361,6 @@ class docParaType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -11515,6 +11483,9 @@ class docParaType(GeneratedsSuper):
         for copydoc_ in self.copydoc:
             namespaceprefix_ = self.copydoc_nsprefix_ + ':' if (UseCapturedNS_ and self.copydoc_nsprefix_) else ''
             copydoc_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='copydoc', pretty_print=pretty_print)
+        for details_ in self.details:
+            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
+            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for blockquote_ in self.blockquote:
             namespaceprefix_ = self.blockquote_nsprefix_ + ':' if (UseCapturedNS_ and self.blockquote_nsprefix_) else ''
             blockquote_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='blockquote', pretty_print=pretty_print)
@@ -11680,16 +11651,6 @@ class docParaType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -12054,6 +12015,16 @@ class docParaType(GeneratedsSuper):
               self.add_copydoc(obj_.value)
             elif hasattr(self, 'set_copydoc'):
               self.set_copydoc(obj_.value)
+        elif nodeName_ == 'details':
+            obj_ = docDetailsType.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
+                MixedContainer.TypeNone, 'details', obj_)
+            self.content_.append(obj_)
+            if hasattr(self, 'add_details'):
+              self.add_details(obj_.value)
+            elif hasattr(self, 'set_details'):
+              self.set_details(obj_.value)
         elif nodeName_ == 'blockquote':
             obj_ = docBlockQuoteType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -12085,7 +12056,7 @@ class docMarkupType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, hruler=None, preformatted=None, programlisting=None, verbatim=None, javadocliteral=None, javadoccode=None, indexentry=None, orderedlist=None, itemizedlist=None, simplesect=None, title=None, variablelist=None, table=None, heading=None, dotfile=None, mscfile=None, diafile=None, toclist=None, language=None, parameterlist=None, xrefsect=None, copydoc=None, blockquote=None, parblock=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, hruler=None, preformatted=None, programlisting=None, verbatim=None, javadocliteral=None, javadoccode=None, indexentry=None, orderedlist=None, itemizedlist=None, simplesect=None, title=None, variablelist=None, table=None, heading=None, dotfile=None, mscfile=None, diafile=None, toclist=None, language=None, parameterlist=None, xrefsect=None, copydoc=None, details=None, blockquote=None, parblock=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -12161,11 +12132,6 @@ class docMarkupType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -12356,6 +12322,11 @@ class docMarkupType(GeneratedsSuper):
         else:
             self.copydoc = copydoc
         self.copydoc_nsprefix_ = None
+        if details is None:
+            self.details = []
+        else:
+            self.details = details
+        self.details_nsprefix_ = None
         if blockquote is None:
             self.blockquote = []
         else:
@@ -12531,16 +12502,6 @@ class docMarkupType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -12921,6 +12882,16 @@ class docMarkupType(GeneratedsSuper):
         self.copydoc.insert(index, value)
     def replace_copydoc_at(self, index, value):
         self.copydoc[index] = value
+    def get_details(self):
+        return self.details
+    def set_details(self, details):
+        self.details = details
+    def add_details(self, value):
+        self.details.append(value)
+    def insert_details_at(self, index, value):
+        self.details.insert(index, value)
+    def replace_details_at(self, index, value):
+        self.details[index] = value
     def get_blockquote(self):
         return self.blockquote
     def set_blockquote(self, blockquote):
@@ -12959,7 +12930,6 @@ class docMarkupType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -12998,6 +12968,7 @@ class docMarkupType(GeneratedsSuper):
             self.parameterlist or
             self.xrefsect or
             self.copydoc or
+            self.details or
             self.blockquote or
             self.parblock or
             (1 if type(self.valueOf_) in [int,float] else self.valueOf_) or
@@ -13081,9 +13052,6 @@ class docMarkupType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -13206,6 +13174,9 @@ class docMarkupType(GeneratedsSuper):
         for copydoc_ in self.copydoc:
             namespaceprefix_ = self.copydoc_nsprefix_ + ':' if (UseCapturedNS_ and self.copydoc_nsprefix_) else ''
             copydoc_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='copydoc', pretty_print=pretty_print)
+        for details_ in self.details:
+            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
+            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for blockquote_ in self.blockquote:
             namespaceprefix_ = self.blockquote_nsprefix_ + ':' if (UseCapturedNS_ and self.blockquote_nsprefix_) else ''
             blockquote_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='blockquote', pretty_print=pretty_print)
@@ -13371,16 +13342,6 @@ class docMarkupType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -13745,6 +13706,16 @@ class docMarkupType(GeneratedsSuper):
               self.add_copydoc(obj_.value)
             elif hasattr(self, 'set_copydoc'):
               self.set_copydoc(obj_.value)
+        elif nodeName_ == 'details':
+            obj_ = docDetailsType.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
+                MixedContainer.TypeNone, 'details', obj_)
+            self.content_.append(obj_)
+            if hasattr(self, 'add_details'):
+              self.add_details(obj_.value)
+            elif hasattr(self, 'set_details'):
+              self.set_details(obj_.value)
         elif nodeName_ == 'blockquote':
             obj_ = docBlockQuoteType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -13776,7 +13747,7 @@ class docURLLink(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, url=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, url=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -13854,11 +13825,6 @@ class docURLLink(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -14104,16 +14070,6 @@ class docURLLink(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -14296,7 +14252,6 @@ class docURLLink(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -14396,9 +14351,6 @@ class docURLLink(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -14614,16 +14566,6 @@ class docURLLink(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -15725,7 +15667,7 @@ class docRefTextType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, refid=None, kindref=None, external=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, refid=None, kindref=None, external=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -15807,11 +15749,6 @@ class docRefTextType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -16057,16 +15994,6 @@ class docRefTextType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -16270,7 +16197,6 @@ class docRefTextType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -16376,9 +16302,6 @@ class docRefTextType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -16603,16 +16526,6 @@ class docRefTextType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -17301,7 +17214,7 @@ class docCaptionType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, id=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, id=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -17379,11 +17292,6 @@ class docCaptionType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -17629,16 +17537,6 @@ class docCaptionType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -17821,7 +17719,6 @@ class docCaptionType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -17921,9 +17818,6 @@ class docCaptionType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -18139,16 +18033,6 @@ class docCaptionType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -18310,7 +18194,7 @@ class docHeadingType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, level=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, level=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -18388,11 +18272,6 @@ class docHeadingType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -18638,16 +18517,6 @@ class docHeadingType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -18830,7 +18699,6 @@ class docHeadingType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -18930,9 +18798,6 @@ class docHeadingType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -19148,16 +19013,6 @@ class docHeadingType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -19319,7 +19174,7 @@ class docImageType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, type_=None, name=None, width=None, height=None, alt=None, inline=None, caption=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, type_=None, name=None, width=None, height=None, alt=None, inline=None, caption=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -19409,11 +19264,6 @@ class docImageType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -19659,16 +19509,6 @@ class docImageType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -19901,7 +19741,6 @@ class docImageType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -20019,9 +19858,6 @@ class docImageType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -20263,16 +20099,6 @@ class docImageType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -20434,7 +20260,7 @@ class docDotMscType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, name=None, width=None, height=None, caption=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, name=None, width=None, height=None, caption=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -20518,11 +20344,6 @@ class docDotMscType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -20768,16 +20589,6 @@ class docDotMscType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -20972,7 +20783,6 @@ class docDotMscType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -21081,9 +20891,6 @@ class docDotMscType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -21311,16 +21118,6 @@ class docDotMscType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -21484,7 +21281,7 @@ class docImageFileType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, name=None, width=None, height=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, name=None, width=None, height=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -21566,11 +21363,6 @@ class docImageFileType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -21816,16 +21608,6 @@ class docImageFileType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -22016,7 +21798,6 @@ class docImageFileType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -22122,9 +21903,6 @@ class docImageFileType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -22348,16 +22126,6 @@ class docImageFileType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -22519,7 +22287,7 @@ class docPlantumlType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, name=None, width=None, height=None, caption=None, engine=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, name=None, width=None, height=None, caption=None, engine=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -22605,11 +22373,6 @@ class docPlantumlType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -22855,16 +22618,6 @@ class docPlantumlType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -23076,7 +22829,6 @@ class docPlantumlType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -23188,9 +22940,6 @@ class docPlantumlType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -23423,16 +23172,6 @@ class docPlantumlType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -23594,7 +23333,7 @@ class docTocItemType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, id=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, details=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
+    def __init__(self, id=None, ulink=None, bold=None, s=None, strike=None, underline=None, emphasis=None, computeroutput=None, subscript=None, superscript=None, center=None, small=None, cite=None, del_=None, ins=None, summary=None, htmlonly=None, manonly=None, xmlonly=None, rtfonly=None, latexonly=None, docbookonly=None, image=None, dot=None, msc=None, plantuml=None, anchor=None, formula=None, ref=None, emoji=None, linebreak=None, valueOf_=None, mixedclass_=None, content_=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -23672,11 +23411,6 @@ class docTocItemType(GeneratedsSuper):
         else:
             self.ins = ins
         self.ins_nsprefix_ = None
-        if details is None:
-            self.details = []
-        else:
-            self.details = details
-        self.details_nsprefix_ = None
         if summary is None:
             self.summary = []
         else:
@@ -23922,16 +23656,6 @@ class docTocItemType(GeneratedsSuper):
         self.ins.insert(index, value)
     def replace_ins_at(self, index, value):
         self.ins[index] = value
-    def get_details(self):
-        return self.details
-    def set_details(self, details):
-        self.details = details
-    def add_details(self, value):
-        self.details.append(value)
-    def insert_details_at(self, index, value):
-        self.details.insert(index, value)
-    def replace_details_at(self, index, value):
-        self.details[index] = value
     def get_summary(self):
         return self.summary
     def set_summary(self, summary):
@@ -24114,7 +23838,6 @@ class docTocItemType(GeneratedsSuper):
             self.cite or
             self.del_ or
             self.ins or
-            self.details or
             self.summary or
             self.htmlonly or
             self.manonly or
@@ -24214,9 +23937,6 @@ class docTocItemType(GeneratedsSuper):
         for ins_ in self.ins:
             namespaceprefix_ = self.ins_nsprefix_ + ':' if (UseCapturedNS_ and self.ins_nsprefix_) else ''
             ins_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ins', pretty_print=pretty_print)
-        for details_ in self.details:
-            namespaceprefix_ = self.details_nsprefix_ + ':' if (UseCapturedNS_ and self.details_nsprefix_) else ''
-            details_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='details', pretty_print=pretty_print)
         for summary_ in self.summary:
             namespaceprefix_ = self.summary_nsprefix_ + ':' if (UseCapturedNS_ and self.summary_nsprefix_) else ''
             summary_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='summary', pretty_print=pretty_print)
@@ -24432,16 +24152,6 @@ class docTocItemType(GeneratedsSuper):
               self.add_ins(obj_.value)
             elif hasattr(self, 'set_ins'):
               self.set_ins(obj_.value)
-        elif nodeName_ == 'details':
-            obj_ = docMarkupType.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            obj_ = self.mixedclass_(MixedContainer.CategoryComplex,
-                MixedContainer.TypeNone, 'details', obj_)
-            self.content_.append(obj_)
-            if hasattr(self, 'add_details'):
-              self.add_details(obj_.value)
-            elif hasattr(self, 'set_details'):
-              self.set_details(obj_.value)
         elif nodeName_ == 'summary':
             obj_ = docMarkupType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
@@ -25739,6 +25449,108 @@ class docCopyType(GeneratedsSuper):
 # end class docCopyType
 
 
+class docDetailsType(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    subclass = None
+    superclass = None
+    def __init__(self, para=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        if para is None:
+            self.para = []
+        else:
+            self.para = para
+        self.para_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, docDetailsType)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if docDetailsType.subclass:
+            return docDetailsType.subclass(*args_, **kwargs_)
+        else:
+            return docDetailsType(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_ns_prefix_(self):
+        return self.ns_prefix_
+    def set_ns_prefix_(self, ns_prefix):
+        self.ns_prefix_ = ns_prefix
+    def get_para(self):
+        return self.para
+    def set_para(self, para):
+        self.para = para
+    def add_para(self, value):
+        self.para.append(value)
+    def insert_para_at(self, index, value):
+        self.para.insert(index, value)
+    def replace_para_at(self, index, value):
+        self.para[index] = value
+    def hasContent_(self):
+        if (
+            self.para
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='docDetailsType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('docDetailsType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'docDetailsType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='docDetailsType')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='docDetailsType', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='docDetailsType'):
+        pass
+    def exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='docDetailsType', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for para_ in self.para:
+            namespaceprefix_ = self.para_nsprefix_ + ':' if (UseCapturedNS_ and self.para_nsprefix_) else ''
+            para_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='para', pretty_print=pretty_print)
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'para':
+            obj_ = docParaType.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.para.append(obj_)
+            obj_.original_tagname_ = 'para'
+# end class docDetailsType
+
+
 class docBlockQuoteType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
@@ -26571,6 +26383,7 @@ __all__ = [
     "docBlockQuoteType",
     "docCaptionType",
     "docCopyType",
+    "docDetailsType",
     "docDotMscType",
     "docEmojiType",
     "docEmptyType",

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -306,20 +306,8 @@ DB_VIS_C
     case DocStyleChange::Ins:        break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-    case DocStyleChange::Details: /* emulation of the <details> tag */
-      if (s.enable())
-      {
-        m_t << "\n";
-        m_t << "<para>";
-      }
-      else
-      {
-        m_t << "</para>";
-        m_t << "\n";
-      }
-      break;
     case DocStyleChange::Summary: /* emulation of the <summary> tag inside a <details> tag */
-      if (s.enable()) m_t << "<emphasis role=\"bold\">";      else m_t << "</emphasis>";
+      if (s.enable()) m_t << "<para><emphasis role=\"bold\">";      else m_t << "</emphasis></para>";
       break;
   }
 }
@@ -1182,6 +1170,17 @@ DB_VIS_C
   }
   visitChildren(href);
   m_t << "</link>";
+}
+
+void DocbookDocVisitor::operator()(const DocHtmlDetails &d)
+{
+DB_VIS_C
+  if (m_hide) return;
+  m_t << "\n";
+  m_t << "<para>";
+  visitChildren(d);
+  m_t << "</para>";
+  m_t << "\n";
 }
 
 void DocbookDocVisitor::operator()(const DocHtmlHeader &h)

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -86,6 +86,7 @@ class DocbookDocVisitor : public DocVisitor
     void operator()(const DocHtmlCaption &);
     void operator()(const DocInternal &);
     void operator()(const DocHRef &);
+    void operator()(const DocHtmlDetails &);
     void operator()(const DocHtmlHeader &);
     void operator()(const DocImage &);
     void operator()(const DocDotFile &);

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -45,7 +45,8 @@ class DocParser;
 /* 35 */  DN(DocSecRefList)     DN_SEP DN(DocInternal)      DN_SEP DN(DocParBlock)       DN_SEP DN(DocSimpleList)   DN_SEP DN(DocHtmlList)    DN_SEP   \
 /* 40 */  DN(DocSimpleSect)     DN_SEP DN(DocSimpleSectSep) DN_SEP DN(DocParamSect)      DN_SEP DN(DocPara)         DN_SEP DN(DocParamList)   DN_SEP   \
 /* 45 */  DN(DocSimpleListItem) DN_SEP DN(DocHtmlListItem)  DN_SEP DN(DocHtmlDescData)   DN_SEP DN(DocHtmlCell)     DN_SEP DN(DocHtmlCaption) DN_SEP   \
-/* 50 */  DN(DocHtmlRow)        DN_SEP DN(DocHtmlTable)     DN_SEP DN(DocHtmlBlockQuote) DN_SEP DN(DocText)         DN_SEP DN(DocRoot)                 \
+/* 50 */  DN(DocHtmlRow)        DN_SEP DN(DocHtmlTable)     DN_SEP DN(DocHtmlBlockQuote) DN_SEP DN(DocText)         DN_SEP DN(DocRoot)        DN_SEP   \
+/* 55 */  DN(DocHtmlDetails)                                                                                                                           \
 
 // forward declarations
 #define DN(x) class x;
@@ -271,7 +272,6 @@ class DocStyleChange : public DocNode
                  Del           = (1<<12),
                  Ins           = (1<<13),
                  S             = (1<<14),
-                 Details       = (1<<15),
                  Summary       = (1<<16),
                  Cite          = (1<<17)
                };
@@ -791,6 +791,19 @@ class DocHRef : public DocCompoundNode
     QCString   m_url;
     QCString   m_relPath;
     QCString   m_file;
+};
+
+/** Node Html details */
+class DocHtmlDetails : public DocCompoundNode
+{
+  public:
+    DocHtmlDetails(DocParser *parser,DocNodeVariant *parent,const HtmlAttribList &attribs) :
+       DocCompoundNode(parser,parent), m_attribs(attribs) {}
+    const HtmlAttribList &attribs() const { return m_attribs; }
+    int parse(DocNodeVariant*);
+
+  private:
+    HtmlAttribList m_attribs;
 };
 
 /** Node Html heading */

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1394,16 +1394,6 @@ reparsetoken:
               handleStyleLeave(parent,children,DocStyleChange::Ins,tokenName);
             }
             break;
-          case HTML_DETAILS:
-            if (!context.token->endTag)
-            {
-              handleStyleEnter(parent,children,DocStyleChange::Details,tokenName,&context.token->attribs);
-            }
-            else
-            {
-              handleStyleLeave(parent,children,DocStyleChange::Details,tokenName);
-            }
-            break;
           case HTML_CODE:
           case XML_C:
             if (!context.token->endTag)

--- a/src/docparser_p.h
+++ b/src/docparser_p.h
@@ -236,13 +236,14 @@ inline bool insideTable(const DocNodeVariant *n)
 
 //---------------------------------------------------------------------------
 
-inline bool insideDetails(DocStyleChangeStack styleStack)
+inline bool insideDetails(const DocNodeVariant *n)
 {
-  for (auto i : styleStack)
+  while (n)
   {
-     if (std::get<DocStyleChange>(*i).style() == DocStyleChange::Details) return true;
+    if (std::holds_alternative<DocHtmlDetails>(*n)) return TRUE;
+    n=parent(n);
   }
-  return false;
+  return FALSE;
 }
 
 

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -63,7 +63,8 @@ enum Tokens
   RetVal_EndBlockQuote  = 0x10014,
   RetVal_CopyDoc        = 0x10015,
   RetVal_EndInternal    = 0x10016,
-  RetVal_EndParBlock    = 0x10017
+  RetVal_EndParBlock    = 0x10017,
+  RetVal_EndHtmlDetails = 0x10018
 };
 
 #define TK_COMMAND_CHAR(token) ((token)==TK_COMMAND_AT ? "@" : "\\")

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -116,6 +116,7 @@ static bool mustBeOutsideParagraph(const DocNodeVariant &n)
                                  /* <hr> */         DocHorRuler,
                                  /* <blockquote> */ DocHtmlBlockQuote,
                                  /* \parblock */    DocParBlock,
+                                 /* <details> */    DocHtmlDetails,
                                                     DocIncOperator >(n))
   {
     return TRUE;
@@ -521,9 +522,6 @@ void HtmlDocVisitor::operator()(const DocStyleChange &s)
       break;
     case DocStyleChange::Span:
       if (s.enable()) m_t << "<span" << htmlAttribsToString(s.attribs()) << ">";  else m_t << "</span>";
-      break;
-    case DocStyleChange::Details:
-      if (s.enable()) m_t << "<details" << htmlAttribsToString(s.attribs()) << ">\n"; else m_t << "</details>\n";
       break;
     case DocStyleChange::Summary:
       if (s.enable()) m_t << "<summary" << htmlAttribsToString(s.attribs()) << ">";  else m_t << "</summary>";
@@ -1227,7 +1225,8 @@ static bool determineIfNeedsTag(const DocPara &p)
                          DocSimpleSect,
                          DocXRefItem,
                          DocHtmlBlockQuote,
-                         DocParBlock
+                         DocParBlock,
+                         DocHtmlDetails
                          >(*p.parent()))
     {
       needsTag = TRUE;
@@ -1578,6 +1577,16 @@ void HtmlDocVisitor::operator()(const DocHRef &href)
   }
   visitChildren(href);
   m_t << "</a>";
+}
+
+void HtmlDocVisitor::operator()(const DocHtmlDetails &d)
+{
+  if (m_hide) return;
+  forceEndParagraph(d);
+  m_t << "<details " << htmlAttribsToString(d.attribs()) << ">\n";
+  visitChildren(d);
+  m_t << "</details>\n";
+  forceStartParagraph(d);
 }
 
 void HtmlDocVisitor::operator()(const DocHtmlHeader &header)
@@ -1954,7 +1963,6 @@ void HtmlDocVisitor::operator()(const DocHtmlBlockQuote &b)
 {
   if (m_hide) return;
   forceEndParagraph(b);
-  QCString attrs = htmlAttribsToString(b.attribs());
   m_t << "<blockquote class=\"doxtable\"" << htmlAttribsToString(b.attribs()) << ">\n";
   visitChildren(b);
   m_t << "</blockquote>\n";

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -78,6 +78,7 @@ class HtmlDocVisitor : public DocVisitor
     void operator()(const DocHtmlCaption &);
     void operator()(const DocInternal &);
     void operator()(const DocHRef &);
+    void operator()(const DocHtmlDetails &);
     void operator()(const DocHtmlHeader &);
     void operator()(const DocImage &);
     void operator()(const DocDotFile &);

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -378,11 +378,8 @@ void LatexDocVisitor::operator()(const DocStyleChange &s)
       break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-    case DocStyleChange::Details: /* emulation of the <details> tag */
-      if (!s.enable()) m_t << "\n\n";
-      break;
     case DocStyleChange::Summary: /* emulation of the <summary> tag inside a <details> tag */
-      if (s.enable()) m_t << "{\\bfseries{";      else m_t << "}}";
+      if (s.enable()) m_t << "{\\bfseries{";      else m_t << "}}\\newline";
       break;
   }
 }
@@ -1410,6 +1407,14 @@ void LatexDocVisitor::operator()(const DocHRef &href)
   m_t << "{\\texttt{ ";
   visitChildren(href);
   m_t << "}}";
+}
+
+void LatexDocVisitor::operator()(const DocHtmlDetails &d)
+{
+  if (m_hide) return;
+  m_t << "\n\n";
+  visitChildren(d);
+  m_t << "\n\n";
 }
 
 void LatexDocVisitor::operator()(const DocHtmlHeader &header)

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -80,6 +80,7 @@ class LatexDocVisitor : public DocVisitor
     void operator()(const DocHtmlCell &);
     void operator()(const DocInternal &);
     void operator()(const DocHRef &);
+    void operator()(const DocHtmlDetails &);
     void operator()(const DocHtmlHeader &);
     void operator()(const DocImage &);
     void operator()(const DocDotFile &);

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -188,16 +188,8 @@ void ManDocVisitor::operator()(const DocStyleChange &s)
       break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-    case DocStyleChange::Details: /* emulation of the <details> tag */
-      if (!s.enable())
-      {
-        if (!m_firstCol) m_t << "\n";
-        m_t << ".PP\n";
-        m_firstCol=TRUE;
-      }
-      break;
     case DocStyleChange::Summary: /* emulation of the <summary> tag inside a <details> tag */
-      if (s.enable()) m_t << "\\fB";      else m_t << "\\fP";
+      if (s.enable()) m_t << "\\fB";      else m_t << "\\fP\n.PP\n";
       m_firstCol=FALSE;
       break;
   }
@@ -782,6 +774,22 @@ void ManDocVisitor::operator()(const DocHRef &href)
   m_t << "\\fC";
   visitChildren(href);
   m_t << "\\fP";
+}
+
+void ManDocVisitor::operator()(const DocHtmlDetails &d)
+{
+  if (m_hide) return;
+  if (!m_firstCol)
+  {
+    m_t << "\n";
+    m_t << ".PP\n";
+  }
+  m_t << ".RS 4\n"; // TODO: add support for nested detailes sections
+  visitChildren(d);
+  if (!m_firstCol) m_t << "\n";
+  m_t << ".RE\n";
+  m_t << ".PP\n";
+  m_firstCol=TRUE;
 }
 
 void ManDocVisitor::operator()(const DocHtmlHeader &header)

--- a/src/mandocvisitor.h
+++ b/src/mandocvisitor.h
@@ -81,6 +81,7 @@ class ManDocVisitor : public DocVisitor
     void operator()(const DocHtmlCell &);
     void operator()(const DocInternal &);
     void operator()(const DocHRef &);
+    void operator()(const DocHtmlDetails &);
     void operator()(const DocHtmlHeader &);
     void operator()(const DocImage &);
     void operator()(const DocDotFile &);

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -627,7 +627,7 @@ void ManGenerator::endSection(const QCString &,SectionType type)
   }
   else
   {
-    m_t << "\n";
+    m_t << "\n.PP\n";
     m_firstCol=TRUE;
     m_paragraph=FALSE;
     m_inHeader=FALSE;

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -336,6 +336,7 @@ class PerlModDocVisitor : public DocVisitor
     void operator()(const DocHtmlCaption &);
     void operator()(const DocInternal &);
     void operator()(const DocHRef &);
+    void operator()(const DocHtmlDetails &);
     void operator()(const DocHtmlHeader &);
     void operator()(const DocImage &);
     void operator()(const DocDotFile &);
@@ -625,9 +626,6 @@ void PerlModDocVisitor::operator()(const DocStyleChange &s)
     case DocStyleChange::Preformatted:  style = "preformatted"; break;
     case DocStyleChange::Div:           style = "div"; break;
     case DocStyleChange::Span:          style = "span"; break;
-    case DocStyleChange::Details: /* emulation of the <details> tag */
-      style = "details";
-      break;
     case DocStyleChange::Summary: /* emulation of the <summary> tag inside a <details> tag */
       style = "summary";
       break;
@@ -1031,6 +1029,15 @@ void PerlModDocVisitor::operator()(const DocHRef &href)
 #if 0
   m_output.add("</ulink>");
 #endif
+}
+
+void PerlModDocVisitor::operator()(const DocHtmlDetails &details)
+{
+  openItem("details");
+  openSubBlock("content");
+  visitChildren(details);
+  closeSubBlock();
+  closeItem();
 }
 
 void PerlModDocVisitor::operator()(const DocHtmlHeader &header)

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -147,18 +147,6 @@ class PrintDocVisitor
         case DocStyleChange::Span:
           if (s.enable()) printf("<span>"); else printf("</span>");
           break;
-        case DocStyleChange::Details:
-          if (s.enable())
-          {
-            indent_pre();
-            printf("<details>\n");
-          }
-          else
-          {
-            indent_post();
-            printf("</details>\n");
-          }
-          break;
         case DocStyleChange::Summary:
           if (s.enable())
           {
@@ -529,6 +517,19 @@ class PrintDocVisitor
       visitChildren(href);
       indent_post();
       printf("</a>\n");
+    }
+    void operator()(const DocHtmlDetails &details)
+    {
+      indent_pre();
+      printf("<details");
+      for (const auto &opt : details.attribs())
+      {
+        printf(" %s=\"%s\"",qPrint(opt.name),qPrint(opt.value));
+      }
+      printf(">\n");
+      visitChildren(details);
+      indent_post();
+      printf("</details>\n");
     }
     void operator()(const DocHtmlHeader &header)
     {

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -286,21 +286,8 @@ void RTFDocVisitor::operator()(const DocStyleChange &s)
       break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-    case DocStyleChange::Details: /* emulation of the <details> tag */
-      if (s.enable())
-      {
-        m_t << "{\n";
-        m_t << "\\par\n";
-      }
-      else
-      {
-        m_t << "\\par";
-        m_t << "}\n";
-      }
-      m_lastIsPara=TRUE;
-      break;
     case DocStyleChange::Summary: /* emulation of the <summary> tag inside a <details> tag */
-      if (s.enable()) m_t << "{\\b ";      else m_t << "} ";
+      if (s.enable()) m_t << "{\\b ";      else m_t << "}\\par ";
       break;
   }
 }
@@ -1142,6 +1129,28 @@ void RTFDocVisitor::operator()(const DocHRef &href)
     m_t << "}";
   }
   m_lastIsPara=FALSE;
+}
+
+void RTFDocVisitor::operator()(const DocHtmlDetails &d)
+{
+  if (m_hide) return;
+  //m_lastIsPara=TRUE;
+  //m_t << "{\n";
+  //m_t << "\\par\n";
+  //visitChildren(d);
+  //m_t << "\\par";
+  //m_t << "}\n";
+  //m_lastIsPara=TRUE;
+  DBG_RTF("{\\comment RTFDocVisitor::operator()(const DocHtmlDetails &)}\n");
+  if (!m_lastIsPara) m_t << "\\par\n";
+  m_t << "{"; // start desc
+  incIndentLevel();
+  m_t << rtf_Style_Reset << getStyle("DescContinue");
+  visitChildren(d);
+  if (!m_lastIsPara) m_t << "\\par\n";
+  decIndentLevel();
+  m_t << "}"; // end desc
+  m_lastIsPara=TRUE;
 }
 
 void RTFDocVisitor::operator()(const DocHtmlHeader &header)

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -80,6 +80,7 @@ class RTFDocVisitor : public DocVisitor
     void operator()(const DocHtmlCell &);
     void operator()(const DocInternal &);
     void operator()(const DocHRef &);
+    void operator()(const DocHtmlDetails &);
     void operator()(const DocHtmlHeader &);
     void operator()(const DocImage &);
     void operator()(const DocDotFile &);

--- a/src/textdocvisitor.h
+++ b/src/textdocvisitor.h
@@ -85,6 +85,7 @@ class TextDocVisitor : public DocVisitor
     void operator()(const DocHtmlCaption &c)     { visitChildren(c);  }
     void operator()(const DocInternal &i)        { visitChildren(i);  }
     void operator()(const DocHRef &h)            { visitChildren(h);  }
+    void operator()(const DocHtmlDetails &d)     { visitChildren(d);  }
     void operator()(const DocHtmlHeader &h)      { visitChildren(h);  }
     void operator()(const DocImage &i)           { visitChildren(i);  }
     void operator()(const DocDotFile &df)        { visitChildren(df); }

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -294,9 +294,6 @@ void XmlDocVisitor::operator()(const DocStyleChange &s)
       break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-    case DocStyleChange::Details:
-      if (s.enable()) m_t << "<details>";  else m_t << "</details>";
-      break;
     case DocStyleChange::Summary:
       if (s.enable()) m_t << "<summary>";  else m_t << "</summary>";
       break;
@@ -888,6 +885,14 @@ void XmlDocVisitor::operator()(const DocHRef &href)
   m_t << "<ulink url=\"" << convertToXML(href.url(), TRUE) << "\">";
   visitChildren(href);
   m_t << "</ulink>";
+}
+
+void XmlDocVisitor::operator()(const DocHtmlDetails &d)
+{
+  if (m_hide) return;
+  m_t << "<details>";
+  visitChildren(d);
+  m_t << "</details>";
 }
 
 void XmlDocVisitor::operator()(const DocHtmlHeader &header)

--- a/src/xmldocvisitor.h
+++ b/src/xmldocvisitor.h
@@ -82,6 +82,7 @@ class XmlDocVisitor : public DocVisitor
     void operator()(const DocHtmlCaption &);
     void operator()(const DocInternal &);
     void operator()(const DocHRef &);
+    void operator()(const DocHtmlDetails &);
     void operator()(const DocHtmlHeader &);
     void operator()(const DocImage &);
     void operator()(const DocDotFile &);

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -431,7 +431,6 @@
       <xsd:element name="cite" type="docMarkupType" />
       <xsd:element name="del" type="docMarkupType" />
       <xsd:element name="ins" type="docMarkupType" />
-      <xsd:element name="details" type="docMarkupType" />
       <xsd:element name="summary" type="docMarkupType" />
       <xsd:element name="htmlonly" type="docHtmlOnlyType" />
       <xsd:element name="manonly" type="xsd:string" />
@@ -481,6 +480,7 @@
       <xsd:element name="parameterlist" type="docParamListType" />
       <xsd:element name="xrefsect" type="docXRefSectType" />
       <xsd:element name="copydoc" type="docCopyType" />
+      <xsd:element name="details" type="docDetailsType" />
       <xsd:element name="blockquote" type="docBlockQuoteType" />
       <xsd:element name="parblock" type="docParBlockType" />
     </xsd:choice>
@@ -711,6 +711,12 @@
       <xsd:element name="internal" type="docInternalType" minOccurs="0" />
     </xsd:sequence>
     <xsd:attribute name="link" type="xsd:string" /> 
+  </xsd:complexType>
+
+  <xsd:complexType name="docDetailsType">
+    <xsd:sequence>
+      <xsd:element name="para" type="docParaType" minOccurs="0" maxOccurs="unbounded" />
+    </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="docBlockQuoteType">


### PR DESCRIPTION
With #8890 the HTML details tag had been implemented as a style change though this give a problem when inside the details part there are multiple paragraphs.
The HTML details tag has been re-implemented as a so called `DocNode`, so that it is possible to have multiple paragraphs in a detailed section.