### PR TITLE
Fixes minor grammatical errors

### DIFF
--- a/doc/doxygen_usage.doc
+++ b/doc/doxygen_usage.doc
@@ -1,12 +1,12 @@
 /******************************************************************************
  *
- * 
+ *
  *
  * Copyright (C) 1997-2015 by Dimitri van Heesch.
  *
  * Permission to use, copy, modify, and distribute this software and its
- * documentation under the terms of the GNU General Public License is hereby 
- * granted. No representations are made about the suitability of this software 
+ * documentation under the terms of the GNU General Public License is hereby
+ * granted. No representations are made about the suitability of this software
  * for any purpose. It is provided "as is" without express or implied warranty.
  * See the GNU General Public License for more details.
  *
@@ -16,19 +16,19 @@
  */
 /*! \page doxygen_usage Doxygen usage
 
-Doxygen is a command line based utility.  Calling \c doxygen with the
-`--help` option at the command line will give you a brief description of the 
+Doxygen is a command-line based utility. Calling \c doxygen with the
+`--help` option at the command line will give you a brief description of the
 usage of the program.
 
-All options consist of a leading character <tt>-</tt>, 
+All options consist of a leading character <tt>-</tt>,
 followed by one character and one or more arguments depending on the option.
 
-To generate a manual for your project you typically 
+To generate a manual for your project you typically
 need to follow these steps:
 <ol>
-<li> You document your source code with 
+<li> You document your source code with
      special documentation blocks (see section \ref specialblock).
-<li> You generate a configuration file (see section \ref config) by 
+<li> You generate a configuration file (see section \ref config) by
      calling doxygen with the \c -g option:
 \verbatim
 doxygen -g <config_file>
@@ -44,34 +44,34 @@ doxygen <config_file>
 </ol>
 
 If you have a configuration file generated with an older version of
-doxygen, you can upgrade it to the current version by running doxygen
+Doxygen, you can upgrade it to the current version by running doxygen
 with the -u option.
 \verbatim
 doxygen -u <config_file>
 \endverbatim
 All configuration settings in the original configuration file will be copied
 to the new configuration file. Any new options will have their default value.
-Note that comments that you may have added in the original configuration file 
+Note that comments that you may have added in the original configuration file
 will be lost.
 
 \section doxygen_finetune Fine-tuning the output
-If you want to fine-tune the way the output looks, doxygen allows you 
+If you want to fine-tune the way the output looks, Doxygen allows you
 generate default style sheet, header, and footer files that you can edit
-afterwards:
+afterward:
 <ul>
-<li>For HTML output, you can generate the default header file 
-    (see \ref cfg_html_header "HTML_HEADER"), the default footer 
+<li>For HTML output, you can generate the default header file
+    (see \ref cfg_html_header "HTML_HEADER"), the default footer
     (see \ref cfg_html_footer "HTML_FOOTER"), and the default style
     sheet (see \ref cfg_html_stylesheet "HTML_STYLESHEET"), using the
     following command:
 \verbatim
 doxygen -w html header.html footer.html stylesheet.css <config_file>
 \endverbatim
-  The `config_file` is optional. When omitted doxygen will search for 
+  The `config_file` is optional. When omitted doxygen will search for
   a file named `Doxyfile` and process that. When this is also not found it
-  will used the default settings.
+  will use the default settings.
 
-<li>For \LaTeX output, you can generate the first and last part of \c refman.tex 
+<li>For \LaTeX output, you can generate the first and last part of \c refman.tex
     (see \ref cfg_latex_header "LATEX_HEADER" and
      \ref cfg_latex_footer "LATEX_FOOTER") and the style sheet included
     by that header (normally <code>doxygen.sty</code>), using the following
@@ -79,10 +79,10 @@ doxygen -w html header.html footer.html stylesheet.css <config_file>
 \verbatim
 doxygen -w latex header.tex footer.tex doxygen.sty <config_file>
 \endverbatim
-If you need non-default options (for instance to use extra \LaTeX packages) 
+If you need non-default options (for instance to use extra \LaTeX packages)
 you need to make a configuration file with those options set correctly and then specify
 that configuration file after the generated files (make a backup of the configuration
-file first so you don't loose it in case you forget to specify one of the 
+file first so you don't loose it in case you forget to specify one of the
 output files).
 <li>For RTF output, you can generate the default style sheet file (see
     \ref cfg_rtf_stylesheet_file "RTF_STYLESHEET_FILE") using:
@@ -90,8 +90,8 @@ output files).
 doxygen -w rtf rtfstyle.cfg
 \endverbatim
 </ul>
-\warning When using a custom header you are responsible 
-  for the proper inclusion of any scripts and style sheets that doxygen 
+\warning When using a custom header you are responsible
+  for the proper inclusion of any scripts and style sheets that doxygen
   needs, which is dependent on the configuration options and may changes
   when upgrading to a new doxygen release.
 
@@ -106,7 +106,7 @@ doxygen -w rtf rtfstyle.cfg
      Please use the \c -s or \c -x or \c -x_noenv option if you send me a
      configuration file as part of a bug report or post an issue on GitHub!
      (see also: \ref bug_reports "How to report a bug")
-<li> To make doxygen read/write to standard input/output instead of from/to 
+<li> To make doxygen read/write to standard input/output instead of from/to
      a file, use \c - for the file name.
 </ul>
 

--- a/doc/doxywizard_usage.doc
+++ b/doc/doxywizard_usage.doc
@@ -14,12 +14,12 @@
  */
 /*! \page doxywizard_usage Doxywizard usage
 
-Doxywizard is a GUI front-end for configuring and running doxygen.
+Doxywizard is a GUI front-end for configuring and running Doxygen.
 
-When starting doxywizard one can specify an existing configuration file to use as argument,
-otherwise the default settings will be used as a starting point.
+When starting Doxywizard one can specify an existing configuration file to use as an
+argument, otherwise, the default settings will be used as a starting point.
 
-When you start doxywizard it will display the main window
+When you start Doxywizard it will display the main window
 (the actual look depends on the platform used).
 
 \image html doxywizard_main.png "Main window"
@@ -34,8 +34,8 @@ The user interface consists of the following sections:
 <dt>Specify the working directory from which doxygen will run
 <dd>
 Using the <tt>Select...</tt> button a directory can be selected.
-When doxywizard is started with a configuration file or one is loaded using the open command
-(see: \ref dw_menu_file) the directory of this settings file used as the working directory.
+When Doxywizard is started with a configuration file or one is loaded using the open command
+(see: \ref dw_menu_file) the directory of this settings file is used as the working directory.
 
 <dt>Configure doxygen using the Wizard and/or Expert tab...
 <dd>
@@ -49,26 +49,26 @@ When doxywizard is started with a configuration file or one is loaded using the 
   </dl>
 
 Switching between these tabs is possible, e.g you could start with the wizard tab
-and then fine tune some settings by switching to the expert tab.
+and then fine-tune some settings by switching to the expert tab.
 
 </dl>
 
-After doxygen is configured you need to save (see: \ref dw_menu_file) the configuration as a file
-to disk. This allows doxygen to use the configuration
-and also allows running doxygen again with the same settings at a later point in time.
+After Doxygen is configured you need to save (see: \ref dw_menu_file) the configuration as a file
+to disk. This allows Doxygen to use the configuration
+and also allows running Doxygen again with the same settings at a later point in time.
 
 Since some configuration options may use relative paths, be sure to
-select a working directory that is root of those paths.
+select a working directory that is the root of those paths.
 This is often the root of the source tree and will typically be correctly filled in
 if the configuration file is stored at this location as well.
 
 Once the configuration file is saved and the working directory is set, you
-can run doxygen based on the selected settings. Do this by switching to the
+can run Doxygen based on the selected settings. Do this by switching to the
 \ref dw_run "Run" tab, and click the "Run doxygen" button.
 
-Once doxygen runs you can cancel it by clicking the same
-button again. The output produced by doxygen is captured and shown in the "Output produced by doxygen"
-pane. Once doxygen finishes, the log can be saved as a text file.
+Once Doxygen runs you can cancel it by clicking the same
+button again. The output produced by Doxygen is captured and shown in the "Output produced by doxygen"
+pane. Once Doxygen finishes, the log can be saved as a text file.
 
 \section dw_wizard Wizard tab
 
@@ -81,13 +81,13 @@ pane.
 settings that are available for the selected topic.
 </dl>
 
-The wizard only gives the possibility to quickly setup doxygen, for full control
+The wizard only gives the possibility to quickly setup Doxygen, for full control
 one should use the \ref dw_expert.
 
 \forceNewPage
 \subsection dw_wizard_project Project settings
 
-The fields in the Project pane speak for themselves. Once doxygen has finished
+The fields in the Project pane speak for themselves. Once Doxygen has finished
 the Destination directory is where to look for the results. Doxygen will
 put each output format in a separate sub-directory by default.
 
@@ -97,10 +97,10 @@ put each output format in a separate sub-directory by default.
 \forceNewPage
 \subsection dw_wizard_mode Mode of operating
 
-The Mode pane allows you to select how doxygen will look at your sources.
+The Mode pane allows you to select how Doxygen will look at your sources.
 The default is to only look for things that have been documented. Furthermore, the
 terminology used in the output can be changed to better match the main programming language used
-(this doesn't affect the way doxygen parses your source code).
+(this doesn't affect the way Doxygen parses your source code).
 
 \image html doxywizard_page2.png "Wizard tab: Mode of operating"
 \image latex doxywizard_page2.png "Wizard tab: Mode of operating" width=15cm
@@ -108,7 +108,7 @@ terminology used in the output can be changed to better match the main programmi
 \forceNewPage
 \subsection dw_wizard_output Output to produce
 
-The Output pane allows you to select what kinds of output doxygen will produce.
+The Output pane allows you to select what kinds of output Doxygen will produce.
 For HTML and \LaTeX there are additional options available.
 
 \image html doxywizard_page3.png "Wizard tab: Output to produce"
@@ -117,7 +117,7 @@ For HTML and \LaTeX there are additional options available.
 \forceNewPage
 \subsection dw_wizard_diagrams Diagrams to generate
 
-Doxygen can produce a number of diagrams. Using the Diagrams pane you
+Doxygen can produce several diagrams. Using the Diagrams pane you
 can select which ones to generate. For most diagrams the
 `dot` tool of the <a href="http://www.graphviz.org">GraphViz</a> package
 is needed. This needs to be installed separately.
@@ -211,7 +211,7 @@ The representation of the input field depends on the type of the configuration o
 
 \section dw_run Run tab
 
-The run tab gives the possibility to run doxygen with the given settings, see the HTML results,
+The run tab gives the possibility to run Doxygen with the given settings, see the HTML results,
 see the settings used and save the output as displayed in the output pane.
 
 \image html doxywizard_run.png "Run tab"

--- a/doc/features.doc
+++ b/doc/features.doc
@@ -1,12 +1,12 @@
 /******************************************************************************
  *
- * 
+ *
  *
  * Copyright (C) 1997-2015 by Dimitri van Heesch.
  *
  * Permission to use, copy, modify, and distribute this software and its
- * documentation under the terms of the GNU General Public License is hereby 
- * granted. No representations are made about the suitability of this software 
+ * documentation under the terms of the GNU General Public License is hereby
+ * granted. No representations are made about the suitability of this software
  * for any purpose. It is provided "as is" without express or implied warranty.
  * See the GNU General Public License for more details.
  *
@@ -18,76 +18,76 @@
 
 \addindex features
 <UL>
-<li>Requires very little overhead from the writer of the documentation. 
-    Plain text will do, Markdown is support, and for more fancy or 
-    structured output HTML tags and/or some of doxygen's special commands 
+<li>Requires very little overhead from the writer of the documentation.
+    Plain text will do, Markdown is supported, and for more fancy or
+    structured output HTML tags and/or some of doxygen's special commands
     can be used.
 <li>Cross platform: works on Windows and many Unix flavors (including Linux and
     MacOSX).
-<li>Indexes, organizes and generates browsable and cross-referenced 
+<li>Indexes, organizes and generates browsable and cross-referenced
     output even from undocumented code.
-<li>Generates structured XML output for parsed sources, which can be 
+<li>Generates structured XML output for parsed sources, which can be
     used by external tools.
 <li>Supports C/C++, Lex, Java, (Corba and Microsoft) Java, Python, VHDL, PHP
     IDL, C#, Fortran, Objective-C 2.0, and to some extent D sources.
-<li>Supports documentation of files, namespaces, packages, classes, 
-    structs, unions, templates, variables, functions, typedefs, enums and 
-    defines. 
+<li>Supports documentation of files, namespaces, packages, classes,
+    structs, unions, templates, variables, functions, typedefs, enums and
+    defines.
 <li>Javadoc (1.1), qdoc3 (partially), and ECMA-334 (C# spec.) compatible.
-<li>Comes with a GUI frontend (Doxywizard) to ease editing the options and 
+<li>Comes with a GUI frontend (Doxywizard) to ease editing the options and
     run doxygen. The GUI is available on Windows, Linux, and MacOSX.
-<li>Automatically generates class and collaboration diagrams in HTML (as clickable 
+<li>Automatically generates class and collaboration diagrams in HTML (as clickable
     image maps) and \LaTeX (as Encapsulated PostScript images).
 <li>Uses the `dot` tool of the Graphviz tool kit to generate
     include dependency graphs, collaboration diagrams, call graphs, directory structure
-    graphs, and graphical class hierarchy graphs. 
+    graphs, and graphical class hierarchy graphs.
 <li>Allows grouping of entities in modules and creating a hierarchy of modules.
-<li>Flexible comment placement: Allows you to put documentation in the 
-    header file (before the 
-    declaration of an entity), source file (before the definition of an entity) 
+<li>Flexible comment placement: Allows you to put documentation in the
+    header file (before the
+    declaration of an entity), source file (before the definition of an entity)
     or in a separate file.
 <li>Generates a list of all members of a class (including any inherited
     members) along with their protection level.
-<li>Outputs documentation in on-line format (XHTML and UNIX man page) and 
-    off-line format (\LaTeX and RTF) simultaneously 
-    (any of these can be disabled if desired). All formats are optimized for 
+<li>Outputs documentation in on-line format (XHTML and UNIX man page) and
+    off-line format (\LaTeX and RTF) simultaneously
+    (any of these can be disabled if desired). All formats are optimized for
     ease of reading. <br>
-    Furthermore, compressed HTML can be generated from HTML output using 
-    Microsoft's HTML Help Workshop (Windows only) and PDF can be generated 
+    Furthermore, compressed HTML can be generated from HTML output using
+    Microsoft's HTML Help Workshop (Windows only) and PDF can be generated
     from the \LaTeX output.
 <li>Support for various third party help formats including HTML Help,
     docsets, Qt-Help, and eclipse help.
-<li>Includes a full C preprocessor to allow proper parsing of conditional 
+<li>Includes a full C preprocessor to allow proper parsing of conditional
     code fragments and to allow expansion of all or part of macros definitions.
 <li>Automatically detects public, protected and private sections, as well as
-    the Qt specific signal and slots sections. Extraction of private class 
+    the Qt specific signal and slots sections. Extraction of private class
     members is optional.
 <li>Automatically generates references to documented classes, files, namespaces
-    and members. Documentation of global functions, global variables, 
+    and members. Documentation of global functions, global variables,
     typedefs, defines and enumerations is also supported.
-<li>References to base/super classes and inherited/overridden members are 
+<li>References to base/super classes and inherited/overridden members are
     generated automatically.
-<li>Includes a fast, rank based search engine to search for strings or words 
+<li>Includes a fast, rank based search engine to search for strings or words
     in the class and member documentation (PHP based).
 <li>Includes an JavaScript based live search feature to search for symbols
     as you type (for small to medium sized projects).
 <li>You can type normal HTML tags in your documentation. Doxygen will convert
-    them to their equivalent \LaTeX, RTF, and man-page 
+    them to their equivalent \LaTeX, RTF, and man-page
     counterparts automatically.
-<li>Allows references to documentation generated for other (doxygen documented) 
+<li>Allows references to documentation generated for other (doxygen documented)
     projects (or another part of the same project) in a location independent way.
-<li>Allows inclusion of source code examples that are automatically 
+<li>Allows inclusion of source code examples that are automatically
     cross-referenced with the documentation.
 <li>Inclusion of undocumented classes is also supported, allowing to quickly
-    learn the structure and interfaces of a (large) piece of code without 
+    learn the structure and interfaces of a (large) piece of code without
     looking into the implementation details.
 <li>Allows automatic cross-referencing of (documented) entities with their
     definition in the source code.
 <li>All source code fragments are syntax highlighted for ease of reading.
 <li>Allows inclusion of function/member/class definitions in the documentation.
-<li>All options are read from an easy to edit and (optionally) annotated 
+<li>All options are read from an easy to edit and (optionally) annotated
     configuration file.
-<li>Documentation and search engine can be transferred to another 
+<li>Documentation and search engine can be transferred to another
     location or machine without regenerating the documentation.
 <li>Supports many different character encodings and uses UTF-8 internally and
     for the generated output.
@@ -97,21 +97,21 @@
 <li>Can cope with large projects easily.
 </UL>
 
-Although doxygen can now be used in any project written in a language that is 
-supported by doxygen, initially it was specifically designed to be used for projects 
-that make use of Qt Software's 
-<A HREF="https://www.qt.io/developers">Qt toolkit</A>. I have tried to 
-make doxygen `Qt-compatible'. That is: Doxygen can read the documentation contained in 
-the Qt source code and create a class browser that looks quite similar to the 
-one that is generated by Qt Software. Doxygen understands the C++ extensions 
+Although Doxygen can now be used in any project written in a language that is
+supported by Doxygen, initially it was specifically designed to be used for projects
+that make use of Qt Software's
+<A HREF="https://www.qt.io/developers">Qt toolkit</A>. I have tried to
+make Doxygen `Qt-compatible'. That is: Doxygen can read the documentation contained in
+the Qt source code and create a class browser that looks quite similar to the
+one that is generated by Qt Software. Doxygen understands the C++ extensions
 used by Qt such as signals and slots and many of the markup commands used in the Qt sources.
 
 Doxygen can also automatically generate links to existing documentation
-that was generated with doxygen or with Qt's non-public class browser 
-generator. For a Qt based project this means that whenever you refer to 
-members or classes belonging to the Qt toolkit, a link will be generated to 
-the Qt documentation. This is done independent of where this documentation 
-is located! 
+that was generated with Doxygen or with Qt's non-public class browser
+generator. For a Qt based project this means that whenever you refer to
+members or classes belonging to the Qt toolkit, a link will be generated to
+the Qt documentation. This is done independently of where this documentation
+is located!
 
 
 \htmlonly


### PR DESCRIPTION
1. Removes spaces at end of the lines.
2. Appropriately replaces `doxygen` with `Doxygen`.
3. Replaces `doxywizard` with `Doxywizard`.
4. Fixes a few other grammatical errors.