### PR TITLE
Correction to internal documentation

### DIFF
--- a/src/doxygen.md
+++ b/src/doxygen.md
@@ -1,4 +1,4 @@
-Doxygen Internals {#mainpage}
+%Doxygen Internals {#mainpage}
 =================
 
 Introduction
@@ -78,7 +78,7 @@ The Entry objects created and filled during parsing are stored on disk
 location on disk of each Entry is stored as a tree of EntryNav nodes, which is
 kept in memory.
 
-Doxygen does a number of tree walks over the EntryNav nodes in the tree to
+%Doxygen does a number of tree walks over the EntryNav nodes in the tree to
 build up the data structures needed to produce the output.
 
 The resulting data structures are all children of the generic base class
@@ -115,12 +115,13 @@ easy ways to get debug information.
       - set the item `Write used lex rules` to `Yes`
       - see to it that the `.l` file is newer than the corresponding `.cpp` file
         or remove the corresponding `.cpp` file
+    - when using `nmake` the same possibilities exist as described with "unices".
   - unices
     - global change<br>
       In the chapter "Doxygen's internals" a `perl` script is given to toggle the
       possibility of having the rules debug information.
     - command line change<br>
-      It is possible to the option `LEX="flex -d"` with the `make` command on the
+      It is possible to the option `LEX_FLAGS="-d"` with the `make` command on the
       command line. In this case the `.l` that are converted to the corresponding
       `.cpp` files during this `make` get the rules debug information.<br>
       To undo the rules debug information output just recompile the file with
@@ -144,6 +145,9 @@ easy ways to get debug information.
     Shows the results of the preprocessing phase, i.e. results from include files,
     <tt>\#define</tt> statements etc., definitions in the doxygen configuration file like:
     `EXPAND_ONLY_PREDEF`, `PREDEFINED` and `MACRO_EXPANSION`.
+  - nolineno<br>
+    In case the line numbers in the results of the preprocessing phase are not wanted they
+    can be removed by means of this option (without `-d preprocessor` this option has no effect.
   - commentcnv<br>
     Shows the results of the comment conversion, the comment conversion does the
     following:
@@ -172,13 +176,32 @@ easy ways to get debug information.
     Provide output of the `lex` files used. When a lexer is started and when a lexer
     ends the name of the `lex` file is given so it is possible to see in which lexer the
     problem occurs. This makes it easier to select the file to be compiled in `lex` debug mode.
+  - cite<br>
+    Retains the temporary files as created and used for the non LaTeX output results of the 
+    generation of the bibliographical references.
+  - fortranfixed2free<br>
+    Shows the result ogf the conversion of Fortran fixed formatted files to Fortran free formatted 
+    files as done by doxygen.
+  - plantuml<br>
+    Shows information about the plantuml process run and the used input / output filenames, the content of the
+    input file.
+  - rtf<br>
+    - Shows the original names and the anchors names (called bookmarks in RTF) where they are mapped to.
+    - At the end of the generation of the RTF files these files are merged into one large RTF file, with
+      this option the original files are retained.
+  - qhp<br>
+    - The qhp file is created with indentation for better readability (normally no indentation so the file is smaller).
+    - When the setting `QHG_LOCATION` is pointing to the `qhelpgenerator` besides generating the `qch` file 
+      also some extra checks are done by means of the `-c` flag of the `qhelpgenerator`.
+  - tag<br>
+    Shows the results of reading the tag files.
 
 Producing output
 ================
 
 TODO
 
-Topics TODO
+Documentation Topics TODO
 ===========
 - Grouping of files in Model / Parser / Generator categories
 - Index files based on IndexIntf


### PR DESCRIPTION
Some small corrections and enhancement to the doxygen internal general description
- the used word `Doxygen` is not the `Doxygen` class but the program (so no link necessary)
- the `LEX=` flag didn't work, replaced it with a description of the `LEX_FLAGS=` flag and adding it also when using `nmake`
- adding missing doxygn `-d` commandline options.