### PR TITLE
Strange internal documentation in docnode.h

### DIFF
--- a/src/docnode.h
+++ b/src/docnode.h
@@ -56,13 +56,13 @@ DOC_NODES
 #undef DN_SEP
 
 // define a variant type
-using DocNodeVariant = std::variant<
 #define DN(x) x
 #define DN_SEP ,
+using DocNodeVariant = std::variant<
 DOC_NODES
+>;
 #undef DN
 #undef DN_SEP
->;
 
 // getter functions to return the name of a doc node type
 #define DN(x) constexpr const char *docNodeName(const x &n) { return #x; }
@@ -1323,17 +1323,17 @@ inline T *DocNodeList::get_last()
   return std::get_if<T>(&back());
 }
 
-/// ---------------- Debug helpers -------------------------------
+// ---------------- Debug helpers -------------------------------
 
-inline const char *docNodeName(const DocNodeVariant &v)
-{
 #define DN(x)  #x
 #define DN_SEP ,
+inline const char *docNodeName(const DocNodeVariant &v)
+{
   static const char *table[] = { DOC_NODES };
-#undef DN
-#undef DN_SEP
   return table[v.index()];
 }
+#undef DN
+#undef DN_SEP
 
 inline void dumpDocNodeSizes()
 {


### PR DESCRIPTION
In the doxygen internal output we see in the documentation of `docnode.h`:
- with the typedefs: `using  DocNodeVariant = std::variant< #define DN(x) #define DN_SEP DOC_NODES >`, the `#define`s  should not be present. When possible the `define`s should be located outside the function / block
- a line as brief description with a.o. the text "Debugs helpers" due to a doxygen comment hat should not be a doxygen comment (in this form)