### PR TITLE
EXPAND_AS_DEFINED not expanded recursively

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -277,7 +277,7 @@ INCLUDE_PATH           = libmd5 \
                          libmscgen
 INCLUDE_FILE_PATTERNS  =
 PREDEFINED             =
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = DOC_NODES DN DN_SEP
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
 # Configuration options related to external references

--- a/src/pre.l
+++ b/src/pre.l
@@ -661,7 +661,7 @@ WSopt [ \t\r]*
                                               (!yyextra->expandOnlyPredef || def->isPredefined)
                                              )
                                           {
-                                            QCString result=def->isPredefined ? def->definition : expandMacro(yyscanner,yytext);
+                                            QCString result=expandMacro(yyscanner,yytext);
                                             outputString(yyscanner,result);
                                           }
                                           else

--- a/src/pre.l
+++ b/src/pre.l
@@ -2557,6 +2557,7 @@ static int getNextId(const QCString &expr,int p,int *l)
  */
 static bool expandExpression(yyscan_t yyscanner,QCString &expr,QCString *rest,int pos,int level)
 {
+  struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
   YY_EXTRA_TYPE state = preYYget_extra(yyscanner);
   //printf(">expandExpression(expr='%s',rest='%s',pos=%d,level=%d)\n",qPrint(expr),rest ? qPrint(*rest) : "", pos, level);
   if (expr.isEmpty())
@@ -2590,6 +2591,7 @@ static bool expandExpression(yyscan_t yyscanner,QCString &expr,QCString *rest,in
       if (state->expandedDict.find(macroName.str())==state->expandedDict.end()) // expand macro
       {
         Define *def=isDefined(yyscanner,macroName);
+        if (!(!yyextra->expandOnlyPredef || (def && def->isPredefined))) def = NULL;
         if (macroName=="defined")
         {
           //printf("found defined inside macro definition '%s'\n",qPrint(expr.right(expr.length()-p)));


### PR DESCRIPTION
When having:
```
#define DOC_NODES DN(DocWord)           DN_SEP DN(DocLinkedWord)    DN_SEP

#define DN(x) constexpr const char *docNodeName(const x &n) { return #x; }
#define DN_SEP
DOC_NODES
#undef DN
#undef DN_SEP
```
with the settings:
```
QUIET                  = YES
EXTRACT_ALL            = YES
ENABLE_PREPROCESSING   = YES
MACRO_EXPANSION        = YES
EXPAND_ONLY_PREDEF     = YES
ALWAYS_DETAILED_SEC    = YES
PREDEFINED             =
EXPAND_AS_DEFINED     += DN
EXPAND_AS_DEFINED     += DN_SEP
EXPAND_AS_DEFINED     += DOC_NODES
```
The result is that `DOC_NODES` is expanded, but not the `DN` and `DN_SEP` used inside.
So the functions:
```
constexpr const char *  docNodeName (const DocWord &n)
constexpr const char *  docNodeName (const DocLinkedWord &n)
```
are not shown.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8699888/example.tar.gz)
