### PR TITLE
bug_751023 Predefined macros are handled incorrectly in source browser

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1216,7 +1216,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           yyextra->delimiter=yyextra->delimiter.left(yyextra->delimiter.length()-1);
                                           BEGIN( RawString );
                                         }
-<FuncCall,Body,MemberCall,MemberCall2,SkipInits,InlineInit>\"   {
+<FuncCall,Body,MemberCall,MemberCall2,SkipInits,InlineInit,ClassVar>\"   {
                                           startFontClass(yyscanner,"stringliteral");
                                           yyextra->code->codify(yytext);
                                           yyextra->lastStringContext=YY_START;


### PR DESCRIPTION
The strings as part of a `ClassVar` should also be caught as a string. Until now it was caught as a general rule in `<*>.` and the `%` in the rule `<ClassName,ClassVar>[*&^%]+ `.

I create a bit a larger example:
```
#define GTY(x)
struct  bug2 {
  int field2;
};
struct GTY("y") bug3 {
  int field3;
  char *x = "something";
  char *y = "some%thing";
};
struct GTY("%") bug {
  int field;
};
struct  bug1 {
  int field1;
};
```
and modified the `stringliteral` color for better visibility in the test.
**Before**
![image](https://user-images.githubusercontent.com/5223533/168781799-a6330af1-2dc3-494b-89df-9fa4e7c2afaa.png)

**After**
![image](https://user-images.githubusercontent.com/5223533/168781878-d7893e8f-90e2-43bb-8065-eb15744c5f62.png)


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8707122/example.tar.gz)
