### PR TITLE
deduplicate writeGraphHeader

### DIFF
--- a/src/dotgroupcollaboration.cpp
+++ b/src/dotgroupcollaboration.cpp
@@ -316,25 +316,6 @@ bool DotGroupCollaboration::isTrivial() const
 
 void DotGroupCollaboration::writeGraphHeader(TextStream &t,const QCString &title) const
 {
-  int fontSize      = Config_getInt(DOT_FONTSIZE);
-  QCString fontName = Config_getString(DOT_FONTNAME);
-  t << "digraph ";
-  if (title.isEmpty())
-  {
-    t << "\"Dot Graph\"";
-  }
-  else
-  {
-    t << "\"" << convertToXML(title) << "\"";
-  }
-  t << "\n";
-  t << "{\n";
-  if (Config_getBool(DOT_TRANSPARENT))
-  {
-    t << "  bgcolor=\"transparent\";\n";
-  }
-  t << "  edge [fontname=\"" << fontName << "\",fontsize=\"" << fontSize << "\","
-    "labelfontname=\"" << fontName << "\",labelfontsize=\"" << fontSize << "\"];\n";
-  t << "  node [fontname=\"" << fontName << "\",fontsize=\"" << fontSize << "\",shape=box];\n";
+  DotGraph::writeGraphHeader(t, title);
   t << "  rankdir=LR;\n";
 }


### PR DESCRIPTION
deduplicate writeGraphHeader
    
No need to redefine node shape.
