### PR TITLE
issue #9352 Qt Q_GADGET macro is not supported

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2091,7 +2091,7 @@ NONLopt [^\n]*
 <CopyHereDocEnd>.                       {
                                           *yyextra->pCopyHereDocGString <<  yytext;
                                         }
-<FindMembers>"Q_OBJECT"                 { // Qt object macro
+<FindMembers>"Q_OBJECT"|"Q_GADGET"      { // Qt object / gadget macro
                                         }
 <FindMembers>"Q_PROPERTY"               { // Qt property declaration
                                           yyextra->current->protection = Public ; // see bug734245 & bug735462


### PR DESCRIPTION
Not all `Q_...` type of macros are supported by doxygen.
It is quite easy for a user to "support" the `Q_GADGET` macro by means of the settings:
```
PREDEFINED += Q_GADGET
MACRO_EXPANSION = YES
```

as the `Q_GADGET` macro is quite similar to the `Q_OBJECT` macro it is supported by means of this change