### PR TITLE
Specify input encoding based on a file pattern

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1455,6 +1455,22 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
  Doxygen uses `libiconv` (or the `iconv` built into `libc`) for the transcoding.
  See <a href="https://www.gnu.org/software/libiconv/">the libiconv documentation</a> for
  the list of possible encodings.
+
+ \sa  \ref cfg_input_file_encoding "INPUT_FILE_ENCODING"
+]]>
+      </docs>
+    </option>
+    <option type='list' id='INPUT_FILE_ENCODING' format='string'>
+      <docs>
+<![CDATA[
+ This tag can be used to specify the character encoding of the source files that doxygen
+ parses
+ The \c INPUT_FILE_ENCODING tag can be used to specify character encoding on a per file pattern
+ basis. Doxygen will compare the file name with each pattern and apply the
+ encoding instead of the default \ref cfg_input_encoding "INPUT_ENCODING") if there is a match.
+ The character encodings are a list of the form: pattern=encoding (like `*.php=ISO-8859-1`).
+
+ See cfg_input_encoding "INPUT_ENCODING" for further information on supported encodings.
 ]]>
       </docs>
     </option>

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -653,7 +653,8 @@ static QCString configStringRecode(
   void *cd = portable_iconv_open(outputEncoding.data(),inputEncoding.data());
   if (cd==reinterpret_cast<void *>(-1))
   {
-    config_term("Error: unsupported character conversion: '%s'->'%s'\n",
+    config_term("Error: unsupported character conversion: '%s'->'%s'\n"
+                "Check the 'DOXYFILE_ENCODING' setting in the config file!\n",
         qPrint(inputEncoding),qPrint(outputEncoding));
   }
   size_t iLeft=inputSize;
@@ -1796,6 +1797,10 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   //------------------------
   // check FILTER_SOURCE_PATTERNS
   checkList(Config_getList(FILTER_SOURCE_PATTERNS),"FILTER_SOURCE_PATTERNS",FALSE,FALSE);
+
+  //------------------------
+  // check INPUT_FILE_ENCODING
+  checkList(Config_getList(INPUT_FILE_ENCODING),"INPUT_FILE_ENCODING",TRUE,TRUE);
 
   //------------------------
   // check TAGFILES

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -35,6 +35,7 @@
 #include "reflist.h"
 #include "utf8.h"
 #include "indexlist.h"
+#include "fileinfo.h"
 
 //-----------------------------------------------------------------------------------------
 
@@ -850,7 +851,8 @@ bool readCodeFragment(const QCString &fileName,
       Debug::print(Debug::FilterOutput,0,"-------------\n%s\n-------------\n",qPrint(result));
     }
   }
-  result = transcodeCharacterStringToUTF8(result);
+  FileInfo fi(fileName.str());
+  result = transcodeCharacterStringToUTF8(getEncoding(fi),result);
   if (!result.isEmpty() && result.at(result.length()-1)!='\n') result += "\n";
   //printf("readCodeFragment(%d-%d)=%s\n",startLine,endLine,qPrint(result));
   return found;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11407,6 +11407,10 @@ void adjustConfiguration()
         "Check the 'INPUT_ENCODING' setting in the config file!\n",
         qPrint(Config_getString(INPUT_ENCODING)),qPrint("UTF-8"),strerror(errno));
   }
+  else
+  {
+    portable_iconv_close(cd);
+  }
 
   // check and split INPUT_FILE_ENCODING
   const StringVector &fileEncod = Config_getList(INPUT_FILE_ENCODING);
@@ -11433,6 +11437,10 @@ void adjustConfiguration()
         term("unsupported character conversion: '%s'->'%s': %s\n"
             "Check the 'INPUT_FILE_ENCODING' setting in the config file!\n",
             qPrint(encoding),qPrint("UTF-8"),strerror(errno));
+      }
+      else
+      {
+        portable_iconv_close(cd);
       }
 
       Doxygen::inputFileEncoding.push_back(InputFileEncoding(pattern, encoding));

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -66,6 +66,17 @@ struct LookupInfo
   QCString   resolvedType;
 };
 
+class InputFileEncoding
+{
+  public:
+    InputFileEncoding(QCString pattern, QCString encoding) : m_pattern(pattern), m_encoding(encoding){}
+    QCString pattern()  {return m_pattern;}
+    QCString encoding() {return m_encoding;}
+  private:
+    QCString m_pattern;
+    QCString m_encoding;
+};
+
 using ClangUsrMap = std::unordered_map<std::string,const Definition *>;
 
 /*! \brief This class serves as a namespace for global variables used by doxygen.
@@ -119,6 +130,7 @@ class Doxygen
     static bool                      clangAssistedParsing;
     static QCString                  verifiedDotPath;
     static volatile bool             terminating;
+    static std::vector<InputFileEncoding> inputFileEncoding;
 };
 
 /** Deleter that only deletes an object if doxygen is not already terminating */

--- a/src/util.h
+++ b/src/util.h
@@ -342,7 +342,7 @@ bool checkIfTypedef(const Definition *scope,const FileDef *fileScope,const QCStr
 
 QCString parseCommentAsText(const Definition *scope,const MemberDef *member,const QCString &doc,const QCString &fileName,int lineNr);
 
-QCString transcodeCharacterStringToUTF8(const QCString &input);
+QCString transcodeCharacterStringToUTF8(QCString inputEncoding,const QCString &input);
 
 QCString recodeString(const QCString &str,const char *fromEncoding,const char *toEncoding);
 
@@ -430,4 +430,5 @@ FortranFormat convertFileNameFortranParserCode(QCString fn);
 QCString integerToAlpha(int n, bool upper=true);
 QCString integerToRoman(int n, bool upper=true);
 
+QCString getEncoding(FileInfo &fi);
 #endif


### PR DESCRIPTION
Sometimes a few files in a project are encoded according to another encoding then the default `INPUT_ENCODING`.
With the setting `INPUT_FILE_ENCODING` at pattern and encoding can be given to overcome this problem.

Found by Fossies for the project: symfony
See also: https://github.com/symfony/symfony/discussions/46477

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8799196/example.tar.gz)
