### PR TITLE
issue #9367 Current git master does not honor PROJECT_NUMBER in LaTeX

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -693,10 +693,12 @@ static QCString substituteLatexKeywords(const QCString &str,
     copyFile(formulaMacrofile,Config_getString(LATEX_OUTPUT) + "/" + stripMacroFile);
   }
 
+  QCString projectNumber = Config_getString(PROJECT_NUMBER);
+
   // first substitute generic keywords
   QCString result = substituteKeywords(str,title,
     convertToLaTeX(Config_getString(PROJECT_NAME)),
-    convertToLaTeX(Config_getString(PROJECT_NUMBER)),
+    convertToLaTeX(projectNumber),
         convertToLaTeX(Config_getString(PROJECT_BRIEF)));
 
   // additional LaTeX only keywords
@@ -726,6 +728,7 @@ static QCString substituteLatexKeywords(const QCString &str,
   result = selectBlock(result,"LATEX_BATCHMODE",latexBatchmode,OutputGenerator::Latex);
   result = selectBlock(result,"LATEX_FONTENC",!latexFontenc.isEmpty(),OutputGenerator::Latex);
   result = selectBlock(result,"FORMULA_MACROFILE",!formulaMacrofile.isEmpty(),OutputGenerator::Latex);
+  result = selectBlock(result,"PROJECT_NUMBER",!projectNumber.isEmpty(),OutputGenerator::Latex);
 
   result = removeEmptyLines(result);
 

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -220,6 +220,9 @@
   \vspace*{7cm}
   \begin{center}%
   {\Large $title}\\
+%%BEGIN PROJECT_NUMBER
+  [1ex]\large $projectnumber \\
+%%END PROJECT_NUMBER
   \vspace*{1cm}
   {\large $generatedby Doxygen $doxygenversion}\\
 %%BEGIN LATEX_TIMESTAMP


### PR DESCRIPTION
During the conversion from the hard coded template for the LaTeX header / footer apparently the `PROJECT_NUMBER` was not properly considered (see #8309 /  Default LaTeX header misses $-placeholders (Origin: bugzilla 668003) #4530).

This has been corrected.