### PR TITLE
Enabling include files for lex files

### DIFF
--- a/addon/doxywizard/CMakeLists.txt
+++ b/addon/doxywizard/CMakeLists.txt
@@ -80,15 +80,33 @@ add_custom_command(
 set_source_files_properties(${GENERATED_SRC_WIZARD}/configdoc.cpp PROPERTIES GENERATED 1)
 
 set(LEX_FILES config_doxyw)
+
+# Currently the complete list of lex include files for the dependency
+# The dependency should be a more dynamic list based on the content of the lex file
+set(LEX_INC_FILES)
+
 foreach(lex_file ${LEX_FILES})
     add_custom_command(
-        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/scan_states.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l > ${GENERATED_SRC_WIZARD}/${lex_file}.l.h
-        DEPENDS ${PROJECT_SOURCE_DIR}/src/scan_states.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l
+        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/pre_lex.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l  ${GENERATED_SRC_WIZARD}/${lex_file}.l ${GENERATED_SRC_WIZARD}/${lex_file}.corr ${PROJECT_SOURCE_DIR}/src
+        DEPENDS ${PROJECT_SOURCE_DIR}/src/pre_lex.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l ${LEX_INC_FILES}
+        OUTPUT  ${GENERATED_SRC_WIZARD}/${lex_file}.corr ${GENERATED_SRC_WIZARD}/${lex_file}.l
+    )
+    add_custom_command(
+        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/scan_states.py ${GENERATED_SRC_WIZARD}/${lex_file}.l > ${GENERATED_SRC_WIZARD}/${lex_file}.l.h
+        DEPENDS ${PROJECT_SOURCE_DIR}/src/scan_states.py ${GENERATED_SRC_WIZARD}/${lex_file}.l
         OUTPUT  ${GENERATED_SRC_WIZARD}/${lex_file}.l.h
     )
     set_source_files_properties(${GENERATED_SRC_WIZARD}/${lex_file}.l.h PROPERTIES GENERATED 1)
 
-    FLEX_TARGET(${lex_file}        ${lex_file}.l        ${GENERATED_SRC_WIZARD}/${lex_file}.cpp        COMPILE_FLAGS "${LEX_FLAGS}")
+    FLEX_TARGET(${lex_file}
+                ${GENERATED_SRC_WIZARD}/${lex_file}.l
+                ${GENERATED_SRC_WIZARD}/${lex_file}_intermediate.cpp
+                COMPILE_FLAGS "${LEX_FLAGS}")
+    add_custom_command(
+        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/post_lex.py ${GENERATED_SRC_WIZARD}/${lex_file}_intermediate.cpp ${GENERATED_SRC_WIZARD}/${lex_file}.cpp  ${GENERATED_SRC_WIZARD}/${lex_file}.corr ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l  ${GENERATED_SRC_WIZARD}/${lex_file}.l
+        DEPENDS ${PROJECT_SOURCE_DIR}/src/post_lex.py ${GENERATED_SRC_WIZARD}/${lex_file}_intermediate.cpp ${GENERATED_SRC_WIZARD}/${lex_file}.corr
+        OUTPUT  ${GENERATED_SRC_WIZARD}/${lex_file}.cpp
+    )
 endforeach()
 
 qt_wrap_cpp(doxywizard_MOC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,27 +112,43 @@ set(LEX_FILES scanner
     lexscanner
     configimpl)
 
+# Currently the complete list of lex include files for the dependency
+# The dependency should be a more dynamic list based on the content of the lex file
+set(LEX_INC_FILES)
+
 # unfortunately ${LEX_FILES_H} and ${LEX_FILES_CPP} don't work in older versions of CMake (like 3.6.2) for add_library
 foreach(lex_file ${LEX_FILES})
     set(LEX_FILES_H ${LEX_FILES_H} " " ${GENERATED_SRC}/${lex_file}.l.h CACHE INTERNAL "Stores generated files")
     set(LEX_FILES_CPP ${LEX_FILES_CPP} " " ${GENERATED_SRC}/${lex_file}.cpp CACHE INTERNAL "Stores generated files")
+
     add_custom_command(
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scan_states.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l > ${GENERATED_SRC}/${lex_file}.l.h
-        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/scan_states.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${CMAKE_CURRENT_LIST_DIR}
+        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l ${LEX_INC_FILES}
+        OUTPUT  ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.l
+    )
+    add_custom_command(
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scan_states.py ${GENERATED_SRC}/${lex_file}.l > ${GENERATED_SRC}/${lex_file}.l.h
+        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/scan_states.py ${GENERATED_SRC}/${lex_file}.l
         OUTPUT  ${GENERATED_SRC}/${lex_file}.l.h
     )
     set_source_files_properties(${GENERATED_SRC}/${lex_file}.l.h PROPERTIES GENERATED 1)
+
     # for code coverage we need the flex sources in the build src directory
     add_custom_command(
-        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/${lex_file}.l ${PROJECT_BINARY_DIR}/src/${lex_file}.l
-        DEPENDS ${PROJECT_SOURCE_DIR}/src/${lex_file}.l
+        COMMAND ${CMAKE_COMMAND} -E copy ${GENERATED_SRC}/${lex_file}.l ${PROJECT_BINARY_DIR}/src/${lex_file}.l
+        DEPENDS ${GENERATED_SRC}/${lex_file}.l
         OUTPUT  ${PROJECT_BINARY_DIR}/src/${lex_file}.l
     )
 
     FLEX_TARGET(${lex_file}
-                ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l
-                ${GENERATED_SRC}/${lex_file}.cpp
+                ${GENERATED_SRC}/${lex_file}.l
+                ${GENERATED_SRC}/${lex_file}_intermediate.cpp
                 COMPILE_FLAGS "${LEX_FLAGS}")
+    add_custom_command(
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/post_lex.py ${GENERATED_SRC}/${lex_file}_intermediate.cpp ${GENERATED_SRC}/${lex_file}.cpp  ${GENERATED_SRC}/${lex_file}.corr ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l  ${GENERATED_SRC}/${lex_file}.l
+        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/post_lex.py ${GENERATED_SRC}/${lex_file}_intermediate.cpp ${GENERATED_SRC}/${lex_file}.corr
+        OUTPUT  ${GENERATED_SRC}/${lex_file}.cpp
+    )
 endforeach()
 
 

--- a/src/post_lex.py
+++ b/src/post_lex.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+# python script to correct the linenumbers due to inclusion of comon parts in lex files
+#
+# Copyright (C) 1997-2022 by Dimitri van Heesch.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation under the terms of the GNU General Public License is hereby
+# granted. No representations are made about the suitability of this software
+# for any purpose. It is provided "as is" without express or implied warranty.
+# See the GNU General Public License for more details.
+#
+# Documents produced by Doxygen are derivative works derived from the
+# input used in their production; they are not affected by this license.
+#
+import sys
+import os
+import re
+
+
+def main():
+    if len(sys.argv)!=6:
+        sys.exit('Usage: %s <input_cpp_file> <output_cpp_file> <correction_file> <original_lex_file> <genetrated_lex_file>' % sys.argv[0])
+
+    inp_cpp_file = sys.argv[1]
+    quoted_inp_cpp_file = '"' + inp_cpp_file + '"'
+    out_cpp_file = sys.argv[2]
+    corr_cpp_file = sys.argv[3]
+    org_lex = sys.argv[4]
+    gen_lex = sys.argv[5]
+    quoted_gen_lex = '"' + gen_lex + '"'
+
+    corr_list = []
+    if (os.path.exists(corr_cpp_file)):
+        corr = open(corr_cpp_file,"r")
+        # read file
+        with open(corr_cpp_file,"r") as corr:
+            corr_list = [tuple(map(int, i.split(' '))) for i in corr]
+            corr.close()
+
+    if (os.path.exists(inp_cpp_file)):
+        out = open(out_cpp_file,"w")
+        rule_correction = False
+        with open(inp_cpp_file) as f:
+            for line in f:
+                if re.search(r'^#line ', line):
+                    if line.split()[2] == quoted_inp_cpp_file:
+                        out.write("%s %s \"%s\"\n"%(line.split()[0],line.split()[1],out_cpp_file))
+                    elif line.split()[2] == quoted_gen_lex:
+                        line_cnt = int(line.split()[1])
+                        # run correction
+                        corr_cnt = 0
+                        for elem in corr_list:
+                            if elem[0] <= line_cnt:
+                                corr_cnt = elem[1]
+                        line_cnt -= corr_cnt
+                        out.write("%s %d \"%s\"\n"%(line.split()[0],line_cnt,org_lex))
+                    else:
+                        out.write("%s"%(line))
+                elif re.search(r'^  /\* #line ', line):
+                    out.write("%s %s \"%s\"\n"%(line.split()[1],line.split()[2],line.split()[3]))
+                elif re.search(r'static .* yy_rule_linenum', line):
+                    out.write("%s"%(line))
+                    rule_correction = True
+                    # read next lines till } and correct numbers
+                    # Assumption structure is like:
+                    #   static const flex_int16_t yy_rule_linenum[26] =
+                    #      {   0,
+                    #        981,  985,  989,  995, 1093, 1151, 1153, 1154, 1179, 1182,
+                    #       1195, 1198, 1201, 1207, 1211, 1214, 1217, 1223, 1226, 1228,
+                    #       1230, 1235, 1236, 1237, 1238
+                    #      } ;
+                elif rule_correction:
+                    if re.search(r'{', line):
+                        out.write("%s"%(line))
+                    elif re.search(r'}', line):
+                        out.write("%s"%(line))
+                        rule_correction = False
+                    else:
+                        out.write("    ")
+                        out_list = []
+                        rule_list = line.replace(',','').split()
+                        for rule_cnt in rule_list:
+                            rule_num = int(rule_cnt)
+                            corr_cnt = 0
+                            for elem in corr_list:
+                                if elem[0] <= rule_num:
+                                    corr_cnt = elem[1]
+                            out_list.append("%5d"%(rule_num-corr_cnt))
+                        out.write(','.join(out_list));
+                        if re.search(r',$', line):
+                            out.write(",")
+                        out.write("\n")
+                else:
+                    out.write("%s"%(line))
+            f.close()
+        out.close()
+
+if __name__ == '__main__':
+    main()

--- a/src/pre_lex.py
+++ b/src/pre_lex.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+# python script to include common parts in lex file
+#
+# Copyright (C) 1997-2022 by Dimitri van Heesch.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation under the terms of the GNU General Public License is hereby
+# granted. No representations are made about the suitability of this software
+# for any purpose. It is provided "as is" without express or implied warranty.
+# See the GNU General Public License for more details.
+#
+# Documents produced by Doxygen are derivative works derived from the
+# input used in their production; they are not affected by this license.
+#
+import sys
+import os
+import re
+
+
+def main():
+    if len(sys.argv)!=5:
+        sys.exit('Usage: %s <input_lex_file> <output_lex_file> <correction_file> <include_path>' % sys.argv[0])
+
+    inp_lex_file = sys.argv[1]
+    out_lex_file = sys.argv[2]
+    corr_lex_file = sys.argv[3]
+    inc_path = sys.argv[4]
+
+    cnt = 0
+    rd_cnt = 0
+    add_cnt = 0
+    if (os.path.exists(inp_lex_file)):
+        out = open(out_lex_file,"w")
+        corr = open(corr_lex_file,"w")
+        first_corr  = True
+        with open(inp_lex_file) as f:
+            for line in f:
+                if re.search(r'^%doxygen', line):
+                    inc_file = inc_path + "/" + line.split()[1]
+                    first_line = True
+                    with open(inc_file) as f_inc:
+                        for inc_line in f_inc:
+                            if first_line:
+                                first_line = False
+                                out.write("  /* #line 1 %s */\n"%(inc_file))
+                            cnt += 1
+                            add_cnt += 1
+                            out.write("%s"%(inc_line))
+                        f_inc.close()
+                    if not first_line:
+                        out.write("  /* #line %d %s */\n"%(rd_cnt+2,inp_lex_file))
+                        cnt += 2
+                        add_cnt += 1
+                        if first_corr:
+                            corr.write("%d %d\n"%(0,0))
+                            first_corr = False
+                        corr.write("%d %d\n"%(cnt,add_cnt))
+                else:
+                    cnt += 1
+                    rd_cnt += 1
+                    out.write("%s"%(line))
+            f.close()
+        if not first_corr:
+            # sufficient large
+            corr.write("%d %d\n"%(cnt*2,add_cnt*2))
+        corr.close()
+        out.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The motivation for this is that make the rules and code as used in the different lexers more consistent as now some definitions are used in multiple lexers (e.g. for white space) and they are not always consistent.
This patch provides the infrastructure so that late on it is easy to add the include files.

The (f)lex program is missing an include facility and the suggestion (https://stackoverflow.com/questions/66197941/defining-lex-include-files-for-flexers) was to write an own pre-processor.
The code presented here functions as a pre-processor and consists of a number of states:
- pre processing the `.l` file to include files and remember where these lines are included
- creating the so called scan states include file, this was already present but now uses the result of the previous step
- translate the pre-processed `.l` file to an `.cpp` file
- post-process the file created `.cpp` file from  the previous step so that line numbers and used files refer to the original file(s) and the now adjusted `cpp` file.