### PR TITLE
issue #9378 Dollar Sign Escape Sequence Ignored in Markdown Backtick Syntax (Inline Code)

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -311,6 +311,8 @@ static QCString escapeSpecialChars(const QCString &s)
       case '\\': if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('\\'); break;
       case '@':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('@'); break;
       case '#':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('#'); break;
+      case '$':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('$'); break;
+      case '&':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('&'); break;
       default:   growBuf.addChar(c); break;
     }
     pc=c;


### PR DESCRIPTION
In case a `$` or `&` is inside a code span it should be escaped so it  won't be seen as just a literal `$` and `&` during further processing and not as a potential environment variable or HTML entity.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8861704/example.tar.gz)
