### PR TITLE
delete TAGFILE for build error:

### DIFF
--- a/examples/tag.cfg
+++ b/examples/tag.cfg
@@ -7,7 +7,6 @@ GENERATE_MAN     = NO
 GENERATE_RTF     = NO
 CASE_SENSE_NAMES = NO
 INPUT            = tag.cpp
-TAGFILES         = example.tag=../../example/html
 QUIET            = YES
 JAVADOC_AUTOBRIEF = YES
 SEARCHENGINE     = NO


### PR DESCRIPTION
error: Tag file 'example.tag' does not exist or is not a file.