### PR TITLE
Incorrect determination of sub-sections for index.

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -372,10 +372,10 @@ void DefinitionImpl::addSectionsToIndex()
       }
       QCString title = si->title();
       if (title.isEmpty()) title = si->label();
-      // determine if there is a next level inside this item
+      // determine if there is a next level inside this item, but be aware of the anchor and table section references.
       auto it_next = std::next(it);
       bool isDir = (it_next!=m_impl->sectionRefs.end()) ?
-                       (static_cast<int>((*it_next)->type()) > nextLevel) : FALSE;
+                       (isSection((*it_next)->type()) && static_cast<int>((*it_next)->type()) > nextLevel) : FALSE;
       Doxygen::indexList->addContentsItem(isDir,title,
                                          getReference(),
                                          m_impl->def->getOutputFileBase(),


### PR DESCRIPTION
Having an example like:
```
/*! \page commands Special Commands

\section cmd_intro Introduction

\section cmd_intro1 Introduction1

\anchor anc1

\section cmd_intro2 Introduction2
*/
```
the sections `Introduction` and `Introduction2` are shown as "pages" in the index of the CHM file but the section `Introduction1` is shown as a "book".

The problem is the `anchor` in the `Introduction1` section as an `anchor` (and `table`) are also handled with section references but should have been excluded here as it was done earlier for the current section for which the sub-sections are determined.


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8877217/example.tar.gz)
