### PR TITLE
No click possible on chapters in doxygen's CHM documentation

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -316,6 +316,8 @@ class HtmlHelp::Private
     Private() : index(recoder) {}
     void createProjectFile();
     std::ofstream cts,kts;
+    QCString prevFile;
+    QCString prevAnc;
     bool ctsItemPresent = false;
     int dc = 0;
     StringSet indexFiles;
@@ -522,16 +524,6 @@ void HtmlHelp::addContentsItem(bool isDir,
                                bool /* addToNavIndex */,
                                const Definition * /* def */)
 {
-  bool binaryTOC = Config_getBool(BINARY_TOC);
-  // If we're using a binary toc then folders cannot have links.
-  // Tried this and I didn't see any problems, when not using
-  // the resetting of file and anchor the TOC works better
-  // (prev / next button)
-  //if(Config_getBool(BINARY_TOC) && isDir)
-  //{
-    //file = 0;
-    //anchor = 0;
-  //}
   p->ctsItemPresent = true;
   int i; for (i=0;i<p->dc;i++) p->cts << "  ";
   p->cts << "<LI><OBJECT type=\"text/sitemap\">";
@@ -548,13 +540,18 @@ void HtmlHelp::addContentsItem(bool isDir,
     }
     else
     {
-      if (!(binaryTOC && isDir))
+      QCString currFile = addHtmlExtensionIfMissing(file);
+      QCString currAnc = anchor;
+      p->cts << "<param name=\"Local\" value=\"";
+      p->cts << currFile;
+      if (p->prevFile == currFile && p->prevAnc.isEmpty() && currAnc.isEmpty())
       {
-        p->cts << "<param name=\"Local\" value=\"";
-        p->cts << addHtmlExtensionIfMissing(file);
-        if (!anchor.isEmpty()) p->cts << "#" << anchor;
-        p->cts << "\">";
+        currAnc = "top";
       }
+      if (!currAnc.isEmpty()) p->cts << "#" << currAnc;
+      p->cts << "\">";
+      p->prevFile = currFile;
+      p->prevAnc = currAnc;
     }
   }
   p->cts << "<param name=\"ImageNumber\" value=\"";


### PR DESCRIPTION
In the pull request #8843 (for the issue #6000  Class Members is missing in the CHM. (Origin: bugzilla 766164)) a fix was made for the fact that the `Classes` item was not shown in the CHM index.
The side effect of this PR is that now the main "books" / chapters cannot opened anymore which can be seen in e.g. the CHM  version of the doxygen manual.
E.g. when one wants to see the introduction text in the chapter `Markdown support ` one first has to decent into the tree:
`Markdown support ` -> `Standard Markdown` -> `Paragraphs` and at that moment it is possible to scroll up to the top of the page.

The problem in the original problem (bug 766164) was that there are 2 consecutive items with a different name but with the same reference (here to "annotated.html").
The problem only occurs at the moment that an "page" and a "sub page" refer to the same generated page, by comparing the references to have the same file name and an empty anchor we know we are in this situation and as we are at page level we also know that an `id=top` is present so for the second reference (first one has already been completely handled) we can use this `id` to get the references correct and the doxygen CHM manual works again and also the bug 766164 is gone.