### PR TITLE
issue 9386 Problems with the directory dependency graph

### DIFF
--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -301,7 +301,7 @@ void DotGraph::writeGraphHeader(TextStream &t,const QCString &title)
          "labelfontname=\"" << fontName << "\","
          "labelfontsize=\"" << fontSize << "\"];\n";
   t << "  node [fontname=\"" << fontName << "\","
-         "fontsize=\"" << fontSize << "\",shape=record];\n";
+         "fontsize=\"" << fontSize << "\",shape=\"box\"];\n";
 }
 
 void DotGraph::writeGraphFooter(TextStream &t)


### PR DESCRIPTION
Seen
- the discussion with the mentioned issue
- the fact that a `record` is not really suited / intended for the us doxygen has for it
- the fact that the "problem" already exists since `dot` version 2.40 (as far as we can tell)

I think it is better to use `shape="box"` globally instead of `shape=record` even when GraphViz will improve `dot` to suit our needs as the problem remains in the older versions of `dot` (which wil probably be used for some time).