### PR TITLE
Enabling dependencies for include files in lex files

### DIFF
--- a/addon/doxywizard/CMakeLists.txt
+++ b/addon/doxywizard/CMakeLists.txt
@@ -81,16 +81,17 @@ set_source_files_properties(${GENERATED_SRC_WIZARD}/configdoc.cpp PROPERTIES GEN
 
 set(LEX_FILES config_doxyw)
 
-# Currently the complete list of lex include files for the dependency
-# The dependency should be a more dynamic list based on the content of the lex file
-set(LEX_INC_FILES)
-
 foreach(lex_file ${LEX_FILES})
     add_custom_command(
-        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/pre_lex.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l  ${GENERATED_SRC_WIZARD}/${lex_file}.l ${GENERATED_SRC_WIZARD}/${lex_file}.corr ${PROJECT_SOURCE_DIR}/src
-        DEPENDS ${PROJECT_SOURCE_DIR}/src/pre_lex.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l ${LEX_INC_FILES}
-        OUTPUT  ${GENERATED_SRC_WIZARD}/${lex_file}.corr ${GENERATED_SRC_WIZARD}/${lex_file}.l
+        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/pre_lex.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l  ${GENERATED_SRC_WIZARD}/${lex_file}.l ${GENERATED_SRC_WIZARD}/${lex_file}.corr ${GENERATED_SRC_WIZARD}/${lex_file}.d ${PROJECT_SOURCE_DIR}/src
+        DEPENDS ${PROJECT_SOURCE_DIR}/src/pre_lex.py ${PROJECT_SOURCE_DIR}/addon/doxywizard/${lex_file}.l
+        DEPFILE ${GENERATED_SRC_WIZARD}/${lex_file}.d
+        OUTPUT  ${GENERATED_SRC_WIZARD}/${lex_file}.l ${GENERATED_SRC_WIZARD}/${lex_file}.corr ${GENERATED_SRC_WIZARD}/${lex_file}.d
     )
+    set_source_files_properties(${GENERATED_SRC_WIZARD}/${lex_file}.l PROPERTIES GENERATED 1)
+    set_source_files_properties(${GENERATED_SRC_WIZARD}/${lex_file}.corr PROPERTIES GENERATED 1)
+    set_source_files_properties(${GENERATED_SRC_WIZARD}/${lex_file}.d PROPERTIES GENERATED 1)
+
     add_custom_command(
         COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/scan_states.py ${GENERATED_SRC_WIZARD}/${lex_file}.l > ${GENERATED_SRC_WIZARD}/${lex_file}.l.h
         DEPENDS ${PROJECT_SOURCE_DIR}/src/scan_states.py ${GENERATED_SRC_WIZARD}/${lex_file}.l

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,20 +112,20 @@ set(LEX_FILES scanner
     lexscanner
     configimpl)
 
-# Currently the complete list of lex include files for the dependency
-# The dependency should be a more dynamic list based on the content of the lex file
-set(LEX_INC_FILES)
-
 # unfortunately ${LEX_FILES_H} and ${LEX_FILES_CPP} don't work in older versions of CMake (like 3.6.2) for add_library
 foreach(lex_file ${LEX_FILES})
     set(LEX_FILES_H ${LEX_FILES_H} " " ${GENERATED_SRC}/${lex_file}.l.h CACHE INTERNAL "Stores generated files")
     set(LEX_FILES_CPP ${LEX_FILES_CPP} " " ${GENERATED_SRC}/${lex_file}.cpp CACHE INTERNAL "Stores generated files")
 
     add_custom_command(
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${CMAKE_CURRENT_LIST_DIR}
-        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l ${LEX_INC_FILES}
-        OUTPUT  ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.l
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.d ${CMAKE_CURRENT_LIST_DIR}
+        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l
+        DEPFILE ${GENERATED_SRC}/${lex_file}.d
+        OUTPUT  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.d
     )
+    set_source_files_properties(${GENERATED_SRC}/${lex_file}.l PROPERTIES GENERATED 1)
+    set_source_files_properties(${GENERATED_SRC}/${lex_file}.corr PROPERTIES GENERATED 1)
+    set_source_files_properties(${GENERATED_SRC}/${lex_file}.d PROPERTIES GENERATED 1)
     add_custom_command(
         COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scan_states.py ${GENERATED_SRC}/${lex_file}.l > ${GENERATED_SRC}/${lex_file}.l.h
         DEPENDS ${CMAKE_CURRENT_LIST_DIR}/scan_states.py ${GENERATED_SRC}/${lex_file}.l

--- a/src/pre_lex.py
+++ b/src/pre_lex.py
@@ -17,42 +17,46 @@ import os
 import re
 
 def main():
-    if len(sys.argv)!=5:
-        sys.exit('Usage: {0} <input_lex_file> <output_lex_file> <correction_file> <include_path>'.format(sys.argv[0]))
+    if len(sys.argv)!=6:
+        sys.exit('Usage: {0} <input_lex_file> <output_lex_file> <correction_file> <dependency_lex_file> <include_path>'.format(sys.argv[0]))
 
-    inp_lex_file, out_lex_file, corr_lex_file, inc_path = sys.argv[1:]
+    inp_lex_file, out_lex_file, corr_lex_file, dep_lex_file, inc_path = sys.argv[1:]
 
     out_cnt = rd_cnt = add_cnt = 0
     if (os.path.exists(inp_lex_file)):
         with open(out_lex_file,"w") as out_file:
             with open(corr_lex_file,"w") as corr_file:
                 first_corr  = True
-                with open(inp_lex_file) as in_file:
-                    for line in in_file:
-                        if re.search(r'^%doxygen', line): # special include file marker
-                            inc_file = inc_path + "/" + line.split()[1]
-                            first_line = True
-                            with open(inc_file) as f_inc:
-                                for inc_line in f_inc:
-                                    if first_line:
-                                        first_line = False
-                                        out_file.write("  /* #line 1 {0} */\n".format(inc_file))
-                                    out_cnt += 1
+                with open(dep_lex_file,"w") as dep_file:
+                    dep_file.write("{0}:".format(out_lex_file))
+                    with open(inp_lex_file) as in_file:
+                        for line in in_file:
+                            if re.search(r'^%doxygen', line): # special include file marker
+                                inc_file = inc_path + "/" + line.split()[1]
+                                dep_file.write(" {0}".format(inc_file))
+                                first_line = True
+                                with open(inc_file) as f_inc:
+                                    for inc_line in f_inc:
+                                        if first_line:
+                                            first_line = False
+                                            out_file.write("  /* #line 1 {0} */\n".format(inc_file))
+                                        out_cnt += 1
+                                        add_cnt += 1
+                                        out_file.write(inc_line)
+                                    f_inc.close()
+                                if not first_line:
+                                    out_file.write("  /* #line {0} {1} */\n".format(rd_cnt+2,inp_lex_file))
+                                    out_cnt += 2
                                     add_cnt += 1
-                                    out_file.write(inc_line)
-                                f_inc.close()
-                            if not first_line:
-                                out_file.write("  /* #line {0} {1} */\n".format(rd_cnt+2,inp_lex_file))
-                                out_cnt += 2
-                                add_cnt += 1
-                                if first_corr:
-                                    corr_file.write("{0} {1}\n".format(0,0))
-                                    first_corr = False
-                                corr_file.write("{0} {1}\n".format(out_cnt,add_cnt))
-                        else:
-                            out_cnt += 1
-                            rd_cnt  += 1
-                            out_file.write(line)
+                                    if first_corr:
+                                        corr_file.write("{0} {1}\n".format(0,0))
+                                        first_corr = False
+                                    corr_file.write("{0} {1}\n".format(out_cnt,add_cnt))
+                            else:
+                                out_cnt += 1
+                                rd_cnt  += 1
+                                out_file.write(line)
+                    dep_file.write("\n")
     else: # input file does not exist
         sys.exit("Input lex file '{0}' does not exist.".format(sys.argv[1]))
 


### PR DESCRIPTION
In the pull request #9375 the possibility was created to have lex include files for common parts.
The missing part was the dependencies of between the `.l` file and the included files.
By means of the stack exchange question:
- https://stackoverflow.com/questions/62713117/dynamic-dependency-within-custom-source-files
- https://stackoverflow.com/questions/72518401/cmake-dependencies-on-included-files

a solution was found for the dependency problem by:
- using the `DEPFILE` directive
- creating the dependency file (essential is that the dependencies i.e. the included file all are on one line).