### PR TITLE
issue #9096 Call Graph corrupt and/or incomplete (2)

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2835,12 +2835,6 @@ static bool getLinkInScope(yyscan_t yyscanner,
         return TRUE;
       }
     }
-    else // found member, but it is not linkable, so make sure content inside is not assigned
-         // to the previous member, see bug762760
-    {
-      DBG_CTX((stderr,"unlinkable member %s\n",qPrint(md->name())));
-      yyextra->currentMemberDef = 0;
-    }
   }
   return FALSE;
 }


### PR DESCRIPTION
In case of the problem as reported by @septatrix, the problem is caused by the setting of the `currentMemberDef` to 0 in case the member "does not exist" / is not documented. When documenting the (here enum value) or setting `EXTRACT_ALL=YES` the problem does not occur.

The problem was introduced when fixing  References for one function can inherit References from subsequent non documented function (Origin: bugzilla 762670) #5958.
```
Commit: 9abcad810b8d41d338d501ff5b32524e1ced7f33 [9abcad8]
Date: Sunday, March 20, 2016 11:51:25 AM
```

Removing the setting of `currentMemberDef=0` fixes the current issue but also the original issue is still OK.

Note: that the the in the code mentioned `bug762760` is  not correct this has to be `bug762670`.