### PR TITLE
End of "here document"  can be indented

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2074,9 +2074,9 @@ NONLopt [^\n]*
                                           }
                                         }
 <HereDocEnd>.                           { }
-<CopyHereDocEnd>^{ID}                   { // id at start of the line could mark the end of the block
+<CopyHereDocEnd>^{Bopt}{ID}             { // id at start of the line could mark the end of the block
                                           *yyextra->pCopyHereDocGString << yytext;
-                                          if (yyextra->delimiter==yytext) // it is the end marker
+                                          if (yyextra->delimiter==QCString(yytext).stripWhiteSpace()) // it is the end marker
                                           {
                                             BEGIN(yyextra->lastHereDocContext);
                                           }


### PR DESCRIPTION
Based on the question: https://stackoverflow.com/questions/72615791/doxygen-does-not-document-one-php-class#72615791
the end of the "here document" should be the first word on the line.

From: https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
> The closing identifier may be indented by space or tab, in which case the indentation will be stripped from all lines in the doc string. Prior to PHP 7.3.0, the closing identifier must begin in the first column of the line.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8899985/example.tar.gz)
