### PR TITLE
issue #9399 XML / perlmod fortran output, the type of a parameter of  function is set to the name of the parameter

### DIFF
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1481,6 +1481,7 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
     case MemberType_Dictionary:  memType="dictionary"; break;
   }
 
+  bool isFortran = md->getLanguage()==SrcLangExt_Fortran;
   name = md->name();
   if (md->isAnonymous()) name = "__unnamed" + name.right(name.length() - 1)+"__";
 
@@ -1524,7 +1525,9 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
 	if (defArg && !defArg->name.isEmpty() && defArg->name!=a.name)
 	  m_output.addFieldQuotedString("definition_name", defArg->name);
 
-	if (!a.type.isEmpty())
+        if (isFortran && defArg && !defArg->type.isEmpty())
+	  m_output.addFieldQuotedString("type", defArg->type);
+	else if (!a.type.isEmpty())
 	  m_output.addFieldQuotedString("type", a.type);
 
 	if (!a.array.isEmpty())

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -866,6 +866,7 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
   {
     const ArgumentList &declAl = md->declArgumentList();
     const ArgumentList &defAl = md->argumentList();
+    bool isFortran = md->getLanguage()==SrcLangExt_Fortran;
     if (declAl.hasParameters())
     {
       auto defIt = defAl.begin();
@@ -885,7 +886,13 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
           writeXMLString(t,a.attrib);
           t << "</attributes>\n";
         }
-        if (!a.type.isEmpty())
+        if (isFortran && defArg && !defArg->type.isEmpty())
+        {
+          t << "          <type>";
+          linkifyText(TextGeneratorXMLImpl(t),def,md->getBodyDef(),md,defArg->type);
+          t << "</type>\n";
+        }
+        else if (!a.type.isEmpty())
         {
           t << "          <type>";
           linkifyText(TextGeneratorXMLImpl(t),def,md->getBodyDef(),md,a.type);


### PR DESCRIPTION
Fortran has, regarding the definition of the type of an argument a bit of a different style compared to other languages, i.e. the type is defined, more or less, defined in the body and by doxygen not stored in the declaration list but only in the definition list.

Added for Fortran the possibility that the type should come from the definition list (when available).