### PR TITLE
bug_777266 Environment variable expansion to default if not set in config file

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1285,8 +1285,8 @@ void ConfigImpl::emptyValueToDefault()
   }
 }
 
-static const reg::Ex reEnvVar(R"(\$\((\a[\w.-]*)\))");                 // e.g. $(HOME)
-static const reg::Ex reEnvVarExt(R"(\$\((\a[\w.-]*\(\a[\w.-]*\))\))"); // e.g. $(PROGRAMFILES(X86))
+static const reg::Ex reEnvVar(R"(\$\((\a[\w.-]*(:\-.*)?)\))");                 // e.g. $(HOME) or $(HOME:val)
+static const reg::Ex reEnvVarExt(R"(\$\((\a[\w.-]*\(\a[\w.-]*\)(:\-.*)?)\))"); // e.g. $(PROGRAMFILES(X86)) or $(PROGRAMFILES(X86):val)
 
 static bool containsEnvVar(QCString &str)
 {
@@ -1311,7 +1311,15 @@ static void substEnvVarsInString(QCString &str)
       size_t l = match.length();
       result+=s.substr(p,i-p);
       std::string matchContents = match[1].str();
+      std::string replVal = "";
+      size_t splitPos;
+      if ((splitPos = matchContents.find(":-")) != std::string::npos)
+      {
+        replVal = matchContents.substr(splitPos+2);
+        matchContents = matchContents.substr(0,splitPos);
+      }
       QCString env=Portable::getenv(matchContents.c_str()); // get content of $(..) match
+      if (env.isEmpty()) env = replVal;
       substEnvVarsInString(env); // recursively expand variables if needed.
       result+=env.str();
       p=i+l;


### PR DESCRIPTION
Use BASH-Like parameter expansion: https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion

An example would be: `GENERATE_HTML = "$(DX_GENERATE_HTML:-YES)"`