### PR TITLE
Files Quick Link results in a non existing page

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2338,9 +2338,9 @@ static bool quickLinkVisible(LayoutNavEntry::Kind kind)
     case LayoutNavEntry::ClassIndex:         return annotatedClasses>0;
     case LayoutNavEntry::ClassHierarchy:     return hierarchyClasses>0;
     case LayoutNavEntry::ClassMembers:       return documentedClassMembers[CMHL_All]>0;
-    case LayoutNavEntry::Files:              return documentedFiles>0;
-    case LayoutNavEntry::FileList:           return documentedFiles>0;
-    case LayoutNavEntry::FileGlobals:        return documentedFileMembers[FMHL_All]>0;
+    case LayoutNavEntry::Files:              return Config_getBool(SHOW_FILES) && documentedFiles>0;
+    case LayoutNavEntry::FileList:           return Config_getBool(SHOW_FILES) && documentedFiles>0;
+    case LayoutNavEntry::FileGlobals:        return Config_getBool(SHOW_FILES) && documentedFileMembers[FMHL_All]>0;
     case LayoutNavEntry::Examples:           return !Doxygen::exampleLinkedMap->empty();
     case LayoutNavEntry::Interfaces:         return annotatedInterfaces>0;
     case LayoutNavEntry::InterfaceList:      return annotatedInterfaces>0;


### PR DESCRIPTION
When investigating bug 771822 ( Doxygen wrongly infers that a macro invocation in a header file is a function rather than a variable declaration (Origin: bugzilla 771822) #6076 ) in the current version there the quick link "Files" was shown although there was the setting `SHOW_FILES=NO`. 

The problem was not present in the 1.9.3 version but appeared in the 1.9.4 version. A bisection revealed:
```
7f514f1822de413da25bd5a6eba8938a3483e793 is the first bad commit
commit 7f514f1822de413da25bd5a6eba8938a3483e793
Date:   Sun Apr 24 13:35:58 2022 +0200

    SHOW_FILES=NO could cause broken links for grouped files

 src/index.cpp | 44 ++++++++++++++++++++------------------------
 1 file changed, 20 insertions(+), 24 deletions(-)
```
due to the removal of the test on `SHOW_FILES` here it has to be added in the quick link section test.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/8916984/example.tar.gz)
