### PR TITLE
Prohibit in-place doxygen builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,10 @@ set_property(CACHE force_qt PROPERTY STRINGS OFF Qt6 Qt5)
 
 SET(enlarge_lex_buffers "262144" CACHE INTERNAL "Sets the lex input and read buffers to the specified size")
 
-if ("${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
-  message(FATAL_ERROR "Doxygen cannot be generated in-place, the build directory (${PROJECT_BINARY_DIR}) has to differ from the doxygen main directory (${PROJECT_SOURCE_DIR})\nPlease don't forget to remove the already file created file 'CMakeCache.txt' and the directory 'CMakeFiles'!")
+if(enable_coverage)
+  if ("${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+    message(FATAL_ERROR "Doxygen cannot be generated in-place, the build directory (${PROJECT_BINARY_DIR}) has to differ from the doxygen main directory (${PROJECT_SOURCE_DIR})\nPlease don't forget to remove the already file created file 'CMakeCache.txt' and the directory 'CMakeFiles'!")
+  endif()
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ set_property(CACHE force_qt PROPERTY STRINGS OFF Qt6 Qt5)
 
 SET(enlarge_lex_buffers "262144" CACHE INTERNAL "Sets the lex input and read buffers to the specified size")
 
+if ("${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+  message(FATAL_ERROR "Doxygen cannot be generated in-place, the build directory (${PROJECT_BINARY_DIR}) has to differ from the doxygen main directory (${PROJECT_SOURCE_DIR})\nPlease don't forget to remove the already file created file 'CMakeCache.txt' and the directory 'CMakeFiles'!")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Sanitizers")
 set(TOP "${PROJECT_SOURCE_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,12 +133,14 @@ foreach(lex_file ${LEX_FILES})
     )
     set_source_files_properties(${GENERATED_SRC}/${lex_file}.l.h PROPERTIES GENERATED 1)
 
-    # for code coverage we need the flex sources in the build src directory
-    add_custom_command(
-        COMMAND ${CMAKE_COMMAND} -E copy ${GENERATED_SRC}/${lex_file}.l ${PROJECT_BINARY_DIR}/src/${lex_file}.l
-        DEPENDS ${GENERATED_SRC}/${lex_file}.l
-        OUTPUT  ${PROJECT_BINARY_DIR}/src/${lex_file}.l
-    )
+    if(enable_coverage)
+        # for code coverage we need the flex sources in the build src directory
+        add_custom_command(
+            COMMAND ${CMAKE_COMMAND} -E copy ${GENERATED_SRC}/${lex_file}.l ${PROJECT_BINARY_DIR}/src/${lex_file}.l
+            DEPENDS ${GENERATED_SRC}/${lex_file}.l
+            OUTPUT  ${PROJECT_BINARY_DIR}/src/${lex_file}.l
+        )
+    endif()
 
     FLEX_TARGET(${lex_file}
                 ${GENERATED_SRC}/${lex_file}.l
@@ -157,11 +159,13 @@ BISON_TARGET(constexp
              ${GENERATED_SRC}/ce_parse.cpp
              COMPILE_FLAGS "${YACC_FLAGS}")
 
-add_custom_command(
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/constexp.y ${PROJECT_BINARY_DIR}/src
-    DEPENDS ${PROJECT_SOURCE_DIR}/src/constexp.y
-    OUTPUT  ${PROJECT_BINARY_DIR}/src/constexp.y
-)
+if(enable_coverage)
+    add_custom_command(
+        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/constexp.y ${PROJECT_BINARY_DIR}/src
+        DEPENDS ${PROJECT_SOURCE_DIR}/src/constexp.y
+        OUTPUT  ${PROJECT_BINARY_DIR}/src/constexp.y
+    )
+endif()
 
 add_library(doxycfg STATIC
     ${GENERATED_SRC}/configvalues.h


### PR DESCRIPTION
Based on some build problems in issue #9413,  it is checked that there is no attempt to build doxygen in-place (i.e. that the main source directory and the build directory have to be different directories).
(The original problem shows errors like:
```
cycle in dependency tree for target 'generated_src\configimpl.corr'
```
)