### PR TITLE
issue #9415 fixed format source with wide lines

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1682,6 +1682,17 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
 ]]>
       </docs>
     </option>
+    <option type='int' id='FORTRAN_COMMENT_AFTER' defval='72' minval='7' maxval='10000'>
+      <docs>
+<![CDATA[
+ The Fortran standard specifies that for fixed formatted Fortran code all characters
+ from position 72 are to be considered as comment. A common extension is to allow
+ longer lines before the automatic comment starts.
+ The setting \c FORTRAN_COMMENT_AFTER will also make it possible that longer lines can be
+ processed before the automatic comment starts.
+]]>
+      </docs>
+    </option>
   </group>
   <group name='Source_Browser' docs='Configuration options related to source browsing'>
     <option type='bool' id='SOURCE_BROWSER' defval='0'>

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -63,8 +63,6 @@ typedef yyguts_t *yyscan_t;
 #include "fortranscanner.h"
 #include "containers.h"
 
-const int fixedCommentAfter = 72;
-
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
@@ -171,6 +169,8 @@ struct fortrancodeYY_state
 
   bool          endComment = false;
   TooltipManager tooltipManager;
+
+   int fixedCommentAfter = 72;
 };
 
 #if USE_STATE2STRING
@@ -807,7 +807,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <*>^{BS}"type"{BS}"="                   { yyextra->code->codify(QCString(yytext)); }
 
 <*>[\x80-\xFF]*                         { // keep utf8 characters together...
-                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
+                                          if (yyextra->isFixedForm && yy_my_start > yyextra->fixedCommentAfter)
                                           {
                                             startFontClass(yyscanner,"comment");
                                             codifyLines(yyscanner,yytext);
@@ -818,7 +818,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           }
                                         }
 <*>.                                    {
-                                          if (yyextra->isFixedForm && yy_my_start > fixedCommentAfter)
+                                          if (yyextra->isFixedForm && yy_my_start > yyextra->fixedCommentAfter)
                                           {
                                             //yy_push_state(YY_START,yyscanner);
                                             //BEGIN(DocBlock);
@@ -1395,7 +1395,7 @@ static void checkContLines(yyscan_t yyscanner,const char *s)
   yyextra->hasContLine = (int *) malloc((numLines) * sizeof(int));
   for (i = 0; i < numLines; i++)
     yyextra->hasContLine[i] = 0;
-  p = prepassFixedForm(s, yyextra->hasContLine);
+  p = prepassFixedForm(s, yyextra->hasContLine,yyextra->fixedCommentAfter);
   yyextra->hasContLine[0] = 0;
 }
 
@@ -1482,6 +1482,7 @@ void FortranCodeParser::parseCode(CodeOutputInterface & codeOutIntf,
   if (yyextra->isFixedForm)
   {
     checkContLines(yyscanner,yyextra->inputString);
+    yyextra->fixedCommentAfter = Config_getInt(FORTRAN_COMMENT_AFTER);
   }
   yyextra->currentFontClass = 0;
   yyextra->insideCodeLine = FALSE;

--- a/src/fortranscanner.h
+++ b/src/fortranscanner.h
@@ -53,6 +53,6 @@ class FortranOutlineParserFixed : public FortranOutlineParser
     FortranOutlineParserFixed() : FortranOutlineParser(FortranFormat_Fixed) { }
 };
 
-const char* prepassFixedForm(const char* contents, int *hasContLine);
+const char* prepassFixedForm(const char* contents, int *hasContLine, int fixedCommentAfter);
 
 #endif

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -74,7 +74,6 @@ typedef yyguts_t *yyscan_t;
 #include "debug.h"
 #include "markdown.h"
 
-const int fixedCommentAfter = 72;
 
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x
@@ -205,6 +204,8 @@ struct fortranscannerYY_state
 //! Holds program scope->symbol name->symbol modifiers.
   std::map<Entry*,std::map<std::string,SymbolModifiers> > modifiers;
   int                      anonCount    = 0 ;
+
+  int fixedCommentAfter = 72;
 };
 
 //-----------------------------------------------------------------------------
@@ -1519,7 +1520,7 @@ static void insertCharacter(char *contents, int length, int pos, char c)
 
 /* change yyextra->comments and bring line continuation character to previous line */
 /* also used to set continuation marks in case of fortran code usage, done here as it is quite complicated code */
-const char* prepassFixedForm(const char* contents, int *hasContLine)
+const char* prepassFixedForm(const char* contents, int *hasContLine,int fixedCommentAfter)
 {
   int column=0;
   int prevLineLength=0;
@@ -2668,13 +2669,14 @@ static void parseMain(yyscan_t yyscanner, const QCString &fileName,const char *f
 
   if (yyextra->isFixedForm)
   {
+    yyextra->fixedCommentAfter = Config_getInt(FORTRAN_COMMENT_AFTER);
     msg("Prepassing fixed form of %s\n", qPrint(fileName));
     //printf("---strlen=%d\n", strlen(fileBuf));
     //clock_t start=clock();
 
     //printf("Input fixed form string:\n%s\n", fileBuf);
     //printf("===========================\n");
-    yyextra->inputString = prepassFixedForm(fileBuf, nullptr);
+    yyextra->inputString = prepassFixedForm(fileBuf, nullptr,yyextra->fixedCommentAfter);
     Debug::print(Debug::FortranFixed2Free,0,"======== Fixed to Free format  =========\n---- Input fixed form string ------- \n%s\n", fileBuf);
     Debug::print(Debug::FortranFixed2Free,0,"---- Resulting free form string ------- \n%s\n", yyextra->inputString);
     //printf("Resulting free form string:\n%s\n", yyextra->inputString);


### PR DESCRIPTION
Enable possibility to have extended code lines (i.e. beyond position 72) in fixed formatted Fortran.