### PR TITLE
issue #9417 Java: Issue with static initializer if no space after static

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1100,6 +1100,10 @@ NONLopt [^\n]*
                                           if (yyextra->insideCli) yyextra->current->spec |= Entry::Initonly;
                                           lineCount(yyscanner);
                                         }
+<FindMembers>{B}*"static"{BN}*/"{"      { yyextra->current->type += " static ";
+                                          yyextra->current->stat = TRUE;
+                                          lineCount(yyscanner);
+                                        }
 <FindMembers>{B}*"static"{BN}+          { yyextra->current->type += " static ";
                                           yyextra->current->stat = TRUE;
                                           lineCount(yyscanner);


### PR DESCRIPTION
don't see only white space, but also a direct `{` as separator (handle `{` later on).