### PR TITLE
bug 531817 Python: Backslash prevent showing the proper preview

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1187,6 +1187,10 @@ STARTDOCSYMS      "##"
                         yyextra->start_init = FALSE;
                         yyextra->current->initializer << yytext;
                       }
+   "\\\n"             {
+                        yyextra->current->initializer << yytext;
+                        incLineNr(yyscanner);
+                      }
    .                  {
                         yyextra->start_init = FALSE;
                         yyextra->current->initializer << *yytext;


### PR DESCRIPTION
Enable for variable initialization the line continuation.