### PR TITLE
bug 539818 C Preprocessor enum printing trick not handled properly by Doxygen

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -889,7 +889,7 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
   size_t strLen = txtStr.length();
   if (strLen==0) return;
 
-  static const reg::Ex regExp(R"((::)?\a[\w~!\\.:$]*)");
+  static const reg::Ex regExp(R"((::)?\a[\w~!\\.:$"]*)");
   reg::Iterator it(txtStr,regExp);
   reg::Iterator end;
 
@@ -919,6 +919,7 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
     for (size_t i=index;i<newIndex;i++)
     {
       if (txtStr.at(i)=='"') insideString=!insideString;
+      if (txtStr.at(i)=='\\') i++; // skip next character it is escaped
     }
 
     //printf("floatingIndex=%d strlen=%d autoBreak=%d\n",floatingIndex,strLen,autoBreak);
@@ -1060,7 +1061,7 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
         if (md!=self && (self==0 || md->name()!=self->name()))
           // name check is needed for overloaded members, where getDefs just returns one
         {
-          /* in case of Fortran scop and the variable is a non Fortran variable: don't link,
+          /* in case of Fortran scope and the variable is a non Fortran variable: don't link,
            * see also getLink in fortrancode.l
            */
           if (!(scope && (scope->getLanguage() == SrcLangExt_Fortran) && md->isVariable() && (md->getLanguage() != SrcLangExt_Fortran)))
@@ -1081,6 +1082,7 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
     // set next start point in the string
     //printf("index=%d/%d\n",index,txtStr.length());
     skipIndex=index=newIndex+matchLen;
+    if (insideString) index++;
   }
   // add last part of the string to the result.
   //ol.docify(txtStr.right(txtStr.length()-skipIndex));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1082,7 +1082,6 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
     // set next start point in the string
     //printf("index=%d/%d\n",index,txtStr.length());
     skipIndex=index=newIndex+matchLen;
-    if (insideString) index++;
   }
   // add last part of the string to the result.
   //ol.docify(txtStr.right(txtStr.length()-skipIndex));


### PR DESCRIPTION
The determination of the end quote was not handled properly, so when inside a string we had, at the end, also skip the end quote.
Special attention had to be paid to  escaped quotes.

(Extended) example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9038609/example.tar.gz)
