### PR TITLE
issue #9440: Fix search label regression

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1172,7 +1172,7 @@ void HtmlGenerator::startFile(const QCString &name,const QCString &,
     m_t << "<script type=\"text/javascript\">\n";
     m_t << "/* @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&amp;dn=expat.txt MIT */\n";
     m_t << "var searchBox = new SearchBox(\"searchBox\", \""
-        << m_relPath<< "search\",'" << theTranslator->trSearch() << "','" << Doxygen::htmlFileExtension << "');\n";
+        << m_relPath<< "search\",'" << Doxygen::htmlFileExtension << "');\n";
     m_t << "/* @license-end */\n";
     m_t << "</script>\n";
   }
@@ -2723,7 +2723,7 @@ void HtmlGenerator::writeSearchPage()
     t << "<script type=\"text/javascript\">\n";
 		t << "/* @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&amp;dn=expat.txt MIT */\n";
 		t << "var searchBox = new SearchBox(\"searchBox\", \""
-      << "search\",'" << theTranslator->trSearch() << "','" << Doxygen::htmlFileExtension << "');\n";
+      << "search\",'" << Doxygen::htmlFileExtension << "');\n";
 		t << "/* @license-end */\n";
     t << "</script>\n";
     if (!Config_getBool(DISABLE_INDEX))
@@ -2779,7 +2779,7 @@ void HtmlGenerator::writeExternalSearchPage()
     t << "<script type=\"text/javascript\">\n";
 		t << "/* @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&amp;dn=expat.txt MIT */\n";
 		t << "var searchBox = new SearchBox(\"searchBox\", \""
-      << "search\",'" << theTranslator->trSearch() << "','" << Doxygen::htmlFileExtension << "');\n";
+      << "search\",'" << Doxygen::htmlFileExtension << "');\n";
 		t << "/* @license-end */\n";
     t << "</script>\n";
     if (!Config_getBool(DISABLE_INDEX))

--- a/templates/html/extsearch.js
+++ b/templates/html/extsearch.js
@@ -22,9 +22,8 @@
 
  @licend  The above is the entire license notice for the JavaScript code in this file
  */
-function SearchBox(name, resultsPath, inFrame, label)
+function SearchBox(name, resultsPath, extension)
 {
-  this.searchLabel = label;
   this.DOMSearchField = function()
   {  return document.getElementById("MSearchField");  }
   this.DOMSearchBox = function()
@@ -34,16 +33,10 @@ function SearchBox(name, resultsPath, inFrame, label)
     if (isActive)
     {
       this.DOMSearchBox().className = 'MSearchBoxActive';
-      var searchField = this.DOMSearchField();
-      if (searchField.value == this.searchLabel)
-      {
-        searchField.value = '';
-      }
     }
     else
     {
       this.DOMSearchBox().className = 'MSearchBoxInactive';
-      this.DOMSearchField().value   = this.searchLabel;
     }
   }
 }

--- a/templates/html/htmlbase.tpl
+++ b/templates/html/htmlbase.tpl
@@ -122,7 +122,7 @@ MathJax.Hub.Config({
     <div class="left">
      <form id="FSearchBox" action="{{ page.relPath }}{% if config.EXTERNAL_SEARCH %}search{{ doxygen.htmlFileExtension }}{% else %}search.php{% endif %}" method="get">
       <img id="MSearchSelect" src="{{ page.relPath }}search/mag.svg" alt=""/>
-      <input type="text" id="MSearchField" name="query" value="{{ tr.search }}" size="20" accesskey="S"
+      <input type="text" id="MSearchField" name="query" value="" placeholder="{{ tr.search }}" size="20" accesskey="S"
                 onfocus="searchBox.OnSearchFieldFocus(true)"
                 onblur="searchBox.OnSearchFieldFocus(false)"/>
      </form>
@@ -136,7 +136,7 @@ MathJax.Hub.Config({
            onmouseover="return searchBox.OnSearchSelectShow()"
            onmouseout="return searchBox.OnSearchSelectHide()"
            alt=""/>
-      <input type="text" id="MSearchField" value="{{ tr.search }}" accesskey="S"
+      <input type="text" id="MSearchField" value="" placeholder="{{ tr.search }}" accesskey="S"
            onfocus="searchBox.OnSearchFieldFocus(true)"
            onblur="searchBox.OnSearchFieldFocus(false)"
            onkeyup="searchBox.OnSearchFieldChange(event)"/>
@@ -161,7 +161,7 @@ MathJax.Hub.Config({
 {% if config.SEARCHENGINE %}
 <script type="text/javascript">
 /* @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&amp;dn=expat.txt MIT */
-	var searchBox = new SearchBox("searchBox", "{{ page.relPath }}search",'{{ tr.search }}','{{ config.HTML_FILE_EXTENSION }}');
+	var searchBox = new SearchBox("searchBox", "{{ page.relPath }}search", '{{ config.HTML_FILE_EXTENSION }}');
 /* @license-end */
 </script>
 {% endif %}

--- a/templates/html/menu.js
+++ b/templates/html/menu.js
@@ -52,7 +52,7 @@ function initMenu(relPath,searchEnabled,serverSide,searchPage,search) {
                   '<form id="FSearchBox" action="'+relPath+searchPage+
                     '" method="get"><img id="MSearchSelect" src="'+
                     relPath+'search/mag.svg" alt=""/>'+
-                  '<input type="text" id="MSearchField" name="query" value="'+search+
+                  '<input type="text" id="MSearchField" name="query" value="" placeholder="'+search+
                     '" size="20" accesskey="S" onfocus="searchBox.OnSearchFieldFocus(true)"'+
                     ' onblur="searchBox.OnSearchFieldFocus(false)">'+
                   '</form>'+
@@ -65,7 +65,7 @@ function initMenu(relPath,searchEnabled,serverSide,searchPage,search) {
                   '<img id="MSearchSelect" src="'+relPath+
                      'search/mag_sel.svg" onmouseover="return searchBox.OnSearchSelectShow()"'+
                      ' onmouseout="return searchBox.OnSearchSelectHide()" alt=""/>'+
-                  '<input type="text" id="MSearchField" value="'+search+
+                  '<input type="text" id="MSearchField" value="" placeholder="'+search+
                     '" accesskey="S" onfocus="searchBox.OnSearchFieldFocus(true)" '+
                     'onblur="searchBox.OnSearchFieldFocus(false)" '+
                     'onkeyup="searchBox.OnSearchFieldChange(event)"/>'+

--- a/templates/html/search.js
+++ b/templates/html/search.js
@@ -80,7 +80,7 @@ function getYPos(item)
           storing this instance.  Is needed to be able to set timeouts.
    resultPath - path to use for external files
 */
-function SearchBox(name, resultsPath, label, extension)
+function SearchBox(name, resultsPath, extension)
 {
   if (!name || !resultsPath) {  alert("Missing parameters to SearchBox."); }
   if (!extension || extension == "") { extension = ".html"; }
@@ -96,7 +96,6 @@ function SearchBox(name, resultsPath, label, extension)
   this.hideTimeout           = 0;
   this.searchIndex           = 0;
   this.searchActive          = false;
-  this.searchLabel           = label;
   this.extension             = extension;
 
   // ----------- DOM Elements
@@ -379,19 +378,11 @@ function SearchBox(name, resultsPath, label, extension)
        )
     {
       this.DOMSearchBox().className = 'MSearchBoxActive';
-
-      var searchField = this.DOMSearchField();
-
-      if (searchField.value == this.searchLabel) // clear "Search" term upon entry
-      {
-        searchField.value = '';
-        this.searchActive = true;
-      }
+      this.searchActive = true;
     }
     else if (!isActive) // directly remove the panel
     {
       this.DOMSearchBox().className = 'MSearchBoxInactive';
-      this.DOMSearchField().value   = this.searchLabel;
       this.searchActive             = false;
       this.lastSearchValue          = ''
       this.lastResultsPage          = '';


### PR DESCRIPTION
### Background:

The extension value (`.html`) was injected instead of the search
label.

This meant that upon focussing the field it was no longer cleared,
so the "Search" text remains in the input field and thus had
to be removed manually.

It also meant that after de-focussing the field (click anywhere),
the field value was assigned to `.html` which made it show up in the
user interface even.

### Change:

Use the HTML5 placeholder attribute instead, which is a browser
built-in that does this automatically. It displays the value
while the field is empty, and makes it dissappear when the empty
field is focussed.

This has the added benefit of no longer destroying the user input
if you type something and then click or tab elsewhere before
submitting the form.

Also:

* Remove the now-unused code for managing this value.
* Synchronise the signature of the two SearchBox js classes to avoid
  mistakes like this in the future. The `inFrame` argument is not
  used in extsearch.js. Replace it with an equally-unused `extension`
  arg for consistency with search.js.

Fixes https://github.com/doxygen/doxygen/issues/9440.