### PR TITLE
issue #9047 Support @param-taint in PHP (permit dashes in command aliases)?

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3458,7 +3458,7 @@ class Receiver
 
   \b Note:
     environment variables (like \$(HOME) ) are resolved inside a
-    \LaTeX-only block.
+    \LaTeX\-only block.
 
   \sa sections \ref cmdrtfonly "\\rtfonly",
                \ref cmdxmlonly "\\xmlonly",

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -901,10 +901,10 @@ SLASHopt [/]*
                                      handleCondSectionId(yyscanner," "); // fake section id causing the section to be hidden unconditionally
 				     if (*yytext=='\n') { yyextra->lineNr++; copyToOutput(yyscanner,"\n",1);}
   				   }
-<CComment,ReadLine>[\\@][a-z_A-Z][a-z_A-Z0-9]*  { // expand alias without arguments
+<CComment,ReadLine>[\\@][a-z_A-Z][a-z_A-Z0-9-]*  { // expand alias without arguments
 				     replaceAliases(yyscanner,QCString(yytext));
   				   }
-<CComment,ReadLine>[\\@][a-z_A-Z][a-z_A-Z0-9]*"{" { // expand alias with arguments
+<CComment,ReadLine>[\\@][a-z_A-Z][a-z_A-Z0-9-]*"{" { // expand alias with arguments
                                      yyextra->lastBlockContext=YY_START;
 				     yyextra->blockCount=1;
 				     yyextra->aliasString=yytext;

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1814,8 +1814,8 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   for (const auto &alias : aliasList)
   {
     // match aliases of the form re1='name=' and re2='name{2} ='
-    static const reg::Ex re1(R"(^\a\w*\s*=)");
-    static const reg::Ex re2(R"(^\a\w*{\d+}\s*=)");
+    static const reg::Ex re1(R"(^\a[\w-]*\s*=)");
+    static const reg::Ex re2(R"(^\a[\w-]*{\d+}\s*=)");
     if (!reg::search(alias,re1) && !reg::search(alias,re2))
     {
       err("Illegal ALIASES format '%s'. Use \"name=value\" or \"name{n}=value\", where n is the number of arguments\n",

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6072,7 +6072,7 @@ static QCString escapeCommas(const QCString &s)
 static QCString expandAliasRec(StringUnorderedSet &aliasesProcessed,const QCString &s,bool allowRecursion)
 {
   QCString result;
-  static const reg::Ex re(R"([\\@](\a\w*))");
+  static const reg::Ex re(R"([\\@](\a[\w-]*))");
   std::string str = s.str();
   reg::Match match;
   size_t p = 0;


### PR DESCRIPTION
Add the possibility to have a dash in an ALIASES.