### PR TITLE
issue #8214 missing lang attribute and meta description for SEO

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3470,6 +3470,7 @@ QCString substituteKeywords(const QCString &s,const QCString &title,
   result = substitute(result,"$projectnumber",projNum);
   result = substitute(result,"$projectbrief",projBrief);
   result = substitute(result,"$projectlogo",stripPath(Config_getString(PROJECT_LOGO)));
+  result = substitute(result,"$lang",theTranslator->trISOLang());
   return result;
 }
 

--- a/templates/html/header.html
+++ b/templates/html/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=11"/>


### PR DESCRIPTION
Implementing the language code for HTML based on the translation function `trISOLang()`

This proposed pull request supersedes the proposed pull request #8215