### PR TITLE
[regression] Non resolved ALIASES with minus sign

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6134,6 +6134,13 @@ static QCString expandAliasRec(StringUnorderedSet &aliasesProcessed,const QCStri
   result+=s.right(s.length()-p);
 
   //printf("expandAliases '%s'->'%s'\n",s.data(),result.data());
+  if (result == s)
+  {
+    std::string orgStr = s.str();
+    int ridx = orgStr.rfind('-');
+    if (ridx != -1) return expandAliasRec(aliasesProcessed,s.left(ridx),allowRecursion) + s.right(s.length() - ridx);
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Small regression on  #9451 issue #9047 Support @param-taint in PHP (permit dashes in command aliases)?
In a number of project (e.g. CGAL) we now got the warning like
```
warning: Found unknown command '\cgal'
```
as the code was:
```
\cgal-like
```
and
```
ALIASES += cgal=%CGAL
```

made the alias replacement so that when the expansion didn't do anything and the input string contains a `-` sign the last `-` sign is stripped as well as the part after it and a new attempt is made to resolve the command.