### PR TITLE
[Regression] $lang and $languagesupport replacement problem

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -2948,6 +2948,7 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
  <dt><code>$papertype</code><dd>will be replaced by the paper type as set in
            \ref cfg_paper_type "PAPER_TYPE" and the word "paper" is directly appended to it to have
            a correct \f$\mbox{\LaTeX}\f$ paper type.
+ <dt><code>$langISO</code><dd>will be replaced by the ISO language name.
  <dt><code>$languagesupport</code><dd>will be replaced by an output language dependent setting
            of packages required for translating terms of the specified language.
  <dt><code>$latexfontenc</code><dd>will be replaced by an output language dependent setting

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3470,7 +3470,7 @@ QCString substituteKeywords(const QCString &s,const QCString &title,
   result = substitute(result,"$projectnumber",projNum);
   result = substitute(result,"$projectbrief",projBrief);
   result = substitute(result,"$projectlogo",stripPath(Config_getString(PROJECT_LOGO)));
-  result = substitute(result,"$lang",theTranslator->trISOLang());
+  result = substitute(result,"$langISO",theTranslator->trISOLang());
   return result;
 }
 

--- a/templates/html/header.html
+++ b/templates/html/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=11"/>


### PR DESCRIPTION
In the LaTeX template the `$languagesupport` placeholder is used, but in the HTML output a `$lang` placeholder has been added by means of #9457 (for issue #8214) resulting tin the LaTeX output `en-USuagesupport` as in `$languagesupport` was first handling the `$lang`part.
- renaming the newer $lang` placeholder to `$langISO`
- adding documentation for `$langISO` placeholder