### PR TITLE
Placing of the version number in the head template

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1132,13 +1132,17 @@ void HtmlGenerator::writeStyleSheetFile(TextStream &t)
 
 void HtmlGenerator::writeHeaderFile(TextStream &t, const QCString & /*cssname*/)
 {
-  t << "<!-- HTML header for doxygen " << getDoxygenVersion() << "-->\n";
-  t << ResourceMgr::instance().getAsString("header.html");
+  QCString head =  ResourceMgr::instance().getAsString("header.html");
+  int endPlace = head.find("<head>") + 7;
+
+  t << head.left(endPlace);
+  t << "<!-- HTML header for doxygen " << getDoxygenVersion() << " -->\n";
+  t << head.right(head.length() - endPlace);
 }
 
 void HtmlGenerator::writeFooterFile(TextStream &t)
 {
-  t << "<!-- HTML footer for doxygen " << getDoxygenVersion() << "-->\n";
+  t << "<!-- HTML footer for doxygen " << getDoxygenVersion() << " -->\n";
   t << ResourceMgr::instance().getAsString("footer.html");
 }
 


### PR DESCRIPTION
In the old pull request #8215 it was mentioned as a side note:
> The <!DOCTYPE html attribute should really come first in the document. Perhaps the autogenerated doxygen version line 

comment could come at the end? or second line?
In the "HTML standard" it is written:
> A DOCTYPE is a required preamble.

It is strange that comment cannot be at the beginning of the file though.

The choice is to put the version comment directly inside the `<head>` tag.