### PR TITLE
Fix typo in generated Makefile for LaTex

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -337,7 +337,7 @@ static void writeLatexMakefile()
     }
     t << "\techo \"Rerunning latex....\"\n"
       << "\t$(LATEX_CMD) $(MANUAL_FILE).tex\n"
-      << "\tlatex_count=%(LATEX_COUNT) ; \\\n"
+      << "\tlatex_count=$(LATEX_COUNT) ; \\\n"
       << "\twhile egrep -s 'Rerun (LaTeX|to get cross-references right|to get bibliographical references right)' $(MANUAL_FILE).log && [ $$latex_count -gt 0 ] ;\\\n"
       << "\t    do \\\n"
       << "\t      echo \"Rerunning latex....\" ;\\\n"


### PR DESCRIPTION
Fix a typo in generated Makefile for LaTex.

This is the error when using doxygen 1.9.4:
```
latex_count=%(LATEX_COUNT) ; \
while egrep -s 'Rerun (LaTeX|to get cross-references right|to get bibliographical references right)' refman.log && [ $latex_count -gt 0 ] ;\
    do \
      echo "Rerunning latex...." ;\
      latex refman.tex ; \
      latex_count=`expr $latex_count - 1` ;\
    done
/bin/sh: -c: line 1: syntax error near unexpected token `('
/bin/sh: -c: line 1: `latex_count=%(LATEX_COUNT) ; \'
```