### PR TITLE
bug 786576 regression with ALIASES or image latex interpretation

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -993,6 +993,7 @@ void DocParser::defaultHandleTitleAndSize(const int cmd, DocNodeVariant *parent,
       }
       else
       {
+        tokenizer.unputString(context.token->name);
         warn_doc_error(context.fileName,tokenizer.getLineNr(),"Unknown option '%s' after \\%s command, expected 'width' or 'height'",
                        qPrint(context.token->name), qPrint(Mappers::cmdMapper->find(cmd)));
         break;
@@ -1000,6 +1001,18 @@ void DocParser::defaultHandleTitleAndSize(const int cmd, DocNodeVariant *parent,
     }
 
     tok=tokenizer.lex();
+    if (!(tok==TK_WHITESPACE || tok==TK_WORD))
+    {
+      if (tok==TK_COMMAND_AT || tok ==TK_COMMAND_BS)
+      {
+        tokenizer.unputString(context.token->name);
+        tokenizer.unputString(tok==TK_COMMAND_AT ? "@" : "\\");
+      }
+      else if (tok==TK_SYMBOL || tok==TK_HTMLTAG)
+      {
+        tokenizer.unputString(context.token->name);
+      }
+    }
   }
   tokenizer.setStatePara();
 

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -142,6 +142,7 @@ class DocTokenizer
     void pushContext();
     bool popContext();
     int  lex();
+    void unputString(const QCString &tag);
     void setStatePara();
     void setStateTitle();
     void setStateTitleAttrValue();

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -955,7 +955,8 @@ LINENR {BLANK}*[1-9][0-9]*
                          return TK_SYMBOL;
                        }
 <St_TitleN>{HTMLTAG}   {
-                         lineCount(yytext,yyleng);
+                         yyextra->token->name = yytext;
+                         return TK_HTMLTAG;
                        }
 <St_TitleN>\n          { /* new line => end of title */
                          unput(*yytext);
@@ -1660,6 +1661,18 @@ DocTokenizer::~DocTokenizer()
 int DocTokenizer::lex()
 {
   return doctokenizerYYlex(p->yyscanner);
+}
+
+void DocTokenizer::unputString(const QCString &tag)
+{
+  yyscan_t yyscanner = p->yyscanner;
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  QCString tagName = tag;
+  int i,l = tagName.length();
+  for (i=l-1;i>=0;i--)
+  {
+    unput(tag[i]);
+  }
 }
 
 void DocTokenizer::findSections(const QCString &input,const Definition *d,


### PR DESCRIPTION
The problem is not the ALIAS but just the way the `\image` command handles its (complex) set of arguments.
For this reason it is also advised to use `^^` i.e. an artificial line break in the `ALIASES` after a `\image` command.

The problem is that at with the image command and argument was "read" and checked, but when it didn't fulfill the requirements it was discarded   (and thus lost).

The arguments of the `\image` command are well defined and we can see that there won't be commands (i.e. starting with `\` or `@` like `\htmlonly`) , symbols (starting with `&` like `&nbsp`) or html tags  (starting with `<`).
These constructions are, when found, terminating the `\image` command and pushed back into the "read stream".