### PR TITLE
issue #9476 fatal: Cannot open 'doxygen/graph_legend.dox': No such file or directory

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1524,7 +1524,7 @@ void FileDefImpl::acquireFileVersion()
 {
   QCString vercmd = Config_getString(FILE_VERSION_FILTER);
   if (!vercmd.isEmpty() && !m_filePath.isEmpty() &&
-      m_filePath!="generated" && m_filePath!="graph_legend")
+      m_filePath!="generated" && m_filePath!="graph_legend.dox")
   {
     msg("Version of %s : ",qPrint(m_filePath));
     QCString cmd = vercmd+" \""+m_filePath+"\"";


### PR DESCRIPTION
Looks like this is introduced with the commit cc4253926 : Refactoring code for dot related source files
Corrected the filename in `filedef.cpp`