### PR TITLE
Better handling of the size indicators with the different image formats

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3408,12 +3408,16 @@ class Receiver
   width or height of the image. This can be useful for \LaTeX or DocBook output
   (i.e. format=<code>latex</code> or format=<code>docbook</code>).
   \anchor image_sizeindicator \par Size indication
-  The \c sizeindication can specify the width or height to be used (or a combination).
-  The size specifier in \LaTeX (for example `10cm` or
-  `4in` or a symbolic width like `\textwidth`).
-
+  The \c sizeindication can specify the width or height to be used (or a combination),
+  in the form `[size_opt[:size]][,size_opt[:size]]*`, where the `size_opt` van be one of
+  the output formats \c html, \c latex, \c docbook or \c xml. In case the the `size_opt` is not specified
+  the specified `size` is used for all the formats where no explicit setting has been done.
+  In case a setting has been done multiple times the last setting is used.
+  The size specifier in \LaTeX is e.g. `10cm` or `4in` or a symbolic width like `\textwidth`
+  (so `width=latex:10cm`).
+  
   Currently only the options `inline` and `anchor` are supported. In case the option `inline` is
-  specified the image is placed "in the line", when a caption s present it is shown
+  specified the image is placed "in the line", when a caption is present it is shown
   in HTML as tooltip (ignored for the other formats). For the `anchor` option the syntax is:
   `anchor:<anchorId>`.
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1205,7 +1205,7 @@ DB_VIS_C
     {
       baseName=baseName.right(baseName.length()-i-1);
     }
-    visitPreStart(m_t, img.children(), img.hasCaption(), img.relPath() + baseName, img.width(), img.height(), img.isInlineImage());
+    visitPreStart(m_t, img.children(), img.hasCaption(), img.relPath() + baseName, img.width(DocOutputTypeDocbook), img.height(DocOutputTypeDocbook), img.isInlineImage());
     visitChildren(img);
     visitPostEnd(m_t, img.hasCaption(),img.isInlineImage());
     QCString file;
@@ -1227,7 +1227,7 @@ void DocbookDocVisitor::operator()(const DocDotFile &df)
 DB_VIS_C
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file()));
-  startDotFile(df.file(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
+  startDotFile(df.file(),df.width(DocOutputTypeDocbook),df.height(DocOutputTypeDocbook),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
   visitChildren(df);
   endDotFile(df.hasCaption());
 }
@@ -1237,7 +1237,7 @@ void DocbookDocVisitor::operator()(const DocMscFile &df)
 DB_VIS_C
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file()));
-  startMscFile(df.file(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
+  startMscFile(df.file(),df.width(DocOutputTypeDocbook),df.height(DocOutputTypeDocbook),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
   visitChildren(df);
   endMscFile(df.hasCaption());
 }
@@ -1247,7 +1247,7 @@ void DocbookDocVisitor::operator()(const DocDiaFile &df)
 DB_VIS_C
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file()));
-  startDiaFile(df.file(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
+  startDiaFile(df.file(),df.width(DocOutputTypeDocbook),df.height(DocOutputTypeDocbook),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
   visitChildren(df);
   endDiaFile(df.hasCaption());
 }
@@ -1505,7 +1505,7 @@ DB_VIS_C
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_BITMAP,s.srcFile(),s.srcLine());
-  visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(), s.height());
+  visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(DocOutputTypeDocbook), s.height(DocOutputTypeDocbook));
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
 }
@@ -1521,7 +1521,7 @@ DB_VIS_C
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
-  visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(),s.height());
+  visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(DocOutputTypeDocbook),s.height(DocOutputTypeDocbook));
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
 }
@@ -1572,7 +1572,7 @@ DB_VIS_C
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DIA_BITMAP,s.srcFile(),s.srcLine());
-  visitPreStart(m_t, s.children(), s.hasCaption(), shortName, s.width(),s.height());
+  visitPreStart(m_t, s.children(), s.hasCaption(), shortName, s.width(DocOutputTypeDocbook),s.height(DocOutputTypeDocbook));
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
 }
@@ -1623,7 +1623,7 @@ DB_VIS_C
   }
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeDotGraphFromFile(baseName+".dot",outDir,shortName,GOF_BITMAP,s.srcFile(),s.srcLine());
-  visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + "." + getDotImageExtension(), s.width(),s.height());
+  visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + "." + getDotImageExtension(), s.width(DocOutputTypeDocbook),s.height(DocOutputTypeDocbook));
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
 }

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -71,6 +71,19 @@ DOC_NODES
 #undef DN
 #undef DN_SEP
 
+enum DocOutputType
+{
+  DocOutputTypeAll,
+  DocOutputTypeHTML,
+  DocOutputTypeLatex,
+  DocOutputTypeDocbook,
+  DocOutputTypeRTF,
+  DocOutputTypeXML,
+  DocOutputTypeSize,
+};
+
+void setSizeAttrib(QCString dim[DocOutputTypeSize], QCString attr);
+
 /** Abstract node interface with type information. */
 class DocNode
 {
@@ -363,8 +376,8 @@ class DocVerbatim : public DocNode
     QCString language() const    { return p->lang; }
     bool isBlock() const         { return p->isBlock; }
     bool hasCaption() const      { return !p->children.empty(); }
-    QCString width() const       { return p->width; }
-    QCString height() const      { return p->height; }
+    QCString width(DocOutputType type) const  { return p->width[type].isEmpty() ? p->width[DocOutputTypeAll] : p->width[type]; }
+    QCString height(DocOutputType type) const { return p->height[type].isEmpty() ? p->height[DocOutputTypeAll] : p->height[type]; }
     QCString engine() const      { return p->engine; }
     bool useBitmap() const       { return p->useBitmap; }
     const DocNodeList &children() const { return p->children; }
@@ -372,8 +385,8 @@ class DocVerbatim : public DocNode
     QCString srcFile() const     { return p->srcFile; }
     int srcLine() const          { return p->srcLine; }
     void setText(const QCString &t)   { p->text=t;   }
-    void setWidth(const QCString &w)  { p->width=w;  }
-    void setHeight(const QCString &h) { p->height=h; }
+    void setWidth(const QCString &w)  { setSizeAttrib(p->width,w);  }
+    void setHeight(const QCString &h) { setSizeAttrib(p->height,h); }
     void setEngine(const QCString &e) { p->engine=e; }
     void setUseBitmap(const bool &u)  { p->useBitmap=u; }
     void setLocation(const QCString &file,int line) { p->srcFile=file; p->srcLine=line; }
@@ -393,8 +406,8 @@ class DocVerbatim : public DocNode
       QCString  relPath;
       QCString  lang;
       bool      isBlock;
-      QCString  width;
-      QCString  height;
+      QCString  width[DocOutputTypeSize];
+      QCString  height[DocOutputTypeSize];
       QCString  engine;
       bool      useBitmap=false; // some PlantUML engines cannot output data in EPS format so bitmap format is required
       DocNodeList children;
@@ -612,8 +625,8 @@ class DocImage : public DocCompoundNode
     Type type() const           { return p->type; }
     QCString name() const       { return p->name; }
     bool hasCaption() const     { return !children().empty(); }
-    QCString width() const      { return p->width; }
-    QCString height() const     { return p->height; }
+    QCString width(DocOutputType type) const  { return p->width[type].isEmpty() ? p->width[DocOutputTypeAll] : p->width[type]; }
+    QCString height(DocOutputType type) const { return p->height[type].isEmpty() ? p->height[DocOutputTypeAll] : p->height[type]; }
     QCString relPath() const    { return p->relPath; }
     QCString url() const        { return p->url; }
     bool isInlineImage() const  { return p->inlineImage; }
@@ -628,11 +641,13 @@ class DocImage : public DocCompoundNode
               const QCString &relPath_, const QCString &url_,bool inlineImage_)
         : attribs(attribs_), name(name_), type(type_),
           relPath(relPath_), url(url_),   inlineImage(inlineImage_) {}
+      void setWidth(const QCString &w)  { setSizeAttrib(width,w);  }
+      void setHeight(const QCString &h) { setSizeAttrib(height,h); }
       HtmlAttribList attribs;
       QCString  name;
       Type      type = Html;
-      QCString  width;
-      QCString  height;
+      QCString  width[DocOutputTypeSize];
+      QCString  height[DocOutputTypeSize];
       QCString  relPath;
       QCString  url;
       bool      inlineImage;
@@ -650,8 +665,8 @@ class DocDiagramFileBase : public DocCompoundNode
     QCString file() const      { return p->file; }
     QCString relPath() const   { return p->relPath; }
     bool hasCaption() const    { return !children().empty(); }
-    QCString width() const     { return p->width; }
-    QCString height() const    { return p->height; }
+    QCString width(DocOutputType type) const  { return p->width[type].isEmpty() ? p->width[DocOutputTypeAll] : p->width[type]; }
+    QCString height(DocOutputType type) const { return p->height[type].isEmpty() ? p->height[DocOutputTypeAll] : p->height[type]; }
     QCString context() const   { return p->context; }
     QCString srcFile() const   { return p->srcFile; }
     int srcLine() const        { return p->srcLine; }
@@ -661,11 +676,13 @@ class DocDiagramFileBase : public DocCompoundNode
     {
       Private(const QCString &name_,const QCString &context_,const QCString &srcFile_,int srcLine_)
         : name(name_), context(context_), srcFile(srcFile_), srcLine(srcLine_) {}
+      void setWidth(const QCString &w)  { setSizeAttrib(width,w);  }
+      void setHeight(const QCString &h) { setSizeAttrib(height,h); }
       QCString  name;
       QCString  file;
       QCString  relPath;
-      QCString  width;
-      QCString  height;
+      QCString  width[DocOutputTypeSize];
+      QCString  height[DocOutputTypeSize];
       QCString  context;
       QCString  srcFile;
       int       srcLine;

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -320,7 +320,8 @@ void writeDotImageMapFromFile(TextStream &t,
                             const QCString &inFile, const QCString &outDir,
                             const QCString &relPath, const QCString &baseName,
                             const QCString &context,int graphId,
-                            const QCString &srcFile,int srcLine)
+                            const QCString &srcFile,int srcLine,
+                            QCString width, QCString height)
 {
 
   Dir d(outDir.str());
@@ -352,9 +353,18 @@ void writeDotImageMapFromFile(TextStream &t,
   }
   else // bitmap graphics
   {
+    QCString sizeAttribs;
+    if (!width.isEmpty())
+    {
+      sizeAttribs+=" width=\""+width+"\"";
+    }
+    if (!height.isEmpty())
+    {
+      sizeAttribs+=" height=\""+height+"\"";
+    }
     TextStream tt;
     t << "<img src=\"" << relPath << imgName << "\" alt=\""
-      << imgName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>\n";
+      << imgName << "\" border=\"0\" usemap=\"#" << mapName << "\" " << sizeAttribs << "/>\n";
     DotFilePatcher::convertMapFile(tt, absOutFile, relPath ,TRUE, context);
     if (!tt.empty())
     {

--- a/src/dot.h
+++ b/src/dot.h
@@ -57,6 +57,7 @@ void writeDotImageMapFromFile(TextStream &t,
                               const QCString &inFile, const QCString& outDir,
                               const QCString &relPath,const QCString& baseName,
                               const QCString &context,int graphId,
-                              const QCString &srcFile,int srcLine);
+                              const QCString &srcFile,int srcLine,
+                              QCString width, QCString height);
 
 #endif

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -616,7 +616,7 @@ void HtmlDocVisitor::operator()(const DocVerbatim &s)
           file.close();
 
           m_t << "<div class=\"dotgraph\">\n";
-          writeDotFile(fileName,s.relPath(),s.context(),s.srcFile(),s.srcLine());
+          writeDotFile(fileName,s.relPath(),s.context(),s.srcFile(),s.srcLine(),s.width(DocOutputTypeHTML),s.height(DocOutputTypeHTML));
           visitCaption(m_t, s);
           m_t << "</div>\n";
 
@@ -651,7 +651,7 @@ void HtmlDocVisitor::operator()(const DocVerbatim &s)
           file.close();
 
           m_t << "<div class=\"mscgraph\">\n";
-          writeMscFile(baseName+".msc",s.relPath(),s.context(),s.srcFile(),s.srcLine());
+          writeMscFile(baseName+".msc",s.relPath(),s.context(),s.srcFile(),s.srcLine(),s.width(DocOutputTypeHTML),s.height(DocOutputTypeHTML));
           visitCaption(m_t, s);
           m_t << "</div>\n";
 
@@ -674,7 +674,7 @@ void HtmlDocVisitor::operator()(const DocVerbatim &s)
                                     htmlOutput,s.exampleFile(),
                                     s.text(),format,s.engine(),s.srcFile(),s.srcLine());
         m_t << "<div class=\"plantumlgraph\">\n";
-        writePlantUMLFile(baseName,s.relPath(),s.context(),s.srcFile(),s.srcLine());
+        writePlantUMLFile(baseName,s.relPath(),s.context(),s.srcFile(),s.srcLine(),s.width(DocOutputTypeHTML),s.height(DocOutputTypeHTML));
         visitCaption(m_t, s);
         m_t << "</div>\n";
         forceStartParagraph(s);
@@ -1621,13 +1621,13 @@ void HtmlDocVisitor::operator()(const DocImage &img)
     }
     if (!inlineImage) m_t << "<div class=\"image\">\n";
     QCString sizeAttribs;
-    if (!img.width().isEmpty())
+    if (!img.width(DocOutputTypeHTML).isEmpty())
     {
-      sizeAttribs+=" width=\""+img.width()+"\"";
+      sizeAttribs+=" width=\""+img.width(DocOutputTypeHTML)+"\"";
     }
-    if (!img.height().isEmpty()) // link to local file
+    if (!img.height(DocOutputTypeHTML).isEmpty()) // link to local file
     {
-      sizeAttribs+=" height=\""+img.height()+"\"";
+      sizeAttribs+=" height=\""+img.height(DocOutputTypeHTML)+"\"";
     }
     // 16 cases: url.isEmpty() | typeSVG | inlineImage | img.hasCaption()
 
@@ -1723,7 +1723,7 @@ void HtmlDocVisitor::operator()(const DocDotFile &df)
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
   m_t << "<div class=\"dotgraph\">\n";
-  writeDotFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
+  writeDotFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine(),df.width(DocOutputTypeHTML),df.height(DocOutputTypeHTML));
   if (df.hasCaption())
   {
     m_t << "<div class=\"caption\">\n";
@@ -1741,7 +1741,7 @@ void HtmlDocVisitor::operator()(const DocMscFile &df)
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
   m_t << "<div class=\"mscgraph\">\n";
-  writeMscFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
+  writeMscFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine(),df.width(DocOutputTypeHTML),df.height(DocOutputTypeHTML));
   if (df.hasCaption())
   {
     m_t << "<div class=\"caption\">\n";
@@ -1759,7 +1759,7 @@ void HtmlDocVisitor::operator()(const DocDiaFile &df)
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
   m_t << "<div class=\"diagraph\">\n";
-  writeDiaFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
+  writeDiaFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine(),df.width(DocOutputTypeHTML),df.height(DocOutputTypeHTML));
   if (df.hasCaption())
   {
     m_t << "<div class=\"caption\">\n";
@@ -2109,7 +2109,8 @@ void HtmlDocVisitor::endLink()
 }
 
 void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
-                                  const QCString &context,const QCString &srcFile,int srcLine)
+                                  const QCString &context,const QCString &srcFile,int srcLine,
+                                  QCString width, QCString height)
 {
   QCString baseName=fn;
   int i;
@@ -2124,11 +2125,12 @@ void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
   baseName.prepend("dot_");
   QCString outDir = Config_getString(HTML_OUTPUT);
   writeDotGraphFromFile(fn,outDir,baseName,GOF_BITMAP,srcFile,srcLine);
-  writeDotImageMapFromFile(m_t,fn,outDir,relPath,baseName,context,-1,srcFile,srcLine);
+  writeDotImageMapFromFile(m_t,fn,outDir,relPath,baseName,context,-1,srcFile,srcLine,width,height);
 }
 
 void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPath,
-                                  const QCString &context,const QCString &srcFile,int srcLine)
+                                  const QCString &context,const QCString &srcFile,int srcLine,
+                                  QCString width, QCString height)
 {
   QCString baseName=fileName;
   int i;
@@ -2147,11 +2149,12 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPa
   if ("svg" == imgExt)
     mscFormat = MSC_SVG;
   writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,srcFile,srcLine);
-  writeMscImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,mscFormat,srcFile,srcLine);
+  writeMscImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,mscFormat,srcFile,srcLine,width,height);
 }
 
 void HtmlDocVisitor::writeDiaFile(const QCString &fileName, const QCString &relPath,
-                                  const QCString &,const QCString &srcFile,int srcLine)
+                                  const QCString &,const QCString &srcFile,int srcLine,
+                                  QCString width, QCString height)
 {
   QCString baseName=fileName;
   int i;
@@ -2167,11 +2170,21 @@ void HtmlDocVisitor::writeDiaFile(const QCString &fileName, const QCString &relP
   QCString outDir = Config_getString(HTML_OUTPUT);
   writeDiaGraphFromFile(fileName,outDir,baseName,DIA_BITMAP,srcFile,srcLine);
 
-  m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
+  QCString sizeAttribs;
+  if (!width.isEmpty())
+  {
+    sizeAttribs+=" width=\""+width+"\"";
+  }
+  if (!height.isEmpty())
+  {
+    sizeAttribs+=" height=\""+height+"\"";
+  }
+  m_t << "<img src=\"" << relPath << baseName << ".png" << "\" " << sizeAttribs << "/>\n";
 }
 
 void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString &relPath,
-                                       const QCString &,const QCString &srcFile,int srcLine)
+                                       const QCString &,const QCString &srcFile,int srcLine,
+                                       QCString width, QCString height)
 {
   QCString baseName=fileName;
   int i;
@@ -2185,18 +2198,27 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   }
   QCString outDir = Config_getString(HTML_OUTPUT);
   QCString imgExt = getDotImageExtension();
+  QCString sizeAttribs;
+  if (!width.isEmpty())
+  {
+    sizeAttribs+=" width=\""+width+"\"";
+  }
+  if (!height.isEmpty())
+  {
+    sizeAttribs+=" height=\""+height+"\"";
+  }
   if (imgExt=="svg")
   {
     PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />\n";
     //m_t << "<p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p>";
     //m_t << "</iframe>\n";
-    m_t << "<object type=\"image/svg+xml\" data=\"" << relPath << baseName << ".svg\"></object>\n";
+    m_t << "<object type=\"image/svg+xml\" data=\"" << relPath << baseName << ".svg\" " << sizeAttribs << "></object>\n";
   }
   else
   {
     PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
-    m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
+    m_t << "<img src=\"" << relPath << baseName << ".png" << "\" " << sizeAttribs << "/>\n";
   }
 }
 

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -122,13 +122,13 @@ class HtmlDocVisitor : public DocVisitor
                    const QCString &tooltip = "");
     void endLink();
     void writeDotFile(const QCString &fileName,const QCString &relPath,const QCString &context,
-                      const QCString &srcFile,int srcLine);
+                      const QCString &srcFile,int srcLine,QCString width,QCString height);
     void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context,
-                      const QCString &srcFile,int srcLine);
+                      const QCString &srcFile,int srcLine,QCString width,QCString height);
     void writeDiaFile(const QCString &fileName,const QCString &relPath,const QCString &context,
-                      const QCString &srcFile,int srcLine);
+                      const QCString &srcFile,int srcLine,QCString width,QCString height);
     void writePlantUMLFile(const QCString &fileName,const QCString &relPath,const QCString &context,
-                           const QCString &srcFile,int srcLine);
+                           const QCString &srcFile,int srcLine,QCString width,QCString height);
 
     template<class DocNode>
     void forceEndParagraph(const DocNode &n);

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -446,7 +446,7 @@ void LatexDocVisitor::operator()(const DocVerbatim &s)
           file.write( s.text().data(), s.text().length() );
           file.close();
 
-          startDotFile(fileName,s.width(),s.height(),s.hasCaption(),s.srcFile(),s.srcLine());
+          startDotFile(fileName,s.width(DocOutputTypeLatex),s.height(DocOutputTypeLatex),s.hasCaption(),s.srcFile(),s.srcLine());
           visitChildren(s);
           endDotFile(s.hasCaption());
 
@@ -1436,7 +1436,7 @@ void LatexDocVisitor::operator()(const DocImage &img)
       gfxName=gfxName.left(gfxName.length()-4);
     }
 
-    visitPreStart(m_t,img.hasCaption(), gfxName, img.width(),  img.height(), img.isInlineImage());
+    visitPreStart(m_t,img.hasCaption(), gfxName, img.width(DocOutputTypeLatex),  img.height(DocOutputTypeLatex), img.isInlineImage());
     visitChildren(img);
     visitPostEnd(m_t,img.hasCaption(), img.isInlineImage());
   }
@@ -1449,7 +1449,7 @@ void LatexDocVisitor::operator()(const DocDotFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file()));
-  startDotFile(df.file(),df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine());
+  startDotFile(df.file(),df.width(DocOutputTypeLatex),df.height(DocOutputTypeLatex),df.hasCaption(),df.srcFile(),df.srcLine());
   visitChildren(df);
   endDotFile(df.hasCaption());
 }
@@ -1458,7 +1458,7 @@ void LatexDocVisitor::operator()(const DocMscFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file()));
-  startMscFile(df.file(),df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine());
+  startMscFile(df.file(),df.width(DocOutputTypeLatex),df.height(DocOutputTypeLatex),df.hasCaption(),df.srcFile(),df.srcLine());
   visitChildren(df);
   endMscFile(df.hasCaption());
 }
@@ -1467,7 +1467,7 @@ void LatexDocVisitor::operator()(const DocDiaFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file()));
-  startDiaFile(df.file(),df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine());
+  startDiaFile(df.file(),df.width(DocOutputTypeLatex),df.height(DocOutputTypeLatex),df.hasCaption(),df.srcFile(),df.srcLine());
   visitChildren(df);
   endDiaFile(df.hasCaption());
 }
@@ -1892,7 +1892,7 @@ void LatexDocVisitor::writeMscFile(const QCString &baseName, const DocVerbatim &
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
   writeMscGraphFromFile(baseName+".msc",outDir,shortName,MSC_EPS,s.srcFile(),s.srcLine());
-  visitPreStart(m_t, s.hasCaption(), shortName, s.width(),s.height());
+  visitPreStart(m_t, s.hasCaption(), shortName, s.width(DocOutputTypeLatex),s.height(DocOutputTypeLatex));
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
 }
@@ -1940,7 +1940,7 @@ void LatexDocVisitor::writeDiaFile(const QCString &baseName, const DocVerbatim &
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
   writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DIA_EPS,s.srcFile(),s.srcLine());
-  visitPreStart(m_t, s.hasCaption(), shortName, s.width(), s.height());
+  visitPreStart(m_t, s.hasCaption(), shortName, s.width(DocOutputTypeLatex), s.height(DocOutputTypeLatex));
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
 }
@@ -1960,7 +1960,7 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, const DocVerba
   QCString outDir = Config_getString(LATEX_OUTPUT);
   PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,
                               s.useBitmap() ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS);
-  visitPreStart(m_t, s.hasCaption(), shortName, s.width(), s.height());
+  visitPreStart(m_t, s.hasCaption(), shortName, s.width(DocOutputTypeLatex), s.height(DocOutputTypeLatex));
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
 }

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -176,7 +176,9 @@ void writeMscImageMapFromFile(TextStream &t,const QCString &inFile,
                               const QCString &context,
 			      MscOutputFormat format,
                               const QCString &srcFile,
-                              int srcLine
+                              int srcLine,
+                              QCString width,
+                              QCString height
  			    )
 {
   QCString mapName = baseName+".map";
@@ -195,16 +197,26 @@ void writeMscImageMapFromFile(TextStream &t,const QCString &inFile,
     default:
       t << "unknown";
   }
+  QCString sizeAttribs;
+  if (!width.isEmpty())
+  {
+    sizeAttribs+=" width=\""+width+"\"";
+  }
+  if (!height.isEmpty())
+  {
+    sizeAttribs+=" height=\""+height+"\"";
+  }
+
   QCString imap = getMscImageMapFromFile(inFile,outDir,relPath,context,format==MSC_SVG,srcFile,srcLine);
+  t << "\" alt=\"" << baseName << "\" border=\"0\" " << sizeAttribs;
   if (!imap.isEmpty())
   {
-    t << "\" alt=\""
-      << baseName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>\n";
+    t << " usemap=\"#" << mapName << "\"/>\n";
     t << "<map name=\"" << mapName << "\" id=\"" << mapName << "\">" << imap << "</map>\n";
   }
   else
   {
-    t << "\" alt=\"" << baseName << "\" border=\"0\"/>\n";
+    t << "/>\n";
   }
 }
 

--- a/src/msc.h
+++ b/src/msc.h
@@ -33,7 +33,8 @@ void writeMscImageMapFromFile(TextStream &t,const QCString &inFile,
                               const QCString &outDir, const QCString &relPath,
                               const QCString &baseName, const QCString &context,
 			      MscOutputFormat format,
-                              const QCString &srcFile,int srcLine
+                              const QCString &srcFile,int srcLine,
+                              QCString width, QCString height
  			    );
 
 #endif

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -541,17 +541,18 @@ class PrintDocVisitor
     }
     void operator()(const DocImage &img)
     {
+      DocOutputType type = DocOutputTypeAll;
       indent_pre();
       printf("<image src=\"%s\" type=\"",qPrint(img.name()));
       switch(img.type())
       {
-        case DocImage::Html:    printf("html"); break;
-        case DocImage::Latex:   printf("latex"); break;
-        case DocImage::Rtf:     printf("rtf"); break;
-        case DocImage::DocBook: printf("docbook"); break;
-        case DocImage::Xml:     printf("xml"); break;
+        case DocImage::Html:    {printf("html"); type = DocOutputTypeHTML;} break;
+        case DocImage::Latex:   {printf("latex"); type = DocOutputTypeLatex;} break;
+        case DocImage::Rtf:     {printf("rtf"); type = DocOutputTypeRTF;} break;
+        case DocImage::DocBook: {printf("docbook"); type = DocOutputTypeDocbook;} break;
+        case DocImage::Xml:     {printf("xml"); type = DocOutputTypeXML;} break;
       }
-      printf("\" %s %s inline=\"%s\">\n",qPrint(img.width()),qPrint(img.height()),img.isInlineImage() ? "yes" : "no");
+      printf("\" %s %s inline=\"%s\">\n",qPrint(img.width(type)),qPrint(img.height(type)),img.isInlineImage() ? "yes" : "no");
       visitChildren(img);
       indent_post();
       printf("</image>\n");

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -372,17 +372,17 @@ void XmlDocVisitor::operator()(const DocVerbatim &s)
       m_t << s.text();
       break;
     case DocVerbatim::Dot:
-      visitPreStart(m_t, "dot", s.hasCaption(), *this, s.children(), QCString(""), FALSE, DocImage::Html, s.width(), s.height());
+      visitPreStart(m_t, "dot", s.hasCaption(), *this, s.children(), QCString(""), FALSE, DocImage::Html, s.width(DocOutputTypeHTML), s.height(DocOutputTypeHTML));
       filter(s.text());
       visitPostEnd(m_t, "dot");
       break;
     case DocVerbatim::Msc:
-      visitPreStart(m_t, "msc", s.hasCaption(), *this, s.children(),  QCString(""), FALSE, DocImage::Html, s.width(), s.height());
+      visitPreStart(m_t, "msc", s.hasCaption(), *this, s.children(),  QCString(""), FALSE, DocImage::Html, s.width(DocOutputTypeHTML), s.height(DocOutputTypeHTML));
       filter(s.text());
       visitPostEnd(m_t, "msc");
       break;
     case DocVerbatim::PlantUML:
-      visitPreStart(m_t, "plantuml", s.hasCaption(), *this, s.children(),  QCString(""), FALSE, DocImage::Html, s.width(), s.height(), s.engine());
+      visitPreStart(m_t, "plantuml", s.hasCaption(), *this, s.children(),  QCString(""), FALSE, DocImage::Html, s.width(DocOutputTypeHTML), s.height(DocOutputTypeHTML), s.engine());
       filter(s.text());
       visitPostEnd(m_t, "plantuml");
       break;
@@ -921,8 +921,18 @@ void XmlDocVisitor::operator()(const DocImage &img)
   auto it = std::find_if(attribs.begin(),attribs.end(),
                          [](const auto &att) { return att.name=="alt"; });
   QCString altValue = it!=attribs.end() ? it->value : "";
+  DocOutputType type = DocOutputTypeAll;
+  switch(img.type())
+  {
+    case DocImage::Html:    type = DocOutputTypeHTML; break;
+    case DocImage::Latex:   type = DocOutputTypeLatex; break;
+    case DocImage::Rtf:     type = DocOutputTypeRTF; break;
+    case DocImage::DocBook: type = DocOutputTypeDocbook; break;
+    case DocImage::Xml:     type = DocOutputTypeXML; break;
+  }
+
   visitPreStart(m_t, "image", FALSE, *this, img.children(), baseName, TRUE,
-                img.type(), img.width(), img.height(), QCString(),
+                img.type(), img.width(type), img.height(type), QCString(),
                 altValue, img.isInlineImage());
 
   // copy the image to the output dir
@@ -940,7 +950,7 @@ void XmlDocVisitor::operator()(const DocDotFile &df)
 {
   if (m_hide) return;
   copyFile(df.file(),Config_getString(XML_OUTPUT)+"/"+stripPath(df.file()));
-  visitPreStart(m_t, "dotfile", FALSE, *this, df.children(), stripPath(df.file()), FALSE, DocImage::Html, df.width(), df.height());
+  visitPreStart(m_t, "dotfile", FALSE, *this, df.children(), stripPath(df.file()), FALSE, DocImage::Html, df.width(DocOutputTypeHTML), df.height(DocOutputTypeHTML));
   visitChildren(df);
   visitPostEnd(m_t, "dotfile");
 }
@@ -949,7 +959,7 @@ void XmlDocVisitor::operator()(const DocMscFile &df)
 {
   if (m_hide) return;
   copyFile(df.file(),Config_getString(XML_OUTPUT)+"/"+stripPath(df.file()));
-  visitPreStart(m_t, "mscfile", FALSE, *this, df.children(), stripPath(df.file()), FALSE, DocImage::Html, df.width(), df.height());
+  visitPreStart(m_t, "mscfile", FALSE, *this, df.children(), stripPath(df.file()), FALSE, DocImage::Html, df.width(DocOutputTypeHTML), df.height(DocOutputTypeHTML));
   visitChildren(df);
   visitPostEnd(m_t, "mscfile");
 }
@@ -958,7 +968,7 @@ void XmlDocVisitor::operator()(const DocDiaFile &df)
 {
   if (m_hide) return;
   copyFile(df.file(),Config_getString(XML_OUTPUT)+"/"+stripPath(df.file()));
-  visitPreStart(m_t, "diafile", FALSE, *this, df.children(), stripPath(df.file()), FALSE, DocImage::Html, df.width(), df.height());
+  visitPreStart(m_t, "diafile", FALSE, *this, df.children(), stripPath(df.file()), FALSE, DocImage::Html, df.width(DocOutputTypeHTML), df.height(DocOutputTypeHTML));
   visitChildren(df);
   visitPostEnd(m_t, "diafile");
 }


### PR DESCRIPTION
- enabling the possibility to specify the size indicators per output type
- adding for the HTML output format the size indicator handling with the different image possibilities (were missing)
- with the `\startuml` command the name of the file and the size indicator were running into one and another when no caption was present.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9233730/example.tar.gz)
