### PR TITLE
[regression] bug 786576 regression with ALIASES or image latex interpretation

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -965,6 +965,7 @@ void DocParser::defaultHandleTitleAndSize(const int cmd, DocNodeVariant *parent,
     }
     else if (tok==TK_HTMLTAG)
     {
+      tokenizer.unputString(context.token->name);
       break;
     }
     if (!defaultHandleToken(parent,tok,children))

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -963,6 +963,10 @@ void DocParser::defaultHandleTitleAndSize(const int cmd, DocNodeVariant *parent,
       // special case: no title, but we do have a size indicator
       break;
     }
+    else if (tok==TK_HTMLTAG)
+    {
+      break;
+    }
     if (!defaultHandleToken(parent,tok,children))
     {
       errorHandleDefaultToken(parent,tok,children,Mappers::cmdMapper->find(cmd));


### PR DESCRIPTION
With the CGAL Program we got:
```
doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt:2779: warning: Unexpected token TK_HTMLTAG found as part of a image
```
as the code (shortened) was like:
```
<table border=0>
<tr>
<td>\image html sphere.png</td>
<tr align="center">
<td>(a) Sphere</td>
</tr>
</table>
```
the problem is the `</td>` as this is now not seen properly (in the past it was ignored!).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9234259/example.tar.gz)
