### PR TITLE
bug 564252 HTML output for pure virtual function with "throws()" hint is wrong

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2947,7 +2947,7 @@ void ClassDefImpl::writeMemberList(OutputList &ol) const
 
             if ( md->isFunction() || md->isSignal() || md->isSlot() ||
                 (md->isFriend() && md->argsString().isEmpty()))
-              ol.docify(md->argsString());
+              ol.docify(md->argsString() + md->explicitFunctionDefinition());
             else if (md->isEnumerate())
               ol.parseText(" "+theTranslator->trEnumName());
             else if (md->isEnumValue())
@@ -2995,7 +2995,7 @@ void ClassDefImpl::writeMemberList(OutputList &ol) const
           if (!md->isObjCMethod())
           {
             if ( md->isFunction() || md->isSignal() || md->isSlot() )
-              ol.docify(md->argsString());
+              ol.docify(md->argsString() + md->explicitFunctionDefinition());
             else if (md->isEnumerate())
               ol.parseText(" "+theTranslator->trEnumName());
             else if (md->isEnumValue())

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -157,7 +157,7 @@ static void writeBoxMemberList(TextStream &t,
           {
             if (dotUmlDetails==DOT_UML_DETAILS_t::YES)
             {
-              label+=mma->argsString();
+              label+=mma->argsString() + mma->explicitFunctionDefinition();
             }
             else
             {

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -91,6 +91,7 @@ Entry::Entry(const Entry &e)
   write       = e.write;
   inside      = e.inside;
   exception   = e.exception;
+  explFunDef  = e.explFunDef;
   typeConstr  = e.typeConstr;
   bodyLine    = e.bodyLine;
   bodyColumn  = e.bodyColumn;
@@ -192,6 +193,7 @@ void Entry::reset()
   args.resize(0);
   bitfields.resize(0);
   exception.resize(0);
+  explFunDef.resize(0);
   program.str(std::string());
   includeFile.resize(0);
   includeName.resize(0);

--- a/src/entry.h
+++ b/src/entry.h
@@ -279,6 +279,7 @@ class Entry
     QCString     write;       //!< property write accessor
     QCString     inside;      //!< name of the class in which documents are found
     QCString     exception;   //!< throw specification
+    QCString     explFunDef;  //!< explicit function definition (text)
     ArgumentList typeConstr;  //!< where clause (C#) for type constraints
     int          bodyLine;    //!< line number of the body in the source
     int          bodyColumn;  //!< column of the body in the source

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -584,7 +584,7 @@ void HtmlHelp::addIndexItem(const Definition *context,const MemberDef *md,
     if (context==0) return; // should not happen
 
     QCString cfname  = md->getOutputFileBase();
-    QCString argStr  = md->argsString();
+    QCString argStr  = md->argsString() + md->explicitFunctionDefinition();
     QCString cfiname = context->getOutputFileBase();
     QCString level1  = context->name();
     QCString level2  = md->name() + argStr;

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -157,6 +157,7 @@ class MemberDef : public Definition
     virtual bool isTypeAlias() const = 0;
     virtual bool isDefault() const = 0;
     virtual bool isDelete() const = 0;
+    virtual QCString explicitFunctionDefinition() const = 0;
     virtual bool isNoExcept() const = 0;
     virtual bool isAttribute() const = 0; // UNO IDL attribute
     virtual bool isUNOProperty() const = 0; // UNO IDL property
@@ -449,7 +450,7 @@ MemberDefMutable *createMemberDef(const QCString &defFileName,int defLine,int de
               const QCString &type,const QCString &name,const QCString &args,
               const QCString &excp,Protection prot,Specifier virt,bool stat,
               Relationship related,MemberType t,const ArgumentList &tal,
-              const ArgumentList &al,const QCString &metaData);
+              const ArgumentList &al,const QCString &metaData,const QCString &efdef);
 
 MemberDef *createMemberDefAlias(const Definition *newScope,const MemberDef *aliasMd);
 

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1558,7 +1558,7 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
   }
   else if (md->argsString()!=0)
   {
-    m_output.addFieldQuotedString("arguments", md->argsString());
+    m_output.addFieldQuotedString("arguments", md->argsString() + md->explicitFunctionDefinition());
   }
 
   if (!md->initializer().isEmpty())

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -350,7 +350,7 @@ void Qhp::addIndexItem(const Definition *context,const MemberDef *md,
     }
     if (context==0) return; // should not happen
     QCString cfname  = md->getOutputFileBase();
-    QCString argStr  = md->argsString();
+    QCString argStr  = md->argsString() + md->explicitFunctionDefinition();
     QCString cfiname = context->getOutputFileBase();
     QCString level1  = context->name();
     QCString level2  = !word.isEmpty() ? word : md->name();

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4906,21 +4906,21 @@ NONLopt [^\n]*
 
 <FuncQual,TrailingReturn>{BN}*"="{BN}*"0"{BN}*          { // pure virtual member function
                                           lineCount(yyscanner) ;
-                                          yyextra->current->args += " = 0";
+                                          yyextra->current->explFunDef = " = 0";
                                           yyextra->current->virt = Pure;
                                           yyextra->current->argList.setPureSpecifier(TRUE);
                                           BEGIN(FuncQual);
                                         }
 <FuncQual,TrailingReturn>{BN}*"="{BN}*"delete"{BN}*     { // C++11 explicitly delete member
                                           lineCount(yyscanner);
-                                          yyextra->current->args += " = delete";
+                                          yyextra->current->explFunDef = " = delete";
                                           yyextra->current->spec |= Entry::Delete;
                                           yyextra->current->argList.setIsDeleted(TRUE);
                                           BEGIN(FuncQual);
                                         }
 <FuncQual,TrailingReturn>{BN}*"="{BN}*"default"{BN}*     { // C++11 explicitly defaulted constructor/assignment operator
                                           lineCount(yyscanner);
-                                          yyextra->current->args += " = default";
+                                          yyextra->current->explFunDef = " = default";
                                           yyextra->current->spec |= Entry::Default;
                                           BEGIN(FuncQual);
                                         }

--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -478,7 +478,7 @@ void SearchIndexExternal::setCurrentDoc(const Definition *ctx,const QCString &an
     e.name = ctx->qualifiedName();
     if (ctx->definitionType()==Definition::TypeMember)
     {
-      e.args = (toMemberDef(ctx))->argsString();
+      e.args = (toMemberDef(ctx))->argsString() + (toMemberDef(ctx))->explicitFunctionDefinition();
     }
     e.extId = extId;
     e.url  = url;

--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -555,7 +555,7 @@ void writeJavaScriptSearchIndex()
             if (md) prefix=convertToXML(md->localName());
             if (overloadedFunction) // overloaded member function
             {
-              prefix+=convertToXML(md->argsString());
+              prefix+=convertToXML(md->argsString() + md->explicitFunctionDefinition());
               // show argument list to disambiguate overloaded functions
             }
             else if (md) // unique member function

--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -1743,7 +1743,7 @@ static void generateSqlite3ForMember(const MemberDef *md, struct Refid scope_ref
 
     if (!md->argsString().isEmpty())
     {
-      bindTextParameter(memberdef_insert,":argsstring",md->argsString());
+      bindTextParameter(memberdef_insert,":argsstring",md->argsString() + md->explicitFunctionDefinition());
     }
   }
 

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2581,7 +2581,8 @@ ferr:
       MemberType_Variable,
       ArgumentList(),
       ArgumentList(),
-      "") };
+      "",
+      QCString()) };
 
   if (!ar->getOutputFileBase().isEmpty())
   {

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -807,7 +807,7 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
     linkifyText(TextGeneratorXMLImpl(t),def,md->getBodyDef(),md,typeStr);
     t << "</type>\n";
     t << "        <definition>" << convertToXML(md->definition()) << "</definition>\n";
-    t << "        <argsstring>" << convertToXML(md->argsString()) << "</argsstring>\n";
+    t << "        <argsstring>" << convertToXML(md->argsString() + md->explicitFunctionDefinition()) << "</argsstring>\n";
   }
 
   if (md->memberType() == MemberType_Enumeration)

--- a/testing/080/class_interface.xml
+++ b/testing/080/class_interface.xml
@@ -13,7 +13,7 @@
           <para>Load things. </para>
         </briefdescription>
         <detaileddescription>
-          <para>Calls <ref refid="class_interface_1a328e0a16ccee5d796ca93801a055d27d" kindref="member">doLoad()</ref>. </para>
+          <para>Calls <ref refid="class_interface_1a3ca47b3b87c7d4fa2bd540e4253d7101" kindref="member">doLoad()</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
@@ -21,10 +21,10 @@
       </memberdef>
     </sectiondef>
     <sectiondef kind="private-func">
-      <memberdef kind="function" id="class_interface_1a328e0a16ccee5d796ca93801a055d27d" prot="private" static="no" const="no" explicit="no" inline="no" virt="pure-virtual">
+      <memberdef kind="function" id="class_interface_1a3ca47b3b87c7d4fa2bd540e4253d7101" prot="private" static="no" const="no" explicit="no" inline="no" virt="pure-virtual">
         <type>void</type>
         <definition>virtual void Interface::doLoad</definition>
-        <argsstring>()=0</argsstring>
+        <argsstring>() = 0</argsstring>
         <name>doLoad</name>
         <qualifiedname>Interface::doLoad</qualifiedname>
         <briefdescription>
@@ -90,7 +90,7 @@
     </detaileddescription>
     <location file="080_extract_private_virtual.cpp" line="6" column="1" bodyfile="080_extract_private_virtual.cpp" bodystart="6" bodyend="35"/>
     <listofallmembers>
-      <member refid="class_interface_1a328e0a16ccee5d796ca93801a055d27d" prot="private" virt="pure-virtual">
+      <member refid="class_interface_1a3ca47b3b87c7d4fa2bd540e4253d7101" prot="private" virt="pure-virtual">
         <scope>Interface</scope>
         <name>doLoad</name>
       </member>


### PR DESCRIPTION
The parts after the closing round bracket of a function definition are stored in multiple places, so in case of
```
virtual myclass() const trow() = 0;
```
throw part is stored in a separate string and the `cons t` and `=0` part are stored in another string but concatenated, during output this was not handled properly, now the `=0` part is stored separately.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9275155/example.tar.gz)
