### PR TITLE
Warning of missing parameter description

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1567,12 +1567,12 @@ QCString DefinitionImpl::documentation() const
 
 int DefinitionImpl::docLine() const
 {
-  return m_impl->details ? m_impl->details->line : 1;
+  return m_impl->details ? m_impl->details->line : m_impl->brief ? m_impl->brief->line : 1;
 }
 
 QCString DefinitionImpl::docFile() const
 {
-  return m_impl->details ? m_impl->details->file : QCString("<"+m_impl->name+">");
+  return m_impl->details ? m_impl->details->file : m_impl->brief ? m_impl->brief->file : QCString("<"+m_impl->name+">");
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
In case we have the simple code:
```
/// \file

/// the fie
void fie0(int i)
{
  printf("Integer %d\n",i);
}
```
with setting
```
WARN_NO_PARAMDOC = YES
```
we get the warning like:
```
<fie0>:1: warning: parameters of member fie0 are not documented
```
this is due to the fact that there is only a brief description and the warning call just looks at this, instead of also looking for a brief description to get a better message:
```
.../test.cpp:3: warning: parameters of member fie0 are not documented
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9276658/example.tar.gz)
