### PR TITLE
Warning when compiling with -Wpedantic

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -3233,7 +3233,7 @@ static bool hasNonReferenceSuperClassRec(const ClassDef *cd,int level)
     }
   }
   return found;
-};
+}
 
 /*! Returns \c TRUE iff this class or a class inheriting from this class
  *  is \e not defined in an external tag file.


### PR DESCRIPTION
When compiling with `-Wpedantic` we get:
```
.../src/classdef.cpp:3236:2: warning: extra ‘;’ [-Wpedantic]
```

(Reported by CGAL)