### PR TITLE
Documenting parameter of function without parameters

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -371,6 +371,17 @@ void DocParser::checkUnOrMultipleDocumentedParams()
                             qPrint(substitute(errMsg,"%","%%")));
       }
     }
+    else
+    {
+      if (!context.paramsFound.size() && Config_getBool(WARN_IF_DOC_ERROR))
+      {
+        warn_doc_error(context.memberDef->docFile(),
+                       context.memberDef->docLine(),
+                       "%s",
+                       QCString(context.memberDef->qualifiedName()) +
+                       " has @param documentation sections but no arguments");
+      }
+    }
   }
 }
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -378,8 +378,8 @@ void DocParser::checkUnOrMultipleDocumentedParams()
         warn_doc_error(context.memberDef->docFile(),
                        context.memberDef->docLine(),
                        "%s",
-                       QCString(context.memberDef->qualifiedName()) +
-                       " has @param documentation sections but no arguments");
+                       qPrint(context.memberDef->qualifiedName() +
+                              " has @param documentation sections but no arguments"));
       }
     }
   }


### PR DESCRIPTION
When having a simple function:
```
/// \file

/// the fie
/// \param x the unknown
void fie_u();
```
and a standard doxygen setup, we don't get a warning even though an attempt is made to document an argument.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9281062/example.tar.gz)
