### PR TITLE
Recognizing and name of implicit Fortran programs

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -206,6 +206,8 @@ struct fortranscannerYY_state
   int                      anonCount    = 0 ;
 
   int fixedCommentAfter = 72;
+  //! counter for the number of main programs in this file
+  int mainPrograms      = 0; 
 };
 
 //-----------------------------------------------------------------------------
@@ -827,13 +829,30 @@ private                                 {
 {ATTR_STMT}/{BS}"::"                    {
                                           /* attribute statement starts */
                                           DBG_CTX((stderr,"5=========> Attribute statement: %s\n", yytext));
+                                          if (YY_START == Start)
+                                          {
+                                            addModule(yyscanner);
+                                            yy_push_state(ModuleBody,yyscanner); //anon program
+                                          }
                                           QCString tmp = yytext;
                                           yyextra->currentModifiers |= tmp.stripWhiteSpace();
                                           yyextra->argType="";
                                           yy_push_state(YY_START,yyscanner);
                                           BEGIN( AttributeList ) ;
                                         }
+"common"                                {
+                                          if (YY_START == Start)
+                                          {
+                                            addModule(yyscanner);
+                                            yy_push_state(ModuleBody,yyscanner); //anon program
+                                          }
+                                        }
 {ID}                                    {
+                                          if (YY_START == Start)
+                                          {
+                                            addModule(yyscanner);
+                                            yy_push_state(ModuleBody,yyscanner); //anon program
+                                          }
                                         }
 ^{BS}"type"{BS_}"is"/{BT_}              {}
 ^{BS}"type"{BS}"="                      {}
@@ -2352,8 +2371,10 @@ static void addModule(yyscan_t yyscanner,const QCString &name, bool isModule)
     QCString fname = yyextra->fileName;
     int index = std::max(fname.findRev('/'), fname.findRev('\\'));
     fname = fname.right(fname.length()-index-1);
+    if (yyextra->mainPrograms) fname += "__" + QCString().setNum(yyextra->mainPrograms);
+    yyextra->mainPrograms++;
     fname = fname.prepend("__").append("__");
-    yyextra->current->name = fname;
+    yyextra->current->name = substitute(fname, ".", "_");
   }
   yyextra->current->type = "program";
   yyextra->current->fileName  = yyextra->fileName;


### PR DESCRIPTION
In Fortran it is possible that a part of code doesn't start with a `program` / `subroutine`/ `function` etc statement and that is should be considered as the main program.
Some examples have multiple sections with "main" programs (this won't compile, but serves just as example code.
When this happens we see warnings like:
```
.../music5.f:693: warning: documented symbol 'program __music5 f__' was not declared or defined.
.../music5.f:985: warning: documented symbol 'program __music5 f__' was not declared or defined.
```
In the resulting code we see a number of problems
- just one "main" program
- the name in the warning containing a space

after correcting this we still see in the source code
- incorrect reference to begin of the "main" program as not all constructs are recognized as starting a "main" program.


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9290320/example.tar.gz)
