### PR TITLE
Handling of `@...@` setting with `doxygen -x_noenv`

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -263,7 +263,7 @@ are different from the standard doxygen configuration file settings one can run 
 doxygen command: with the `-x` option and the name of the configuration file (default
 is `Doxyfile`). The output will be a list of the not default settings (in `Doxyfile`
 format). Alternatively also `-x_noenv` is possible which is identical to the `-x`
-option but without replacing the environment variables.
+option but without replacing the environment variables and the CMake type replacement variables.
 
 \htmlonly
 Return to the <a href="index.html">index</a>.

--- a/doc/doxygen.1
+++ b/doc/doxygen.1
@@ -53,7 +53,7 @@ doxygen \fB\-x\fR [configFile]
 .TP
    Use doxygen to compare the used configuration file with the template configuration file
 .RS 0
-   without replacing the environment variables
+   without replacing the environment variables or CMake type replacement variables
 .RE
 .IP
 doxygen \fB\-x_noenv\fR [configFile]

--- a/src/config.h
+++ b/src/config.h
@@ -81,7 +81,7 @@ namespace Config
    *  and replaces environment variables.
    *  \param clearHeaderAndFooter set to TRUE when writing header and footer templates.
    *  \param compareMode signals if we in Doxyfile compare (`-x` or `-x_noenv`) mode are or not.
-   *   Influences setting of the default value and replacement of environment variables.
+   *   Influences setting of the default value and replacement of environment variables and CMake type replacement variables.
    */
   void postProcess(bool clearHeaderAndFooter, CompareMode compareMode = CompareMode::Full);
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -95,7 +95,7 @@ Use doxygen to compare the used configuration file with the template configurati
       doxygen -x [configFile]
 \endverbatim
 Use doxygen to compare the used configuration file with the template configuration file
-without replacing the environment variables:
+without replacing the environment variables or CMake type replacement variables:
 \verbatim
       doxygen -x_noenv [configFile]
 \endverbatim

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1289,12 +1289,13 @@ void ConfigImpl::emptyValueToDefault()
 
 static const reg::Ex reEnvVar(R"(\$\((\a[\w.-]*)\))");                 // e.g. $(HOME)
 static const reg::Ex reEnvVarExt(R"(\$\((\a[\w.-]*\(\a[\w.-]*\))\))"); // e.g. $(PROGRAMFILES(X86))
+static const reg::Ex reEnvVarCMake(R"(@\a\w*)");                       // CMake type replacement
 
 static bool containsEnvVar(QCString &str)
 {
   reg::Match m;
   std::string s = str.str();
-  return reg::search(s,m,reEnvVar) || reg::search(s,m,reEnvVarExt);
+  return reg::search(s,m,reEnvVar) || reg::search(s,m,reEnvVarExt) || reg::search(s,m,reEnvVarCMake);
 }
 
 static void substEnvVarsInString(QCString &str)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10782,7 +10782,7 @@ static void usage(const QCString &name,const QCString &versionString)
   msg("7) Use doxygen to compare the used configuration file with the template configuration file\n");
   msg("    %s -x [configFile]\n\n",qPrint(name));
   msg("   Use doxygen to compare the used configuration file with the template configuration file\n");
-  msg("   without replacing the environment variables\n");
+  msg("   without replacing the environment variables or CMake type replacement variables\n");
   msg("    %s -x_noenv [configFile]\n\n",qPrint(name));
   msg("8) Use doxygen to show a list of built-in emojis.\n");
   msg("    %s -f emoji outputFileName\n\n",qPrint(name));


### PR DESCRIPTION
The (defacto) standard for replacement variables in the CMake contest is `@..@`  though when using `doxygen -x_noenv` we get warnings like:
```
warning: argument '@ENABLE_LATEX@' for option GENERATE_LATEX is not a valid boolean value
Using the default: YES!
```
when we have a setting like:
```
GENERATE_LATEX=@ENABLE_LATEX@
```
whilst the setting
```
GENERATE_HTML=$(ENABLE_HTML)
```
is handled correctly

Example; [example.tar.gz](https://github.com/doxygen/doxygen/files/9333419/example.tar.gz)
