### PR TITLE
Some minor documentation improvements

### DIFF
--- a/doc/emojisup.doc
+++ b/doc/emojisup.doc
@@ -21,7 +21,7 @@ The [Unicode consortium](http://www.unicode.org/) has defined a set of
 sequences. Doxygen supports the subset of emoji characters as used by GitHub (based on the list
 https://api.github.com/emojis).
 An emoji is created using the \ref cmdemoji "\\emoji" command.
-For example `\emoji smile` (or `\emoji :smile:`) both produce \emoji smile.
+For example `\emoji smile` or `\emoji :smile:` both produce \emoji smile.
 
 \section emojirep Representation
 

--- a/doc/language.tpl
+++ b/doc/language.tpl
@@ -67,7 +67,7 @@ Just follow the following steps:
 \endverbatim
     <p>Now, in <code>setTranslator()</code> add
 \verbatim
-    case OUTPUT_LANGUAGE_t::YourLanguage:          theTranslator = new TranslatorYourLanguage; break;
+case OUTPUT_LANGUAGE_t::YourLanguage: theTranslator = new TranslatorYourLanguage; break;
 \endverbatim
 <li>Edit <code>doxygen/src/translator_xx.h</code>:
    <ul>

--- a/doc/tables.doc
+++ b/doc/tables.doc
@@ -62,6 +62,7 @@ a nested table as one of the cells, and a item list in another cell.
 Note that the end tags (like `</td>`) are left out in the example above.
 This is allowed, and in the HTML output doxygen will add the end tags again.
 
+\latexonly \newpage \endlatexonly
 The output will look as follows:
 
 <table>

--- a/doc/xmlcmds.doc
+++ b/doc/xmlcmds.doc
@@ -41,7 +41,6 @@ Here is the list of tags supported by doxygen:
                          member of a base class into the documentation of a 
                          member of a derived class that reimplements it.
 <li><tt>\anchor xmltag_item \addindex "\<item\>" \<item\></tt> List item. Can only be used inside a \ref xmltag_list "\<list\>" context.
-
 <li><tt>\anchor xmltag_list \addindex "\<list\>" \<list type="type"\></tt> Starts a list, supported types are <tt>bullet</tt>
                          or <tt>number</tt> and <tt>table</tt>. 
                          A list consists of a number of <tt>\<item\></tt> tags.


### PR DESCRIPTION
- tables.doc prevent in LaTeX a split over pages (did look very ugly)
- language.tpl prevent line to run into the border (LaTeX) or have a scrollbar (HTML)
- emoji small textual improvement