### PR TITLE
Fix build on GNU/Hurd

### DIFF
--- a/filesystem/filesystem.hpp
+++ b/filesystem/filesystem.hpp
@@ -4081,6 +4081,13 @@ GHC_INLINE path current_path(std::error_code& ec)
         return path();
     }
     return path(std::wstring(buffer.get()), path::native_format);
+#elif defined(__GLIBC__)
+    std::unique_ptr<char, decltype(&std::free)> buffer { ::getcwd(NULL, 0), std::free };
+    if (buffer == nullptr) {
+        ec = detail::make_system_error();
+        return path();
+    }
+    return path(buffer.get());
 #else
     size_t pathlen = static_cast<size_t>(std::max(int(::pathconf(".", _PC_PATH_MAX)), int(PATH_MAX)));
     std::unique_ptr<char[]> buffer(new char[pathlen + 1]);


### PR DESCRIPTION
There is no path length limitation there, even via pathconf.  But glibc
provides a getcwd function that allocates the buffer dynamically so we can
just leverage that.