### PR TITLE
issue #9520 Rest of file silently ignored after a certain string literal [PHP]

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3275,6 +3275,15 @@ NONLopt [^\n]*
                                           yyextra->lastStringContext=YY_START;
                                           BEGIN(CopyGString);
                                         }
+<GCopyQuare>\'                          {
+                                          *yyextra->pCopySquareGString << *yytext;
+                                          if (yyextra->insidePHP)
+                                          {
+                                            yyextra->pCopyQuotedGString=yyextra->pCopySquareGString;
+                                            yyextra->lastStringContext=YY_START;
+                                            BEGIN(CopyPHPGString);
+                                          }
+                                        }
 <GCopySquare>"["                        {
                                           *yyextra->pCopySquareGString << *yytext;
                                           yyextra->squareCount++;
@@ -3311,7 +3320,7 @@ NONLopt [^\n]*
                                             *yyextra->pCopySquareGString << yytext;
                                           }
                                         }
-<GCopySquare>[^"\[\]\n\/,]+              {
+<GCopySquare>[^"'\[\]\n\/,]+            {
                                           *yyextra->pCopySquareGString << yytext;
                                         }
 <GCopySquare>.                          {


### PR DESCRIPTION
For PHP we also have to handle in the square brackets the `'...'` string.