### PR TITLE
issue #9236 doxygen x_noenv should always diff system-dependent settings

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -995,7 +995,7 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
-    <option type='bool' id='CASE_SENSE_NAMES' defval='0' altdefval='Portable::fileSystemIsCaseSensitive()'>
+    <option type='enum' id='CASE_SENSE_NAMES' defval='SYSTEM'>
       <docs>
 <![CDATA[
  With the correct setting of option \c CASE_SENSE_NAMES doxygen will better be able to match the
@@ -1014,6 +1014,9 @@ Go to the <a href="commands.html">next</a> section or return to the
  whereas on Linux or other Unix flavors it should typically be set to \c YES.
 ]]>
       </docs>
+      <value name="SYSTEM" />
+      <value name="NO"/>
+      <value name="YES" />
     </option>
     <option type='bool' id='HIDE_SCOPE_NAMES' defval='0'>
       <docs>

--- a/src/filename.h
+++ b/src/filename.h
@@ -20,8 +20,8 @@
 #include <vector>
 
 #include "linkedmap.h"
-#include "config.h"
 #include "utf8.h"
+#include "util.h"
 
 class FileDef;
 
@@ -59,7 +59,7 @@ class FileNameFn
     std::string searchKey(std::string input) const
     {
       std::string key = input;
-      if (!Config_getBool(CASE_SENSE_NAMES))
+      if (!getCaseSenseNames())
       {
         key = convertUTF8ToLower(key);
       }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3594,11 +3594,20 @@ int getUtf8Char(const char *input,char ids[MAX_UTF8_CHAR_SIZE],CaseModifier modi
 }
 #endif
 
+bool getCaseSenseNames()
+{
+  auto caseSenseNames = Config_getEnum(CASE_SENSE_NAMES);
+
+  if (caseSenseNames == CASE_SENSE_NAMES_t::YES) return true;
+  else if (caseSenseNames == CASE_SENSE_NAMES_t::NO) return false;
+  else return Portable::fileSystemIsCaseSensitive();
+}
+
 // note that this function is not reentrant due to the use of static growBuf!
 QCString escapeCharsInString(const QCString &name,bool allowDots,bool allowUnderscore)
 {
   if (name.isEmpty()) return name;
-  bool caseSenseNames = Config_getBool(CASE_SENSE_NAMES);
+  bool caseSenseNames = getCaseSenseNames();
   bool allowUnicodeNames = Config_getBool(ALLOW_UNICODE_NAMES);
   GrowBuf growBuf;
   signed char c;
@@ -3680,7 +3689,7 @@ QCString escapeCharsInString(const QCString &name,bool allowDots,bool allowUnder
 QCString unescapeCharsInString(const QCString &s)
 {
   if (s.isEmpty()) return s;
-  bool caseSenseNames = Config_getBool(CASE_SENSE_NAMES);
+  bool caseSenseNames = getCaseSenseNames();
   QCString result;
   const char *p = s.data();
   if (p)
@@ -6457,7 +6466,7 @@ QCString filterTitle(const QCString &title)
 
 bool patternMatch(const FileInfo &fi,const StringVector &patList)
 {
-  bool caseSenseNames = Config_getBool(CASE_SENSE_NAMES);
+  bool caseSenseNames = getCaseSenseNames();
   bool found = FALSE;
 
   // For platforms where the file system is non case sensitive overrule the setting

--- a/src/util.h
+++ b/src/util.h
@@ -283,6 +283,8 @@ PageDef *addRelatedPage(const QCString &name,
                         SrcLangExt lang=SrcLangExt_Unknown
                        );
 
+bool getCaseSenseNames();
+
 QCString escapeCharsInString(const QCString &name,bool allowDots,bool allowUnderscore=FALSE);
 QCString unescapeCharsInString(const QCString &s);
 


### PR DESCRIPTION
Making the `CASE_SENSE_NAMES` settings an enum with values `SYSTEM`, `YES` and `NO`.
In case `SYSTEM` is chosen the value is, system dependently changed at runtime.