### PR TITLE
issue #9317 File-scoped nested namespaces in C#

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5615,12 +5615,12 @@ NONLopt [^\n]*
 <ClassTemplSpec>.                       {
                                           yyextra->current->name += yytext;
                                         }
-<CompoundName>{SCOPENAME}{BN}*";"       { // forward declaration?
+<CompoundName>({SCOPENAME}|{CSSCOPENAME}){BN}*";"       { // forward declaration?
                                           if (yyextra->insideCS && yyextra->current->type == "namespace")
                                           {
                                             // file scoped CSharp namespace
                                             lineCount(yyscanner);
-                                            yyextra->current->name = yytext;
+                                            yyextra->current->name = substitute(yytext,".","::");
                                             yyextra->current->name=yyextra->current->name.left(yyextra->current->name.length()-1).stripWhiteSpace();
                                             yyextra->fakeNS++;
                                             unput('{'); // fake start of body


### PR DESCRIPTION
Previous fix did not support nested file-scoped namespaces, this commit impliments it.