### PR TITLE
Correcting warning in `translator_report.txt`

### DIFF
--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -34,7 +34,7 @@
  * Updated to 1.8.4 by Bartomeu Creus Navarro (17-julio-2013)
  */
 
-class TranslatorSpanish : public TranslatorAdapter_1_8_15
+class TranslatorSpanish : public TranslatorAdapter_1_8_19
 {
   public:
 

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -103,7 +103,7 @@
 // Translator class (by the local maintainer) when the localized
 // translator is made up-to-date again.
 
-class TranslatorFrench : public TranslatorAdapter_1_8_15
+class TranslatorFrench : public TranslatorAdapter_1_8_19
 {
    public:
 


### PR DESCRIPTION
The French and Spanish translations give in the `translator_report.txt` the warnings:
```
  TranslatorSpanish               1.8.19        10 methods to implement (3 %)
        Note: Change the base class to TranslatorAdapter_1_8_19.

  TranslatorFrench                1.8.19        10 methods to implement (3 %)
        Note: Change the base class to TranslatorAdapter_1_8_19.
```

setting the used adapter correctly, so the version is correct (number of methods to implement remains unchanged)