### PR TITLE
Incorrect handling of escaped command start commands in markdown

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1488,6 +1488,9 @@ STopt  [^\n@\\]*
                                           yyextra->lineNr++;
                                           addOutput(yyscanner,'\n');
                                         }
+<LineParam>({CMD}{CMD}){ID}             { // escaped command
+                                          addOutput(yyscanner,yytext);
+                                        }
 <LineParam>.                            { // ignore other stuff
                                           addOutput(yyscanner,*yytext);
                                         }
@@ -1532,11 +1535,11 @@ STopt  [^\n@\\]*
                                           yyextra->sectionTitle+=yytext;
                                           addOutput(yyscanner,yytext);
                                         }
-<SectionTitle>({CMD}{CMD}){ID}          { // unescape escaped command
+<SectionTitle>({CMD}{CMD}){ID}          { // escaped command
                                           yyextra->sectionTitle+=&yytext[1];
                                           addOutput(yyscanner,yytext);
                                         }
-<SectionTitle>{CMD}[$@\\&~<>#%]         { // unescape escaped character
+<SectionTitle>{CMD}[$@\\&~<>#%]         { // unescaped character
                                           yyextra->sectionTitle+=yytext[1];
                                           addOutput(yyscanner,yytext);
                                         }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1735,6 +1735,13 @@ int Markdown::processSpecialCommand(const char *data, int offset, int size)
       TRACE_RESULT(2);
       return 2;
     }
+    else if (c=='\\' || c=='@')
+    {
+      m_out.addChar(data[0]);
+      m_out.addChar(data[1]);
+      TRACE_RESULT(2);
+      return 2;
+    }
     else if (c=='-' && size>3 && data[2]=='-' && data[3]=='-') // \---
     {
       m_out.addStr(&data[1],3);
@@ -1746,6 +1753,17 @@ int Markdown::processSpecialCommand(const char *data, int offset, int size)
       m_out.addStr(&data[1],2);
       TRACE_RESULT(3);
       return 3;
+    }
+  }
+  else if (size>1 && data[0]=='@') // escaped characters
+  {
+    char c=data[1];
+    if (c=='\\' || c=='@')
+    {
+      m_out.addChar(data[0]);
+      m_out.addChar(data[1]);
+      TRACE_RESULT(2);
+      return 2;
     }
   }
   TRACE_RESULT(0);


### PR DESCRIPTION
When having a simple file like:
```
\secreflist
\refitem cmdilinebr0 @@ilinebr
\refitem cmdilinebr1 \\ilinebr
\refitem cmdilinebr2 @\ilinebr
\refitem cmdilinebr3 \@ilinebr
\endsecreflist

as @@_ilinebr <br>
and \\_ilinebr <br>
as @\_ilinebr <br>
and \@_ilinebr <br>

\anchor cmdilinebr0
\anchor cmdilinebr1
\anchor cmdilinebr2
\anchor cmdilinebr3
```

- in the output \of `\\ilinebr` there is only `\` instead of `\ilinebr`
- for the `as` and `and` lines we get warnings:
```
.../aa.md:7: warning: Found unknown command '\_ilinebr'
.../aa.md:8: warning: Found unknown command '@_ilinebr'
```
due to the fact that in the markdown parser the starting `@` is not see as a potential escaped command (and also a wrong output for the second `as`).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9446920/example.tar.gz)

- Old output:
   ![image](https://user-images.githubusercontent.com/5223533/187267813-934fd066-a6ac-478f-8eb7-c941dcef970a.png)
- New output:
   ![image](https://user-images.githubusercontent.com/5223533/187267938-b2d3d2b6-2b42-414c-a03e-642768af5455.png)

