### PR TITLE
Extending internal documentation with some version information

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -111,7 +111,12 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = src \
+INPUT                  = \
+                         doc_internal/commands_history.md \
+                         doc_internal/commands_internal.md \
+                         doc_internal/releases.md \
+                         doc_internal/tags_history.md \
+                         src \
                          vhdlparser \
                          libxml
 INPUT_ENCODING         = UTF-8
@@ -161,7 +166,7 @@ HTML_FILE_EXTENSION    = .html
 HTML_HEADER            =
 HTML_FOOTER            =
 HTML_STYLESHEET        =
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = doc_internal/doc_internal.css
 HTML_EXTRA_FILES       =
 HTML_COLORSTYLE        = TOGGLE
 HTML_COLORSTYLE_HUE    = 220

--- a/doc_internal/commands_history.md
+++ b/doc_internal/commands_history.md
@@ -1,0 +1,206 @@
+\page pg_cmds Overview of introduction of special commands
+
+The following table gives an overview of the doxygen special commands and the version in which they were introduced.
+
+<dl class="multicol">
+<dt>New in 1.0.0</dt> <dd>\\\\</dd>
+<dt></dt>             <dd>\\#</dd>
+<dt></dt>             <dd>\\$</dd>
+<dt></dt>             <dd>\\&</dd>
+<dt></dt>             <dd>\\@@</dd>
+<dt></dt>             <dd>\\<</dd>
+<dt></dt>             <dd>\\></dd>
+<dt></dt>             <dd>\\a</dd>
+<dt></dt>             <dd>\\addindex</dd>
+<dt></dt>             <dd>\\anchor</dd>
+<dt></dt>             <dd>\\arg</dd>
+<dt></dt>             <dd>\\author</dd>
+<dt></dt>             <dd>\\b</dd>
+<dt></dt>             <dd>\\brief</dd>
+<dt></dt>             <dd>\\bug</dd>
+<dt></dt>             <dd>\\c</dd>
+<dt></dt>             <dd>\\class</dd>
+<dt></dt>             <dd>\\code</dd>
+<dt></dt>             <dd>\\date</dd>
+<dt></dt>             <dd>\\def</dd>
+<dt></dt>             <dd>\\defgroup</dd>
+<dt></dt>             <dd>\\deprecated</dd>
+<dt></dt>             <dd>\\dontinclude</dd>
+<dt></dt>             <dd>\\e</dd>
+<dt></dt>             <dd>\\endcode</dd>
+<dt></dt>             <dd>\\endhtmlonly</dd>
+<dt></dt>             <dd>\\endlatexonly</dd>
+<dt></dt>             <dd>\\endlink</dd>
+<dt></dt>             <dd>endverbatim</dd>
+<dt></dt>             <dd>\\enum</dd>
+<dt></dt>             <dd>\\example</dd>
+<dt></dt>             <dd>\\exception</dd>
+<dt></dt>             <dd>\\f$</dd>
+<dt></dt>             <dd>\\f[</dd>
+<dt></dt>             <dd>\\f]</dd>
+<dt></dt>             <dd>\\file</dd>
+<dt></dt>             <dd>\\fn</dd>
+<dt></dt>             <dd>\\htmlonly</dd>
+<dt></dt>             <dd>\\image</dd>
+<dt></dt>             <dd>\\include</dd>
+<dt></dt>             <dd>\\ingroup</dd>
+<dt></dt>             <dd>\\internal</dd>
+<dt></dt>             <dd>\\latexonly</dd>
+<dt></dt>             <dd>\\line</dd>
+<dt></dt>             <dd>\\link</dd>
+<dt></dt>             <dd>\\mainpage</dd>
+<dt></dt>             <dd>\\namespace</dd>
+<dt></dt>             <dd>\\overload</dd>
+<dt></dt>             <dd>\\page</dd>
+<dt></dt>             <dd>\\par</dd>
+<dt></dt>             <dd>\\param</dd>
+<dt></dt>             <dd>\\ref</dd>
+<dt></dt>             <dd>\\relates</dd>
+<dt></dt>             <dd>\\return</dd>
+<dt></dt>             <dd>\\retval</dd>
+<dt></dt>             <dd>\\sa</dd>
+<dt></dt>             <dd>\\section</dd>
+<dt></dt>             <dd>\\skip</dd>
+<dt></dt>             <dd>\\skipline</dd>
+<dt></dt>             <dd>\\struct</dd>
+<dt></dt>             <dd>\\subsection</dd>
+<dt></dt>             <dd>\\throw</dd>
+<dt></dt>             <dd>\\typedef</dd>
+<dt></dt>             <dd>\\union</dd>
+<dt></dt>             <dd>\\until</dd>
+<dt></dt>             <dd>\\var</dd>
+<dt></dt>             <dd>\\verbatim</dd>
+<dt></dt>             <dd>\\verbinclude</dd>
+<dt></dt>             <dd>\\version</dd>
+<dt></dt>             <dd>\\warning</dd>
+<dt>New in 1.1.0</dt><dd>\\invariant</dd>
+<dt></dt>             <dd>\\post</dd>
+<dt></dt>             <dd>\\pre</dd>
+<dt>New in 1.1.3</dt><dd>\\endif</dd>
+<dt></dt>             <dd>\\if</dd>
+<dt></dt>             <dd>\\name</dd>
+<dt>New in 1.1.4</dt><dd>\\hideinitializer</dd>
+<dt></dt>             <dd>\\nosubgrouping</dd>
+<dt></dt>             <dd>\\showinitializer</dd>
+<dt></dt>             <dd>\\todo</dd>
+<dt>New in 1.1.5</dt><dd>\\attention</dd>
+<dt></dt>             <dd>\\remarks</dd>
+<dt></dt>             <dd>\\since</dd>
+<dt>New in 1.2.0</dt><dd>\\em</dd>
+<dt></dt>             <dd>\\li</dd>
+<dt></dt>             <dd>\\note</dd>
+<dt></dt>             <dd>\\p</dd>
+<dt>New in 1.2.1</dt><dd>\\test</dd>
+<dt>New in 1.2.7</dt><dd>\\addtogroup</dd>
+<dt></dt>             <dd>\\htmlinclude</dd>
+<dt>New in 1.2.8</dt><dd>\\interface</dd>
+<dt></dt>             <dd>\\weakgroup</dd>
+<dt>New in 1.2.9.1</dt><dd>\\else</dd>
+<dt></dt>             <dd>\\elseif</dd>
+<dt></dt>             <dd>\\ifnot</dd>
+<dt>New in 1.2.10</dt><dd>\\dotfile</dd>
+<dt></dt>             <dd>\\package</dd>
+<dt>New in 1.2.14</dt><dd>\\~</dd>
+<dt>New in 1.2.17</dt><dd>\\copydoc</dd>
+<dt>New in 1.2.18</dt><dd>\\n</dd>
+<dt></dt>             <dd>\\subsubsection</dd>
+<dt>New in 1.3.1</dt><dd>\\xrefitem</dd>
+<dt>New in 1.3.2</dt><dd>\\callgraph</dd>
+<dt></dt>             <dd>\\endxmlonly</dd>
+<dt></dt>             <dd>\\xmlonly</dd>
+<dt>New in 1.3.4</dt><dd>\\dot</dd>
+<dt></dt>             <dd>\\enddot</dd>
+<dt></dt>             <dd>\\relatesalso</dd>
+<dt>New in 1.3.7</dt><dd>\\%</dd>
+<dt></dt>             <dd>\\endmanonly</dd>
+<dt></dt>             <dd>\\includelineno</dd>
+<dt></dt>             <dd>\\manonly</dd>
+<dt></dt>             <dd>\\property</dd>
+<dt>New in 1.3.8</dt><dd>\\category</dd>
+<dt></dt>             <dd>\\paragraph</dd>
+<dt></dt>             <dd>\\private</dd>
+<dt></dt>             <dd>\\privatesection</dd>
+<dt></dt>             <dd>\\protected</dd>
+<dt></dt>             <dd>\\protectedsection</dd>
+<dt></dt>             <dd>\\protocol</dd>
+<dt></dt>             <dd>\\public</dd>
+<dt></dt>             <dd>\\publicsection</dd>
+<dt>New in 1.3.9</dt><dd>\\dir</dd>
+<dt>New in 1.4.0</dt><dd>\\cond</dd>
+<dt></dt>             <dd>\\endcond</dd>
+<dt></dt>             <dd>\\see</dd>
+<dt>New in 1.4.2</dt><dd>\\subpage</dd>
+<dt>New in 1.4.7</dt><dd>\\callergraph</dd>
+<dt>New in 1.5.2</dt><dd>\\endmsc</dd>
+<dt></dt>             <dd>\\msc</dd>
+<dt>New in 1.5.3</dt><dd>\\details</dd>
+<dt>New in 1.5.4</dt><dd>\\f{</dd>
+<dt></dt>             <dd>\\f}</dd>
+<dt>New in 1.5.5</dt><dd>\\headerfile</dd>
+<dt>New in 1.5.6</dt><dd>\\copybrief</dd>
+<dt></dt>             <dd>\\copydetails</dd>
+<dt></dt>             <dd>\\tparam</dd>
+<dt>New in 1.5.7</dt><dd>\\extends</dd>
+<dt></dt>             <dd>\\implements</dd>
+<dt></dt>             <dd>\\memberof</dd>
+<dt>New in 1.6.2</dt><dd>\\"</dd>
+<dt>New in 1.7.2</dt><dd>\\authors</dd>
+<dt></dt>             <dd>\\endinternal</dd>
+<dt></dt>             <dd>\\endrtfonly</dd>
+<dt></dt>             <dd>\\mscfile</dd>
+<dt></dt>             <dd>\\related</dd>
+<dt></dt>             <dd>\\relatedalso</dd>
+<dt></dt>             <dd>\\remark</dd>
+<dt></dt>             <dd>\\returns</dd>
+<dt></dt>             <dd>\\rtfonly</dd>
+<dt></dt>             <dd>\\short</dd>
+<dt></dt>             <dd>\\throws</dd>
+<dt>New in 1.7.3</dt><dd>\\::</dd>
+<dt></dt>             <dd>\\result</dd>
+<dt>New in 1.7.5</dt><dd>\\cite</dd>
+<dt></dt>             <dd>\\copyright</dd>
+<dt></dt>             <dd>\\snippet</dd>
+<dt>New in 1.8.0</dt><dd>\\.</dd>
+<dt></dt>             <dd>\\tableofcontents</dd>
+<dt>New in 1.8.3</dt><dd>\\vhdlflow</dd>
+<dt>New in 1.8.4</dt><dd>\\|</dd>
+<dt></dt>             <dd>\\docbookonly</dd>
+<dt></dt>             <dd>\\enddocbookonly</dd>
+<dt></dt>             <dd>\\endsecreflist</dd>
+<dt></dt>             <dd>\\idlexcept</dd>
+<dt></dt>             <dd>\\pure</dd>
+<dt></dt>             <dd>\\refitem</dd>
+<dt></dt>             <dd>\\secreflist</dd>
+<dt>New in 1.8.6</dt><dd>\\diafile</dd>
+<dt></dt>             <dd>\\endparblock</dd>
+<dt></dt>             <dd>\\parblock</dd>
+<dt>New in 1.8.7</dt><dd>\\\\--</dd>
+<dt></dt>             <dd>\\\\---</dd>
+<dt></dt>             <dd>\\latexinclude</dd>
+<dt>New in 1.8.8</dt><dd>\\enduml</dd>
+<dt></dt>             <dd>\\startuml</dd>
+<dt>New in 1.8.10</dt><dd>\\hidecallergraph</dd>
+<dt></dt>             <dd>\\hidecallgraph</dd>
+<dt>New in 1.8.12</dt><dd>\\includedoc</dd>
+<dt></dt>             <dd>\\snippetdoc</dd>
+<dt></dt>             <dd>\\snippetlineno</dd>
+<dt>New in 1.8.15</dt><dd>\\=</dd>
+<dt></dt>             <dd>\\emoji</dd>
+<dt></dt>             <dd>\\hiderefby</dd>
+<dt></dt>             <dd>\\hiderefs</dd>
+<dt></dt>             <dd>\\showrefby</dd>
+<dt></dt>             <dd>\\showrefs</dd>
+<dt>New in 1.8.18</dt><dd>\\docbookinclude</dd>
+<dt></dt>             <dd>\\maninclude</dd>
+<dt></dt>             <dd>\\rtfinclude</dd>
+<dt></dt>             <dd>\\xmlinclude</dd>
+<dt>New in 1.9.0</dt><dd>\\noop</dd>
+<dt></dt>             <dd>\\static</dd>
+<dt>New in 1.9.2</dt><dd>\\concept</dd>
+<dt></dt>             <dd>\\f(</dd>
+<dt></dt>             <dd>\\f)</dd>
+<dt>New in 1.9.3</dt><dd>\\raisewarning</dd>
+<dt>New in 1.9.5</dt><dd>\\fileinfo</dd>
+<dt></dt>             <dd>\\lineinfo</dd>
+<dt></dt>             <dd>\\showdate</dd>
+</dl>

--- a/doc_internal/commands_internal.md
+++ b/doc_internal/commands_internal.md
@@ -1,0 +1,117 @@
+\page pg_cmds_int Overview of introduction of internal special commands
+
+The following table gives an overview of the doxygen internal special commands
+and the version in which they were introduced.
+
+\secreflist
+\refitem cmdendicode \\endicode
+\refitem cmdendiliteral \\endiliteral
+\refitem cmdendiverbatim \\endiverbatim
+\refitem cmdicode \\icode
+\refitem cmdifile \\ifile
+\refitem cmdiline \\iline
+\refitem cmdilinebr \\ilinebr
+\refitem cmdiliteral \\iliteral
+\refitem cmdiverbatim \\iverbatim
+\endsecreflist
+
+<hr>
+\section cmdilinebr \\ilinebr
+
+  \addindex \\ilinebr
+  Internal doxygen command to simulate an end of line, but without advancing the
+  line counter. In this way it is possible to have multiple commands on one line
+  that read till the end of line.
+  This command is internally used by doxygen and for replacement of the `^^` in
+  `ALIASES` settings.
+  This command sees to it that e.g. warning messages stay correct when a command
+  is replaced internally by multiple commands.
+
+  Temporarily also as `@_ilinebr` (doxygen version 1.8.14) and `\_ilinebr`
+  (doxygen version 1.8.15 till 1.8.18)
+
+\since doxygen version 1.8.19
+
+<hr>
+\section cmdifile \\ifile <filename>
+  \addindex \\ifile
+
+  Internal doxygen command to reset the current filename in a documentation block
+  so that doxygen can give a better warning about the original source of a problem
+  when a documentation block is constructed from multiple files.
+
+\since doxygen version 1.9.5
+
+<hr>
+\section cmdiline \\iline <linenr>
+  \addindex \\iline
+
+  Internal doxygen command to reset the current line counter in a documentation block
+  so that doxygen can give a better warning about the original source of a problem when
+  a documentation block is constructed from multiple files or blocks from one file.
+
+\since doxygen version 1.9.2
+
+<hr>
+\section cmdicode \\icode['{'<word>'}']
+
+  \addindex \\icode
+  This command has a similar syntax and function as the command `\code`, but is internally used
+  for markdown fenced code blocks (i.e. <code>\`\`\`</code> and `~~~` type of blocks)
+  to replace these markers.
+  The `\code` command cannot be used as in that case the block cannot contain
+  a `\endcode` as this would terminate the `\code` block.
+
+\since doxygen version 1.9.5
+
+<hr>
+\section cmdendicode \\endicode
+
+  \addindex \\endicode
+  Ends a block of text that was started with a \ref cmdicode "\\icode" command.
+
+\since doxygen version 1.9.5
+
+<hr>
+\section cmdiliteral \\iliteral['{'<option>'}']
+  \addindex \\iliteral
+
+  This command is to replace the Java documentation commands `{@literal .... }` and
+  `{@code ...}`. 
+  The text in the blocks will not be interpreted by doxygen in any way.
+  The text in the `{@literal` will put as is text in the output.
+  The text in the `{@code` will be replaced by a code block with class `JavaDocCode`
+  i.e. `<code class="JavaDocCode">...</code>`.
+
+\since doxygen version 1.9.3
+
+<hr>
+\section cmdendiliteral \\endiliteral
+
+  \addindex \\endiliteral
+  Ends a block of text that was started with a \ref cmdiliteral "\\iliteral" command.
+
+\since doxygen version 1.9.3
+
+<hr>
+\section cmdiverbatim \\iverbatim
+
+  \addindex \\iverbatim
+  This command has a similar function as the command `\verbatim`, but is internally used
+  for markdown code blocks (i.e. blocks of text indented with at least 4 extra spaces compared to
+  the previous block) and python unformatted docstrings (i.e. <code>'''</code> type of blocks)
+  to replace these markers.
+  The `\verbatim` command cannot be used as in that case the block cannot contain
+  a `\endverbatim` as this would terminate the `\verbatim` block.
+
+\since doxygen version 1.9.5
+
+<hr>
+\section cmdendiverbatim \\endiverbatim
+
+  \addindex \\endiverbatim
+  Ends a block of text that was started with a \ref cmdiverbatim "\\iverbatim" command.
+
+\since doxygen version 1.9.5
+
+<hr>

--- a/doc_internal/doc_internal.css
+++ b/doc_internal/doc_internal.css
@@ -1,0 +1,12 @@
+ul.multicol, dl.multicol {
+        -moz-column-gap: 1em;
+        -webkit-column-gap: 1em;
+        column-gap: 1em;
+        -moz-column-count: 3;
+        -webkit-column-count: 3;
+        column-count: 3;
+        list-style-type: none;
+}
+ul.multicol {
+        font-family: courier;
+}

--- a/doc_internal/releases.md
+++ b/doc_internal/releases.md
@@ -1,0 +1,119 @@
+\page pg_rel Overview of doxygen release dates
+
+The following table gives an overview of the doxygen releases with together with the release dates.
+<ul class="multicol">
+<li><b>Release 1.9.5</b>&nbsp;&nbsp;&nbsp; 26-08-2022</li>
+<li><b>Release 1.9.4</b>&nbsp;&nbsp;&nbsp; 05-05-2022</li>
+<li><b>Release 1.9.3</b>&nbsp;&nbsp;&nbsp; 03-01-2022</li>
+<li><b>Release 1.9.3</b>&nbsp;&nbsp;&nbsp; 31-12-2021</li>
+<li><b>Release 1.9.2</b>&nbsp;&nbsp;&nbsp; 18-08-2021</li>
+<li><b>Release 1.9.1</b>&nbsp;&nbsp;&nbsp; 08-01-2021</li>
+<li><b>Release 1.9.0</b>&nbsp;&nbsp;&nbsp; 27-12-2020</li>
+<li><hr></li>
+<li><b>Release 1.8.20</b>&nbsp;&nbsp; 24-08-2020</li>
+<li><b>Release 1.8.19</b>&nbsp;&nbsp; 08-08-2020</li>
+<li><b>Release 1.8.18</b>&nbsp;&nbsp; 12-04-2020</li>
+<li><b>Release 1.8.17</b>&nbsp;&nbsp; 27-12-2019</li>
+<li><b>Release 1.8.16</b>&nbsp;&nbsp; 08-08-2019</li>
+<li><b>Release 1.8.15</b>&nbsp;&nbsp; 27-12-2018</li>
+<li><b>Release 1.8.14</b>&nbsp;&nbsp; 25-12-2017</li>
+<li><b>Release 1.8.13</b>&nbsp;&nbsp; 29-12-2016</li>
+<li><b>Release 1.8.12</b>&nbsp;&nbsp; 05-09-2016</li>
+<li><b>Release 1.8.11</b>&nbsp;&nbsp; 30-12-2015</li>
+<li><b>Release 1.8.10</b>&nbsp;&nbsp; 27-06-2015</li>
+<li><b>Release 1.8.9.1</b>&nbsp; 04-01-2015</li>
+<li><b>Release 1.8.9</b>&nbsp;&nbsp;&nbsp; 25-12-2014</li>
+<li><b>Release 1.8.8</b>&nbsp;&nbsp;&nbsp; 21-08-2014</li>
+<li><b>Release 1.8.7</b>&nbsp;&nbsp;&nbsp; 21-04-2014</li>
+<li><b>Release 1.8.6</b>&nbsp;&nbsp;&nbsp; 24-12-2013</li>
+<li><b>Release 1.8.5</b>&nbsp;&nbsp;&nbsp; 23-08-2013</li>
+<li><b>Release 1.8.4</b>&nbsp;&nbsp;&nbsp; 19-05-2013</li>
+<li><b>Release 1.8.3.1</b>&nbsp; 20-01-2013</li>
+<li><b>Release 1.8.3</b>&nbsp;&nbsp;&nbsp; 26-12-2012</li>
+<li><b>Release 1.8.2</b>&nbsp;&nbsp;&nbsp; 11-08-2012</li>
+<li><b>Release 1.8.1.2</b>&nbsp; 12-07-2012</li>
+<li><b>Release 1.8.1.1</b>&nbsp; 10-06-2012</li>
+<li><b>Release 1.8.1</b>&nbsp;&nbsp;&nbsp; 19-05-2012</li>
+<li><b>Release 1.8.0</b>&nbsp;&nbsp;&nbsp; 25-02-2012</li>
+<li><hr></li>
+<li><b>Release 1.7.6.1</b>&nbsp; 10-12-2011</li>
+<li><b>Release 1.7.6</b>&nbsp;&nbsp;&nbsp; 03-12-2011</li>
+<li><b>Release 1.7.5.1</b>&nbsp; 21-08-2011</li>
+<li><b>Release 1.7.5</b>&nbsp;&nbsp;&nbsp; 14-08-2011</li>
+<li><b>Release 1.7.4</b>&nbsp;&nbsp;&nbsp; 28-03-2011</li>
+<li><b>Release 1.7.3</b>&nbsp;&nbsp;&nbsp; 03-01-2011</li>
+<li><b>Release 1.7.2</b>&nbsp;&nbsp;&nbsp; 09-10-2010</li>
+<li><b>Release 1.7.1</b>&nbsp;&nbsp;&nbsp; 25-06-2010</li>
+<li><b>Release 1.7.0</b>&nbsp;&nbsp;&nbsp; 15-06-2010</li>
+<li><hr></li>
+<li><b>Release 1.6.3</b>&nbsp;&nbsp;&nbsp; 21-02-2010</li>
+<li><b>Release 1.6.2</b>&nbsp;&nbsp;&nbsp; 30-12-2009</li>
+<li><b>Release 1.6.1</b>&nbsp;&nbsp;&nbsp; 25-08-2009</li>
+<li><b>Release 1.6.0</b>&nbsp;&nbsp;&nbsp; 20-08-2009</li>
+<li><hr></li>
+<li><b>Release 1.5.9</b>&nbsp;&nbsp;&nbsp; 30-04-2009</li>
+<li><b>Release 1.5.8</b>&nbsp;&nbsp;&nbsp; 27-12-2008</li>
+<li><b>Release 1.5.7.1</b>&nbsp; 05-10-2008</li>
+<li><b>Release 1.5.7</b>&nbsp;&nbsp;&nbsp; 28-09-2008</li>
+<li><b>Release 1.5.6</b>&nbsp;&nbsp;&nbsp; 18-05-2008</li>
+<li><b>Release 1.5.5</b>&nbsp;&nbsp;&nbsp; 10-02-2008</li>
+<li><b>Release 1.5.4</b>&nbsp;&nbsp;&nbsp; 27-10-2007</li>
+<li><b>Release 1.5.3</b>&nbsp;&nbsp;&nbsp; 27-07-2007</li>
+<li><b>Release 1.5.2</b>&nbsp;&nbsp;&nbsp; 04-04-2007</li>
+<li><b>Release 1.5.1</b>&nbsp;&nbsp;&nbsp; 29-10-2006</li>
+<li><b>Release 1.5.0</b>&nbsp;&nbsp;&nbsp; 16-10-2006</li>
+<li><hr></li>
+<li><b>Release 1.4.7</b>&nbsp;&nbsp;&nbsp; 11-06-2006</li>
+<li><b>Release 1.4.6</b>&nbsp;&nbsp;&nbsp; 30-12-2005</li>
+<li><b>Release 1.4.5</b>&nbsp;&nbsp;&nbsp; 04-10-2005</li>
+<li><b>Release 1.4.4</b>&nbsp;&nbsp;&nbsp; 21-07-2005</li>
+<li><b>Release 1.4.3</b>&nbsp;&nbsp;&nbsp; 16-05-2005</li>
+<li><b>Release 1.4.2</b>&nbsp;&nbsp;&nbsp; 28-03-2005</li>
+<li><b>Release 1.4.1</b>&nbsp;&nbsp;&nbsp; 11-01-2005</li>
+<li><b>Release 1.4.0</b>&nbsp;&nbsp;&nbsp; 31-12-2004</li>
+<li><hr></li>
+<li><b>Release 1.3.9.1</b>&nbsp; 10-10-2004</li>
+<li><b>Release 1.3.9</b>&nbsp;&nbsp;&nbsp; 05-10-2004</li>
+<li><b>Release 1.3.8</b>&nbsp;&nbsp;&nbsp; 25-07-2004</li>
+<li><b>Release 1.3.7</b>&nbsp;&nbsp;&nbsp; 07-05-2004</li>
+<li><b>Release 1.3.6</b>&nbsp;&nbsp;&nbsp; 12-02-2004</li>
+<li><b>Release 1.3.5</b>&nbsp;&nbsp;&nbsp; 21-11-2003</li>
+<li><b>Release 1.3.4</b>&nbsp;&nbsp;&nbsp; 22-09-2003</li>
+<li><b>Release 1.3.3</b>&nbsp;&nbsp;&nbsp; 25-07-2003</li>
+<li><b>Release 1.3.2</b>&nbsp;&nbsp;&nbsp; 15-06-2003</li>
+<li><b>Release 1.3.1</b>&nbsp;&nbsp;&nbsp; 28-05-2003</li>
+<li><b>Release 1.3</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12-04-2003</li>
+<li><hr></li>
+<li><b>Release 1.2.18</b>&nbsp;&nbsp; 18-09-2002</li>
+<li><b>Release 1.2.17</b>&nbsp;&nbsp; 15-07-2002</li>
+<li><b>Release 1.2.16</b>&nbsp;&nbsp; 20-05-2002</li>
+<li><b>Release 1.2.15</b>&nbsp;&nbsp; 01-04-2002</li>
+<li><b>Release 1.2.14</b>&nbsp;&nbsp; 18-02-2002</li>
+<li><b>Release 1.2.13.1</b> 05-01-2002</li>
+<li><b>Release 1.2.13</b>&nbsp;&nbsp; 29-12-2001</li>
+<li><b>Release 1.2.12</b>&nbsp;&nbsp; 18-11-2001</li>
+<li><b>Release 1.2.11.1</b> 07-10-2001</li>
+<li><b>Release 1.2.11</b>&nbsp;&nbsp; 30-09-2001</li>
+<li><b>Release 1.2.10</b>&nbsp;&nbsp; 26-08-2001</li>
+<li><b>Release 1.2.9.1</b>&nbsp; 05-08-2001</li>
+<li><b>Release 1.2.9</b>&nbsp;&nbsp;&nbsp; 01-08-2001</li>
+<li><b>Release 1.2.8.1</b>&nbsp; 10-06-2001</li>
+<li><b>Release 1.2.8</b>&nbsp;&nbsp;&nbsp; 04-06-2001</li>
+<li><b>Release 1.2.7</b>&nbsp;&nbsp;&nbsp; 30-04-2001</li>
+<li><b>Release 1.2.6</b>&nbsp;&nbsp;&nbsp; 11-03-2001</li>
+<li><b>Release 1.2.5</b>&nbsp;&nbsp;&nbsp; 04-02-2001</li>
+<li><b>Release 1.2.4</b>&nbsp;&nbsp;&nbsp; 24-12-2000</li>
+<li><b>Release 1.2.3</b>&nbsp;&nbsp;&nbsp; 30-10-2000</li>
+<li><b>Release 1.2.2</b>&nbsp;&nbsp;&nbsp; 24-09-2000</li>
+<li><b>Release 1.2.1</b>&nbsp;&nbsp;&nbsp; 13-08-2000</li>
+<li><b>Release 1.2.0</b>&nbsp;&nbsp;&nbsp; 23-07-2000</li>
+<li><hr></li>
+<li><b>Release 1.1.5</b>&nbsp;&nbsp;&nbsp; 03-07-2000</li>
+<li><b>Release 1.1.4</b>&nbsp;&nbsp;&nbsp; 04-06-2000</li>
+<li><b>Release 1.1.3</b>&nbsp;&nbsp;&nbsp; 08-05-2000</li>
+<li><b>Release 1.1.2</b>&nbsp;&nbsp;&nbsp; 09-04-2000</li>
+<li><b>Release 1.1.1</b>&nbsp;&nbsp;&nbsp; 12-03-2000</li>
+<li><b>Release 1.1.0</b>&nbsp;&nbsp;&nbsp; 15-02-2000</li>
+<li><b>Release 1.0.0</b>&nbsp;&nbsp;&nbsp; 08-02-2000</li>
+</ul>
+<hr>

--- a/doc_internal/tags_history.md
+++ b/doc_internal/tags_history.md
@@ -1,0 +1,492 @@
+\page pg_tags Overview of introduction of doxygen configuration settings
+
+The following table gives an overview of the doxygen configuration settings and the version in which they were introduced or became obsolete.
+
+<dl class="multicol">
+<dt>New in 1.0.0</dt>
+<dt></dt>              <dd>ALLEXTERNALS</dd>
+<dt></dt>              <dd>ALPHABETICAL_INDEX</dd>
+<dt></dt>              <dd>ALWAYS_DETAILED_SEC</dd>
+<dt></dt>              <dd>BIN_ABSPATH</dd>
+<dt></dt>              <dd>BRIEF_MEMBER_DESC</dd>
+<dt></dt>              <dd>CASE_SENSE_NAMES</dd>
+<dt></dt>              <dd>CGI_NAME</dd>
+<dt></dt>              <dd>CGI_URL</dd>
+<dt></dt>              <dd>CLASS_DIAGRAMS</dd>
+<dt></dt>              <dd>COLS_IN_ALPHA_INDEX</dd>
+<dt></dt>              <dd>COMPACT_LATEX</dd>
+<dt></dt>              <dd>DISABLE_INDEX</dd>
+<dt></dt>              <dd>DOC_ABSPATH</dd>
+<dt></dt>              <dd>DOC_URL</dd>
+<dt></dt>              <dd>ENABLE_PREPROCESSING</dd>
+<dt></dt>              <dd>EXAMPLE_PATH</dd>
+<dt></dt>              <dd>EXAMPLE_PATTERNS</dd>
+<dt></dt>              <dd>EXCLUDE</dd>
+<dt></dt>              <dd>EXCLUDE_PATTERNS</dd>
+<dt></dt>              <dd>EXPAND_ONLY_PREDEF</dd>
+<dt></dt>              <dd>EXT_DOC_PATHS</dd>
+<dt></dt>              <dd>EXTRA_PACKAGES</dd>
+<dt></dt>              <dd>EXTRACT_ALL</dd>
+<dt></dt>              <dd>EXTRACT_PRIVATE</dd>
+<dt></dt>              <dd>FILE_PATTERNS</dd>
+<dt></dt>              <dd>FULL_PATH_NAMES</dd>
+<dt></dt>              <dd>GENERATE_HTML</dd>
+<dt></dt>              <dd>GENERATE_HTMLHELP</dd>
+<dt></dt>              <dd>GENERATE_LATEX</dd>
+<dt></dt>              <dd>GENERATE_MAN</dd>
+<dt></dt>              <dd>GENERATE_TAGFILE</dd>
+<dt></dt>              <dd>HIDE_UNDOC_CLASSES</dd>
+<dt></dt>              <dd>HIDE_UNDOC_MEMBERS</dd>
+<dt></dt>              <dd>HTML_ALIGN_MEMBERS</dd>
+<dt></dt>              <dd>HTML_FOOTER</dd>
+<dt></dt>              <dd>HTML_HEADER</dd>
+<dt></dt>              <dd>HTML_OUTPUT</dd>
+<dt></dt>              <dd>HTML_STYLESHEET</dd>
+<dt></dt>              <dd>IMAGE_PATH</dd>
+<dt></dt>              <dd>IMAGE_PATTERNS</dd>
+<dt></dt>              <dd>INCLUDE_PATH</dd>
+<dt></dt>              <dd>INHERIT_DOCS</dd>
+<dt></dt>              <dd>INLINE_INFO</dd>
+<dt></dt>              <dd>INLINE_SOURCES</dd>
+<dt></dt>              <dd>INPUT</dd>
+<dt></dt>              <dd>INPUT_FILTER</dd>
+<dt></dt>              <dd>INTERNAL_DOCS</dd>
+<dt></dt>              <dd>JAVADOC_AUTOBRIEF</dd>
+<dt></dt>              <dd>LATEX_HEADER</dd>
+<dt></dt>              <dd>LATEX_OUTPUT</dd>
+<dt></dt>              <dd>MACRO_EXPANSION</dd>
+<dt></dt>              <dd>MAN_EXTENSION</dd>
+<dt></dt>              <dd>MAN_OUTPUT</dd>
+<dt></dt>              <dd>OUTPUT_DIRECTORY</dd>
+<dt></dt>              <dd>OUTPUT_LANGUAGE</dd>
+<dt></dt>              <dd>PAPER_TYPE</dd>
+<dt></dt>              <dd>PDF_HYPERLINKS</dd>
+<dt></dt>              <dd>PERL_PATH</dd>
+<dt></dt>              <dd>PREDEFINED</dd>
+<dt></dt>              <dd>PROJECT_NAME</dd>
+<dt></dt>              <dd>PROJECT_NUMBER</dd>
+<dt></dt>              <dd>QUIET</dd>
+<dt></dt>              <dd>RECURSIVE</dd>
+<dt></dt>              <dd>REPEAT_BRIEF</dd>
+<dt></dt>              <dd>SEARCH_INCLUDES</dd>
+<dt></dt>              <dd>SEARCHENGINE</dd>
+<dt></dt>              <dd>SOURCE_BROWSER</dd>
+<dt></dt>              <dd>STRIP_FROM_PATH</dd>
+<dt></dt>              <dd>TAB_SIZE</dd>
+<dt></dt>              <dd>TAGFILES</dd>
+<dt></dt>              <dd>VERBATIM_HEADERS</dd>
+<dt></dt>              <dd>WARNINGS</dd>
+<dt>New in 1.1.0</dt>
+<dt></dt>              <dd>COLLABORATION_GRAPH</dd>
+<dt></dt>              <dd>COMPACT_RTF</dd>
+<dt></dt>              <dd>GENERATE_RTF</dd>
+<dt></dt>              <dd>GRAPHICAL_HIERARCHY</dd>
+<dt></dt>              <dd>HAVE_DOT</dd>
+<dt></dt>              <dd>IGNORE_PREFIX</dd>
+<dt></dt>              <dd>INCLUDE_GRAPH</dd>
+<dt></dt>              <dd>RTF_HYPERLINKS</dd>
+<dt></dt>              <dd>RTF_OUTPUT</dd>
+<dt>New in 1.1.1</dt>
+<dt></dt>              <dd>SHOW_INCLUDE_FILES</dd>
+<dt></dt>              <dd>SORT_MEMBER_DOCS</dd>
+<dt></dt>              <dd>STRIP_CODE_COMMENTS</dd>
+<dt>New in 1.1.2</dt>
+<dt></dt>              <dd>ENABLED_SECTIONS</dd>
+<dt></dt>              <dd>LATEX_BATCHMODE</dd>
+<dt>New in 1.1.3</dt>
+<dt></dt>              <dd>CLASS_GRAPH</dd>
+<dt>Obsolete in 1.1.3</dt>
+<dt></dt>              <dd>IMAGE_PATTERNS</dd>
+<dt>New in 1.1.4</dt>
+<dt></dt>              <dd>DOT_PATH</dd>
+<dt></dt>              <dd>WARN_FORMAT</dd>
+<dt></dt>              <dd>WARN_IF_UNDOCUMENTED</dd>
+<dt>New in 1.1.5</dt>
+<dt></dt>              <dd>EXPAND_AS_DEFINED</dd>
+<dt></dt>              <dd>EXTRACT_STATIC</dd>
+<dt></dt>              <dd>HIDE_SCOPE_NAMES</dd>
+<dt></dt>              <dd>INCLUDED_BY_GRAPH</dd>
+<dt></dt>              <dd>MAX_DOT_GRAPH_HEIGHT</dd>
+<dt></dt>              <dd>MAX_DOT_GRAPH_WIDTH</dd>
+<dt></dt>              <dd>RTF_STYLESHEET_FILE</dd>
+<dt>New in 1.2.0</dt>
+<dt></dt>              <dd>INCLUDE_FILE_PATTERNS</dd>
+<dt>New in 1.2.1</dt>
+<dt></dt>              <dd>GENERATE_TESTLIST</dd>
+<dt></dt>              <dd>GENERATE_TODOLIST</dd>
+<dt></dt>              <dd>GENERATE_XML</dd>
+<dt></dt>              <dd>USE_PDFLATEX</dd>
+<dt>New in 1.2.2</dt>
+<dt></dt>              <dd>ALIASES</dd>
+<dt></dt>              <dd>DISTRIBUTE_GROUP_DOC</dd>
+<dt>New in 1.2.3</dt>
+<dt></dt>              <dd>ENUM_VALUES_PER_LINE</dd>
+<dt></dt>              <dd>FILTER_SOURCE_FILES</dd>
+<dt></dt>              <dd>GENERATE_LEGEND</dd>
+<dt></dt>              <dd>WARN_LOGFILE</dd>
+<dt>New in 1.2.4</dt>
+<dt></dt>              <dd>GENERATE_TREEVIEW</dd>
+<dt></dt>              <dd>TREEVIEW_WIDTH</dd>
+<dt>New in 1.2.5</dt>
+<dt></dt>              <dd>MAX_INITIALIZER_LINES</dd>
+<dt></dt>              <dd>OPTIMIZE_OUTPUT_FOR_C</dd>
+<dt>Obsolete in 1.2.5</dt>
+<dt></dt>              <dd>GENERATE_XML</dd>
+<dt>New in 1.2.6</dt>
+<dt></dt>              <dd>BINARY_TOC</dd>
+<dt></dt>              <dd>DOT_CLEANUP</dd>
+<dt></dt>              <dd>GENERATE_BUGLIST</dd>
+<dt></dt>              <dd>GENERATE_CHI</dd>
+<dt></dt>              <dd>SHOW_USED_FILES</dd>
+<dt></dt>              <dd>TOC_EXPAND</dd>
+<dt>New in 1.2.7</dt>
+<dt></dt>              <dd>RTF_EXTENSIONS_FILE</dd>
+<dt></dt>              <dd>SHORT_NAMES</dd>
+<dt>New in 1.2.8</dt>
+<dt></dt>              <dd>MAN_LINKS</dd>
+<dt>New in 1.2.9</dt>
+<dt></dt>              <dd>GENERATE_XML</dd>
+<dt>New in 1.2.10</dt>
+<dt></dt>              <dd>DOTFILE_DIRS</dd>
+<dt></dt>              <dd>TEMPLATE_RELATIONS</dd>
+<dt>New in 1.2.11</dt>
+<dt></dt>              <dd>SKIP_FUNCTION_MACROS</dd>
+<dt>New in 1.2.12</dt>
+<dt></dt>              <dd>EXAMPLE_RECURSIVE</dd>
+<dt></dt>              <dd>HIDE_UNDOC_RELATIONS</dd>
+<dt></dt>              <dd>REFERENCED_BY_RELATION</dd>
+<dt></dt>              <dd>REFERENCES_RELATION</dd>
+<dt>New in 1.2.13</dt>
+<dt></dt>              <dd></dd>
+<dt></dt>              <dd>EXTRACT_LOCAL_CLASSES</dd>
+<dt></dt>              <dd>GENERATE_AUTOGEN_DEF</dd>
+<dt></dt>              <dd>INLINE_INHERITED_MEMB</dd>
+<dt>New in 1.2.14</dt>
+<dt></dt>              <dd>DOT_IMAGE_FORMAT</dd>
+<dt></dt>              <dd>EXCLUDE_SYMLINKS</dd>
+<dt></dt>              <dd>EXTERNAL_GROUPS</dd>
+<dt></dt>              <dd>HTML_FILE_EXTENSION</dd>
+<dt>New in 1.2.15</dt>
+<dt></dt>              <dd>LATEX_CMD_NAME</dd>
+<dt></dt>              <dd>MAKEINDEX_CMD_NAME</dd>
+<dt></dt>              <dd>OPTIMIZE_OUTPUT_JAVA</dd>
+<dt>New in 1.2.16</dt>
+<dt></dt>              <dd>DETAILS_AT_TOP</dd>
+<dt>New in 1.2.17</dt>
+<dt></dt>              <dd>CHM_FILE</dd>
+<dt></dt>              <dd>HHC_LOCATION</dd>
+<dt></dt>              <dd>MULTILINE_CPP_IS_BRIEF</dd>
+<dt>New in 1.2.18</dt>
+<dt></dt>              <dd>GENERATE_DEPRECATEDLIST</dd>
+<dt></dt>              <dd>HIDE_FRIEND_COMPOUNDS</dd>
+<dt></dt>              <dd>XML_DTD</dd>
+<dt></dt>              <dd>XML_SCHEMA</dd>
+<dt>New in 1.3</dt>
+<dt></dt>              <dd>GENERATE_PERLMOD</dd>
+<dt></dt>              <dd>HIDE_IN_BODY_DOCS</dd>
+<dt></dt>              <dd>LATEX_HIDE_INDICES</dd>
+<dt></dt>              <dd>MAX_DOT_GRAPH_DEPTH</dd>
+<dt></dt>              <dd>PERLMOD_LATEX</dd>
+<dt></dt>              <dd>PERLMOD_MAKEVAR_PREFIX</dd>
+<dt></dt>              <dd>PERLMOD_PRETTY</dd>
+<dt></dt>              <dd>USE_WINDOWS_ENCODING</dd>
+<dt></dt>              <dd>WARN_IF_DOC_ERROR</dd>
+<dt>New in 1.3.1</dt>
+<dt></dt>              <dd>XML_OUTPUT</dd>
+<dt>New in 1.3.2</dt>
+<dt></dt>              <dd>CALL_GRAPH</dd>
+<dt></dt>              <dd>UML_LOOK</dd>
+<dt>New in 1.3.3</dt>
+<dt></dt>              <dd>SUBGROUPING</dd>
+<dt>Obsolete in 1.3.4</dt>
+<dt></dt>              <dd>BIN_ABSPATH</dd>
+<dt></dt>              <dd>CGI_NAME</dd>
+<dt></dt>              <dd>CGI_URL</dd>
+<dt></dt>              <dd>DOC_ABSPATH</dd>
+<dt></dt>              <dd>DOC_URL</dd>
+<dt></dt>              <dd>EXT_DOC_PATHS</dd>
+<dt>New in 1.3.5</dt>
+<dt></dt>              <dd>ABBREVIATE_BRIEF</dd>
+<dt></dt>              <dd>XML_PROGRAMLISTING</dd>
+<dt>New in 1.3.6</dt>
+<dt></dt>              <dd>SORT_BRIEF_DOCS</dd>
+<dt></dt>              <dd>SORT_BY_SCOPE_NAME</dd>
+<dt>New in 1.3.7</dt>
+<dt></dt>              <dd>CREATE_SUBDIRS</dd>
+<dt></dt>              <dd>EXTRACT_LOCAL_METHODS</dd>
+<dt></dt>              <dd>STRIP_FROM_INC_PATH</dd>
+<dt>New in 1.3.8</dt>
+<dt></dt>              <dd>FILTER_PATTERNS</dd>
+<dt>New in 1.3.9</dt>
+<dt></dt>              <dd>SHOW_DIRECTORIES</dd>
+<dt>New in 1.4.0</dt>
+<dt></dt>              <dd>DIRECTORY_GRAPH</dd>
+<dt></dt>              <dd>DOT_MULTI_TARGETS</dd>
+<dt></dt>              <dd>DOT_TRANSPARENT</dd>
+<dt></dt>              <dd>FILE_VERSION_FILTER</dd>
+<dt></dt>              <dd>GROUP_GRAPHS</dd>
+<dt></dt>              <dd>WARN_NO_PARAMDOC</dd>
+<dt>New in 1.4.2</dt>
+<dt></dt>              <dd>SEPARATE_MEMBER_PAGES</dd>
+<dt>New in 1.4.3</dt>
+<dt></dt>              <dd>USE_HTAGS</dd>
+<dt>New in 1.4.5</dt>
+<dt></dt>              <dd>BUILTIN_STL_SUPPORT</dd>
+<dt>New in 1.4.7</dt>
+<dt></dt>              <dd>CALLER_GRAPH</dd>
+<dt></dt>              <dd>REFERENCES_LINK_SOURCE</dd>
+<dt>New in 1.5.2</dt>
+<dt></dt>              <dd>CPP_CLI_SUPPORT</dd>
+<dt></dt>              <dd>DOT_GRAPH_MAX_NODES</dd>
+<dt></dt>              <dd>DOXYFILE_ENCODING</dd>
+<dt></dt>              <dd>EXCLUDE_SYMBOLS</dd>
+<dt></dt>              <dd>INPUT_ENCODING</dd>
+<dt></dt>              <dd>LATEX_OUTPUT_ENCODING</dd>
+<dt></dt>              <dd>MSCGEN_PATH</dd>
+<dt></dt>              <dd>RTF_OUTPUT_ENCODING</dd>
+<dt>Obsolete in 1.5.2</dt>
+<dt></dt>              <dd>MAX_DOT_GRAPH_DEPTH</dd>
+<dt></dt>              <dd>MAX_DOT_GRAPH_HEIGHT</dd>
+<dt></dt>              <dd>MAX_DOT_GRAPH_WIDTH</dd>
+<dt></dt>              <dd>USE_WINDOWS_ENCODING</dd>
+<dt>New in 1.5.3</dt>
+<dt></dt>              <dd>EXTRACT_ANON_NSPACES</dd>
+<dt></dt>              <dd>HTML_DYNAMIC_SECTIONS</dd>
+<dt></dt>              <dd>MAX_DOT_GRAPH_DEPTH</dd>
+<dt></dt>              <dd>QT_AUTOBRIEF</dd>
+<dt>New in 1.5.4</dt>
+<dt></dt>              <dd>SIP_SUPPORT</dd>
+<dt></dt>              <dd>TYPEDEF_HIDES_STRUCT</dd>
+<dt>New in 1.5.5</dt>
+<dt></dt>              <dd>DOCSET_BUNDLE_ID</dd>
+<dt></dt>              <dd>DOCSET_FEEDNAME</dd>
+<dt></dt>              <dd>GENERATE_DOCSET</dd>
+<dt></dt>              <dd>OPTIMIZE_FOR_FORTRAN</dd>
+<dt></dt>              <dd>OPTIMIZE_OUTPUT_VHDL</dd>
+<dt></dt>              <dd>SORT_GROUP_NAMES</dd>
+<dt>New in 1.5.6</dt>
+<dt></dt>              <dd>CHM_INDEX_ENCODING</dd>
+<dt></dt>              <dd>DOT_FONTNAME</dd>
+<dt></dt>              <dd>DOT_FONTPATH</dd>
+<dt></dt>              <dd>FORMULA_FONTSIZE</dd>
+<dt></dt>              <dd>IDL_PROPERTY_SUPPORT</dd>
+<dt></dt>              <dd>SHOW_FILES</dd>
+<dt></dt>              <dd>SHOW_NAMESPACES</dd>
+<dt>New in 1.5.7</dt>
+<dt></dt>              <dd>GENERATE_INDEXLOG</dd>
+<dt></dt>              <dd>GENERATE_QHP</dd>
+<dt></dt>              <dd>LAYOUT_FILE</dd>
+<dt></dt>              <dd>QCH_FILE</dd>
+<dt></dt>              <dd>QHG_LOCATION</dd>
+<dt></dt>              <dd>QHP_NAMESPACE</dd>
+<dt></dt>              <dd>QHP_VIRTUAL_FOLDER</dd>
+<dt></dt>              <dd>SYMBOL_CACHE_SIZE</dd>
+<dt>Obsolete in 1.5.7</dt>
+<dt></dt>              <dd>ALPHABETICAL_INDEX</dd>
+<dt></dt>              <dd>DETAILS_AT_TOP</dd>
+<dt></dt>              <dd>DOXYGEN2QTHELP_LOC</dd>
+<dt></dt>              <dd>QTHELP_CONFIG</dd>
+<dt></dt>              <dd>QTHELP_FILE</dd>
+<dt>New in 1.5.7.1</dt>
+<dt></dt>              <dd>ALPHABETICAL_INDEX</dd>
+<dt></dt>              <dd>DOT_FONTSIZE</dd>
+<dt>Obsolete in 1.5.7.1</dt>
+<dt></dt>              <dd>GENERATE_INDEXLOG</dd>
+<dt>New in 1.5.8</dt>
+<dt></dt>              <dd>EXTENSION_MAPPING</dd>
+<dt></dt>              <dd>QHP_CUST_FILTER_ATTRS</dd>
+<dt></dt>              <dd>QHP_CUST_FILTER_NAME</dd>
+<dt></dt>              <dd>QHP_SECT_FILTER_ATTRS</dd>
+<dt></dt>              <dd>DETAILS_AT_TOP</dd>
+<dt>Obsolete in 1.5.8</dt>
+<dt></dt>              <dd>LATEX_OUTPUT_ENCODING</dd>
+<dt></dt>              <dd>RTF_OUTPUT_ENCODING</dd>
+<dt>New in 1.5.9</dt>
+<dt></dt>              <dd>LATEX_SOURCE_CODE</dd>
+<dt>Obsolete in 1.5.9</dt>
+<dt></dt>              <dd>SHOW_USED_FILES</dd>
+<dt>New in 1.6.0</dt>
+<dt></dt>              <dd>SORT_MEMBERS_CTORS_1ST</dd>
+<dt></dt>              <dd>USE_INLINE_TREES</dd>
+<dt>New in 1.6.1</dt>
+<dt></dt>              <dd>SHOW_USED_FILES</dd>
+<dt>New in 1.6.2</dt>
+<dt></dt>              <dd>ECLIPSE_DOC_ID</dd>
+<dt></dt>              <dd>FORCE_LOCAL_INCLUDES</dd>
+<dt></dt>              <dd>GENERATE_ECLIPSEHELP</dd>
+<dt></dt>              <dd>HTML_TIMESTAMP</dd>
+<dt></dt>              <dd>SERVER_BASED_SEARCH</dd>
+<dt>New in 1.7.0</dt>
+<dt></dt>              <dd>DOCSET_PUBLISHER_ID</dd>
+<dt></dt>              <dd>DOCSET_PUBLISHER_NAME</dd>
+<dt></dt>              <dd>DOT_NUM_THREADS</dd>
+<dt></dt>              <dd>EXT_LINKS_IN_WINDOW</dd>
+<dt></dt>              <dd>HTML_COLORSTYLE_GAMMA</dd>
+<dt></dt>              <dd>HTML_COLORSTYLE_HUE</dd>
+<dt></dt>              <dd>HTML_COLORSTYLE_SAT</dd>
+<dt>New in 1.7.1</dt>
+<dt></dt>              <dd>FORMULA_TRANSPARENT</dd>
+<dt>New in 1.7.2</dt>
+<dt></dt>              <dd>MATHJAX_RELPATH</dd>
+<dt></dt>              <dd>MSCFILE_DIRS</dd>
+<dt></dt>              <dd>USE_MATHJAX</dd>
+<dt>New in 1.7.3</dt>
+<dt></dt>              <dd>FILTER_SOURCE_PATTERNS</dd>
+<dt></dt>              <dd>PROJECT_BRIEF</dd>
+<dt></dt>              <dd>PROJECT_LOGO</dd>
+<dt></dt>              <dd>STRICT_PROTO_MATCHING</dd>
+<dt>New in 1.7.4</dt>
+<dt></dt>              <dd>HTML_EXTRA_FILES</dd>
+<dt></dt>              <dd>INLINE_GROUPED_CLASSES</dd>
+<dt></dt>              <dd>LATEX_FOOTER</dd>
+<dt>New in 1.7.5</dt>
+<dt></dt>              <dd>CITE_BIB_FILES</dd>
+<dt></dt>              <dd>INLINE_SIMPLE_STRUCTS</dd>
+<dt></dt>              <dd>INTERACTIVE_SVG</dd>
+<dt></dt>              <dd>LATEX_BIB_STYLE</dd>
+<dt></dt>              <dd>MATHJAX_EXTENSIONS</dd>
+<dt>New in 1.7.6</dt>
+<dt></dt>              <dd>TCL_SUBST</dd>
+<dt>New in 1.7.6.1</dt>
+<dt></dt>              <dd>LOOKUP_CACHE_SIZE</dd>
+<dt>New in 1.8.0</dt>
+<dt></dt>              <dd>EXTRACT_PACKAGE</dd>
+<dt></dt>              <dd>MARKDOWN_SUPPORT</dd>
+<dt></dt>              <dd>UML_LIMIT_NUM_FIELDS</dd>
+<dt>New in 1.8.1</dt>
+<dt></dt>              <dd>HTML_INDEX_NUM_ENTRIES</dd>
+<dt>Obsolete in 1.8.1</dt>
+<dt></dt>              <dd>HTML_ALIGN_MEMBERS</dd>
+<dt></dt>              <dd>SHOW_DIRECTORIES</dd>
+<dt></dt>              <dd>USE_INLINE_TREES</dd>
+<dt>New in 1.8.2</dt>
+<dt></dt>              <dd>AUTOLINK_SUPPORT</dd>
+<dt></dt>              <dd>HTML_EXTRA_STYLESHEET</dd>
+<dt>New in 1.8.3</dt>
+<dt></dt>              <dd>EXTERNAL_SEARCH</dd>
+<dt></dt>              <dd>EXTRA_SEARCH_MAPPINGS</dd>
+<dt></dt>              <dd>MATHJAX_FORMAT</dd>
+<dt></dt>              <dd>SEARCHDATA_FILE</dd>
+<dt></dt>              <dd>SEARCHENGINE_URL</dd>
+<dt></dt>              <dd>USE_MDFILE_AS_MAINPAGE</dd>
+<dt>New in 1.8.3.1</dt>
+<dt></dt>              <dd>EXTERNAL_SEARCH_ID</dd>
+<dt>New in 1.8.4</dt>
+<dt></dt>              <dd>CLANG_ASSISTED_PARSING</dd>
+<dt></dt>              <dd>CLANG_OPTIONS</dd>
+<dt></dt>              <dd>DOCBOOK_OUTPUT</dd>
+<dt></dt>              <dd>EXTERNAL_PAGES</dd>
+<dt></dt>              <dd>GENERATE_DOCBOOK</dd>
+<dt></dt>              <dd>GENERATE_SQLITE3</dd>
+<dt></dt>              <dd>LATEX_EXTRA_FILES</dd>
+<dt></dt>              <dd>MATHJAX_CODEFILE</dd>
+<dt></dt>              <dd>SQLITE3_OUTPUT</dd>
+<dt>Obsolete in 1.8.4</dt>
+<dt></dt>              <dd>SYMBOL_CACHE_SIZE</dd>
+<dt>New in 1.8.5</dt>
+<dt></dt>              <dd>SOURCE_TOOLTIPS</dd>
+<dt>New in 1.8.6</dt>
+<dt></dt>              <dd>DIA_PATH</dd>
+<dt></dt>              <dd>DIAFILE_DIRS</dd>
+<dt></dt>              <dd>SHOW_GROUPED_MEMB_INC</dd>
+<dt>New in 1.8.7</dt>
+<dt></dt>              <dd>ALLOW_UNICODE_NAMES</dd>
+<dt></dt>              <dd>MAN_SUBDIR</dd>
+<dt>Obsolete in 1.8.7</dt>
+<dt></dt>              <dd>XML_DTD</dd>
+<dt></dt>              <dd>XML_SCHEMA</dd>
+<dt>New in 1.8.8</dt>
+<dt></dt>              <dd>DOCBOOK_PROGRAMLISTING</dd>
+<dt></dt>              <dd>PLANTUML_JAR_PATH</dd>
+<dt>New in 1.8.9</dt>
+<dt></dt>              <dd>HIDE_COMPOUND_REFERENCE</dd>
+<dt></dt>              <dd>LATEX_EXTRA_STYLESHEET</dd>
+<dt></dt>              <dd>PLANTUML_INCLUDE_PATH</dd>
+<dt></dt>              <dd>RTF_SOURCE_CODE</dd>
+<dt>New in 1.8.10</dt>
+<dt></dt>              <dd>GROUP_NESTED_COMPOUNDS</dd>
+<dt>New in 1.8.11</dt>
+<dt></dt>              <dd>LATEX_TIMESTAMP</dd>
+<dt></dt>              <dd>WARN_AS_ERROR</dd>
+<dt>New in 1.8.12</dt>
+<dt></dt>              <dd>TOC_INCLUDE_HEADINGS</dd>
+<dt>New in 1.8.13</dt>
+<dt></dt>              <dd>PLANTUML_CFG_FILE</dd>
+<dt>New in 1.8.14</dt>
+<dt></dt>              <dd>CLANG_COMPILATION_DATABASE_PATH</dd>
+<dt></dt>              <dd>HTML_DYNAMIC_MENUS</dd>
+<dt>New in 1.8.15</dt>
+<dt></dt>              <dd>CLANG_DATABASE_PATH</dd>
+<dt></dt>              <dd>LATEX_EMOJI_DIRECTORY</dd>
+<dt></dt>              <dd>LATEX_MAKEINDEX_CMD</dd>
+<dt></dt>              <dd>OPTIMIZE_OUTPUT_SLICE</dd>
+<dt></dt>              <dd>OUTPUT_TEXT_DIRECTION</dd>
+<dt></dt>              <dd>XML_NS_MEMB_FILE_SCOPE</dd>
+<dt>Obsolete in 1.8.15</dt>
+<dt></dt>              <dd>CLANG_COMPILATION_DATABASE_PATH</dd>
+<dt>New in 1.8.16</dt>
+<dt></dt>              <dd>EXTRACT_PRIV_VIRTUAL</dd>
+<dt></dt>              <dd>JAVADOC_BANNER</dd>
+<dt>Obsolete in 1.8.16</dt>
+<dt></dt>              <dd>MSCGEN_PATH</dd>
+<dt></dt>              <dd>PERL_PATH</dd>
+<dt>New in 1.8.17</dt>
+<dt></dt>              <dd>FORMULA_MACROFILE</dd>
+<dt>New in 1.8.18</dt>
+<dt></dt>              <dd>HTML_FORMULA_FORMAT</dd>
+<dt>Obsolete in 1.8.18</dt>
+<dt></dt>              <dd>TCL_SUBST</dd>
+<dt>New in 1.8.19</dt>
+<dt></dt>              <dd>NUM_PROC_THREADS</dd>
+<dt></dt>              <dd>SQLITE3_RECREATE_DB</dd>
+<dt>New in 1.8.20</dt>
+<dt></dt>              <dd>PYTHON_DOCSTRING</dd>
+<dt>New in 1.9.0</dt>
+<dt></dt>              <dd>DOT_UML_DETAILS</dd>
+<dt></dt>              <dd>DOT_WRAP_THRESHOLD</dd>
+<dt></dt>              <dd>RESOLVE_UNNAMED_PARAMS</dd>
+<dt>Obsolete in 1.9.0</dt>
+<dt></dt>              <dd>COLS_IN_ALPHA_INDEX</dd>
+<dt>New in 1.9.1</dt>
+<dt></dt>              <dd>CLANG_ADD_INC_PATHS</dd>
+<dt>New in 1.9.2</dt>
+<dt></dt>              <dd>FULL_SIDEBAR</dd>
+<dt></dt>              <dd>MATHJAX_VERSION</dd>
+<dt></dt>              <dd>SHOW_HEADERFILE</dd>
+<dt></dt>              <dd>WARN_IF_INCOMPLETE_DOC</dd>
+<dt>Obsolete  in 1.9.2</dt>
+<dt></dt>              <dd>DOCBOOK_PROGRAMLISTING</dd>
+<dt></dt>              <dd>LATEX_SOURCE_CODE</dd>
+<dt></dt>              <dd>OUTPUT_TEXT_DIRECTION</dd>
+<dt></dt>              <dd>RTF_SOURCE_CODE</dd>
+<dt></dt>              <dd>SORT_MEMBER_DOCS</dd>
+<dt>New in 1.9.3</dt>
+<dt></dt>              <dd>DIR_GRAPH_MAX_DEPTH</dd>
+<dt></dt>              <dd>DOCSET_FEEDURL</dd>
+<dt></dt>              <dd>OBFUSCATE_EMAILS</dd>
+<dt>Obsolete  in 1.9.3</dt>
+<dt></dt>              <dd>CLASS_DIAGRAMS</dd>
+<dt>New in 1.9.4</dt>
+<dt></dt>              <dd>CREATE_SUBDIRS_LEVEL</dd>
+<dt></dt>              <dd>WARN_LINE_FORMAT</dd>
+<dt>New in 1.9.5</dt>
+<dt></dt>              <dd>DOT_COMMON_ATTR</dd>
+<dt></dt>              <dd>DOT_EDGE_ATTR</dd>
+<dt></dt>              <dd>DOT_NODE_ATTR</dd>
+<dt></dt>              <dd>FORTRAN_COMMENT_AFTER</dd>
+<dt></dt>              <dd>HTML_COLORSTYLE</dd>
+<dt></dt>              <dd>INPUT_FILE_ENCODING</dd>
+<dt>Obsolete  in 1.9.5</dt>
+<dt></dt>              <dd>DOT_FONTNAME</dd>
+<dt></dt>              <dd>DOT_FONTSIZE</dd>
+<dt></dt>              <dd>DOT_TRANSPARENT</dd>
+<dt></dt>              <dd>FORMULA_TRANSPARENT</dd>
+</dl>
+
+## Directives
+
+<dl>
+<dt>New in 1.2.1</dt>
+<dt></dt>              <dd>@@INCLUDE</dd>
+<dt></dt>              <dd>@@INCLUDE_PATH</dd>
+</dl>


### PR DESCRIPTION
Enhancing the doxygen internal documentation with overviews of:
- release dates
- versions where special commands entered doxygen
- versions where  settings have entered / become obsolete in doxygen

Adding a small description of the doxygen internal commands