### PR TITLE
Hash comment in php

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -361,14 +361,14 @@ SLASHopt [/]*
                                      yyextra->commentStack.push(yyextra->lineNr);
                                    }
 <Scan>"#"("#")?		           {
-                                     if (yyextra->lang!=SrcLangExt_Python)
+                                     if (yyextra->lang!=SrcLangExt_Python && yyextra->lang!=SrcLangExt_PHP)
 				     {
 				       REJECT;
 				     }
 				     else
 				     {
                                        copyToOutput(yyscanner,yytext,(int)yyleng); 
-                                       yyextra->nestingCount=0; // Python doesn't have an end comment for #
+                                       yyextra->nestingCount=0; // Python and PHP don't have an end comment for #
                                        clearCommentStack(yyscanner); /*  to be on the save side */
 				       BEGIN(CComment);
                                        yyextra->commentStack.push(yyextra->lineNr);
@@ -730,7 +730,7 @@ SLASHopt [/]*
 				     }
                                    }
 <CComment,CNComment>"\n"/[ \t]*[^ \t#\-] 	   {
-                                     if (yyextra->lang==SrcLangExt_Python)
+                                     if (yyextra->lang==SrcLangExt_Python || yyextra->lang==SrcLangExt_PHP)
                                      {
                                        if (yyextra->pythonDocString)
                                        {


### PR DESCRIPTION
The hash (`#`) comment was not recognized in the comment converter for php so sthe code like:
```
<?php
## page's elements with
class PageStore {
  function ls($pats=NULL) {
    $dirlist = array(preg_replace('!/*[^/]*\\$.*$!','',$dir));
    return $out;
  }
}
```
resulted, incorrectly, in the warning
```
aa.php:9: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (probable line reference: 5)
```
as the single quote in the comment was interpreted and this should not have been the case.


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9461531/example.tar.gz)
(Found by Fossies for package pmwiki)
