### PR TITLE
Shadowed variable in fortranscanner.l

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2342,9 +2342,9 @@ static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot)
 
         // remove prefix
         QCString name = ce->name.lower();
-        int i = name.findRev(":");
-        if (i != -1)
-          name.remove(0, i+1);
+        int ii = name.findRev(":");
+        if (ii != -1)
+          name.remove(0, ii+1);
         Argument *arg = findArgument(scope->parent(), name);
         if (arg != 0) 
         {


### PR DESCRIPTION
Prevent shadowing of variable:
```
.../src/fortranscanner.l:
In function ‘bool endScope(yyscan_t, Entry*, bool)’:
.../src/fortranscanner.l:2354:29:
warning: declaration of ‘i’ shadows a previous local [-Wshadow]
            {
                              ^
.../src/fortranscanner.l:2346:13:
note: shadowed declaration is here
          if (i != -1)
```

(as reported by @sloriot)