### PR TITLE
Warning during compilation on Windows systems

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -3729,7 +3729,7 @@ static void writeObjCMethodCall(yyscan_t yyscanner,ObjCCallCtx *ctx)
           }
           else // illegal marker
           {
-            ASSERT("invalid escape sequence"==0);
+            ASSERT(0); // "invalid escape sequence"
           }
         }
       }

--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -331,7 +331,7 @@ bool DotFilePatcher::run() const
     return FALSE;
   }
   TextStream t(&fo);
-  int width,height;
+  int width=0,height=0;
   bool insideHeader=FALSE;
   bool replacedHeader=FALSE;
   bool foundSize=FALSE;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9676,27 +9676,6 @@ static void runQHelpGenerator()
   Dir::setCurrent(oldDir);
 }
 
-#if defined(_WIN32)
-static QCString fixSlashes(QCString &s)
-{
-  QCString result;
-  uint i;
-  for (i=0;i<s.length();i++)
-  {
-    switch(s.at(i))
-    {
-      case '/':
-      case '\\':
-        result+="\\\\";
-        break;
-      default:
-        result+=s.at(i);
-    }
-  }
-  return result;
-}
-#endif
-
 //----------------------------------------------------------------------------
 
 static void computeVerifiedDotPath()
@@ -10872,7 +10851,7 @@ void initDoxygen()
   initNamespaceMemberIndices();
   initFileMemberIndices();
 
-#ifdef USE_LIBCLANG
+#if USE_LIBCLANG
   Doxygen::clangUsrMap   = new ClangUsrMap;
 #endif
   Doxygen::memberNameLinkedMap = new MemberNameLinkedMap;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -503,17 +503,13 @@ class LayoutParser
           QCString()
         }
       };
-      LayoutNavEntry::Kind kind = static_cast<LayoutNavEntry::Kind>(0);
       // find type in the table
       int i=0;
       QCString type = XMLHandlers::value(attrib,"type");
       while (mapping[i].typeStr)
       {
         if (mapping[i].typeStr==type)
-        {
-          kind = mapping[i].kind;
           break;
-        }
         i++;
       }
       if (mapping[i].typeStr==0)
@@ -530,6 +526,7 @@ class LayoutParser
         m_invalidEntry=TRUE;
         return;
       }
+      LayoutNavEntry::Kind kind = mapping[i].kind;
       QCString baseFile = mapping[i].baseFile;
       QCString title = XMLHandlers::value(attrib,"title");
       bool isVisible = elemIsVisible(attrib) && parentIsVisible(m_rootNav);

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -503,7 +503,7 @@ class LayoutParser
           QCString()
         }
       };
-      LayoutNavEntry::Kind kind;
+      LayoutNavEntry::Kind kind = static_cast<LayoutNavEntry::Kind>(0);
       // find type in the table
       int i=0;
       QCString type = XMLHandlers::value(attrib,"type");
@@ -1658,7 +1658,7 @@ QCString extractLanguageSpecificTitle(const QCString &input,SrcLangExt lang)
     e=input.find('|',s);
     i=input.find('=',s);
     assert(i>s);
-    size_t key=input.mid(s,i-s).toUInt();
+    SrcLangExt key= static_cast<SrcLangExt>(input.mid(s,i-s).toUInt());
     if (key==lang) // found matching key
     {
       if (e==-1) e=input.length();

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -185,13 +185,11 @@ int Portable::system(const QCString &command,const QCString &args,bool commandHa
       WaitForSingleObject(sInfo.hProcess,INFINITE);
       /* get process exit code */
       DWORD exitCode;
-      if (!GetExitCodeProcess(sInfo.hProcess,&exitCode))
-      {
-        exitCode = -1;
-      }
+      bool retval = !GetExitCodeProcess(sInfo.hProcess,&exitCode);
       CloseHandle(sInfo.hProcess);
       delete[] commandw;
       delete[] argsw;
+      if (!retval) return -1;
       return exitCode;
     }
   }

--- a/src/pre.l
+++ b/src/pre.l
@@ -2586,7 +2586,7 @@ static bool expandExpression(yyscan_t yyscanner,QCString &expr,QCString *rest,in
   QCString macroName;
   QCString expMacro;
   bool definedTest=FALSE;
-  int i=pos,l,p,len;
+  int i=pos,l,p,len=0;
   int startPos = pos;
   int samePosCount=0;
   while ((p=getNextId(expr,i,&l))!=-1) // search for an macro name

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6591,7 +6591,7 @@ bool copyFile(const QCString &src,const QCString &dest)
 QCString extractBlock(const QCString &text,const QCString &marker)
 {
   QCString result;
-  int p=0,i;
+  int p=0,i=-1;
   bool found=FALSE;
 
   // find the character positions of the markers

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -926,11 +926,11 @@ void XmlDocVisitor::operator()(const DocImage &img)
                 altValue, img.isInlineImage());
 
   // copy the image to the output dir
-  FileDef *fd;
+  FileDef *fd = 0;
   bool ambig;
   if (url.isEmpty() && (fd=findFileDef(Doxygen::imageNameLinkedMap,img.name(),ambig)))
   {
-    copyFile(fd->absFilePath(),Config_getString(XML_OUTPUT)+"/"+baseName);
+    if (fd) copyFile(fd->absFilePath(),Config_getString(XML_OUTPUT)+"/"+baseName);
   }
   visitChildren(img);
   visitPostEnd(m_t, "image");

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -930,7 +930,7 @@ void XmlDocVisitor::operator()(const DocImage &img)
   bool ambig;
   if (url.isEmpty() && (fd=findFileDef(Doxygen::imageNameLinkedMap,img.name(),ambig)))
   {
-    if (fd) copyFile(fd->absFilePath(),Config_getString(XML_OUTPUT)+"/"+baseName);
+    copyFile(fd->absFilePath(),Config_getString(XML_OUTPUT)+"/"+baseName);
   }
   visitChildren(img);
   visitPostEnd(m_t, "image");


### PR DESCRIPTION
Fixing a (first set) of warnings on Windows systems as found by means of setting `/Wall`