### PR TITLE
Warning during compilation on Windows systems

### DIFF
--- a/src/condparser.cpp
+++ b/src/condparser.cpp
@@ -217,7 +217,7 @@ bool CondParser::parseLevel3()
     if (m_token=="(")
     {
       getToken();
-      int ans = parseLevel1();
+      bool ans = parseLevel1();
       if (m_tokenType!=DELIMITER || m_token!=")")
       {
         m_err="Parenthesis ) missing";

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -495,7 +495,7 @@ def getEnum2BoolMapping(node):
             bool_rep = nv.getAttribute("bool_representation")
             if name and bool_rep:
                 bool_value = "true" if bool_rep and bool_rep.upper() == 'YES' else "false"
-                mapping.append( "{{ \"{0}\", \"{1}\" }}".format(escape(name),bool_value))
+                mapping.append( "{{ \"{0}\", {1} }}".format(escape(name),bool_value))
     return mapping
 
 def parseGroupMapInit(node):

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1583,7 +1583,7 @@ bool ConfigImpl::parseString(const QCString &fn,const QCString &str,bool update)
 
 bool ConfigImpl::parse(const QCString &fn,bool update)
 {
-  int retval;
+  bool retval;
   g_encoding = "UTF-8";
   printlex(yy_flex_debug, TRUE, __FILE__, qPrint(fn));
   retval =  parseString(fn,configFileToString(fn), update);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -476,7 +476,7 @@ static void buildFileList(const Entry *root)
     FileDef *fd=findFileDef(Doxygen::inputNameLinkedMap,root->name,ambig);
     if (!fd || ambig)
     {
-      int save_ambig = ambig;
+      bool save_ambig = ambig;
       // use the directory of the file to see if the described file is in the same
       // directory as the describing file.
       QCString fn = root->fileName;

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -959,7 +959,7 @@ static void startCodeLine(yyscan_t yyscanner)
                                      !yyextra->includeCodeFragment);
     }
   }
-  yyextra->code->startCodeLine(yyextra->sourceFileDef);
+  yyextra->code->startCodeLine(yyextra->sourceFileDef!=0);
   yyextra->insideCodeLine=true;
   if (yyextra->currentFontClass)
   {

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1998,8 +1998,8 @@ SymbolModifiers& SymbolModifiers::operator|=(QCString mdfStringArg)
   else if (mdfString.contains("intent"))
   {
     QCString tmp = extractFromParens(mdfString);
-    bool isin = tmp.contains("in");
-    bool isout = tmp.contains("out");
+    bool isin = tmp.contains("in")!=0;
+    bool isout = tmp.contains("out")!=0;
     if (isin && isout) newMdf.direction = SymbolModifiers::INOUT;
     else if (isin) newMdf.direction = SymbolModifiers::IN;
     else if (isout) newMdf.direction = SymbolModifiers::OUT;

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2325,7 +2325,7 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
                 isTypedef() ?
                    substitute(argsString(),")(",") (") :
                    argsString(),         // text
-                m_impl->annMemb,         // autoBreak
+                m_impl->annMemb!=0,      // autoBreak
                 TRUE,                    // external
                 FALSE,                   // keepSpaces
                 indentLevel

--- a/src/pre.l
+++ b/src/pre.l
@@ -1883,7 +1883,8 @@ static void setFileName(yyscan_t yyscanner,const QCString &name)
   state->insideIDL = getLanguageFromFileName(state->fileName)==SrcLangExt_IDL;
   state->insideCS = getLanguageFromFileName(state->fileName)==SrcLangExt_CSharp;
   state->insideFtn = getLanguageFromFileName(state->fileName)==SrcLangExt_Fortran;
-  state->isSource = guessSection(state->fileName);
+  int isSource = guessSection(state->fileName);
+  state->isSource = isSource==Entry::HEADER_SEC || isSource==Entry::SOURCE_SEC;
 }
 
 static void incrLevel(yyscan_t yyscanner)

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1067,7 +1067,7 @@ static void startCodeLine(yyscan_t yyscanner)
                                      !yyextra->includeCodeFragment);
     }
   }
-  yyextra->code->startCodeLine(yyextra->sourceFileDef);
+  yyextra->code->startCodeLine(yyextra->sourceFileDef!=0);
   yyextra->insideCodeLine=true;
 
   if (yyextra->currentFontClass)

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -267,7 +267,7 @@ static void startCodeLine(yyscan_t yyscanner)
     }
   }
 
-  yyextra->code->startCodeLine(yyextra->sourceFileDef);
+  yyextra->code->startCodeLine(yyextra->sourceFileDef!=0);
   yyextra->insideCodeLine=true;
 
   if (yyextra->currentFontClass)

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -1057,7 +1057,7 @@ static void startCodeLine(yyscan_t yyscanner)
                                      !yyextra->includeCodeFragment);
     }
   }
-  yyextra->code->startCodeLine(yyextra->sourceFileDef);
+  yyextra->code->startCodeLine(yyextra->sourceFileDef!=0);
   yyextra->insideCodeLine=true;
   if (yyextra->currentFontClass)
   {

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -282,7 +282,7 @@ static void startCodeLine(yyscan_t yyscanner)
     }
   }
 
-  yyextra->code->startCodeLine(yyextra->sourceFileDef);
+  yyextra->code->startCodeLine(yyextra->sourceFileDef!=0);
   yyextra->insideCodeLine = true;
 
   if (yyextra->currentFontClass)


### PR DESCRIPTION
This is based on the warning type: C4800: Implicit conversion from 'type' to bool. Possible information loss
A real bug was found in the writing out of the boolean replacement values in configgen.py. The boolean values got double quotes and the string would always result in true instead of the intended value