### PR TITLE
Warning during compilation on Windows systems

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -48,6 +48,9 @@
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
+// For debugging
+#define SHOW_INCLUDES 0
+
 #define USE_STATE2STRING 0
 
 #if USE_STATE2STRING

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -594,24 +594,6 @@ inline QCString operator+( const char *s1, const QCString &s2 )
     return tmp;
 }
 
-#define HAD_PLUS_OPERATOR_FOR_CHAR 0
-#if HAS_PLUS_OPERATOR_FOR_CHAR
-inline QCString operator+( const QCString &s1, char c2 )
-{
-    QCString tmp( s1.data() );
-    tmp.append(c2);
-    return tmp;
-}
-
-inline QCString operator+( char c1, const QCString &s2 )
-{
-    QCString tmp;
-    tmp.append(c1);
-    tmp.append(s2);
-    return tmp;
-}
-#endif
-
 inline const char *qPrint(const char *s)
 {
   if (s) return s; else return "";

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -53,6 +53,8 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
+#define USE_STATE2STRING 0
+
 struct xmlcodeYY_state
 {
   CodeOutputInterface * code;


### PR DESCRIPTION
This is based on the warning type: 4668 'symbol' is not defined as a preprocessor macro, replacing with '0' for 'directives'