### PR TITLE
issue #9566 Same member groups in multibyte characters are separately generated.

### DIFF
--- a/src/qcstring.cpp
+++ b/src/qcstring.cpp
@@ -442,7 +442,7 @@ int qstricmp( const char *s1, const char *s2 )
       return s1 == s2 ? 0 : static_cast<int>(s2 - s1);
     }
     int res;
-    uchar c;
+    char c;
     for ( ; !(res = ((c=toLowerChar(*s1)) - toLowerChar(*s2))); s1++, s2++ )
     {
       if ( !c )				// strings are equal


### PR DESCRIPTION
The function `toLowerChar` returns a `char` and not an `uchar`, it resulted in some wrong arithmetic.


Note:
(would have been found as part of:  `warning C4365: '=': conversion from 'char' to 'uchar', signed/unsigned mismatch` as well, but probably the resulting fix would not have been recognized)

