### PR TITLE
issue #9582 `noexcept(false)`-function is labeled as noexcept

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4895,6 +4895,10 @@ NONLopt [^\n]*
                                           yyextra->current->args += " noexcept ";
                                           yyextra->current->spec |= Entry::NoExcept;
                                         }
+<FuncQual>{BN}*"noexcept"{BN}*"("{B}*false{B}*")"{BN}* { // noexcept(false) expression
+                                          lineCount(yyscanner) ;
+                                          yyextra->current->args += " noexcept(false)";
+                                        }
 <FuncQual>{BN}*"noexcept"{BN}*"("       { // noexcept expression
                                           lineCount(yyscanner) ;
                                           yyextra->current->args += " noexcept(";


### PR DESCRIPTION
Doxygen is not a compiler and does, in most cases, not try to interpret the values in the code.
The special case of the constant `false` value can be evaluated as a special case.