### PR TITLE
[regression] PHP normal comment

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -360,15 +360,22 @@ SLASHopt [/]*
 				       BEGIN(CNComment); 
                                      yyextra->commentStack.push(yyextra->lineNr);
                                    }
+<Scan>"#"[^\n]*\n                  {
+                                     if (yyextra->lang!=SrcLangExt_PHP)
+				     {
+				       REJECT;
+				     }
+                                     copyToOutput(yyscanner,yytext,(int)yyleng);
+                                   }
 <Scan>"#"("#")?		           {
-                                     if (yyextra->lang!=SrcLangExt_Python && yyextra->lang!=SrcLangExt_PHP)
+                                     if (yyextra->lang!=SrcLangExt_Python)
 				     {
 				       REJECT;
 				     }
 				     else
 				     {
                                        copyToOutput(yyscanner,yytext,(int)yyleng); 
-                                       yyextra->nestingCount=0; // Python and PHP don't have an end comment for #
+                                       yyextra->nestingCount=0; // Python doesn't have an end comment for #
                                        clearCommentStack(yyscanner); /*  to be on the save side */
 				       BEGIN(CComment);
                                        yyextra->commentStack.push(yyextra->lineNr);
@@ -730,7 +737,7 @@ SLASHopt [/]*
 				     }
                                    }
 <CComment,CNComment>"\n"/[ \t]*[^ \t#\-] 	   {
-                                     if (yyextra->lang==SrcLangExt_Python || yyextra->lang==SrcLangExt_PHP)
+                                     if (yyextra->lang==SrcLangExt_Python)
                                      {
                                        if (yyextra->pythonDocString)
                                        {


### PR DESCRIPTION
In the pull request #9558 the situation for PHP `#` type was handled, but a small side effect appears, the "normal" PHP comment `/**...` is not handled properly anymore it will give a warning like:
```
warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (probable line reference: 5)
```
for the, stripped down, example:
```
<?php

class Kernel extends ConsoleKernel
{
    /**
     * Define the application's command schedule.
     */
    protected function schedule(Schedule $schedule) { }
}
```

PHP comments of type `#` shouldn't be interpreted like Python comments, but just copied verbatim to the output.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9504021/example.tar.gz)


(Found by Fossies where quite a few extra warnings appeared).
