### PR TITLE
issue #9584 Warning "Illegal command \ifile found as part of a \c command" in \copydoc, but not original documentation

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1826,20 +1826,20 @@ QCString DocParser::processCopyDoc(const char *data,uint &len)
             context.copyStack.push_back(def);
             if (isBrief)
             {
-              buf.addStr("\\ifile \""+QCString(def->briefFile())+"\" ");
+              buf.addStr(" \\ilinebr\\ifile \""+QCString(def->briefFile())+"\" ");
               buf.addStr("\\iline "+QCString().setNum(def->briefLine())+" ");
               uint l=static_cast<uint>(brief.length());
               buf.addStr(processCopyDoc(brief.data(),l));
             }
             else
             {
-              buf.addStr("\\ifile \""+QCString(def->docFile())+"\" ");
+              buf.addStr(" \\ilinebr\\ifile \""+QCString(def->docFile())+"\" ");
               buf.addStr("\\iline "+QCString().setNum(def->docLine())+" ");
               uint l=static_cast<uint>(doc.length());
               buf.addStr(processCopyDoc(doc.data(),l));
             }
             context.copyStack.pop_back();
-            buf.addStr("\\ifile \""+context.fileName+"\" ");
+            buf.addStr(" \\ilinebr\\ifile \""+context.fileName+"\" ");
             buf.addStr("\\iline "+QCString().setNum(lineNr)+" ");
           }
           else


### PR DESCRIPTION
The (internal command `\ifile`, for better warnings ) was placed directly after the existing pext an so the `\ifile` was part of of the `nullptr` text. Problem occurred only when no other text followed. We need a `<space>` as well as the, internal, command  `\ilinebr` e.g. for the `\addindex` command as this would run to the end of the line and would with a space still show the same problems.

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9504762/example.tar.gz)
