### PR TITLE
Warning during compilation on Windows systems

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11573,7 +11573,7 @@ static void writeTagFile()
   tagFile << "</tagfile>\n";
 }
 
-static void exitDoxygen()
+static void exitDoxygen() noexcept
 {
   if (!g_successfulRun)  // premature exit
   {


### PR DESCRIPTION
This is based on the warning: warning C5039: 'atexit': pointer or reference to potentially throwing function passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this function throws an exception.