### PR TITLE
Portuguese translators updated to 1.9.6 (format fixed)

### DIFF
--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 1997-2018 by Dimitri van Heesch.
+ * Copyright (C) 1997-2022 by Dimitri van Heesch.
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation under the terms of the GNU General Public License is hereby
@@ -20,7 +20,7 @@
  *
  * History:
  * 20220911:
- *  - Updated to 1.9.6;
+ *  - Updated to 1.9.6; 
  * 20220525:
  * 	- Updated to 1.9.4;
  * 20211003:
@@ -60,2754 +60,2381 @@
 
 class TranslatorBrazilian : public Translator
 {
-public:
-  // --- Language control methods -------------------
+  public:
 
-  /*! Used for identification of the language. The identification
-   * should not be translated. It should be replaced by the name
-   * of the language in English using lower-case characters only
-   * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
-   * the identification used in language.cpp.
-   */
-  virtual QCString idLanguage()
-  {
-    return "brazilian";
-  }
+    // --- Language control methods -------------------
 
-  /*! Used to get the LaTeX command(s) for the language support.
-   *  This method should return string with commands that switch
-   *  LaTeX to the desired language.  For example
-   *  <pre>"\\usepackage[german]{babel}\n"
-   *  </pre>
-   *  or
-   *  <pre>"\\usepackage{polski}\n"
-   *  "\\usepackage[latin2]{inputenc}\n"
-   *  "\\usepackage[T1]{fontenc}\n"
-   *  </pre>
-   *
-   * The English LaTeX does not use such commands.  Because of this
-   * the empty string is returned in this implementation.
-   */
-  virtual QCString latexLanguageSupportCommand()
-  {
-    return "\\usepackage[brazil]{babel}";
-  }
-
-  virtual QCString trISOLang()
-  {
-    return "pt-BR";
-  }
-  virtual QCString getLanguageString()
-  {
-    return "0x416 Portuguese(Brazil)";
-  }
-
-  // --- Language translation methods -------------------
-
-  /*! used in the compound documentation before a list of related functions. */
-  virtual QCString trRelatedFunctions()
-  {
-    return "Funções Relacionadas";
-  }
-
-  /*! subscript for the related functions. */
-  virtual QCString trRelatedSubscript()
-  {
-    return "(Note que estas não são funções membros.)";
-  }
-
-  /*! header that is put before the detailed description of files, classes and namespaces. */
-  virtual QCString trDetailedDescription()
-  {
-    return "Descrição detalhada";
-  }
-
-  /*! header that is put before the list of typedefs. */
-  virtual QCString trMemberTypedefDocumentation()
-  {
-    return "Documentação das definições de tipos";
-  }
-
-  /*! header that is put before the list of enumerations. */
-  virtual QCString trMemberEnumerationDocumentation()
-  {
-    return "Documentação das enumerações";
-  }
-
-  /*! header that is put before the list of member functions. */
-  virtual QCString trMemberFunctionDocumentation()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+    /*! Used for identification of the language. The identification
+     * should not be translated. It should be replaced by the name
+     * of the language in English using lower-case characters only
+     * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
+     * the identification used in language.cpp.
+     */
+    virtual QCString idLanguage()
     {
-      return "Documentação das funções, procedimentos e processos";
+      return "brazilian";
     }
-    else
+
+    /*! Used to get the LaTeX command(s) for the language support.
+     *  This method should return string with commands that switch
+     *  LaTeX to the desired language.  For example
+     *  <pre>"\\usepackage[german]{babel}\n"
+     *  </pre>
+     *  or
+     *  <pre>"\\usepackage{polski}\n"
+     *  "\\usepackage[latin2]{inputenc}\n"
+     *  "\\usepackage[T1]{fontenc}\n"
+     *  </pre>
+     *
+     * The English LaTeX does not use such commands.  Because of this
+     * the empty string is returned in this implementation.
+     */
+    virtual QCString latexLanguageSupportCommand()
     {
-      return "Documentação das funções";
+      return "\\usepackage[brazil]{babel}";
     }
-  }
 
-  /*! header that is put before the list of member attributes. */
-  virtual QCString trMemberDataDocumentation()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    virtual QCString trISOLang()
     {
-      return "Campos";
+      return "pt-BR";
     }
-    else
+    virtual QCString getLanguageString()
     {
-      return "Atributos";
+      return "0x416 Portuguese(Brazil)";
     }
-  }
 
-  /*! this is the text of a link put after brief descriptions. */
-  virtual QCString trMore()
-  {
-    return "Mais...";
-  }
+    // --- Language translation methods -------------------
 
-  /*! put in the class documentation */
-  virtual QCString trListOfAllMembers()
-  {
-    return "Lista de todos os Membros";
-  }
+    /*! used in the compound documentation before a list of related functions. */
+    virtual QCString trRelatedFunctions()
+    { return "Funções Relacionadas"; }
 
-  /*! used as the title of the "list of all members" page of a class */
-  virtual QCString trMemberList()
-  {
-    return "Lista dos Membros";
-  }
+    /*! subscript for the related functions. */
+    virtual QCString trRelatedSubscript()
+    { return "(Note que estas não são funções membros.)"; }
 
-  /*! this is the first part of a sentence that is followed by a class name */
-  virtual QCString trThisIsTheListOfAllMembers()
-  {
-    return "Esta é a lista de todos os membros de ";
-  }
+    /*! header that is put before the detailed description of files, classes and namespaces. */
+    virtual QCString trDetailedDescription()
+    { return "Descrição detalhada"; }
 
-  /*! this is the remainder of the sentence after the class name */
-  virtual QCString trIncludingInheritedMembers()
-  {
-    return ", incluindo os membros herdados.";
-  }
+    /*! header that is put before the list of typedefs. */
+    virtual QCString trMemberTypedefDocumentation()
+    { return "Documentação das definições de tipos"; }
 
-  /*! this is put at the author sections at the bottom of man pages.
-   *  parameter s is name of the project name.
-   */
-  virtual QCString trGeneratedAutomatically(const QCString &s)
-  {
-    QCString result = "Gerado automaticamente por Doxygen";
-    if (!s.isEmpty())
-      result += " para " + s;
-    result += " a partir do código-fonte.";
-    return result;
-  }
+    /*! header that is put before the list of enumerations. */
+    virtual QCString trMemberEnumerationDocumentation()
+    { return "Documentação das enumerações"; }
 
-  /*! put after an enum name in the list of all members */
-  virtual QCString trEnumName()
-  {
-    return "Enumeração";
-  }
-
-  /*! put after an enum value in the list of all members */
-  virtual QCString trEnumValue()
-  {
-    return "Valor da enumeração";
-  }
-
-  /*! put after an undocumented member in the list of all members */
-  virtual QCString trDefinedIn()
-  {
-    return "definido(a) em";
-  }
-
-  // quick reference sections
-
-  /*! This is put above each page as a link to the list of all groups of
-   *  compounds or files (see the \\group command).
-   */
-  virtual QCString trModules()
-  {
-    return "Módulos";
-  }
-
-  /*! This is put above each page as a link to the class hierarchy */
-  virtual QCString trClassHierarchy()
-  {
-    return "Hierarquia de Classes";
-  }
-
-  /*! This is put above each page as a link to the list of annotated classes */
-  virtual QCString trCompoundList()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! header that is put before the list of member functions. */
+    virtual QCString trMemberFunctionDocumentation()
     {
-      return "Estruturas de Dados";
+        if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+        {
+          return "Documentação das funções, procedimentos e processos";
+        }
+        else
+        {
+            return "Documentação das funções";
+        }
     }
-    else
-    {
-      return "Lista de Classes";
-    }
-  }
 
-  /*! This is put above each page as a link to the list of documented files */
-  virtual QCString trFileList()
-  {
-    return "Lista de Arquivos";
-  }
-
-  /*! This is put above each page as a link to all members of compounds. */
-  virtual QCString trCompoundMembers()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      return "Campos de Dados";
-    }
-    else
-    {
-      return "Membros de classe";
-    }
-  }
-
-  /*! This is put above each page as a link to all members of files. */
-  virtual QCString trFileMembers()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      return "Ítens globais";
-    }
-    else
-    {
-      return "Membros dos Arquivos";
-    }
-  }
-
-  /*! This is put above each page as a link to all related pages. */
-  virtual QCString trRelatedPages()
-  {
-    return "Páginas relacionadas";
-  }
-
-  /*! This is put above each page as a link to all examples. */
-  virtual QCString trExamples()
-  {
-    return "Exemplos";
-  }
-
-  /*! This is put above each page as a link to the search engine. */
-  virtual QCString trSearch()
-  {
-    return "Busca";
-  }
-
-  /*! This is an introduction to the class hierarchy. */
-  virtual QCString trClassHierarchyDescription()
-  {
-    return "Esta lista de hierarquias está parcialmente ordenada (ordem alfabética):";
-  }
-
-  /*! This is an introduction to the list with all files. */
-  virtual QCString trFileListDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os arquivos ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "e suas respectivas descrições:";
-    return result;
-  }
-
-  /*! This is an introduction to the annotated compound list. */
-  virtual QCString trCompoundListDescription()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      return "Aqui estão as estruturas de dados, uniões e suas respectivas descrições:";
-    }
-    else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
-    {
-      return "Aqui estão as classes e suas respectivas descrições:";
-    }
-    else
-    {
-      return "Aqui estão as classes, estruturas, uniões e interfaces e suas respectivas descrições:";
-    }
-  }
-
-  /*! This is an introduction to the page with all class members. */
-  virtual QCString trCompoundMembersDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de ";
-
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      result += "todas as estruturas e campos de uniões ";
-      if (!extractAll)
-      {
-        result += "documentados";
-      }
-    }
-    else
-    {
-      result += "todos os membros de classes ";
-      if (!extractAll)
-      {
-        result += "documentados";
-      }
-    }
-    result += " com referências para ";
-    if (!extractAll)
+    /*! header that is put before the list of member attributes. */
+    virtual QCString trMemberDataDocumentation()
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        result += "a documentação da estrutura/união de cada campo:";
+        return "Campos";
       }
       else
       {
-        result += "a documentação da classe de cada membro:";
+        return "Atributos";
       }
     }
-    else
+
+    /*! this is the text of a link put after brief descriptions. */
+    virtual QCString trMore()
+    { return "Mais..."; }
+
+    /*! put in the class documentation */
+    virtual QCString trListOfAllMembers()
+    { return "Lista de todos os Membros"; }
+
+    /*! used as the title of the "list of all members" page of a class */
+    virtual QCString trMemberList()
+    { return "Lista dos Membros"; }
+
+    /*! this is the first part of a sentence that is followed by a class name */
+    virtual QCString trThisIsTheListOfAllMembers()
+    { return "Esta é a lista de todos os membros de "; }
+
+    /*! this is the remainder of the sentence after the class name */
+    virtual QCString trIncludingInheritedMembers()
+    { return ", incluindo os membros herdados."; }
+
+    /*! this is put at the author sections at the bottom of man pages.
+     *  parameter s is name of the project name.
+     */
+    virtual QCString trGeneratedAutomatically(const QCString &s)
+    { QCString result="Gerado automaticamente por Doxygen";
+      if (!s.isEmpty()) result+=" para "+s;
+      result+=" a partir do código-fonte.";
+      return result;
+    }
+
+    /*! put after an enum name in the list of all members */
+    virtual QCString trEnumName()
+    { return "Enumeração"; }
+
+    /*! put after an enum value in the list of all members */
+    virtual QCString trEnumValue()
+    { return "Valor da enumeração"; }
+
+    /*! put after an undocumented member in the list of all members */
+    virtual QCString trDefinedIn()
+    { return "definido(a) em"; }
+
+    // quick reference sections
+
+    /*! This is put above each page as a link to the list of all groups of
+     *  compounds or files (see the \\group command).
+     */
+    virtual QCString trModules()
+    { return "Módulos"; }
+
+    /*! This is put above each page as a link to the class hierarchy */
+    virtual QCString trClassHierarchy()
+    { return "Hierarquia de Classes"; }
+
+    /*! This is put above each page as a link to the list of annotated classes */
+    virtual QCString trCompoundList()
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        result += "a estrutura/união a que pertencem:";
+        return "Estruturas de Dados";
       }
       else
       {
-        result += "a classe a que pertencem:";
+        return "Lista de Classes";
       }
     }
-    return result;
-  }
 
-  /*! This is an introduction to the page with all file members. */
-  virtual QCString trFileMembersDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de ";
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! This is put above each page as a link to the list of documented files */
+    virtual QCString trFileList()
+    { return "Lista de Arquivos"; }
+
+    /*! This is put above each page as a link to all members of compounds. */
+    virtual QCString trCompoundMembers()
     {
-      result += "todas as funções, variáveis, definições, enumerações e definições de tipos ";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Campos de Dados";
+      }
+      else
+      {
+        return "Membros de classe";
+      }
+    }
+
+    /*! This is put above each page as a link to all members of files. */
+    virtual QCString trFileMembers()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Ítens globais";
+      }
+      else
+      {
+        return "Membros dos Arquivos";
+      }
+    }
+
+    /*! This is put above each page as a link to all related pages. */
+    virtual QCString trRelatedPages()
+    { return "Páginas relacionadas"; }
+
+    /*! This is put above each page as a link to all examples. */
+    virtual QCString trExamples()
+    { return "Exemplos"; }
+
+    /*! This is put above each page as a link to the search engine. */
+    virtual QCString trSearch()
+    { return "Busca"; }
+
+    /*! This is an introduction to the class hierarchy. */
+    virtual QCString trClassHierarchyDescription()
+    { return "Esta lista de hierarquias está parcialmente ordenada (ordem alfabética):"; }
+
+    /*! This is an introduction to the list with all files. */
+    virtual QCString trFileListDescription(bool extractAll)
+    {
+      QCString result="Esta é a lista de todos os arquivos ";
+      if (!extractAll) result+="documentados ";
+      result+="e suas respectivas descrições:";
+      return result;
+    }
+
+    /*! This is an introduction to the annotated compound list. */
+    virtual QCString trCompoundListDescription()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Aqui estão as estruturas de dados, uniões e suas respectivas descrições:";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Aqui estão as classes e suas respectivas descrições:";
+      }
+      else
+      {
+        return "Aqui estão as classes, estruturas, uniões e interfaces e suas respectivas descrições:";
+      }
+    }
+
+    /*! This is an introduction to the page with all class members. */
+    virtual QCString trCompoundMembersDescription(bool extractAll)
+    {
+      QCString result="Esta é a lista de ";
+
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        result+="todas as estruturas e campos de uniões ";
+        if (!extractAll)
+        {
+          result+="documentados";
+        }
+      }
+      else
+      {
+        result+="todos os membros de classes ";
+        if (!extractAll)
+        {
+          result+="documentados";
+        }
+      }
+      result+=" com referências para ";
       if (!extractAll)
-        result += "documentadas ";
+      {
+        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+        {
+          result+="a documentação da estrutura/união de cada campo:";
+        }
+        else
+        {
+          result+="a documentação da classe de cada membro:";
+        }
+      }
+      else
+      {
+        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+        {
+          result+="a estrutura/união a que pertencem:";
+        }
+        else
+        {
+          result+="a classe a que pertencem:";
+        }
+      }
+      return result;
     }
-    else
+
+    /*! This is an introduction to the page with all file members. */
+    virtual QCString trFileMembersDescription(bool extractAll)
     {
-      result += "todos os membros dos arquivos ";
-      if (!extractAll)
-        result += "documentados ";
+      QCString result="Esta é a lista de ";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        result+="todas as funções, variáveis, definições, enumerações e definições de tipos ";
+        if (!extractAll) result+="documentadas ";
+      }
+      else
+      {
+        result+="todos os membros dos arquivos ";
+        if (!extractAll) result+="documentados ";
+      }
+      result+="com referências para ";
+      if (extractAll)
+        result+="seus respectivos arquivos:";
+      else
+        result+="suas respectivas documentações:";
+      return result;
     }
-    result += "com referências para ";
-    if (extractAll)
-      result += "seus respectivos arquivos:";
-    else
-      result += "suas respectivas documentações:";
-    return result;
-  }
 
-  /*! This is an introduction to the page with the list of all examples */
-  virtual QCString trExamplesDescription()
-  {
-    return "Esta é a lista de todos os exemplos:";
-  }
+    /*! This is an introduction to the page with the list of all examples */
+    virtual QCString trExamplesDescription()
+    { return "Esta é a lista de todos os exemplos:"; }
 
-  /*! This is an introduction to the page with the list of related pages */
-  virtual QCString trRelatedPagesDescription()
-  {
-    return "Esta é a lista de toda a documentação relacionadas:";
-  }
+    /*! This is an introduction to the page with the list of related pages */
+    virtual QCString trRelatedPagesDescription()
+    { return "Esta é a lista de toda a documentação relacionadas:"; }
 
-  /*! This is an introduction to the page with the list of class/file groups */
-  virtual QCString trModulesDescription()
-  {
-    return "Esta é a lista de todos os módulos:";
-  }
+    /*! This is an introduction to the page with the list of class/file groups */
+    virtual QCString trModulesDescription()
+    { return "Esta é a lista de todos os módulos:"; }
 
-  /*! This is used in HTML as the title of index.html. */
-  virtual QCString trDocumentation()
-  {
-    // TODO In the future, I think I'll suggest the replacement of this
-    // method to something like trDocumentationOf(projPrefix). This will allow
-    // the latin construction "Documentação de ProjA"
-    return "Documentação";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * index of all groups.
-   */
-  virtual QCString trModuleIndex()
-  {
-    return "Índice dos Módulos";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * class hierarchy.
-   */
-  virtual QCString trHierarchicalIndex()
-  {
-    return "Índice Hierárquico";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * annotated compound index.
-   */
-  virtual QCString trCompoundIndex()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! This is used in HTML as the title of index.html. */
+    virtual QCString trDocumentation()
     {
-      return "Índice das Estruturas de Dados";
+      // TODO In the future, I think I'll suggest the replacement of this
+      // method to something like trDocumentationOf(projPrefix). This will allow
+      // the latin construction "Documentação de ProjA"
+      return "Documentação";
     }
-    else
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * index of all groups.
+     */
+    virtual QCString trModuleIndex()
+    { return "Índice dos Módulos"; }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * class hierarchy.
+     */
+    virtual QCString trHierarchicalIndex()
+    { return "Índice Hierárquico"; }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * annotated compound index.
+     */
+    virtual QCString trCompoundIndex()
     {
-      return "Índice dos Componentes";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Índice das Estruturas de Dados";
+      }
+      else
+      {
+        return "Índice dos Componentes";
+      }
     }
-  }
 
-  /*! This is used in LaTeX as the title of the chapter with the
-   * list of all files.
-   */
-  virtual QCString trFileIndex()
-  {
-    return "Índice dos Arquivos";
-  }
+    /*! This is used in LaTeX as the title of the chapter with the
+     * list of all files.
+     */
+    virtual QCString trFileIndex()
+    { return "Índice dos Arquivos"; }
 
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all groups.
-   */
-  virtual QCString trModuleDocumentation()
-  {
-    return "Módulos";
-  }
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all groups.
+     */
+    virtual QCString trModuleDocumentation()
+    { return "Módulos"; }
 
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all classes, structs and unions.
-   */
-  virtual QCString trClassDocumentation()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all classes, structs and unions.
+     */
+    virtual QCString trClassDocumentation()
     {
-      return "Estruturas";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Estruturas";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
+      else
+      {
+        return "Classes";
+      }
     }
-    else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all files.
+     */
+    virtual QCString trFileDocumentation()
+    { return "Arquivos"; }
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all examples.
+     */
+    virtual QCString trExampleDocumentation()
+    { return "Exemplos"; }
+
+    /*! This is used in LaTeX as the title of the document */
+    virtual QCString trReferenceManual()
+    { return "Guia de Referência"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of defines
+     */
+    virtual QCString trDefines()
+    { return "Definições e Macros"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of typedefs
+     */
+    virtual QCString trTypedefs()
+    { return "Definições de Tipos"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of enumerations
+     */
+    virtual QCString trEnumerations()
+    { return "Enumerações"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) functions
+     */
+    virtual QCString trFunctions()
+    { return "Funções"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) variables
+     */
+    virtual QCString trVariables()
+    { return "Variáveis"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) variables
+     */
+    virtual QCString trEnumerationValues()
+    { return "Enumeradores"; }
+
+    /*! This is used in the documentation of a file before the list of
+     *  documentation blocks for defines
+     */
+    virtual QCString trDefineDocumentation()
+    { return "Definições e macros"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for typedefs
+     */
+    virtual QCString trTypedefDocumentation()
+    { return "Definições dos tipos"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for enumeration types
+     */
+    virtual QCString trEnumerationTypeDocumentation()
+    { return "Enumerações"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for functions
+     */
+    virtual QCString trFunctionDocumentation()
+    { return "Funções"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for variables
+     */
+    virtual QCString trVariableDocumentation()
+    { return "Variáveis"; }
+
+    /*! This is used in the documentation of a file/namespace/group before
+     *  the list of links to documented compounds
+     */
+    virtual QCString trCompounds()
     {
-      return trDesignUnitDocumentation();
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Estruturas de Dados";
+      }
+      else
+      {
+        return "Componentes";
+      }
     }
-    else
+
+    /*! This is used in the standard footer of each page and indicates when
+     *  the page was generated
+     */
+    virtual QCString trGeneratedAt(const QCString &date,const QCString &projName)
     {
-      return "Classes";
+      QCString result="Gerado em "+date;
+      if (!projName.isEmpty()) result+=" para "+projName;
+      result+=" por";
+      return result;
     }
-  }
 
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all files.
-   */
-  virtual QCString trFileDocumentation()
-  {
-    return "Arquivos";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all examples.
-   */
-  virtual QCString trExampleDocumentation()
-  {
-    return "Exemplos";
-  }
-
-  /*! This is used in LaTeX as the title of the document */
-  virtual QCString trReferenceManual()
-  {
-    return "Guia de Referência";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of defines
-   */
-  virtual QCString trDefines()
-  {
-    return "Definições e Macros";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of typedefs
-   */
-  virtual QCString trTypedefs()
-  {
-    return "Definições de Tipos";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of enumerations
-   */
-  virtual QCString trEnumerations()
-  {
-    return "Enumerações";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) functions
-   */
-  virtual QCString trFunctions()
-  {
-    return "Funções";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) variables
-   */
-  virtual QCString trVariables()
-  {
-    return "Variáveis";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) variables
-   */
-  virtual QCString trEnumerationValues()
-  {
-    return "Enumeradores";
-  }
-
-  /*! This is used in the documentation of a file before the list of
-   *  documentation blocks for defines
-   */
-  virtual QCString trDefineDocumentation()
-  {
-    return "Definições e macros";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for typedefs
-   */
-  virtual QCString trTypedefDocumentation()
-  {
-    return "Definições dos tipos";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for enumeration types
-   */
-  virtual QCString trEnumerationTypeDocumentation()
-  {
-    return "Enumerações";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for functions
-   */
-  virtual QCString trFunctionDocumentation()
-  {
-    return "Funções";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for variables
-   */
-  virtual QCString trVariableDocumentation()
-  {
-    return "Variáveis";
-  }
-
-  /*! This is used in the documentation of a file/namespace/group before
-   *  the list of links to documented compounds
-   */
-  virtual QCString trCompounds()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! this text is put before a class diagram */
+    virtual QCString trClassDiagram(const QCString &clName)
     {
-      return "Estruturas de Dados";
+      return "Diagrama de hierarquia para "+clName+":";
     }
-    else
+
+    /*! this text is generated when the \\warning command is used. */
+    virtual QCString trWarning()
+    { return "Aviso"; }
+
+    /*! this text is generated when the \\version command is used. */
+    virtual QCString trVersion()
+    { return "Versão"; }
+
+    /*! this text is generated when the \\date command is used. */
+    virtual QCString trDate()
+    { return "Data"; }
+
+    /*! this text is generated when the \\return command is used. */
+    virtual QCString trReturns()
+    { return "Retorna"; }
+
+    /*! this text is generated when the \\sa command is used. */
+    virtual QCString trSeeAlso()
+    { return "Veja também"; }
+
+    /*! this text is generated when the \\param command is used. */
+    virtual QCString trParameters()
+    { return "Parâmetros"; }
+
+    /*! this text is generated when the \\exception command is used. */
+    virtual QCString trExceptions()
+    { return "Exceções"; }
+
+    /*! this text is used in the title page of a LaTeX document. */
+    virtual QCString trGeneratedBy()
+    { return "Gerado por"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990307
+//////////////////////////////////////////////////////////////////////////
+
+    /*! used as the title of page containing all the index of all namespaces. */
+    virtual QCString trNamespaceList()
+    { return "Lista de Namespaces"; }
+
+    /*! used as an introduction to the namespace list */
+    virtual QCString trNamespaceListDescription(bool extractAll)
     {
-      return "Componentes";
+      QCString result="Esta é a lista de todos os Namespaces ";
+      if (!extractAll) result+="documentados ";
+      result+="com suas respectivas descrições:";
+      return result;
     }
-  }
 
-  /*! This is used in the standard footer of each page and indicates when
-   *  the page was generated
-   */
-  virtual QCString trGeneratedAt(const QCString &date, const QCString &projName)
-  {
-    QCString result = "Gerado em " + date;
-    if (!projName.isEmpty())
-      result += " para " + projName;
-    result += " por";
-    return result;
-  }
+    /*! used in the class documentation as a header before the list of all
+     *  friends of a class
+     */
+    virtual QCString trFriends()
+    { return "Amigas"; }
 
-  /*! this text is put before a class diagram */
-  virtual QCString trClassDiagram(const QCString &clName)
-  {
-    return "Diagrama de hierarquia para " + clName + ":";
-  }
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990405
+//////////////////////////////////////////////////////////////////////////
 
-  /*! this text is generated when the \\warning command is used. */
-  virtual QCString trWarning()
-  {
-    return "Aviso";
-  }
+    /*! used in the class documentation as a header before the list of all
+     * related classes
+     */
+    virtual QCString trRelatedFunctionDocumentation()
+    { return "Amigas e Funções Relacionadas"; }
 
-  /*! this text is generated when the \\version command is used. */
-  virtual QCString trVersion()
-  {
-    return "Versão";
-  }
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990425
+//////////////////////////////////////////////////////////////////////////
 
-  /*! this text is generated when the \\date command is used. */
-  virtual QCString trDate()
-  {
-    return "Data";
-  }
-
-  /*! this text is generated when the \\return command is used. */
-  virtual QCString trReturns()
-  {
-    return "Retorna";
-  }
-
-  /*! this text is generated when the \\sa command is used. */
-  virtual QCString trSeeAlso()
-  {
-    return "Veja também";
-  }
-
-  /*! this text is generated when the \\param command is used. */
-  virtual QCString trParameters()
-  {
-    return "Parâmetros";
-  }
-
-  /*! this text is generated when the \\exception command is used. */
-  virtual QCString trExceptions()
-  {
-    return "Exceções";
-  }
-
-  /*! this text is used in the title page of a LaTeX document. */
-  virtual QCString trGeneratedBy()
-  {
-    return "Gerado por";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990307
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used as the title of page containing all the index of all namespaces. */
-  virtual QCString trNamespaceList()
-  {
-    return "Lista de Namespaces";
-  }
-
-  /*! used as an introduction to the namespace list */
-  virtual QCString trNamespaceListDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os Namespaces ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "com suas respectivas descrições:";
-    return result;
-  }
-
-  /*! used in the class documentation as a header before the list of all
-   *  friends of a class
-   */
-  virtual QCString trFriends()
-  {
-    return "Amigas";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990405
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used in the class documentation as a header before the list of all
-   * related classes
-   */
-  virtual QCString trRelatedFunctionDocumentation()
-  {
-    return "Amigas e Funções Relacionadas";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990425
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used as the title of the HTML page of a class/struct/union */
-  virtual QCString trCompoundReference(const QCString &clName,
-                                       ClassDef::CompoundType compType,
-                                       bool isTemplate)
-  {
-    QCString result = "Referência";
-    if (isTemplate)
-      result += " do <em>Template</em>";
-    if (compType == ClassDef::Protocol)
+    /*! used as the title of the HTML page of a class/struct/union */
+    virtual QCString trCompoundReference(const QCString &clName,
+                                    ClassDef::CompoundType compType,
+                                    bool isTemplate)
     {
-      result += " do ";
+      QCString result="Referência";
+      if (isTemplate) result+=" do <em>Template</em>";
+      if (compType == ClassDef::Protocol)
+      {
+        result+=" do ";
+      }
+      else
+      {
+        result+=" da ";
+      }
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="Classe "; break;
+        case ClassDef::Struct:     result+="Estrutura "; break;
+        case ClassDef::Union:      result+="União "; break;
+        case ClassDef::Interface:  result+="Interface "; break;
+        case ClassDef::Protocol:   result+="Protocolo "; break;
+        case ClassDef::Category:   result+="Categoria "; break;
+        case ClassDef::Exception:  result+="Exceção "; break;
+        default: break;
+      }
+      result+=clName;
+      return result;
     }
-    else
+
+    /*! used as the title of the HTML page of a file */
+    virtual QCString trFileReference(const QCString &fileName)
     {
-      result += " da ";
+      QCString result = "Referência do Arquivo ";
+      result += fileName;
+      return result;
     }
-    switch (compType)
+
+    /*! used as the title of the HTML page of a namespace */
+    virtual QCString trNamespaceReference(const QCString &namespaceName)
     {
-    case ClassDef::Class:
-      result += "Classe ";
-      break;
-    case ClassDef::Struct:
-      result += "Estrutura ";
-      break;
-    case ClassDef::Union:
-      result += "União ";
-      break;
-    case ClassDef::Interface:
-      result += "Interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "Protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "Categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "Exceção ";
-      break;
-    default:
-      break;
+      QCString result ="Refência do Namespace ";
+      result += namespaceName;
+      return result;
     }
-    result += clName;
-    return result;
-  }
 
-  /*! used as the title of the HTML page of a file */
-  virtual QCString trFileReference(const QCString &fileName)
-  {
-    QCString result = "Referência do Arquivo ";
-    result += fileName;
-    return result;
-  }
-
-  /*! used as the title of the HTML page of a namespace */
-  virtual QCString trNamespaceReference(const QCString &namespaceName)
-  {
-    QCString result = "Refência do Namespace ";
-    result += namespaceName;
-    return result;
-  }
-
-  virtual QCString trPublicMembers()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_JAVA))
+    virtual QCString trPublicMembers()
     {
-      return "Métodos Públicos";
+      if (Config_getBool(OPTIMIZE_OUTPUT_JAVA))
+      {
+        return "Métodos Públicos";
+      }
+      else
+      {
+        return "Membros Públicos";
+      }
     }
-    else
+
+    virtual QCString trPublicSlots()
+    { return "Slots Públicos"; }
+
+    virtual QCString trSignals()
+    { return "Sinais"; }
+
+    virtual QCString trStaticPublicMembers()
+    { return "Membros Públicos Estáticos"; }
+
+    virtual QCString trProtectedMembers()
+    { return "Membros Protegidos"; }
+
+    virtual QCString trProtectedSlots()
+    { return "Slots Protegidos"; }
+
+    virtual QCString trStaticProtectedMembers()
+    { return "Membros Protegidos Estáticos"; }
+
+    virtual QCString trPrivateMembers()
+    { return "Membros Privados"; }
+
+    virtual QCString trPrivateSlots()
+    { return "Slots Privados"; }
+
+    virtual QCString trStaticPrivateMembers()
+    { return "Membros Privados Estáticos"; }
+
+    /*! this function is used to produce a comma-separated list of items.
+     *  use generateMarker(i) to indicate where item i should be put.
+     */
+    virtual QCString trWriteList(int numEntries)
     {
-      return "Membros Públicos";
-    }
-  }
-
-  virtual QCString trPublicSlots()
-  {
-    return "Slots Públicos";
-  }
-
-  virtual QCString trSignals()
-  {
-    return "Sinais";
-  }
-
-  virtual QCString trStaticPublicMembers()
-  {
-    return "Membros Públicos Estáticos";
-  }
-
-  virtual QCString trProtectedMembers()
-  {
-    return "Membros Protegidos";
-  }
-
-  virtual QCString trProtectedSlots()
-  {
-    return "Slots Protegidos";
-  }
-
-  virtual QCString trStaticProtectedMembers()
-  {
-    return "Membros Protegidos Estáticos";
-  }
-
-  virtual QCString trPrivateMembers()
-  {
-    return "Membros Privados";
-  }
-
-  virtual QCString trPrivateSlots()
-  {
-    return "Slots Privados";
-  }
-
-  virtual QCString trStaticPrivateMembers()
-  {
-    return "Membros Privados Estáticos";
-  }
-
-  /*! this function is used to produce a comma-separated list of items.
-   *  use generateMarker(i) to indicate where item i should be put.
-   */
-  virtual QCString trWriteList(int numEntries)
-  {
-    QCString result;
-    int i;
-    // the inherits list contain `numEntries' classes
-    for (i = 0; i < numEntries; i++)
-    {
-      // use generateMarker to generate placeholders for the class links!
-      result += generateMarker(i); // generate marker for entry i in the list
+      QCString result;
+      int i;
+      // the inherits list contain `numEntries' classes
+      for (i=0;i<numEntries;i++)
+      {
+        // use generateMarker to generate placeholders for the class links!
+        result+=generateMarker(i); // generate marker for entry i in the list
                                    // (order is left to right)
 
-      if (i != numEntries - 1) // not the last entry, so we need a separator
+        if (i!=numEntries-1)  // not the last entry, so we need a separator
+        {
+          if (i<numEntries-2) // not the fore last entry
+            result+=", ";
+          else                // the fore last entry
+            result+=" e ";
+        }
+      }
+      return result;
+    }
+
+    /*! used in class documentation to produce a list of base classes,
+     *  if class diagrams are disabled.
+     */
+    virtual QCString trInheritsList(int numEntries)
+    {
+      return "Subclasse de " + trWriteList(numEntries) + ".";
+    }
+
+    /*! used in class documentation to produce a list of super classes,
+     *  if class diagrams are disabled.
+     */
+    virtual QCString trInheritedByList(int numEntries)
+    {
+      return "Superclasse de "+trWriteList(numEntries)+".";
+    }
+
+    /*! used in member documentation blocks to produce a list of
+     *  members that are hidden by this one.
+     */
+    virtual QCString trReimplementedFromList(int numEntries)
+    {
+      return "Reimplementa "+trWriteList(numEntries)+".";
+    }
+
+    /*! used in member documentation blocks to produce a list of
+     *  all member that overwrite the implementation of this member.
+     */
+    virtual QCString trReimplementedInList(int numEntries)
+    {
+      return "Reimplementado por "+trWriteList(numEntries)+".";
+    }
+
+    /*! This is put above each page as a link to all members of namespaces. */
+    virtual QCString trNamespaceMembers()
+    { return "Membros do <em>Namespace</em>"; }
+
+    /*! This is an introduction to the page with all namespace members */
+    virtual QCString trNamespaceMemberDescription(bool extractAll)
+    {
+      QCString result="Essa é a lista com todos os membros ";
+      if (!extractAll) result+="documentados ";
+      result+="do <em>Namespace</em> com referências para ";
+      if (extractAll)
+        result+="a documentação do <em>Namespace</em> para cada membro:";
+      else
+        result+="os seus respectivos <em>Namespaces</em>:";
+      return result;
+    }
+    /*! This is used in LaTeX as the title of the chapter with the
+     *  index of all namespaces.
+     */
+    virtual QCString trNamespaceIndex()
+    { return "<em>Namespaces</em>"; }
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all namespaces.
+     */
+    virtual QCString trNamespaceDocumentation()
+    { return "<em>Namespace</em>"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990522
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used in the documentation before the list of all
+     *  namespaces in a file.
+     */
+    virtual QCString trNamespaces()
+    { return "<em>Namespaces</em>"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990728
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is put at the bottom of a class documentation page and is
+     *  followed by a list of files that were used to generate the page.
+     */
+    virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
+        bool single)
+    { // here s is one of " Class", " Struct" or " Union"
+      // single is true implies a single file
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      QCString result="A documentação para ";
+      if (compType == ClassDef::Protocol)
       {
-        if (i < numEntries - 2) // not the fore last entry
-          result += ", ";
-        else // the fore last entry
-          result += " e ";
+         result+= "esse ";
+      }
+      else
+      {
+         result+= "essa ";
+      }
+      switch(compType)
+      {
+        case ClassDef::Class:      result+=vhdlOpt?"Unidade de Design ":"classe "; break;
+        case ClassDef::Struct:     result+="estrutura "; break;
+        case ClassDef::Union:      result+="união "; break;
+        case ClassDef::Interface:  result+="interface "; break;
+        case ClassDef::Protocol:   result+="protocolo "; break;
+        case ClassDef::Category:   result+="categoria "; break;
+        case ClassDef::Exception:  result+="exceção "; break;
+        default: break;
+      }
+      result+=" foi gerada a partir ";
+      if (single) result+="do seguinte arquivo:"; else result+="dos seguintes arquivos:";
+      return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990901
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used as the heading text for the retval command. */
+    virtual QCString trReturnValues()
+    { return "Valores Retornados"; }
+
+    /*! This is in the (quick) index as a link to the main page (index.html)
+     */
+    virtual QCString trMainPage()
+    { return "Página Principal"; }
+
+    /*! This is used in references to page that are put in the LaTeX
+     *  documentation. It should be an abbreviation of the word page.
+     */
+    virtual QCString trPageAbbreviation()
+    {
+      // Decidi mudar de página para "p." para ficar mais compacto.
+      return "p.";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-991003
+//////////////////////////////////////////////////////////////////////////
+
+    virtual QCString trDefinedAtLineInSourceFile()
+    {
+      return "Definição na linha @0 do arquivo @1.";
+    }
+    virtual QCString trDefinedInSourceFile()
+    {
+      return "Definição no arquivo @0.";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-991205
+//////////////////////////////////////////////////////////////////////////
+
+    virtual QCString trDeprecated()
+    {
+      return "Obsoleto(a)";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.0.0
+//////////////////////////////////////////////////////////////////////////
+
+    /*! this text is put before a collaboration diagram */
+    virtual QCString trCollaborationDiagram(const QCString &clName)
+    {
+      return "Diagrama de colaboração para "+clName+":";
+    }
+    /*! this text is put before an include dependency graph */
+    virtual QCString trInclDepGraph(const QCString &fName)
+    {
+      return "Gráfico de dependência de inclusões para "+fName+":";
+    }
+    /*! header that is put before the list of constructor/destructors. */
+    virtual QCString trConstructorDocumentation()
+    {
+      return "Construtores e Destrutores";
+    }
+    /*! Used in the file documentation to point to the corresponding sources. */
+    virtual QCString trGotoSourceCode()
+    {
+      return "Vá para o código-fonte desse arquivo.";
+    }
+    /*! Used in the file sources to point to the corresponding documentation. */
+    virtual QCString trGotoDocumentation()
+    {
+      return "Vá para a documentação desse arquivo.";
+    }
+    /*! Text for the \\pre command */
+    virtual QCString trPrecondition()
+    {
+      return "Pré-condição";
+    }
+    /*! Text for the \\post command */
+    virtual QCString trPostcondition()
+    {
+      return "Pós-condição";
+    }
+    /*! Text for the \\invariant command */
+    virtual QCString trInvariant()
+    {
+      return "Invariante";
+    }
+    /*! Text shown before a multi-line variable/enum initialization */
+    virtual QCString trInitialValue()
+    {
+      return "Valor inicial:";
+    }
+    /*! Text used the source code in the file index */
+    virtual QCString trCode()
+    {
+      return "código";
+    }
+    virtual QCString trGraphicalHierarchy()
+    {
+      return "Gráfico de Hierarquia de Classes";
+    }
+    virtual QCString trGotoGraphicalHierarchy()
+    {
+      return "Vá para o gráfico de hierarquia de classes";
+    }
+    virtual QCString trGotoTextualHierarchy()
+    {
+      return "Vá para a hierarquia de classes (texto)";
+    }
+    virtual QCString trPageIndex()
+    {
+      return "Índice da Página";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.0
+//////////////////////////////////////////////////////////////////////////
+
+    virtual QCString trNote()
+    {
+      return "Observação";
+    }
+    virtual QCString trPublicTypes()
+    {
+      return "Tipos Públicos";
+    }
+    virtual QCString trPublicAttribs()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Campos de Dados";
+      }
+      else
+      {
+        return "Atributos Públicos";
       }
     }
-    return result;
-  }
-
-  /*! used in class documentation to produce a list of base classes,
-   *  if class diagrams are disabled.
-   */
-  virtual QCString trInheritsList(int numEntries)
-  {
-    return "Subclasse de " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in class documentation to produce a list of super classes,
-   *  if class diagrams are disabled.
-   */
-  virtual QCString trInheritedByList(int numEntries)
-  {
-    return "Superclasse de " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in member documentation blocks to produce a list of
-   *  members that are hidden by this one.
-   */
-  virtual QCString trReimplementedFromList(int numEntries)
-  {
-    return "Reimplementa " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in member documentation blocks to produce a list of
-   *  all member that overwrite the implementation of this member.
-   */
-  virtual QCString trReimplementedInList(int numEntries)
-  {
-    return "Reimplementado por " + trWriteList(numEntries) + ".";
-  }
-
-  /*! This is put above each page as a link to all members of namespaces. */
-  virtual QCString trNamespaceMembers()
-  {
-    return "Membros do <em>Namespace</em>";
-  }
-
-  /*! This is an introduction to the page with all namespace members */
-  virtual QCString trNamespaceMemberDescription(bool extractAll)
-  {
-    QCString result = "Essa é a lista com todos os membros ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "do <em>Namespace</em> com referências para ";
-    if (extractAll)
-      result += "a documentação do <em>Namespace</em> para cada membro:";
-    else
-      result += "os seus respectivos <em>Namespaces</em>:";
-    return result;
-  }
-  /*! This is used in LaTeX as the title of the chapter with the
-   *  index of all namespaces.
-   */
-  virtual QCString trNamespaceIndex()
-  {
-    return "<em>Namespaces</em>";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all namespaces.
-   */
-  virtual QCString trNamespaceDocumentation()
-  {
-    return "<em>Namespace</em>";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990522
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used in the documentation before the list of all
-   *  namespaces in a file.
-   */
-  virtual QCString trNamespaces()
-  {
-    return "<em>Namespaces</em>";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990728
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is put at the bottom of a class documentation page and is
-   *  followed by a list of files that were used to generate the page.
-   */
-  virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
-                                        bool single)
-  { // here s is one of " Class", " Struct" or " Union"
-    // single is true implies a single file
-    bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-    QCString result = "A documentação para ";
-    if (compType == ClassDef::Protocol)
+    virtual QCString trStaticPublicAttribs()
     {
-      result += "esse ";
+      return "Atributos Estáticos Públicos";
     }
-    else
+    virtual QCString trProtectedTypes()
     {
-      result += "essa ";
+      return "Tipos Protegidos";
     }
-    switch (compType)
+    virtual QCString trProtectedAttribs()
     {
-    case ClassDef::Class:
-      result += vhdlOpt ? "Unidade de Design " : "classe ";
-      break;
-    case ClassDef::Struct:
-      result += "estrutura ";
-      break;
-    case ClassDef::Union:
-      result += "união ";
-      break;
-    case ClassDef::Interface:
-      result += "interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "exceção ";
-      break;
-    default:
-      break;
+      return "Atributos Protegidos";
     }
-    result += " foi gerada a partir ";
-    if (single)
-      result += "do seguinte arquivo:";
-    else
-      result += "dos seguintes arquivos:";
-    return result;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990901
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used as the heading text for the retval command. */
-  virtual QCString trReturnValues()
-  {
-    return "Valores Retornados";
-  }
-
-  /*! This is in the (quick) index as a link to the main page (index.html)
-   */
-  virtual QCString trMainPage()
-  {
-    return "Página Principal";
-  }
-
-  /*! This is used in references to page that are put in the LaTeX
-   *  documentation. It should be an abbreviation of the word page.
-   */
-  virtual QCString trPageAbbreviation()
-  {
-    // Decidi mudar de página para "p." para ficar mais compacto.
-    return "p.";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-991003
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trDefinedAtLineInSourceFile()
-  {
-    return "Definição na linha @0 do arquivo @1.";
-  }
-  virtual QCString trDefinedInSourceFile()
-  {
-    return "Definição no arquivo @0.";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-991205
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trDeprecated()
-  {
-    return "Obsoleto(a)";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.0.0
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! this text is put before a collaboration diagram */
-  virtual QCString trCollaborationDiagram(const QCString &clName)
-  {
-    return "Diagrama de colaboração para " + clName + ":";
-  }
-  /*! this text is put before an include dependency graph */
-  virtual QCString trInclDepGraph(const QCString &fName)
-  {
-    return "Gráfico de dependência de inclusões para " + fName + ":";
-  }
-  /*! header that is put before the list of constructor/destructors. */
-  virtual QCString trConstructorDocumentation()
-  {
-    return "Construtores e Destrutores";
-  }
-  /*! Used in the file documentation to point to the corresponding sources. */
-  virtual QCString trGotoSourceCode()
-  {
-    return "Vá para o código-fonte desse arquivo.";
-  }
-  /*! Used in the file sources to point to the corresponding documentation. */
-  virtual QCString trGotoDocumentation()
-  {
-    return "Vá para a documentação desse arquivo.";
-  }
-  /*! Text for the \\pre command */
-  virtual QCString trPrecondition()
-  {
-    return "Pré-condição";
-  }
-  /*! Text for the \\post command */
-  virtual QCString trPostcondition()
-  {
-    return "Pós-condição";
-  }
-  /*! Text for the \\invariant command */
-  virtual QCString trInvariant()
-  {
-    return "Invariante";
-  }
-  /*! Text shown before a multi-line variable/enum initialization */
-  virtual QCString trInitialValue()
-  {
-    return "Valor inicial:";
-  }
-  /*! Text used the source code in the file index */
-  virtual QCString trCode()
-  {
-    return "código";
-  }
-  virtual QCString trGraphicalHierarchy()
-  {
-    return "Gráfico de Hierarquia de Classes";
-  }
-  virtual QCString trGotoGraphicalHierarchy()
-  {
-    return "Vá para o gráfico de hierarquia de classes";
-  }
-  virtual QCString trGotoTextualHierarchy()
-  {
-    return "Vá para a hierarquia de classes (texto)";
-  }
-  virtual QCString trPageIndex()
-  {
-    return "Índice da Página";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.0
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trNote()
-  {
-    return "Observação";
-  }
-  virtual QCString trPublicTypes()
-  {
-    return "Tipos Públicos";
-  }
-  virtual QCString trPublicAttribs()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    virtual QCString trStaticProtectedAttribs()
     {
-      return "Campos de Dados";
+      return "Atributos Estáticos Protegidos";
     }
-    else
+    virtual QCString trPrivateTypes()
     {
-      return "Atributos Públicos";
+      return "Tipos Privados";
     }
-  }
-  virtual QCString trStaticPublicAttribs()
-  {
-    return "Atributos Estáticos Públicos";
-  }
-  virtual QCString trProtectedTypes()
-  {
-    return "Tipos Protegidos";
-  }
-  virtual QCString trProtectedAttribs()
-  {
-    return "Atributos Protegidos";
-  }
-  virtual QCString trStaticProtectedAttribs()
-  {
-    return "Atributos Estáticos Protegidos";
-  }
-  virtual QCString trPrivateTypes()
-  {
-    return "Tipos Privados";
-  }
-  virtual QCString trPrivateAttribs()
-  {
-    return "Atributos Privados";
-  }
-  virtual QCString trStaticPrivateAttribs()
-  {
-    return "Atributos Privados Estáticos";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.3
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a marker that is put before a todo item */
-  virtual QCString trTodo()
-  {
-    return "Atividades futuras";
-  }
-  /*! Used as the header of the todo list */
-  virtual QCString trTodoList()
-  {
-    return "Lista de atividades futuras";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.4
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trReferencedBy()
-  {
-    return "Referenciado(a) por";
-  }
-  virtual QCString trRemarks()
-  {
-    return "Anotações";
-  }
-  virtual QCString trAttention()
-  {
-    return "Atenção";
-  }
-  virtual QCString trInclByDepGraph()
-  {
-    return "Este grafo mostra quais arquivos estão direta ou indiretamente relacionados com esse arquivo:";
-  }
-  virtual QCString trSince()
-  {
-    return "Desde";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.5
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! title of the graph legend page */
-  virtual QCString trLegendTitle()
-  {
-    return "Legenda do Grafo";
-  }
-  /*! page explaining how the dot graph's should be interpreted
-   *  The %A in the text below are to prevent link to classes called "A".
-   */
-  virtual QCString trLegendDocs()
-  {
-    return "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
-           "Considere o seguinte exemplo:\n"
-           "\\code\n"
-           "/*! Classe oculta por causa da truncagem */\n"
-           "class Invisible { };\n\n"
-           "/*! Classe Truncated, relação de herança está oculta */\n"
-           "class Truncated : public Invisible { };\n\n"
-           "/* Classe não documentada com os comentários do Doxygen */\n"
-           "class Undocumented { };\n\n"
-           "/*! Classe possui que possui uma relação de herança pública */\n"
-           "class PublicBase : public Truncated { };\n\n"
-           "/*! Um template de classe */\n"
-           "template<class T> class Templ { };\n\n"
-           "/*! Classe possui que possui uma relação de herança protegida  */\n"
-           "class ProtectedBase { };\n\n"
-           "/*! Classe possui que possui uma relação de herança privada  */\n"
-           "class PrivateBase { };\n\n"
-           "/*! Classe utilizada pela classe Inherited */\n"
-           "class Used { };\n\n"
-           "/*! Super classe que herda outras classes */\n"
-           "class Inherited : public PublicBase,\n"
-           "                  protected ProtectedBase,\n"
-           "                  private PrivateBase,\n"
-           "                  public Undocumented,\n"
-           "                  public Templ<int>\n"
-           "{\n"
-           "  private:\n"
-           "    Used *m_usedClass;\n"
-           "};\n"
-           "\\endcode\n"
-           "Isto irá gerar o seguinte gráfo:"
-           "<p><center><img src=\"graph_legend." +
-           getDotImageExtension() + "\"></center>\n"
-                                    "<p>\n"
-                                    "As caixas no grafo acima possuem os seguintes significados:\n"
-                                    "</p>\n"
-                                    "<ul>\n"
-                                    "<li>Uma caixa cinza denota a estrutura ou a classe que gerou"
-                                    "este grafo.</li>\n"
-                                    "<li>Uma caixa com a borda preta denota uma estrutura ou classe documentada.</li>\n"
-                                    "<li>Uma caixa com a borda cinza denota uma estrutura ou classe não documentada.</li>\n"
-                                    "<li>Uma caixa com a borda vermelha denota uma estrutura ou classe na"
-                                    "qual nem todas as relações são mostradas. Um grafo é truncado quando "
-                                    "esse não cabe no espaço especificado.</li>\n"
-                                    "</ul>\n"
-                                    "<p>\n"
-                                    "As setas possuem os seguintes significados:\n"
-                                    "</p>\n"
-                                    "<ul>\n"
-                                    "<li>Uma seta azul escura denota a relação de herança pública entre "
-                                    "duas classes.</li>\n"
-                                    "<li>Uma seta verde escura denota a relação de herança protegida entre "
-                                    "duas classes.</li>\n"
-                                    "<li>Uma seta vermelha escura denota a relação de herança privada entre "
-                                    "duas classes.</li>\n"
-                                    "<li>Uma seta pontilhada púrpura denota a relação de uso e/ou agragação "
-                                    "por outra classe/estrutura. A etiqueta da seta denota o nome do(s) campo(s) "
-                                    "que representa(m) este apontamento.</li>\n"
-                                    "<li>Uma seta pontilhada amarela denota a relação de instanciação de uma "
-                                    "<em>template</em>. A etiqueta da seta denota os parâmetros de instanciação "
-                                    "desta <em>template</em>.</li>\n"
-                                    "</ul>\n";
-  }
-  /*! text for the link to the legend page */
-  virtual QCString trLegend()
-  {
-    return "legenda";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.0
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a marker that is put before a test item */
-  virtual QCString trTest()
-  {
-    return "Teste";
-  }
-  /*! Used as the header of the test list */
-  virtual QCString trTestList()
-  {
-    return "Lista de Testes";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.2
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a section header for IDL properties */
-  virtual QCString trProperties()
-  {
-    return "Propriedades";
-  }
-  /*! Used as a section header for IDL property documentation */
-  virtual QCString trPropertyDocumentation()
-  {
-    return "Propriedades";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.4
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used for Java classes in the summary section of Java packages */
-  virtual QCString trClasses()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    virtual QCString trPrivateAttribs()
     {
-      return "Estruturas de Dados";
+      return "Atributos Privados";
     }
-    else
+    virtual QCString trStaticPrivateAttribs()
     {
-      return "Classes";
-    }
-  }
-  /*! Used as the title of a Java package */
-  virtual QCString trPackage(const QCString &name)
-  {
-    return "Pacote " + name;
-  }
-  /*! The description of the package index page */
-  virtual QCString trPackageListDescription()
-  {
-    return "Esta é a lista com os pacotes e suas respectivas descrições (quando disponíveis):";
-  }
-  /*! The link name in the Quick links header for each page */
-  virtual QCString trPackages()
-  {
-    return "Pacotes";
-  }
-  /*! Text shown before a multi-line define */
-  virtual QCString trDefineValue()
-  {
-    return "Valor:";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.5
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a marker that is put before a \\bug item */
-  virtual QCString trBug()
-  {
-    return "Bug";
-  }
-  /*! Used as the header of the bug list */
-  virtual QCString trBugList()
-  {
-    return "Lista de Bugs";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.6
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as ansicpg for RTF file
-   *
-   * The following table shows the correlation of Charset name, Charset Value and
-   * <pre>
-   * Codepage number:
-   * Charset Name       Charset Value(hex)  Codepage number
-   * ------------------------------------------------------
-   * DEFAULT_CHARSET           1 (x01)
-   * SYMBOL_CHARSET            2 (x02)
-   * OEM_CHARSET             255 (xFF)
-   * ANSI_CHARSET              0 (x00)            1252
-   * RUSSIAN_CHARSET         204 (xCC)            1251
-   * EE_CHARSET              238 (xEE)            1250
-   * GREEK_CHARSET           161 (xA1)            1253
-   * TURKISH_CHARSET         162 (xA2)            1254
-   * BALTIC_CHARSET          186 (xBA)            1257
-   * HEBREW_CHARSET          177 (xB1)            1255
-   * ARABIC _CHARSET         178 (xB2)            1256
-   * SHIFTJIS_CHARSET        128 (x80)             932
-   * HANGEUL_CHARSET         129 (x81)             949
-   * GB2313_CHARSET          134 (x86)             936
-   * CHINESEBIG5_CHARSET     136 (x88)             950
-   * </pre>
-   *
-   */
-  virtual QCString trRTFansicp()
-  {
-    return "1252";
-  }
-
-  /*! Used as ansicpg for RTF fcharset
-   *  \see trRTFansicp() for a table of possible values.
-   */
-  virtual QCString trRTFCharSet()
-  {
-    return "0";
-  }
-
-  /*! Used as header RTF general index */
-  virtual QCString trRTFGeneralIndex()
-  {
-    return "Sumário";
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trClass(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Classe" : "classe"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trFile(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Arquivo" : "arquivo"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trNamespace(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Namespace" : "namespace"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trGroup(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Grupo" : "grupo"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trPage(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Página" : "página"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trMember(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Membro" : "membro"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trGlobal(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Globa" : "globa"));
-    if (!singular)
-    {
-      result += "is";
-    }
-    else
-    {
-      result += "l";
-    }
-    return result;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.7
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This text is generated when the \\author command is used and
-   *  for the author section in man pages. */
-  virtual QCString trAuthor(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Autor" : "autor"));
-    if (!singular)
-      result += "es";
-    return result;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.11
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This text is put before the list of members referenced by a member
-   */
-  virtual QCString trReferences()
-  {
-    return "Referencias";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.13
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used in member documentation blocks to produce a list of
-   *  members that are implemented by this one.
-   */
-  virtual QCString trImplementedFromList(int numEntries)
-  {
-    return "Implementa " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in member documentation blocks to produce a list of
-   *  all members that implementation this member.
-   */
-  virtual QCString trImplementedInList(int numEntries)
-  {
-    return "Implementado por " + trWriteList(numEntries) + ".";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.16
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used in RTF documentation as a heading for the Table
-   *  of Contents.
-   */
-  virtual QCString trRTFTableOfContents()
-  {
-    return "Sumário";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.17
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as the header of the list of item that have been
-   *  flagged deprecated
-   */
-  virtual QCString trDeprecatedList()
-  {
-    return "Lista de itens obsoletos";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.18
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a header for declaration section of the events found in
-   * a C# program
-   */
-  virtual QCString trEvents()
-  {
-    return "Eventos";
-  }
-  /*! Header used for the documentation section of a class' events. */
-  virtual QCString trEventDocumentation()
-  {
-    return "Eventos";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a heading for a list of Java class types with package scope.
-   */
-  virtual QCString trPackageTypes()
-  {
-    return "Tipos do Pacote";
-  }
-  /*! Used as a heading for a list of Java class functions with package
-   * scope.
-   */
-  virtual QCString trPackageFunctions()
-  {
-    return "Funções do Pacote";
-  }
-  virtual QCString trPackageMembers()
-  {
-    return "Membros do Pacote";
-  }
-  /*! Used as a heading for a list of static Java class functions with
-   *  package scope.
-   */
-  virtual QCString trStaticPackageFunctions()
-  {
-    return "Funções Estáticas do Pacote";
-  }
-  /*! Used as a heading for a list of Java class variables with package
-   * scope.
-   */
-  virtual QCString trPackageAttribs()
-  {
-    return "Atributos do Pacote";
-  }
-  /*! Used as a heading for a list of static Java class variables with
-   * package scope.
-   */
-  virtual QCString trStaticPackageAttribs()
-  {
-    return "Atributos Estáticos do Pacote";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.1
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used in the quick index of a class/file/namespace member list page
-   *  to link to the unfiltered list of all members.
-   */
-  virtual QCString trAll()
-  {
-    return "Todos";
-  }
-  /*! Put in front of the call graph for a function. */
-  virtual QCString trCallGraph()
-  {
-    return "Este é o diagrama das funções utilizadas por essa função:";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.3
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This string is used as the title for the page listing the search
-   *  results.
-   */
-  virtual QCString trSearchResultsTitle()
-  {
-    return "Resultado(s) da Busca";
-  }
-  /*! This string is put just before listing the search results. The
-   *  text can be different depending on the number of documents found.
-   *  Inside the text you can put the special marker $num to insert
-   *  the number representing the actual number of search results.
-   *  The @a numDocuments parameter can be either 0, 1 or 2, where the
-   *  value 2 represents 2 or more matches. HTML markup is allowed inside
-   *  the returned string.
-   */
-  virtual QCString trSearchResults(int numDocuments)
-  {
-    if (numDocuments == 0)
-    {
-      return "Nenhum documento foi encontrado.";
-    }
-    else if (numDocuments == 1)
-    {
-      return "Apenas <b>1</b> documento foi encontrado.";
-    }
-    else
-    {
-      return "<b>$num</b> documentos encontrados. "
-             "Mostrando os melhores resultados primeiro.";
-    }
-  }
-  /*! This string is put before the list of matched words, for each search
-   *  result. What follows is the list of words that matched the query.
-   */
-  virtual QCString trSearchMatches()
-  {
-    return "Resultados:";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.8
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used in HTML as the title of page with source code for file filename
-   */
-  virtual QCString trSourceFile(QCString &filename)
-  {
-    return "Código-Fonte de " + filename;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.9
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used as the name of the chapter containing the directory
-   *  hierarchy.
-   */
-  virtual QCString trDirIndex()
-  {
-    return "Hierarquia de Diretórios";
-  }
-
-  /*! This is used as the name of the chapter containing the documentation
-   *  of the directories.
-   */
-  virtual QCString trDirDocumentation()
-  {
-    return "Documentação do Diretório";
-  }
-
-  /*! This is used as the title of the directory index and also in the
-   *  Quick links of a HTML page, to link to the directory hierarchy.
-   */
-  virtual QCString trDirectories()
-  {
-    return "Diretórios";
-  }
-
-  /*! This returns the title of a directory page. The name of the
-   *  directory is passed via \a dirName.
-   */
-  virtual QCString trDirReference(const QCString &dirName)
-  {
-    QCString result = "Referência do diretório ";
-    result += dirName;
-    return result;
-  }
-
-  /*! This returns the word directory with or without starting capital
-   *  (\a first_capital) and in sigular or plural form (\a singular).
-   */
-  virtual QCString trDir(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Diretório" : "diretório"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.4.1
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This text is added to the documentation when the \\overload command
-   *  is used for a overloaded function.
-   */
-  virtual QCString trOverloadText()
-  {
-    return "Esse é um método provido por conveniência. "
-           "Ele difere do método acima apenas na lista de "
-           "argumentos que devem ser utilizados.";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.4.6
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used to introduce a caller (or called-by) graph */
-  virtual QCString trCallerGraph()
-  {
-    return "Esse é o diagrama das funções que utilizam essa função:";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for enumeration values
-   */
-  virtual QCString trEnumerationValueDocumentation()
-  {
-    return "Documentação da enumeração";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.5.4 (mainly for Fortran)
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! header that is put before the list of member subprograms (Fortran). */
-  virtual QCString trMemberFunctionDocumentationFortran()
-  {
-    return "Documentação de Função Membro/Subrotina";
-  }
-
-  /*! This is put above each page as a link to the list of annotated data types (Fortran). */
-  virtual QCString trCompoundListFortran()
-  {
-    return "Lista de Tipos de Dados";
-  }
-
-  /*! This is put above each page as a link to all members of compounds (Fortran). */
-  virtual QCString trCompoundMembersFortran()
-  {
-    return "Campos de Dados";
-  }
-
-  /*! This is an introduction to the annotated compound list (Fortran). */
-  virtual QCString trCompoundListDescriptionFortran()
-  {
-    return "Aqui estão os tipos de dados com descrições resumidas:";
-  }
-
-  /*! This is an introduction to the page with all data types (Fortran). */
-  virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os membros ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "dos tipos de dados com links para ";
-    if (extractAll)
-    {
-      result += "a documentação dos tipos de dados para cada membro:";
-    }
-    else
-    {
-      result += "os tipos de dados a que pertencem:";
-    }
-    return result;
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * annotated compound index (Fortran).
-   */
-  virtual QCString trCompoundIndexFortran()
-  {
-    return "Índice de Tipos de Dados";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all data types (Fortran).
-   */
-  virtual QCString trTypeDocumentation()
-  {
-    return "Documentação dos Tipos de Dados";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) subprograms (Fortran).
-   */
-  virtual QCString trSubprograms()
-  {
-    return "Funções/Subrotinas";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for subprograms (Fortran)
-   */
-  virtual QCString trSubprogramDocumentation()
-  {
-    return "Documentação da Função/Subrotina";
-  }
-
-  /*! This is used in the documentation of a file/namespace/group before
-   *  the list of links to documented compounds (Fortran)
-   */
-  virtual QCString trDataTypes()
-  {
-    return "Tipos de Dados";
-  }
-
-  /*! used as the title of page containing all the index of all modules (Fortran). */
-  virtual QCString trModulesList()
-  {
-    return "Lista de Módulos";
-  }
-
-  /*! used as an introduction to the modules list (Fortran) */
-  virtual QCString trModulesListDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os módulos ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "com descrições resumidas:";
-    return result;
-  }
-
-  /*! used as the title of the HTML page of a module/type (Fortran) */
-  virtual QCString trCompoundReferenceFortran(const QCString &clName,
-                                              ClassDef::CompoundType compType,
-                                              bool isTemplate)
-  {
-    QCString result = "Referência ";
-
-    if (isTemplate)
-      result += "do <em>Template</em> ";
-
-    switch (compType)
-    {
-    case ClassDef::Class:
-      result += "do Modulo ";
-      break;
-    case ClassDef::Struct:
-      result += "do Tipo ";
-      break;
-    case ClassDef::Union:
-      result += "da União ";
-      break;
-    case ClassDef::Interface:
-      result += "da Interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "do Protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "da Categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "da Exceção ";
-      break;
-    default:
-      break;
-    }
-    result += clName;
-
-    return result;
-  }
-  /*! used as the title of the HTML page of a module (Fortran) */
-  virtual QCString trModuleReference(const QCString &namespaceName)
-  {
-    QCString result = "Referência do Módulo ";
-    result += namespaceName;
-    return result;
-  }
-
-  /*! This is put above each page as a link to all members of modules. (Fortran) */
-  virtual QCString trModulesMembers()
-  {
-    return "Membros do Módulo";
-  }
-
-  /*! This is an introduction to the page with all modules members (Fortran) */
-  virtual QCString trModulesMemberDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os membros ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "dos módulos com links para ";
-    if (extractAll)
-    {
-      result += "a documentação dos módulos para cada membro:";
-    }
-    else
-    {
-      result += "os módulos a que pertencem:";
-    }
-    return result;
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   *  index of all modules (Fortran).
-   */
-  virtual QCString trModulesIndex()
-  {
-    return "Índice dos Módulos";
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trModule(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Módulo" : "módulo"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is put at the bottom of a module documentation page and is
-   *  followed by a list of files that were used to generate the page.
-   */
-  virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
-                                               bool single)
-  {
-    // single is true implies a single file
-    QCString result = "A documentação para ";
-    switch (compType)
-    {
-    case ClassDef::Class:
-      result += "esse modulo ";
-      break;
-    case ClassDef::Struct:
-      result += "esse tipo ";
-      break;
-    case ClassDef::Union:
-      result += "essa união ";
-      break;
-    case ClassDef::Interface:
-      result += "essa interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "esso protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "essa categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "essa exceção ";
-      break;
-    default:
-      break;
+      return "Atributos Privados Estáticos";
     }
 
-    result += " foi gerada a partir do";
-    if (single)
-      result += " seguinte arquivo:";
-    else
-      result += "s seguintes arquivos:";
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.3
+//////////////////////////////////////////////////////////////////////////
 
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trType(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Tipo" : "tipo"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trSubprogram(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Subrotina" : "subrotina"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! C# Type Contraint list */
-  virtual QCString trTypeConstraints()
-  {
-    return "Restrições do Tipo";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.6.0 (mainly for the new search engine)
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! directory relation for \a name */
-  virtual QCString trDirRelation(const QCString &name)
-  {
-    return "Relação " + QCString(name);
-  }
-
-  /*! Loading message shown when loading search results */
-  virtual QCString trLoading()
-  {
-    return "Carregando...";
-  }
-
-  /*! Label used for search results in the global namespace */
-  virtual QCString trGlobalNamespace()
-  {
-    return "<em>Namespace</em> global";
-  }
-
-  /*! Message shown while searching */
-  virtual QCString trSearching()
-  {
-    return "Procurando...";
-  }
-
-  /*! Text shown when no search results are found */
-  virtual QCString trNoMatches()
-  {
-    return "Nenhum resultado encontrado";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.6.3 (missing items for the directory pages)
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! when clicking a directory dependency label, a page with a
-   *  table is shown. The heading for the first column mentions the
-   *  source file that has a relation to another file.
-   */
-  virtual QCString trFileIn(const QCString &name)
-  {
-    return "Arquivo em " + name;
-  }
-
-  /*! when clicking a directory dependency label, a page with a
-   *  table is shown. The heading for the second column mentions the
-   *  destination file that is included.
-   */
-  virtual QCString trIncludesFileIn(const QCString &name)
-  {
-    return "Inclui arquivo em " + name;
-  }
-
-  /** Compiles a date string.
-   *  @param year Year in 4 digits
-   *  @param month Month of the year: 1=January
-   *  @param day Day of the Month: 1..31
-   *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
-   *  @param hour Hour of the day: 0..23
-   *  @param minutes Minutes in the hour: 0..59
-   *  @param seconds Seconds within the minute: 0..59
-   *  @param includeTime Include time in the result string?
-   */
-  virtual QCString trDateTime(int year, int month, int day, int dayOfWeek,
-                              int hour, int minutes, int seconds,
-                              bool includeTime)
-  {
-    static const char *days[] = {"Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"};
-    static const char *months[] = {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"};
-    QCString sdate;
-    sdate.sprintf("%s, %d de %s de %d", days[dayOfWeek - 1], day, months[month - 1], year);
-    if (includeTime)
+    /*! Used as a marker that is put before a todo item */
+    virtual QCString trTodo()
     {
-      QCString stime;
-      stime.sprintf(" %.2d:%.2d:%.2d", hour, minutes, seconds);
-      sdate += stime;
+      return "Atividades futuras";
     }
-    return sdate;
-  }
-  virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
-  {
-    static const char *days_short[] = {"seg", "ter", "qua", "qui", "sex", "sáb", "dom"};
-    static const char *days_full[] = {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo"};
-    QCString text = full ? days_full[dayOfWeek - 1] : days_short[dayOfWeek - 1];
-    if (first_capital)
-      return text.mid(0, 1).upper() + text.mid(1);
-    else
-      return text;
-  }
-  virtual QCString trMonth(int month, bool first_capital, bool full)
-  {
-    static const char *months_short[] = {"jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez"};
-    static const char *months_full[] = {"janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro"};
-    QCString text = full ? months_full[month - 1] : months_short[month - 1];
-    if (first_capital)
-      return text.mid(0, 1).upper() + text.mid(1);
-    else
-      return text;
-  }
-  virtual QCString trDayPeriod(int period)
-  {
-    static const char *dayPeriod[] = {"AM", "PM"};
-    return dayPeriod[period];
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.7.5
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Header for the page with bibliographic citations */
-  virtual QCString trCiteReferences()
-  {
-    return "Referências Bibliográficas";
-  }
-
-  /*! Text for copyright paragraph */
-  virtual QCString trCopyright()
-  {
-    // Note: I will left it as is because "Direitos autorais" may not fit
-    // in the text.
-    return "Copyright";
-  }
-
-  /*! Header for the graph showing the directory dependencies */
-  virtual QCString trDirDepGraph(const QCString &name)
-  {
-    return QCString("Grafo de dependências do diretório ") + name + ":";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.0
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Detail level selector shown for hierarchical indices */
-  virtual QCString trDetailLevel()
-  {
-    return "nível de detalhes";
-  }
-
-  /*! Section header for list of template parameters */
-  virtual QCString trTemplateParameters()
-  {
-    return "Parâmetros do <em>template</em>";
-  }
-
-  /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
-  virtual QCString trAndMore(const QCString &number)
-  {
-    return "e " + number + " mais...";
-  }
-
-  /*! Used file list for a Java enum */
-  virtual QCString trEnumGeneratedFromFiles(bool single)
-  {
-    QCString result = "A documentação para essa enumeração foi gerada a partir ";
-    if (single)
+    /*! Used as the header of the todo list */
+    virtual QCString trTodoList()
     {
-      result += "do seguinte arquivo:";
-    }
-    else
-    {
-      result += "dos seguintes arquivos:";
-    }
-    return result;
-  }
-
-  /*! Header of a Java enum page (Java enums are represented as classes). */
-  virtual QCString trEnumReference(const QCString &name)
-  {
-    QCString result = "Referência da enumeração ";
-    return result + name;
-  }
-
-  /*! Used for a section containing inherited members */
-  virtual QCString trInheritedFrom(const QCString &members, const QCString &what)
-  {
-    return QCString(members) + " herdados de " + what;
-  }
-
-  /*! Header of the sections with inherited members specific for the
-   *  base class(es)
-   */
-  virtual QCString trAdditionalInheritedMembers()
-  {
-    return "Outros membros herdados";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.2
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a tooltip for the toggle button that appears in the
-   *  navigation tree in the HTML output when GENERATE_TREEVIEW is
-   *  enabled. This tooltip explains the meaning of the button.
-   */
-  virtual QCString trPanelSynchronisationTooltip(bool enable)
-  {
-    QCString opt = enable ? "ativar" : "desativar";
-    return "clique para " + opt + " a sincronização do painel";
-  }
-
-  /*! Used in a method of an Objective-C class that is declared in a
-   *  a category. Note that the @1 marker is required and is replaced
-   *  by a link.
-   */
-  virtual QCString trProvidedByCategory()
-  {
-    return "Provido pela categoria @0.";
-  }
-
-  /*! Used in a method of an Objective-C category that extends a class.
-   *  Note that the @1 marker is required and is replaced by a link to
-   *  the class method.
-   */
-  virtual QCString trExtendsClass()
-  {
-    return "estende a classe @0.";
-  }
-
-  /*! Used as the header of a list of class methods in Objective-C.
-   *  These are similar to static public member functions in C++.
-   */
-  virtual QCString trClassMethods()
-  {
-    return "Métodos da classe";
-  }
-
-  /*! Used as the header of a list of instance methods in Objective-C.
-   *  These are similar to public member functions in C++.
-   */
-  virtual QCString trInstanceMethods()
-  {
-    return "Métodos da instância";
-  }
-
-  /*! Used as the header of the member functions of an Objective-C class.
-   */
-  virtual QCString trMethodDocumentation()
-  {
-    return "Documentação do método";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.4
-  //////////////////////////////////////////////////////////////////////////
-
-  /** old style UNO IDL services: implemented interfaces */
-  virtual QCString trInterfaces()
-  {
-    return "Interfaces Exportadas";
-  }
-
-  /** old style UNO IDL services: inherited services */
-  virtual QCString trServices()
-  {
-    return "Serviços Inclusos";
-  }
-
-  /** UNO IDL constant groups */
-  virtual QCString trConstantGroups()
-  {
-    return "Grupos de Constantes";
-  }
-
-  /** UNO IDL constant groups */
-  virtual QCString trConstantGroupReference(const QCString &namespaceName)
-  {
-    QCString result = "Referência do grupo de constantes ";
-    result += namespaceName;
-    return result;
-  }
-  /** UNO IDL service page title */
-  virtual QCString trServiceReference(const QCString &sName)
-  {
-    QCString result = "Referência do serviço ";
-    result += sName;
-    return result;
-  }
-  /** UNO IDL singleton page title */
-  virtual QCString trSingletonReference(const QCString &sName)
-  {
-    // TODO: Emerson Ferreira proposes to add emphasis around the word
-    // Singleton but I'm not sure if this will work for non HTML generators.
-    QCString result = "Referência do Singleton ";
-    result += sName;
-    return result;
-  }
-  /** UNO IDL service page */
-  virtual QCString trServiceGeneratedFromFiles(bool single)
-  {
-    // single is true implies a single file
-    QCString result = "A documentação para esse serviço "
-                      "foi gerada a partir ";
-    if (single)
-    {
-      result += "do seguinte arquivo:";
-    }
-    else
-    {
-      result += "dos seguintes arquivos:";
-    }
-    return result;
-  }
-  /** UNO IDL singleton page */
-  virtual QCString trSingletonGeneratedFromFiles(bool single)
-  {
-    // single is true implies a single file
-    QCString result = "A documentação para esse <em>Singleton</em> "
-                      "foi gerada a partir ";
-    if (single)
-    {
-      result += "do seguinte arquivo:";
-    }
-    else
-    {
-      result += "dos: seguintes arquivos:";
+      return "Lista de atividades futuras";
     }
 
-    return result;
-  }
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.15
-  //////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.4
+//////////////////////////////////////////////////////////////////////////
 
-  /** VHDL design unit hierarchy */
-  virtual QCString trDesignUnitHierarchy()
-  {
-    return "Hierarquia da Unidade de Design";
-  }
-  /** VHDL design unit list */
-  virtual QCString trDesignUnitList()
-  {
-    return "Lista de Unidades de Design";
-  }
-  /** VHDL design unit members */
-  virtual QCString trDesignUnitMembers()
-  {
-    return "Membros da Unidade de Design";
-  }
-  /** VHDL design unit list description */
-  virtual QCString trDesignUnitListDescription()
-  {
-    return "Esta é uma lista de todos os membros de unidades de design "
-           "com ligações para as entidades às quais pertencem:";
-  }
-  /** VHDL design unit index */
-  virtual QCString trDesignUnitIndex()
-  {
-    return "Índice de Unidades de Design";
-  }
-  /** VHDL design units */
-  virtual QCString trDesignUnits()
-  {
-    return "Unidades de Design";
-  }
-  /** VHDL functions/procedures/processes */
-  virtual QCString trFunctionAndProc()
-  {
-    return "Funções/Procedimentos/Processos";
-  }
-  /** VHDL type */
-  virtual QCString trVhdlType(uint64 type, bool single)
-  {
-    switch (type)
+    virtual QCString trReferencedBy()
     {
-    case VhdlDocGen::LIBRARY:
-      if (single)
-        return "Biblioteca";
+      return "Referenciado(a) por";
+    }
+    virtual QCString trRemarks()
+    {
+      return "Anotações";
+    }
+    virtual QCString trAttention()
+    {
+      return "Atenção";
+    }
+    virtual QCString trInclByDepGraph()
+    {
+      return "Este grafo mostra quais arquivos estão direta ou indiretamente relacionados com esse arquivo:";
+    }
+    virtual QCString trSince()
+    {
+      return "Desde";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.5
+//////////////////////////////////////////////////////////////////////////
+
+    /*! title of the graph legend page */
+    virtual QCString trLegendTitle()
+    {
+      return "Legenda do Grafo";
+    }
+    /*! page explaining how the dot graph's should be interpreted
+     *  The %A in the text below are to prevent link to classes called "A".
+     */
+    virtual QCString trLegendDocs()
+    {
+      return
+        "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
+        "Considere o seguinte exemplo:\n"
+        "\\code\n"
+        "/*! Classe oculta por causa da truncagem */\n"
+        "class Invisible { };\n\n"
+        "/*! Classe Truncated, relação de herança está oculta */\n"
+        "class Truncated : public Invisible { };\n\n"
+        "/* Classe não documentada com os comentários do Doxygen */\n"
+        "class Undocumented { };\n\n"
+        "/*! Classe possui que possui uma relação de herança pública */\n"
+        "class PublicBase : public Truncated { };\n\n"
+        "/*! Um template de classe */\n"
+        "template<class T> class Templ { };\n\n"
+        "/*! Classe possui que possui uma relação de herança protegida  */\n"
+        "class ProtectedBase { };\n\n"
+        "/*! Classe possui que possui uma relação de herança privada  */\n"
+        "class PrivateBase { };\n\n"
+        "/*! Classe utilizada pela classe Inherited */\n"
+        "class Used { };\n\n"
+        "/*! Super classe que herda outras classes */\n"
+        "class Inherited : public PublicBase,\n"
+        "                  protected ProtectedBase,\n"
+        "                  private PrivateBase,\n"
+        "                  public Undocumented,\n"
+        "                  public Templ<int>\n"
+        "{\n"
+        "  private:\n"
+        "    Used *m_usedClass;\n"
+        "};\n"
+        "\\endcode\n"
+        "Isto irá gerar o seguinte gráfo:"
+        "<p><center><img src=\"graph_legend."+getDotImageExtension()+"\"></center>\n"
+        "<p>\n"
+        "As caixas no grafo acima possuem os seguintes significados:\n"
+        "</p>\n"
+        "<ul>\n"
+        "<li>Uma caixa cinza denota a estrutura ou a classe que gerou"
+	"este grafo.</li>\n"
+        "<li>Uma caixa com a borda preta denota uma estrutura ou classe documentada.</li>\n"
+        "<li>Uma caixa com a borda cinza denota uma estrutura ou classe não documentada.</li>\n"
+        "<li>Uma caixa com a borda vermelha denota uma estrutura ou classe na"
+        "qual nem todas as relações são mostradas. Um grafo é truncado quando "
+        "esse não cabe no espaço especificado.</li>\n"
+        "</ul>\n"
+        "<p>\n"
+        "As setas possuem os seguintes significados:\n"
+        "</p>\n"
+        "<ul>\n"
+        "<li>Uma seta azul escura denota a relação de herança pública entre "
+        "duas classes.</li>\n"
+        "<li>Uma seta verde escura denota a relação de herança protegida entre "
+        "duas classes.</li>\n"
+        "<li>Uma seta vermelha escura denota a relação de herança privada entre "
+        "duas classes.</li>\n"
+        "<li>Uma seta pontilhada púrpura denota a relação de uso e/ou agragação "
+        "por outra classe/estrutura. A etiqueta da seta denota o nome do(s) campo(s) "
+        "que representa(m) este apontamento.</li>\n"
+        "<li>Uma seta pontilhada amarela denota a relação de instanciação de uma "
+        "<em>template</em>. A etiqueta da seta denota os parâmetros de instanciação "
+        "desta <em>template</em>.</li>\n"
+        "</ul>\n";
+    }
+    /*! text for the link to the legend page */
+    virtual QCString trLegend()
+    {
+      return "legenda";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.0
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a marker that is put before a test item */
+    virtual QCString trTest()
+    {
+      return "Teste";
+    }
+    /*! Used as the header of the test list */
+    virtual QCString trTestList()
+    {
+      return "Lista de Testes";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.2
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a section header for IDL properties */
+    virtual QCString trProperties()
+    {
+      return "Propriedades";
+    }
+    /*! Used as a section header for IDL property documentation */
+    virtual QCString trPropertyDocumentation()
+    {
+      return "Propriedades";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.4
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used for Java classes in the summary section of Java packages */
+    virtual QCString trClasses()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Estruturas de Dados";
+      }
       else
-        return "Bibliotecas";
-    case VhdlDocGen::PACKAGE:
-      if (single)
-        return "Pacote";
+      {
+        return "Classes";
+      }
+    }
+    /*! Used as the title of a Java package */
+    virtual QCString trPackage(const QCString &name)
+    {
+      return "Pacote "+name;
+    }
+    /*! The description of the package index page */
+    virtual QCString trPackageListDescription()
+    {
+      return "Esta é a lista com os pacotes e suas respectivas descrições (quando disponíveis):";
+    }
+    /*! The link name in the Quick links header for each page */
+    virtual QCString trPackages()
+    {
+      return "Pacotes";
+    }
+    /*! Text shown before a multi-line define */
+    virtual QCString trDefineValue()
+    {
+      return "Valor:";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.5
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a marker that is put before a \\bug item */
+    virtual QCString trBug()
+    {
+      return "Bug";
+    }
+    /*! Used as the header of the bug list */
+    virtual QCString trBugList()
+    {
+      return "Lista de Bugs";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.6
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as ansicpg for RTF file
+     *
+     * The following table shows the correlation of Charset name, Charset Value and
+     * <pre>
+     * Codepage number:
+     * Charset Name       Charset Value(hex)  Codepage number
+     * ------------------------------------------------------
+     * DEFAULT_CHARSET           1 (x01)
+     * SYMBOL_CHARSET            2 (x02)
+     * OEM_CHARSET             255 (xFF)
+     * ANSI_CHARSET              0 (x00)            1252
+     * RUSSIAN_CHARSET         204 (xCC)            1251
+     * EE_CHARSET              238 (xEE)            1250
+     * GREEK_CHARSET           161 (xA1)            1253
+     * TURKISH_CHARSET         162 (xA2)            1254
+     * BALTIC_CHARSET          186 (xBA)            1257
+     * HEBREW_CHARSET          177 (xB1)            1255
+     * ARABIC _CHARSET         178 (xB2)            1256
+     * SHIFTJIS_CHARSET        128 (x80)             932
+     * HANGEUL_CHARSET         129 (x81)             949
+     * GB2313_CHARSET          134 (x86)             936
+     * CHINESEBIG5_CHARSET     136 (x88)             950
+     * </pre>
+     *
+     */
+    virtual QCString trRTFansicp()
+    {
+      return "1252";
+    }
+
+
+    /*! Used as ansicpg for RTF fcharset
+     *  \see trRTFansicp() for a table of possible values.
+     */
+    virtual QCString trRTFCharSet()
+    {
+      return "0";
+    }
+
+    /*! Used as header RTF general index */
+    virtual QCString trRTFGeneralIndex()
+    {
+      return "Sumário";
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trClass(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Classe" : "classe"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trFile(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Arquivo": "arquivo"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trNamespace(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Namespace" : "namespace"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trGroup(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Grupo" : "grupo"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trPage(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Página" : "página"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trMember(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Membro" : "membro"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trGlobal(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Globa" : "globa"));
+      if (!singular){
+        result+="is";
+      }else{
+        result+="l";
+      }
+      return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.7
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This text is generated when the \\author command is used and
+     *  for the author section in man pages. */
+    virtual QCString trAuthor(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Autor" : "autor"));
+      if (!singular)  result+="es";
+      return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.11
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This text is put before the list of members referenced by a member
+     */
+    virtual QCString trReferences()
+    {
+      return "Referencias";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.13
+//////////////////////////////////////////////////////////////////////////
+
+    /*! used in member documentation blocks to produce a list of
+     *  members that are implemented by this one.
+     */
+    virtual QCString trImplementedFromList(int numEntries)
+    {
+      return "Implementa "+trWriteList(numEntries)+".";
+    }
+
+    /*! used in member documentation blocks to produce a list of
+     *  all members that implementation this member.
+     */
+    virtual QCString trImplementedInList(int numEntries)
+    {
+      return "Implementado por "+trWriteList(numEntries)+".";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.16
+//////////////////////////////////////////////////////////////////////////
+
+    /*! used in RTF documentation as a heading for the Table
+     *  of Contents.
+     */
+    virtual QCString trRTFTableOfContents()
+    {
+      return "Sumário";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.17
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as the header of the list of item that have been
+     *  flagged deprecated
+     */
+    virtual QCString trDeprecatedList()
+    {
+      return "Lista de itens obsoletos";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.18
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a header for declaration section of the events found in
+     * a C# program
+     */
+    virtual QCString trEvents()
+    {
+      return "Eventos";
+    }
+    /*! Header used for the documentation section of a class' events. */
+    virtual QCString trEventDocumentation()
+    {
+      return "Eventos";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a heading for a list of Java class types with package scope.
+     */
+    virtual QCString trPackageTypes()
+    {
+      return "Tipos do Pacote";
+    }
+    /*! Used as a heading for a list of Java class functions with package
+     * scope.
+     */
+    virtual QCString trPackageFunctions()
+    {
+      return "Funções do Pacote";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membros do Pacote";
+    }
+    /*! Used as a heading for a list of static Java class functions with
+     *  package scope.
+     */
+    virtual QCString trStaticPackageFunctions()
+    {
+      return "Funções Estáticas do Pacote";
+    }
+    /*! Used as a heading for a list of Java class variables with package
+     * scope.
+     */
+    virtual QCString trPackageAttribs()
+    {
+      return "Atributos do Pacote";
+    }
+    /*! Used as a heading for a list of static Java class variables with
+     * package scope.
+     */
+    virtual QCString trStaticPackageAttribs()
+    {
+      return "Atributos Estáticos do Pacote";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.1
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used in the quick index of a class/file/namespace member list page
+     *  to link to the unfiltered list of all members.
+     */
+    virtual QCString trAll()
+    {
+      return "Todos";
+    }
+    /*! Put in front of the call graph for a function. */
+    virtual QCString trCallGraph()
+    {
+      return "Este é o diagrama das funções utilizadas por essa função:";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.3
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This string is used as the title for the page listing the search
+     *  results.
+     */
+    virtual QCString trSearchResultsTitle()
+    {
+      return "Resultado(s) da Busca";
+    }
+    /*! This string is put just before listing the search results. The
+     *  text can be different depending on the number of documents found.
+     *  Inside the text you can put the special marker $num to insert
+     *  the number representing the actual number of search results.
+     *  The @a numDocuments parameter can be either 0, 1 or 2, where the
+     *  value 2 represents 2 or more matches. HTML markup is allowed inside
+     *  the returned string.
+     */
+    virtual QCString trSearchResults(int numDocuments)
+    {
+      if (numDocuments==0)
+      {
+        return "Nenhum documento foi encontrado.";
+      }
+      else if (numDocuments==1)
+      {
+        return "Apenas <b>1</b> documento foi encontrado.";
+      }
       else
-        return "Pacotes";
-    case VhdlDocGen::SIGNAL:
-      if (single)
-        return "Sinal";
+      {
+        return "<b>$num</b> documentos encontrados. "
+               "Mostrando os melhores resultados primeiro.";
+      }
+    }
+    /*! This string is put before the list of matched words, for each search
+     *  result. What follows is the list of words that matched the query.
+     */
+    virtual QCString trSearchMatches()
+    {
+      return "Resultados:";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.8
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used in HTML as the title of page with source code for file filename
+     */
+    virtual QCString trSourceFile(QCString& filename)
+    {
+      return  "Código-Fonte de " + filename;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.9
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used as the name of the chapter containing the directory
+     *  hierarchy.
+     */
+    virtual QCString trDirIndex()
+    { return "Hierarquia de Diretórios"; }
+
+    /*! This is used as the name of the chapter containing the documentation
+     *  of the directories.
+     */
+    virtual QCString trDirDocumentation()
+    { return "Documentação do Diretório"; }
+
+    /*! This is used as the title of the directory index and also in the
+     *  Quick links of a HTML page, to link to the directory hierarchy.
+     */
+    virtual QCString trDirectories()
+    { return "Diretórios"; }
+
+    /*! This returns the title of a directory page. The name of the
+     *  directory is passed via \a dirName.
+     */
+    virtual QCString trDirReference(const QCString &dirName)
+    {
+        QCString result = "Referência do diretório ";
+     	result += dirName;
+     	return result;
+    }
+
+    /*! This returns the word directory with or without starting capital
+     *  (\a first_capital) and in sigular or plural form (\a singular).
+     */
+    virtual QCString trDir(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Diretório" : "diretório"));
+      if (!singular) result+="s";
+      return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.4.1
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This text is added to the documentation when the \\overload command
+     *  is used for a overloaded function.
+     */
+    virtual QCString trOverloadText()
+    {
+       return "Esse é um método provido por conveniência. "
+       		"Ele difere do método acima apenas na lista de "
+       		"argumentos que devem ser utilizados.";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.4.6
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used to introduce a caller (or called-by) graph */
+    virtual QCString trCallerGraph()
+    {
+      return "Esse é o diagrama das funções que utilizam essa função:";
+    }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for enumeration values
+     */
+    virtual QCString trEnumerationValueDocumentation()
+    { return "Documentação da enumeração"; }
+
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.5.4 (mainly for Fortran)
+//////////////////////////////////////////////////////////////////////////
+
+    /*! header that is put before the list of member subprograms (Fortran). */
+    virtual QCString trMemberFunctionDocumentationFortran()
+    { return "Documentação de Função Membro/Subrotina"; }
+
+    /*! This is put above each page as a link to the list of annotated data types (Fortran). */
+    virtual QCString trCompoundListFortran()
+    { return "Lista de Tipos de Dados"; }
+
+    /*! This is put above each page as a link to all members of compounds (Fortran). */
+    virtual QCString trCompoundMembersFortran()
+    { return "Campos de Dados"; }
+
+    /*! This is an introduction to the annotated compound list (Fortran). */
+    virtual QCString trCompoundListDescriptionFortran()
+    { return "Aqui estão os tipos de dados com descrições resumidas:"; }
+
+    /*! This is an introduction to the page with all data types (Fortran). */
+    virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
+    {
+      QCString result="Esta é a lista de todos os membros ";
+      if (!extractAll) result+="documentados ";
+      result+="dos tipos de dados com links para ";
+      if (extractAll)
+      {
+        result+="a documentação dos tipos de dados para cada membro:";
+      }
       else
-        return "Sinais";
-    case VhdlDocGen::COMPONENT:
-      if (single)
-        return "Componente";
+      {
+        result+="os tipos de dados a que pertencem:";
+      }
+      return result;
+    }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * annotated compound index (Fortran).
+     */
+    virtual QCString trCompoundIndexFortran()
+    { return "Índice de Tipos de Dados"; }
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all data types (Fortran).
+     */
+    virtual QCString trTypeDocumentation()
+    { return "Documentação dos Tipos de Dados"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) subprograms (Fortran).
+     */
+    virtual QCString trSubprograms()
+    { return "Funções/Subrotinas"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for subprograms (Fortran)
+     */
+    virtual QCString trSubprogramDocumentation()
+    { return "Documentação da Função/Subrotina"; }
+
+    /*! This is used in the documentation of a file/namespace/group before
+     *  the list of links to documented compounds (Fortran)
+     */
+     virtual QCString trDataTypes()
+    { return "Tipos de Dados"; }
+
+    /*! used as the title of page containing all the index of all modules (Fortran). */
+    virtual QCString trModulesList()
+    { return "Lista de Módulos"; }
+
+    /*! used as an introduction to the modules list (Fortran) */
+    virtual QCString trModulesListDescription(bool extractAll)
+    {
+      QCString result="Esta é a lista de todos os módulos ";
+      if (!extractAll) result+="documentados ";
+      result+="com descrições resumidas:";
+      return result;
+    }
+
+    /*! used as the title of the HTML page of a module/type (Fortran) */
+    virtual QCString trCompoundReferenceFortran(const QCString &clName,
+                                    ClassDef::CompoundType compType,
+                                    bool isTemplate)
+    {
+      QCString result = "Referência ";
+
+      if (isTemplate) result+="do <em>Template</em> ";
+
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="do Modulo "; break;
+        case ClassDef::Struct:     result+="do Tipo "; break;
+        case ClassDef::Union:      result+="da União "; break;
+        case ClassDef::Interface:  result+="da Interface "; break;
+        case ClassDef::Protocol:   result+="do Protocolo "; break;
+        case ClassDef::Category:   result+="da Categoria "; break;
+        case ClassDef::Exception:  result+="da Exceção "; break;
+        default: break;
+      }
+      result += clName;
+
+      return result;
+    }
+    /*! used as the title of the HTML page of a module (Fortran) */
+    virtual QCString trModuleReference(const QCString &namespaceName)
+    {
+      QCString result = "Referência do Módulo ";
+      result += namespaceName;
+      return result;
+    }
+
+    /*! This is put above each page as a link to all members of modules. (Fortran) */
+    virtual QCString trModulesMembers()
+    { return "Membros do Módulo"; }
+
+    /*! This is an introduction to the page with all modules members (Fortran) */
+    virtual QCString trModulesMemberDescription(bool extractAll)
+    {
+      QCString result="Esta é a lista de todos os membros ";
+      if (!extractAll) result+="documentados ";
+      result+="dos módulos com links para ";
+      if (extractAll)
+      {
+        result+="a documentação dos módulos para cada membro:";
+      }
       else
-        return "Componentes";
-    case VhdlDocGen::CONSTANT:
+      {
+        result+="os módulos a que pertencem:";
+      }
+      return result;
+    }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     *  index of all modules (Fortran).
+     */
+    virtual QCString trModulesIndex()
+    { return "Índice dos Módulos"; }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trModule(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Módulo" : "módulo"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is put at the bottom of a module documentation page and is
+     *  followed by a list of files that were used to generate the page.
+     */
+    virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
+        bool single)
+    {
+      // single is true implies a single file
+      QCString result="A documentação para ";
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="esse modulo "; break;
+        case ClassDef::Struct:     result+="esse tipo "; break;
+        case ClassDef::Union:      result+="essa união "; break;
+        case ClassDef::Interface:  result+="essa interface "; break;
+        case ClassDef::Protocol:   result+="esso protocolo "; break;
+        case ClassDef::Category:   result+="essa categoria "; break;
+        case ClassDef::Exception:  result+="essa exceção "; break;
+        default: break;
+      }
+
+      result+=" foi gerada a partir do";
       if (single)
-        return "Constante";
+    	result+=" seguinte arquivo:";
       else
+    	result+="s seguintes arquivos:";
+
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trType(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Tipo" : "tipo"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trSubprogram(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Subrotina" : "subrotina"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! C# Type Contraint list */
+    virtual QCString trTypeConstraints()
+    {
+      return "Restrições do Tipo";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.6.0 (mainly for the new search engine)
+//////////////////////////////////////////////////////////////////////////
+
+    /*! directory relation for \a name */
+    virtual QCString trDirRelation(const QCString &name)
+    {
+      return "Relação " + QCString(name);
+    }
+
+    /*! Loading message shown when loading search results */
+    virtual QCString trLoading()
+    {
+      return "Carregando...";
+    }
+
+    /*! Label used for search results in the global namespace */
+    virtual QCString trGlobalNamespace()
+    {
+      return "<em>Namespace</em> global";
+    }
+
+    /*! Message shown while searching */
+    virtual QCString trSearching()
+    {
+      return "Procurando...";
+    }
+
+    /*! Text shown when no search results are found */
+    virtual QCString trNoMatches()
+    {
+      return "Nenhum resultado encontrado";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.6.3 (missing items for the directory pages)
+//////////////////////////////////////////////////////////////////////////
+
+    /*! when clicking a directory dependency label, a page with a
+     *  table is shown. The heading for the first column mentions the
+     *  source file that has a relation to another file.
+     */
+    virtual QCString trFileIn(const QCString &name)
+    {
+      return "Arquivo em "+name;
+    }
+
+    /*! when clicking a directory dependency label, a page with a
+     *  table is shown. The heading for the second column mentions the
+     *  destination file that is included.
+     */
+    virtual QCString trIncludesFileIn(const QCString &name)
+    {
+      return "Inclui arquivo em "+name;
+    }
+
+    /** Compiles a date string.
+     *  @param year Year in 4 digits
+     *  @param month Month of the year: 1=January
+     *  @param day Day of the Month: 1..31
+     *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
+     *  @param hour Hour of the day: 0..23
+     *  @param minutes Minutes in the hour: 0..59
+     *  @param seconds Seconds within the minute: 0..59
+     *  @param includeTime Include time in the result string?
+     */
+    virtual QCString trDateTime(int year,int month,int day,int dayOfWeek,
+                                int hour,int minutes,int seconds,
+                                bool includeTime)
+    {
+      static const char *days[]   = { "Segunda","Terça","Quarta","Quinta","Sexta","Sábado","Domingo" };
+      static const char *months[] = { "Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro" };
+      QCString sdate;
+      sdate.sprintf("%s, %d de %s de %d",days[dayOfWeek-1],day,months[month-1],year);
+      if (includeTime)
+      {
+        QCString stime;
+        stime.sprintf(" %.2d:%.2d:%.2d",hour,minutes,seconds);
+        sdate+=stime;
+      }
+      return sdate;
+    }
+    virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
+    {
+      static const char *days_short[]   = { "seg", "ter", "qua", "qui", "sex", "sáb", "dom" };
+      static const char *days_full[]    = { "segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo" };
+      QCString text  = full? days_full[dayOfWeek-1] : days_short[dayOfWeek-1];
+      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
+      else return text;
+    }
+    virtual QCString trMonth(int month, bool first_capital, bool full)
+    {
+      static const char *months_short[] = { "jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez" };
+      static const char *months_full[]  = { "janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro" };
+      QCString text  = full? months_full[month-1] : months_short[month-1];
+      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
+      else return text;
+    }
+    virtual QCString trDayPeriod(int period)
+    {
+      static const char *dayPeriod[] = { "AM", "PM" };
+      return dayPeriod[period];
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.7.5
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Header for the page with bibliographic citations */
+    virtual QCString trCiteReferences()
+    { return "Referências Bibliográficas"; }
+
+    /*! Text for copyright paragraph */
+    virtual QCString trCopyright()
+    {
+      // Note: I will left it as is because "Direitos autorais" may not fit
+      // in the text.
+      return "Copyright";
+    }
+
+    /*! Header for the graph showing the directory dependencies */
+    virtual QCString trDirDepGraph(const QCString &name)
+    { return QCString("Grafo de dependências do diretório ")+name+":"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.0
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Detail level selector shown for hierarchical indices */
+    virtual QCString trDetailLevel()
+    { return "nível de detalhes"; }
+
+    /*! Section header for list of template parameters */
+    virtual QCString trTemplateParameters()
+    { return "Parâmetros do <em>template</em>"; }
+
+    /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
+    virtual QCString trAndMore(const QCString &number)
+    { return "e "+number+" mais..."; }
+
+    /*! Used file list for a Java enum */
+    virtual QCString trEnumGeneratedFromFiles(bool single)
+    { QCString result = "A documentação para essa enumeração foi gerada a partir ";
+      if (single) {
+        result += "do seguinte arquivo:";
+      } else {
+        result += "dos seguintes arquivos:";
+      }
+      return result;
+    }
+
+    /*! Header of a Java enum page (Java enums are represented as classes). */
+    virtual QCString trEnumReference(const QCString &name)
+    {
+      QCString result = "Referência da enumeração ";
+      return result + name;
+    }
+
+    /*! Used for a section containing inherited members */
+    virtual QCString trInheritedFrom(const QCString &members,const QCString &what)
+    { return QCString(members)+" herdados de "+what; }
+
+    /*! Header of the sections with inherited members specific for the
+     *  base class(es)
+     */
+    virtual QCString trAdditionalInheritedMembers()
+    { return "Outros membros herdados"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.2
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a tooltip for the toggle button that appears in the
+     *  navigation tree in the HTML output when GENERATE_TREEVIEW is
+     *  enabled. This tooltip explains the meaning of the button.
+     */
+    virtual QCString trPanelSynchronisationTooltip(bool enable)
+    {
+      QCString opt = enable ? "ativar" : "desativar";
+      return "clique para "+opt+" a sincronização do painel";
+    }
+
+    /*! Used in a method of an Objective-C class that is declared in a
+     *  a category. Note that the @1 marker is required and is replaced
+     *  by a link.
+     */
+    virtual QCString trProvidedByCategory()
+    {
+      return "Provido pela categoria @0.";
+    }
+
+    /*! Used in a method of an Objective-C category that extends a class.
+     *  Note that the @1 marker is required and is replaced by a link to
+     *  the class method.
+     */
+    virtual QCString trExtendsClass()
+    {
+      return "estende a classe @0.";
+    }
+
+    /*! Used as the header of a list of class methods in Objective-C.
+     *  These are similar to static public member functions in C++.
+     */
+    virtual QCString trClassMethods()
+    {
+      return "Métodos da classe";
+    }
+
+    /*! Used as the header of a list of instance methods in Objective-C.
+     *  These are similar to public member functions in C++.
+     */
+    virtual QCString trInstanceMethods()
+    {
+      return "Métodos da instância";
+    }
+
+    /*! Used as the header of the member functions of an Objective-C class.
+     */
+    virtual QCString trMethodDocumentation()
+    {
+      return "Documentação do método";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.4
+//////////////////////////////////////////////////////////////////////////
+
+    /** old style UNO IDL services: implemented interfaces */
+    virtual QCString trInterfaces()
+    { return "Interfaces Exportadas"; }
+
+    /** old style UNO IDL services: inherited services */
+    virtual QCString trServices()
+    { return "Serviços Inclusos"; }
+
+    /** UNO IDL constant groups */
+    virtual QCString trConstantGroups()
+    { return "Grupos de Constantes"; }
+
+    /** UNO IDL constant groups */
+    virtual QCString trConstantGroupReference(const QCString &namespaceName)
+    {
+      QCString result = "Referência do grupo de constantes ";
+      result += namespaceName;
+      return result;
+    }
+    /** UNO IDL service page title */
+    virtual QCString trServiceReference(const QCString &sName)
+    {
+      QCString result = "Referência do serviço ";
+      result += sName;
+      return result;
+    }
+    /** UNO IDL singleton page title */
+    virtual QCString trSingletonReference(const QCString &sName)
+    {
+      // TODO: Emerson Ferreira proposes to add emphasis around the word
+      // Singleton but I'm not sure if this will work for non HTML generators.
+      QCString result = "Referência do Singleton ";
+      result += sName;
+      return result;
+    }
+    /** UNO IDL service page */
+    virtual QCString trServiceGeneratedFromFiles(bool single)
+    {
+      // single is true implies a single file
+      QCString result="A documentação para esse serviço "
+                                "foi gerada a partir ";
+      if (single) {
+        result+="do seguinte arquivo:";
+      } else {
+        result+="dos seguintes arquivos:";
+      }
+      return result;
+    }
+    /** UNO IDL singleton page */
+    virtual QCString trSingletonGeneratedFromFiles(bool single)
+    {
+      // single is true implies a single file
+      QCString result="A documentação para esse <em>Singleton</em> "
+                                "foi gerada a partir ";
+      if (single) {
+        result+="do seguinte arquivo:";
+      } else {
+        result+="dos: seguintes arquivos:";
+      }
+
+      return result;
+    }
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.8.15
+    //////////////////////////////////////////////////////////////////////////
+
+    /** VHDL design unit hierarchy */
+    virtual QCString trDesignUnitHierarchy()
+    { return "Hierarquia da Unidade de Design"; }
+    /** VHDL design unit list */
+    virtual QCString trDesignUnitList()
+    { return "Lista de Unidades de Design"; }
+    /** VHDL design unit members */
+    virtual QCString trDesignUnitMembers()
+    { return "Membros da Unidade de Design"; }
+    /** VHDL design unit list description */
+    virtual QCString trDesignUnitListDescription()
+    {
+        return "Esta é uma lista de todos os membros de unidades de design "
+        		"com ligações para as entidades às quais pertencem:";
+    }
+    /** VHDL design unit index */
+    virtual QCString trDesignUnitIndex()
+    { return "Índice de Unidades de Design"; }
+    /** VHDL design units */
+    virtual QCString trDesignUnits()
+    { return "Unidades de Design"; }
+    /** VHDL functions/procedures/processes */
+    virtual QCString trFunctionAndProc()
+    { return "Funções/Procedimentos/Processos"; }
+    /** VHDL type */
+    virtual QCString trVhdlType(uint64 type,bool single)
+    {
+      switch(type)
+      {
+        case VhdlDocGen::LIBRARY:
+          if (single) return "Biblioteca";
+          else        return "Bibliotecas";
+        case VhdlDocGen::PACKAGE:
+          if (single) return "Pacote";
+          else        return "Pacotes";
+        case VhdlDocGen::SIGNAL:
+          if (single) return "Sinal";
+          else        return "Sinais";
+        case VhdlDocGen::COMPONENT:
+          if (single) return "Componente";
+          else        return "Componentes";
+        case VhdlDocGen::CONSTANT:
+          if (single) return "Constante";
+          else        return "Constantes";
+        case VhdlDocGen::ENTITY:
+          if (single) return "Entidade";
+          else        return "Entidades";
+        case VhdlDocGen::TYPE:
+          if (single) return "Tipo";
+          else        return "Tipos";
+        case VhdlDocGen::SUBTYPE:
+          if (single) return "Subtipo";
+          else        return "Subtipos";
+        case VhdlDocGen::FUNCTION:
+          if (single) return "Função";
+          else        return "Funções";
+        case VhdlDocGen::RECORD:
+          if (single) return "Registro";
+          else        return "Registros";
+        case VhdlDocGen::PROCEDURE:
+          if (single) return "Procedimento";
+          else        return "Procedimentos";
+        case VhdlDocGen::ARCHITECTURE:
+          if (single) return "Arquitetura";
+          else        return "Arquiteturas";
+        case VhdlDocGen::ATTRIBUTE:
+          if (single) return "Atributo";
+          else        return "Atributos";
+        case VhdlDocGen::PROCESS:
+          if (single) return "Processo";
+          else        return "Processos";
+        case VhdlDocGen::PORT:
+          if (single) return "Porta";
+          else        return "Portas";
+        case VhdlDocGen::USE:
+          if (single) return "cláusula de uso";
+          else        return "cláusulas de uso";
+        case VhdlDocGen::GENERIC:
+          if (single) return "Generico";
+          else        return "Genericos";
+        case VhdlDocGen::PACKAGE_BODY:
+          return "Corpo do Pacote";
+        case VhdlDocGen::UNITS:
+          return "Unidades";
+        case VhdlDocGen::SHAREDVARIABLE:
+          if (single) return "Variável Compartilhada";
+          else        return "Variáveis Compartilhadas";
+        case VhdlDocGen::VFILE:
+          if (single) return "Arquivo";
+          else        return "Arquivos";
+        case VhdlDocGen::GROUP:
+          if (single) return "Grupo";
+          else        return "Grupos";
+        case VhdlDocGen::INSTANTIATION:
+            if (single) return "Instância";
+            else        return "Instâncias";
+        case VhdlDocGen::ALIAS:
+          if (single) return "Apelido";
+          else        return "Apelidos";
+        case VhdlDocGen::CONFIG:
+          if (single) return "Configuração";
+          else        return "Configurações";
+        case VhdlDocGen::MISCELLANEOUS:
+          return "Outros"; // Is this correct for VHDL?
+        case VhdlDocGen::UCF_CONST:
+          return "Restrições";
+        default:
+          return "Classe";
+      }
+    }
+    virtual QCString trCustomReference(const QCString &name)
+    { return "Referência de " + QCString(name); }
+
+    /* Slice */
+    virtual QCString trConstants()
+    {
         return "Constantes";
-    case VhdlDocGen::ENTITY:
-      if (single)
-        return "Entidade";
-      else
-        return "Entidades";
-    case VhdlDocGen::TYPE:
-      if (single)
-        return "Tipo";
-      else
-        return "Tipos";
-    case VhdlDocGen::SUBTYPE:
-      if (single)
-        return "Subtipo";
-      else
-        return "Subtipos";
-    case VhdlDocGen::FUNCTION:
-      if (single)
-        return "Função";
-      else
-        return "Funções";
-    case VhdlDocGen::RECORD:
-      if (single)
-        return "Registro";
-      else
-        return "Registros";
-    case VhdlDocGen::PROCEDURE:
-      if (single)
-        return "Procedimento";
-      else
-        return "Procedimentos";
-    case VhdlDocGen::ARCHITECTURE:
-      if (single)
-        return "Arquitetura";
-      else
-        return "Arquiteturas";
-    case VhdlDocGen::ATTRIBUTE:
-      if (single)
-        return "Atributo";
-      else
-        return "Atributos";
-    case VhdlDocGen::PROCESS:
-      if (single)
-        return "Processo";
-      else
-        return "Processos";
-    case VhdlDocGen::PORT:
-      if (single)
-        return "Porta";
-      else
-        return "Portas";
-    case VhdlDocGen::USE:
-      if (single)
-        return "cláusula de uso";
-      else
-        return "cláusulas de uso";
-    case VhdlDocGen::GENERIC:
-      if (single)
-        return "Generico";
-      else
-        return "Genericos";
-    case VhdlDocGen::PACKAGE_BODY:
-      return "Corpo do Pacote";
-    case VhdlDocGen::UNITS:
-      return "Unidades";
-    case VhdlDocGen::SHAREDVARIABLE:
-      if (single)
-        return "Variável Compartilhada";
-      else
-        return "Variáveis Compartilhadas";
-    case VhdlDocGen::VFILE:
-      if (single)
-        return "Arquivo";
-      else
-        return "Arquivos";
-    case VhdlDocGen::GROUP:
-      if (single)
-        return "Grupo";
-      else
-        return "Grupos";
-    case VhdlDocGen::INSTANTIATION:
-      if (single)
-        return "Instância";
-      else
-        return "Instâncias";
-    case VhdlDocGen::ALIAS:
-      if (single)
-        return "Apelido";
-      else
-        return "Apelidos";
-    case VhdlDocGen::CONFIG:
-      if (single)
-        return "Configuração";
-      else
-        return "Configurações";
-    case VhdlDocGen::MISCELLANEOUS:
-      return "Outros"; // Is this correct for VHDL?
-    case VhdlDocGen::UCF_CONST:
-      return "Restrições";
-    default:
-      return "Classe";
     }
-  }
-  virtual QCString trCustomReference(const QCString &name)
-  {
-    return "Referência de " + QCString(name);
-  }
-
-  /* Slice */
-  virtual QCString trConstants()
-  {
-    return "Constantes";
-  }
-  virtual QCString trConstantDocumentation()
-  {
-    return "Constantes";
-  }
-  virtual QCString trSequences()
-  {
-    return "Sequências";
-  }
-  virtual QCString trSequenceDocumentation()
-  {
-    return "Sequências";
-  }
-  virtual QCString trDictionaries()
-  {
-    return "Dicionários";
-  }
-  virtual QCString trDictionaryDocumentation()
-  {
-    return "Dicionários";
-  }
-  virtual QCString trSliceInterfaces()
-  {
-    return "Interfaces";
-  }
-  virtual QCString trInterfaceIndex()
-  {
-    return "Índice de Interfaces";
-  }
-  virtual QCString trInterfaceList()
-  {
-    return "Lista de Interfaces";
-  }
-  virtual QCString trInterfaceListDescription()
-  {
-    return "Estas são as interfaces com suas respectivas descrições:";
-  }
-  virtual QCString trInterfaceHierarchy()
-  {
-    return "Hierarquia de Interfaces";
-  }
-  virtual QCString trInterfaceHierarchyDescription()
-  {
-    return "Esta é a lista parcialmente ordenadas de heranças:";
-  }
-  virtual QCString trInterfaceDocumentation()
-  {
-    return "Interfaces";
-  }
-  virtual QCString trStructs()
-  {
-    return "Estruturas";
-  }
-  virtual QCString trStructIndex()
-  {
-    return "Índice de Estruturas";
-  }
-  virtual QCString trStructList()
-  {
-    return "Lista de Estruturas";
-  }
-  virtual QCString trStructListDescription()
-  {
-    return "Estas são as estruturas com suas respectivas descrições:";
-  }
-  virtual QCString trStructDocumentation()
-  {
-    return "Estruturas";
-  }
-  virtual QCString trExceptionIndex()
-  {
-    return "Índice the Exceções";
-  }
-  virtual QCString trExceptionList()
-  {
-    return "Lista de Exceções";
-  }
-  virtual QCString trExceptionListDescription()
-  {
-    return "Estas são as exceções com suas respectivas descrições:";
-  }
-  virtual QCString trExceptionHierarchy()
-  {
-    return "Hierarquia de Exceções";
-  }
-  virtual QCString trExceptionHierarchyDescription()
-  {
-    return "Esta é a lista parcialmente ordenadas de heranças:";
-  }
-  virtual QCString trExceptionDocumentation()
-  {
-    return "Exceções";
-  }
-  virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
-  {
-    QCString result = "Referência ";
-    switch (compType)
+    virtual QCString trConstantDocumentation()
     {
-    case ClassDef::Class:
-      result += "da Classe ";
-      break;
-    case ClassDef::Struct:
-      result += "da Estrutura ";
-      break;
-    case ClassDef::Union:
-      result += "da União ";
-      break;
-    case ClassDef::Interface:
-      result += "da Interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "do Protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "da Categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "da Exceção ";
-      break;
-    default:
-      break;
+        return "Constantes";
     }
-    if (isLocal)
-      result += "Local ";
-    result += clName;
-    return result;
-  }
-  virtual QCString trOperations()
-  {
-    return "Operações";
-  }
-  virtual QCString trOperationDocumentation()
-  {
-    return "Operações";
-  }
-  virtual QCString trDataMembers()
-  {
-    return "Dados Membros";
-  }
-  virtual QCString trDataMemberDocumentation()
-  {
-    return "Dados Membros";
-  }
+    virtual QCString trSequences()
+    {
+        return "Sequências";
+    }
+    virtual QCString trSequenceDocumentation()
+    {
+        return "Sequências";
+    }
+    virtual QCString trDictionaries()
+    {
+        return "Dicionários";
+    }
+    virtual QCString trDictionaryDocumentation()
+    {
+        return "Dicionários";
+    }
+    virtual QCString trSliceInterfaces()
+    {
+        return "Interfaces";
+    }
+    virtual QCString trInterfaceIndex()
+    {
+        return "Índice de Interfaces";
+    }
+    virtual QCString trInterfaceList()
+    {
+        return "Lista de Interfaces";
+    }
+    virtual QCString trInterfaceListDescription()
+    {
+        return "Estas são as interfaces com suas respectivas descrições:";
+    }
+    virtual QCString trInterfaceHierarchy()
+    {
+        return "Hierarquia de Interfaces";
+    }
+    virtual QCString trInterfaceHierarchyDescription()
+    {
+        return "Esta é a lista parcialmente ordenadas de heranças:";
+    }
+    virtual QCString trInterfaceDocumentation()
+    {
+        return "Interfaces";
+    }
+    virtual QCString trStructs()
+    {
+        return "Estruturas";
+    }
+    virtual QCString trStructIndex()
+    {
+        return "Índice de Estruturas";
+    }
+    virtual QCString trStructList()
+    {
+        return "Lista de Estruturas";
+    }
+    virtual QCString trStructListDescription()
+    {
+        return "Estas são as estruturas com suas respectivas descrições:";
+    }
+    virtual QCString trStructDocumentation()
+    {
+        return "Estruturas";
+    }
+    virtual QCString trExceptionIndex()
+    {
+        return "Índice the Exceções";
+    }
+    virtual QCString trExceptionList()
+    {
+        return "Lista de Exceções";
+    }
+    virtual QCString trExceptionListDescription()
+    {
+        return "Estas são as exceções com suas respectivas descrições:";
+    }
+    virtual QCString trExceptionHierarchy()
+    {
+        return "Hierarquia de Exceções";
+    }
+    virtual QCString trExceptionHierarchyDescription()
+    {
+        return "Esta é a lista parcialmente ordenadas de heranças:";
+    }
+    virtual QCString trExceptionDocumentation()
+    {
+        return "Exceções";
+    }
+    virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
+    {
+      QCString result="Referência ";
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="da Classe "; break;
+        case ClassDef::Struct:     result+="da Estrutura "; break;
+        case ClassDef::Union:      result+="da União "; break;
+        case ClassDef::Interface:  result+="da Interface "; break;
+        case ClassDef::Protocol:   result+="do Protocolo "; break;
+        case ClassDef::Category:   result+="da Categoria "; break;
+        case ClassDef::Exception:  result+="da Exceção "; break;
+        default: break;
+      }
+      if (isLocal) result+="Local ";
+      result+= clName;
+      return result;
+    }
+    virtual QCString trOperations()
+    {
+        return "Operações";
+    }
+    virtual QCString trOperationDocumentation()
+    {
+        return "Operações";
+    }
+    virtual QCString trDataMembers()
+    {
+        return "Dados Membros";
+    }
+    virtual QCString trDataMemberDocumentation()
+    {
+        return "Dados Membros";
+    }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.19
-  //////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.8.19
+    //////////////////////////////////////////////////////////////////////////
 
-  /** VHDL design unit documentation */
-  virtual QCString trDesignUnitDocumentation()
-  {
-    return "Documentação da Unidade de Projeto";
-  }
+    /** VHDL design unit documentation */
+    virtual QCString trDesignUnitDocumentation()
+    {
+        return "Documentação da Unidade de Projeto";
+    }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.9.2
-  //////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.9.2
+    //////////////////////////////////////////////////////////////////////////
 
-  /** C++20 concept */
-  virtual QCString trConcept(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Conceito" : "conceito"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-  /*! used as the title of the HTML page of a C++20 concept page */
-  virtual QCString trConceptReference(const QCString &conceptName)
-  {
-    QCString result = "Referência do Conceito ";
-    result += conceptName;
-    return result;
-  }
+    /** C++20 concept */
+    virtual QCString trConcept(bool first_capital, bool singular)
+    {
+        QCString result((first_capital ? "Conceito" : "conceito"));
+        if (!singular) result+="s";
+        return result;
+    }
+    /*! used as the title of the HTML page of a C++20 concept page */
+    virtual QCString trConceptReference(const QCString &conceptName)
+    {
+        QCString result= "Referência do Conceito ";
+        result+=conceptName;
+        return result;
+    }
 
-  /*! used as the title of page containing all the index of all concepts. */
-  virtual QCString trConceptList()
-  {
-    return "Lista de Conceitos";
-  }
+    /*! used as the title of page containing all the index of all concepts. */
+    virtual QCString trConceptList()
+    { return "Lista de Conceitos"; }
 
-  /*! used as the title of chapter containing the index listing all concepts. */
-  virtual QCString trConceptIndex()
-  {
-    return "Índice de Conceitos";
-  }
+    /*! used as the title of chapter containing the index listing all concepts. */
+    virtual QCString trConceptIndex()
+    { return "Índice de Conceitos"; }
 
-  /*! used as the title of chapter containing all information about concepts. */
-  virtual QCString trConceptDocumentation()
-  {
-    return "Documentação do Conceito";
-  }
+    /*! used as the title of chapter containing all information about concepts. */
+    virtual QCString trConceptDocumentation()
+    { return "Documentação do Conceito"; }
 
-  /*! used as an introduction to the concept list */
-  virtual QCString trConceptListDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os conceitos ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "com suas respectivas descrições:";
-    return result;
-  }
+    /*! used as an introduction to the concept list */
+    virtual QCString trConceptListDescription(bool extractAll)
+    {
+        QCString result="Esta é a lista de todos os conceitos ";
+        if (!extractAll) result+="documentados ";
+        result+="com suas respectivas descrições:";
+        return result;
+    }
 
-  /*! used to introduce the definition of the C++20 concept */
-  virtual QCString trConceptDefinition()
-  {
-    return "Definição de conceito";
-  }
+    /*! used to introduce the definition of the C++20 concept */
+    virtual QCString trConceptDefinition()
+    {
+        return "Definição de conceito";
+    }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.9.4
-  //////////////////////////////////////////////////////////////////////////
-  virtual QCString trPackageList()
-  {
-    return "Lista de pacotes";
-  }
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.9.4
+    //////////////////////////////////////////////////////////////////////////
+    virtual QCString trPackageList()
+    { return "Lista de pacotes"; }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.9.6
-  //////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.9.6
+    //////////////////////////////////////////////////////////////////////////
 
-  /*! This is used for translation of the word that will be
-   *  followed by a single name of the VHDL process flowchart.
-   */
-  virtual QCString trFlowchart()
-  {
-    return "Fluxograma: ";
-  }
+    /*! This is used for translation of the word that will be
+     *  followed by a single name of the VHDL process flowchart.
+     */
+    virtual QCString trFlowchart()
+    {
+        return "Fluxograma: ";
+    }
 
-  /*! Please translate also updated body of the method
-   *  trMemberFunctionDocumentation(), now better adapted for
-   *  VHDL sources documentation.
-   */
+    /*! Please translate also updated body of the method
+     *  trMemberFunctionDocumentation(), now better adapted for
+     *  VHDL sources documentation.
+    */    
 };
 
 #endif

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -19,6 +19,8 @@
  *    Thanks to Jorge Ramos, Fernando Carijo and others for their contributions.
  *
  * History:
+ * 20220911:
+ *  - Updated to 1.9.6;
  * 20220525:
  * 	- Updated to 1.9.4;
  * 20211003:
@@ -56,2367 +58,2756 @@
 #ifndef TRANSLATOR_BR_H
 #define TRANSLATOR_BR_H
 
-class TranslatorBrazilian : public TranslatorAdapter_1_9_5
+class TranslatorBrazilian : public Translator
 {
-  public:
+public:
+  // --- Language control methods -------------------
 
-    // --- Language control methods -------------------
+  /*! Used for identification of the language. The identification
+   * should not be translated. It should be replaced by the name
+   * of the language in English using lower-case characters only
+   * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
+   * the identification used in language.cpp.
+   */
+  virtual QCString idLanguage()
+  {
+    return "brazilian";
+  }
 
-    /*! Used for identification of the language. The identification
-     * should not be translated. It should be replaced by the name
-     * of the language in English using lower-case characters only
-     * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
-     * the identification used in language.cpp.
-     */
-    virtual QCString idLanguage()
+  /*! Used to get the LaTeX command(s) for the language support.
+   *  This method should return string with commands that switch
+   *  LaTeX to the desired language.  For example
+   *  <pre>"\\usepackage[german]{babel}\n"
+   *  </pre>
+   *  or
+   *  <pre>"\\usepackage{polski}\n"
+   *  "\\usepackage[latin2]{inputenc}\n"
+   *  "\\usepackage[T1]{fontenc}\n"
+   *  </pre>
+   *
+   * The English LaTeX does not use such commands.  Because of this
+   * the empty string is returned in this implementation.
+   */
+  virtual QCString latexLanguageSupportCommand()
+  {
+    return "\\usepackage[brazil]{babel}";
+  }
+
+  virtual QCString trISOLang()
+  {
+    return "pt-BR";
+  }
+  virtual QCString getLanguageString()
+  {
+    return "0x416 Portuguese(Brazil)";
+  }
+
+  // --- Language translation methods -------------------
+
+  /*! used in the compound documentation before a list of related functions. */
+  virtual QCString trRelatedFunctions()
+  {
+    return "Funções Relacionadas";
+  }
+
+  /*! subscript for the related functions. */
+  virtual QCString trRelatedSubscript()
+  {
+    return "(Note que estas não são funções membros.)";
+  }
+
+  /*! header that is put before the detailed description of files, classes and namespaces. */
+  virtual QCString trDetailedDescription()
+  {
+    return "Descrição detalhada";
+  }
+
+  /*! header that is put before the list of typedefs. */
+  virtual QCString trMemberTypedefDocumentation()
+  {
+    return "Documentação das definições de tipos";
+  }
+
+  /*! header that is put before the list of enumerations. */
+  virtual QCString trMemberEnumerationDocumentation()
+  {
+    return "Documentação das enumerações";
+  }
+
+  /*! header that is put before the list of member functions. */
+  virtual QCString trMemberFunctionDocumentation()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
     {
-      return "brazilian";
+      return "Documentação das funções, procedimentos e processos";
     }
-
-    /*! Used to get the LaTeX command(s) for the language support.
-     *  This method should return string with commands that switch
-     *  LaTeX to the desired language.  For example
-     *  <pre>"\\usepackage[german]{babel}\n"
-     *  </pre>
-     *  or
-     *  <pre>"\\usepackage{polski}\n"
-     *  "\\usepackage[latin2]{inputenc}\n"
-     *  "\\usepackage[T1]{fontenc}\n"
-     *  </pre>
-     *
-     * The English LaTeX does not use such commands.  Because of this
-     * the empty string is returned in this implementation.
-     */
-    virtual QCString latexLanguageSupportCommand()
+    else
     {
-      return "\\usepackage[brazil]{babel}";
+      return "Documentação das funções";
     }
+  }
 
-    virtual QCString trISOLang()
+  /*! header that is put before the list of member attributes. */
+  virtual QCString trMemberDataDocumentation()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      return "pt-BR";
+      return "Campos";
     }
-    virtual QCString getLanguageString()
+    else
     {
-      return "0x416 Portuguese(Brazil)";
+      return "Atributos";
     }
+  }
 
-    // --- Language translation methods -------------------
+  /*! this is the text of a link put after brief descriptions. */
+  virtual QCString trMore()
+  {
+    return "Mais...";
+  }
 
-    /*! used in the compound documentation before a list of related functions. */
-    virtual QCString trRelatedFunctions()
-    { return "Funções Relacionadas"; }
+  /*! put in the class documentation */
+  virtual QCString trListOfAllMembers()
+  {
+    return "Lista de todos os Membros";
+  }
 
-    /*! subscript for the related functions. */
-    virtual QCString trRelatedSubscript()
-    { return "(Note que estas não são funções membros.)"; }
+  /*! used as the title of the "list of all members" page of a class */
+  virtual QCString trMemberList()
+  {
+    return "Lista dos Membros";
+  }
 
-    /*! header that is put before the detailed description of files, classes and namespaces. */
-    virtual QCString trDetailedDescription()
-    { return "Descrição detalhada"; }
+  /*! this is the first part of a sentence that is followed by a class name */
+  virtual QCString trThisIsTheListOfAllMembers()
+  {
+    return "Esta é a lista de todos os membros de ";
+  }
 
-    /*! header that is put before the list of typedefs. */
-    virtual QCString trMemberTypedefDocumentation()
-    { return "Definições de tipos"; }
+  /*! this is the remainder of the sentence after the class name */
+  virtual QCString trIncludingInheritedMembers()
+  {
+    return ", incluindo os membros herdados.";
+  }
 
-    /*! header that is put before the list of enumerations. */
-    virtual QCString trMemberEnumerationDocumentation()
-    { return "Enumerações"; }
+  /*! this is put at the author sections at the bottom of man pages.
+   *  parameter s is name of the project name.
+   */
+  virtual QCString trGeneratedAutomatically(const QCString &s)
+  {
+    QCString result = "Gerado automaticamente por Doxygen";
+    if (!s.isEmpty())
+      result += " para " + s;
+    result += " a partir do código-fonte.";
+    return result;
+  }
 
-    /*! header that is put before the list of member functions. */
-    virtual QCString trMemberFunctionDocumentation()
+  /*! put after an enum name in the list of all members */
+  virtual QCString trEnumName()
+  {
+    return "Enumeração";
+  }
+
+  /*! put after an enum value in the list of all members */
+  virtual QCString trEnumValue()
+  {
+    return "Valor da enumeração";
+  }
+
+  /*! put after an undocumented member in the list of all members */
+  virtual QCString trDefinedIn()
+  {
+    return "definido(a) em";
+  }
+
+  // quick reference sections
+
+  /*! This is put above each page as a link to the list of all groups of
+   *  compounds or files (see the \\group command).
+   */
+  virtual QCString trModules()
+  {
+    return "Módulos";
+  }
+
+  /*! This is put above each page as a link to the class hierarchy */
+  virtual QCString trClassHierarchy()
+  {
+    return "Hierarquia de Classes";
+  }
+
+  /*! This is put above each page as a link to the list of annotated classes */
+  virtual QCString trCompoundList()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_JAVA))
-      {
-        return "Métodos";
-      }
-      else
-      {
-        return "Funções membros";
-      }
+      return "Estruturas de Dados";
     }
-
-    /*! header that is put before the list of member attributes. */
-    virtual QCString trMemberDataDocumentation()
+    else
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Campos";
-      }
-      else
-      {
-        return "Atributos";
-      }
+      return "Lista de Classes";
     }
+  }
 
-    /*! this is the text of a link put after brief descriptions. */
-    virtual QCString trMore()
-    { return "Mais..."; }
+  /*! This is put above each page as a link to the list of documented files */
+  virtual QCString trFileList()
+  {
+    return "Lista de Arquivos";
+  }
 
-    /*! put in the class documentation */
-    virtual QCString trListOfAllMembers()
-    { return "Lista de todos os Membros"; }
-
-    /*! used as the title of the "list of all members" page of a class */
-    virtual QCString trMemberList()
-    { return "Lista dos Membros"; }
-
-    /*! this is the first part of a sentence that is followed by a class name */
-    virtual QCString trThisIsTheListOfAllMembers()
-    { return "Esta é a lista de todos os membros de "; }
-
-    /*! this is the remainder of the sentence after the class name */
-    virtual QCString trIncludingInheritedMembers()
-    { return ", incluindo os membros herdados."; }
-
-    /*! this is put at the author sections at the bottom of man pages.
-     *  parameter s is name of the project name.
-     */
-    virtual QCString trGeneratedAutomatically(const QCString &s)
-    { QCString result="Gerado automaticamente por Doxygen";
-      if (!s.isEmpty()) result+=" para "+s;
-      result+=" a partir do código-fonte.";
-      return result;
-    }
-
-    /*! put after an enum name in the list of all members */
-    virtual QCString trEnumName()
-    { return "Enumeração"; }
-
-    /*! put after an enum value in the list of all members */
-    virtual QCString trEnumValue()
-    { return "Valor da enumeração"; }
-
-    /*! put after an undocumented member in the list of all members */
-    virtual QCString trDefinedIn()
-    { return "definido(a) em"; }
-
-    // quick reference sections
-
-    /*! This is put above each page as a link to the list of all groups of
-     *  compounds or files (see the \\group command).
-     */
-    virtual QCString trModules()
-    { return "Módulos"; }
-
-    /*! This is put above each page as a link to the class hierarchy */
-    virtual QCString trClassHierarchy()
-    { return "Hierarquia de Classes"; }
-
-    /*! This is put above each page as a link to the list of annotated classes */
-    virtual QCString trCompoundList()
+  /*! This is put above each page as a link to all members of compounds. */
+  virtual QCString trCompoundMembers()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Estruturas de Dados";
-      }
-      else
-      {
-        return "Lista de Classes";
-      }
+      return "Campos de Dados";
     }
-
-    /*! This is put above each page as a link to the list of documented files */
-    virtual QCString trFileList()
-    { return "Lista de Arquivos"; }
-
-    /*! This is put above each page as a link to all members of compounds. */
-    virtual QCString trCompoundMembers()
+    else
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Campos de Dados";
-      }
-      else
-      {
-        return "Membros de classe";
-      }
+      return "Membros de classe";
     }
+  }
 
-    /*! This is put above each page as a link to all members of files. */
-    virtual QCString trFileMembers()
+  /*! This is put above each page as a link to all members of files. */
+  virtual QCString trFileMembers()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Ítens globais";
-      }
-      else
-      {
-        return "Membros dos Arquivos";
-      }
+      return "Ítens globais";
     }
-
-    /*! This is put above each page as a link to all related pages. */
-    virtual QCString trRelatedPages()
-    { return "Páginas relacionadas"; }
-
-    /*! This is put above each page as a link to all examples. */
-    virtual QCString trExamples()
-    { return "Exemplos"; }
-
-    /*! This is put above each page as a link to the search engine. */
-    virtual QCString trSearch()
-    { return "Busca"; }
-
-    /*! This is an introduction to the class hierarchy. */
-    virtual QCString trClassHierarchyDescription()
-    { return "Esta lista de hierarquias está parcialmente ordenada (ordem alfabética):"; }
-
-    /*! This is an introduction to the list with all files. */
-    virtual QCString trFileListDescription(bool extractAll)
+    else
     {
-      QCString result="Esta é a lista de todos os arquivos ";
-      if (!extractAll) result+="documentados ";
-      result+="e suas respectivas descrições:";
-      return result;
+      return "Membros dos Arquivos";
     }
+  }
 
-    /*! This is an introduction to the annotated compound list. */
-    virtual QCString trCompoundListDescription()
+  /*! This is put above each page as a link to all related pages. */
+  virtual QCString trRelatedPages()
+  {
+    return "Páginas relacionadas";
+  }
+
+  /*! This is put above each page as a link to all examples. */
+  virtual QCString trExamples()
+  {
+    return "Exemplos";
+  }
+
+  /*! This is put above each page as a link to the search engine. */
+  virtual QCString trSearch()
+  {
+    return "Busca";
+  }
+
+  /*! This is an introduction to the class hierarchy. */
+  virtual QCString trClassHierarchyDescription()
+  {
+    return "Esta lista de hierarquias está parcialmente ordenada (ordem alfabética):";
+  }
+
+  /*! This is an introduction to the list with all files. */
+  virtual QCString trFileListDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os arquivos ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "e suas respectivas descrições:";
+    return result;
+  }
+
+  /*! This is an introduction to the annotated compound list. */
+  virtual QCString trCompoundListDescription()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Aqui estão as estruturas de dados, uniões e suas respectivas descrições:";
-      }
-      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
-      {
-        return "Aqui estão as classes e suas respectivas descrições:";
-      }
-      else
-      {
-        return "Aqui estão as classes, estruturas, uniões e interfaces e suas respectivas descrições:";
-      }
+      return "Aqui estão as estruturas de dados, uniões e suas respectivas descrições:";
     }
-
-    /*! This is an introduction to the page with all class members. */
-    virtual QCString trCompoundMembersDescription(bool extractAll)
+    else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
     {
-      QCString result="Esta é a lista de ";
+      return "Aqui estão as classes e suas respectivas descrições:";
+    }
+    else
+    {
+      return "Aqui estão as classes, estruturas, uniões e interfaces e suas respectivas descrições:";
+    }
+  }
 
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        result+="todas as estruturas e campos de uniões ";
-        if (!extractAll)
-        {
-          result+="documentados";
-        }
-      }
-      else
-      {
-        result+="todos os membros de classes ";
-        if (!extractAll)
-        {
-          result+="documentados";
-        }
-      }
-      result+=" com referências para ";
+  /*! This is an introduction to the page with all class members. */
+  virtual QCString trCompoundMembersDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de ";
+
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      result += "todas as estruturas e campos de uniões ";
       if (!extractAll)
       {
-        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-        {
-          result+="a documentação da estrutura/união de cada campo:";
-        }
-        else
-        {
-          result+="a documentação da classe de cada membro:";
-        }
+        result += "documentados";
       }
-      else
-      {
-        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-        {
-          result+="a estrutura/união a que pertencem:";
-        }
-        else
-        {
-          result+="a classe a que pertencem:";
-        }
-      }
-      return result;
     }
-
-    /*! This is an introduction to the page with all file members. */
-    virtual QCString trFileMembersDescription(bool extractAll)
+    else
     {
-      QCString result="Esta é a lista de ";
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      result += "todos os membros de classes ";
+      if (!extractAll)
       {
-        result+="todas as funções, variáveis, definições, enumerações e definições de tipos ";
-        if (!extractAll) result+="documentadas ";
+        result += "documentados";
       }
-      else
-      {
-        result+="todos os membros dos arquivos ";
-        if (!extractAll) result+="documentados ";
-      }
-      result+="com referências para ";
-      if (extractAll)
-        result+="seus respectivos arquivos:";
-      else
-        result+="suas respectivas documentações:";
-      return result;
     }
-
-    /*! This is an introduction to the page with the list of all examples */
-    virtual QCString trExamplesDescription()
-    { return "Esta é a lista de todos os exemplos:"; }
-
-    /*! This is an introduction to the page with the list of related pages */
-    virtual QCString trRelatedPagesDescription()
-    { return "Esta é a lista de toda a documentação relacionadas:"; }
-
-    /*! This is an introduction to the page with the list of class/file groups */
-    virtual QCString trModulesDescription()
-    { return "Esta é a lista de todos os módulos:"; }
-
-    /*! This is used in HTML as the title of index.html. */
-    virtual QCString trDocumentation()
-    {
-      // TODO In the future, I think I'll suggest the replacement of this
-      // method to something like trDocumentationOf(projPrefix). This will allow
-      // the latin construction "Documentação de ProjA"
-      return "Documentação";
-    }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * index of all groups.
-     */
-    virtual QCString trModuleIndex()
-    { return "Índice dos Módulos"; }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * class hierarchy.
-     */
-    virtual QCString trHierarchicalIndex()
-    { return "Índice Hierárquico"; }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * annotated compound index.
-     */
-    virtual QCString trCompoundIndex()
+    result += " com referências para ";
+    if (!extractAll)
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        return "Índice das Estruturas de Dados";
+        result += "a documentação da estrutura/união de cada campo:";
       }
       else
       {
-        return "Índice dos Componentes";
+        result += "a documentação da classe de cada membro:";
       }
     }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * list of all files.
-     */
-    virtual QCString trFileIndex()
-    { return "Índice dos Arquivos"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all groups.
-     */
-    virtual QCString trModuleDocumentation()
-    { return "Módulos"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all classes, structs and unions.
-     */
-    virtual QCString trClassDocumentation()
+    else
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        return "Estruturas";
-      }
-      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
-      {
-          return trDesignUnitDocumentation();
+        result += "a estrutura/união a que pertencem:";
       }
       else
       {
-        return "Classes";
+        result += "a classe a que pertencem:";
       }
     }
+    return result;
+  }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all files.
-     */
-    virtual QCString trFileDocumentation()
-    { return "Arquivos"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all examples.
-     */
-    virtual QCString trExampleDocumentation()
-    { return "Exemplos"; }
-
-    /*! This is used in LaTeX as the title of the document */
-    virtual QCString trReferenceManual()
-    { return "Guia de Referência"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of defines
-     */
-    virtual QCString trDefines()
-    { return "Definições e Macros"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of typedefs
-     */
-    virtual QCString trTypedefs()
-    { return "Definições de Tipos"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of enumerations
-     */
-    virtual QCString trEnumerations()
-    { return "Enumerações"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) functions
-     */
-    virtual QCString trFunctions()
-    { return "Funções"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) variables
-     */
-    virtual QCString trVariables()
-    { return "Variáveis"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) variables
-     */
-    virtual QCString trEnumerationValues()
-    { return "Enumeradores"; }
-
-    /*! This is used in the documentation of a file before the list of
-     *  documentation blocks for defines
-     */
-    virtual QCString trDefineDocumentation()
-    { return "Definições e macros"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for typedefs
-     */
-    virtual QCString trTypedefDocumentation()
-    { return "Definições dos tipos"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for enumeration types
-     */
-    virtual QCString trEnumerationTypeDocumentation()
-    { return "Enumerações"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for functions
-     */
-    virtual QCString trFunctionDocumentation()
-    { return "Funções"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for variables
-     */
-    virtual QCString trVariableDocumentation()
-    { return "Variáveis"; }
-
-    /*! This is used in the documentation of a file/namespace/group before
-     *  the list of links to documented compounds
-     */
-    virtual QCString trCompounds()
+  /*! This is an introduction to the page with all file members. */
+  virtual QCString trFileMembersDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de ";
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Estruturas de Dados";
-      }
-      else
-      {
-        return "Componentes";
-      }
+      result += "todas as funções, variáveis, definições, enumerações e definições de tipos ";
+      if (!extractAll)
+        result += "documentadas ";
     }
-
-    /*! This is used in the standard footer of each page and indicates when
-     *  the page was generated
-     */
-    virtual QCString trGeneratedAt(const QCString &date,const QCString &projName)
+    else
     {
-      QCString result="Gerado em "+date;
-      if (!projName.isEmpty()) result+=" para "+projName;
-      result+=" por";
-      return result;
+      result += "todos os membros dos arquivos ";
+      if (!extractAll)
+        result += "documentados ";
     }
+    result += "com referências para ";
+    if (extractAll)
+      result += "seus respectivos arquivos:";
+    else
+      result += "suas respectivas documentações:";
+    return result;
+  }
 
-    /*! this text is put before a class diagram */
-    virtual QCString trClassDiagram(const QCString &clName)
+  /*! This is an introduction to the page with the list of all examples */
+  virtual QCString trExamplesDescription()
+  {
+    return "Esta é a lista de todos os exemplos:";
+  }
+
+  /*! This is an introduction to the page with the list of related pages */
+  virtual QCString trRelatedPagesDescription()
+  {
+    return "Esta é a lista de toda a documentação relacionadas:";
+  }
+
+  /*! This is an introduction to the page with the list of class/file groups */
+  virtual QCString trModulesDescription()
+  {
+    return "Esta é a lista de todos os módulos:";
+  }
+
+  /*! This is used in HTML as the title of index.html. */
+  virtual QCString trDocumentation()
+  {
+    // TODO In the future, I think I'll suggest the replacement of this
+    // method to something like trDocumentationOf(projPrefix). This will allow
+    // the latin construction "Documentação de ProjA"
+    return "Documentação";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   * index of all groups.
+   */
+  virtual QCString trModuleIndex()
+  {
+    return "Índice dos Módulos";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   * class hierarchy.
+   */
+  virtual QCString trHierarchicalIndex()
+  {
+    return "Índice Hierárquico";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   * annotated compound index.
+   */
+  virtual QCString trCompoundIndex()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      return "Diagrama de hierarquia para "+clName+":";
+      return "Índice das Estruturas de Dados";
     }
-
-    /*! this text is generated when the \\warning command is used. */
-    virtual QCString trWarning()
-    { return "Aviso"; }
-
-    /*! this text is generated when the \\version command is used. */
-    virtual QCString trVersion()
-    { return "Versão"; }
-
-    /*! this text is generated when the \\date command is used. */
-    virtual QCString trDate()
-    { return "Data"; }
-
-    /*! this text is generated when the \\return command is used. */
-    virtual QCString trReturns()
-    { return "Retorna"; }
-
-    /*! this text is generated when the \\sa command is used. */
-    virtual QCString trSeeAlso()
-    { return "Veja também"; }
-
-    /*! this text is generated when the \\param command is used. */
-    virtual QCString trParameters()
-    { return "Parâmetros"; }
-
-    /*! this text is generated when the \\exception command is used. */
-    virtual QCString trExceptions()
-    { return "Exceções"; }
-
-    /*! this text is used in the title page of a LaTeX document. */
-    virtual QCString trGeneratedBy()
-    { return "Gerado por"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990307
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used as the title of page containing all the index of all namespaces. */
-    virtual QCString trNamespaceList()
-    { return "Lista de Namespaces"; }
-
-    /*! used as an introduction to the namespace list */
-    virtual QCString trNamespaceListDescription(bool extractAll)
+    else
     {
-      QCString result="Esta é a lista de todos os Namespaces ";
-      if (!extractAll) result+="documentados ";
-      result+="com suas respectivas descrições:";
-      return result;
+      return "Índice dos Componentes";
     }
+  }
 
-    /*! used in the class documentation as a header before the list of all
-     *  friends of a class
-     */
-    virtual QCString trFriends()
-    { return "Amigas"; }
+  /*! This is used in LaTeX as the title of the chapter with the
+   * list of all files.
+   */
+  virtual QCString trFileIndex()
+  {
+    return "Índice dos Arquivos";
+  }
 
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990405
-//////////////////////////////////////////////////////////////////////////
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all groups.
+   */
+  virtual QCString trModuleDocumentation()
+  {
+    return "Módulos";
+  }
 
-    /*! used in the class documentation as a header before the list of all
-     * related classes
-     */
-    virtual QCString trRelatedFunctionDocumentation()
-    { return "Amigas e Funções Relacionadas"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990425
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used as the title of the HTML page of a class/struct/union */
-    virtual QCString trCompoundReference(const QCString &clName,
-                                    ClassDef::CompoundType compType,
-                                    bool isTemplate)
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all classes, structs and unions.
+   */
+  virtual QCString trClassDocumentation()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      QCString result="Referência";
-      if (isTemplate) result+=" do <em>Template</em>";
-      if (compType == ClassDef::Protocol)
-      {
-        result+=" do ";
-      }
-      else
-      {
-        result+=" da ";
-      }
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="Classe "; break;
-        case ClassDef::Struct:     result+="Estrutura "; break;
-        case ClassDef::Union:      result+="União "; break;
-        case ClassDef::Interface:  result+="Interface "; break;
-        case ClassDef::Protocol:   result+="Protocolo "; break;
-        case ClassDef::Category:   result+="Categoria "; break;
-        case ClassDef::Exception:  result+="Exceção "; break;
-        default: break;
-      }
-      result+=clName;
-      return result;
+      return "Estruturas";
     }
-
-    /*! used as the title of the HTML page of a file */
-    virtual QCString trFileReference(const QCString &fileName)
+    else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
     {
-      QCString result = "Referência do Arquivo ";
-      result += fileName;
-      return result;
+      return trDesignUnitDocumentation();
     }
-
-    /*! used as the title of the HTML page of a namespace */
-    virtual QCString trNamespaceReference(const QCString &namespaceName)
+    else
     {
-      QCString result ="Refência do Namespace ";
-      result += namespaceName;
-      return result;
+      return "Classes";
     }
+  }
 
-    virtual QCString trPublicMembers()
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all files.
+   */
+  virtual QCString trFileDocumentation()
+  {
+    return "Arquivos";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all examples.
+   */
+  virtual QCString trExampleDocumentation()
+  {
+    return "Exemplos";
+  }
+
+  /*! This is used in LaTeX as the title of the document */
+  virtual QCString trReferenceManual()
+  {
+    return "Guia de Referência";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of defines
+   */
+  virtual QCString trDefines()
+  {
+    return "Definições e Macros";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of typedefs
+   */
+  virtual QCString trTypedefs()
+  {
+    return "Definições de Tipos";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of enumerations
+   */
+  virtual QCString trEnumerations()
+  {
+    return "Enumerações";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) functions
+   */
+  virtual QCString trFunctions()
+  {
+    return "Funções";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) variables
+   */
+  virtual QCString trVariables()
+  {
+    return "Variáveis";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) variables
+   */
+  virtual QCString trEnumerationValues()
+  {
+    return "Enumeradores";
+  }
+
+  /*! This is used in the documentation of a file before the list of
+   *  documentation blocks for defines
+   */
+  virtual QCString trDefineDocumentation()
+  {
+    return "Definições e macros";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for typedefs
+   */
+  virtual QCString trTypedefDocumentation()
+  {
+    return "Definições dos tipos";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for enumeration types
+   */
+  virtual QCString trEnumerationTypeDocumentation()
+  {
+    return "Enumerações";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for functions
+   */
+  virtual QCString trFunctionDocumentation()
+  {
+    return "Funções";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for variables
+   */
+  virtual QCString trVariableDocumentation()
+  {
+    return "Variáveis";
+  }
+
+  /*! This is used in the documentation of a file/namespace/group before
+   *  the list of links to documented compounds
+   */
+  virtual QCString trCompounds()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_JAVA))
-      {
-        return "Métodos Públicos";
-      }
-      else
-      {
-        return "Membros Públicos";
-      }
+      return "Estruturas de Dados";
     }
-
-    virtual QCString trPublicSlots()
-    { return "Slots Públicos"; }
-
-    virtual QCString trSignals()
-    { return "Sinais"; }
-
-    virtual QCString trStaticPublicMembers()
-    { return "Membros Públicos Estáticos"; }
-
-    virtual QCString trProtectedMembers()
-    { return "Membros Protegidos"; }
-
-    virtual QCString trProtectedSlots()
-    { return "Slots Protegidos"; }
-
-    virtual QCString trStaticProtectedMembers()
-    { return "Membros Protegidos Estáticos"; }
-
-    virtual QCString trPrivateMembers()
-    { return "Membros Privados"; }
-
-    virtual QCString trPrivateSlots()
-    { return "Slots Privados"; }
-
-    virtual QCString trStaticPrivateMembers()
-    { return "Membros Privados Estáticos"; }
-
-    /*! this function is used to produce a comma-separated list of items.
-     *  use generateMarker(i) to indicate where item i should be put.
-     */
-    virtual QCString trWriteList(int numEntries)
+    else
     {
-      QCString result;
-      int i;
-      // the inherits list contain `numEntries' classes
-      for (i=0;i<numEntries;i++)
-      {
-        // use generateMarker to generate placeholders for the class links!
-        result+=generateMarker(i); // generate marker for entry i in the list
+      return "Componentes";
+    }
+  }
+
+  /*! This is used in the standard footer of each page and indicates when
+   *  the page was generated
+   */
+  virtual QCString trGeneratedAt(const QCString &date, const QCString &projName)
+  {
+    QCString result = "Gerado em " + date;
+    if (!projName.isEmpty())
+      result += " para " + projName;
+    result += " por";
+    return result;
+  }
+
+  /*! this text is put before a class diagram */
+  virtual QCString trClassDiagram(const QCString &clName)
+  {
+    return "Diagrama de hierarquia para " + clName + ":";
+  }
+
+  /*! this text is generated when the \\warning command is used. */
+  virtual QCString trWarning()
+  {
+    return "Aviso";
+  }
+
+  /*! this text is generated when the \\version command is used. */
+  virtual QCString trVersion()
+  {
+    return "Versão";
+  }
+
+  /*! this text is generated when the \\date command is used. */
+  virtual QCString trDate()
+  {
+    return "Data";
+  }
+
+  /*! this text is generated when the \\return command is used. */
+  virtual QCString trReturns()
+  {
+    return "Retorna";
+  }
+
+  /*! this text is generated when the \\sa command is used. */
+  virtual QCString trSeeAlso()
+  {
+    return "Veja também";
+  }
+
+  /*! this text is generated when the \\param command is used. */
+  virtual QCString trParameters()
+  {
+    return "Parâmetros";
+  }
+
+  /*! this text is generated when the \\exception command is used. */
+  virtual QCString trExceptions()
+  {
+    return "Exceções";
+  }
+
+  /*! this text is used in the title page of a LaTeX document. */
+  virtual QCString trGeneratedBy()
+  {
+    return "Gerado por";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990307
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used as the title of page containing all the index of all namespaces. */
+  virtual QCString trNamespaceList()
+  {
+    return "Lista de Namespaces";
+  }
+
+  /*! used as an introduction to the namespace list */
+  virtual QCString trNamespaceListDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os Namespaces ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "com suas respectivas descrições:";
+    return result;
+  }
+
+  /*! used in the class documentation as a header before the list of all
+   *  friends of a class
+   */
+  virtual QCString trFriends()
+  {
+    return "Amigas";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990405
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used in the class documentation as a header before the list of all
+   * related classes
+   */
+  virtual QCString trRelatedFunctionDocumentation()
+  {
+    return "Amigas e Funções Relacionadas";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990425
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used as the title of the HTML page of a class/struct/union */
+  virtual QCString trCompoundReference(const QCString &clName,
+                                       ClassDef::CompoundType compType,
+                                       bool isTemplate)
+  {
+    QCString result = "Referência";
+    if (isTemplate)
+      result += " do <em>Template</em>";
+    if (compType == ClassDef::Protocol)
+    {
+      result += " do ";
+    }
+    else
+    {
+      result += " da ";
+    }
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "Classe ";
+      break;
+    case ClassDef::Struct:
+      result += "Estrutura ";
+      break;
+    case ClassDef::Union:
+      result += "União ";
+      break;
+    case ClassDef::Interface:
+      result += "Interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "Protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "Categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "Exceção ";
+      break;
+    default:
+      break;
+    }
+    result += clName;
+    return result;
+  }
+
+  /*! used as the title of the HTML page of a file */
+  virtual QCString trFileReference(const QCString &fileName)
+  {
+    QCString result = "Referência do Arquivo ";
+    result += fileName;
+    return result;
+  }
+
+  /*! used as the title of the HTML page of a namespace */
+  virtual QCString trNamespaceReference(const QCString &namespaceName)
+  {
+    QCString result = "Refência do Namespace ";
+    result += namespaceName;
+    return result;
+  }
+
+  virtual QCString trPublicMembers()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_JAVA))
+    {
+      return "Métodos Públicos";
+    }
+    else
+    {
+      return "Membros Públicos";
+    }
+  }
+
+  virtual QCString trPublicSlots()
+  {
+    return "Slots Públicos";
+  }
+
+  virtual QCString trSignals()
+  {
+    return "Sinais";
+  }
+
+  virtual QCString trStaticPublicMembers()
+  {
+    return "Membros Públicos Estáticos";
+  }
+
+  virtual QCString trProtectedMembers()
+  {
+    return "Membros Protegidos";
+  }
+
+  virtual QCString trProtectedSlots()
+  {
+    return "Slots Protegidos";
+  }
+
+  virtual QCString trStaticProtectedMembers()
+  {
+    return "Membros Protegidos Estáticos";
+  }
+
+  virtual QCString trPrivateMembers()
+  {
+    return "Membros Privados";
+  }
+
+  virtual QCString trPrivateSlots()
+  {
+    return "Slots Privados";
+  }
+
+  virtual QCString trStaticPrivateMembers()
+  {
+    return "Membros Privados Estáticos";
+  }
+
+  /*! this function is used to produce a comma-separated list of items.
+   *  use generateMarker(i) to indicate where item i should be put.
+   */
+  virtual QCString trWriteList(int numEntries)
+  {
+    QCString result;
+    int i;
+    // the inherits list contain `numEntries' classes
+    for (i = 0; i < numEntries; i++)
+    {
+      // use generateMarker to generate placeholders for the class links!
+      result += generateMarker(i); // generate marker for entry i in the list
                                    // (order is left to right)
 
-        if (i!=numEntries-1)  // not the last entry, so we need a separator
-        {
-          if (i<numEntries-2) // not the fore last entry
-            result+=", ";
-          else                // the fore last entry
-            result+=" e ";
-        }
-      }
-      return result;
-    }
-
-    /*! used in class documentation to produce a list of base classes,
-     *  if class diagrams are disabled.
-     */
-    virtual QCString trInheritsList(int numEntries)
-    {
-      return "Subclasse de " + trWriteList(numEntries) + ".";
-    }
-
-    /*! used in class documentation to produce a list of super classes,
-     *  if class diagrams are disabled.
-     */
-    virtual QCString trInheritedByList(int numEntries)
-    {
-      return "Superclasse de "+trWriteList(numEntries)+".";
-    }
-
-    /*! used in member documentation blocks to produce a list of
-     *  members that are hidden by this one.
-     */
-    virtual QCString trReimplementedFromList(int numEntries)
-    {
-      return "Reimplementa "+trWriteList(numEntries)+".";
-    }
-
-    /*! used in member documentation blocks to produce a list of
-     *  all member that overwrite the implementation of this member.
-     */
-    virtual QCString trReimplementedInList(int numEntries)
-    {
-      return "Reimplementado por "+trWriteList(numEntries)+".";
-    }
-
-    /*! This is put above each page as a link to all members of namespaces. */
-    virtual QCString trNamespaceMembers()
-    { return "Membros do <em>Namespace</em>"; }
-
-    /*! This is an introduction to the page with all namespace members */
-    virtual QCString trNamespaceMemberDescription(bool extractAll)
-    {
-      QCString result="Essa é a lista com todos os membros ";
-      if (!extractAll) result+="documentados ";
-      result+="do <em>Namespace</em> com referências para ";
-      if (extractAll)
-        result+="a documentação do <em>Namespace</em> para cada membro:";
-      else
-        result+="os seus respectivos <em>Namespaces</em>:";
-      return result;
-    }
-    /*! This is used in LaTeX as the title of the chapter with the
-     *  index of all namespaces.
-     */
-    virtual QCString trNamespaceIndex()
-    { return "<em>Namespaces</em>"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all namespaces.
-     */
-    virtual QCString trNamespaceDocumentation()
-    { return "<em>Namespace</em>"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990522
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is used in the documentation before the list of all
-     *  namespaces in a file.
-     */
-    virtual QCString trNamespaces()
-    { return "<em>Namespaces</em>"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990728
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is put at the bottom of a class documentation page and is
-     *  followed by a list of files that were used to generate the page.
-     */
-    virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
-        bool single)
-    { // here s is one of " Class", " Struct" or " Union"
-      // single is true implies a single file
-      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-      QCString result="A documentação para ";
-      if (compType == ClassDef::Protocol)
+      if (i != numEntries - 1) // not the last entry, so we need a separator
       {
-         result+= "esse ";
-      }
-      else
-      {
-         result+= "essa ";
-      }
-      switch(compType)
-      {
-        case ClassDef::Class:      result+=vhdlOpt?"Unidade de Design ":"classe "; break;
-        case ClassDef::Struct:     result+="estrutura "; break;
-        case ClassDef::Union:      result+="união "; break;
-        case ClassDef::Interface:  result+="interface "; break;
-        case ClassDef::Protocol:   result+="protocolo "; break;
-        case ClassDef::Category:   result+="categoria "; break;
-        case ClassDef::Exception:  result+="exceção "; break;
-        default: break;
-      }
-      result+=" foi gerada a partir ";
-      if (single) result+="do seguinte arquivo:"; else result+="dos seguintes arquivos:";
-      return result;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990901
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is used as the heading text for the retval command. */
-    virtual QCString trReturnValues()
-    { return "Valores Retornados"; }
-
-    /*! This is in the (quick) index as a link to the main page (index.html)
-     */
-    virtual QCString trMainPage()
-    { return "Página Principal"; }
-
-    /*! This is used in references to page that are put in the LaTeX
-     *  documentation. It should be an abbreviation of the word page.
-     */
-    virtual QCString trPageAbbreviation()
-    {
-      // Decidi mudar de página para "p." para ficar mais compacto.
-      return "p.";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-991003
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trDefinedAtLineInSourceFile()
-    {
-      return "Definição na linha @0 do arquivo @1.";
-    }
-    virtual QCString trDefinedInSourceFile()
-    {
-      return "Definição no arquivo @0.";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-991205
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trDeprecated()
-    {
-      return "Obsoleto(a)";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.0.0
-//////////////////////////////////////////////////////////////////////////
-
-    /*! this text is put before a collaboration diagram */
-    virtual QCString trCollaborationDiagram(const QCString &clName)
-    {
-      return "Diagrama de colaboração para "+clName+":";
-    }
-    /*! this text is put before an include dependency graph */
-    virtual QCString trInclDepGraph(const QCString &fName)
-    {
-      return "Gráfico de dependência de inclusões para "+fName+":";
-    }
-    /*! header that is put before the list of constructor/destructors. */
-    virtual QCString trConstructorDocumentation()
-    {
-      return "Construtores e Destrutores";
-    }
-    /*! Used in the file documentation to point to the corresponding sources. */
-    virtual QCString trGotoSourceCode()
-    {
-      return "Vá para o código-fonte desse arquivo.";
-    }
-    /*! Used in the file sources to point to the corresponding documentation. */
-    virtual QCString trGotoDocumentation()
-    {
-      return "Vá para a documentação desse arquivo.";
-    }
-    /*! Text for the \\pre command */
-    virtual QCString trPrecondition()
-    {
-      return "Pré-condição";
-    }
-    /*! Text for the \\post command */
-    virtual QCString trPostcondition()
-    {
-      return "Pós-condição";
-    }
-    /*! Text for the \\invariant command */
-    virtual QCString trInvariant()
-    {
-      return "Invariante";
-    }
-    /*! Text shown before a multi-line variable/enum initialization */
-    virtual QCString trInitialValue()
-    {
-      return "Valor inicial:";
-    }
-    /*! Text used the source code in the file index */
-    virtual QCString trCode()
-    {
-      return "código";
-    }
-    virtual QCString trGraphicalHierarchy()
-    {
-      return "Gráfico de Hierarquia de Classes";
-    }
-    virtual QCString trGotoGraphicalHierarchy()
-    {
-      return "Vá para o gráfico de hierarquia de classes";
-    }
-    virtual QCString trGotoTextualHierarchy()
-    {
-      return "Vá para a hierarquia de classes (texto)";
-    }
-    virtual QCString trPageIndex()
-    {
-      return "Índice da Página";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.0
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trNote()
-    {
-      return "Observação";
-    }
-    virtual QCString trPublicTypes()
-    {
-      return "Tipos Públicos";
-    }
-    virtual QCString trPublicAttribs()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Campos de Dados";
-      }
-      else
-      {
-        return "Atributos Públicos";
+        if (i < numEntries - 2) // not the fore last entry
+          result += ", ";
+        else // the fore last entry
+          result += " e ";
       }
     }
-    virtual QCString trStaticPublicAttribs()
-    {
-      return "Atributos Estáticos Públicos";
-    }
-    virtual QCString trProtectedTypes()
-    {
-      return "Tipos Protegidos";
-    }
-    virtual QCString trProtectedAttribs()
-    {
-      return "Atributos Protegidos";
-    }
-    virtual QCString trStaticProtectedAttribs()
-    {
-      return "Atributos Estáticos Protegidos";
-    }
-    virtual QCString trPrivateTypes()
-    {
-      return "Tipos Privados";
-    }
-    virtual QCString trPrivateAttribs()
-    {
-      return "Atributos Privados";
-    }
-    virtual QCString trStaticPrivateAttribs()
-    {
-      return "Atributos Privados Estáticos";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.3
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a marker that is put before a todo item */
-    virtual QCString trTodo()
-    {
-      return "Atividades futuras";
-    }
-    /*! Used as the header of the todo list */
-    virtual QCString trTodoList()
-    {
-      return "Lista de atividades futuras";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.4
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trReferencedBy()
-    {
-      return "Referenciado(a) por";
-    }
-    virtual QCString trRemarks()
-    {
-      return "Anotações";
-    }
-    virtual QCString trAttention()
-    {
-      return "Atenção";
-    }
-    virtual QCString trInclByDepGraph()
-    {
-      return "Este grafo mostra quais arquivos estão direta ou indiretamente relacionados com esse arquivo:";
-    }
-    virtual QCString trSince()
-    {
-      return "Desde";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.5
-//////////////////////////////////////////////////////////////////////////
-
-    /*! title of the graph legend page */
-    virtual QCString trLegendTitle()
-    {
-      return "Legenda do Grafo";
-    }
-    /*! page explaining how the dot graph's should be interpreted
-     *  The %A in the text below are to prevent link to classes called "A".
-     */
-    virtual QCString trLegendDocs()
-    {
-      return
-        "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
-        "Considere o seguinte exemplo:\n"
-        "\\code\n"
-        "/*! Classe oculta por causa da truncagem */\n"
-        "class Invisible { };\n\n"
-        "/*! Classe Truncated, relação de herança está oculta */\n"
-        "class Truncated : public Invisible { };\n\n"
-        "/* Classe não documentada com os comentários do Doxygen */\n"
-        "class Undocumented { };\n\n"
-        "/*! Classe possui que possui uma relação de herança pública */\n"
-        "class PublicBase : public Truncated { };\n\n"
-        "/*! Um template de classe */\n"
-        "template<class T> class Templ { };\n\n"
-        "/*! Classe possui que possui uma relação de herança protegida  */\n"
-        "class ProtectedBase { };\n\n"
-        "/*! Classe possui que possui uma relação de herança privada  */\n"
-        "class PrivateBase { };\n\n"
-        "/*! Classe utilizada pela classe Inherited */\n"
-        "class Used { };\n\n"
-        "/*! Super classe que herda outras classes */\n"
-        "class Inherited : public PublicBase,\n"
-        "                  protected ProtectedBase,\n"
-        "                  private PrivateBase,\n"
-        "                  public Undocumented,\n"
-        "                  public Templ<int>\n"
-        "{\n"
-        "  private:\n"
-        "    Used *m_usedClass;\n"
-        "};\n"
-        "\\endcode\n"
-        "Isto irá gerar o seguinte gráfo:"
-        "<p><center><img src=\"graph_legend."+getDotImageExtension()+"\"></center>\n"
-        "<p>\n"
-        "As caixas no grafo acima possuem os seguintes significados:\n"
-        "</p>\n"
-        "<ul>\n"
-        "<li>Uma caixa cinza denota a estrutura ou a classe que gerou"
-	"este grafo.</li>\n"
-        "<li>Uma caixa com a borda preta denota uma estrutura ou classe documentada.</li>\n"
-        "<li>Uma caixa com a borda cinza denota uma estrutura ou classe não documentada.</li>\n"
-        "<li>Uma caixa com a borda vermelha denota uma estrutura ou classe na"
-        "qual nem todas as relações são mostradas. Um grafo é truncado quando "
-        "esse não cabe no espaço especificado.</li>\n"
-        "</ul>\n"
-        "<p>\n"
-        "As setas possuem os seguintes significados:\n"
-        "</p>\n"
-        "<ul>\n"
-        "<li>Uma seta azul escura denota a relação de herança pública entre "
-        "duas classes.</li>\n"
-        "<li>Uma seta verde escura denota a relação de herança protegida entre "
-        "duas classes.</li>\n"
-        "<li>Uma seta vermelha escura denota a relação de herança privada entre "
-        "duas classes.</li>\n"
-        "<li>Uma seta pontilhada púrpura denota a relação de uso e/ou agragação "
-        "por outra classe/estrutura. A etiqueta da seta denota o nome do(s) campo(s) "
-        "que representa(m) este apontamento.</li>\n"
-        "<li>Uma seta pontilhada amarela denota a relação de instanciação de uma "
-        "<em>template</em>. A etiqueta da seta denota os parâmetros de instanciação "
-        "desta <em>template</em>.</li>\n"
-        "</ul>\n";
-    }
-    /*! text for the link to the legend page */
-    virtual QCString trLegend()
-    {
-      return "legenda";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.0
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a marker that is put before a test item */
-    virtual QCString trTest()
-    {
-      return "Teste";
-    }
-    /*! Used as the header of the test list */
-    virtual QCString trTestList()
-    {
-      return "Lista de Testes";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.2
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a section header for IDL properties */
-    virtual QCString trProperties()
-    {
-      return "Propriedades";
-    }
-    /*! Used as a section header for IDL property documentation */
-    virtual QCString trPropertyDocumentation()
-    {
-      return "Propriedades";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.4
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used for Java classes in the summary section of Java packages */
-    virtual QCString trClasses()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Estruturas de Dados";
-      }
-      else
-      {
-        return "Classes";
-      }
-    }
-    /*! Used as the title of a Java package */
-    virtual QCString trPackage(const QCString &name)
-    {
-      return "Pacote "+name;
-    }
-    /*! The description of the package index page */
-    virtual QCString trPackageListDescription()
-    {
-      return "Esta é a lista com os pacotes e suas respectivas descrições (quando disponíveis):";
-    }
-    /*! The link name in the Quick links header for each page */
-    virtual QCString trPackages()
-    {
-      return "Pacotes";
-    }
-    /*! Text shown before a multi-line define */
-    virtual QCString trDefineValue()
-    {
-      return "Valor:";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.5
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a marker that is put before a \\bug item */
-    virtual QCString trBug()
-    {
-      return "Bug";
-    }
-    /*! Used as the header of the bug list */
-    virtual QCString trBugList()
-    {
-      return "Lista de Bugs";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.6
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as ansicpg for RTF file
-     *
-     * The following table shows the correlation of Charset name, Charset Value and
-     * <pre>
-     * Codepage number:
-     * Charset Name       Charset Value(hex)  Codepage number
-     * ------------------------------------------------------
-     * DEFAULT_CHARSET           1 (x01)
-     * SYMBOL_CHARSET            2 (x02)
-     * OEM_CHARSET             255 (xFF)
-     * ANSI_CHARSET              0 (x00)            1252
-     * RUSSIAN_CHARSET         204 (xCC)            1251
-     * EE_CHARSET              238 (xEE)            1250
-     * GREEK_CHARSET           161 (xA1)            1253
-     * TURKISH_CHARSET         162 (xA2)            1254
-     * BALTIC_CHARSET          186 (xBA)            1257
-     * HEBREW_CHARSET          177 (xB1)            1255
-     * ARABIC _CHARSET         178 (xB2)            1256
-     * SHIFTJIS_CHARSET        128 (x80)             932
-     * HANGEUL_CHARSET         129 (x81)             949
-     * GB2313_CHARSET          134 (x86)             936
-     * CHINESEBIG5_CHARSET     136 (x88)             950
-     * </pre>
-     *
-     */
-    virtual QCString trRTFansicp()
-    {
-      return "1252";
-    }
-
-
-    /*! Used as ansicpg for RTF fcharset
-     *  \see trRTFansicp() for a table of possible values.
-     */
-    virtual QCString trRTFCharSet()
-    {
-      return "0";
-    }
-
-    /*! Used as header RTF general index */
-    virtual QCString trRTFGeneralIndex()
-    {
-      return "Sumário";
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trClass(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Classe" : "classe"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trFile(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Arquivo": "arquivo"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trNamespace(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trGroup(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Grupo" : "grupo"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trPage(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Página" : "página"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trMember(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Membro" : "membro"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trGlobal(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Globa" : "globa"));
-      if (!singular){
-        result+="is";
-      }else{
-        result+="l";
-      }
-      return result;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.7
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This text is generated when the \\author command is used and
-     *  for the author section in man pages. */
-    virtual QCString trAuthor(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (!singular)  result+="es";
-      return result;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.11
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This text is put before the list of members referenced by a member
-     */
-    virtual QCString trReferences()
-    {
-      return "Referencias";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.13
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used in member documentation blocks to produce a list of
-     *  members that are implemented by this one.
-     */
-    virtual QCString trImplementedFromList(int numEntries)
-    {
-      return "Implementa "+trWriteList(numEntries)+".";
-    }
-
-    /*! used in member documentation blocks to produce a list of
-     *  all members that implementation this member.
-     */
-    virtual QCString trImplementedInList(int numEntries)
-    {
-      return "Implementado por "+trWriteList(numEntries)+".";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.16
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used in RTF documentation as a heading for the Table
-     *  of Contents.
-     */
-    virtual QCString trRTFTableOfContents()
-    {
-      return "Sumário";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.17
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as the header of the list of item that have been
-     *  flagged deprecated
-     */
-    virtual QCString trDeprecatedList()
-    {
-      return "Lista de itens obsoletos";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.18
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a header for declaration section of the events found in
-     * a C# program
-     */
-    virtual QCString trEvents()
-    {
-      return "Eventos";
-    }
-    /*! Header used for the documentation section of a class' events. */
-    virtual QCString trEventDocumentation()
-    {
-      return "Eventos";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a heading for a list of Java class types with package scope.
-     */
-    virtual QCString trPackageTypes()
-    {
-      return "Tipos do Pacote";
-    }
-    /*! Used as a heading for a list of Java class functions with package
-     * scope.
-     */
-    virtual QCString trPackageFunctions()
-    {
-      return "Funções do Pacote";
-    }
-    virtual QCString trPackageMembers()
-    {
-      return "Membros do Pacote";
-    }
-    /*! Used as a heading for a list of static Java class functions with
-     *  package scope.
-     */
-    virtual QCString trStaticPackageFunctions()
-    {
-      return "Funções Estáticas do Pacote";
-    }
-    /*! Used as a heading for a list of Java class variables with package
-     * scope.
-     */
-    virtual QCString trPackageAttribs()
-    {
-      return "Atributos do Pacote";
-    }
-    /*! Used as a heading for a list of static Java class variables with
-     * package scope.
-     */
-    virtual QCString trStaticPackageAttribs()
-    {
-      return "Atributos Estáticos do Pacote";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.1
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used in the quick index of a class/file/namespace member list page
-     *  to link to the unfiltered list of all members.
-     */
-    virtual QCString trAll()
-    {
-      return "Todos";
-    }
-    /*! Put in front of the call graph for a function. */
-    virtual QCString trCallGraph()
-    {
-      return "Este é o diagrama das funções utilizadas por essa função:";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.3
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This string is used as the title for the page listing the search
-     *  results.
-     */
-    virtual QCString trSearchResultsTitle()
-    {
-      return "Resultado(s) da Busca";
-    }
-    /*! This string is put just before listing the search results. The
-     *  text can be different depending on the number of documents found.
-     *  Inside the text you can put the special marker $num to insert
-     *  the number representing the actual number of search results.
-     *  The @a numDocuments parameter can be either 0, 1 or 2, where the
-     *  value 2 represents 2 or more matches. HTML markup is allowed inside
-     *  the returned string.
-     */
-    virtual QCString trSearchResults(int numDocuments)
-    {
-      if (numDocuments==0)
-      {
-        return "Nenhum documento foi encontrado.";
-      }
-      else if (numDocuments==1)
-      {
-        return "Apenas <b>1</b> documento foi encontrado.";
-      }
-      else
-      {
-        return "<b>$num</b> documentos encontrados. "
-               "Mostrando os melhores resultados primeiro.";
-      }
-    }
-    /*! This string is put before the list of matched words, for each search
-     *  result. What follows is the list of words that matched the query.
-     */
-    virtual QCString trSearchMatches()
-    {
-      return "Resultados:";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.8
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is used in HTML as the title of page with source code for file filename
-     */
-    virtual QCString trSourceFile(QCString& filename)
-    {
-      return  "Código-Fonte de " + filename;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.9
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is used as the name of the chapter containing the directory
-     *  hierarchy.
-     */
-    virtual QCString trDirIndex()
-    { return "Hierarquia de Diretórios"; }
-
-    /*! This is used as the name of the chapter containing the documentation
-     *  of the directories.
-     */
-    virtual QCString trDirDocumentation()
-    { return "Documentação do Diretório"; }
-
-    /*! This is used as the title of the directory index and also in the
-     *  Quick links of a HTML page, to link to the directory hierarchy.
-     */
-    virtual QCString trDirectories()
-    { return "Diretórios"; }
-
-    /*! This returns the title of a directory page. The name of the
-     *  directory is passed via \a dirName.
-     */
-    virtual QCString trDirReference(const QCString &dirName)
-    {
-        QCString result = "Referência do diretório ";
-     	result += dirName;
-     	return result;
-    }
-
-    /*! This returns the word directory with or without starting capital
-     *  (\a first_capital) and in sigular or plural form (\a singular).
-     */
-    virtual QCString trDir(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Diretório" : "diretório"));
-      if (!singular) result+="s";
-      return result;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.4.1
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This text is added to the documentation when the \\overload command
-     *  is used for a overloaded function.
-     */
-    virtual QCString trOverloadText()
-    {
-       return "Esse é um método provido por conveniência. "
-       		"Ele difere do método acima apenas na lista de "
-       		"argumentos que devem ser utilizados.";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.4.6
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is used to introduce a caller (or called-by) graph */
-    virtual QCString trCallerGraph()
-    {
-      return "Esse é o diagrama das funções que utilizam essa função:";
-    }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for enumeration values
-     */
-    virtual QCString trEnumerationValueDocumentation()
-    { return "Documentação da enumeração"; }
-
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.5.4 (mainly for Fortran)
-//////////////////////////////////////////////////////////////////////////
-
-    /*! header that is put before the list of member subprograms (Fortran). */
-    virtual QCString trMemberFunctionDocumentationFortran()
-    { return "Documentação de Função Membro/Subrotina"; }
-
-    /*! This is put above each page as a link to the list of annotated data types (Fortran). */
-    virtual QCString trCompoundListFortran()
-    { return "Lista de Tipos de Dados"; }
-
-    /*! This is put above each page as a link to all members of compounds (Fortran). */
-    virtual QCString trCompoundMembersFortran()
-    { return "Campos de Dados"; }
-
-    /*! This is an introduction to the annotated compound list (Fortran). */
-    virtual QCString trCompoundListDescriptionFortran()
-    { return "Aqui estão os tipos de dados com descrições resumidas:"; }
-
-    /*! This is an introduction to the page with all data types (Fortran). */
-    virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
-    {
-      QCString result="Esta é a lista de todos os membros ";
-      if (!extractAll) result+="documentados ";
-      result+="dos tipos de dados com links para ";
-      if (extractAll)
-      {
-        result+="a documentação dos tipos de dados para cada membro:";
-      }
-      else
-      {
-        result+="os tipos de dados a que pertencem:";
-      }
-      return result;
-    }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * annotated compound index (Fortran).
-     */
-    virtual QCString trCompoundIndexFortran()
-    { return "Índice de Tipos de Dados"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all data types (Fortran).
-     */
-    virtual QCString trTypeDocumentation()
-    { return "Documentação dos Tipos de Dados"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) subprograms (Fortran).
-     */
-    virtual QCString trSubprograms()
-    { return "Funções/Subrotinas"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for subprograms (Fortran)
-     */
-    virtual QCString trSubprogramDocumentation()
-    { return "Documentação da Função/Subrotina"; }
-
-    /*! This is used in the documentation of a file/namespace/group before
-     *  the list of links to documented compounds (Fortran)
-     */
-     virtual QCString trDataTypes()
-    { return "Tipos de Dados"; }
-
-    /*! used as the title of page containing all the index of all modules (Fortran). */
-    virtual QCString trModulesList()
-    { return "Lista de Módulos"; }
-
-    /*! used as an introduction to the modules list (Fortran) */
-    virtual QCString trModulesListDescription(bool extractAll)
-    {
-      QCString result="Esta é a lista de todos os módulos ";
-      if (!extractAll) result+="documentados ";
-      result+="com descrições resumidas:";
-      return result;
-    }
-
-    /*! used as the title of the HTML page of a module/type (Fortran) */
-    virtual QCString trCompoundReferenceFortran(const QCString &clName,
-                                    ClassDef::CompoundType compType,
-                                    bool isTemplate)
-    {
-      QCString result = "Referência ";
-
-      if (isTemplate) result+="do <em>Template</em> ";
-
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="do Modulo "; break;
-        case ClassDef::Struct:     result+="do Tipo "; break;
-        case ClassDef::Union:      result+="da União "; break;
-        case ClassDef::Interface:  result+="da Interface "; break;
-        case ClassDef::Protocol:   result+="do Protocolo "; break;
-        case ClassDef::Category:   result+="da Categoria "; break;
-        case ClassDef::Exception:  result+="da Exceção "; break;
-        default: break;
-      }
-      result += clName;
-
-      return result;
-    }
-    /*! used as the title of the HTML page of a module (Fortran) */
-    virtual QCString trModuleReference(const QCString &namespaceName)
-    {
-      QCString result = "Referência do Módulo ";
-      result += namespaceName;
-      return result;
-    }
-
-    /*! This is put above each page as a link to all members of modules. (Fortran) */
-    virtual QCString trModulesMembers()
-    { return "Membros do Módulo"; }
-
-    /*! This is an introduction to the page with all modules members (Fortran) */
-    virtual QCString trModulesMemberDescription(bool extractAll)
-    {
-      QCString result="Esta é a lista de todos os membros ";
-      if (!extractAll) result+="documentados ";
-      result+="dos módulos com links para ";
-      if (extractAll)
-      {
-        result+="a documentação dos módulos para cada membro:";
-      }
-      else
-      {
-        result+="os módulos a que pertencem:";
-      }
-      return result;
-    }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     *  index of all modules (Fortran).
-     */
-    virtual QCString trModulesIndex()
-    { return "Índice dos Módulos"; }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trModule(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Módulo" : "módulo"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is put at the bottom of a module documentation page and is
-     *  followed by a list of files that were used to generate the page.
-     */
-    virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
-        bool single)
-    {
-      // single is true implies a single file
-      QCString result="A documentação para ";
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="esse modulo "; break;
-        case ClassDef::Struct:     result+="esse tipo "; break;
-        case ClassDef::Union:      result+="essa união "; break;
-        case ClassDef::Interface:  result+="essa interface "; break;
-        case ClassDef::Protocol:   result+="esso protocolo "; break;
-        case ClassDef::Category:   result+="essa categoria "; break;
-        case ClassDef::Exception:  result+="essa exceção "; break;
-        default: break;
-      }
-
-      result+=" foi gerada a partir do";
+    return result;
+  }
+
+  /*! used in class documentation to produce a list of base classes,
+   *  if class diagrams are disabled.
+   */
+  virtual QCString trInheritsList(int numEntries)
+  {
+    return "Subclasse de " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in class documentation to produce a list of super classes,
+   *  if class diagrams are disabled.
+   */
+  virtual QCString trInheritedByList(int numEntries)
+  {
+    return "Superclasse de " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in member documentation blocks to produce a list of
+   *  members that are hidden by this one.
+   */
+  virtual QCString trReimplementedFromList(int numEntries)
+  {
+    return "Reimplementa " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in member documentation blocks to produce a list of
+   *  all member that overwrite the implementation of this member.
+   */
+  virtual QCString trReimplementedInList(int numEntries)
+  {
+    return "Reimplementado por " + trWriteList(numEntries) + ".";
+  }
+
+  /*! This is put above each page as a link to all members of namespaces. */
+  virtual QCString trNamespaceMembers()
+  {
+    return "Membros do <em>Namespace</em>";
+  }
+
+  /*! This is an introduction to the page with all namespace members */
+  virtual QCString trNamespaceMemberDescription(bool extractAll)
+  {
+    QCString result = "Essa é a lista com todos os membros ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "do <em>Namespace</em> com referências para ";
+    if (extractAll)
+      result += "a documentação do <em>Namespace</em> para cada membro:";
+    else
+      result += "os seus respectivos <em>Namespaces</em>:";
+    return result;
+  }
+  /*! This is used in LaTeX as the title of the chapter with the
+   *  index of all namespaces.
+   */
+  virtual QCString trNamespaceIndex()
+  {
+    return "<em>Namespaces</em>";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all namespaces.
+   */
+  virtual QCString trNamespaceDocumentation()
+  {
+    return "<em>Namespace</em>";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990522
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used in the documentation before the list of all
+   *  namespaces in a file.
+   */
+  virtual QCString trNamespaces()
+  {
+    return "<em>Namespaces</em>";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990728
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is put at the bottom of a class documentation page and is
+   *  followed by a list of files that were used to generate the page.
+   */
+  virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
+                                        bool single)
+  { // here s is one of " Class", " Struct" or " Union"
+    // single is true implies a single file
+    bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+    QCString result = "A documentação para ";
+    if (compType == ClassDef::Protocol)
+    {
+      result += "esse ";
+    }
+    else
+    {
+      result += "essa ";
+    }
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += vhdlOpt ? "Unidade de Design " : "classe ";
+      break;
+    case ClassDef::Struct:
+      result += "estrutura ";
+      break;
+    case ClassDef::Union:
+      result += "união ";
+      break;
+    case ClassDef::Interface:
+      result += "interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "exceção ";
+      break;
+    default:
+      break;
+    }
+    result += " foi gerada a partir ";
+    if (single)
+      result += "do seguinte arquivo:";
+    else
+      result += "dos seguintes arquivos:";
+    return result;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990901
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used as the heading text for the retval command. */
+  virtual QCString trReturnValues()
+  {
+    return "Valores Retornados";
+  }
+
+  /*! This is in the (quick) index as a link to the main page (index.html)
+   */
+  virtual QCString trMainPage()
+  {
+    return "Página Principal";
+  }
+
+  /*! This is used in references to page that are put in the LaTeX
+   *  documentation. It should be an abbreviation of the word page.
+   */
+  virtual QCString trPageAbbreviation()
+  {
+    // Decidi mudar de página para "p." para ficar mais compacto.
+    return "p.";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-991003
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trDefinedAtLineInSourceFile()
+  {
+    return "Definição na linha @0 do arquivo @1.";
+  }
+  virtual QCString trDefinedInSourceFile()
+  {
+    return "Definição no arquivo @0.";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-991205
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trDeprecated()
+  {
+    return "Obsoleto(a)";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.0.0
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! this text is put before a collaboration diagram */
+  virtual QCString trCollaborationDiagram(const QCString &clName)
+  {
+    return "Diagrama de colaboração para " + clName + ":";
+  }
+  /*! this text is put before an include dependency graph */
+  virtual QCString trInclDepGraph(const QCString &fName)
+  {
+    return "Gráfico de dependência de inclusões para " + fName + ":";
+  }
+  /*! header that is put before the list of constructor/destructors. */
+  virtual QCString trConstructorDocumentation()
+  {
+    return "Construtores e Destrutores";
+  }
+  /*! Used in the file documentation to point to the corresponding sources. */
+  virtual QCString trGotoSourceCode()
+  {
+    return "Vá para o código-fonte desse arquivo.";
+  }
+  /*! Used in the file sources to point to the corresponding documentation. */
+  virtual QCString trGotoDocumentation()
+  {
+    return "Vá para a documentação desse arquivo.";
+  }
+  /*! Text for the \\pre command */
+  virtual QCString trPrecondition()
+  {
+    return "Pré-condição";
+  }
+  /*! Text for the \\post command */
+  virtual QCString trPostcondition()
+  {
+    return "Pós-condição";
+  }
+  /*! Text for the \\invariant command */
+  virtual QCString trInvariant()
+  {
+    return "Invariante";
+  }
+  /*! Text shown before a multi-line variable/enum initialization */
+  virtual QCString trInitialValue()
+  {
+    return "Valor inicial:";
+  }
+  /*! Text used the source code in the file index */
+  virtual QCString trCode()
+  {
+    return "código";
+  }
+  virtual QCString trGraphicalHierarchy()
+  {
+    return "Gráfico de Hierarquia de Classes";
+  }
+  virtual QCString trGotoGraphicalHierarchy()
+  {
+    return "Vá para o gráfico de hierarquia de classes";
+  }
+  virtual QCString trGotoTextualHierarchy()
+  {
+    return "Vá para a hierarquia de classes (texto)";
+  }
+  virtual QCString trPageIndex()
+  {
+    return "Índice da Página";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.0
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trNote()
+  {
+    return "Observação";
+  }
+  virtual QCString trPublicTypes()
+  {
+    return "Tipos Públicos";
+  }
+  virtual QCString trPublicAttribs()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Campos de Dados";
+    }
+    else
+    {
+      return "Atributos Públicos";
+    }
+  }
+  virtual QCString trStaticPublicAttribs()
+  {
+    return "Atributos Estáticos Públicos";
+  }
+  virtual QCString trProtectedTypes()
+  {
+    return "Tipos Protegidos";
+  }
+  virtual QCString trProtectedAttribs()
+  {
+    return "Atributos Protegidos";
+  }
+  virtual QCString trStaticProtectedAttribs()
+  {
+    return "Atributos Estáticos Protegidos";
+  }
+  virtual QCString trPrivateTypes()
+  {
+    return "Tipos Privados";
+  }
+  virtual QCString trPrivateAttribs()
+  {
+    return "Atributos Privados";
+  }
+  virtual QCString trStaticPrivateAttribs()
+  {
+    return "Atributos Privados Estáticos";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.3
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a marker that is put before a todo item */
+  virtual QCString trTodo()
+  {
+    return "Atividades futuras";
+  }
+  /*! Used as the header of the todo list */
+  virtual QCString trTodoList()
+  {
+    return "Lista de atividades futuras";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.4
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trReferencedBy()
+  {
+    return "Referenciado(a) por";
+  }
+  virtual QCString trRemarks()
+  {
+    return "Anotações";
+  }
+  virtual QCString trAttention()
+  {
+    return "Atenção";
+  }
+  virtual QCString trInclByDepGraph()
+  {
+    return "Este grafo mostra quais arquivos estão direta ou indiretamente relacionados com esse arquivo:";
+  }
+  virtual QCString trSince()
+  {
+    return "Desde";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.5
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! title of the graph legend page */
+  virtual QCString trLegendTitle()
+  {
+    return "Legenda do Grafo";
+  }
+  /*! page explaining how the dot graph's should be interpreted
+   *  The %A in the text below are to prevent link to classes called "A".
+   */
+  virtual QCString trLegendDocs()
+  {
+    return "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
+           "Considere o seguinte exemplo:\n"
+           "\\code\n"
+           "/*! Classe oculta por causa da truncagem */\n"
+           "class Invisible { };\n\n"
+           "/*! Classe Truncated, relação de herança está oculta */\n"
+           "class Truncated : public Invisible { };\n\n"
+           "/* Classe não documentada com os comentários do Doxygen */\n"
+           "class Undocumented { };\n\n"
+           "/*! Classe possui que possui uma relação de herança pública */\n"
+           "class PublicBase : public Truncated { };\n\n"
+           "/*! Um template de classe */\n"
+           "template<class T> class Templ { };\n\n"
+           "/*! Classe possui que possui uma relação de herança protegida  */\n"
+           "class ProtectedBase { };\n\n"
+           "/*! Classe possui que possui uma relação de herança privada  */\n"
+           "class PrivateBase { };\n\n"
+           "/*! Classe utilizada pela classe Inherited */\n"
+           "class Used { };\n\n"
+           "/*! Super classe que herda outras classes */\n"
+           "class Inherited : public PublicBase,\n"
+           "                  protected ProtectedBase,\n"
+           "                  private PrivateBase,\n"
+           "                  public Undocumented,\n"
+           "                  public Templ<int>\n"
+           "{\n"
+           "  private:\n"
+           "    Used *m_usedClass;\n"
+           "};\n"
+           "\\endcode\n"
+           "Isto irá gerar o seguinte gráfo:"
+           "<p><center><img src=\"graph_legend." +
+           getDotImageExtension() + "\"></center>\n"
+                                    "<p>\n"
+                                    "As caixas no grafo acima possuem os seguintes significados:\n"
+                                    "</p>\n"
+                                    "<ul>\n"
+                                    "<li>Uma caixa cinza denota a estrutura ou a classe que gerou"
+                                    "este grafo.</li>\n"
+                                    "<li>Uma caixa com a borda preta denota uma estrutura ou classe documentada.</li>\n"
+                                    "<li>Uma caixa com a borda cinza denota uma estrutura ou classe não documentada.</li>\n"
+                                    "<li>Uma caixa com a borda vermelha denota uma estrutura ou classe na"
+                                    "qual nem todas as relações são mostradas. Um grafo é truncado quando "
+                                    "esse não cabe no espaço especificado.</li>\n"
+                                    "</ul>\n"
+                                    "<p>\n"
+                                    "As setas possuem os seguintes significados:\n"
+                                    "</p>\n"
+                                    "<ul>\n"
+                                    "<li>Uma seta azul escura denota a relação de herança pública entre "
+                                    "duas classes.</li>\n"
+                                    "<li>Uma seta verde escura denota a relação de herança protegida entre "
+                                    "duas classes.</li>\n"
+                                    "<li>Uma seta vermelha escura denota a relação de herança privada entre "
+                                    "duas classes.</li>\n"
+                                    "<li>Uma seta pontilhada púrpura denota a relação de uso e/ou agragação "
+                                    "por outra classe/estrutura. A etiqueta da seta denota o nome do(s) campo(s) "
+                                    "que representa(m) este apontamento.</li>\n"
+                                    "<li>Uma seta pontilhada amarela denota a relação de instanciação de uma "
+                                    "<em>template</em>. A etiqueta da seta denota os parâmetros de instanciação "
+                                    "desta <em>template</em>.</li>\n"
+                                    "</ul>\n";
+  }
+  /*! text for the link to the legend page */
+  virtual QCString trLegend()
+  {
+    return "legenda";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.0
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a marker that is put before a test item */
+  virtual QCString trTest()
+  {
+    return "Teste";
+  }
+  /*! Used as the header of the test list */
+  virtual QCString trTestList()
+  {
+    return "Lista de Testes";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.2
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a section header for IDL properties */
+  virtual QCString trProperties()
+  {
+    return "Propriedades";
+  }
+  /*! Used as a section header for IDL property documentation */
+  virtual QCString trPropertyDocumentation()
+  {
+    return "Propriedades";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.4
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used for Java classes in the summary section of Java packages */
+  virtual QCString trClasses()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Estruturas de Dados";
+    }
+    else
+    {
+      return "Classes";
+    }
+  }
+  /*! Used as the title of a Java package */
+  virtual QCString trPackage(const QCString &name)
+  {
+    return "Pacote " + name;
+  }
+  /*! The description of the package index page */
+  virtual QCString trPackageListDescription()
+  {
+    return "Esta é a lista com os pacotes e suas respectivas descrições (quando disponíveis):";
+  }
+  /*! The link name in the Quick links header for each page */
+  virtual QCString trPackages()
+  {
+    return "Pacotes";
+  }
+  /*! Text shown before a multi-line define */
+  virtual QCString trDefineValue()
+  {
+    return "Valor:";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.5
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a marker that is put before a \\bug item */
+  virtual QCString trBug()
+  {
+    return "Bug";
+  }
+  /*! Used as the header of the bug list */
+  virtual QCString trBugList()
+  {
+    return "Lista de Bugs";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.6
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as ansicpg for RTF file
+   *
+   * The following table shows the correlation of Charset name, Charset Value and
+   * <pre>
+   * Codepage number:
+   * Charset Name       Charset Value(hex)  Codepage number
+   * ------------------------------------------------------
+   * DEFAULT_CHARSET           1 (x01)
+   * SYMBOL_CHARSET            2 (x02)
+   * OEM_CHARSET             255 (xFF)
+   * ANSI_CHARSET              0 (x00)            1252
+   * RUSSIAN_CHARSET         204 (xCC)            1251
+   * EE_CHARSET              238 (xEE)            1250
+   * GREEK_CHARSET           161 (xA1)            1253
+   * TURKISH_CHARSET         162 (xA2)            1254
+   * BALTIC_CHARSET          186 (xBA)            1257
+   * HEBREW_CHARSET          177 (xB1)            1255
+   * ARABIC _CHARSET         178 (xB2)            1256
+   * SHIFTJIS_CHARSET        128 (x80)             932
+   * HANGEUL_CHARSET         129 (x81)             949
+   * GB2313_CHARSET          134 (x86)             936
+   * CHINESEBIG5_CHARSET     136 (x88)             950
+   * </pre>
+   *
+   */
+  virtual QCString trRTFansicp()
+  {
+    return "1252";
+  }
+
+  /*! Used as ansicpg for RTF fcharset
+   *  \see trRTFansicp() for a table of possible values.
+   */
+  virtual QCString trRTFCharSet()
+  {
+    return "0";
+  }
+
+  /*! Used as header RTF general index */
+  virtual QCString trRTFGeneralIndex()
+  {
+    return "Sumário";
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trClass(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Classe" : "classe"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trFile(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Arquivo" : "arquivo"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trNamespace(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Namespace" : "namespace"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trGroup(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Grupo" : "grupo"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trPage(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Página" : "página"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trMember(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Membro" : "membro"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trGlobal(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Globa" : "globa"));
+    if (!singular)
+    {
+      result += "is";
+    }
+    else
+    {
+      result += "l";
+    }
+    return result;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.7
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This text is generated when the \\author command is used and
+   *  for the author section in man pages. */
+  virtual QCString trAuthor(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Autor" : "autor"));
+    if (!singular)
+      result += "es";
+    return result;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.11
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This text is put before the list of members referenced by a member
+   */
+  virtual QCString trReferences()
+  {
+    return "Referencias";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.13
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used in member documentation blocks to produce a list of
+   *  members that are implemented by this one.
+   */
+  virtual QCString trImplementedFromList(int numEntries)
+  {
+    return "Implementa " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in member documentation blocks to produce a list of
+   *  all members that implementation this member.
+   */
+  virtual QCString trImplementedInList(int numEntries)
+  {
+    return "Implementado por " + trWriteList(numEntries) + ".";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.16
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used in RTF documentation as a heading for the Table
+   *  of Contents.
+   */
+  virtual QCString trRTFTableOfContents()
+  {
+    return "Sumário";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.17
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as the header of the list of item that have been
+   *  flagged deprecated
+   */
+  virtual QCString trDeprecatedList()
+  {
+    return "Lista de itens obsoletos";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.18
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a header for declaration section of the events found in
+   * a C# program
+   */
+  virtual QCString trEvents()
+  {
+    return "Eventos";
+  }
+  /*! Header used for the documentation section of a class' events. */
+  virtual QCString trEventDocumentation()
+  {
+    return "Eventos";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a heading for a list of Java class types with package scope.
+   */
+  virtual QCString trPackageTypes()
+  {
+    return "Tipos do Pacote";
+  }
+  /*! Used as a heading for a list of Java class functions with package
+   * scope.
+   */
+  virtual QCString trPackageFunctions()
+  {
+    return "Funções do Pacote";
+  }
+  virtual QCString trPackageMembers()
+  {
+    return "Membros do Pacote";
+  }
+  /*! Used as a heading for a list of static Java class functions with
+   *  package scope.
+   */
+  virtual QCString trStaticPackageFunctions()
+  {
+    return "Funções Estáticas do Pacote";
+  }
+  /*! Used as a heading for a list of Java class variables with package
+   * scope.
+   */
+  virtual QCString trPackageAttribs()
+  {
+    return "Atributos do Pacote";
+  }
+  /*! Used as a heading for a list of static Java class variables with
+   * package scope.
+   */
+  virtual QCString trStaticPackageAttribs()
+  {
+    return "Atributos Estáticos do Pacote";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.1
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used in the quick index of a class/file/namespace member list page
+   *  to link to the unfiltered list of all members.
+   */
+  virtual QCString trAll()
+  {
+    return "Todos";
+  }
+  /*! Put in front of the call graph for a function. */
+  virtual QCString trCallGraph()
+  {
+    return "Este é o diagrama das funções utilizadas por essa função:";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.3
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This string is used as the title for the page listing the search
+   *  results.
+   */
+  virtual QCString trSearchResultsTitle()
+  {
+    return "Resultado(s) da Busca";
+  }
+  /*! This string is put just before listing the search results. The
+   *  text can be different depending on the number of documents found.
+   *  Inside the text you can put the special marker $num to insert
+   *  the number representing the actual number of search results.
+   *  The @a numDocuments parameter can be either 0, 1 or 2, where the
+   *  value 2 represents 2 or more matches. HTML markup is allowed inside
+   *  the returned string.
+   */
+  virtual QCString trSearchResults(int numDocuments)
+  {
+    if (numDocuments == 0)
+    {
+      return "Nenhum documento foi encontrado.";
+    }
+    else if (numDocuments == 1)
+    {
+      return "Apenas <b>1</b> documento foi encontrado.";
+    }
+    else
+    {
+      return "<b>$num</b> documentos encontrados. "
+             "Mostrando os melhores resultados primeiro.";
+    }
+  }
+  /*! This string is put before the list of matched words, for each search
+   *  result. What follows is the list of words that matched the query.
+   */
+  virtual QCString trSearchMatches()
+  {
+    return "Resultados:";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.8
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used in HTML as the title of page with source code for file filename
+   */
+  virtual QCString trSourceFile(QCString &filename)
+  {
+    return "Código-Fonte de " + filename;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.9
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used as the name of the chapter containing the directory
+   *  hierarchy.
+   */
+  virtual QCString trDirIndex()
+  {
+    return "Hierarquia de Diretórios";
+  }
+
+  /*! This is used as the name of the chapter containing the documentation
+   *  of the directories.
+   */
+  virtual QCString trDirDocumentation()
+  {
+    return "Documentação do Diretório";
+  }
+
+  /*! This is used as the title of the directory index and also in the
+   *  Quick links of a HTML page, to link to the directory hierarchy.
+   */
+  virtual QCString trDirectories()
+  {
+    return "Diretórios";
+  }
+
+  /*! This returns the title of a directory page. The name of the
+   *  directory is passed via \a dirName.
+   */
+  virtual QCString trDirReference(const QCString &dirName)
+  {
+    QCString result = "Referência do diretório ";
+    result += dirName;
+    return result;
+  }
+
+  /*! This returns the word directory with or without starting capital
+   *  (\a first_capital) and in sigular or plural form (\a singular).
+   */
+  virtual QCString trDir(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Diretório" : "diretório"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.4.1
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This text is added to the documentation when the \\overload command
+   *  is used for a overloaded function.
+   */
+  virtual QCString trOverloadText()
+  {
+    return "Esse é um método provido por conveniência. "
+           "Ele difere do método acima apenas na lista de "
+           "argumentos que devem ser utilizados.";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.4.6
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used to introduce a caller (or called-by) graph */
+  virtual QCString trCallerGraph()
+  {
+    return "Esse é o diagrama das funções que utilizam essa função:";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for enumeration values
+   */
+  virtual QCString trEnumerationValueDocumentation()
+  {
+    return "Documentação da enumeração";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.5.4 (mainly for Fortran)
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! header that is put before the list of member subprograms (Fortran). */
+  virtual QCString trMemberFunctionDocumentationFortran()
+  {
+    return "Documentação de Função Membro/Subrotina";
+  }
+
+  /*! This is put above each page as a link to the list of annotated data types (Fortran). */
+  virtual QCString trCompoundListFortran()
+  {
+    return "Lista de Tipos de Dados";
+  }
+
+  /*! This is put above each page as a link to all members of compounds (Fortran). */
+  virtual QCString trCompoundMembersFortran()
+  {
+    return "Campos de Dados";
+  }
+
+  /*! This is an introduction to the annotated compound list (Fortran). */
+  virtual QCString trCompoundListDescriptionFortran()
+  {
+    return "Aqui estão os tipos de dados com descrições resumidas:";
+  }
+
+  /*! This is an introduction to the page with all data types (Fortran). */
+  virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os membros ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "dos tipos de dados com links para ";
+    if (extractAll)
+    {
+      result += "a documentação dos tipos de dados para cada membro:";
+    }
+    else
+    {
+      result += "os tipos de dados a que pertencem:";
+    }
+    return result;
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   * annotated compound index (Fortran).
+   */
+  virtual QCString trCompoundIndexFortran()
+  {
+    return "Índice de Tipos de Dados";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all data types (Fortran).
+   */
+  virtual QCString trTypeDocumentation()
+  {
+    return "Documentação dos Tipos de Dados";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) subprograms (Fortran).
+   */
+  virtual QCString trSubprograms()
+  {
+    return "Funções/Subrotinas";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for subprograms (Fortran)
+   */
+  virtual QCString trSubprogramDocumentation()
+  {
+    return "Documentação da Função/Subrotina";
+  }
+
+  /*! This is used in the documentation of a file/namespace/group before
+   *  the list of links to documented compounds (Fortran)
+   */
+  virtual QCString trDataTypes()
+  {
+    return "Tipos de Dados";
+  }
+
+  /*! used as the title of page containing all the index of all modules (Fortran). */
+  virtual QCString trModulesList()
+  {
+    return "Lista de Módulos";
+  }
+
+  /*! used as an introduction to the modules list (Fortran) */
+  virtual QCString trModulesListDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os módulos ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "com descrições resumidas:";
+    return result;
+  }
+
+  /*! used as the title of the HTML page of a module/type (Fortran) */
+  virtual QCString trCompoundReferenceFortran(const QCString &clName,
+                                              ClassDef::CompoundType compType,
+                                              bool isTemplate)
+  {
+    QCString result = "Referência ";
+
+    if (isTemplate)
+      result += "do <em>Template</em> ";
+
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "do Modulo ";
+      break;
+    case ClassDef::Struct:
+      result += "do Tipo ";
+      break;
+    case ClassDef::Union:
+      result += "da União ";
+      break;
+    case ClassDef::Interface:
+      result += "da Interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "do Protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "da Categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "da Exceção ";
+      break;
+    default:
+      break;
+    }
+    result += clName;
+
+    return result;
+  }
+  /*! used as the title of the HTML page of a module (Fortran) */
+  virtual QCString trModuleReference(const QCString &namespaceName)
+  {
+    QCString result = "Referência do Módulo ";
+    result += namespaceName;
+    return result;
+  }
+
+  /*! This is put above each page as a link to all members of modules. (Fortran) */
+  virtual QCString trModulesMembers()
+  {
+    return "Membros do Módulo";
+  }
+
+  /*! This is an introduction to the page with all modules members (Fortran) */
+  virtual QCString trModulesMemberDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os membros ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "dos módulos com links para ";
+    if (extractAll)
+    {
+      result += "a documentação dos módulos para cada membro:";
+    }
+    else
+    {
+      result += "os módulos a que pertencem:";
+    }
+    return result;
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   *  index of all modules (Fortran).
+   */
+  virtual QCString trModulesIndex()
+  {
+    return "Índice dos Módulos";
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trModule(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Módulo" : "módulo"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is put at the bottom of a module documentation page and is
+   *  followed by a list of files that were used to generate the page.
+   */
+  virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
+                                               bool single)
+  {
+    // single is true implies a single file
+    QCString result = "A documentação para ";
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "esse modulo ";
+      break;
+    case ClassDef::Struct:
+      result += "esse tipo ";
+      break;
+    case ClassDef::Union:
+      result += "essa união ";
+      break;
+    case ClassDef::Interface:
+      result += "essa interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "esso protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "essa categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "essa exceção ";
+      break;
+    default:
+      break;
+    }
+
+    result += " foi gerada a partir do";
+    if (single)
+      result += " seguinte arquivo:";
+    else
+      result += "s seguintes arquivos:";
+
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trType(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Tipo" : "tipo"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trSubprogram(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Subrotina" : "subrotina"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! C# Type Contraint list */
+  virtual QCString trTypeConstraints()
+  {
+    return "Restrições do Tipo";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.6.0 (mainly for the new search engine)
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! directory relation for \a name */
+  virtual QCString trDirRelation(const QCString &name)
+  {
+    return "Relação " + QCString(name);
+  }
+
+  /*! Loading message shown when loading search results */
+  virtual QCString trLoading()
+  {
+    return "Carregando...";
+  }
+
+  /*! Label used for search results in the global namespace */
+  virtual QCString trGlobalNamespace()
+  {
+    return "<em>Namespace</em> global";
+  }
+
+  /*! Message shown while searching */
+  virtual QCString trSearching()
+  {
+    return "Procurando...";
+  }
+
+  /*! Text shown when no search results are found */
+  virtual QCString trNoMatches()
+  {
+    return "Nenhum resultado encontrado";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.6.3 (missing items for the directory pages)
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! when clicking a directory dependency label, a page with a
+   *  table is shown. The heading for the first column mentions the
+   *  source file that has a relation to another file.
+   */
+  virtual QCString trFileIn(const QCString &name)
+  {
+    return "Arquivo em " + name;
+  }
+
+  /*! when clicking a directory dependency label, a page with a
+   *  table is shown. The heading for the second column mentions the
+   *  destination file that is included.
+   */
+  virtual QCString trIncludesFileIn(const QCString &name)
+  {
+    return "Inclui arquivo em " + name;
+  }
+
+  /** Compiles a date string.
+   *  @param year Year in 4 digits
+   *  @param month Month of the year: 1=January
+   *  @param day Day of the Month: 1..31
+   *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
+   *  @param hour Hour of the day: 0..23
+   *  @param minutes Minutes in the hour: 0..59
+   *  @param seconds Seconds within the minute: 0..59
+   *  @param includeTime Include time in the result string?
+   */
+  virtual QCString trDateTime(int year, int month, int day, int dayOfWeek,
+                              int hour, int minutes, int seconds,
+                              bool includeTime)
+  {
+    static const char *days[] = {"Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"};
+    static const char *months[] = {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"};
+    QCString sdate;
+    sdate.sprintf("%s, %d de %s de %d", days[dayOfWeek - 1], day, months[month - 1], year);
+    if (includeTime)
+    {
+      QCString stime;
+      stime.sprintf(" %.2d:%.2d:%.2d", hour, minutes, seconds);
+      sdate += stime;
+    }
+    return sdate;
+  }
+  virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
+  {
+    static const char *days_short[] = {"seg", "ter", "qua", "qui", "sex", "sáb", "dom"};
+    static const char *days_full[] = {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo"};
+    QCString text = full ? days_full[dayOfWeek - 1] : days_short[dayOfWeek - 1];
+    if (first_capital)
+      return text.mid(0, 1).upper() + text.mid(1);
+    else
+      return text;
+  }
+  virtual QCString trMonth(int month, bool first_capital, bool full)
+  {
+    static const char *months_short[] = {"jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez"};
+    static const char *months_full[] = {"janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro"};
+    QCString text = full ? months_full[month - 1] : months_short[month - 1];
+    if (first_capital)
+      return text.mid(0, 1).upper() + text.mid(1);
+    else
+      return text;
+  }
+  virtual QCString trDayPeriod(int period)
+  {
+    static const char *dayPeriod[] = {"AM", "PM"};
+    return dayPeriod[period];
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.7.5
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Header for the page with bibliographic citations */
+  virtual QCString trCiteReferences()
+  {
+    return "Referências Bibliográficas";
+  }
+
+  /*! Text for copyright paragraph */
+  virtual QCString trCopyright()
+  {
+    // Note: I will left it as is because "Direitos autorais" may not fit
+    // in the text.
+    return "Copyright";
+  }
+
+  /*! Header for the graph showing the directory dependencies */
+  virtual QCString trDirDepGraph(const QCString &name)
+  {
+    return QCString("Grafo de dependências do diretório ") + name + ":";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.0
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Detail level selector shown for hierarchical indices */
+  virtual QCString trDetailLevel()
+  {
+    return "nível de detalhes";
+  }
+
+  /*! Section header for list of template parameters */
+  virtual QCString trTemplateParameters()
+  {
+    return "Parâmetros do <em>template</em>";
+  }
+
+  /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
+  virtual QCString trAndMore(const QCString &number)
+  {
+    return "e " + number + " mais...";
+  }
+
+  /*! Used file list for a Java enum */
+  virtual QCString trEnumGeneratedFromFiles(bool single)
+  {
+    QCString result = "A documentação para essa enumeração foi gerada a partir ";
+    if (single)
+    {
+      result += "do seguinte arquivo:";
+    }
+    else
+    {
+      result += "dos seguintes arquivos:";
+    }
+    return result;
+  }
+
+  /*! Header of a Java enum page (Java enums are represented as classes). */
+  virtual QCString trEnumReference(const QCString &name)
+  {
+    QCString result = "Referência da enumeração ";
+    return result + name;
+  }
+
+  /*! Used for a section containing inherited members */
+  virtual QCString trInheritedFrom(const QCString &members, const QCString &what)
+  {
+    return QCString(members) + " herdados de " + what;
+  }
+
+  /*! Header of the sections with inherited members specific for the
+   *  base class(es)
+   */
+  virtual QCString trAdditionalInheritedMembers()
+  {
+    return "Outros membros herdados";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.2
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a tooltip for the toggle button that appears in the
+   *  navigation tree in the HTML output when GENERATE_TREEVIEW is
+   *  enabled. This tooltip explains the meaning of the button.
+   */
+  virtual QCString trPanelSynchronisationTooltip(bool enable)
+  {
+    QCString opt = enable ? "ativar" : "desativar";
+    return "clique para " + opt + " a sincronização do painel";
+  }
+
+  /*! Used in a method of an Objective-C class that is declared in a
+   *  a category. Note that the @1 marker is required and is replaced
+   *  by a link.
+   */
+  virtual QCString trProvidedByCategory()
+  {
+    return "Provido pela categoria @0.";
+  }
+
+  /*! Used in a method of an Objective-C category that extends a class.
+   *  Note that the @1 marker is required and is replaced by a link to
+   *  the class method.
+   */
+  virtual QCString trExtendsClass()
+  {
+    return "estende a classe @0.";
+  }
+
+  /*! Used as the header of a list of class methods in Objective-C.
+   *  These are similar to static public member functions in C++.
+   */
+  virtual QCString trClassMethods()
+  {
+    return "Métodos da classe";
+  }
+
+  /*! Used as the header of a list of instance methods in Objective-C.
+   *  These are similar to public member functions in C++.
+   */
+  virtual QCString trInstanceMethods()
+  {
+    return "Métodos da instância";
+  }
+
+  /*! Used as the header of the member functions of an Objective-C class.
+   */
+  virtual QCString trMethodDocumentation()
+  {
+    return "Documentação do método";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.4
+  //////////////////////////////////////////////////////////////////////////
+
+  /** old style UNO IDL services: implemented interfaces */
+  virtual QCString trInterfaces()
+  {
+    return "Interfaces Exportadas";
+  }
+
+  /** old style UNO IDL services: inherited services */
+  virtual QCString trServices()
+  {
+    return "Serviços Inclusos";
+  }
+
+  /** UNO IDL constant groups */
+  virtual QCString trConstantGroups()
+  {
+    return "Grupos de Constantes";
+  }
+
+  /** UNO IDL constant groups */
+  virtual QCString trConstantGroupReference(const QCString &namespaceName)
+  {
+    QCString result = "Referência do grupo de constantes ";
+    result += namespaceName;
+    return result;
+  }
+  /** UNO IDL service page title */
+  virtual QCString trServiceReference(const QCString &sName)
+  {
+    QCString result = "Referência do serviço ";
+    result += sName;
+    return result;
+  }
+  /** UNO IDL singleton page title */
+  virtual QCString trSingletonReference(const QCString &sName)
+  {
+    // TODO: Emerson Ferreira proposes to add emphasis around the word
+    // Singleton but I'm not sure if this will work for non HTML generators.
+    QCString result = "Referência do Singleton ";
+    result += sName;
+    return result;
+  }
+  /** UNO IDL service page */
+  virtual QCString trServiceGeneratedFromFiles(bool single)
+  {
+    // single is true implies a single file
+    QCString result = "A documentação para esse serviço "
+                      "foi gerada a partir ";
+    if (single)
+    {
+      result += "do seguinte arquivo:";
+    }
+    else
+    {
+      result += "dos seguintes arquivos:";
+    }
+    return result;
+  }
+  /** UNO IDL singleton page */
+  virtual QCString trSingletonGeneratedFromFiles(bool single)
+  {
+    // single is true implies a single file
+    QCString result = "A documentação para esse <em>Singleton</em> "
+                      "foi gerada a partir ";
+    if (single)
+    {
+      result += "do seguinte arquivo:";
+    }
+    else
+    {
+      result += "dos: seguintes arquivos:";
+    }
+
+    return result;
+  }
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.15
+  //////////////////////////////////////////////////////////////////////////
+
+  /** VHDL design unit hierarchy */
+  virtual QCString trDesignUnitHierarchy()
+  {
+    return "Hierarquia da Unidade de Design";
+  }
+  /** VHDL design unit list */
+  virtual QCString trDesignUnitList()
+  {
+    return "Lista de Unidades de Design";
+  }
+  /** VHDL design unit members */
+  virtual QCString trDesignUnitMembers()
+  {
+    return "Membros da Unidade de Design";
+  }
+  /** VHDL design unit list description */
+  virtual QCString trDesignUnitListDescription()
+  {
+    return "Esta é uma lista de todos os membros de unidades de design "
+           "com ligações para as entidades às quais pertencem:";
+  }
+  /** VHDL design unit index */
+  virtual QCString trDesignUnitIndex()
+  {
+    return "Índice de Unidades de Design";
+  }
+  /** VHDL design units */
+  virtual QCString trDesignUnits()
+  {
+    return "Unidades de Design";
+  }
+  /** VHDL functions/procedures/processes */
+  virtual QCString trFunctionAndProc()
+  {
+    return "Funções/Procedimentos/Processos";
+  }
+  /** VHDL type */
+  virtual QCString trVhdlType(uint64 type, bool single)
+  {
+    switch (type)
+    {
+    case VhdlDocGen::LIBRARY:
       if (single)
-    	result+=" seguinte arquivo:";
+        return "Biblioteca";
       else
-    	result+="s seguintes arquivos:";
-
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trType(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Tipo" : "tipo"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trSubprogram(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Subrotina" : "subrotina"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! C# Type Contraint list */
-    virtual QCString trTypeConstraints()
-    {
-      return "Restrições do Tipo";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.6.0 (mainly for the new search engine)
-//////////////////////////////////////////////////////////////////////////
-
-    /*! directory relation for \a name */
-    virtual QCString trDirRelation(const QCString &name)
-    {
-      return "Relação " + QCString(name);
-    }
-
-    /*! Loading message shown when loading search results */
-    virtual QCString trLoading()
-    {
-      return "Carregando...";
-    }
-
-    /*! Label used for search results in the global namespace */
-    virtual QCString trGlobalNamespace()
-    {
-      return "<em>Namespace</em> global";
-    }
-
-    /*! Message shown while searching */
-    virtual QCString trSearching()
-    {
-      return "Procurando...";
-    }
-
-    /*! Text shown when no search results are found */
-    virtual QCString trNoMatches()
-    {
-      return "Nenhum resultado encontrado";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.6.3 (missing items for the directory pages)
-//////////////////////////////////////////////////////////////////////////
-
-    /*! when clicking a directory dependency label, a page with a
-     *  table is shown. The heading for the first column mentions the
-     *  source file that has a relation to another file.
-     */
-    virtual QCString trFileIn(const QCString &name)
-    {
-      return "Arquivo em "+name;
-    }
-
-    /*! when clicking a directory dependency label, a page with a
-     *  table is shown. The heading for the second column mentions the
-     *  destination file that is included.
-     */
-    virtual QCString trIncludesFileIn(const QCString &name)
-    {
-      return "Inclui arquivo em "+name;
-    }
-
-    /** Compiles a date string.
-     *  @param year Year in 4 digits
-     *  @param month Month of the year: 1=January
-     *  @param day Day of the Month: 1..31
-     *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
-     *  @param hour Hour of the day: 0..23
-     *  @param minutes Minutes in the hour: 0..59
-     *  @param seconds Seconds within the minute: 0..59
-     *  @param includeTime Include time in the result string?
-     */
-    virtual QCString trDateTime(int year,int month,int day,int dayOfWeek,
-                                int hour,int minutes,int seconds,
-                                bool includeTime)
-    {
-      static const char *days[]   = { "Segunda","Terça","Quarta","Quinta","Sexta","Sábado","Domingo" };
-      static const char *months[] = { "Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro" };
-      QCString sdate;
-      sdate.sprintf("%s, %d de %s de %d",days[dayOfWeek-1],day,months[month-1],year);
-      if (includeTime)
-      {
-        QCString stime;
-        stime.sprintf(" %.2d:%.2d:%.2d",hour,minutes,seconds);
-        sdate+=stime;
-      }
-      return sdate;
-    }
-    virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
-    {
-      static const char *days_short[]   = { "seg", "ter", "qua", "qui", "sex", "sáb", "dom" };
-      static const char *days_full[]    = { "segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo" };
-      QCString text  = full? days_full[dayOfWeek-1] : days_short[dayOfWeek-1];
-      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
-      else return text;
-    }
-    virtual QCString trMonth(int month, bool first_capital, bool full)
-    {
-      static const char *months_short[] = { "jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez" };
-      static const char *months_full[]  = { "janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro" };
-      QCString text  = full? months_full[month-1] : months_short[month-1];
-      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
-      else return text;
-    }
-    virtual QCString trDayPeriod(int period)
-    {
-      static const char *dayPeriod[] = { "AM", "PM" };
-      return dayPeriod[period];
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.7.5
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Header for the page with bibliographic citations */
-    virtual QCString trCiteReferences()
-    { return "Referências Bibliográficas"; }
-
-    /*! Text for copyright paragraph */
-    virtual QCString trCopyright()
-    {
-      // Note: I will left it as is because "Direitos autorais" may not fit
-      // in the text.
-      return "Copyright";
-    }
-
-    /*! Header for the graph showing the directory dependencies */
-    virtual QCString trDirDepGraph(const QCString &name)
-    { return QCString("Grafo de dependências do diretório ")+name+":"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.8.0
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Detail level selector shown for hierarchical indices */
-    virtual QCString trDetailLevel()
-    { return "nível de detalhes"; }
-
-    /*! Section header for list of template parameters */
-    virtual QCString trTemplateParameters()
-    { return "Parâmetros do <em>template</em>"; }
-
-    /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
-    virtual QCString trAndMore(const QCString &number)
-    { return "e "+number+" mais..."; }
-
-    /*! Used file list for a Java enum */
-    virtual QCString trEnumGeneratedFromFiles(bool single)
-    { QCString result = "A documentação para essa enumeração foi gerada a partir ";
-      if (single) {
-        result += "do seguinte arquivo:";
-      } else {
-        result += "dos seguintes arquivos:";
-      }
-      return result;
-    }
-
-    /*! Header of a Java enum page (Java enums are represented as classes). */
-    virtual QCString trEnumReference(const QCString &name)
-    {
-      QCString result = "Referência da enumeração ";
-      return result + name;
-    }
-
-    /*! Used for a section containing inherited members */
-    virtual QCString trInheritedFrom(const QCString &members,const QCString &what)
-    { return QCString(members)+" herdados de "+what; }
-
-    /*! Header of the sections with inherited members specific for the
-     *  base class(es)
-     */
-    virtual QCString trAdditionalInheritedMembers()
-    { return "Outros membros herdados"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.8.2
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a tooltip for the toggle button that appears in the
-     *  navigation tree in the HTML output when GENERATE_TREEVIEW is
-     *  enabled. This tooltip explains the meaning of the button.
-     */
-    virtual QCString trPanelSynchronisationTooltip(bool enable)
-    {
-      QCString opt = enable ? "ativar" : "desativar";
-      return "clique para "+opt+" a sincronização do painel";
-    }
-
-    /*! Used in a method of an Objective-C class that is declared in a
-     *  a category. Note that the @1 marker is required and is replaced
-     *  by a link.
-     */
-    virtual QCString trProvidedByCategory()
-    {
-      return "Provido pela categoria @0.";
-    }
-
-    /*! Used in a method of an Objective-C category that extends a class.
-     *  Note that the @1 marker is required and is replaced by a link to
-     *  the class method.
-     */
-    virtual QCString trExtendsClass()
-    {
-      return "estende a classe @0.";
-    }
-
-    /*! Used as the header of a list of class methods in Objective-C.
-     *  These are similar to static public member functions in C++.
-     */
-    virtual QCString trClassMethods()
-    {
-      return "Métodos da classe";
-    }
-
-    /*! Used as the header of a list of instance methods in Objective-C.
-     *  These are similar to public member functions in C++.
-     */
-    virtual QCString trInstanceMethods()
-    {
-      return "Métodos da instância";
-    }
-
-    /*! Used as the header of the member functions of an Objective-C class.
-     */
-    virtual QCString trMethodDocumentation()
-    {
-      return "Documentação do método";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.8.4
-//////////////////////////////////////////////////////////////////////////
-
-    /** old style UNO IDL services: implemented interfaces */
-    virtual QCString trInterfaces()
-    { return "Interfaces Exportadas"; }
-
-    /** old style UNO IDL services: inherited services */
-    virtual QCString trServices()
-    { return "Serviços Inclusos"; }
-
-    /** UNO IDL constant groups */
-    virtual QCString trConstantGroups()
-    { return "Grupos de Constantes"; }
-
-    /** UNO IDL constant groups */
-    virtual QCString trConstantGroupReference(const QCString &namespaceName)
-    {
-      QCString result = "Referência do grupo de constantes ";
-      result += namespaceName;
-      return result;
-    }
-    /** UNO IDL service page title */
-    virtual QCString trServiceReference(const QCString &sName)
-    {
-      QCString result = "Referência do serviço ";
-      result += sName;
-      return result;
-    }
-    /** UNO IDL singleton page title */
-    virtual QCString trSingletonReference(const QCString &sName)
-    {
-      // TODO: Emerson Ferreira proposes to add emphasis around the word
-      // Singleton but I'm not sure if this will work for non HTML generators.
-      QCString result = "Referência do Singleton ";
-      result += sName;
-      return result;
-    }
-    /** UNO IDL service page */
-    virtual QCString trServiceGeneratedFromFiles(bool single)
-    {
-      // single is true implies a single file
-      QCString result="A documentação para esse serviço "
-                                "foi gerada a partir ";
-      if (single) {
-        result+="do seguinte arquivo:";
-      } else {
-        result+="dos seguintes arquivos:";
-      }
-      return result;
-    }
-    /** UNO IDL singleton page */
-    virtual QCString trSingletonGeneratedFromFiles(bool single)
-    {
-      // single is true implies a single file
-      QCString result="A documentação para esse <em>Singleton</em> "
-                                "foi gerada a partir ";
-      if (single) {
-        result+="do seguinte arquivo:";
-      } else {
-        result+="dos: seguintes arquivos:";
-      }
-
-      return result;
-    }
-    //////////////////////////////////////////////////////////////////////////
-    // new since 1.8.15
-    //////////////////////////////////////////////////////////////////////////
-
-    /** VHDL design unit hierarchy */
-    virtual QCString trDesignUnitHierarchy()
-    { return "Hierarquia da Unidade de Design"; }
-    /** VHDL design unit list */
-    virtual QCString trDesignUnitList()
-    { return "Lista de Unidades de Design"; }
-    /** VHDL design unit members */
-    virtual QCString trDesignUnitMembers()
-    { return "Membros da Unidade de Design"; }
-    /** VHDL design unit list description */
-    virtual QCString trDesignUnitListDescription()
-    {
-        return "Esta é uma lista de todos os membros de unidades de design "
-        		"com ligações para as entidades às quais pertencem:";
-    }
-    /** VHDL design unit index */
-    virtual QCString trDesignUnitIndex()
-    { return "Índice de Unidades de Design"; }
-    /** VHDL design units */
-    virtual QCString trDesignUnits()
-    { return "Unidades de Design"; }
-    /** VHDL functions/procedures/processes */
-    virtual QCString trFunctionAndProc()
-    { return "Funções/Procedimentos/Processos"; }
-    /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
-    {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
-          if (single) return "Biblioteca";
-          else        return "Bibliotecas";
-        case VhdlDocGen::PACKAGE:
-          if (single) return "Pacote";
-          else        return "Pacotes";
-        case VhdlDocGen::SIGNAL:
-          if (single) return "Sinal";
-          else        return "Sinais";
-        case VhdlDocGen::COMPONENT:
-          if (single) return "Componente";
-          else        return "Componentes";
-        case VhdlDocGen::CONSTANT:
-          if (single) return "Constante";
-          else        return "Constantes";
-        case VhdlDocGen::ENTITY:
-          if (single) return "Entidade";
-          else        return "Entidades";
-        case VhdlDocGen::TYPE:
-          if (single) return "Tipo";
-          else        return "Tipos";
-        case VhdlDocGen::SUBTYPE:
-          if (single) return "Subtipo";
-          else        return "Subtipos";
-        case VhdlDocGen::FUNCTION:
-          if (single) return "Função";
-          else        return "Funções";
-        case VhdlDocGen::RECORD:
-          if (single) return "Registro";
-          else        return "Registros";
-        case VhdlDocGen::PROCEDURE:
-          if (single) return "Procedimento";
-          else        return "Procedimentos";
-        case VhdlDocGen::ARCHITECTURE:
-          if (single) return "Arquitetura";
-          else        return "Arquiteturas";
-        case VhdlDocGen::ATTRIBUTE:
-          if (single) return "Atributo";
-          else        return "Atributos";
-        case VhdlDocGen::PROCESS:
-          if (single) return "Processo";
-          else        return "Processos";
-        case VhdlDocGen::PORT:
-          if (single) return "Porta";
-          else        return "Portas";
-        case VhdlDocGen::USE:
-          if (single) return "cláusula de uso";
-          else        return "cláusulas de uso";
-        case VhdlDocGen::GENERIC:
-          if (single) return "Generico";
-          else        return "Genericos";
-        case VhdlDocGen::PACKAGE_BODY:
-          return "Corpo do Pacote";
-        case VhdlDocGen::UNITS:
-          return "Unidades";
-        case VhdlDocGen::SHAREDVARIABLE:
-          if (single) return "Variável Compartilhada";
-          else        return "Variáveis Compartilhadas";
-        case VhdlDocGen::VFILE:
-          if (single) return "Arquivo";
-          else        return "Arquivos";
-        case VhdlDocGen::GROUP:
-          if (single) return "Grupo";
-          else        return "Grupos";
-        case VhdlDocGen::INSTANTIATION:
-            if (single) return "Instância";
-            else        return "Instâncias";
-        case VhdlDocGen::ALIAS:
-          if (single) return "Apelido";
-          else        return "Apelidos";
-        case VhdlDocGen::CONFIG:
-          if (single) return "Configuração";
-          else        return "Configurações";
-        case VhdlDocGen::MISCELLANEOUS:
-          return "Outros"; // Is this correct for VHDL?
-        case VhdlDocGen::UCF_CONST:
-          return "Restrições";
-        default:
-          return "Classe";
-      }
-    }
-    virtual QCString trCustomReference(const QCString &name)
-    { return "Referência de " + QCString(name); }
-
-    /* Slice */
-    virtual QCString trConstants()
-    {
+        return "Bibliotecas";
+    case VhdlDocGen::PACKAGE:
+      if (single)
+        return "Pacote";
+      else
+        return "Pacotes";
+    case VhdlDocGen::SIGNAL:
+      if (single)
+        return "Sinal";
+      else
+        return "Sinais";
+    case VhdlDocGen::COMPONENT:
+      if (single)
+        return "Componente";
+      else
+        return "Componentes";
+    case VhdlDocGen::CONSTANT:
+      if (single)
+        return "Constante";
+      else
         return "Constantes";
+    case VhdlDocGen::ENTITY:
+      if (single)
+        return "Entidade";
+      else
+        return "Entidades";
+    case VhdlDocGen::TYPE:
+      if (single)
+        return "Tipo";
+      else
+        return "Tipos";
+    case VhdlDocGen::SUBTYPE:
+      if (single)
+        return "Subtipo";
+      else
+        return "Subtipos";
+    case VhdlDocGen::FUNCTION:
+      if (single)
+        return "Função";
+      else
+        return "Funções";
+    case VhdlDocGen::RECORD:
+      if (single)
+        return "Registro";
+      else
+        return "Registros";
+    case VhdlDocGen::PROCEDURE:
+      if (single)
+        return "Procedimento";
+      else
+        return "Procedimentos";
+    case VhdlDocGen::ARCHITECTURE:
+      if (single)
+        return "Arquitetura";
+      else
+        return "Arquiteturas";
+    case VhdlDocGen::ATTRIBUTE:
+      if (single)
+        return "Atributo";
+      else
+        return "Atributos";
+    case VhdlDocGen::PROCESS:
+      if (single)
+        return "Processo";
+      else
+        return "Processos";
+    case VhdlDocGen::PORT:
+      if (single)
+        return "Porta";
+      else
+        return "Portas";
+    case VhdlDocGen::USE:
+      if (single)
+        return "cláusula de uso";
+      else
+        return "cláusulas de uso";
+    case VhdlDocGen::GENERIC:
+      if (single)
+        return "Generico";
+      else
+        return "Genericos";
+    case VhdlDocGen::PACKAGE_BODY:
+      return "Corpo do Pacote";
+    case VhdlDocGen::UNITS:
+      return "Unidades";
+    case VhdlDocGen::SHAREDVARIABLE:
+      if (single)
+        return "Variável Compartilhada";
+      else
+        return "Variáveis Compartilhadas";
+    case VhdlDocGen::VFILE:
+      if (single)
+        return "Arquivo";
+      else
+        return "Arquivos";
+    case VhdlDocGen::GROUP:
+      if (single)
+        return "Grupo";
+      else
+        return "Grupos";
+    case VhdlDocGen::INSTANTIATION:
+      if (single)
+        return "Instância";
+      else
+        return "Instâncias";
+    case VhdlDocGen::ALIAS:
+      if (single)
+        return "Apelido";
+      else
+        return "Apelidos";
+    case VhdlDocGen::CONFIG:
+      if (single)
+        return "Configuração";
+      else
+        return "Configurações";
+    case VhdlDocGen::MISCELLANEOUS:
+      return "Outros"; // Is this correct for VHDL?
+    case VhdlDocGen::UCF_CONST:
+      return "Restrições";
+    default:
+      return "Classe";
     }
-    virtual QCString trConstantDocumentation()
-    {
-        return "Constantes";
-    }
-    virtual QCString trSequences()
-    {
-        return "Sequências";
-    }
-    virtual QCString trSequenceDocumentation()
-    {
-        return "Sequências";
-    }
-    virtual QCString trDictionaries()
-    {
-        return "Dicionários";
-    }
-    virtual QCString trDictionaryDocumentation()
-    {
-        return "Dicionários";
-    }
-    virtual QCString trSliceInterfaces()
-    {
-        return "Interfaces";
-    }
-    virtual QCString trInterfaceIndex()
-    {
-        return "Índice de Interfaces";
-    }
-    virtual QCString trInterfaceList()
-    {
-        return "Lista de Interfaces";
-    }
-    virtual QCString trInterfaceListDescription()
-    {
-        return "Estas são as interfaces com suas respectivas descrições:";
-    }
-    virtual QCString trInterfaceHierarchy()
-    {
-        return "Hierarquia de Interfaces";
-    }
-    virtual QCString trInterfaceHierarchyDescription()
-    {
-        return "Esta é a lista parcialmente ordenadas de heranças:";
-    }
-    virtual QCString trInterfaceDocumentation()
-    {
-        return "Interfaces";
-    }
-    virtual QCString trStructs()
-    {
-        return "Estruturas";
-    }
-    virtual QCString trStructIndex()
-    {
-        return "Índice de Estruturas";
-    }
-    virtual QCString trStructList()
-    {
-        return "Lista de Estruturas";
-    }
-    virtual QCString trStructListDescription()
-    {
-        return "Estas são as estruturas com suas respectivas descrições:";
-    }
-    virtual QCString trStructDocumentation()
-    {
-        return "Estruturas";
-    }
-    virtual QCString trExceptionIndex()
-    {
-        return "Índice the Exceções";
-    }
-    virtual QCString trExceptionList()
-    {
-        return "Lista de Exceções";
-    }
-    virtual QCString trExceptionListDescription()
-    {
-        return "Estas são as exceções com suas respectivas descrições:";
-    }
-    virtual QCString trExceptionHierarchy()
-    {
-        return "Hierarquia de Exceções";
-    }
-    virtual QCString trExceptionHierarchyDescription()
-    {
-        return "Esta é a lista parcialmente ordenadas de heranças:";
-    }
-    virtual QCString trExceptionDocumentation()
-    {
-        return "Exceções";
-    }
-    virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
-    {
-      QCString result="Referência ";
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="da Classe "; break;
-        case ClassDef::Struct:     result+="da Estrutura "; break;
-        case ClassDef::Union:      result+="da União "; break;
-        case ClassDef::Interface:  result+="da Interface "; break;
-        case ClassDef::Protocol:   result+="do Protocolo "; break;
-        case ClassDef::Category:   result+="da Categoria "; break;
-        case ClassDef::Exception:  result+="da Exceção "; break;
-        default: break;
-      }
-      if (isLocal) result+="Local ";
-      result+= clName;
-      return result;
-    }
-    virtual QCString trOperations()
-    {
-        return "Operações";
-    }
-    virtual QCString trOperationDocumentation()
-    {
-        return "Operações";
-    }
-    virtual QCString trDataMembers()
-    {
-        return "Dados Membros";
-    }
-    virtual QCString trDataMemberDocumentation()
-    {
-        return "Dados Membros";
-    }
+  }
+  virtual QCString trCustomReference(const QCString &name)
+  {
+    return "Referência de " + QCString(name);
+  }
 
-    //////////////////////////////////////////////////////////////////////////
-    // new since 1.8.19
-    //////////////////////////////////////////////////////////////////////////
+  /* Slice */
+  virtual QCString trConstants()
+  {
+    return "Constantes";
+  }
+  virtual QCString trConstantDocumentation()
+  {
+    return "Constantes";
+  }
+  virtual QCString trSequences()
+  {
+    return "Sequências";
+  }
+  virtual QCString trSequenceDocumentation()
+  {
+    return "Sequências";
+  }
+  virtual QCString trDictionaries()
+  {
+    return "Dicionários";
+  }
+  virtual QCString trDictionaryDocumentation()
+  {
+    return "Dicionários";
+  }
+  virtual QCString trSliceInterfaces()
+  {
+    return "Interfaces";
+  }
+  virtual QCString trInterfaceIndex()
+  {
+    return "Índice de Interfaces";
+  }
+  virtual QCString trInterfaceList()
+  {
+    return "Lista de Interfaces";
+  }
+  virtual QCString trInterfaceListDescription()
+  {
+    return "Estas são as interfaces com suas respectivas descrições:";
+  }
+  virtual QCString trInterfaceHierarchy()
+  {
+    return "Hierarquia de Interfaces";
+  }
+  virtual QCString trInterfaceHierarchyDescription()
+  {
+    return "Esta é a lista parcialmente ordenadas de heranças:";
+  }
+  virtual QCString trInterfaceDocumentation()
+  {
+    return "Interfaces";
+  }
+  virtual QCString trStructs()
+  {
+    return "Estruturas";
+  }
+  virtual QCString trStructIndex()
+  {
+    return "Índice de Estruturas";
+  }
+  virtual QCString trStructList()
+  {
+    return "Lista de Estruturas";
+  }
+  virtual QCString trStructListDescription()
+  {
+    return "Estas são as estruturas com suas respectivas descrições:";
+  }
+  virtual QCString trStructDocumentation()
+  {
+    return "Estruturas";
+  }
+  virtual QCString trExceptionIndex()
+  {
+    return "Índice the Exceções";
+  }
+  virtual QCString trExceptionList()
+  {
+    return "Lista de Exceções";
+  }
+  virtual QCString trExceptionListDescription()
+  {
+    return "Estas são as exceções com suas respectivas descrições:";
+  }
+  virtual QCString trExceptionHierarchy()
+  {
+    return "Hierarquia de Exceções";
+  }
+  virtual QCString trExceptionHierarchyDescription()
+  {
+    return "Esta é a lista parcialmente ordenadas de heranças:";
+  }
+  virtual QCString trExceptionDocumentation()
+  {
+    return "Exceções";
+  }
+  virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
+  {
+    QCString result = "Referência ";
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "da Classe ";
+      break;
+    case ClassDef::Struct:
+      result += "da Estrutura ";
+      break;
+    case ClassDef::Union:
+      result += "da União ";
+      break;
+    case ClassDef::Interface:
+      result += "da Interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "do Protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "da Categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "da Exceção ";
+      break;
+    default:
+      break;
+    }
+    if (isLocal)
+      result += "Local ";
+    result += clName;
+    return result;
+  }
+  virtual QCString trOperations()
+  {
+    return "Operações";
+  }
+  virtual QCString trOperationDocumentation()
+  {
+    return "Operações";
+  }
+  virtual QCString trDataMembers()
+  {
+    return "Dados Membros";
+  }
+  virtual QCString trDataMemberDocumentation()
+  {
+    return "Dados Membros";
+  }
 
-    /** VHDL design unit documentation */
-	virtual QCString trDesignUnitDocumentation()
-	{
-	    return "Documentação da Unidade de Projeto";
-        }
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.19
+  //////////////////////////////////////////////////////////////////////////
 
+  /** VHDL design unit documentation */
+  virtual QCString trDesignUnitDocumentation()
+  {
+    return "Documentação da Unidade de Projeto";
+  }
 
-	//////////////////////////////////////////////////////////////////////////
-	// new since 1.9.2
-	//////////////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.9.2
+  //////////////////////////////////////////////////////////////////////////
 
-	/** C++20 concept */
-	virtual QCString trConcept(bool first_capital, bool singular)
-	{
-	  QCString result((first_capital ? "Conceito" : "conceito"));
-	  if (!singular) result+="s";
-	  return result;
-	}
-	/*! used as the title of the HTML page of a C++20 concept page */
-	virtual QCString trConceptReference(const QCString &conceptName)
-	{
-	  QCString result= "Referência do Conceito ";
-	  result+=conceptName;
-	  return result;
-	}
+  /** C++20 concept */
+  virtual QCString trConcept(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Conceito" : "conceito"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+  /*! used as the title of the HTML page of a C++20 concept page */
+  virtual QCString trConceptReference(const QCString &conceptName)
+  {
+    QCString result = "Referência do Conceito ";
+    result += conceptName;
+    return result;
+  }
 
-	/*! used as the title of page containing all the index of all concepts. */
-	virtual QCString trConceptList()
-	{ return "Lista de Conceitos"; }
+  /*! used as the title of page containing all the index of all concepts. */
+  virtual QCString trConceptList()
+  {
+    return "Lista de Conceitos";
+  }
 
-	/*! used as the title of chapter containing the index listing all concepts. */
-	virtual QCString trConceptIndex()
-	{ return "Índice de Conceitos"; }
+  /*! used as the title of chapter containing the index listing all concepts. */
+  virtual QCString trConceptIndex()
+  {
+    return "Índice de Conceitos";
+  }
 
-	/*! used as the title of chapter containing all information about concepts. */
-	virtual QCString trConceptDocumentation()
-	{ return "Documentação do Conceito"; }
+  /*! used as the title of chapter containing all information about concepts. */
+  virtual QCString trConceptDocumentation()
+  {
+    return "Documentação do Conceito";
+  }
 
-	/*! used as an introduction to the concept list */
-	virtual QCString trConceptListDescription(bool extractAll)
-	{
-	  QCString result="Esta é a lista de todos os conceitos ";
-	  if (!extractAll) result+="documentados ";
-	  result+="com suas respectivas descrições:";
-	  return result;
-	}
+  /*! used as an introduction to the concept list */
+  virtual QCString trConceptListDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os conceitos ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "com suas respectivas descrições:";
+    return result;
+  }
 
-	/*! used to introduce the definition of the C++20 concept */
-	virtual QCString trConceptDefinition()
-	{
-	  return "Definição de conceito";
-	}
+  /*! used to introduce the definition of the C++20 concept */
+  virtual QCString trConceptDefinition()
+  {
+    return "Definição de conceito";
+  }
 
-	//////////////////////////////////////////////////////////////////////////
-	// new since 1.9.4
-	//////////////////////////////////////////////////////////////////////////
-    virtual QCString trPackageList()
-    { return "Lista de pacotes"; }
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.9.4
+  //////////////////////////////////////////////////////////////////////////
+  virtual QCString trPackageList()
+  {
+    return "Lista de pacotes";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.9.6
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used for translation of the word that will be
+   *  followed by a single name of the VHDL process flowchart.
+   */
+  virtual QCString trFlowchart()
+  {
+    return "Fluxograma: ";
+  }
+
+  /*! Please translate also updated body of the method
+   *  trMemberFunctionDocumentation(), now better adapted for
+   *  VHDL sources documentation.
+   */
 };
 
 #endif

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -26,7 +26,9 @@
  * VERSION HISTORY
  * ---------------
  * History:
-  * 20220525:
+ * 20220911:
+ *  - Updated to 1.9.6;
+ * 20220525:
  * 	- Updated to 1.9.4;
  * 20211003:
  *  - Updated to 1.9.3;
@@ -66,2303 +68,2703 @@
 #ifndef TRANSLATOR_PT_H
 #define TRANSLATOR_PT_H
 
-
-class TranslatorPortuguese : public TranslatorAdapter_1_9_5
+class TranslatorPortuguese : public Translator
 {
-  public:
+public:
+  // --- Language control methods -------------------
 
-    // --- Language control methods -------------------
+  /*! Used for identification of the language. The identification
+   * should not be translated. It should be replaced by the name
+   * of the language in English using lower-case characters only
+   * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
+   * the identification used in language.cpp.
+   */
+  QCString idLanguage()
+  {
+    return "portuguese";
+  }
 
-    /*! Used for identification of the language. The identification
-     * should not be translated. It should be replaced by the name
-     * of the language in English using lower-case characters only
-     * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
-     * the identification used in language.cpp.
-     */
-    QCString idLanguage()
-    { return "portuguese"; }
+  /*! Used to get the LaTeX command(s) for the language support.
+   *  This method should return string with commands that switch
+   *  LaTeX to the desired language.  For example
+   *  <pre>"\\usepackage[german]{babel}\n"
+   *  </pre>
+   *  or
+   *  <pre>"\\usepackage{polski}\n"
+   *  "\\usepackage[latin2]{inputenc}\n"
+   *  "\\usepackage[T1]{fontenc}\n"
+   *  </pre>
+   *
+   * The English LaTeX does not use such commands.  Because of this
+   * the empty string is returned in this implementation.
+   */
+  virtual QCString latexLanguageSupportCommand()
+  {
+    return "\\usepackage[portuges]{babel}\n";
+  }
 
-    /*! Used to get the LaTeX command(s) for the language support.
-     *  This method should return string with commands that switch
-     *  LaTeX to the desired language.  For example
-     *  <pre>"\\usepackage[german]{babel}\n"
-     *  </pre>
-     *  or
-     *  <pre>"\\usepackage{polski}\n"
-     *  "\\usepackage[latin2]{inputenc}\n"
-     *  "\\usepackage[T1]{fontenc}\n"
-     *  </pre>
-     *
-     * The English LaTeX does not use such commands.  Because of this
-     * the empty string is returned in this implementation.
-     */
-    virtual QCString latexLanguageSupportCommand()
+  virtual QCString trISOLang()
+  {
+    return "pt";
+  }
+  virtual QCString getLanguageString()
+  {
+    return "0x816 Portuguese(Portugal)";
+  }
+
+  // --- Language translation methods -------------------
+
+  /*! used in the compound documentation before a list of related functions. */
+  QCString trRelatedFunctions()
+  {
+    return "Funções associadas";
+  }
+
+  /*! subscript for the related functions. */
+  QCString trRelatedSubscript()
+  {
+    return "(Note que não são funções membro)";
+  }
+
+  /*! header that is put before the detailed description of files, classes and namespaces. */
+  QCString trDetailedDescription()
+  {
+    return "Descrição detalhada";
+  }
+
+  /*! header that is put before the list of typedefs. */
+  QCString trMemberTypedefDocumentation()
+  {
+    return "Documentação das definições de tipos";
+  }
+
+  /*! header that is put before the list of enumerations. */
+  QCString trMemberEnumerationDocumentation()
+  {
+    return "Documentação das enumerações";
+  }
+
+  /*! header that is put before the list of member functions. */
+  QCString trMemberFunctionDocumentation()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
     {
-      return
-        "\\usepackage[portuges]{babel}\n";
+      return "Documentação das funções, procedimentos e processos";
     }
-
-    virtual QCString trISOLang()
+    else
     {
-      return "pt";
+      return "Documentação das funções";
     }
-    virtual QCString getLanguageString()
+  }
+
+  /*! header that is put before the list of member attributes. */
+  QCString trMemberDataDocumentation()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      return "0x816 Portuguese(Portugal)";
+      return "Documentação dos campos e atributos";
     }
+    else
+    {
+      return "Documentação dos dados membro";
+    }
+  }
 
-    // --- Language translation methods -------------------
+  /*! this is the text of a link put after brief descriptions. */
+  QCString trMore()
+  {
+    return "Mais...";
+  }
 
-    /*! used in the compound documentation before a list of related functions. */
-    QCString trRelatedFunctions()
-    { return "Funções associadas"; }
+  /*! put in the class documentation */
+  QCString trListOfAllMembers()
+  {
+    return "Mostrar lista completa dos membros";
+  }
 
-    /*! subscript for the related functions. */
-    QCString trRelatedSubscript()
-    { return "(Note que não são funções membro)"; }
+  /*! used as the title of the "list of all members" page of a class */
+  QCString trMemberList()
+  {
+    return "Lista dos membros";
+  }
 
-    /*! header that is put before the detailed description of files, classes and namespaces. */
-    QCString trDetailedDescription()
-    { return "Descrição detalhada"; }
+  /*! this is the first part of a sentence that is followed by a class name */
+  QCString trThisIsTheListOfAllMembers()
+  {
+    return "Lista completa de todos os membros de ";
+  }
 
-    /*! header that is put before the list of typedefs. */
-    QCString trMemberTypedefDocumentation()
-    { return "Documentação das definições de tipo"; }
+  /*! this is the remainder of the sentence after the class name */
+  QCString trIncludingInheritedMembers()
+  {
+    return ", incluindo todos os membros herdados.";
+  }
 
-    /*! header that is put before the list of enumerations. */
-    QCString trMemberEnumerationDocumentation()
-    { return "Documentação das enumerações"; }
+  /*! this is put at the author sections at the bottom of man pages.
+   *  parameter s is name of the project name.
+   */
+  QCString trGeneratedAutomatically(const QCString &s)
+  {
+    QCString result = "Gerado automaticamente por Doxygen";
+    if (!s.isEmpty())
+      result += " para " + s;
+    result += " a partir do código fonte.";
+    return result;
+  }
 
-    /*! header that is put before the list of member functions. */
-    QCString trMemberFunctionDocumentation()
-    { return "Documentação dos métodos"; }
+  /*! put after an enum name in the list of all members */
+  QCString trEnumName()
+  {
+    return "enumeração";
+  }
 
-    /*! header that is put before the list of member attributes. */
-    QCString trMemberDataDocumentation()
+  /*! put after an enum value in the list of all members */
+  QCString trEnumValue()
+  {
+    return "valor enumerado";
+  }
+
+  /*! put after an undocumented member in the list of all members */
+  QCString trDefinedIn()
+  {
+    return "definido em";
+  }
+
+  // quick reference sections
+
+  /*! This is put above each page as a link to the list of all groups of
+   *  compounds or files (see the \\group command).
+   */
+  QCString trModules()
+  {
+    return "Módulos";
+  }
+
+  /*! This is put above each page as a link to the class hierarchy */
+  QCString trClassHierarchy()
+  {
+    return "Hierarquia de classes";
+  }
+
+  /*! This is put above each page as a link to the list of annotated classes */
+  QCString trCompoundList()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Estruturas de dados";
+    }
+    else
+    {
+      return "Lista de componentes";
+    }
+  }
+
+  /*! This is put above each page as a link to the list of documented files */
+  QCString trFileList()
+  {
+    return "Lista de ficheiros";
+  }
+
+  /*! This is put above each page as a link to all members of compounds. */
+  QCString trCompoundMembers()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Campos de dados";
+    }
+    else
+    {
+      return "Componentes membro";
+    }
+  }
+
+  /*! This is put above each page as a link to all members of files. */
+  QCString trFileMembers()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Globais";
+    }
+    else
+    {
+      return "Membros dos Ficheiros";
+    }
+  }
+
+  /*! This is put above each page as a link to all related pages. */
+  QCString trRelatedPages()
+  {
+    return "Páginas relacionadas";
+  }
+
+  /*! This is put above each page as a link to all examples. */
+  QCString trExamples()
+  {
+    return "Exemplos";
+  }
+
+  /*! This is put above each page as a link to the search engine. */
+  QCString trSearch()
+  {
+    return "Localizar";
+  }
+
+  /*! This is an introduction to the class hierarchy. */
+  QCString trClassHierarchyDescription()
+  {
+    return "Esta lista de heranças está organizada, dentro do possível, por ordem alfabética:";
+  }
+
+  /*! This is an introduction to the list with all files. */
+  QCString trFileListDescription(bool extractAll)
+  {
+    QCString result = "Lista de todos os ficheiros ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "com uma breve descrição:";
+    return result;
+  }
+
+  /*! This is an introduction to the annotated compound list. */
+  QCString trCompoundListDescription()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Lista das estruturas de dados com uma breve descrição:";
+    }
+    else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+    {
+      return "Lista de classes com uma breve descrição:";
+    }
+    else
+    {
+      return "Lista de classes, estruturas, uniões e interfaces com uma breve descrição:";
+    }
+  }
+
+  /*! This is an introduction to the page with all class members. */
+  QCString trCompoundMembersDescription(bool extractAll)
+  {
+    QCString result = "Lista de todas as";
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      result += " estruturas e campos de uniões";
+    }
+    else
+    {
+      result += " classes membro";
+    }
+    if (!extractAll)
+    {
+      result += " documentadas";
+    }
+    result += " com referência para ";
+    if (!extractAll)
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        return "Documentação dos campos e atributos";
+        result += "a respectiva documentação:";
       }
       else
       {
-        return "Documentação dos dados membro";
+        result += "a documentação de cada membro:";
       }
     }
-
-    /*! this is the text of a link put after brief descriptions. */
-    QCString trMore()
-    { return "Mais..."; }
-
-    /*! put in the class documentation */
-    QCString trListOfAllMembers()
-    { return "Mostrar lista completa dos membros"; }
-
-    /*! used as the title of the "list of all members" page of a class */
-    QCString trMemberList()
-    { return "Lista dos membros"; }
-
-    /*! this is the first part of a sentence that is followed by a class name */
-    QCString trThisIsTheListOfAllMembers()
-    { return "Lista completa de todos os membros de "; }
-
-    /*! this is the remainder of the sentence after the class name */
-    QCString trIncludingInheritedMembers()
-    { return ", incluindo todos os membros herdados."; }
-
-    /*! this is put at the author sections at the bottom of man pages.
-     *  parameter s is name of the project name.
-     */
-    QCString trGeneratedAutomatically(const QCString &s)
-    { QCString result="Gerado automaticamente por Doxygen";
-      if (!s.isEmpty()) result+=" para "+s;
-      result+=" a partir do código fonte.";
-      return result;
-    }
-
-    /*! put after an enum name in the list of all members */
-    QCString trEnumName()
-    { return "enumeração"; }
-
-    /*! put after an enum value in the list of all members */
-    QCString trEnumValue()
-    { return "valor enumerado"; }
-
-    /*! put after an undocumented member in the list of all members */
-    QCString trDefinedIn()
-    { return "definido em"; }
-
-    // quick reference sections
-
-    /*! This is put above each page as a link to the list of all groups of
-     *  compounds or files (see the \\group command).
-     */
-    QCString trModules()
-    { return "Módulos"; }
-
-    /*! This is put above each page as a link to the class hierarchy */
-    QCString trClassHierarchy()
-    { return "Hierarquia de classes"; }
-
-    /*! This is put above each page as a link to the list of annotated classes */
-    QCString trCompoundList()
+    else
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        return "Estruturas de dados";
+        result += "as estruturas/uniões a que pertencem:";
       }
       else
       {
-        return "Lista de componentes";
+        result += "as classes a que pertencem:";
       }
     }
+    return result;
+  }
 
-    /*! This is put above each page as a link to the list of documented files */
-    QCString trFileList()
-    { return "Lista de ficheiros"; }
-
-    /*! This is put above each page as a link to all members of compounds. */
-    QCString trCompoundMembers()
+  /*! This is an introduction to the page with all file members. */
+  QCString trFileMembersDescription(bool extractAll)
+  {
+    QCString result = "Lista de ";
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
     {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Campos de dados";
-      }
-      else
-      {
-        return "Componentes membro";
-      }
-    }
-
-    /*! This is put above each page as a link to all members of files. */
-    QCString trFileMembers()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Globais";
-      }
-      else
-      {
-        return "Membros dos Ficheiros";
-      }
-    }
-
-    /*! This is put above each page as a link to all related pages. */
-    QCString trRelatedPages()
-    { return "Páginas relacionadas"; }
-
-    /*! This is put above each page as a link to all examples. */
-    QCString trExamples()
-    { return "Exemplos"; }
-
-    /*! This is put above each page as a link to the search engine. */
-    QCString trSearch()
-    { return "Localizar"; }
-
-    /*! This is an introduction to the class hierarchy. */
-    QCString trClassHierarchyDescription()
-    { return "Esta lista de heranças está organizada, dentro do possível, por ordem alfabética:"; }
-
-    /*! This is an introduction to the list with all files. */
-    QCString trFileListDescription(bool extractAll)
-    {
-      QCString result="Lista de todos os ficheiros ";
-      if (!extractAll) result+="documentados ";
-      result+="com uma breve descrição:";
-      return result;
-    }
-
-    /*! This is an introduction to the annotated compound list. */
-    QCString trCompoundListDescription()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Lista das estruturas de dados com uma breve descrição:";
-      }
-      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
-      {
-        return "Lista de classes com uma breve descrição:";
-      }
-      else
-      {
-        return "Lista de classes, estruturas, uniões e interfaces com uma breve descrição:";
-      }
-    }
-
-    /*! This is an introduction to the page with all class members. */
-    QCString trCompoundMembersDescription(bool extractAll)
-    {
-      QCString result="Lista de todas as";
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        result+=" estruturas e campos de uniões";
-      }
-      else
-      {
-        result+=" classes membro";
-      }
+      result += "todas as funções, variáveis, definições, enumerações e definições de tipo ";
       if (!extractAll)
-      {
-        result+=" documentadas";
-      }
-      result+=" com referência para ";
+        result += "documentadas ";
+    }
+    else
+    {
+      result += "todos os ficheiros membro ";
       if (!extractAll)
-      {
-        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-        {
-          result+="a respectiva documentação:";
-        }
-        else
-        {
-          result+="a documentação de cada membro:";
-        }
-      }
-      else
-      {
-        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-        {
-          result+="as estruturas/uniões a que pertencem:";
-        }
-        else
-        {
-          result+="as classes a que pertencem:";
-        }
-      }
-      return result;
+        result += "documentados ";
     }
+    result += "com referência para ";
+    if (extractAll)
+      result += "o ficheiro a que pertecem:";
+    else
+      result += "a respectiva documentação:";
+    return result;
+  }
 
-    /*! This is an introduction to the page with all file members. */
-    QCString trFileMembersDescription(bool extractAll)
-    {
-      QCString result="Lista de ";
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        result+="todas as funções, variáveis, definições, enumerações e definições de tipo ";
-        if (!extractAll) result+="documentadas ";
-      }
-      else
-      {
-        result+="todos os ficheiros membro ";
-        if (!extractAll) result+="documentados ";
-      }
-      result+="com referência para ";
-      if (extractAll)
-        result+="o ficheiro a que pertecem:";
-      else
-        result+="a respectiva documentação:";
-      return result;
-    }
+  /*! This is an introduction to the page with the list of all examples */
+  QCString trExamplesDescription()
+  {
+    return "Lista de todos os exemplos:";
+  }
 
-    /*! This is an introduction to the page with the list of all examples */
-    QCString trExamplesDescription()
-    { return "Lista de todos os exemplos:"; }
+  /*! This is an introduction to the page with the list of related pages */
+  QCString trRelatedPagesDescription()
+  {
+    return "Lista de documentação relacionada:";
+  }
 
-    /*! This is an introduction to the page with the list of related pages */
-    QCString trRelatedPagesDescription()
-    { return "Lista de documentação relacionada:"; }
+  /*! This is an introduction to the page with the list of class/file groups */
+  QCString trModulesDescription()
+  {
+    return "Lista de todos os módulos:";
+  }
 
-    /*! This is an introduction to the page with the list of class/file groups */
-    QCString trModulesDescription()
-    { return "Lista de todos os módulos:"; }
+  // index titles (the project name is prepended for these)
 
-    // index titles (the project name is prepended for these)
-
-
-    /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation()
-    { return "Documentação"; }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * index of all groups.
-     */
-    QCString trModuleIndex()
-    { return "Índice dos módulos"; }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * class hierarchy.
-     */
-    QCString trHierarchicalIndex()
-    { return "Índice da hierarquia"; }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * annotated compound index.
-     */
-    QCString trCompoundIndex()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Índice das estruturas de dados";
-      }
-      else
-      {
-        return "Índice dos componentes";
-      }
-    }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * list of all files.
-     */
-    QCString trFileIndex()
-    { return "Índice dos ficheiros"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all groups.
-     */
-    QCString trModuleDocumentation()
-    { return "Documentação do módulo"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all classes, structs and unions.
-     */
-    QCString trClassDocumentation()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Documentação da estruturas de dados";
-      }
-      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
-      {
-          return trDesignUnitDocumentation();
-      }
-      else
-      {
-        return "Documentação da classe";
-      }
-    }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all files.
-     */
-    QCString trFileDocumentation()
-    { return "Documentação do ficheiro"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all examples.
-     */
-    QCString trExampleDocumentation()
-    { return "Documentação do exemplo"; }
-
-    /*! This is used in LaTeX as the title of the document */
-    QCString trReferenceManual()
-    { return "Manual de referência"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of defines
-     */
-    QCString trDefines()
-    { return "Macros"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of typedefs
-     */
-    QCString trTypedefs()
-    { return "Definições de tipos"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of enumerations
-     */
-    QCString trEnumerations()
-    { return "Enumerações"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) functions
-     */
-    QCString trFunctions()
-    { return "Funções"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) variables
-     */
-    QCString trVariables()
-    { return "Variáveis"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) variables
-     */
-    QCString trEnumerationValues()
-    { return "Valores de enumerações"; }
-
-    /*! This is used in the documentation of a file before the list of
-     *  documentation blocks for defines
-     */
-    QCString trDefineDocumentation()
-    { return "Documentação das macros"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for typedefs
-     */
-    QCString trTypedefDocumentation()
-    { return "Documentação dos tipos"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for enumeration types
-     */
-    QCString trEnumerationTypeDocumentation()
-    { return "Documentação dos valores da enumeração"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for functions
-     */
-    QCString trFunctionDocumentation()
-    { return "Documentação das funções"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for variables
-     */
-    QCString trVariableDocumentation()
-    { return "Documentação das variáveis"; }
-
-    /*! This is used in the documentation of a file/namespace/group before
-     *  the list of links to documented compounds
-     */
-    QCString trCompounds()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Estruturas de Dados";
-      }
-      else
-      {
-        return "Componentes";
-      }
-    }
-
-    /*! This is used in the standard footer of each page and indicates when
-     *  the page was generated
-     */
-    QCString trGeneratedAt(const QCString &date,const QCString &projName)
-    {
-      QCString result="Gerado em "+date;
-      if (!projName.isEmpty()) result+=" para "+projName;
-      result+=" por";
-      return result;
-    }
-
-    /*! this text is put before a class diagram */
-    QCString trClassDiagram(const QCString &clName)
-    {
-      return "Diagrama de heranças da classe "+clName;
-    }
-
-    /*! this text is generated when the \\warning command is used. */
-    QCString trWarning()
-    { return "Aviso"; }
-
-    /*! this text is generated when the \\version command is used. */
-    QCString trVersion()
-    { return "Versão"; }
-
-    /*! this text is generated when the \\date command is used. */
-    QCString trDate()
-    { return "Data"; }
-
-    /*! this text is generated when the \\return command is used. */
-    QCString trReturns()
-    { return "Retorna"; }
-
-    /*! this text is generated when the \\sa command is used. */
-    QCString trSeeAlso()
-    { return "Veja também"; }
-
-    /*! this text is generated when the \\param command is used. */
-    QCString trParameters()
-    { return "Parâmetros"; }
-
-    /*! this text is generated when the \\exception command is used. */
-    QCString trExceptions()
-    { return "Excepções"; }
-
-    /*! this text is used in the title page of a LaTeX document. */
-    QCString trGeneratedBy()
-    { return "Gerado por"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990307
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used as the title of page containing all the index of all namespaces. */
-    virtual QCString trNamespaceList()
-    { return "Lista de namespaces"; }
-
-    /*! used as an introduction to the namespace list */
-    virtual QCString trNamespaceListDescription(bool extractAll)
-    {
-      QCString result="Lista ";
-      if (!extractAll) result+="de toda a documentação ";
-      result+="dos namespaces com uma breve descrição:";
-      return result;
-    }
-
-    /*! used in the class documentation as a header before the list of all
-     *  friends of a class
-     */
-    virtual QCString trFriends()
-    { return "Amigos"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990405
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used in the class documentation as a header before the list of all
-     * related classes
-     */
-    virtual QCString trRelatedFunctionDocumentation()
-    { return "Documentação das classes amigas e funções relacionadas"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990425
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used as the title of the HTML page of a class/struct/union */
-    virtual QCString trCompoundReference(const QCString &clName,
-                                    ClassDef::CompoundType compType,
-                                    bool isTemplate)
-    {
-      QCString result="Referência ";
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="à classe "; break;
-        case ClassDef::Struct:     result+="à estrutura "; break;
-        case ClassDef::Union:      result+="à união "; break;
-        case ClassDef::Interface:  result+="ao interface "; break;
-        case ClassDef::Protocol:   result+="ao protocolo "; break;
-        case ClassDef::Category:   result+="à categoria "; break;
-        case ClassDef::Exception:  result+="à excepção "; break;
-        default: break;
-      }
-      if (isTemplate) result+="Template ";
-      result+=clName;
-      return result;
-    }
-
-    /*! used as the title of the HTML page of a file */
-    virtual QCString trFileReference(const QCString &fileName)
-    {
-      QCString result= "Referência ao ficheiro ";
-      result += fileName;
-      return result;
-    }
-
-    /*! used as the title of the HTML page of a namespace */
-    virtual QCString trNamespaceReference(const QCString &namespaceName)
-    {
-      QCString result= "Referência ao namespace ";
-      result += namespaceName;
-      return result;
-    }
-
-    /* these are for the member sections of a class, struct or union */
-    virtual QCString trPublicMembers()
-    { return "Membros públicos"; }
-    virtual QCString trPublicSlots()
-    { return "Slots públicos"; }
-    virtual QCString trSignals()
-    { return "Sinais"; }
-    virtual QCString trStaticPublicMembers()
-    { return "Membros públicos estáticos"; }
-    virtual QCString trProtectedMembers()
-    { return "Membros protegidos"; }
-    virtual QCString trProtectedSlots()
-    { return "Slots protegidos"; }
-    virtual QCString trStaticProtectedMembers()
-    { return "Membros protegidos estáticos"; }
-    virtual QCString trPrivateMembers()
-    { return "Membros privados"; }
-    virtual QCString trPrivateSlots()
-    { return "Slots privados"; }
-    virtual QCString trStaticPrivateMembers()
-    { return "Membros privados estáticos"; }
-
-    /*! this function is used to produce a comma-separated list of items.
-     *  use generateMarker(i) to indicate where item i should be put.
-     */
-    virtual QCString trWriteList(int numEntries)
-    {
-      QCString result;
-      int i;
-      // the inherits list contain `numEntries' classes
-      for (i=0;i<numEntries;i++)
-      {
-        // use generateMarker to generate placeholders for the class links!
-        result+=generateMarker(i); // generate marker for entry i in the list
-                                   // (order is left to right)
-
-        if (i!=numEntries-1)  // not the last entry, so we need a separator
-        {
-          if (i<numEntries-2) // not the fore last entry
-            result+=", ";
-          else                // the fore last entry
-            result+=" e ";
-        }
-      }
-      return result;
-    }
-
-    /*! used in class documentation to produce a list of base classes,
-     *  if class diagrams are disabled.
-     */
-    virtual QCString trInheritsList(int numEntries)
-    {
-      return "Derivada de "+trWriteList(numEntries)+".";
-    }
-
-    /*! used in class documentation to produce a list of super classes,
-     *  if class diagrams are disabled.
-     */
-    virtual QCString trInheritedByList(int numEntries)
-    {
-      return "Herdado por "+trWriteList(numEntries)+".";
-    }
-
-    /*! used in member documentation blocks to produce a list of
-     *  members that are hidden by this one.
-     */
-    virtual QCString trReimplementedFromList(int numEntries)
-    {
-      return "Reimplementado de "+trWriteList(numEntries)+".";
-    }
-
-    /*! used in member documentation blocks to produce a list of
-     *  all member that overwrite the implementation of this member.
-     */
-    virtual QCString trReimplementedInList(int numEntries)
-    {
-      return "Reimplementado em "+trWriteList(numEntries)+".";
-    }
-
-    /*! This is put above each page as a link to all members of namespaces. */
-    virtual QCString trNamespaceMembers()
-    { return "Membros do namespace"; }
-
-    /*! This is an introduction to the page with all namespace members */
-    virtual QCString trNamespaceMemberDescription(bool extractAll)
-    {
-      QCString result="Lista ";
-      if (extractAll) result+="de todos os ";
-      else result+="de toda a documentação dos ";
-      result+="membros do namespace com referência para ";
-      if (extractAll)
-        result+="a documentação de cada membro:";
-      else
-        result+="o namespace correspondente:";
-      return result;
-    }
+  /*! This is used in HTML as the title of index.html. */
+  QCString trDocumentation()
+  {
+    return "Documentação";
+  }
 
   /*! This is used in LaTeX as the title of the chapter with the
-     *  index of all namespaces.
-     */
-    virtual QCString trNamespaceIndex()
-    { return "Índice dos namespaces"; }
+   * index of all groups.
+   */
+  QCString trModuleIndex()
+  {
+    return "Índice dos módulos";
+  }
 
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all namespaces.
-     */
-    virtual QCString trNamespaceDocumentation()
-    { return "Documentação dos namespaces"; }
+  /*! This is used in LaTeX as the title of the chapter with the
+   * class hierarchy.
+   */
+  QCString trHierarchicalIndex()
+  {
+    return "Índice da hierarquia";
+  }
 
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990522
-//////////////////////////////////////////////////////////////////////////
+  /*! This is used in LaTeX as the title of the chapter with the
+   * annotated compound index.
+   */
+  QCString trCompoundIndex()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Índice das estruturas de dados";
+    }
+    else
+    {
+      return "Índice dos componentes";
+    }
+  }
 
-    /*! This is used in the documentation before the list of all
-     *  namespaces in a file.
-     */
-    virtual QCString trNamespaces()
-    { return "Namespaces"; }
+  /*! This is used in LaTeX as the title of the chapter with the
+   * list of all files.
+   */
+  QCString trFileIndex()
+  {
+    return "Índice dos ficheiros";
+  }
 
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990728
-//////////////////////////////////////////////////////////////////////////
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all groups.
+   */
+  QCString trModuleDocumentation()
+  {
+    return "Documentação do módulo";
+  }
 
-    /*! This is put at the bottom of a class documentation page and is
-     *  followed by a list of files that were used to generate the page.
-     */
-    virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
-        bool single)
-    { // here s is one of " Class", " Struct" or " Union"
-      // single is true implies a single file
-      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-      QCString result="A documentação para ";
-      switch(compType)
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all classes, structs and unions.
+   */
+  QCString trClassDocumentation()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Documentação da estruturas de dados";
+    }
+    else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+    {
+      return trDesignUnitDocumentation();
+    }
+    else
+    {
+      return "Documentação da classe";
+    }
+  }
+
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all files.
+   */
+  QCString trFileDocumentation()
+  {
+    return "Documentação do ficheiro";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all examples.
+   */
+  QCString trExampleDocumentation()
+  {
+    return "Documentação do exemplo";
+  }
+
+  /*! This is used in LaTeX as the title of the document */
+  QCString trReferenceManual()
+  {
+    return "Manual de referência";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of defines
+   */
+  QCString trDefines()
+  {
+    return "Macros";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of typedefs
+   */
+  QCString trTypedefs()
+  {
+    return "Definições de tipos";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of enumerations
+   */
+  QCString trEnumerations()
+  {
+    return "Enumerações";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) functions
+   */
+  QCString trFunctions()
+  {
+    return "Funções";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) variables
+   */
+  QCString trVariables()
+  {
+    return "Variáveis";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) variables
+   */
+  QCString trEnumerationValues()
+  {
+    return "Valores de enumerações";
+  }
+
+  /*! This is used in the documentation of a file before the list of
+   *  documentation blocks for defines
+   */
+  QCString trDefineDocumentation()
+  {
+    return "Documentação das macros";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for typedefs
+   */
+  QCString trTypedefDocumentation()
+  {
+    return "Documentação dos tipos";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for enumeration types
+   */
+  QCString trEnumerationTypeDocumentation()
+  {
+    return "Documentação dos valores da enumeração";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for functions
+   */
+  QCString trFunctionDocumentation()
+  {
+    return "Documentação das funções";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for variables
+   */
+  QCString trVariableDocumentation()
+  {
+    return "Documentação das variáveis";
+  }
+
+  /*! This is used in the documentation of a file/namespace/group before
+   *  the list of links to documented compounds
+   */
+  QCString trCompounds()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Estruturas de Dados";
+    }
+    else
+    {
+      return "Componentes";
+    }
+  }
+
+  /*! This is used in the standard footer of each page and indicates when
+   *  the page was generated
+   */
+  QCString trGeneratedAt(const QCString &date, const QCString &projName)
+  {
+    QCString result = "Gerado em " + date;
+    if (!projName.isEmpty())
+      result += " para " + projName;
+    result += " por";
+    return result;
+  }
+
+  /*! this text is put before a class diagram */
+  QCString trClassDiagram(const QCString &clName)
+  {
+    return "Diagrama de heranças da classe " + clName;
+  }
+
+  /*! this text is generated when the \\warning command is used. */
+  QCString trWarning()
+  {
+    return "Aviso";
+  }
+
+  /*! this text is generated when the \\version command is used. */
+  QCString trVersion()
+  {
+    return "Versão";
+  }
+
+  /*! this text is generated when the \\date command is used. */
+  QCString trDate()
+  {
+    return "Data";
+  }
+
+  /*! this text is generated when the \\return command is used. */
+  QCString trReturns()
+  {
+    return "Retorna";
+  }
+
+  /*! this text is generated when the \\sa command is used. */
+  QCString trSeeAlso()
+  {
+    return "Veja também";
+  }
+
+  /*! this text is generated when the \\param command is used. */
+  QCString trParameters()
+  {
+    return "Parâmetros";
+  }
+
+  /*! this text is generated when the \\exception command is used. */
+  QCString trExceptions()
+  {
+    return "Excepções";
+  }
+
+  /*! this text is used in the title page of a LaTeX document. */
+  QCString trGeneratedBy()
+  {
+    return "Gerado por";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990307
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used as the title of page containing all the index of all namespaces. */
+  virtual QCString trNamespaceList()
+  {
+    return "Lista de namespaces";
+  }
+
+  /*! used as an introduction to the namespace list */
+  virtual QCString trNamespaceListDescription(bool extractAll)
+  {
+    QCString result = "Lista ";
+    if (!extractAll)
+      result += "de toda a documentação ";
+    result += "dos namespaces com uma breve descrição:";
+    return result;
+  }
+
+  /*! used in the class documentation as a header before the list of all
+   *  friends of a class
+   */
+  virtual QCString trFriends()
+  {
+    return "Amigos";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990405
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used in the class documentation as a header before the list of all
+   * related classes
+   */
+  virtual QCString trRelatedFunctionDocumentation()
+  {
+    return "Documentação das classes amigas e funções relacionadas";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990425
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used as the title of the HTML page of a class/struct/union */
+  virtual QCString trCompoundReference(const QCString &clName,
+                                       ClassDef::CompoundType compType,
+                                       bool isTemplate)
+  {
+    QCString result = "Referência ";
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "à classe ";
+      break;
+    case ClassDef::Struct:
+      result += "à estrutura ";
+      break;
+    case ClassDef::Union:
+      result += "à união ";
+      break;
+    case ClassDef::Interface:
+      result += "ao interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "ao protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "à categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "à excepção ";
+      break;
+    default:
+      break;
+    }
+    if (isTemplate)
+      result += "Template ";
+    result += clName;
+    return result;
+  }
+
+  /*! used as the title of the HTML page of a file */
+  virtual QCString trFileReference(const QCString &fileName)
+  {
+    QCString result = "Referência ao ficheiro ";
+    result += fileName;
+    return result;
+  }
+
+  /*! used as the title of the HTML page of a namespace */
+  virtual QCString trNamespaceReference(const QCString &namespaceName)
+  {
+    QCString result = "Referência ao namespace ";
+    result += namespaceName;
+    return result;
+  }
+
+  /* these are for the member sections of a class, struct or union */
+  virtual QCString trPublicMembers()
+  {
+    return "Membros públicos";
+  }
+  virtual QCString trPublicSlots()
+  {
+    return "Slots públicos";
+  }
+  virtual QCString trSignals()
+  {
+    return "Sinais";
+  }
+  virtual QCString trStaticPublicMembers()
+  {
+    return "Membros públicos estáticos";
+  }
+  virtual QCString trProtectedMembers()
+  {
+    return "Membros protegidos";
+  }
+  virtual QCString trProtectedSlots()
+  {
+    return "Slots protegidos";
+  }
+  virtual QCString trStaticProtectedMembers()
+  {
+    return "Membros protegidos estáticos";
+  }
+  virtual QCString trPrivateMembers()
+  {
+    return "Membros privados";
+  }
+  virtual QCString trPrivateSlots()
+  {
+    return "Slots privados";
+  }
+  virtual QCString trStaticPrivateMembers()
+  {
+    return "Membros privados estáticos";
+  }
+
+  /*! this function is used to produce a comma-separated list of items.
+   *  use generateMarker(i) to indicate where item i should be put.
+   */
+  virtual QCString trWriteList(int numEntries)
+  {
+    QCString result;
+    int i;
+    // the inherits list contain `numEntries' classes
+    for (i = 0; i < numEntries; i++)
+    {
+      // use generateMarker to generate placeholders for the class links!
+      result += generateMarker(i); // generate marker for entry i in the list
+                                   // (order is left to right)
+
+      if (i != numEntries - 1) // not the last entry, so we need a separator
       {
-        case ClassDef::Class:      result+=vhdlOpt?"esta Unidade de Design":"esta classe"; break;
-        case ClassDef::Struct:     result+="esta estrutura"; break;
-        case ClassDef::Union:      result+="esta união"; break;
-        case ClassDef::Interface:  result+="este interface"; break;
-        case ClassDef::Protocol:   result+="este protocolo"; break;
-        case ClassDef::Category:   result+="esta categoria"; break;
-        case ClassDef::Exception:  result+="esta excepção"; break;
-        default: break;
-      }
-      result+=" foi gerada a partir ";
-      if (single) result+=" do seguinte ficheiro:";
-      else result+="dos seguintes ficheiros:";
-      return result;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-990901
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is used as the heading text for the retval command. */
-    virtual QCString trReturnValues()
-    { return "Valores retornados"; }
-
-    /*! This is in the (quick) index as a link to the main page (index.html)
-     */
-    virtual QCString trMainPage()
-    { return "Página principal"; }
-
-    /*! This is used in references to page that are put in the LaTeX
-     *  documentation. It should be an abbreviation of the word page.
-     */
-    virtual QCString trPageAbbreviation()
-    { return "p. "; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-991003
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trDefinedAtLineInSourceFile()
-    {
-      return "Definido na linha @0 do ficheiro @1.";
-    }
-    virtual QCString trDefinedInSourceFile()
-    {
-      return "Definido no ficheiro @0.";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 0.49-991205
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trDeprecated()
-    {
-      return "Desaprovado";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.0.0
-//////////////////////////////////////////////////////////////////////////
-
-    /*! this text is put before a collaboration diagram */
-    virtual QCString trCollaborationDiagram(const QCString &clName)
-    {
-      return "Diagrama de colaboração para "+clName+":";
-    }
-    /*! this text is put before an include dependency graph */
-    virtual QCString trInclDepGraph(const QCString &fName)
-    {
-      return "Diagrama de dependências de inclusão para "+fName+":";
-    }
-    /*! header that is put before the list of constructor/destructors. */
-    virtual QCString trConstructorDocumentation()
-    {
-      return "Documentação dos Construtores & Destrutor";
-    }
-    /*! Used in the file documentation to point to the corresponding sources. */
-    virtual QCString trGotoSourceCode()
-    {
-      return "Ir para o código fonte deste ficheiro.";
-    }
-    /*! Used in the file sources to point to the corresponding documentation. */
-    virtual QCString trGotoDocumentation()
-    {
-      return "Ir para a documentação deste ficheiro.";
-    }
-    /*! Text for the \\pre command */
-    virtual QCString trPrecondition()
-    {
-      return "Precondição";
-    }
-    /*! Text for the \\post command */
-    virtual QCString trPostcondition()
-    {
-      return "Poscondição";
-    }
-    /*! Text for the \\invariant command */
-    virtual QCString trInvariant()
-    {
-      return "Invariante";
-    }
-    /*! Text shown before a multi-line variable/enum initialization */
-    virtual QCString trInitialValue()
-    {
-      return "Valor inicial:";
-    }
-    /*! Text used the source code in the file index */
-    virtual QCString trCode()
-    {
-      return "código";
-    }
-    virtual QCString trGraphicalHierarchy()
-    {
-      return "Representação gráfica da hiearquia da classe";
-    }
-    virtual QCString trGotoGraphicalHierarchy()
-    {
-      return "Ir para a representação gráfica da hierarquia da classe";
-    }
-    virtual QCString trGotoTextualHierarchy()
-    {
-      return "Ir para a representação textual da hierarquia da classe";
-    }
-    virtual QCString trPageIndex()
-    {
-      return "Índice da página";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.0
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trNote()
-    {
-      return "Nota";
-    }
-    virtual QCString trPublicTypes()
-    {
-      return "Tipos Públicos";
-    }
-    virtual QCString trPublicAttribs()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Campos de Dados";
-      }
-      else
-      {
-        return "Atributos Públicos";
-      }
-    }
-    virtual QCString trStaticPublicAttribs()
-    {
-      return "Atributos Públicos Estáticos";
-    }
-    virtual QCString trProtectedTypes()
-    {
-      return "Tipos Protegidos";
-    }
-    virtual QCString trProtectedAttribs()
-    {
-      return "Atributos Protegidos";
-    }
-    virtual QCString trStaticProtectedAttribs()
-    {
-      return "Atributos Protegidos Estáticos";
-    }
-    virtual QCString trPrivateTypes()
-    {
-      return "Tipos Privados";
-    }
-    virtual QCString trPrivateAttribs()
-    {
-      return "Atributos Privados";
-    }
-    virtual QCString trStaticPrivateAttribs()
-    {
-      return "Atributos Privados Estáticos";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.3
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a marker that is put before a todo item */
-    virtual QCString trTodo()
-    {
-      return "Tarefa";
-    }
-    /*! Used as the header of the todo list */
-    virtual QCString trTodoList()
-    {
-      return "Lista de tarefas";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.4
-//////////////////////////////////////////////////////////////////////////
-
-    virtual QCString trReferencedBy()
-    {
-      return "Referenciado por";
-    }
-    virtual QCString trRemarks()
-    {
-      return "Observações";
-    }
-    virtual QCString trAttention()
-    {
-      return "Atenção";
-    }
-    virtual QCString trInclByDepGraph()
-    {
-      return "Este grafo mostra quais são os ficheiros que incluem directamente ou indirectamente este ficheiro:";
-    }
-    virtual QCString trSince()
-    {
-      return "Desde";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.1.5
-//////////////////////////////////////////////////////////////////////////
-
-    /*! title of the graph legend page */
-    virtual QCString trLegendTitle()
-    {
-      return "Legenda do grafo";
-    }
-    /*! page explaining how the dot graph's should be interpreted */
-    virtual QCString trLegendDocs()
-    {
-      return
-        "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
-        "Considere o seguinte exemplo:\n"
-        "\\code\n"
-        "/*! Esta classe vai estar escondida devido à truncação */\n"
-        "class Invisible { };\n\n"
-        "/*! Esta classe tem a relação de herança escondida */\n"
-        "class Truncated : public Invisible { };\n\n"
-        "/* Classe não documentada por comentários doxygen */\n"
-        "class Undocumented { };\n\n"
-        "/*! Classe derivada usando derivação pública */\n"
-        "class PublicBase : public Truncated { };\n\n"
-        "/*! A template class */\n"
-        "template<class T> class Templ { };\n\n"
-        "/*! Classe derivada usando derivação protegida */\n"
-        "class ProtectedBase { };\n\n"
-        "/*! Classe derivada usando derivação privada */\n"
-        "class PrivateBase { };\n\n"
-        "/*! Classe usada pela classe Inherited */\n"
-        "class Used { };\n\n"
-        "/*! Super classe que deriva de várias classes */\n"
-        "class Inherited : public PublicBase,\n"
-        "                  protected ProtectedBase,\n"
-        "                  private PrivateBase,\n"
-        "                  public Undocumented,\n"
-        "                  public Templ<int>\n"
-        "{\n"
-        "  private:\n"
-        "    Used *m_usedClass;\n"
-        "};\n"
-        "\\endcode\n"
-        "Isto irá gerar o seguinte gráfo:"
-        "<p><center><img src=\"graph_legend."+getDotImageExtension()+"\"></center>\n"
-        "<p>\n"
-        "As caixas no grafo anterior têm as seguintes interpretações:\n"
-        "<ul>\n"
-        "<li>Uma caixa inteiramente preta representa a estrutura ou a classe para "
-        "a qual o grafo foi gerado.\n"
-        "<li>Uma caixa com borda preta representa uma estrutura ou classe documentada.\n"
-        "<li>Uma caixa com borda cinzenta representa uma estrutura ou classe não documentada.\n"
-        "<li>Uma caixa com borda vermelha representa uma estrutura ou classe documentada onde "
-        "nem todas as relações de herança/encapsulamento são exibidas. Um grafo é truncado "
-        "quando não cabe na sua área predefinida.\n"
-        "</ul>\n"
-        "As setas têm a seguinte interpretação:\n"
-        "<ul>\n"
-        "<li>Uma seta azul escura representa uma relação de herança pública entre duas classes.\n"
-        "<li>Uma seta verde escura representa uma relação de herança protegida.\n"
-        "<li>Uma seta vermelha escura representa uma relação de herança privada.\n"
-        "<li>Uma seta rocha em tracejado representa uma relação de encapsulamento ou uso por "
-        "parte de outra classe. A legenda da seta contém o nome da variável ou variáveis da "
-        "relação. A seta aponta da classe que estabelece a relação para a classe ou estrutura que "
-        "é acessível.\n"
-        "</ul>\n";
-    }
-    /*! text for the link to the legend page */
-    virtual QCString trLegend()
-    {
-      return "legenda";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.0
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a marker that is put before a test item */
-    virtual QCString trTest()
-    {
-      return "Teste";
-    }
-    /*! Used as the header of the test list */
-    virtual QCString trTestList()
-    {
-      return "Lista de teste";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.2
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a section header for IDL properties */
-    virtual QCString trProperties()
-    {
-      return "Propriedades";
-    }
-    /*! Used as a section header for IDL property documentation */
-    virtual QCString trPropertyDocumentation()
-    {
-      return "Documentação das propriedades";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.4
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used for Java classes in the summary section of Java packages */
-    virtual QCString trClasses()
-    {
-      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-      {
-        return "Estruturas de dados";
-      }
-      else
-      {
-        return "Classes";
-      }
-    }
-    /*! Used as the title of a Java package */
-    virtual QCString trPackage(const QCString &name)
-    {
-      return "Pacote "+name;
-    }
-    /*! The description of the package index page */
-    virtual QCString trPackageListDescription()
-    {
-      return "Lista de pacotes com uma breve descrição (se disponível):";
-    }
-    /*! The link name in the Quick links header for each page */
-    virtual QCString trPackages()
-    {
-      return "Pacotes";
-    }
-    /*! Text shown before a multi-line define */
-    virtual QCString trDefineValue()
-    {
-      return "Valor:";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.5
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a marker that is put before a \\bug item */
-    virtual QCString trBug()
-    {
-      return "Bug";
-    }
-    /*! Used as the header of the bug list */
-    virtual QCString trBugList()
-    {
-      return "Lista de Bugs";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.6
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as ansicpg for RTF file
-     *
-     * The following table shows the correlation of Charset name, Charset Value and
-     * <pre>
-     * Codepage number:
-     * Charset Name       Charset Value(hex)  Codepage number
-     * ------------------------------------------------------
-     * DEFAULT_CHARSET           1 (x01)
-     * SYMBOL_CHARSET            2 (x02)
-     * OEM_CHARSET             255 (xFF)
-     * ANSI_CHARSET              0 (x00)            1252
-     * RUSSIAN_CHARSET         204 (xCC)            1251
-     * EE_CHARSET              238 (xEE)            1250
-     * GREEK_CHARSET           161 (xA1)            1253
-     * TURKISH_CHARSET         162 (xA2)            1254
-     * BALTIC_CHARSET          186 (xBA)            1257
-     * HEBREW_CHARSET          177 (xB1)            1255
-     * ARABIC _CHARSET         178 (xB2)            1256
-     * SHIFTJIS_CHARSET        128 (x80)             932
-     * HANGEUL_CHARSET         129 (x81)             949
-     * GB2313_CHARSET          134 (x86)             936
-     * CHINESEBIG5_CHARSET     136 (x88)             950
-     * </pre>
-     *
-     */
-    virtual QCString trRTFansicp()
-    {
-      return "1252";
-    }
-
-
-    /*! Used as ansicpg for RTF fcharset
-     *  \see trRTFansicp() for a table of possible values.
-     */
-    virtual QCString trRTFCharSet()
-    {
-      return "0";
-    }
-
-    /*! Used as header RTF general index */
-    virtual QCString trRTFGeneralIndex()
-    {
-      return "Índice";
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trClass(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Classe" : "classe"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trFile(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Ficheiro" : "ficheiro"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trNamespace(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trGroup(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Grupo" : "grupo"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trPage(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Página" : "página"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trMember(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Membro" : "membro"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trGlobal(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Globa" : "globa"));
-      result+= singular? "l" : "ais";
-      return result;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.7
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This text is generated when the \\author command is used and
-     *  for the author section in man pages. */
-    virtual QCString trAuthor(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (!singular) result+="es";
-      return result;
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.11
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This text is put before the list of members referenced by a member
-     */
-    virtual QCString trReferences()
-    {
-      return "Referências";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.13
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used in member documentation blocks to produce a list of
-     *  members that are implemented by this one.
-     */
-    virtual QCString trImplementedFromList(int numEntries)
-    {
-      return "Implementa "+trWriteList(numEntries)+".";
-    }
-
-    /*! used in member documentation blocks to produce a list of
-     *  all members that implement this abstract member.
-     */
-    virtual QCString trImplementedInList(int numEntries)
-    {
-      return "Implementado em "+trWriteList(numEntries)+".";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.16
-//////////////////////////////////////////////////////////////////////////
-
-    /*! used in RTF documentation as a heading for the Table
-     *  of Contents.
-     */
-    virtual QCString trRTFTableOfContents()
-    {
-      return "Índice";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.17
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as the header of the list of item that have been
-     *  flagged deprecated
-     */
-    virtual QCString trDeprecatedList()
-    {
-      return "Lista de Deprecados";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.2.18
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a header for declaration section of the events found in
-     * a C# program
-     */
-    virtual QCString trEvents()
-    {
-      return "Eventos";
-    }
-    /*! Header used for the documentation section of a class' events. */
-    virtual QCString trEventDocumentation()
-    {
-      return "Documentação dos eventos";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a heading for a list of Java class types with package scope.
-     */
-    virtual QCString trPackageTypes()
-    {
-      return "Tipos do Pacote";
-    }
-    /*! Used as a heading for a list of Java class functions with package
-     * scope.
-     */
-    virtual QCString trPackageFunctions()
-    {
-      return "Funções do Pacote";
-    }
-    virtual QCString trPackageMembers()
-    {
-      return "Membros do Pacote";
-    }
-    /*! Used as a heading for a list of static Java class functions with
-     *  package scope.
-     */
-    virtual QCString trStaticPackageFunctions()
-    {
-      return "Funções Estáticas do Pacote";
-    }
-    /*! Used as a heading for a list of Java class variables with package
-     * scope.
-     */
-    virtual QCString trPackageAttribs()
-    {
-      return "Atributos do Pacote";
-    }
-    /*! Used as a heading for a list of static Java class variables with
-     * package scope.
-     */
-    virtual QCString trStaticPackageAttribs()
-    {
-      return "Atributos Estáticos do Pacote";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.1
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used in the quick index of a class/file/namespace member list page
-     *  to link to the unfiltered list of all members.
-     */
-    virtual QCString trAll()
-    {
-      return "Tudo";
-    }
-    /*! Put in front of the call graph for a function. */
-    virtual QCString trCallGraph()
-    {
-      return "Grafo de chamadas desta função:";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.3 - Based on the Brazilian Portuguese Translation
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This string is used as the title for the page listing the search
-     *  results.
-     */
-    virtual QCString trSearchResultsTitle()
-    {
-      return "Resultado da Busca";
-    }
-    /*! This string is put just before listing the search results. The
-     *  text can be different depending on the number of documents found.
-     *  Inside the text you can put the special marker $num to insert
-     *  the number representing the actual number of search results.
-     *  The @a numDocuments parameter can be either 0, 1 or 2, where the
-     *  value 2 represents 2 or more matches. HTML markup is allowed inside
-     *  the returned string.
-     */
-    virtual QCString trSearchResults(int numDocuments)
-    {
-      if (numDocuments==0)
-      {
-        return "Nenhum documento foi encontrado.";
-      }
-      else if (numDocuments==1)
-      {
-        return "Apenas <b>1</b> documento foi encontrado.";
-      }
-      else
-      {
-        return "<b>$num</b> documentos encontrados. "
-               "Os melhores resultados vem primeiro.";
+        if (i < numEntries - 2) // not the fore last entry
+          result += ", ";
+        else // the fore last entry
+          result += " e ";
       }
     }
-    /*! This string is put before the list of matched words, for each search
-     *  result. What follows is the list of words that matched the query.
-     */
-    virtual QCString trSearchMatches()
+    return result;
+  }
+
+  /*! used in class documentation to produce a list of base classes,
+   *  if class diagrams are disabled.
+   */
+  virtual QCString trInheritsList(int numEntries)
+  {
+    return "Derivada de " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in class documentation to produce a list of super classes,
+   *  if class diagrams are disabled.
+   */
+  virtual QCString trInheritedByList(int numEntries)
+  {
+    return "Herdado por " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in member documentation blocks to produce a list of
+   *  members that are hidden by this one.
+   */
+  virtual QCString trReimplementedFromList(int numEntries)
+  {
+    return "Reimplementado de " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in member documentation blocks to produce a list of
+   *  all member that overwrite the implementation of this member.
+   */
+  virtual QCString trReimplementedInList(int numEntries)
+  {
+    return "Reimplementado em " + trWriteList(numEntries) + ".";
+  }
+
+  /*! This is put above each page as a link to all members of namespaces. */
+  virtual QCString trNamespaceMembers()
+  {
+    return "Membros do namespace";
+  }
+
+  /*! This is an introduction to the page with all namespace members */
+  virtual QCString trNamespaceMemberDescription(bool extractAll)
+  {
+    QCString result = "Lista ";
+    if (extractAll)
+      result += "de todos os ";
+    else
+      result += "de toda a documentação dos ";
+    result += "membros do namespace com referência para ";
+    if (extractAll)
+      result += "a documentação de cada membro:";
+    else
+      result += "o namespace correspondente:";
+    return result;
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   *  index of all namespaces.
+   */
+  virtual QCString trNamespaceIndex()
+  {
+    return "Índice dos namespaces";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all namespaces.
+   */
+  virtual QCString trNamespaceDocumentation()
+  {
+    return "Documentação dos namespaces";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990522
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used in the documentation before the list of all
+   *  namespaces in a file.
+   */
+  virtual QCString trNamespaces()
+  {
+    return "Namespaces";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990728
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is put at the bottom of a class documentation page and is
+   *  followed by a list of files that were used to generate the page.
+   */
+  virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
+                                        bool single)
+  { // here s is one of " Class", " Struct" or " Union"
+    // single is true implies a single file
+    bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+    QCString result = "A documentação para ";
+    switch (compType)
     {
-      return "Resultados:";
+    case ClassDef::Class:
+      result += vhdlOpt ? "esta Unidade de Design" : "esta classe";
+      break;
+    case ClassDef::Struct:
+      result += "esta estrutura";
+      break;
+    case ClassDef::Union:
+      result += "esta união";
+      break;
+    case ClassDef::Interface:
+      result += "este interface";
+      break;
+    case ClassDef::Protocol:
+      result += "este protocolo";
+      break;
+    case ClassDef::Category:
+      result += "esta categoria";
+      break;
+    case ClassDef::Exception:
+      result += "esta excepção";
+      break;
+    default:
+      break;
+    }
+    result += " foi gerada a partir ";
+    if (single)
+      result += " do seguinte ficheiro:";
+    else
+      result += "dos seguintes ficheiros:";
+    return result;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-990901
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used as the heading text for the retval command. */
+  virtual QCString trReturnValues()
+  {
+    return "Valores retornados";
+  }
+
+  /*! This is in the (quick) index as a link to the main page (index.html)
+   */
+  virtual QCString trMainPage()
+  {
+    return "Página principal";
+  }
+
+  /*! This is used in references to page that are put in the LaTeX
+   *  documentation. It should be an abbreviation of the word page.
+   */
+  virtual QCString trPageAbbreviation()
+  {
+    return "p. ";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-991003
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trDefinedAtLineInSourceFile()
+  {
+    return "Definido na linha @0 do ficheiro @1.";
+  }
+  virtual QCString trDefinedInSourceFile()
+  {
+    return "Definido no ficheiro @0.";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 0.49-991205
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trDeprecated()
+  {
+    return "Desaprovado";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.0.0
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! this text is put before a collaboration diagram */
+  virtual QCString trCollaborationDiagram(const QCString &clName)
+  {
+    return "Diagrama de colaboração para " + clName + ":";
+  }
+  /*! this text is put before an include dependency graph */
+  virtual QCString trInclDepGraph(const QCString &fName)
+  {
+    return "Diagrama de dependências de inclusão para " + fName + ":";
+  }
+  /*! header that is put before the list of constructor/destructors. */
+  virtual QCString trConstructorDocumentation()
+  {
+    return "Documentação dos Construtores & Destrutor";
+  }
+  /*! Used in the file documentation to point to the corresponding sources. */
+  virtual QCString trGotoSourceCode()
+  {
+    return "Ir para o código fonte deste ficheiro.";
+  }
+  /*! Used in the file sources to point to the corresponding documentation. */
+  virtual QCString trGotoDocumentation()
+  {
+    return "Ir para a documentação deste ficheiro.";
+  }
+  /*! Text for the \\pre command */
+  virtual QCString trPrecondition()
+  {
+    return "Precondição";
+  }
+  /*! Text for the \\post command */
+  virtual QCString trPostcondition()
+  {
+    return "Poscondição";
+  }
+  /*! Text for the \\invariant command */
+  virtual QCString trInvariant()
+  {
+    return "Invariante";
+  }
+  /*! Text shown before a multi-line variable/enum initialization */
+  virtual QCString trInitialValue()
+  {
+    return "Valor inicial:";
+  }
+  /*! Text used the source code in the file index */
+  virtual QCString trCode()
+  {
+    return "código";
+  }
+  virtual QCString trGraphicalHierarchy()
+  {
+    return "Representação gráfica da hiearquia da classe";
+  }
+  virtual QCString trGotoGraphicalHierarchy()
+  {
+    return "Ir para a representação gráfica da hierarquia da classe";
+  }
+  virtual QCString trGotoTextualHierarchy()
+  {
+    return "Ir para a representação textual da hierarquia da classe";
+  }
+  virtual QCString trPageIndex()
+  {
+    return "Índice da página";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.0
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trNote()
+  {
+    return "Nota";
+  }
+  virtual QCString trPublicTypes()
+  {
+    return "Tipos Públicos";
+  }
+  virtual QCString trPublicAttribs()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Campos de Dados";
+    }
+    else
+    {
+      return "Atributos Públicos";
+    }
+  }
+  virtual QCString trStaticPublicAttribs()
+  {
+    return "Atributos Públicos Estáticos";
+  }
+  virtual QCString trProtectedTypes()
+  {
+    return "Tipos Protegidos";
+  }
+  virtual QCString trProtectedAttribs()
+  {
+    return "Atributos Protegidos";
+  }
+  virtual QCString trStaticProtectedAttribs()
+  {
+    return "Atributos Protegidos Estáticos";
+  }
+  virtual QCString trPrivateTypes()
+  {
+    return "Tipos Privados";
+  }
+  virtual QCString trPrivateAttribs()
+  {
+    return "Atributos Privados";
+  }
+  virtual QCString trStaticPrivateAttribs()
+  {
+    return "Atributos Privados Estáticos";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.3
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a marker that is put before a todo item */
+  virtual QCString trTodo()
+  {
+    return "Tarefa";
+  }
+  /*! Used as the header of the todo list */
+  virtual QCString trTodoList()
+  {
+    return "Lista de tarefas";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.4
+  //////////////////////////////////////////////////////////////////////////
+
+  virtual QCString trReferencedBy()
+  {
+    return "Referenciado por";
+  }
+  virtual QCString trRemarks()
+  {
+    return "Observações";
+  }
+  virtual QCString trAttention()
+  {
+    return "Atenção";
+  }
+  virtual QCString trInclByDepGraph()
+  {
+    return "Este grafo mostra quais são os ficheiros que incluem directamente ou indirectamente este ficheiro:";
+  }
+  virtual QCString trSince()
+  {
+    return "Desde";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.1.5
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! title of the graph legend page */
+  virtual QCString trLegendTitle()
+  {
+    return "Legenda do grafo";
+  }
+  /*! page explaining how the dot graph's should be interpreted */
+  virtual QCString trLegendDocs()
+  {
+    return "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
+           "Considere o seguinte exemplo:\n"
+           "\\code\n"
+           "/*! Esta classe vai estar escondida devido à truncação */\n"
+           "class Invisible { };\n\n"
+           "/*! Esta classe tem a relação de herança escondida */\n"
+           "class Truncated : public Invisible { };\n\n"
+           "/* Classe não documentada por comentários doxygen */\n"
+           "class Undocumented { };\n\n"
+           "/*! Classe derivada usando derivação pública */\n"
+           "class PublicBase : public Truncated { };\n\n"
+           "/*! A template class */\n"
+           "template<class T> class Templ { };\n\n"
+           "/*! Classe derivada usando derivação protegida */\n"
+           "class ProtectedBase { };\n\n"
+           "/*! Classe derivada usando derivação privada */\n"
+           "class PrivateBase { };\n\n"
+           "/*! Classe usada pela classe Inherited */\n"
+           "class Used { };\n\n"
+           "/*! Super classe que deriva de várias classes */\n"
+           "class Inherited : public PublicBase,\n"
+           "                  protected ProtectedBase,\n"
+           "                  private PrivateBase,\n"
+           "                  public Undocumented,\n"
+           "                  public Templ<int>\n"
+           "{\n"
+           "  private:\n"
+           "    Used *m_usedClass;\n"
+           "};\n"
+           "\\endcode\n"
+           "Isto irá gerar o seguinte gráfo:"
+           "<p><center><img src=\"graph_legend." +
+           getDotImageExtension() + "\"></center>\n"
+                                    "<p>\n"
+                                    "As caixas no grafo anterior têm as seguintes interpretações:\n"
+                                    "<ul>\n"
+                                    "<li>Uma caixa inteiramente preta representa a estrutura ou a classe para "
+                                    "a qual o grafo foi gerado.\n"
+                                    "<li>Uma caixa com borda preta representa uma estrutura ou classe documentada.\n"
+                                    "<li>Uma caixa com borda cinzenta representa uma estrutura ou classe não documentada.\n"
+                                    "<li>Uma caixa com borda vermelha representa uma estrutura ou classe documentada onde "
+                                    "nem todas as relações de herança/encapsulamento são exibidas. Um grafo é truncado "
+                                    "quando não cabe na sua área predefinida.\n"
+                                    "</ul>\n"
+                                    "As setas têm a seguinte interpretação:\n"
+                                    "<ul>\n"
+                                    "<li>Uma seta azul escura representa uma relação de herança pública entre duas classes.\n"
+                                    "<li>Uma seta verde escura representa uma relação de herança protegida.\n"
+                                    "<li>Uma seta vermelha escura representa uma relação de herança privada.\n"
+                                    "<li>Uma seta rocha em tracejado representa uma relação de encapsulamento ou uso por "
+                                    "parte de outra classe. A legenda da seta contém o nome da variável ou variáveis da "
+                                    "relação. A seta aponta da classe que estabelece a relação para a classe ou estrutura que "
+                                    "é acessível.\n"
+                                    "</ul>\n";
+  }
+  /*! text for the link to the legend page */
+  virtual QCString trLegend()
+  {
+    return "legenda";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.0
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a marker that is put before a test item */
+  virtual QCString trTest()
+  {
+    return "Teste";
+  }
+  /*! Used as the header of the test list */
+  virtual QCString trTestList()
+  {
+    return "Lista de teste";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.2
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a section header for IDL properties */
+  virtual QCString trProperties()
+  {
+    return "Propriedades";
+  }
+  /*! Used as a section header for IDL property documentation */
+  virtual QCString trPropertyDocumentation()
+  {
+    return "Documentação das propriedades";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.4
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used for Java classes in the summary section of Java packages */
+  virtual QCString trClasses()
+  {
+    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    {
+      return "Estruturas de dados";
+    }
+    else
+    {
+      return "Classes";
+    }
+  }
+  /*! Used as the title of a Java package */
+  virtual QCString trPackage(const QCString &name)
+  {
+    return "Pacote " + name;
+  }
+  /*! The description of the package index page */
+  virtual QCString trPackageListDescription()
+  {
+    return "Lista de pacotes com uma breve descrição (se disponível):";
+  }
+  /*! The link name in the Quick links header for each page */
+  virtual QCString trPackages()
+  {
+    return "Pacotes";
+  }
+  /*! Text shown before a multi-line define */
+  virtual QCString trDefineValue()
+  {
+    return "Valor:";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.5
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a marker that is put before a \\bug item */
+  virtual QCString trBug()
+  {
+    return "Bug";
+  }
+  /*! Used as the header of the bug list */
+  virtual QCString trBugList()
+  {
+    return "Lista de Bugs";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.6
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as ansicpg for RTF file
+   *
+   * The following table shows the correlation of Charset name, Charset Value and
+   * <pre>
+   * Codepage number:
+   * Charset Name       Charset Value(hex)  Codepage number
+   * ------------------------------------------------------
+   * DEFAULT_CHARSET           1 (x01)
+   * SYMBOL_CHARSET            2 (x02)
+   * OEM_CHARSET             255 (xFF)
+   * ANSI_CHARSET              0 (x00)            1252
+   * RUSSIAN_CHARSET         204 (xCC)            1251
+   * EE_CHARSET              238 (xEE)            1250
+   * GREEK_CHARSET           161 (xA1)            1253
+   * TURKISH_CHARSET         162 (xA2)            1254
+   * BALTIC_CHARSET          186 (xBA)            1257
+   * HEBREW_CHARSET          177 (xB1)            1255
+   * ARABIC _CHARSET         178 (xB2)            1256
+   * SHIFTJIS_CHARSET        128 (x80)             932
+   * HANGEUL_CHARSET         129 (x81)             949
+   * GB2313_CHARSET          134 (x86)             936
+   * CHINESEBIG5_CHARSET     136 (x88)             950
+   * </pre>
+   *
+   */
+  virtual QCString trRTFansicp()
+  {
+    return "1252";
+  }
+
+  /*! Used as ansicpg for RTF fcharset
+   *  \see trRTFansicp() for a table of possible values.
+   */
+  virtual QCString trRTFCharSet()
+  {
+    return "0";
+  }
+
+  /*! Used as header RTF general index */
+  virtual QCString trRTFGeneralIndex()
+  {
+    return "Índice";
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trClass(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Classe" : "classe"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trFile(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Ficheiro" : "ficheiro"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trNamespace(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Namespace" : "namespace"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trGroup(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Grupo" : "grupo"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trPage(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Página" : "página"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trMember(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Membro" : "membro"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trGlobal(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Globa" : "globa"));
+    result += singular ? "l" : "ais";
+    return result;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.7
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This text is generated when the \\author command is used and
+   *  for the author section in man pages. */
+  virtual QCString trAuthor(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Autor" : "autor"));
+    if (!singular)
+      result += "es";
+    return result;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.11
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This text is put before the list of members referenced by a member
+   */
+  virtual QCString trReferences()
+  {
+    return "Referências";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.13
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used in member documentation blocks to produce a list of
+   *  members that are implemented by this one.
+   */
+  virtual QCString trImplementedFromList(int numEntries)
+  {
+    return "Implementa " + trWriteList(numEntries) + ".";
+  }
+
+  /*! used in member documentation blocks to produce a list of
+   *  all members that implement this abstract member.
+   */
+  virtual QCString trImplementedInList(int numEntries)
+  {
+    return "Implementado em " + trWriteList(numEntries) + ".";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.16
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! used in RTF documentation as a heading for the Table
+   *  of Contents.
+   */
+  virtual QCString trRTFTableOfContents()
+  {
+    return "Índice";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.17
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as the header of the list of item that have been
+   *  flagged deprecated
+   */
+  virtual QCString trDeprecatedList()
+  {
+    return "Lista de Deprecados";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.2.18
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a header for declaration section of the events found in
+   * a C# program
+   */
+  virtual QCString trEvents()
+  {
+    return "Eventos";
+  }
+  /*! Header used for the documentation section of a class' events. */
+  virtual QCString trEventDocumentation()
+  {
+    return "Documentação dos eventos";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a heading for a list of Java class types with package scope.
+   */
+  virtual QCString trPackageTypes()
+  {
+    return "Tipos do Pacote";
+  }
+  /*! Used as a heading for a list of Java class functions with package
+   * scope.
+   */
+  virtual QCString trPackageFunctions()
+  {
+    return "Funções do Pacote";
+  }
+  virtual QCString trPackageMembers()
+  {
+    return "Membros do Pacote";
+  }
+  /*! Used as a heading for a list of static Java class functions with
+   *  package scope.
+   */
+  virtual QCString trStaticPackageFunctions()
+  {
+    return "Funções Estáticas do Pacote";
+  }
+  /*! Used as a heading for a list of Java class variables with package
+   * scope.
+   */
+  virtual QCString trPackageAttribs()
+  {
+    return "Atributos do Pacote";
+  }
+  /*! Used as a heading for a list of static Java class variables with
+   * package scope.
+   */
+  virtual QCString trStaticPackageAttribs()
+  {
+    return "Atributos Estáticos do Pacote";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.1
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used in the quick index of a class/file/namespace member list page
+   *  to link to the unfiltered list of all members.
+   */
+  virtual QCString trAll()
+  {
+    return "Tudo";
+  }
+  /*! Put in front of the call graph for a function. */
+  virtual QCString trCallGraph()
+  {
+    return "Grafo de chamadas desta função:";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.3 - Based on the Brazilian Portuguese Translation
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This string is used as the title for the page listing the search
+   *  results.
+   */
+  virtual QCString trSearchResultsTitle()
+  {
+    return "Resultado da Busca";
+  }
+  /*! This string is put just before listing the search results. The
+   *  text can be different depending on the number of documents found.
+   *  Inside the text you can put the special marker $num to insert
+   *  the number representing the actual number of search results.
+   *  The @a numDocuments parameter can be either 0, 1 or 2, where the
+   *  value 2 represents 2 or more matches. HTML markup is allowed inside
+   *  the returned string.
+   */
+  virtual QCString trSearchResults(int numDocuments)
+  {
+    if (numDocuments == 0)
+    {
+      return "Nenhum documento foi encontrado.";
+    }
+    else if (numDocuments == 1)
+    {
+      return "Apenas <b>1</b> documento foi encontrado.";
+    }
+    else
+    {
+      return "<b>$num</b> documentos encontrados. "
+             "Os melhores resultados vem primeiro.";
+    }
+  }
+  /*! This string is put before the list of matched words, for each search
+   *  result. What follows is the list of words that matched the query.
+   */
+  virtual QCString trSearchMatches()
+  {
+    return "Resultados:";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.8
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used in HTML as the title of page with source code for file filename
+   */
+  virtual QCString trSourceFile(QCString &filename)
+  {
+    return "Código-Fonte de " + filename;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.3.9
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used as the name of the chapter containing the directory
+   *  hierarchy.
+   */
+  virtual QCString trDirIndex()
+  {
+    return "Hierarquia de Diretórios";
+  }
+
+  /*! This is used as the name of the chapter containing the documentation
+   *  of the directories.
+   */
+  virtual QCString trDirDocumentation()
+  {
+    return "Documentação do Directório";
+  }
+
+  /*! This is used as the title of the directory index and also in the
+   *  Quick links of a HTML page, to link to the directory hierarchy.
+   */
+  virtual QCString trDirectories()
+  {
+    return "Diretórios";
+  }
+
+  /*! This returns the title of a directory page. The name of the
+   *  directory is passed via \a dirName.
+   */
+  virtual QCString trDirReference(const QCString &dirName)
+  {
+    QCString result = "Referência do diretório ";
+    result += dirName;
+    return result;
+  }
+
+  /*! This returns the word directory with or without starting capital
+   *  (\a first_capital) and in sigular or plural form (\a singular).
+   */
+  virtual QCString trDir(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Diretório" : "diretório"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.4.1
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This text is added to the documentation when the \\overload command
+   *  is used for a overloaded function.
+   */
+  virtual QCString trOverloadText()
+  {
+    return "Este é um método provido por conveniência. "
+           "Ele difere do método acima apenas na lista de "
+           "argumentos que devem ser utilizados.";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.4.6
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used to introduce a caller (or called-by) graph */
+  virtual QCString trCallerGraph()
+  {
+    return "Este é o diagrama das funções que utilizam esta função:";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for enumeration values
+   */
+  virtual QCString trEnumerationValueDocumentation()
+  {
+    return "Documentação da enumeração";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.5.4 (mainly for Fortran)
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! header that is put before the list of member subprograms (Fortran). */
+  virtual QCString trMemberFunctionDocumentationFortran()
+  {
+    return "Documentação de Função Membro/Subrotina";
+  }
+
+  /*! This is put above each page as a link to the list of annotated data types (Fortran). */
+  virtual QCString trCompoundListFortran()
+  {
+    return "Lista de Tipos de Dados";
+  }
+
+  /*! This is put above each page as a link to all members of compounds (Fortran). */
+  virtual QCString trCompoundMembersFortran()
+  {
+    return "Campos de Dados";
+  }
+
+  /*! This is an introduction to the annotated compound list (Fortran). */
+  virtual QCString trCompoundListDescriptionFortran()
+  {
+    return "Aqui estão os tipos de dados com descrições resumidas:";
+  }
+
+  /*! This is an introduction to the page with all data types (Fortran). */
+  virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os membros ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "dos tipos de dados com links para ";
+    if (extractAll)
+    {
+      result += "a documentação dos tipos de dados para cada membro:";
+    }
+    else
+    {
+      result += "os tipos de dados a que pertencem:";
+    }
+    return result;
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   * annotated compound index (Fortran).
+   */
+  virtual QCString trCompoundIndexFortran()
+  {
+    return "Índice de Tipos de Dados";
+  }
+
+  /*! This is used in LaTeX as the title of the chapter containing
+   *  the documentation of all data types (Fortran).
+   */
+  virtual QCString trTypeDocumentation()
+  {
+    return "Documentação dos Tipos de Dados";
+  }
+
+  /*! This is used in the documentation of a file as a header before the
+   *  list of (global) subprograms (Fortran).
+   */
+  virtual QCString trSubprograms()
+  {
+    return "Funções/Subrotinas";
+  }
+
+  /*! This is used in the documentation of a file/namespace before the list
+   *  of documentation blocks for subprograms (Fortran)
+   */
+  virtual QCString trSubprogramDocumentation()
+  {
+    return "Documentação da Função/Subrotina";
+  }
+
+  /*! This is used in the documentation of a file/namespace/group before
+   *  the list of links to documented compounds (Fortran)
+   */
+  virtual QCString trDataTypes()
+  {
+    return "Tipos de Dados";
+  }
+
+  /*! used as the title of page containing all the index of all modules (Fortran). */
+  virtual QCString trModulesList()
+  {
+    return "Lista de Módulos";
+  }
+
+  /*! used as an introduction to the modules list (Fortran) */
+  virtual QCString trModulesListDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os módulos ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "com descrições resumidas:";
+    return result;
+  }
+
+  /*! used as the title of the HTML page of a module/type (Fortran) */
+  virtual QCString trCompoundReferenceFortran(const QCString &clName,
+                                              ClassDef::CompoundType compType,
+                                              bool isTemplate)
+  {
+    QCString result = "Referência ";
+
+    if (isTemplate)
+      result += "da Template ";
+
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "do Modulo ";
+      break;
+    case ClassDef::Struct:
+      result += "do Tipo ";
+      break;
+    case ClassDef::Union:
+      result += "da União ";
+      break;
+    case ClassDef::Interface:
+      result += "da Interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "do Protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "da Categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "da Exceção ";
+      break;
+    default:
+      break;
+    }
+    result += clName;
+
+    return result;
+  }
+  /*! used as the title of the HTML page of a module (Fortran) */
+  virtual QCString trModuleReference(const QCString &namespaceName)
+  {
+    QCString result = "Referência do Módulo ";
+    result += namespaceName;
+    return result;
+  }
+
+  /*! This is put above each page as a link to all members of modules. (Fortran) */
+  virtual QCString trModulesMembers()
+  {
+    return "Membros do Módulo";
+  }
+
+  /*! This is an introduction to the page with all modules members (Fortran) */
+  virtual QCString trModulesMemberDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os membros ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "dos módulos com links para ";
+    if (extractAll)
+    {
+      result += "a documentação dos módulos para cada membro:";
+    }
+    else
+    {
+      result += "os módulos a que pertencem:";
+    }
+    return result;
+  }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+   *  index of all modules (Fortran).
+   */
+  virtual QCString trModulesIndex()
+  {
+    return "Índice dos Módulos";
+  }
+
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trModule(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Modulo" : "modulo"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+  /*! This is put at the bottom of a module documentation page and is
+   *  followed by a list of files that were used to generate the page.
+   */
+  virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
+                                               bool single)
+  { // here s is one of " Module", " Struct" or " Union"
+    // single is true implies a single file
+    QCString result = "A documentação para ";
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "este modulo ";
+      break;
+    case ClassDef::Struct:
+      result += "este tipo ";
+      break;
+    case ClassDef::Union:
+      result += "esta união ";
+      break;
+    case ClassDef::Interface:
+      result += "esta interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "esto protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "esta categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "esta exceção ";
+      break;
+    default:
+      break;
     }
 
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.8
-//////////////////////////////////////////////////////////////////////////
+    result += " foi gerada a partir do";
+    if (single)
+      result += " seguinte ficheiro:";
+    else
+      result += "s seguintes ficheiros:";
 
-    /*! This is used in HTML as the title of page with source code for file filename
-     */
-    virtual QCString trSourceFile(QCString& filename)
+    return result;
+  }
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trType(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Tipo" : "tipo"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+  /*! This is used for translation of the word that will possibly
+   *  be followed by a single name or by a list of names
+   *  of the category.
+   */
+  virtual QCString trSubprogram(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Subprograma" : "subprograma"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+
+  /*! C# Type Contraint list */
+  virtual QCString trTypeConstraints()
+  {
+    return "Restrições do Tipo";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.6.0 (mainly for the new search engine)
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! directory relation for \a name
+   */
+  virtual QCString trDirRelation(const QCString &name)
+  {
+    return "Relação " + QCString(name);
+  }
+
+  /*! Loading message shown when loading search results */
+  virtual QCString trLoading()
+  {
+    return "Carregando...";
+  }
+
+  /*! Label used for search results in the global namespace */
+  virtual QCString trGlobalNamespace()
+  {
+    return "Namespace global";
+  }
+
+  /*! Message shown while searching */
+  virtual QCString trSearching()
+  {
+    return "Procurando...";
+  }
+
+  /*! Text shown when no search results are found */
+  virtual QCString trNoMatches()
+  {
+    return "Nenhuma entrada encontrada";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.6.3 (missing items for the directory pages)
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! when clicking a directory dependency label, a page with a
+   *  table is shown. The heading for the first column mentions the
+   *  source file that has a relation to another file.
+   */
+  virtual QCString trFileIn(const QCString &name)
+  {
+    return "Ficheiro em " + name;
+  }
+
+  /*! when clicking a directory dependency label, a page with a
+   *  table is shown. The heading for the second column mentions the
+   *  destination file that is included.
+   */
+  virtual QCString trIncludesFileIn(const QCString &name)
+  {
+    return "Inclui ficheiro em " + name;
+  }
+
+  /** Compiles a date string.
+   *  @param year Year in 4 digits
+   *  @param month Month of the year: 1=January
+   *  @param day Day of the Month: 1..31
+   *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
+   *  @param hour Hour of the day: 0..23
+   *  @param minutes Minutes in the hour: 0..59
+   *  @param seconds Seconds within the minute: 0..59
+   *  @param includeTime Include time in the result string?
+   */
+  virtual QCString trDateTime(int year, int month, int day, int dayOfWeek,
+                              int hour, int minutes, int seconds,
+                              bool includeTime)
+  {
+    static const char *days[] = {"Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"};
+    static const char *months[] = {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"};
+    QCString sdate;
+    sdate.sprintf("%s, %d de %s de %d", days[dayOfWeek - 1], day, months[month - 1], year);
+    if (includeTime)
     {
-      return  "Código-Fonte de " + filename;
+      QCString stime;
+      stime.sprintf(" %.2d:%.2d:%.2d", hour, minutes, seconds);
+      sdate += stime;
+    }
+    return sdate;
+  }
+  virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
+  {
+    static const char *days_short[] = {"seg", "ter", "qua", "qui", "sex", "sáb", "dom"};
+    static const char *days_full[] = {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo"};
+    QCString text = full ? days_full[dayOfWeek - 1] : days_short[dayOfWeek - 1];
+    if (first_capital)
+      return text.mid(0, 1).upper() + text.mid(1);
+    else
+      return text;
+  }
+  virtual QCString trMonth(int month, bool first_capital, bool full)
+  {
+    static const char *months_short[] = {"jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez"};
+    static const char *months_full[] = {"janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro"};
+    QCString text = full ? months_full[month - 1] : months_short[month - 1];
+    if (first_capital)
+      return text.mid(0, 1).upper() + text.mid(1);
+    else
+      return text;
+  }
+  virtual QCString trDayPeriod(int period)
+  {
+    static const char *dayPeriod[] = {"AM", "PM"};
+    return dayPeriod[period];
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.7.5
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Header for the page with bibliographic citations */
+  virtual QCString trCiteReferences()
+  {
+    return "Referências Bibliográficas";
+  }
+
+  /*! Text for copyright paragraph */
+  virtual QCString trCopyright()
+  {
+    // Note: I will left it as is because "Direitos de autor" may not fit
+    // in the text.
+    return "Copyright";
+  }
+
+  /*! Header for the graph showing the directory dependencies */
+  virtual QCString trDirDepGraph(const QCString &name)
+  {
+    return QCString("Grafo de dependências do directório ") + name + ":";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.0
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Detail level selector shown for hierarchical indices */
+  virtual QCString trDetailLevel()
+  {
+    return "nível de detalhes";
+  }
+
+  /*! Section header for list of template parameters */
+  virtual QCString trTemplateParameters()
+  {
+    return "Parâmetros de template";
+  }
+
+  /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
+  virtual QCString trAndMore(const QCString &number)
+  {
+    return "e " + number + " mais...";
+  }
+
+  /*! Used file list for a Java enum */
+  virtual QCString trEnumGeneratedFromFiles(bool single)
+  {
+    QCString result = "A documentação para esta enumeração foi gerada a partir";
+    if (single)
+    {
+      result += "do seguinte ficheiro:";
+    }
+    else
+    {
+      result += "dos seguintes ficheiros:";
+    }
+    return result;
+  }
+
+  /*! Header of a Java enum page (Java enums are represented as classes). */
+  virtual QCString trEnumReference(const QCString &name)
+  {
+    QCString result = "Referência da enumeração ";
+    return result + name;
+  }
+
+  /*! Used for a section containing inherited members */
+  virtual QCString trInheritedFrom(const QCString &members, const QCString &what)
+  {
+    return QCString(members) + " herdados de " + what;
+  }
+
+  /*! Header of the sections with inherited members specific for the
+   *  base class(es)
+   */
+  virtual QCString trAdditionalInheritedMembers()
+  {
+    return "Outros membros herdados";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.2
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! Used as a tooltip for the toggle button that appears in the
+   *  navigation tree in the HTML output when GENERATE_TREEVIEW is
+   *  enabled. This tooltip explains the meaning of the button.
+   */
+  virtual QCString trPanelSynchronisationTooltip(bool enable)
+  {
+    QCString opt = enable ? "ativar" : "desativar";
+    return "clique para " + opt + " a sincronização do painel";
+  }
+
+  /*! Used in a method of an Objective-C class that is declared in a
+   *  a category. Note that the @1 marker is required and is replaced
+   *  by a link.
+   */
+  virtual QCString trProvidedByCategory()
+  {
+    return "Provido pela categoria @0.";
+  }
+
+  /*! Used in a method of an Objective-C category that extends a class.
+   *  Note that the @1 marker is required and is replaced by a link to
+   *  the class method.
+   */
+  virtual QCString trExtendsClass()
+  {
+    return "estende a classe @0.";
+  }
+
+  /*! Used as the header of a list of class methods in Objective-C.
+   *  These are similar to static public member functions in C++.
+   */
+  virtual QCString trClassMethods()
+  {
+    return "Métodos de classe";
+  }
+
+  /*! Used as the header of a list of instance methods in Objective-C.
+   *  These are similar to public member functions in C++.
+   */
+  virtual QCString trInstanceMethods()
+  {
+    return "Métodos de instância";
+  }
+
+  /*! Used as the header of the member functions of an Objective-C class.
+   */
+  virtual QCString trMethodDocumentation()
+  {
+    return "Documentação do método";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.4
+  //////////////////////////////////////////////////////////////////////////
+
+  /** old style UNO IDL services: implemented interfaces */
+  virtual QCString trInterfaces()
+  {
+    return "Interfaces Exportadas";
+  }
+
+  /** old style UNO IDL services: inherited services */
+  virtual QCString trServices()
+  {
+    return "Serviços Incluídos";
+  }
+
+  /** UNO IDL constant groups */
+  virtual QCString trConstantGroups()
+  {
+    return "Grupos de Constantes";
+  }
+
+  /** UNO IDL constant groups */
+  virtual QCString trConstantGroupReference(const QCString &namespaceName)
+  {
+    QCString result = "Referência do grupo de constantes ";
+    result += namespaceName;
+    return result;
+  }
+
+  /** UNO IDL service page title */
+  virtual QCString trServiceReference(const QCString &sName)
+  {
+    QCString result = "Referência do serviço ";
+    result += sName;
+    return result;
+  }
+
+  /** UNO IDL singleton page title */
+  virtual QCString trSingletonReference(const QCString &sName)
+  {
+    QCString result = "Referência do Singleton ";
+    result += sName;
+    return result;
+  }
+
+  /** UNO IDL service page */
+  virtual QCString trServiceGeneratedFromFiles(bool single)
+  {
+    // single is true implies a single file
+    QCString result = "A documentação para este serviço "
+                      "foi gerada a partir ";
+    if (single)
+    {
+      result += "do seguinte ficheiro:";
+    }
+    else
+    {
+      result += "dos: seguintes ficheiros:";
+    }
+    return result;
+  }
+
+  /** UNO IDL singleton page */
+  virtual QCString trSingletonGeneratedFromFiles(bool single)
+  {
+    // single is true implies a single file
+    QCString result = "A documentação para este singleton "
+                      "foi gerada a partir ";
+    if (single)
+    {
+      result += "do seguinte ficheiro:";
+    }
+    else
+    {
+      result += "dos: seguintes ficheiros:";
     }
 
-//////////////////////////////////////////////////////////////////////////
-// new since 1.3.9
-//////////////////////////////////////////////////////////////////////////
+    return result;
+  }
 
-    /*! This is used as the name of the chapter containing the directory
-     *  hierarchy.
-     */
-    virtual QCString trDirIndex()
-    { return "Hierarquia de Diretórios"; }
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.15
+  //////////////////////////////////////////////////////////////////////////
 
-    /*! This is used as the name of the chapter containing the documentation
-     *  of the directories.
-     */
-    virtual QCString trDirDocumentation()
-    { return "Documentação do Directório"; }
-
-    /*! This is used as the title of the directory index and also in the
-     *  Quick links of a HTML page, to link to the directory hierarchy.
-     */
-    virtual QCString trDirectories()
-    { return "Diretórios"; }
-
-    /*! This returns the title of a directory page. The name of the
-     *  directory is passed via \a dirName.
-     */
-    virtual QCString trDirReference(const QCString &dirName)
+  /** VHDL design unit hierarchy */
+  virtual QCString trDesignUnitHierarchy()
+  {
+    return "Hierarquia da Unidade de Design";
+  }
+  /** VHDL design unit list */
+  virtual QCString trDesignUnitList()
+  {
+    return "Lista de Unidades de Design";
+  }
+  /** VHDL design unit members */
+  virtual QCString trDesignUnitMembers()
+  {
+    return "Membros da Unidade de Design";
+  }
+  /** VHDL design unit list description */
+  virtual QCString trDesignUnitListDescription()
+  {
+    return "Esta é uma lista de todos os membros de unidades de design "
+           "com ligações para as entidades às quais pertencem:";
+  }
+  /** VHDL design unit index */
+  virtual QCString trDesignUnitIndex()
+  {
+    return "Índice de Unidades de Design";
+  }
+  /** VHDL design units */
+  virtual QCString trDesignUnits()
+  {
+    return "Unidades de Design";
+  }
+  /** VHDL functions/procedures/processes */
+  virtual QCString trFunctionAndProc()
+  {
+    return "Funções/Procedimentos/Processos";
+  }
+  /** VHDL type */
+  virtual QCString trVhdlType(uint64 type, bool single)
+  {
+    switch (type)
     {
-        QCString result = "Referência do diretório ";
-     	result += dirName;
-     	return result;
-    }
-
-    /*! This returns the word directory with or without starting capital
-     *  (\a first_capital) and in sigular or plural form (\a singular).
-     */
-    virtual QCString trDir(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Diretório" : "diretório"));
-      if (!singular) result+="s";
-      return result;
-    }
-//////////////////////////////////////////////////////////////////////////
-// new since 1.4.1
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This text is added to the documentation when the \\overload command
-     *  is used for a overloaded function.
-     */
-    virtual QCString trOverloadText()
-    {
-       return "Este é um método provido por conveniência. "
-       		"Ele difere do método acima apenas na lista de "
-       		"argumentos que devem ser utilizados.";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.4.6
-//////////////////////////////////////////////////////////////////////////
-
-    /*! This is used to introduce a caller (or called-by) graph */
-    virtual QCString trCallerGraph()
-    {
-      return "Este é o diagrama das funções que utilizam esta função:";
-    }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for enumeration values
-     */
-    virtual QCString trEnumerationValueDocumentation()
-    { return "Documentação da enumeração"; }
-
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.5.4 (mainly for Fortran)
-//////////////////////////////////////////////////////////////////////////
-
-    /*! header that is put before the list of member subprograms (Fortran). */
-    virtual QCString trMemberFunctionDocumentationFortran()
-    { return "Documentação de Função Membro/Subrotina"; }
-
-    /*! This is put above each page as a link to the list of annotated data types (Fortran). */
-    virtual QCString trCompoundListFortran()
-    { return "Lista de Tipos de Dados"; }
-
-    /*! This is put above each page as a link to all members of compounds (Fortran). */
-    virtual QCString trCompoundMembersFortran()
-    { return "Campos de Dados"; }
-
-    /*! This is an introduction to the annotated compound list (Fortran). */
-    virtual QCString trCompoundListDescriptionFortran()
-    { return "Aqui estão os tipos de dados com descrições resumidas:"; }
-
-    /*! This is an introduction to the page with all data types (Fortran). */
-    virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
-    {
-      QCString result="Esta é a lista de todos os membros ";
-      if (!extractAll) result+="documentados ";
-      result+="dos tipos de dados com links para ";
-      if (extractAll)
-      {
-        result+="a documentação dos tipos de dados para cada membro:";
-      }
-      else
-      {
-        result+="os tipos de dados a que pertencem:";
-      }
-      return result;
-    }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     * annotated compound index (Fortran).
-     */
-    virtual QCString trCompoundIndexFortran()
-    { return "Índice de Tipos de Dados"; }
-
-    /*! This is used in LaTeX as the title of the chapter containing
-     *  the documentation of all data types (Fortran).
-     */
-    virtual QCString trTypeDocumentation()
-    { return "Documentação dos Tipos de Dados"; }
-
-    /*! This is used in the documentation of a file as a header before the
-     *  list of (global) subprograms (Fortran).
-     */
-    virtual QCString trSubprograms()
-    { return "Funções/Subrotinas"; }
-
-    /*! This is used in the documentation of a file/namespace before the list
-     *  of documentation blocks for subprograms (Fortran)
-     */
-    virtual QCString trSubprogramDocumentation()
-    { return "Documentação da Função/Subrotina"; }
-
-    /*! This is used in the documentation of a file/namespace/group before
-     *  the list of links to documented compounds (Fortran)
-     */
-     virtual QCString trDataTypes()
-    { return "Tipos de Dados"; }
-
-    /*! used as the title of page containing all the index of all modules (Fortran). */
-    virtual QCString trModulesList()
-    { return "Lista de Módulos"; }
-
-    /*! used as an introduction to the modules list (Fortran) */
-    virtual QCString trModulesListDescription(bool extractAll)
-    {
-      QCString result="Esta é a lista de todos os módulos ";
-      if (!extractAll) result+="documentados ";
-      result+="com descrições resumidas:";
-      return result;
-    }
-
-    /*! used as the title of the HTML page of a module/type (Fortran) */
-    virtual QCString trCompoundReferenceFortran(const QCString &clName,
-                                    ClassDef::CompoundType compType,
-                                    bool isTemplate)
-    {
-      QCString result = "Referência ";
-
-      if (isTemplate) result+="da Template ";
-
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="do Modulo "; break;
-        case ClassDef::Struct:     result+="do Tipo "; break;
-        case ClassDef::Union:      result+="da União "; break;
-        case ClassDef::Interface:  result+="da Interface "; break;
-        case ClassDef::Protocol:   result+="do Protocolo "; break;
-        case ClassDef::Category:   result+="da Categoria "; break;
-        case ClassDef::Exception:  result+="da Exceção "; break;
-        default: break;
-      }
-      result += clName;
-
-      return result;
-    }
-    /*! used as the title of the HTML page of a module (Fortran) */
-    virtual QCString trModuleReference(const QCString &namespaceName)
-    {
-      QCString result = "Referência do Módulo ";
-      result += namespaceName;
-      return result;
-    }
-
-    /*! This is put above each page as a link to all members of modules. (Fortran) */
-    virtual QCString trModulesMembers()
-    { return "Membros do Módulo"; }
-
-    /*! This is an introduction to the page with all modules members (Fortran) */
-    virtual QCString trModulesMemberDescription(bool extractAll)
-    {
-      QCString result="Esta é a lista de todos os membros ";
-      if (!extractAll) result+="documentados ";
-      result+="dos módulos com links para ";
-      if (extractAll)
-      {
-        result+="a documentação dos módulos para cada membro:";
-      }
-      else
-      {
-        result+="os módulos a que pertencem:";
-      }
-      return result;
-    }
-
-    /*! This is used in LaTeX as the title of the chapter with the
-     *  index of all modules (Fortran).
-     */
-    virtual QCString trModulesIndex()
-    { return "Índice dos Módulos"; }
-
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trModule(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Modulo" : "modulo"));
-      if (!singular)  result+="s";
-      return result;
-    }
-    /*! This is put at the bottom of a module documentation page and is
-     *  followed by a list of files that were used to generate the page.
-     */
-    virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
-        bool single)
-    { // here s is one of " Module", " Struct" or " Union"
-      // single is true implies a single file
-      QCString result="A documentação para ";
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="este modulo "; break;
-        case ClassDef::Struct:     result+="este tipo "; break;
-        case ClassDef::Union:      result+="esta união "; break;
-        case ClassDef::Interface:  result+="esta interface "; break;
-        case ClassDef::Protocol:   result+="esto protocolo "; break;
-        case ClassDef::Category:   result+="esta categoria "; break;
-        case ClassDef::Exception:  result+="esta exceção "; break;
-        default: break;
-      }
-
-      result+=" foi gerada a partir do";
+    case VhdlDocGen::LIBRARY:
       if (single)
-    	result+=" seguinte ficheiro:";
+        return "Biblioteca";
       else
-    	result+="s seguintes ficheiros:";
-
-      return result;
-    }
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trType(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Tipo" : "tipo"));
-      if (!singular)  result+="s";
-      return result;
-    }
-    /*! This is used for translation of the word that will possibly
-     *  be followed by a single name or by a list of names
-     *  of the category.
-     */
-    virtual QCString trSubprogram(bool first_capital, bool singular)
-    {
-      QCString result((first_capital ? "Subprograma" : "subprograma"));
-      if (!singular)  result+="s";
-      return result;
-    }
-
-    /*! C# Type Contraint list */
-    virtual QCString trTypeConstraints()
-    {
-      return "Restrições do Tipo";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.6.0 (mainly for the new search engine)
-//////////////////////////////////////////////////////////////////////////
-
-    /*! directory relation for \a name
-     */
-    virtual QCString trDirRelation(const QCString &name)
-    {
-      return "Relação " + QCString(name);
-    }
-
-    /*! Loading message shown when loading search results */
-    virtual QCString trLoading()
-    {
-      return "Carregando...";
-    }
-
-    /*! Label used for search results in the global namespace */
-    virtual QCString trGlobalNamespace()
-    {
-      return "Namespace global";
-    }
-
-    /*! Message shown while searching */
-    virtual QCString trSearching()
-    {
-      return "Procurando...";
-    }
-
-    /*! Text shown when no search results are found */
-    virtual QCString trNoMatches()
-    {
-      return "Nenhuma entrada encontrada";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.6.3 (missing items for the directory pages)
-//////////////////////////////////////////////////////////////////////////
-
-    /*! when clicking a directory dependency label, a page with a
-     *  table is shown. The heading for the first column mentions the
-     *  source file that has a relation to another file.
-     */
-    virtual QCString trFileIn(const QCString &name)
-    {
-      return "Ficheiro em "+name;
-    }
-
-    /*! when clicking a directory dependency label, a page with a
-     *  table is shown. The heading for the second column mentions the
-     *  destination file that is included.
-     */
-    virtual QCString trIncludesFileIn(const QCString &name)
-    {
-      return "Inclui ficheiro em "+name;
-    }
-
-    /** Compiles a date string.
-     *  @param year Year in 4 digits
-     *  @param month Month of the year: 1=January
-     *  @param day Day of the Month: 1..31
-     *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
-     *  @param hour Hour of the day: 0..23
-     *  @param minutes Minutes in the hour: 0..59
-     *  @param seconds Seconds within the minute: 0..59
-     *  @param includeTime Include time in the result string?
-     */
-    virtual QCString trDateTime(int year,int month,int day,int dayOfWeek,
-                                int hour,int minutes,int seconds,
-                                bool includeTime)
-    {
-      static const char *days[]   = { "Segunda","Terça","Quarta","Quinta","Sexta","Sábado","Domingo" };
-      static const char *months[] = { "Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro" };
-      QCString sdate;
-      sdate.sprintf("%s, %d de %s de %d",days[dayOfWeek-1],day,months[month-1],year);
-      if (includeTime)
-      {
-        QCString stime;
-        stime.sprintf(" %.2d:%.2d:%.2d",hour,minutes,seconds);
-        sdate+=stime;
-      }
-      return sdate;
-    }
-    virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
-    {
-      static const char *days_short[]   = { "seg", "ter", "qua", "qui", "sex", "sáb", "dom" };
-      static const char *days_full[]    = { "segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo" };
-      QCString text  = full? days_full[dayOfWeek-1] : days_short[dayOfWeek-1];
-      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
-      else return text;
-    }
-    virtual QCString trMonth(int month, bool first_capital, bool full)
-    {
-      static const char *months_short[] = { "jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez" };
-      static const char *months_full[]  = { "janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro" };
-      QCString text  = full? months_full[month-1] : months_short[month-1];
-      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
-      else return text;
-    }
-    virtual QCString trDayPeriod(int period)
-    {
-      static const char *dayPeriod[] = { "AM", "PM" };
-      return dayPeriod[period];
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.7.5
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Header for the page with bibliographic citations */
-    virtual QCString trCiteReferences()
-    { return "Referências Bibliográficas"; }
-
-    /*! Text for copyright paragraph */
-    virtual QCString trCopyright()
-    {
-      // Note: I will left it as is because "Direitos de autor" may not fit
-      // in the text.
-      return "Copyright";
-    }
-
-    /*! Header for the graph showing the directory dependencies */
-    virtual QCString trDirDepGraph(const QCString &name)
-    { return QCString("Grafo de dependências do directório ")+name+":"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.8.0
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Detail level selector shown for hierarchical indices */
-    virtual QCString trDetailLevel()
-    { return "nível de detalhes"; }
-
-    /*! Section header for list of template parameters */
-    virtual QCString trTemplateParameters()
-    { return "Parâmetros de template"; }
-
-    /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
-    virtual QCString trAndMore(const QCString &number)
-    { return "e "+number+" mais..."; }
-
-    /*! Used file list for a Java enum */
-    virtual QCString trEnumGeneratedFromFiles(bool single)
-    { QCString result = "A documentação para esta enumeração foi gerada a partir";
-      if (single) {
-        result += "do seguinte ficheiro:";
-      } else {
-        result += "dos seguintes ficheiros:";
-      }
-      return result;
-    }
-
-    /*! Header of a Java enum page (Java enums are represented as classes). */
-    virtual QCString trEnumReference(const QCString &name)
-    {
-      QCString result = "Referência da enumeração ";
-      return result + name;
-    }
-
-    /*! Used for a section containing inherited members */
-    virtual QCString trInheritedFrom(const QCString &members,const QCString &what)
-    { return QCString(members)+" herdados de "+what; }
-
-    /*! Header of the sections with inherited members specific for the
-     *  base class(es)
-     */
-    virtual QCString trAdditionalInheritedMembers()
-    { return "Outros membros herdados"; }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.8.2
-//////////////////////////////////////////////////////////////////////////
-
-    /*! Used as a tooltip for the toggle button that appears in the
-     *  navigation tree in the HTML output when GENERATE_TREEVIEW is
-     *  enabled. This tooltip explains the meaning of the button.
-     */
-    virtual QCString trPanelSynchronisationTooltip(bool enable)
-    {
-      QCString opt = enable ? "ativar" : "desativar";
-      return "clique para "+opt+" a sincronização do painel";
-    }
-
-    /*! Used in a method of an Objective-C class that is declared in a
-     *  a category. Note that the @1 marker is required and is replaced
-     *  by a link.
-     */
-    virtual QCString trProvidedByCategory()
-    {
-      return "Provido pela categoria @0.";
-    }
-
-    /*! Used in a method of an Objective-C category that extends a class.
-     *  Note that the @1 marker is required and is replaced by a link to
-     *  the class method.
-     */
-    virtual QCString trExtendsClass()
-    {
-      return "estende a classe @0.";
-    }
-
-    /*! Used as the header of a list of class methods in Objective-C.
-     *  These are similar to static public member functions in C++.
-     */
-    virtual QCString trClassMethods()
-    {
-      return "Métodos de classe";
-    }
-
-    /*! Used as the header of a list of instance methods in Objective-C.
-     *  These are similar to public member functions in C++.
-     */
-    virtual QCString trInstanceMethods()
-    {
-      return "Métodos de instância";
-    }
-
-    /*! Used as the header of the member functions of an Objective-C class.
-     */
-    virtual QCString trMethodDocumentation()
-    {
-      return "Documentação do método";
-    }
-
-//////////////////////////////////////////////////////////////////////////
-// new since 1.8.4
-//////////////////////////////////////////////////////////////////////////
-
-    /** old style UNO IDL services: implemented interfaces */
-    virtual QCString trInterfaces()
-    { return "Interfaces Exportadas"; }
-
-    /** old style UNO IDL services: inherited services */
-    virtual QCString trServices()
-    { return "Serviços Incluídos"; }
-
-    /** UNO IDL constant groups */
-    virtual QCString trConstantGroups()
-    { return "Grupos de Constantes"; }
-
-    /** UNO IDL constant groups */
-    virtual QCString trConstantGroupReference(const QCString &namespaceName)
-    {
-      QCString result = "Referência do grupo de constantes ";
-      result += namespaceName;
-      return result;
-    }
-
-    /** UNO IDL service page title */
-    virtual QCString trServiceReference(const QCString &sName)
-    {
-      QCString result = "Referência do serviço ";
-      result += sName;
-      return result;
-    }
-
-    /** UNO IDL singleton page title */
-    virtual QCString trSingletonReference(const QCString &sName)
-    {
-      QCString result = "Referência do Singleton ";
-      result += sName;
-      return result;
-    }
-
-    /** UNO IDL service page */
-    virtual QCString trServiceGeneratedFromFiles(bool single)
-    {
-      // single is true implies a single file
-      QCString result="A documentação para este serviço "
-                                "foi gerada a partir ";
-      if (single) {
-        result+="do seguinte ficheiro:";
-      } else {
-        result+="dos: seguintes ficheiros:";
-      }
-      return result;
-    }
-
-    /** UNO IDL singleton page */
-    virtual QCString trSingletonGeneratedFromFiles(bool single)
-    {
-      // single is true implies a single file
-      QCString result="A documentação para este singleton "
-                                "foi gerada a partir ";
-      if (single) {
-        result+="do seguinte ficheiro:";
-      } else {
-        result+="dos: seguintes ficheiros:";
-      }
-
-      return result;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    // new since 1.8.15
-    //////////////////////////////////////////////////////////////////////////
-
-    /** VHDL design unit hierarchy */
-    virtual QCString trDesignUnitHierarchy()
-    { return "Hierarquia da Unidade de Design"; }
-    /** VHDL design unit list */
-    virtual QCString trDesignUnitList()
-    { return "Lista de Unidades de Design"; }
-    /** VHDL design unit members */
-    virtual QCString trDesignUnitMembers()
-    { return "Membros da Unidade de Design"; }
-    /** VHDL design unit list description */
-    virtual QCString trDesignUnitListDescription()
-    {
-        return "Esta é uma lista de todos os membros de unidades de design "
-        		"com ligações para as entidades às quais pertencem:";
-    }
-    /** VHDL design unit index */
-    virtual QCString trDesignUnitIndex()
-    { return "Índice de Unidades de Design"; }
-    /** VHDL design units */
-    virtual QCString trDesignUnits()
-    { return "Unidades de Design"; }
-    /** VHDL functions/procedures/processes */
-    virtual QCString trFunctionAndProc()
-    { return "Funções/Procedimentos/Processos"; }
-    /** VHDL type */
-    virtual QCString trVhdlType(uint64 type,bool single)
-    {
-      switch(type)
-      {
-        case VhdlDocGen::LIBRARY:
-          if (single) return "Biblioteca";
-          else        return "Bibliotecas";
-        case VhdlDocGen::PACKAGE:
-          if (single) return "Pacote";
-          else        return "Pacotes";
-        case VhdlDocGen::SIGNAL:
-          if (single) return "Sinal";
-          else        return "Sinais";
-        case VhdlDocGen::COMPONENT:
-          if (single) return "Componente";
-          else        return "Componentes";
-        case VhdlDocGen::CONSTANT:
-          if (single) return "Constante";
-          else        return "Constantes";
-        case VhdlDocGen::ENTITY:
-          if (single) return "Entidade";
-          else        return "Entidades";
-        case VhdlDocGen::TYPE:
-          if (single) return "Tipo";
-          else        return "Tipos";
-        case VhdlDocGen::SUBTYPE:
-          if (single) return "Subtipo";
-          else        return "Subtipos";
-        case VhdlDocGen::FUNCTION:
-          if (single) return "Função";
-          else        return "Funções";
-        case VhdlDocGen::RECORD:
-          if (single) return "Registro";
-          else        return "Registros";
-        case VhdlDocGen::PROCEDURE:
-          if (single) return "Procedimento";
-          else        return "Procedimentos";
-        case VhdlDocGen::ARCHITECTURE:
-          if (single) return "Arquitetura";
-          else        return "Arquiteturas";
-        case VhdlDocGen::ATTRIBUTE:
-          if (single) return "Atributo";
-          else        return "Atributos";
-        case VhdlDocGen::PROCESS:
-          if (single) return "Processo";
-          else        return "Processos";
-        case VhdlDocGen::PORT:
-          if (single) return "Porta";
-          else        return "Portas";
-        case VhdlDocGen::USE:
-          if (single) return "cláusula de uso";
-          else        return "cláusulas de uso";
-        case VhdlDocGen::GENERIC:
-          if (single) return "Generico";
-          else        return "Genericos";
-        case VhdlDocGen::PACKAGE_BODY:
-          return "Corpo do Pacote";
-        case VhdlDocGen::UNITS:
-          return "Unidades";
-        case VhdlDocGen::SHAREDVARIABLE:
-          if (single) return "Variável Compartilhada";
-          else        return "Variáveis Compartilhadas";
-        case VhdlDocGen::VFILE:
-          if (single) return "Ficheiro";
-          else        return "Ficheiros";
-        case VhdlDocGen::GROUP:
-          if (single) return "Grupo";
-          else        return "Grupos";
-        case VhdlDocGen::INSTANTIATION:
-          if (single) return "Instância";
-          else        return "Instâncias";
-        case VhdlDocGen::ALIAS:
-          if (single) return "Apelido";
-          else        return "Apelidos";
-        case VhdlDocGen::CONFIG:
-          if (single) return "Configuração";
-          else        return "Configurações";
-        case VhdlDocGen::MISCELLANEOUS:
-          return "Outros"; // Is this correct for VHDL?
-        case VhdlDocGen::UCF_CONST:
-          return "Restrições";
-        default:
-          return "Classe";
-      }
-    }
-    virtual QCString trCustomReference(const QCString &name)
-    { return "Referência de " + QCString(name); }
-
-    /* Slice */
-    virtual QCString trConstants()
-    {
+        return "Bibliotecas";
+    case VhdlDocGen::PACKAGE:
+      if (single)
+        return "Pacote";
+      else
+        return "Pacotes";
+    case VhdlDocGen::SIGNAL:
+      if (single)
+        return "Sinal";
+      else
+        return "Sinais";
+    case VhdlDocGen::COMPONENT:
+      if (single)
+        return "Componente";
+      else
+        return "Componentes";
+    case VhdlDocGen::CONSTANT:
+      if (single)
+        return "Constante";
+      else
         return "Constantes";
+    case VhdlDocGen::ENTITY:
+      if (single)
+        return "Entidade";
+      else
+        return "Entidades";
+    case VhdlDocGen::TYPE:
+      if (single)
+        return "Tipo";
+      else
+        return "Tipos";
+    case VhdlDocGen::SUBTYPE:
+      if (single)
+        return "Subtipo";
+      else
+        return "Subtipos";
+    case VhdlDocGen::FUNCTION:
+      if (single)
+        return "Função";
+      else
+        return "Funções";
+    case VhdlDocGen::RECORD:
+      if (single)
+        return "Registro";
+      else
+        return "Registros";
+    case VhdlDocGen::PROCEDURE:
+      if (single)
+        return "Procedimento";
+      else
+        return "Procedimentos";
+    case VhdlDocGen::ARCHITECTURE:
+      if (single)
+        return "Arquitetura";
+      else
+        return "Arquiteturas";
+    case VhdlDocGen::ATTRIBUTE:
+      if (single)
+        return "Atributo";
+      else
+        return "Atributos";
+    case VhdlDocGen::PROCESS:
+      if (single)
+        return "Processo";
+      else
+        return "Processos";
+    case VhdlDocGen::PORT:
+      if (single)
+        return "Porta";
+      else
+        return "Portas";
+    case VhdlDocGen::USE:
+      if (single)
+        return "cláusula de uso";
+      else
+        return "cláusulas de uso";
+    case VhdlDocGen::GENERIC:
+      if (single)
+        return "Generico";
+      else
+        return "Genericos";
+    case VhdlDocGen::PACKAGE_BODY:
+      return "Corpo do Pacote";
+    case VhdlDocGen::UNITS:
+      return "Unidades";
+    case VhdlDocGen::SHAREDVARIABLE:
+      if (single)
+        return "Variável Compartilhada";
+      else
+        return "Variáveis Compartilhadas";
+    case VhdlDocGen::VFILE:
+      if (single)
+        return "Ficheiro";
+      else
+        return "Ficheiros";
+    case VhdlDocGen::GROUP:
+      if (single)
+        return "Grupo";
+      else
+        return "Grupos";
+    case VhdlDocGen::INSTANTIATION:
+      if (single)
+        return "Instância";
+      else
+        return "Instâncias";
+    case VhdlDocGen::ALIAS:
+      if (single)
+        return "Apelido";
+      else
+        return "Apelidos";
+    case VhdlDocGen::CONFIG:
+      if (single)
+        return "Configuração";
+      else
+        return "Configurações";
+    case VhdlDocGen::MISCELLANEOUS:
+      return "Outros"; // Is this correct for VHDL?
+    case VhdlDocGen::UCF_CONST:
+      return "Restrições";
+    default:
+      return "Classe";
     }
-    virtual QCString trConstantDocumentation()
-    {
-        return "Constantes";
-    }
-    virtual QCString trSequences()
-    {
-        return "Sequências";
-    }
-    virtual QCString trSequenceDocumentation()
-    {
-        return "Sequências";
-    }
-    virtual QCString trDictionaries()
-    {
-        return "Dicionários";
-    }
-    virtual QCString trDictionaryDocumentation()
-    {
-        return "Dicionários";
-    }
-    virtual QCString trSliceInterfaces()
-    {
-        return "Interfaces";
-    }
-    virtual QCString trInterfaceIndex()
-    {
-        return "Índice de Interfaces";
-    }
-    virtual QCString trInterfaceList()
-    {
-        return "Lista de Interfaces";
-    }
-    virtual QCString trInterfaceListDescription()
-    {
-        return "Estas são as interfaces com suas respectivas descrições:";
-    }
-    virtual QCString trInterfaceHierarchy()
-    {
-        return "Hierarquia de Interfaces";
-    }
-    virtual QCString trInterfaceHierarchyDescription()
-    {
-        return "Esta é a lista parcialmente ordenadas de heranças:";
-    }
-    virtual QCString trInterfaceDocumentation()
-    {
-        return "Interfaces";
-    }
-    virtual QCString trStructs()
-    {
-        return "Estruturas";
-    }
-    virtual QCString trStructIndex()
-    {
-        return "Índice de Estruturas";
-    }
-    virtual QCString trStructList()
-    {
-        return "Lista de Estruturas";
-    }
-    virtual QCString trStructListDescription()
-    {
-        return "Estas são as estruturas com suas respectivas descrições:";
-    }
-    virtual QCString trStructDocumentation()
-    {
-        return "Estruturas";
-    }
-    virtual QCString trExceptionIndex()
-    {
-        return "Índice the Exceções";
-    }
-    virtual QCString trExceptionList()
-    {
-        return "Lista de Exceções";
-    }
-    virtual QCString trExceptionListDescription()
-    {
-        return "Estas são as exceções com suas respectivas descrições:";
-    }
-    virtual QCString trExceptionHierarchy()
-    {
-        return "Hierarquia de Exceções";
-    }
-    virtual QCString trExceptionHierarchyDescription()
-    {
-        return "Esta é a lista parcialmente ordenadas de heranças:";
-    }
-    virtual QCString trExceptionDocumentation()
-    {
-        return "Exceções";
-    }
-    virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
-    {
-      QCString result="Referência ";
-      switch(compType)
-      {
-        case ClassDef::Class:      result+="da Classe "; break;
-        case ClassDef::Struct:     result+="da Estrutura "; break;
-        case ClassDef::Union:      result+="da União "; break;
-        case ClassDef::Interface:  result+="da Interface "; break;
-        case ClassDef::Protocol:   result+="do Protocolo "; break;
-        case ClassDef::Category:   result+="da Categoria "; break;
-        case ClassDef::Exception:  result+="da Exceção "; break;
-        default: break;
-      }
-      if (isLocal) result+="Local ";
-      result+= clName;
-      return result;
-    }
-    virtual QCString trOperations()
-    {
-        return "Operações";
-    }
-    virtual QCString trOperationDocumentation()
-    {
-        return "Operações";
-    }
-    virtual QCString trDataMembers()
-    {
-        return "Dados Membros";
-    }
-    virtual QCString trDataMemberDocumentation()
-    {
-        return "Dados Membros";
-    }
+  }
+  virtual QCString trCustomReference(const QCString &name)
+  {
+    return "Referência de " + QCString(name);
+  }
 
-    //////////////////////////////////////////////////////////////////////////
-    // new since 1.8.19
-    //////////////////////////////////////////////////////////////////////////
-
-    /** VHDL design unit documentation */
-	virtual QCString trDesignUnitDocumentation()
-	{
-	    return "Documentação da Unidade de Projeto";
+  /* Slice */
+  virtual QCString trConstants()
+  {
+    return "Constantes";
+  }
+  virtual QCString trConstantDocumentation()
+  {
+    return "Constantes";
+  }
+  virtual QCString trSequences()
+  {
+    return "Sequências";
+  }
+  virtual QCString trSequenceDocumentation()
+  {
+    return "Sequências";
+  }
+  virtual QCString trDictionaries()
+  {
+    return "Dicionários";
+  }
+  virtual QCString trDictionaryDocumentation()
+  {
+    return "Dicionários";
+  }
+  virtual QCString trSliceInterfaces()
+  {
+    return "Interfaces";
+  }
+  virtual QCString trInterfaceIndex()
+  {
+    return "Índice de Interfaces";
+  }
+  virtual QCString trInterfaceList()
+  {
+    return "Lista de Interfaces";
+  }
+  virtual QCString trInterfaceListDescription()
+  {
+    return "Estas são as interfaces com suas respectivas descrições:";
+  }
+  virtual QCString trInterfaceHierarchy()
+  {
+    return "Hierarquia de Interfaces";
+  }
+  virtual QCString trInterfaceHierarchyDescription()
+  {
+    return "Esta é a lista parcialmente ordenadas de heranças:";
+  }
+  virtual QCString trInterfaceDocumentation()
+  {
+    return "Interfaces";
+  }
+  virtual QCString trStructs()
+  {
+    return "Estruturas";
+  }
+  virtual QCString trStructIndex()
+  {
+    return "Índice de Estruturas";
+  }
+  virtual QCString trStructList()
+  {
+    return "Lista de Estruturas";
+  }
+  virtual QCString trStructListDescription()
+  {
+    return "Estas são as estruturas com suas respectivas descrições:";
+  }
+  virtual QCString trStructDocumentation()
+  {
+    return "Estruturas";
+  }
+  virtual QCString trExceptionIndex()
+  {
+    return "Índice the Exceções";
+  }
+  virtual QCString trExceptionList()
+  {
+    return "Lista de Exceções";
+  }
+  virtual QCString trExceptionListDescription()
+  {
+    return "Estas são as exceções com suas respectivas descrições:";
+  }
+  virtual QCString trExceptionHierarchy()
+  {
+    return "Hierarquia de Exceções";
+  }
+  virtual QCString trExceptionHierarchyDescription()
+  {
+    return "Esta é a lista parcialmente ordenadas de heranças:";
+  }
+  virtual QCString trExceptionDocumentation()
+  {
+    return "Exceções";
+  }
+  virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
+  {
+    QCString result = "Referência ";
+    switch (compType)
+    {
+    case ClassDef::Class:
+      result += "da Classe ";
+      break;
+    case ClassDef::Struct:
+      result += "da Estrutura ";
+      break;
+    case ClassDef::Union:
+      result += "da União ";
+      break;
+    case ClassDef::Interface:
+      result += "da Interface ";
+      break;
+    case ClassDef::Protocol:
+      result += "do Protocolo ";
+      break;
+    case ClassDef::Category:
+      result += "da Categoria ";
+      break;
+    case ClassDef::Exception:
+      result += "da Exceção ";
+      break;
+    default:
+      break;
     }
+    if (isLocal)
+      result += "Local ";
+    result += clName;
+    return result;
+  }
+  virtual QCString trOperations()
+  {
+    return "Operações";
+  }
+  virtual QCString trOperationDocumentation()
+  {
+    return "Operações";
+  }
+  virtual QCString trDataMembers()
+  {
+    return "Dados Membros";
+  }
+  virtual QCString trDataMemberDocumentation()
+  {
+    return "Dados Membros";
+  }
 
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.8.19
+  //////////////////////////////////////////////////////////////////////////
 
-	//////////////////////////////////////////////////////////////////////////
-	// new since 1.9.2
-	//////////////////////////////////////////////////////////////////////////
-	/** C++20 concept */
-	virtual QCString trConcept(bool first_capital, bool singular)
-	{
-	  QCString result((first_capital ? "Conceito" : "conceito"));
-	  if (!singular) result+="s";
-	  return result;
-	}
-	/*! used as the title of the HTML page of a C++20 concept page */
-	virtual QCString trConceptReference(const QCString &conceptName)
-	{
-	  QCString result= "Referência do Conceito ";
-	  result+=conceptName;
-	  return result;
-	}
+  /** VHDL design unit documentation */
+  virtual QCString trDesignUnitDocumentation()
+  {
+    return "Documentação da Unidade de Projeto";
+  }
 
-	/*! used as the title of page containing all the index of all concepts. */
-	virtual QCString trConceptList()
-	{ return "Lista de Conceitos"; }
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.9.2
+  //////////////////////////////////////////////////////////////////////////
+  /** C++20 concept */
+  virtual QCString trConcept(bool first_capital, bool singular)
+  {
+    QCString result((first_capital ? "Conceito" : "conceito"));
+    if (!singular)
+      result += "s";
+    return result;
+  }
+  /*! used as the title of the HTML page of a C++20 concept page */
+  virtual QCString trConceptReference(const QCString &conceptName)
+  {
+    QCString result = "Referência do Conceito ";
+    result += conceptName;
+    return result;
+  }
 
-	/*! used as the title of chapter containing the index listing all concepts. */
-	virtual QCString trConceptIndex()
-	{ return "Índice de Conceitos"; }
+  /*! used as the title of page containing all the index of all concepts. */
+  virtual QCString trConceptList()
+  {
+    return "Lista de Conceitos";
+  }
 
-	/*! used as the title of chapter containing all information about concepts. */
-	virtual QCString trConceptDocumentation()
-	{ return "Documentação do Conceito"; }
+  /*! used as the title of chapter containing the index listing all concepts. */
+  virtual QCString trConceptIndex()
+  {
+    return "Índice de Conceitos";
+  }
 
-	/*! used as an introduction to the concept list */
-	virtual QCString trConceptListDescription(bool extractAll)
-	{
-	  QCString result="Esta é a lista de todos os conceitos ";
-	  if (!extractAll) result+="documentados ";
-	  result+="com suas respectivas descrições:";
-	  return result;
-	}
+  /*! used as the title of chapter containing all information about concepts. */
+  virtual QCString trConceptDocumentation()
+  {
+    return "Documentação do Conceito";
+  }
 
-	/*! used to introduce the definition of the C++20 concept */
-	virtual QCString trConceptDefinition()
-	{
-	  return "Definição de conceito";
-	}
+  /*! used as an introduction to the concept list */
+  virtual QCString trConceptListDescription(bool extractAll)
+  {
+    QCString result = "Esta é a lista de todos os conceitos ";
+    if (!extractAll)
+      result += "documentados ";
+    result += "com suas respectivas descrições:";
+    return result;
+  }
 
-	//////////////////////////////////////////////////////////////////////////
-	// new since 1.9.4
-	//////////////////////////////////////////////////////////////////////////
-    virtual QCString trPackageList()
-    { return "Lista de pacotes"; }
+  /*! used to introduce the definition of the C++20 concept */
+  virtual QCString trConceptDefinition()
+  {
+    return "Definição de conceito";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.9.4
+  //////////////////////////////////////////////////////////////////////////
+  virtual QCString trPackageList()
+  {
+    return "Lista de pacotes";
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // new since 1.9.6
+  //////////////////////////////////////////////////////////////////////////
+
+  /*! This is used for translation of the word that will be
+   *  followed by a single name of the VHDL process flowchart.
+   */
+  virtual QCString trFlowchart()
+  {
+    return "Fluxograma: ";
+  }
+
+  /*! Please translate also updated body of the method
+   *  trMemberFunctionDocumentation(), now better adapted for
+   *  VHDL sources documentation.
+   */
 };
 
 #endif

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 1997-2018 by Dimitri van Heesch.
+ * Copyright (C) 1997-2022 by Dimitri van Heesch.
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation under the terms of the GNU General Public License is hereby
@@ -27,7 +27,7 @@
  * ---------------
  * History:
  * 20220911:
- *  - Updated to 1.9.6;
+ *  - Updated to 1.9.6;  
  * 20220525:
  * 	- Updated to 1.9.4;
  * 20211003:
@@ -68,2703 +68,2329 @@
 #ifndef TRANSLATOR_PT_H
 #define TRANSLATOR_PT_H
 
+
 class TranslatorPortuguese : public Translator
 {
-public:
-  // --- Language control methods -------------------
+  public:
 
-  /*! Used for identification of the language. The identification
-   * should not be translated. It should be replaced by the name
-   * of the language in English using lower-case characters only
-   * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
-   * the identification used in language.cpp.
-   */
-  QCString idLanguage()
-  {
-    return "portuguese";
-  }
+    // --- Language control methods -------------------
 
-  /*! Used to get the LaTeX command(s) for the language support.
-   *  This method should return string with commands that switch
-   *  LaTeX to the desired language.  For example
-   *  <pre>"\\usepackage[german]{babel}\n"
-   *  </pre>
-   *  or
-   *  <pre>"\\usepackage{polski}\n"
-   *  "\\usepackage[latin2]{inputenc}\n"
-   *  "\\usepackage[T1]{fontenc}\n"
-   *  </pre>
-   *
-   * The English LaTeX does not use such commands.  Because of this
-   * the empty string is returned in this implementation.
-   */
-  virtual QCString latexLanguageSupportCommand()
-  {
-    return "\\usepackage[portuges]{babel}\n";
-  }
+    /*! Used for identification of the language. The identification
+     * should not be translated. It should be replaced by the name
+     * of the language in English using lower-case characters only
+     * (e.g. "czech", "japanese", "russian", etc.). It should be equal to
+     * the identification used in language.cpp.
+     */
+    QCString idLanguage()
+    { return "portuguese"; }
 
-  virtual QCString trISOLang()
-  {
-    return "pt";
-  }
-  virtual QCString getLanguageString()
-  {
-    return "0x816 Portuguese(Portugal)";
-  }
-
-  // --- Language translation methods -------------------
-
-  /*! used in the compound documentation before a list of related functions. */
-  QCString trRelatedFunctions()
-  {
-    return "Funções associadas";
-  }
-
-  /*! subscript for the related functions. */
-  QCString trRelatedSubscript()
-  {
-    return "(Note que não são funções membro)";
-  }
-
-  /*! header that is put before the detailed description of files, classes and namespaces. */
-  QCString trDetailedDescription()
-  {
-    return "Descrição detalhada";
-  }
-
-  /*! header that is put before the list of typedefs. */
-  QCString trMemberTypedefDocumentation()
-  {
-    return "Documentação das definições de tipos";
-  }
-
-  /*! header that is put before the list of enumerations. */
-  QCString trMemberEnumerationDocumentation()
-  {
-    return "Documentação das enumerações";
-  }
-
-  /*! header that is put before the list of member functions. */
-  QCString trMemberFunctionDocumentation()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+    /*! Used to get the LaTeX command(s) for the language support.
+     *  This method should return string with commands that switch
+     *  LaTeX to the desired language.  For example
+     *  <pre>"\\usepackage[german]{babel}\n"
+     *  </pre>
+     *  or
+     *  <pre>"\\usepackage{polski}\n"
+     *  "\\usepackage[latin2]{inputenc}\n"
+     *  "\\usepackage[T1]{fontenc}\n"
+     *  </pre>
+     *
+     * The English LaTeX does not use such commands.  Because of this
+     * the empty string is returned in this implementation.
+     */
+    virtual QCString latexLanguageSupportCommand()
     {
-      return "Documentação das funções, procedimentos e processos";
+      return
+        "\\usepackage[portuges]{babel}\n";
     }
-    else
+
+    virtual QCString trISOLang()
     {
-      return "Documentação das funções";
+      return "pt";
     }
-  }
-
-  /*! header that is put before the list of member attributes. */
-  QCString trMemberDataDocumentation()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    virtual QCString getLanguageString()
     {
-      return "Documentação dos campos e atributos";
+      return "0x816 Portuguese(Portugal)";
     }
-    else
-    {
-      return "Documentação dos dados membro";
+
+    // --- Language translation methods -------------------
+
+    /*! used in the compound documentation before a list of related functions. */
+    QCString trRelatedFunctions()
+    { return "Funções associadas"; }
+
+    /*! subscript for the related functions. */
+    QCString trRelatedSubscript()
+    { return "(Note que não são funções membro)"; }
+
+    /*! header that is put before the detailed description of files, classes and namespaces. */
+    QCString trDetailedDescription()
+    { return "Descrição detalhada"; }
+
+    /*! header that is put before the list of typedefs. */
+    QCString trMemberTypedefDocumentation()
+    { return "Documentação das definições de tipo"; }
+
+    /*! header that is put before the list of enumerations. */
+    QCString trMemberEnumerationDocumentation()
+    { return "Documentação das enumerações"; }
+
+    /*! header that is put before the list of member functions. */
+    QCString trMemberFunctionDocumentation()
+    { 
+        if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+        {
+          return "Documentação das funções, procedimentos e processos";
+        }
+        else
+        {
+            return "Documentação das funções";
+        }    
     }
-  }
 
-  /*! this is the text of a link put after brief descriptions. */
-  QCString trMore()
-  {
-    return "Mais...";
-  }
-
-  /*! put in the class documentation */
-  QCString trListOfAllMembers()
-  {
-    return "Mostrar lista completa dos membros";
-  }
-
-  /*! used as the title of the "list of all members" page of a class */
-  QCString trMemberList()
-  {
-    return "Lista dos membros";
-  }
-
-  /*! this is the first part of a sentence that is followed by a class name */
-  QCString trThisIsTheListOfAllMembers()
-  {
-    return "Lista completa de todos os membros de ";
-  }
-
-  /*! this is the remainder of the sentence after the class name */
-  QCString trIncludingInheritedMembers()
-  {
-    return ", incluindo todos os membros herdados.";
-  }
-
-  /*! this is put at the author sections at the bottom of man pages.
-   *  parameter s is name of the project name.
-   */
-  QCString trGeneratedAutomatically(const QCString &s)
-  {
-    QCString result = "Gerado automaticamente por Doxygen";
-    if (!s.isEmpty())
-      result += " para " + s;
-    result += " a partir do código fonte.";
-    return result;
-  }
-
-  /*! put after an enum name in the list of all members */
-  QCString trEnumName()
-  {
-    return "enumeração";
-  }
-
-  /*! put after an enum value in the list of all members */
-  QCString trEnumValue()
-  {
-    return "valor enumerado";
-  }
-
-  /*! put after an undocumented member in the list of all members */
-  QCString trDefinedIn()
-  {
-    return "definido em";
-  }
-
-  // quick reference sections
-
-  /*! This is put above each page as a link to the list of all groups of
-   *  compounds or files (see the \\group command).
-   */
-  QCString trModules()
-  {
-    return "Módulos";
-  }
-
-  /*! This is put above each page as a link to the class hierarchy */
-  QCString trClassHierarchy()
-  {
-    return "Hierarquia de classes";
-  }
-
-  /*! This is put above each page as a link to the list of annotated classes */
-  QCString trCompoundList()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      return "Estruturas de dados";
-    }
-    else
-    {
-      return "Lista de componentes";
-    }
-  }
-
-  /*! This is put above each page as a link to the list of documented files */
-  QCString trFileList()
-  {
-    return "Lista de ficheiros";
-  }
-
-  /*! This is put above each page as a link to all members of compounds. */
-  QCString trCompoundMembers()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      return "Campos de dados";
-    }
-    else
-    {
-      return "Componentes membro";
-    }
-  }
-
-  /*! This is put above each page as a link to all members of files. */
-  QCString trFileMembers()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      return "Globais";
-    }
-    else
-    {
-      return "Membros dos Ficheiros";
-    }
-  }
-
-  /*! This is put above each page as a link to all related pages. */
-  QCString trRelatedPages()
-  {
-    return "Páginas relacionadas";
-  }
-
-  /*! This is put above each page as a link to all examples. */
-  QCString trExamples()
-  {
-    return "Exemplos";
-  }
-
-  /*! This is put above each page as a link to the search engine. */
-  QCString trSearch()
-  {
-    return "Localizar";
-  }
-
-  /*! This is an introduction to the class hierarchy. */
-  QCString trClassHierarchyDescription()
-  {
-    return "Esta lista de heranças está organizada, dentro do possível, por ordem alfabética:";
-  }
-
-  /*! This is an introduction to the list with all files. */
-  QCString trFileListDescription(bool extractAll)
-  {
-    QCString result = "Lista de todos os ficheiros ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "com uma breve descrição:";
-    return result;
-  }
-
-  /*! This is an introduction to the annotated compound list. */
-  QCString trCompoundListDescription()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      return "Lista das estruturas de dados com uma breve descrição:";
-    }
-    else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
-    {
-      return "Lista de classes com uma breve descrição:";
-    }
-    else
-    {
-      return "Lista de classes, estruturas, uniões e interfaces com uma breve descrição:";
-    }
-  }
-
-  /*! This is an introduction to the page with all class members. */
-  QCString trCompoundMembersDescription(bool extractAll)
-  {
-    QCString result = "Lista de todas as";
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
-    {
-      result += " estruturas e campos de uniões";
-    }
-    else
-    {
-      result += " classes membro";
-    }
-    if (!extractAll)
-    {
-      result += " documentadas";
-    }
-    result += " com referência para ";
-    if (!extractAll)
+    /*! header that is put before the list of member attributes. */
+    QCString trMemberDataDocumentation()
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        result += "a respectiva documentação:";
+        return "Documentação dos campos e atributos";
       }
       else
       {
-        result += "a documentação de cada membro:";
+        return "Documentação dos dados membro";
       }
     }
-    else
+
+    /*! this is the text of a link put after brief descriptions. */
+    QCString trMore()
+    { return "Mais..."; }
+
+    /*! put in the class documentation */
+    QCString trListOfAllMembers()
+    { return "Mostrar lista completa dos membros"; }
+
+    /*! used as the title of the "list of all members" page of a class */
+    QCString trMemberList()
+    { return "Lista dos membros"; }
+
+    /*! this is the first part of a sentence that is followed by a class name */
+    QCString trThisIsTheListOfAllMembers()
+    { return "Lista completa de todos os membros de "; }
+
+    /*! this is the remainder of the sentence after the class name */
+    QCString trIncludingInheritedMembers()
+    { return ", incluindo todos os membros herdados."; }
+
+    /*! this is put at the author sections at the bottom of man pages.
+     *  parameter s is name of the project name.
+     */
+    QCString trGeneratedAutomatically(const QCString &s)
+    { QCString result="Gerado automaticamente por Doxygen";
+      if (!s.isEmpty()) result+=" para "+s;
+      result+=" a partir do código fonte.";
+      return result;
+    }
+
+    /*! put after an enum name in the list of all members */
+    QCString trEnumName()
+    { return "enumeração"; }
+
+    /*! put after an enum value in the list of all members */
+    QCString trEnumValue()
+    { return "valor enumerado"; }
+
+    /*! put after an undocumented member in the list of all members */
+    QCString trDefinedIn()
+    { return "definido em"; }
+
+    // quick reference sections
+
+    /*! This is put above each page as a link to the list of all groups of
+     *  compounds or files (see the \\group command).
+     */
+    QCString trModules()
+    { return "Módulos"; }
+
+    /*! This is put above each page as a link to the class hierarchy */
+    QCString trClassHierarchy()
+    { return "Hierarquia de classes"; }
+
+    /*! This is put above each page as a link to the list of annotated classes */
+    QCString trCompoundList()
     {
       if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
       {
-        result += "as estruturas/uniões a que pertencem:";
+        return "Estruturas de dados";
       }
       else
       {
-        result += "as classes a que pertencem:";
+        return "Lista de componentes";
       }
     }
-    return result;
-  }
 
-  /*! This is an introduction to the page with all file members. */
-  QCString trFileMembersDescription(bool extractAll)
-  {
-    QCString result = "Lista de ";
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! This is put above each page as a link to the list of documented files */
+    QCString trFileList()
+    { return "Lista de ficheiros"; }
+
+    /*! This is put above each page as a link to all members of compounds. */
+    QCString trCompoundMembers()
     {
-      result += "todas as funções, variáveis, definições, enumerações e definições de tipo ";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Campos de dados";
+      }
+      else
+      {
+        return "Componentes membro";
+      }
+    }
+
+    /*! This is put above each page as a link to all members of files. */
+    QCString trFileMembers()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Globais";
+      }
+      else
+      {
+        return "Membros dos Ficheiros";
+      }
+    }
+
+    /*! This is put above each page as a link to all related pages. */
+    QCString trRelatedPages()
+    { return "Páginas relacionadas"; }
+
+    /*! This is put above each page as a link to all examples. */
+    QCString trExamples()
+    { return "Exemplos"; }
+
+    /*! This is put above each page as a link to the search engine. */
+    QCString trSearch()
+    { return "Localizar"; }
+
+    /*! This is an introduction to the class hierarchy. */
+    QCString trClassHierarchyDescription()
+    { return "Esta lista de heranças está organizada, dentro do possível, por ordem alfabética:"; }
+
+    /*! This is an introduction to the list with all files. */
+    QCString trFileListDescription(bool extractAll)
+    {
+      QCString result="Lista de todos os ficheiros ";
+      if (!extractAll) result+="documentados ";
+      result+="com uma breve descrição:";
+      return result;
+    }
+
+    /*! This is an introduction to the annotated compound list. */
+    QCString trCompoundListDescription()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Lista das estruturas de dados com uma breve descrição:";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
+      {
+        return "Lista de classes com uma breve descrição:";
+      }
+      else
+      {
+        return "Lista de classes, estruturas, uniões e interfaces com uma breve descrição:";
+      }
+    }
+
+    /*! This is an introduction to the page with all class members. */
+    QCString trCompoundMembersDescription(bool extractAll)
+    {
+      QCString result="Lista de todas as";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        result+=" estruturas e campos de uniões";
+      }
+      else
+      {
+        result+=" classes membro";
+      }
       if (!extractAll)
-        result += "documentadas ";
-    }
-    else
-    {
-      result += "todos os ficheiros membro ";
+      {
+        result+=" documentadas";
+      }
+      result+=" com referência para ";
       if (!extractAll)
-        result += "documentados ";
+      {
+        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+        {
+          result+="a respectiva documentação:";
+        }
+        else
+        {
+          result+="a documentação de cada membro:";
+        }
+      }
+      else
+      {
+        if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+        {
+          result+="as estruturas/uniões a que pertencem:";
+        }
+        else
+        {
+          result+="as classes a que pertencem:";
+        }
+      }
+      return result;
     }
-    result += "com referência para ";
-    if (extractAll)
-      result += "o ficheiro a que pertecem:";
-    else
-      result += "a respectiva documentação:";
-    return result;
-  }
 
-  /*! This is an introduction to the page with the list of all examples */
-  QCString trExamplesDescription()
-  {
-    return "Lista de todos os exemplos:";
-  }
-
-  /*! This is an introduction to the page with the list of related pages */
-  QCString trRelatedPagesDescription()
-  {
-    return "Lista de documentação relacionada:";
-  }
-
-  /*! This is an introduction to the page with the list of class/file groups */
-  QCString trModulesDescription()
-  {
-    return "Lista de todos os módulos:";
-  }
-
-  // index titles (the project name is prepended for these)
-
-  /*! This is used in HTML as the title of index.html. */
-  QCString trDocumentation()
-  {
-    return "Documentação";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * index of all groups.
-   */
-  QCString trModuleIndex()
-  {
-    return "Índice dos módulos";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * class hierarchy.
-   */
-  QCString trHierarchicalIndex()
-  {
-    return "Índice da hierarquia";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * annotated compound index.
-   */
-  QCString trCompoundIndex()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! This is an introduction to the page with all file members. */
+    QCString trFileMembersDescription(bool extractAll)
     {
-      return "Índice das estruturas de dados";
+      QCString result="Lista de ";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        result+="todas as funções, variáveis, definições, enumerações e definições de tipo ";
+        if (!extractAll) result+="documentadas ";
+      }
+      else
+      {
+        result+="todos os ficheiros membro ";
+        if (!extractAll) result+="documentados ";
+      }
+      result+="com referência para ";
+      if (extractAll)
+        result+="o ficheiro a que pertecem:";
+      else
+        result+="a respectiva documentação:";
+      return result;
     }
-    else
+
+    /*! This is an introduction to the page with the list of all examples */
+    QCString trExamplesDescription()
+    { return "Lista de todos os exemplos:"; }
+
+    /*! This is an introduction to the page with the list of related pages */
+    QCString trRelatedPagesDescription()
+    { return "Lista de documentação relacionada:"; }
+
+    /*! This is an introduction to the page with the list of class/file groups */
+    QCString trModulesDescription()
+    { return "Lista de todos os módulos:"; }
+
+    // index titles (the project name is prepended for these)
+
+
+    /*! This is used in HTML as the title of index.html. */
+    QCString trDocumentation()
+    { return "Documentação"; }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * index of all groups.
+     */
+    QCString trModuleIndex()
+    { return "Índice dos módulos"; }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * class hierarchy.
+     */
+    QCString trHierarchicalIndex()
+    { return "Índice da hierarquia"; }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * annotated compound index.
+     */
+    QCString trCompoundIndex()
     {
-      return "Índice dos componentes";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Índice das estruturas de dados";
+      }
+      else
+      {
+        return "Índice dos componentes";
+      }
     }
-  }
 
-  /*! This is used in LaTeX as the title of the chapter with the
-   * list of all files.
-   */
-  QCString trFileIndex()
-  {
-    return "Índice dos ficheiros";
-  }
+    /*! This is used in LaTeX as the title of the chapter with the
+     * list of all files.
+     */
+    QCString trFileIndex()
+    { return "Índice dos ficheiros"; }
 
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all groups.
-   */
-  QCString trModuleDocumentation()
-  {
-    return "Documentação do módulo";
-  }
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all groups.
+     */
+    QCString trModuleDocumentation()
+    { return "Documentação do módulo"; }
 
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all classes, structs and unions.
-   */
-  QCString trClassDocumentation()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all classes, structs and unions.
+     */
+    QCString trClassDocumentation()
     {
-      return "Documentação da estruturas de dados";
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Documentação da estruturas de dados";
+      }
+      else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+      {
+          return trDesignUnitDocumentation();
+      }
+      else
+      {
+        return "Documentação da classe";
+      }
     }
-    else if (Config_getBool(OPTIMIZE_OUTPUT_VHDL))
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all files.
+     */
+    QCString trFileDocumentation()
+    { return "Documentação do ficheiro"; }
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all examples.
+     */
+    QCString trExampleDocumentation()
+    { return "Documentação do exemplo"; }
+
+    /*! This is used in LaTeX as the title of the document */
+    QCString trReferenceManual()
+    { return "Manual de referência"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of defines
+     */
+    QCString trDefines()
+    { return "Macros"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of typedefs
+     */
+    QCString trTypedefs()
+    { return "Definições de tipos"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of enumerations
+     */
+    QCString trEnumerations()
+    { return "Enumerações"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) functions
+     */
+    QCString trFunctions()
+    { return "Funções"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) variables
+     */
+    QCString trVariables()
+    { return "Variáveis"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) variables
+     */
+    QCString trEnumerationValues()
+    { return "Valores de enumerações"; }
+
+    /*! This is used in the documentation of a file before the list of
+     *  documentation blocks for defines
+     */
+    QCString trDefineDocumentation()
+    { return "Documentação das macros"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for typedefs
+     */
+    QCString trTypedefDocumentation()
+    { return "Documentação dos tipos"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for enumeration types
+     */
+    QCString trEnumerationTypeDocumentation()
+    { return "Documentação dos valores da enumeração"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for functions
+     */
+    QCString trFunctionDocumentation()
+    { return "Documentação das funções"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for variables
+     */
+    QCString trVariableDocumentation()
+    { return "Documentação das variáveis"; }
+
+    /*! This is used in the documentation of a file/namespace/group before
+     *  the list of links to documented compounds
+     */
+    QCString trCompounds()
     {
-      return trDesignUnitDocumentation();
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Estruturas de Dados";
+      }
+      else
+      {
+        return "Componentes";
+      }
     }
-    else
+
+    /*! This is used in the standard footer of each page and indicates when
+     *  the page was generated
+     */
+    QCString trGeneratedAt(const QCString &date,const QCString &projName)
     {
-      return "Documentação da classe";
+      QCString result="Gerado em "+date;
+      if (!projName.isEmpty()) result+=" para "+projName;
+      result+=" por";
+      return result;
     }
-  }
 
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all files.
-   */
-  QCString trFileDocumentation()
-  {
-    return "Documentação do ficheiro";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all examples.
-   */
-  QCString trExampleDocumentation()
-  {
-    return "Documentação do exemplo";
-  }
-
-  /*! This is used in LaTeX as the title of the document */
-  QCString trReferenceManual()
-  {
-    return "Manual de referência";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of defines
-   */
-  QCString trDefines()
-  {
-    return "Macros";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of typedefs
-   */
-  QCString trTypedefs()
-  {
-    return "Definições de tipos";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of enumerations
-   */
-  QCString trEnumerations()
-  {
-    return "Enumerações";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) functions
-   */
-  QCString trFunctions()
-  {
-    return "Funções";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) variables
-   */
-  QCString trVariables()
-  {
-    return "Variáveis";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) variables
-   */
-  QCString trEnumerationValues()
-  {
-    return "Valores de enumerações";
-  }
-
-  /*! This is used in the documentation of a file before the list of
-   *  documentation blocks for defines
-   */
-  QCString trDefineDocumentation()
-  {
-    return "Documentação das macros";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for typedefs
-   */
-  QCString trTypedefDocumentation()
-  {
-    return "Documentação dos tipos";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for enumeration types
-   */
-  QCString trEnumerationTypeDocumentation()
-  {
-    return "Documentação dos valores da enumeração";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for functions
-   */
-  QCString trFunctionDocumentation()
-  {
-    return "Documentação das funções";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for variables
-   */
-  QCString trVariableDocumentation()
-  {
-    return "Documentação das variáveis";
-  }
-
-  /*! This is used in the documentation of a file/namespace/group before
-   *  the list of links to documented compounds
-   */
-  QCString trCompounds()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    /*! this text is put before a class diagram */
+    QCString trClassDiagram(const QCString &clName)
     {
-      return "Estruturas de Dados";
+      return "Diagrama de heranças da classe "+clName;
     }
-    else
+
+    /*! this text is generated when the \\warning command is used. */
+    QCString trWarning()
+    { return "Aviso"; }
+
+    /*! this text is generated when the \\version command is used. */
+    QCString trVersion()
+    { return "Versão"; }
+
+    /*! this text is generated when the \\date command is used. */
+    QCString trDate()
+    { return "Data"; }
+
+    /*! this text is generated when the \\return command is used. */
+    QCString trReturns()
+    { return "Retorna"; }
+
+    /*! this text is generated when the \\sa command is used. */
+    QCString trSeeAlso()
+    { return "Veja também"; }
+
+    /*! this text is generated when the \\param command is used. */
+    QCString trParameters()
+    { return "Parâmetros"; }
+
+    /*! this text is generated when the \\exception command is used. */
+    QCString trExceptions()
+    { return "Excepções"; }
+
+    /*! this text is used in the title page of a LaTeX document. */
+    QCString trGeneratedBy()
+    { return "Gerado por"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990307
+//////////////////////////////////////////////////////////////////////////
+
+    /*! used as the title of page containing all the index of all namespaces. */
+    virtual QCString trNamespaceList()
+    { return "Lista de namespaces"; }
+
+    /*! used as an introduction to the namespace list */
+    virtual QCString trNamespaceListDescription(bool extractAll)
     {
-      return "Componentes";
+      QCString result="Lista ";
+      if (!extractAll) result+="de toda a documentação ";
+      result+="dos namespaces com uma breve descrição:";
+      return result;
     }
-  }
 
-  /*! This is used in the standard footer of each page and indicates when
-   *  the page was generated
-   */
-  QCString trGeneratedAt(const QCString &date, const QCString &projName)
-  {
-    QCString result = "Gerado em " + date;
-    if (!projName.isEmpty())
-      result += " para " + projName;
-    result += " por";
-    return result;
-  }
+    /*! used in the class documentation as a header before the list of all
+     *  friends of a class
+     */
+    virtual QCString trFriends()
+    { return "Amigos"; }
 
-  /*! this text is put before a class diagram */
-  QCString trClassDiagram(const QCString &clName)
-  {
-    return "Diagrama de heranças da classe " + clName;
-  }
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990405
+//////////////////////////////////////////////////////////////////////////
 
-  /*! this text is generated when the \\warning command is used. */
-  QCString trWarning()
-  {
-    return "Aviso";
-  }
+    /*! used in the class documentation as a header before the list of all
+     * related classes
+     */
+    virtual QCString trRelatedFunctionDocumentation()
+    { return "Documentação das classes amigas e funções relacionadas"; }
 
-  /*! this text is generated when the \\version command is used. */
-  QCString trVersion()
-  {
-    return "Versão";
-  }
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990425
+//////////////////////////////////////////////////////////////////////////
 
-  /*! this text is generated when the \\date command is used. */
-  QCString trDate()
-  {
-    return "Data";
-  }
-
-  /*! this text is generated when the \\return command is used. */
-  QCString trReturns()
-  {
-    return "Retorna";
-  }
-
-  /*! this text is generated when the \\sa command is used. */
-  QCString trSeeAlso()
-  {
-    return "Veja também";
-  }
-
-  /*! this text is generated when the \\param command is used. */
-  QCString trParameters()
-  {
-    return "Parâmetros";
-  }
-
-  /*! this text is generated when the \\exception command is used. */
-  QCString trExceptions()
-  {
-    return "Excepções";
-  }
-
-  /*! this text is used in the title page of a LaTeX document. */
-  QCString trGeneratedBy()
-  {
-    return "Gerado por";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990307
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used as the title of page containing all the index of all namespaces. */
-  virtual QCString trNamespaceList()
-  {
-    return "Lista de namespaces";
-  }
-
-  /*! used as an introduction to the namespace list */
-  virtual QCString trNamespaceListDescription(bool extractAll)
-  {
-    QCString result = "Lista ";
-    if (!extractAll)
-      result += "de toda a documentação ";
-    result += "dos namespaces com uma breve descrição:";
-    return result;
-  }
-
-  /*! used in the class documentation as a header before the list of all
-   *  friends of a class
-   */
-  virtual QCString trFriends()
-  {
-    return "Amigos";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990405
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used in the class documentation as a header before the list of all
-   * related classes
-   */
-  virtual QCString trRelatedFunctionDocumentation()
-  {
-    return "Documentação das classes amigas e funções relacionadas";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990425
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used as the title of the HTML page of a class/struct/union */
-  virtual QCString trCompoundReference(const QCString &clName,
-                                       ClassDef::CompoundType compType,
-                                       bool isTemplate)
-  {
-    QCString result = "Referência ";
-    switch (compType)
+    /*! used as the title of the HTML page of a class/struct/union */
+    virtual QCString trCompoundReference(const QCString &clName,
+                                    ClassDef::CompoundType compType,
+                                    bool isTemplate)
     {
-    case ClassDef::Class:
-      result += "à classe ";
-      break;
-    case ClassDef::Struct:
-      result += "à estrutura ";
-      break;
-    case ClassDef::Union:
-      result += "à união ";
-      break;
-    case ClassDef::Interface:
-      result += "ao interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "ao protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "à categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "à excepção ";
-      break;
-    default:
-      break;
+      QCString result="Referência ";
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="à classe "; break;
+        case ClassDef::Struct:     result+="à estrutura "; break;
+        case ClassDef::Union:      result+="à união "; break;
+        case ClassDef::Interface:  result+="ao interface "; break;
+        case ClassDef::Protocol:   result+="ao protocolo "; break;
+        case ClassDef::Category:   result+="à categoria "; break;
+        case ClassDef::Exception:  result+="à excepção "; break;
+        default: break;
+      }
+      if (isTemplate) result+="Template ";
+      result+=clName;
+      return result;
     }
-    if (isTemplate)
-      result += "Template ";
-    result += clName;
-    return result;
-  }
 
-  /*! used as the title of the HTML page of a file */
-  virtual QCString trFileReference(const QCString &fileName)
-  {
-    QCString result = "Referência ao ficheiro ";
-    result += fileName;
-    return result;
-  }
-
-  /*! used as the title of the HTML page of a namespace */
-  virtual QCString trNamespaceReference(const QCString &namespaceName)
-  {
-    QCString result = "Referência ao namespace ";
-    result += namespaceName;
-    return result;
-  }
-
-  /* these are for the member sections of a class, struct or union */
-  virtual QCString trPublicMembers()
-  {
-    return "Membros públicos";
-  }
-  virtual QCString trPublicSlots()
-  {
-    return "Slots públicos";
-  }
-  virtual QCString trSignals()
-  {
-    return "Sinais";
-  }
-  virtual QCString trStaticPublicMembers()
-  {
-    return "Membros públicos estáticos";
-  }
-  virtual QCString trProtectedMembers()
-  {
-    return "Membros protegidos";
-  }
-  virtual QCString trProtectedSlots()
-  {
-    return "Slots protegidos";
-  }
-  virtual QCString trStaticProtectedMembers()
-  {
-    return "Membros protegidos estáticos";
-  }
-  virtual QCString trPrivateMembers()
-  {
-    return "Membros privados";
-  }
-  virtual QCString trPrivateSlots()
-  {
-    return "Slots privados";
-  }
-  virtual QCString trStaticPrivateMembers()
-  {
-    return "Membros privados estáticos";
-  }
-
-  /*! this function is used to produce a comma-separated list of items.
-   *  use generateMarker(i) to indicate where item i should be put.
-   */
-  virtual QCString trWriteList(int numEntries)
-  {
-    QCString result;
-    int i;
-    // the inherits list contain `numEntries' classes
-    for (i = 0; i < numEntries; i++)
+    /*! used as the title of the HTML page of a file */
+    virtual QCString trFileReference(const QCString &fileName)
     {
-      // use generateMarker to generate placeholders for the class links!
-      result += generateMarker(i); // generate marker for entry i in the list
+      QCString result= "Referência ao ficheiro ";
+      result += fileName;
+      return result;
+    }
+
+    /*! used as the title of the HTML page of a namespace */
+    virtual QCString trNamespaceReference(const QCString &namespaceName)
+    {
+      QCString result= "Referência ao namespace ";
+      result += namespaceName;
+      return result;
+    }
+
+    /* these are for the member sections of a class, struct or union */
+    virtual QCString trPublicMembers()
+    { return "Membros públicos"; }
+    virtual QCString trPublicSlots()
+    { return "Slots públicos"; }
+    virtual QCString trSignals()
+    { return "Sinais"; }
+    virtual QCString trStaticPublicMembers()
+    { return "Membros públicos estáticos"; }
+    virtual QCString trProtectedMembers()
+    { return "Membros protegidos"; }
+    virtual QCString trProtectedSlots()
+    { return "Slots protegidos"; }
+    virtual QCString trStaticProtectedMembers()
+    { return "Membros protegidos estáticos"; }
+    virtual QCString trPrivateMembers()
+    { return "Membros privados"; }
+    virtual QCString trPrivateSlots()
+    { return "Slots privados"; }
+    virtual QCString trStaticPrivateMembers()
+    { return "Membros privados estáticos"; }
+
+    /*! this function is used to produce a comma-separated list of items.
+     *  use generateMarker(i) to indicate where item i should be put.
+     */
+    virtual QCString trWriteList(int numEntries)
+    {
+      QCString result;
+      int i;
+      // the inherits list contain `numEntries' classes
+      for (i=0;i<numEntries;i++)
+      {
+        // use generateMarker to generate placeholders for the class links!
+        result+=generateMarker(i); // generate marker for entry i in the list
                                    // (order is left to right)
 
-      if (i != numEntries - 1) // not the last entry, so we need a separator
+        if (i!=numEntries-1)  // not the last entry, so we need a separator
+        {
+          if (i<numEntries-2) // not the fore last entry
+            result+=", ";
+          else                // the fore last entry
+            result+=" e ";
+        }
+      }
+      return result;
+    }
+
+    /*! used in class documentation to produce a list of base classes,
+     *  if class diagrams are disabled.
+     */
+    virtual QCString trInheritsList(int numEntries)
+    {
+      return "Derivada de "+trWriteList(numEntries)+".";
+    }
+
+    /*! used in class documentation to produce a list of super classes,
+     *  if class diagrams are disabled.
+     */
+    virtual QCString trInheritedByList(int numEntries)
+    {
+      return "Herdado por "+trWriteList(numEntries)+".";
+    }
+
+    /*! used in member documentation blocks to produce a list of
+     *  members that are hidden by this one.
+     */
+    virtual QCString trReimplementedFromList(int numEntries)
+    {
+      return "Reimplementado de "+trWriteList(numEntries)+".";
+    }
+
+    /*! used in member documentation blocks to produce a list of
+     *  all member that overwrite the implementation of this member.
+     */
+    virtual QCString trReimplementedInList(int numEntries)
+    {
+      return "Reimplementado em "+trWriteList(numEntries)+".";
+    }
+
+    /*! This is put above each page as a link to all members of namespaces. */
+    virtual QCString trNamespaceMembers()
+    { return "Membros do namespace"; }
+
+    /*! This is an introduction to the page with all namespace members */
+    virtual QCString trNamespaceMemberDescription(bool extractAll)
+    {
+      QCString result="Lista ";
+      if (extractAll) result+="de todos os ";
+      else result+="de toda a documentação dos ";
+      result+="membros do namespace com referência para ";
+      if (extractAll)
+        result+="a documentação de cada membro:";
+      else
+        result+="o namespace correspondente:";
+      return result;
+    }
+
+  /*! This is used in LaTeX as the title of the chapter with the
+     *  index of all namespaces.
+     */
+    virtual QCString trNamespaceIndex()
+    { return "Índice dos namespaces"; }
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all namespaces.
+     */
+    virtual QCString trNamespaceDocumentation()
+    { return "Documentação dos namespaces"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990522
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used in the documentation before the list of all
+     *  namespaces in a file.
+     */
+    virtual QCString trNamespaces()
+    { return "Namespaces"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990728
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is put at the bottom of a class documentation page and is
+     *  followed by a list of files that were used to generate the page.
+     */
+    virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
+        bool single)
+    { // here s is one of " Class", " Struct" or " Union"
+      // single is true implies a single file
+      bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
+      QCString result="A documentação para ";
+      switch(compType)
       {
-        if (i < numEntries - 2) // not the fore last entry
-          result += ", ";
-        else // the fore last entry
-          result += " e ";
+        case ClassDef::Class:      result+=vhdlOpt?"esta Unidade de Design":"esta classe"; break;
+        case ClassDef::Struct:     result+="esta estrutura"; break;
+        case ClassDef::Union:      result+="esta união"; break;
+        case ClassDef::Interface:  result+="este interface"; break;
+        case ClassDef::Protocol:   result+="este protocolo"; break;
+        case ClassDef::Category:   result+="esta categoria"; break;
+        case ClassDef::Exception:  result+="esta excepção"; break;
+        default: break;
+      }
+      result+=" foi gerada a partir ";
+      if (single) result+=" do seguinte ficheiro:";
+      else result+="dos seguintes ficheiros:";
+      return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-990901
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used as the heading text for the retval command. */
+    virtual QCString trReturnValues()
+    { return "Valores retornados"; }
+
+    /*! This is in the (quick) index as a link to the main page (index.html)
+     */
+    virtual QCString trMainPage()
+    { return "Página principal"; }
+
+    /*! This is used in references to page that are put in the LaTeX
+     *  documentation. It should be an abbreviation of the word page.
+     */
+    virtual QCString trPageAbbreviation()
+    { return "p. "; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-991003
+//////////////////////////////////////////////////////////////////////////
+
+    virtual QCString trDefinedAtLineInSourceFile()
+    {
+      return "Definido na linha @0 do ficheiro @1.";
+    }
+    virtual QCString trDefinedInSourceFile()
+    {
+      return "Definido no ficheiro @0.";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 0.49-991205
+//////////////////////////////////////////////////////////////////////////
+
+    virtual QCString trDeprecated()
+    {
+      return "Desaprovado";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.0.0
+//////////////////////////////////////////////////////////////////////////
+
+    /*! this text is put before a collaboration diagram */
+    virtual QCString trCollaborationDiagram(const QCString &clName)
+    {
+      return "Diagrama de colaboração para "+clName+":";
+    }
+    /*! this text is put before an include dependency graph */
+    virtual QCString trInclDepGraph(const QCString &fName)
+    {
+      return "Diagrama de dependências de inclusão para "+fName+":";
+    }
+    /*! header that is put before the list of constructor/destructors. */
+    virtual QCString trConstructorDocumentation()
+    {
+      return "Documentação dos Construtores & Destrutor";
+    }
+    /*! Used in the file documentation to point to the corresponding sources. */
+    virtual QCString trGotoSourceCode()
+    {
+      return "Ir para o código fonte deste ficheiro.";
+    }
+    /*! Used in the file sources to point to the corresponding documentation. */
+    virtual QCString trGotoDocumentation()
+    {
+      return "Ir para a documentação deste ficheiro.";
+    }
+    /*! Text for the \\pre command */
+    virtual QCString trPrecondition()
+    {
+      return "Precondição";
+    }
+    /*! Text for the \\post command */
+    virtual QCString trPostcondition()
+    {
+      return "Poscondição";
+    }
+    /*! Text for the \\invariant command */
+    virtual QCString trInvariant()
+    {
+      return "Invariante";
+    }
+    /*! Text shown before a multi-line variable/enum initialization */
+    virtual QCString trInitialValue()
+    {
+      return "Valor inicial:";
+    }
+    /*! Text used the source code in the file index */
+    virtual QCString trCode()
+    {
+      return "código";
+    }
+    virtual QCString trGraphicalHierarchy()
+    {
+      return "Representação gráfica da hiearquia da classe";
+    }
+    virtual QCString trGotoGraphicalHierarchy()
+    {
+      return "Ir para a representação gráfica da hierarquia da classe";
+    }
+    virtual QCString trGotoTextualHierarchy()
+    {
+      return "Ir para a representação textual da hierarquia da classe";
+    }
+    virtual QCString trPageIndex()
+    {
+      return "Índice da página";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.0
+//////////////////////////////////////////////////////////////////////////
+
+    virtual QCString trNote()
+    {
+      return "Nota";
+    }
+    virtual QCString trPublicTypes()
+    {
+      return "Tipos Públicos";
+    }
+    virtual QCString trPublicAttribs()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Campos de Dados";
+      }
+      else
+      {
+        return "Atributos Públicos";
       }
     }
-    return result;
-  }
-
-  /*! used in class documentation to produce a list of base classes,
-   *  if class diagrams are disabled.
-   */
-  virtual QCString trInheritsList(int numEntries)
-  {
-    return "Derivada de " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in class documentation to produce a list of super classes,
-   *  if class diagrams are disabled.
-   */
-  virtual QCString trInheritedByList(int numEntries)
-  {
-    return "Herdado por " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in member documentation blocks to produce a list of
-   *  members that are hidden by this one.
-   */
-  virtual QCString trReimplementedFromList(int numEntries)
-  {
-    return "Reimplementado de " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in member documentation blocks to produce a list of
-   *  all member that overwrite the implementation of this member.
-   */
-  virtual QCString trReimplementedInList(int numEntries)
-  {
-    return "Reimplementado em " + trWriteList(numEntries) + ".";
-  }
-
-  /*! This is put above each page as a link to all members of namespaces. */
-  virtual QCString trNamespaceMembers()
-  {
-    return "Membros do namespace";
-  }
-
-  /*! This is an introduction to the page with all namespace members */
-  virtual QCString trNamespaceMemberDescription(bool extractAll)
-  {
-    QCString result = "Lista ";
-    if (extractAll)
-      result += "de todos os ";
-    else
-      result += "de toda a documentação dos ";
-    result += "membros do namespace com referência para ";
-    if (extractAll)
-      result += "a documentação de cada membro:";
-    else
-      result += "o namespace correspondente:";
-    return result;
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   *  index of all namespaces.
-   */
-  virtual QCString trNamespaceIndex()
-  {
-    return "Índice dos namespaces";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all namespaces.
-   */
-  virtual QCString trNamespaceDocumentation()
-  {
-    return "Documentação dos namespaces";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990522
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used in the documentation before the list of all
-   *  namespaces in a file.
-   */
-  virtual QCString trNamespaces()
-  {
-    return "Namespaces";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990728
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is put at the bottom of a class documentation page and is
-   *  followed by a list of files that were used to generate the page.
-   */
-  virtual QCString trGeneratedFromFiles(ClassDef::CompoundType compType,
-                                        bool single)
-  { // here s is one of " Class", " Struct" or " Union"
-    // single is true implies a single file
-    bool vhdlOpt = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
-    QCString result = "A documentação para ";
-    switch (compType)
+    virtual QCString trStaticPublicAttribs()
     {
-    case ClassDef::Class:
-      result += vhdlOpt ? "esta Unidade de Design" : "esta classe";
-      break;
-    case ClassDef::Struct:
-      result += "esta estrutura";
-      break;
-    case ClassDef::Union:
-      result += "esta união";
-      break;
-    case ClassDef::Interface:
-      result += "este interface";
-      break;
-    case ClassDef::Protocol:
-      result += "este protocolo";
-      break;
-    case ClassDef::Category:
-      result += "esta categoria";
-      break;
-    case ClassDef::Exception:
-      result += "esta excepção";
-      break;
-    default:
-      break;
+      return "Atributos Públicos Estáticos";
     }
-    result += " foi gerada a partir ";
-    if (single)
-      result += " do seguinte ficheiro:";
-    else
-      result += "dos seguintes ficheiros:";
-    return result;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-990901
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used as the heading text for the retval command. */
-  virtual QCString trReturnValues()
-  {
-    return "Valores retornados";
-  }
-
-  /*! This is in the (quick) index as a link to the main page (index.html)
-   */
-  virtual QCString trMainPage()
-  {
-    return "Página principal";
-  }
-
-  /*! This is used in references to page that are put in the LaTeX
-   *  documentation. It should be an abbreviation of the word page.
-   */
-  virtual QCString trPageAbbreviation()
-  {
-    return "p. ";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-991003
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trDefinedAtLineInSourceFile()
-  {
-    return "Definido na linha @0 do ficheiro @1.";
-  }
-  virtual QCString trDefinedInSourceFile()
-  {
-    return "Definido no ficheiro @0.";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 0.49-991205
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trDeprecated()
-  {
-    return "Desaprovado";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.0.0
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! this text is put before a collaboration diagram */
-  virtual QCString trCollaborationDiagram(const QCString &clName)
-  {
-    return "Diagrama de colaboração para " + clName + ":";
-  }
-  /*! this text is put before an include dependency graph */
-  virtual QCString trInclDepGraph(const QCString &fName)
-  {
-    return "Diagrama de dependências de inclusão para " + fName + ":";
-  }
-  /*! header that is put before the list of constructor/destructors. */
-  virtual QCString trConstructorDocumentation()
-  {
-    return "Documentação dos Construtores & Destrutor";
-  }
-  /*! Used in the file documentation to point to the corresponding sources. */
-  virtual QCString trGotoSourceCode()
-  {
-    return "Ir para o código fonte deste ficheiro.";
-  }
-  /*! Used in the file sources to point to the corresponding documentation. */
-  virtual QCString trGotoDocumentation()
-  {
-    return "Ir para a documentação deste ficheiro.";
-  }
-  /*! Text for the \\pre command */
-  virtual QCString trPrecondition()
-  {
-    return "Precondição";
-  }
-  /*! Text for the \\post command */
-  virtual QCString trPostcondition()
-  {
-    return "Poscondição";
-  }
-  /*! Text for the \\invariant command */
-  virtual QCString trInvariant()
-  {
-    return "Invariante";
-  }
-  /*! Text shown before a multi-line variable/enum initialization */
-  virtual QCString trInitialValue()
-  {
-    return "Valor inicial:";
-  }
-  /*! Text used the source code in the file index */
-  virtual QCString trCode()
-  {
-    return "código";
-  }
-  virtual QCString trGraphicalHierarchy()
-  {
-    return "Representação gráfica da hiearquia da classe";
-  }
-  virtual QCString trGotoGraphicalHierarchy()
-  {
-    return "Ir para a representação gráfica da hierarquia da classe";
-  }
-  virtual QCString trGotoTextualHierarchy()
-  {
-    return "Ir para a representação textual da hierarquia da classe";
-  }
-  virtual QCString trPageIndex()
-  {
-    return "Índice da página";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.0
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trNote()
-  {
-    return "Nota";
-  }
-  virtual QCString trPublicTypes()
-  {
-    return "Tipos Públicos";
-  }
-  virtual QCString trPublicAttribs()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    virtual QCString trProtectedTypes()
     {
-      return "Campos de Dados";
+      return "Tipos Protegidos";
     }
-    else
+    virtual QCString trProtectedAttribs()
     {
-      return "Atributos Públicos";
+      return "Atributos Protegidos";
     }
-  }
-  virtual QCString trStaticPublicAttribs()
-  {
-    return "Atributos Públicos Estáticos";
-  }
-  virtual QCString trProtectedTypes()
-  {
-    return "Tipos Protegidos";
-  }
-  virtual QCString trProtectedAttribs()
-  {
-    return "Atributos Protegidos";
-  }
-  virtual QCString trStaticProtectedAttribs()
-  {
-    return "Atributos Protegidos Estáticos";
-  }
-  virtual QCString trPrivateTypes()
-  {
-    return "Tipos Privados";
-  }
-  virtual QCString trPrivateAttribs()
-  {
-    return "Atributos Privados";
-  }
-  virtual QCString trStaticPrivateAttribs()
-  {
-    return "Atributos Privados Estáticos";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.3
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a marker that is put before a todo item */
-  virtual QCString trTodo()
-  {
-    return "Tarefa";
-  }
-  /*! Used as the header of the todo list */
-  virtual QCString trTodoList()
-  {
-    return "Lista de tarefas";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.4
-  //////////////////////////////////////////////////////////////////////////
-
-  virtual QCString trReferencedBy()
-  {
-    return "Referenciado por";
-  }
-  virtual QCString trRemarks()
-  {
-    return "Observações";
-  }
-  virtual QCString trAttention()
-  {
-    return "Atenção";
-  }
-  virtual QCString trInclByDepGraph()
-  {
-    return "Este grafo mostra quais são os ficheiros que incluem directamente ou indirectamente este ficheiro:";
-  }
-  virtual QCString trSince()
-  {
-    return "Desde";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.1.5
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! title of the graph legend page */
-  virtual QCString trLegendTitle()
-  {
-    return "Legenda do grafo";
-  }
-  /*! page explaining how the dot graph's should be interpreted */
-  virtual QCString trLegendDocs()
-  {
-    return "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
-           "Considere o seguinte exemplo:\n"
-           "\\code\n"
-           "/*! Esta classe vai estar escondida devido à truncação */\n"
-           "class Invisible { };\n\n"
-           "/*! Esta classe tem a relação de herança escondida */\n"
-           "class Truncated : public Invisible { };\n\n"
-           "/* Classe não documentada por comentários doxygen */\n"
-           "class Undocumented { };\n\n"
-           "/*! Classe derivada usando derivação pública */\n"
-           "class PublicBase : public Truncated { };\n\n"
-           "/*! A template class */\n"
-           "template<class T> class Templ { };\n\n"
-           "/*! Classe derivada usando derivação protegida */\n"
-           "class ProtectedBase { };\n\n"
-           "/*! Classe derivada usando derivação privada */\n"
-           "class PrivateBase { };\n\n"
-           "/*! Classe usada pela classe Inherited */\n"
-           "class Used { };\n\n"
-           "/*! Super classe que deriva de várias classes */\n"
-           "class Inherited : public PublicBase,\n"
-           "                  protected ProtectedBase,\n"
-           "                  private PrivateBase,\n"
-           "                  public Undocumented,\n"
-           "                  public Templ<int>\n"
-           "{\n"
-           "  private:\n"
-           "    Used *m_usedClass;\n"
-           "};\n"
-           "\\endcode\n"
-           "Isto irá gerar o seguinte gráfo:"
-           "<p><center><img src=\"graph_legend." +
-           getDotImageExtension() + "\"></center>\n"
-                                    "<p>\n"
-                                    "As caixas no grafo anterior têm as seguintes interpretações:\n"
-                                    "<ul>\n"
-                                    "<li>Uma caixa inteiramente preta representa a estrutura ou a classe para "
-                                    "a qual o grafo foi gerado.\n"
-                                    "<li>Uma caixa com borda preta representa uma estrutura ou classe documentada.\n"
-                                    "<li>Uma caixa com borda cinzenta representa uma estrutura ou classe não documentada.\n"
-                                    "<li>Uma caixa com borda vermelha representa uma estrutura ou classe documentada onde "
-                                    "nem todas as relações de herança/encapsulamento são exibidas. Um grafo é truncado "
-                                    "quando não cabe na sua área predefinida.\n"
-                                    "</ul>\n"
-                                    "As setas têm a seguinte interpretação:\n"
-                                    "<ul>\n"
-                                    "<li>Uma seta azul escura representa uma relação de herança pública entre duas classes.\n"
-                                    "<li>Uma seta verde escura representa uma relação de herança protegida.\n"
-                                    "<li>Uma seta vermelha escura representa uma relação de herança privada.\n"
-                                    "<li>Uma seta rocha em tracejado representa uma relação de encapsulamento ou uso por "
-                                    "parte de outra classe. A legenda da seta contém o nome da variável ou variáveis da "
-                                    "relação. A seta aponta da classe que estabelece a relação para a classe ou estrutura que "
-                                    "é acessível.\n"
-                                    "</ul>\n";
-  }
-  /*! text for the link to the legend page */
-  virtual QCString trLegend()
-  {
-    return "legenda";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.0
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a marker that is put before a test item */
-  virtual QCString trTest()
-  {
-    return "Teste";
-  }
-  /*! Used as the header of the test list */
-  virtual QCString trTestList()
-  {
-    return "Lista de teste";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.2
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a section header for IDL properties */
-  virtual QCString trProperties()
-  {
-    return "Propriedades";
-  }
-  /*! Used as a section header for IDL property documentation */
-  virtual QCString trPropertyDocumentation()
-  {
-    return "Documentação das propriedades";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.4
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used for Java classes in the summary section of Java packages */
-  virtual QCString trClasses()
-  {
-    if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+    virtual QCString trStaticProtectedAttribs()
     {
-      return "Estruturas de dados";
+      return "Atributos Protegidos Estáticos";
     }
-    else
+    virtual QCString trPrivateTypes()
     {
-      return "Classes";
+      return "Tipos Privados";
     }
-  }
-  /*! Used as the title of a Java package */
-  virtual QCString trPackage(const QCString &name)
-  {
-    return "Pacote " + name;
-  }
-  /*! The description of the package index page */
-  virtual QCString trPackageListDescription()
-  {
-    return "Lista de pacotes com uma breve descrição (se disponível):";
-  }
-  /*! The link name in the Quick links header for each page */
-  virtual QCString trPackages()
-  {
-    return "Pacotes";
-  }
-  /*! Text shown before a multi-line define */
-  virtual QCString trDefineValue()
-  {
-    return "Valor:";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.5
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a marker that is put before a \\bug item */
-  virtual QCString trBug()
-  {
-    return "Bug";
-  }
-  /*! Used as the header of the bug list */
-  virtual QCString trBugList()
-  {
-    return "Lista de Bugs";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.6
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as ansicpg for RTF file
-   *
-   * The following table shows the correlation of Charset name, Charset Value and
-   * <pre>
-   * Codepage number:
-   * Charset Name       Charset Value(hex)  Codepage number
-   * ------------------------------------------------------
-   * DEFAULT_CHARSET           1 (x01)
-   * SYMBOL_CHARSET            2 (x02)
-   * OEM_CHARSET             255 (xFF)
-   * ANSI_CHARSET              0 (x00)            1252
-   * RUSSIAN_CHARSET         204 (xCC)            1251
-   * EE_CHARSET              238 (xEE)            1250
-   * GREEK_CHARSET           161 (xA1)            1253
-   * TURKISH_CHARSET         162 (xA2)            1254
-   * BALTIC_CHARSET          186 (xBA)            1257
-   * HEBREW_CHARSET          177 (xB1)            1255
-   * ARABIC _CHARSET         178 (xB2)            1256
-   * SHIFTJIS_CHARSET        128 (x80)             932
-   * HANGEUL_CHARSET         129 (x81)             949
-   * GB2313_CHARSET          134 (x86)             936
-   * CHINESEBIG5_CHARSET     136 (x88)             950
-   * </pre>
-   *
-   */
-  virtual QCString trRTFansicp()
-  {
-    return "1252";
-  }
-
-  /*! Used as ansicpg for RTF fcharset
-   *  \see trRTFansicp() for a table of possible values.
-   */
-  virtual QCString trRTFCharSet()
-  {
-    return "0";
-  }
-
-  /*! Used as header RTF general index */
-  virtual QCString trRTFGeneralIndex()
-  {
-    return "Índice";
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trClass(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Classe" : "classe"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trFile(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Ficheiro" : "ficheiro"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trNamespace(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Namespace" : "namespace"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trGroup(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Grupo" : "grupo"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trPage(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Página" : "página"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trMember(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Membro" : "membro"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trGlobal(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Globa" : "globa"));
-    result += singular ? "l" : "ais";
-    return result;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.7
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This text is generated when the \\author command is used and
-   *  for the author section in man pages. */
-  virtual QCString trAuthor(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Autor" : "autor"));
-    if (!singular)
-      result += "es";
-    return result;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.11
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This text is put before the list of members referenced by a member
-   */
-  virtual QCString trReferences()
-  {
-    return "Referências";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.13
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used in member documentation blocks to produce a list of
-   *  members that are implemented by this one.
-   */
-  virtual QCString trImplementedFromList(int numEntries)
-  {
-    return "Implementa " + trWriteList(numEntries) + ".";
-  }
-
-  /*! used in member documentation blocks to produce a list of
-   *  all members that implement this abstract member.
-   */
-  virtual QCString trImplementedInList(int numEntries)
-  {
-    return "Implementado em " + trWriteList(numEntries) + ".";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.16
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! used in RTF documentation as a heading for the Table
-   *  of Contents.
-   */
-  virtual QCString trRTFTableOfContents()
-  {
-    return "Índice";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.17
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as the header of the list of item that have been
-   *  flagged deprecated
-   */
-  virtual QCString trDeprecatedList()
-  {
-    return "Lista de Deprecados";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.2.18
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a header for declaration section of the events found in
-   * a C# program
-   */
-  virtual QCString trEvents()
-  {
-    return "Eventos";
-  }
-  /*! Header used for the documentation section of a class' events. */
-  virtual QCString trEventDocumentation()
-  {
-    return "Documentação dos eventos";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a heading for a list of Java class types with package scope.
-   */
-  virtual QCString trPackageTypes()
-  {
-    return "Tipos do Pacote";
-  }
-  /*! Used as a heading for a list of Java class functions with package
-   * scope.
-   */
-  virtual QCString trPackageFunctions()
-  {
-    return "Funções do Pacote";
-  }
-  virtual QCString trPackageMembers()
-  {
-    return "Membros do Pacote";
-  }
-  /*! Used as a heading for a list of static Java class functions with
-   *  package scope.
-   */
-  virtual QCString trStaticPackageFunctions()
-  {
-    return "Funções Estáticas do Pacote";
-  }
-  /*! Used as a heading for a list of Java class variables with package
-   * scope.
-   */
-  virtual QCString trPackageAttribs()
-  {
-    return "Atributos do Pacote";
-  }
-  /*! Used as a heading for a list of static Java class variables with
-   * package scope.
-   */
-  virtual QCString trStaticPackageAttribs()
-  {
-    return "Atributos Estáticos do Pacote";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.1
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used in the quick index of a class/file/namespace member list page
-   *  to link to the unfiltered list of all members.
-   */
-  virtual QCString trAll()
-  {
-    return "Tudo";
-  }
-  /*! Put in front of the call graph for a function. */
-  virtual QCString trCallGraph()
-  {
-    return "Grafo de chamadas desta função:";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.3 - Based on the Brazilian Portuguese Translation
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This string is used as the title for the page listing the search
-   *  results.
-   */
-  virtual QCString trSearchResultsTitle()
-  {
-    return "Resultado da Busca";
-  }
-  /*! This string is put just before listing the search results. The
-   *  text can be different depending on the number of documents found.
-   *  Inside the text you can put the special marker $num to insert
-   *  the number representing the actual number of search results.
-   *  The @a numDocuments parameter can be either 0, 1 or 2, where the
-   *  value 2 represents 2 or more matches. HTML markup is allowed inside
-   *  the returned string.
-   */
-  virtual QCString trSearchResults(int numDocuments)
-  {
-    if (numDocuments == 0)
+    virtual QCString trPrivateAttribs()
     {
-      return "Nenhum documento foi encontrado.";
+      return "Atributos Privados";
     }
-    else if (numDocuments == 1)
+    virtual QCString trStaticPrivateAttribs()
     {
-      return "Apenas <b>1</b> documento foi encontrado.";
-    }
-    else
-    {
-      return "<b>$num</b> documentos encontrados. "
-             "Os melhores resultados vem primeiro.";
-    }
-  }
-  /*! This string is put before the list of matched words, for each search
-   *  result. What follows is the list of words that matched the query.
-   */
-  virtual QCString trSearchMatches()
-  {
-    return "Resultados:";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.8
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used in HTML as the title of page with source code for file filename
-   */
-  virtual QCString trSourceFile(QCString &filename)
-  {
-    return "Código-Fonte de " + filename;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.3.9
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used as the name of the chapter containing the directory
-   *  hierarchy.
-   */
-  virtual QCString trDirIndex()
-  {
-    return "Hierarquia de Diretórios";
-  }
-
-  /*! This is used as the name of the chapter containing the documentation
-   *  of the directories.
-   */
-  virtual QCString trDirDocumentation()
-  {
-    return "Documentação do Directório";
-  }
-
-  /*! This is used as the title of the directory index and also in the
-   *  Quick links of a HTML page, to link to the directory hierarchy.
-   */
-  virtual QCString trDirectories()
-  {
-    return "Diretórios";
-  }
-
-  /*! This returns the title of a directory page. The name of the
-   *  directory is passed via \a dirName.
-   */
-  virtual QCString trDirReference(const QCString &dirName)
-  {
-    QCString result = "Referência do diretório ";
-    result += dirName;
-    return result;
-  }
-
-  /*! This returns the word directory with or without starting capital
-   *  (\a first_capital) and in sigular or plural form (\a singular).
-   */
-  virtual QCString trDir(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Diretório" : "diretório"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.4.1
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This text is added to the documentation when the \\overload command
-   *  is used for a overloaded function.
-   */
-  virtual QCString trOverloadText()
-  {
-    return "Este é um método provido por conveniência. "
-           "Ele difere do método acima apenas na lista de "
-           "argumentos que devem ser utilizados.";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.4.6
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! This is used to introduce a caller (or called-by) graph */
-  virtual QCString trCallerGraph()
-  {
-    return "Este é o diagrama das funções que utilizam esta função:";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for enumeration values
-   */
-  virtual QCString trEnumerationValueDocumentation()
-  {
-    return "Documentação da enumeração";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.5.4 (mainly for Fortran)
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! header that is put before the list of member subprograms (Fortran). */
-  virtual QCString trMemberFunctionDocumentationFortran()
-  {
-    return "Documentação de Função Membro/Subrotina";
-  }
-
-  /*! This is put above each page as a link to the list of annotated data types (Fortran). */
-  virtual QCString trCompoundListFortran()
-  {
-    return "Lista de Tipos de Dados";
-  }
-
-  /*! This is put above each page as a link to all members of compounds (Fortran). */
-  virtual QCString trCompoundMembersFortran()
-  {
-    return "Campos de Dados";
-  }
-
-  /*! This is an introduction to the annotated compound list (Fortran). */
-  virtual QCString trCompoundListDescriptionFortran()
-  {
-    return "Aqui estão os tipos de dados com descrições resumidas:";
-  }
-
-  /*! This is an introduction to the page with all data types (Fortran). */
-  virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os membros ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "dos tipos de dados com links para ";
-    if (extractAll)
-    {
-      result += "a documentação dos tipos de dados para cada membro:";
-    }
-    else
-    {
-      result += "os tipos de dados a que pertencem:";
-    }
-    return result;
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   * annotated compound index (Fortran).
-   */
-  virtual QCString trCompoundIndexFortran()
-  {
-    return "Índice de Tipos de Dados";
-  }
-
-  /*! This is used in LaTeX as the title of the chapter containing
-   *  the documentation of all data types (Fortran).
-   */
-  virtual QCString trTypeDocumentation()
-  {
-    return "Documentação dos Tipos de Dados";
-  }
-
-  /*! This is used in the documentation of a file as a header before the
-   *  list of (global) subprograms (Fortran).
-   */
-  virtual QCString trSubprograms()
-  {
-    return "Funções/Subrotinas";
-  }
-
-  /*! This is used in the documentation of a file/namespace before the list
-   *  of documentation blocks for subprograms (Fortran)
-   */
-  virtual QCString trSubprogramDocumentation()
-  {
-    return "Documentação da Função/Subrotina";
-  }
-
-  /*! This is used in the documentation of a file/namespace/group before
-   *  the list of links to documented compounds (Fortran)
-   */
-  virtual QCString trDataTypes()
-  {
-    return "Tipos de Dados";
-  }
-
-  /*! used as the title of page containing all the index of all modules (Fortran). */
-  virtual QCString trModulesList()
-  {
-    return "Lista de Módulos";
-  }
-
-  /*! used as an introduction to the modules list (Fortran) */
-  virtual QCString trModulesListDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os módulos ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "com descrições resumidas:";
-    return result;
-  }
-
-  /*! used as the title of the HTML page of a module/type (Fortran) */
-  virtual QCString trCompoundReferenceFortran(const QCString &clName,
-                                              ClassDef::CompoundType compType,
-                                              bool isTemplate)
-  {
-    QCString result = "Referência ";
-
-    if (isTemplate)
-      result += "da Template ";
-
-    switch (compType)
-    {
-    case ClassDef::Class:
-      result += "do Modulo ";
-      break;
-    case ClassDef::Struct:
-      result += "do Tipo ";
-      break;
-    case ClassDef::Union:
-      result += "da União ";
-      break;
-    case ClassDef::Interface:
-      result += "da Interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "do Protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "da Categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "da Exceção ";
-      break;
-    default:
-      break;
-    }
-    result += clName;
-
-    return result;
-  }
-  /*! used as the title of the HTML page of a module (Fortran) */
-  virtual QCString trModuleReference(const QCString &namespaceName)
-  {
-    QCString result = "Referência do Módulo ";
-    result += namespaceName;
-    return result;
-  }
-
-  /*! This is put above each page as a link to all members of modules. (Fortran) */
-  virtual QCString trModulesMembers()
-  {
-    return "Membros do Módulo";
-  }
-
-  /*! This is an introduction to the page with all modules members (Fortran) */
-  virtual QCString trModulesMemberDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os membros ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "dos módulos com links para ";
-    if (extractAll)
-    {
-      result += "a documentação dos módulos para cada membro:";
-    }
-    else
-    {
-      result += "os módulos a que pertencem:";
-    }
-    return result;
-  }
-
-  /*! This is used in LaTeX as the title of the chapter with the
-   *  index of all modules (Fortran).
-   */
-  virtual QCString trModulesIndex()
-  {
-    return "Índice dos Módulos";
-  }
-
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trModule(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Modulo" : "modulo"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-  /*! This is put at the bottom of a module documentation page and is
-   *  followed by a list of files that were used to generate the page.
-   */
-  virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
-                                               bool single)
-  { // here s is one of " Module", " Struct" or " Union"
-    // single is true implies a single file
-    QCString result = "A documentação para ";
-    switch (compType)
-    {
-    case ClassDef::Class:
-      result += "este modulo ";
-      break;
-    case ClassDef::Struct:
-      result += "este tipo ";
-      break;
-    case ClassDef::Union:
-      result += "esta união ";
-      break;
-    case ClassDef::Interface:
-      result += "esta interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "esto protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "esta categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "esta exceção ";
-      break;
-    default:
-      break;
+      return "Atributos Privados Estáticos";
     }
 
-    result += " foi gerada a partir do";
-    if (single)
-      result += " seguinte ficheiro:";
-    else
-      result += "s seguintes ficheiros:";
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.3
+//////////////////////////////////////////////////////////////////////////
 
-    return result;
-  }
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trType(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Tipo" : "tipo"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-  /*! This is used for translation of the word that will possibly
-   *  be followed by a single name or by a list of names
-   *  of the category.
-   */
-  virtual QCString trSubprogram(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Subprograma" : "subprograma"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-
-  /*! C# Type Contraint list */
-  virtual QCString trTypeConstraints()
-  {
-    return "Restrições do Tipo";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.6.0 (mainly for the new search engine)
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! directory relation for \a name
-   */
-  virtual QCString trDirRelation(const QCString &name)
-  {
-    return "Relação " + QCString(name);
-  }
-
-  /*! Loading message shown when loading search results */
-  virtual QCString trLoading()
-  {
-    return "Carregando...";
-  }
-
-  /*! Label used for search results in the global namespace */
-  virtual QCString trGlobalNamespace()
-  {
-    return "Namespace global";
-  }
-
-  /*! Message shown while searching */
-  virtual QCString trSearching()
-  {
-    return "Procurando...";
-  }
-
-  /*! Text shown when no search results are found */
-  virtual QCString trNoMatches()
-  {
-    return "Nenhuma entrada encontrada";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.6.3 (missing items for the directory pages)
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! when clicking a directory dependency label, a page with a
-   *  table is shown. The heading for the first column mentions the
-   *  source file that has a relation to another file.
-   */
-  virtual QCString trFileIn(const QCString &name)
-  {
-    return "Ficheiro em " + name;
-  }
-
-  /*! when clicking a directory dependency label, a page with a
-   *  table is shown. The heading for the second column mentions the
-   *  destination file that is included.
-   */
-  virtual QCString trIncludesFileIn(const QCString &name)
-  {
-    return "Inclui ficheiro em " + name;
-  }
-
-  /** Compiles a date string.
-   *  @param year Year in 4 digits
-   *  @param month Month of the year: 1=January
-   *  @param day Day of the Month: 1..31
-   *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
-   *  @param hour Hour of the day: 0..23
-   *  @param minutes Minutes in the hour: 0..59
-   *  @param seconds Seconds within the minute: 0..59
-   *  @param includeTime Include time in the result string?
-   */
-  virtual QCString trDateTime(int year, int month, int day, int dayOfWeek,
-                              int hour, int minutes, int seconds,
-                              bool includeTime)
-  {
-    static const char *days[] = {"Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"};
-    static const char *months[] = {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"};
-    QCString sdate;
-    sdate.sprintf("%s, %d de %s de %d", days[dayOfWeek - 1], day, months[month - 1], year);
-    if (includeTime)
+    /*! Used as a marker that is put before a todo item */
+    virtual QCString trTodo()
     {
-      QCString stime;
-      stime.sprintf(" %.2d:%.2d:%.2d", hour, minutes, seconds);
-      sdate += stime;
+      return "Tarefa";
     }
-    return sdate;
-  }
-  virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
-  {
-    static const char *days_short[] = {"seg", "ter", "qua", "qui", "sex", "sáb", "dom"};
-    static const char *days_full[] = {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo"};
-    QCString text = full ? days_full[dayOfWeek - 1] : days_short[dayOfWeek - 1];
-    if (first_capital)
-      return text.mid(0, 1).upper() + text.mid(1);
-    else
-      return text;
-  }
-  virtual QCString trMonth(int month, bool first_capital, bool full)
-  {
-    static const char *months_short[] = {"jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez"};
-    static const char *months_full[] = {"janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro"};
-    QCString text = full ? months_full[month - 1] : months_short[month - 1];
-    if (first_capital)
-      return text.mid(0, 1).upper() + text.mid(1);
-    else
-      return text;
-  }
-  virtual QCString trDayPeriod(int period)
-  {
-    static const char *dayPeriod[] = {"AM", "PM"};
-    return dayPeriod[period];
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.7.5
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Header for the page with bibliographic citations */
-  virtual QCString trCiteReferences()
-  {
-    return "Referências Bibliográficas";
-  }
-
-  /*! Text for copyright paragraph */
-  virtual QCString trCopyright()
-  {
-    // Note: I will left it as is because "Direitos de autor" may not fit
-    // in the text.
-    return "Copyright";
-  }
-
-  /*! Header for the graph showing the directory dependencies */
-  virtual QCString trDirDepGraph(const QCString &name)
-  {
-    return QCString("Grafo de dependências do directório ") + name + ":";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.0
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Detail level selector shown for hierarchical indices */
-  virtual QCString trDetailLevel()
-  {
-    return "nível de detalhes";
-  }
-
-  /*! Section header for list of template parameters */
-  virtual QCString trTemplateParameters()
-  {
-    return "Parâmetros de template";
-  }
-
-  /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
-  virtual QCString trAndMore(const QCString &number)
-  {
-    return "e " + number + " mais...";
-  }
-
-  /*! Used file list for a Java enum */
-  virtual QCString trEnumGeneratedFromFiles(bool single)
-  {
-    QCString result = "A documentação para esta enumeração foi gerada a partir";
-    if (single)
+    /*! Used as the header of the todo list */
+    virtual QCString trTodoList()
     {
-      result += "do seguinte ficheiro:";
-    }
-    else
-    {
-      result += "dos seguintes ficheiros:";
-    }
-    return result;
-  }
-
-  /*! Header of a Java enum page (Java enums are represented as classes). */
-  virtual QCString trEnumReference(const QCString &name)
-  {
-    QCString result = "Referência da enumeração ";
-    return result + name;
-  }
-
-  /*! Used for a section containing inherited members */
-  virtual QCString trInheritedFrom(const QCString &members, const QCString &what)
-  {
-    return QCString(members) + " herdados de " + what;
-  }
-
-  /*! Header of the sections with inherited members specific for the
-   *  base class(es)
-   */
-  virtual QCString trAdditionalInheritedMembers()
-  {
-    return "Outros membros herdados";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.2
-  //////////////////////////////////////////////////////////////////////////
-
-  /*! Used as a tooltip for the toggle button that appears in the
-   *  navigation tree in the HTML output when GENERATE_TREEVIEW is
-   *  enabled. This tooltip explains the meaning of the button.
-   */
-  virtual QCString trPanelSynchronisationTooltip(bool enable)
-  {
-    QCString opt = enable ? "ativar" : "desativar";
-    return "clique para " + opt + " a sincronização do painel";
-  }
-
-  /*! Used in a method of an Objective-C class that is declared in a
-   *  a category. Note that the @1 marker is required and is replaced
-   *  by a link.
-   */
-  virtual QCString trProvidedByCategory()
-  {
-    return "Provido pela categoria @0.";
-  }
-
-  /*! Used in a method of an Objective-C category that extends a class.
-   *  Note that the @1 marker is required and is replaced by a link to
-   *  the class method.
-   */
-  virtual QCString trExtendsClass()
-  {
-    return "estende a classe @0.";
-  }
-
-  /*! Used as the header of a list of class methods in Objective-C.
-   *  These are similar to static public member functions in C++.
-   */
-  virtual QCString trClassMethods()
-  {
-    return "Métodos de classe";
-  }
-
-  /*! Used as the header of a list of instance methods in Objective-C.
-   *  These are similar to public member functions in C++.
-   */
-  virtual QCString trInstanceMethods()
-  {
-    return "Métodos de instância";
-  }
-
-  /*! Used as the header of the member functions of an Objective-C class.
-   */
-  virtual QCString trMethodDocumentation()
-  {
-    return "Documentação do método";
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.4
-  //////////////////////////////////////////////////////////////////////////
-
-  /** old style UNO IDL services: implemented interfaces */
-  virtual QCString trInterfaces()
-  {
-    return "Interfaces Exportadas";
-  }
-
-  /** old style UNO IDL services: inherited services */
-  virtual QCString trServices()
-  {
-    return "Serviços Incluídos";
-  }
-
-  /** UNO IDL constant groups */
-  virtual QCString trConstantGroups()
-  {
-    return "Grupos de Constantes";
-  }
-
-  /** UNO IDL constant groups */
-  virtual QCString trConstantGroupReference(const QCString &namespaceName)
-  {
-    QCString result = "Referência do grupo de constantes ";
-    result += namespaceName;
-    return result;
-  }
-
-  /** UNO IDL service page title */
-  virtual QCString trServiceReference(const QCString &sName)
-  {
-    QCString result = "Referência do serviço ";
-    result += sName;
-    return result;
-  }
-
-  /** UNO IDL singleton page title */
-  virtual QCString trSingletonReference(const QCString &sName)
-  {
-    QCString result = "Referência do Singleton ";
-    result += sName;
-    return result;
-  }
-
-  /** UNO IDL service page */
-  virtual QCString trServiceGeneratedFromFiles(bool single)
-  {
-    // single is true implies a single file
-    QCString result = "A documentação para este serviço "
-                      "foi gerada a partir ";
-    if (single)
-    {
-      result += "do seguinte ficheiro:";
-    }
-    else
-    {
-      result += "dos: seguintes ficheiros:";
-    }
-    return result;
-  }
-
-  /** UNO IDL singleton page */
-  virtual QCString trSingletonGeneratedFromFiles(bool single)
-  {
-    // single is true implies a single file
-    QCString result = "A documentação para este singleton "
-                      "foi gerada a partir ";
-    if (single)
-    {
-      result += "do seguinte ficheiro:";
-    }
-    else
-    {
-      result += "dos: seguintes ficheiros:";
+      return "Lista de tarefas";
     }
 
-    return result;
-  }
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.4
+//////////////////////////////////////////////////////////////////////////
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.15
-  //////////////////////////////////////////////////////////////////////////
-
-  /** VHDL design unit hierarchy */
-  virtual QCString trDesignUnitHierarchy()
-  {
-    return "Hierarquia da Unidade de Design";
-  }
-  /** VHDL design unit list */
-  virtual QCString trDesignUnitList()
-  {
-    return "Lista de Unidades de Design";
-  }
-  /** VHDL design unit members */
-  virtual QCString trDesignUnitMembers()
-  {
-    return "Membros da Unidade de Design";
-  }
-  /** VHDL design unit list description */
-  virtual QCString trDesignUnitListDescription()
-  {
-    return "Esta é uma lista de todos os membros de unidades de design "
-           "com ligações para as entidades às quais pertencem:";
-  }
-  /** VHDL design unit index */
-  virtual QCString trDesignUnitIndex()
-  {
-    return "Índice de Unidades de Design";
-  }
-  /** VHDL design units */
-  virtual QCString trDesignUnits()
-  {
-    return "Unidades de Design";
-  }
-  /** VHDL functions/procedures/processes */
-  virtual QCString trFunctionAndProc()
-  {
-    return "Funções/Procedimentos/Processos";
-  }
-  /** VHDL type */
-  virtual QCString trVhdlType(uint64 type, bool single)
-  {
-    switch (type)
+    virtual QCString trReferencedBy()
     {
-    case VhdlDocGen::LIBRARY:
-      if (single)
-        return "Biblioteca";
+      return "Referenciado por";
+    }
+    virtual QCString trRemarks()
+    {
+      return "Observações";
+    }
+    virtual QCString trAttention()
+    {
+      return "Atenção";
+    }
+    virtual QCString trInclByDepGraph()
+    {
+      return "Este grafo mostra quais são os ficheiros que incluem directamente ou indirectamente este ficheiro:";
+    }
+    virtual QCString trSince()
+    {
+      return "Desde";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.1.5
+//////////////////////////////////////////////////////////////////////////
+
+    /*! title of the graph legend page */
+    virtual QCString trLegendTitle()
+    {
+      return "Legenda do grafo";
+    }
+    /*! page explaining how the dot graph's should be interpreted */
+    virtual QCString trLegendDocs()
+    {
+      return
+        "Esta página explica como interpretar os grafos gerados pelo doxygen.<p>\n"
+        "Considere o seguinte exemplo:\n"
+        "\\code\n"
+        "/*! Esta classe vai estar escondida devido à truncação */\n"
+        "class Invisible { };\n\n"
+        "/*! Esta classe tem a relação de herança escondida */\n"
+        "class Truncated : public Invisible { };\n\n"
+        "/* Classe não documentada por comentários doxygen */\n"
+        "class Undocumented { };\n\n"
+        "/*! Classe derivada usando derivação pública */\n"
+        "class PublicBase : public Truncated { };\n\n"
+        "/*! A template class */\n"
+        "template<class T> class Templ { };\n\n"
+        "/*! Classe derivada usando derivação protegida */\n"
+        "class ProtectedBase { };\n\n"
+        "/*! Classe derivada usando derivação privada */\n"
+        "class PrivateBase { };\n\n"
+        "/*! Classe usada pela classe Inherited */\n"
+        "class Used { };\n\n"
+        "/*! Super classe que deriva de várias classes */\n"
+        "class Inherited : public PublicBase,\n"
+        "                  protected ProtectedBase,\n"
+        "                  private PrivateBase,\n"
+        "                  public Undocumented,\n"
+        "                  public Templ<int>\n"
+        "{\n"
+        "  private:\n"
+        "    Used *m_usedClass;\n"
+        "};\n"
+        "\\endcode\n"
+        "Isto irá gerar o seguinte gráfo:"
+        "<p><center><img src=\"graph_legend."+getDotImageExtension()+"\"></center>\n"
+        "<p>\n"
+        "As caixas no grafo anterior têm as seguintes interpretações:\n"
+        "<ul>\n"
+        "<li>Uma caixa inteiramente preta representa a estrutura ou a classe para "
+        "a qual o grafo foi gerado.\n"
+        "<li>Uma caixa com borda preta representa uma estrutura ou classe documentada.\n"
+        "<li>Uma caixa com borda cinzenta representa uma estrutura ou classe não documentada.\n"
+        "<li>Uma caixa com borda vermelha representa uma estrutura ou classe documentada onde "
+        "nem todas as relações de herança/encapsulamento são exibidas. Um grafo é truncado "
+        "quando não cabe na sua área predefinida.\n"
+        "</ul>\n"
+        "As setas têm a seguinte interpretação:\n"
+        "<ul>\n"
+        "<li>Uma seta azul escura representa uma relação de herança pública entre duas classes.\n"
+        "<li>Uma seta verde escura representa uma relação de herança protegida.\n"
+        "<li>Uma seta vermelha escura representa uma relação de herança privada.\n"
+        "<li>Uma seta rocha em tracejado representa uma relação de encapsulamento ou uso por "
+        "parte de outra classe. A legenda da seta contém o nome da variável ou variáveis da "
+        "relação. A seta aponta da classe que estabelece a relação para a classe ou estrutura que "
+        "é acessível.\n"
+        "</ul>\n";
+    }
+    /*! text for the link to the legend page */
+    virtual QCString trLegend()
+    {
+      return "legenda";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.0
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a marker that is put before a test item */
+    virtual QCString trTest()
+    {
+      return "Teste";
+    }
+    /*! Used as the header of the test list */
+    virtual QCString trTestList()
+    {
+      return "Lista de teste";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.2
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a section header for IDL properties */
+    virtual QCString trProperties()
+    {
+      return "Propriedades";
+    }
+    /*! Used as a section header for IDL property documentation */
+    virtual QCString trPropertyDocumentation()
+    {
+      return "Documentação das propriedades";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.4
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used for Java classes in the summary section of Java packages */
+    virtual QCString trClasses()
+    {
+      if (Config_getBool(OPTIMIZE_OUTPUT_FOR_C))
+      {
+        return "Estruturas de dados";
+      }
       else
-        return "Bibliotecas";
-    case VhdlDocGen::PACKAGE:
-      if (single)
-        return "Pacote";
+      {
+        return "Classes";
+      }
+    }
+    /*! Used as the title of a Java package */
+    virtual QCString trPackage(const QCString &name)
+    {
+      return "Pacote "+name;
+    }
+    /*! The description of the package index page */
+    virtual QCString trPackageListDescription()
+    {
+      return "Lista de pacotes com uma breve descrição (se disponível):";
+    }
+    /*! The link name in the Quick links header for each page */
+    virtual QCString trPackages()
+    {
+      return "Pacotes";
+    }
+    /*! Text shown before a multi-line define */
+    virtual QCString trDefineValue()
+    {
+      return "Valor:";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.5
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a marker that is put before a \\bug item */
+    virtual QCString trBug()
+    {
+      return "Bug";
+    }
+    /*! Used as the header of the bug list */
+    virtual QCString trBugList()
+    {
+      return "Lista de Bugs";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.6
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as ansicpg for RTF file
+     *
+     * The following table shows the correlation of Charset name, Charset Value and
+     * <pre>
+     * Codepage number:
+     * Charset Name       Charset Value(hex)  Codepage number
+     * ------------------------------------------------------
+     * DEFAULT_CHARSET           1 (x01)
+     * SYMBOL_CHARSET            2 (x02)
+     * OEM_CHARSET             255 (xFF)
+     * ANSI_CHARSET              0 (x00)            1252
+     * RUSSIAN_CHARSET         204 (xCC)            1251
+     * EE_CHARSET              238 (xEE)            1250
+     * GREEK_CHARSET           161 (xA1)            1253
+     * TURKISH_CHARSET         162 (xA2)            1254
+     * BALTIC_CHARSET          186 (xBA)            1257
+     * HEBREW_CHARSET          177 (xB1)            1255
+     * ARABIC _CHARSET         178 (xB2)            1256
+     * SHIFTJIS_CHARSET        128 (x80)             932
+     * HANGEUL_CHARSET         129 (x81)             949
+     * GB2313_CHARSET          134 (x86)             936
+     * CHINESEBIG5_CHARSET     136 (x88)             950
+     * </pre>
+     *
+     */
+    virtual QCString trRTFansicp()
+    {
+      return "1252";
+    }
+
+
+    /*! Used as ansicpg for RTF fcharset
+     *  \see trRTFansicp() for a table of possible values.
+     */
+    virtual QCString trRTFCharSet()
+    {
+      return "0";
+    }
+
+    /*! Used as header RTF general index */
+    virtual QCString trRTFGeneralIndex()
+    {
+      return "Índice";
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trClass(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Classe" : "classe"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trFile(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Ficheiro" : "ficheiro"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trNamespace(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Namespace" : "namespace"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trGroup(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Grupo" : "grupo"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trPage(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Página" : "página"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trMember(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Membro" : "membro"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trGlobal(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Globa" : "globa"));
+      result+= singular? "l" : "ais";
+      return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.7
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This text is generated when the \\author command is used and
+     *  for the author section in man pages. */
+    virtual QCString trAuthor(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Autor" : "autor"));
+      if (!singular) result+="es";
+      return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.11
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This text is put before the list of members referenced by a member
+     */
+    virtual QCString trReferences()
+    {
+      return "Referências";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.13
+//////////////////////////////////////////////////////////////////////////
+
+    /*! used in member documentation blocks to produce a list of
+     *  members that are implemented by this one.
+     */
+    virtual QCString trImplementedFromList(int numEntries)
+    {
+      return "Implementa "+trWriteList(numEntries)+".";
+    }
+
+    /*! used in member documentation blocks to produce a list of
+     *  all members that implement this abstract member.
+     */
+    virtual QCString trImplementedInList(int numEntries)
+    {
+      return "Implementado em "+trWriteList(numEntries)+".";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.16
+//////////////////////////////////////////////////////////////////////////
+
+    /*! used in RTF documentation as a heading for the Table
+     *  of Contents.
+     */
+    virtual QCString trRTFTableOfContents()
+    {
+      return "Índice";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.17
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as the header of the list of item that have been
+     *  flagged deprecated
+     */
+    virtual QCString trDeprecatedList()
+    {
+      return "Lista de Deprecados";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.2.18
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a header for declaration section of the events found in
+     * a C# program
+     */
+    virtual QCString trEvents()
+    {
+      return "Eventos";
+    }
+    /*! Header used for the documentation section of a class' events. */
+    virtual QCString trEventDocumentation()
+    {
+      return "Documentação dos eventos";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a heading for a list of Java class types with package scope.
+     */
+    virtual QCString trPackageTypes()
+    {
+      return "Tipos do Pacote";
+    }
+    /*! Used as a heading for a list of Java class functions with package
+     * scope.
+     */
+    virtual QCString trPackageFunctions()
+    {
+      return "Funções do Pacote";
+    }
+    virtual QCString trPackageMembers()
+    {
+      return "Membros do Pacote";
+    }
+    /*! Used as a heading for a list of static Java class functions with
+     *  package scope.
+     */
+    virtual QCString trStaticPackageFunctions()
+    {
+      return "Funções Estáticas do Pacote";
+    }
+    /*! Used as a heading for a list of Java class variables with package
+     * scope.
+     */
+    virtual QCString trPackageAttribs()
+    {
+      return "Atributos do Pacote";
+    }
+    /*! Used as a heading for a list of static Java class variables with
+     * package scope.
+     */
+    virtual QCString trStaticPackageAttribs()
+    {
+      return "Atributos Estáticos do Pacote";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.1
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used in the quick index of a class/file/namespace member list page
+     *  to link to the unfiltered list of all members.
+     */
+    virtual QCString trAll()
+    {
+      return "Tudo";
+    }
+    /*! Put in front of the call graph for a function. */
+    virtual QCString trCallGraph()
+    {
+      return "Grafo de chamadas desta função:";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.3 - Based on the Brazilian Portuguese Translation
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This string is used as the title for the page listing the search
+     *  results.
+     */
+    virtual QCString trSearchResultsTitle()
+    {
+      return "Resultado da Busca";
+    }
+    /*! This string is put just before listing the search results. The
+     *  text can be different depending on the number of documents found.
+     *  Inside the text you can put the special marker $num to insert
+     *  the number representing the actual number of search results.
+     *  The @a numDocuments parameter can be either 0, 1 or 2, where the
+     *  value 2 represents 2 or more matches. HTML markup is allowed inside
+     *  the returned string.
+     */
+    virtual QCString trSearchResults(int numDocuments)
+    {
+      if (numDocuments==0)
+      {
+        return "Nenhum documento foi encontrado.";
+      }
+      else if (numDocuments==1)
+      {
+        return "Apenas <b>1</b> documento foi encontrado.";
+      }
       else
-        return "Pacotes";
-    case VhdlDocGen::SIGNAL:
-      if (single)
-        return "Sinal";
+      {
+        return "<b>$num</b> documentos encontrados. "
+               "Os melhores resultados vem primeiro.";
+      }
+    }
+    /*! This string is put before the list of matched words, for each search
+     *  result. What follows is the list of words that matched the query.
+     */
+    virtual QCString trSearchMatches()
+    {
+      return "Resultados:";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.8
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used in HTML as the title of page with source code for file filename
+     */
+    virtual QCString trSourceFile(QCString& filename)
+    {
+      return  "Código-Fonte de " + filename;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.3.9
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used as the name of the chapter containing the directory
+     *  hierarchy.
+     */
+    virtual QCString trDirIndex()
+    { return "Hierarquia de Diretórios"; }
+
+    /*! This is used as the name of the chapter containing the documentation
+     *  of the directories.
+     */
+    virtual QCString trDirDocumentation()
+    { return "Documentação do Directório"; }
+
+    /*! This is used as the title of the directory index and also in the
+     *  Quick links of a HTML page, to link to the directory hierarchy.
+     */
+    virtual QCString trDirectories()
+    { return "Diretórios"; }
+
+    /*! This returns the title of a directory page. The name of the
+     *  directory is passed via \a dirName.
+     */
+    virtual QCString trDirReference(const QCString &dirName)
+    {
+        QCString result = "Referência do diretório ";
+     	result += dirName;
+     	return result;
+    }
+
+    /*! This returns the word directory with or without starting capital
+     *  (\a first_capital) and in sigular or plural form (\a singular).
+     */
+    virtual QCString trDir(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Diretório" : "diretório"));
+      if (!singular) result+="s";
+      return result;
+    }
+//////////////////////////////////////////////////////////////////////////
+// new since 1.4.1
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This text is added to the documentation when the \\overload command
+     *  is used for a overloaded function.
+     */
+    virtual QCString trOverloadText()
+    {
+       return "Este é um método provido por conveniência. "
+       		"Ele difere do método acima apenas na lista de "
+       		"argumentos que devem ser utilizados.";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.4.6
+//////////////////////////////////////////////////////////////////////////
+
+    /*! This is used to introduce a caller (or called-by) graph */
+    virtual QCString trCallerGraph()
+    {
+      return "Este é o diagrama das funções que utilizam esta função:";
+    }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for enumeration values
+     */
+    virtual QCString trEnumerationValueDocumentation()
+    { return "Documentação da enumeração"; }
+
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.5.4 (mainly for Fortran)
+//////////////////////////////////////////////////////////////////////////
+
+    /*! header that is put before the list of member subprograms (Fortran). */
+    virtual QCString trMemberFunctionDocumentationFortran()
+    { return "Documentação de Função Membro/Subrotina"; }
+
+    /*! This is put above each page as a link to the list of annotated data types (Fortran). */
+    virtual QCString trCompoundListFortran()
+    { return "Lista de Tipos de Dados"; }
+
+    /*! This is put above each page as a link to all members of compounds (Fortran). */
+    virtual QCString trCompoundMembersFortran()
+    { return "Campos de Dados"; }
+
+    /*! This is an introduction to the annotated compound list (Fortran). */
+    virtual QCString trCompoundListDescriptionFortran()
+    { return "Aqui estão os tipos de dados com descrições resumidas:"; }
+
+    /*! This is an introduction to the page with all data types (Fortran). */
+    virtual QCString trCompoundMembersDescriptionFortran(bool extractAll)
+    {
+      QCString result="Esta é a lista de todos os membros ";
+      if (!extractAll) result+="documentados ";
+      result+="dos tipos de dados com links para ";
+      if (extractAll)
+      {
+        result+="a documentação dos tipos de dados para cada membro:";
+      }
       else
-        return "Sinais";
-    case VhdlDocGen::COMPONENT:
-      if (single)
-        return "Componente";
+      {
+        result+="os tipos de dados a que pertencem:";
+      }
+      return result;
+    }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     * annotated compound index (Fortran).
+     */
+    virtual QCString trCompoundIndexFortran()
+    { return "Índice de Tipos de Dados"; }
+
+    /*! This is used in LaTeX as the title of the chapter containing
+     *  the documentation of all data types (Fortran).
+     */
+    virtual QCString trTypeDocumentation()
+    { return "Documentação dos Tipos de Dados"; }
+
+    /*! This is used in the documentation of a file as a header before the
+     *  list of (global) subprograms (Fortran).
+     */
+    virtual QCString trSubprograms()
+    { return "Funções/Subrotinas"; }
+
+    /*! This is used in the documentation of a file/namespace before the list
+     *  of documentation blocks for subprograms (Fortran)
+     */
+    virtual QCString trSubprogramDocumentation()
+    { return "Documentação da Função/Subrotina"; }
+
+    /*! This is used in the documentation of a file/namespace/group before
+     *  the list of links to documented compounds (Fortran)
+     */
+     virtual QCString trDataTypes()
+    { return "Tipos de Dados"; }
+
+    /*! used as the title of page containing all the index of all modules (Fortran). */
+    virtual QCString trModulesList()
+    { return "Lista de Módulos"; }
+
+    /*! used as an introduction to the modules list (Fortran) */
+    virtual QCString trModulesListDescription(bool extractAll)
+    {
+      QCString result="Esta é a lista de todos os módulos ";
+      if (!extractAll) result+="documentados ";
+      result+="com descrições resumidas:";
+      return result;
+    }
+
+    /*! used as the title of the HTML page of a module/type (Fortran) */
+    virtual QCString trCompoundReferenceFortran(const QCString &clName,
+                                    ClassDef::CompoundType compType,
+                                    bool isTemplate)
+    {
+      QCString result = "Referência ";
+
+      if (isTemplate) result+="da Template ";
+
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="do Modulo "; break;
+        case ClassDef::Struct:     result+="do Tipo "; break;
+        case ClassDef::Union:      result+="da União "; break;
+        case ClassDef::Interface:  result+="da Interface "; break;
+        case ClassDef::Protocol:   result+="do Protocolo "; break;
+        case ClassDef::Category:   result+="da Categoria "; break;
+        case ClassDef::Exception:  result+="da Exceção "; break;
+        default: break;
+      }
+      result += clName;
+
+      return result;
+    }
+    /*! used as the title of the HTML page of a module (Fortran) */
+    virtual QCString trModuleReference(const QCString &namespaceName)
+    {
+      QCString result = "Referência do Módulo ";
+      result += namespaceName;
+      return result;
+    }
+
+    /*! This is put above each page as a link to all members of modules. (Fortran) */
+    virtual QCString trModulesMembers()
+    { return "Membros do Módulo"; }
+
+    /*! This is an introduction to the page with all modules members (Fortran) */
+    virtual QCString trModulesMemberDescription(bool extractAll)
+    {
+      QCString result="Esta é a lista de todos os membros ";
+      if (!extractAll) result+="documentados ";
+      result+="dos módulos com links para ";
+      if (extractAll)
+      {
+        result+="a documentação dos módulos para cada membro:";
+      }
       else
-        return "Componentes";
-    case VhdlDocGen::CONSTANT:
+      {
+        result+="os módulos a que pertencem:";
+      }
+      return result;
+    }
+
+    /*! This is used in LaTeX as the title of the chapter with the
+     *  index of all modules (Fortran).
+     */
+    virtual QCString trModulesIndex()
+    { return "Índice dos Módulos"; }
+
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trModule(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Modulo" : "modulo"));
+      if (!singular)  result+="s";
+      return result;
+    }
+    /*! This is put at the bottom of a module documentation page and is
+     *  followed by a list of files that were used to generate the page.
+     */
+    virtual QCString trGeneratedFromFilesFortran(ClassDef::CompoundType compType,
+        bool single)
+    { // here s is one of " Module", " Struct" or " Union"
+      // single is true implies a single file
+      QCString result="A documentação para ";
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="este modulo "; break;
+        case ClassDef::Struct:     result+="este tipo "; break;
+        case ClassDef::Union:      result+="esta união "; break;
+        case ClassDef::Interface:  result+="esta interface "; break;
+        case ClassDef::Protocol:   result+="esto protocolo "; break;
+        case ClassDef::Category:   result+="esta categoria "; break;
+        case ClassDef::Exception:  result+="esta exceção "; break;
+        default: break;
+      }
+
+      result+=" foi gerada a partir do";
       if (single)
-        return "Constante";
+    	result+=" seguinte ficheiro:";
       else
+    	result+="s seguintes ficheiros:";
+
+      return result;
+    }
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trType(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Tipo" : "tipo"));
+      if (!singular)  result+="s";
+      return result;
+    }
+    /*! This is used for translation of the word that will possibly
+     *  be followed by a single name or by a list of names
+     *  of the category.
+     */
+    virtual QCString trSubprogram(bool first_capital, bool singular)
+    {
+      QCString result((first_capital ? "Subprograma" : "subprograma"));
+      if (!singular)  result+="s";
+      return result;
+    }
+
+    /*! C# Type Contraint list */
+    virtual QCString trTypeConstraints()
+    {
+      return "Restrições do Tipo";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.6.0 (mainly for the new search engine)
+//////////////////////////////////////////////////////////////////////////
+
+    /*! directory relation for \a name
+     */
+    virtual QCString trDirRelation(const QCString &name)
+    {
+      return "Relação " + QCString(name);
+    }
+
+    /*! Loading message shown when loading search results */
+    virtual QCString trLoading()
+    {
+      return "Carregando...";
+    }
+
+    /*! Label used for search results in the global namespace */
+    virtual QCString trGlobalNamespace()
+    {
+      return "Namespace global";
+    }
+
+    /*! Message shown while searching */
+    virtual QCString trSearching()
+    {
+      return "Procurando...";
+    }
+
+    /*! Text shown when no search results are found */
+    virtual QCString trNoMatches()
+    {
+      return "Nenhuma entrada encontrada";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.6.3 (missing items for the directory pages)
+//////////////////////////////////////////////////////////////////////////
+
+    /*! when clicking a directory dependency label, a page with a
+     *  table is shown. The heading for the first column mentions the
+     *  source file that has a relation to another file.
+     */
+    virtual QCString trFileIn(const QCString &name)
+    {
+      return "Ficheiro em "+name;
+    }
+
+    /*! when clicking a directory dependency label, a page with a
+     *  table is shown. The heading for the second column mentions the
+     *  destination file that is included.
+     */
+    virtual QCString trIncludesFileIn(const QCString &name)
+    {
+      return "Inclui ficheiro em "+name;
+    }
+
+    /** Compiles a date string.
+     *  @param year Year in 4 digits
+     *  @param month Month of the year: 1=January
+     *  @param day Day of the Month: 1..31
+     *  @param dayOfWeek Day of the week: 1=Monday..7=Sunday
+     *  @param hour Hour of the day: 0..23
+     *  @param minutes Minutes in the hour: 0..59
+     *  @param seconds Seconds within the minute: 0..59
+     *  @param includeTime Include time in the result string?
+     */
+    virtual QCString trDateTime(int year,int month,int day,int dayOfWeek,
+                                int hour,int minutes,int seconds,
+                                bool includeTime)
+    {
+      static const char *days[]   = { "Segunda","Terça","Quarta","Quinta","Sexta","Sábado","Domingo" };
+      static const char *months[] = { "Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro" };
+      QCString sdate;
+      sdate.sprintf("%s, %d de %s de %d",days[dayOfWeek-1],day,months[month-1],year);
+      if (includeTime)
+      {
+        QCString stime;
+        stime.sprintf(" %.2d:%.2d:%.2d",hour,minutes,seconds);
+        sdate+=stime;
+      }
+      return sdate;
+    }
+    virtual QCString trDayOfWeek(int dayOfWeek, bool first_capital, bool full)
+    {
+      static const char *days_short[]   = { "seg", "ter", "qua", "qui", "sex", "sáb", "dom" };
+      static const char *days_full[]    = { "segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado", "domingo" };
+      QCString text  = full? days_full[dayOfWeek-1] : days_short[dayOfWeek-1];
+      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
+      else return text;
+    }
+    virtual QCString trMonth(int month, bool first_capital, bool full)
+    {
+      static const char *months_short[] = { "jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez" };
+      static const char *months_full[]  = { "janeiro", "fevereiro", "março", "abril", "maio", "junho", "julho", "agosto", "setembro", "outubro", "novembro", "dezembro" };
+      QCString text  = full? months_full[month-1] : months_short[month-1];
+      if (first_capital) return text.mid(0,1).upper()+text.mid(1);
+      else return text;
+    }
+    virtual QCString trDayPeriod(int period)
+    {
+      static const char *dayPeriod[] = { "AM", "PM" };
+      return dayPeriod[period];
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.7.5
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Header for the page with bibliographic citations */
+    virtual QCString trCiteReferences()
+    { return "Referências Bibliográficas"; }
+
+    /*! Text for copyright paragraph */
+    virtual QCString trCopyright()
+    {
+      // Note: I will left it as is because "Direitos de autor" may not fit
+      // in the text.
+      return "Copyright";
+    }
+
+    /*! Header for the graph showing the directory dependencies */
+    virtual QCString trDirDepGraph(const QCString &name)
+    { return QCString("Grafo de dependências do directório ")+name+":"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.0
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Detail level selector shown for hierarchical indices */
+    virtual QCString trDetailLevel()
+    { return "nível de detalhes"; }
+
+    /*! Section header for list of template parameters */
+    virtual QCString trTemplateParameters()
+    { return "Parâmetros de template"; }
+
+    /*! Used in dot graph when UML_LOOK is enabled and there are many fields */
+    virtual QCString trAndMore(const QCString &number)
+    { return "e "+number+" mais..."; }
+
+    /*! Used file list for a Java enum */
+    virtual QCString trEnumGeneratedFromFiles(bool single)
+    { QCString result = "A documentação para esta enumeração foi gerada a partir";
+      if (single) {
+        result += "do seguinte ficheiro:";
+      } else {
+        result += "dos seguintes ficheiros:";
+      }
+      return result;
+    }
+
+    /*! Header of a Java enum page (Java enums are represented as classes). */
+    virtual QCString trEnumReference(const QCString &name)
+    {
+      QCString result = "Referência da enumeração ";
+      return result + name;
+    }
+
+    /*! Used for a section containing inherited members */
+    virtual QCString trInheritedFrom(const QCString &members,const QCString &what)
+    { return QCString(members)+" herdados de "+what; }
+
+    /*! Header of the sections with inherited members specific for the
+     *  base class(es)
+     */
+    virtual QCString trAdditionalInheritedMembers()
+    { return "Outros membros herdados"; }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.2
+//////////////////////////////////////////////////////////////////////////
+
+    /*! Used as a tooltip for the toggle button that appears in the
+     *  navigation tree in the HTML output when GENERATE_TREEVIEW is
+     *  enabled. This tooltip explains the meaning of the button.
+     */
+    virtual QCString trPanelSynchronisationTooltip(bool enable)
+    {
+      QCString opt = enable ? "ativar" : "desativar";
+      return "clique para "+opt+" a sincronização do painel";
+    }
+
+    /*! Used in a method of an Objective-C class that is declared in a
+     *  a category. Note that the @1 marker is required and is replaced
+     *  by a link.
+     */
+    virtual QCString trProvidedByCategory()
+    {
+      return "Provido pela categoria @0.";
+    }
+
+    /*! Used in a method of an Objective-C category that extends a class.
+     *  Note that the @1 marker is required and is replaced by a link to
+     *  the class method.
+     */
+    virtual QCString trExtendsClass()
+    {
+      return "estende a classe @0.";
+    }
+
+    /*! Used as the header of a list of class methods in Objective-C.
+     *  These are similar to static public member functions in C++.
+     */
+    virtual QCString trClassMethods()
+    {
+      return "Métodos de classe";
+    }
+
+    /*! Used as the header of a list of instance methods in Objective-C.
+     *  These are similar to public member functions in C++.
+     */
+    virtual QCString trInstanceMethods()
+    {
+      return "Métodos de instância";
+    }
+
+    /*! Used as the header of the member functions of an Objective-C class.
+     */
+    virtual QCString trMethodDocumentation()
+    {
+      return "Documentação do método";
+    }
+
+//////////////////////////////////////////////////////////////////////////
+// new since 1.8.4
+//////////////////////////////////////////////////////////////////////////
+
+    /** old style UNO IDL services: implemented interfaces */
+    virtual QCString trInterfaces()
+    { return "Interfaces Exportadas"; }
+
+    /** old style UNO IDL services: inherited services */
+    virtual QCString trServices()
+    { return "Serviços Incluídos"; }
+
+    /** UNO IDL constant groups */
+    virtual QCString trConstantGroups()
+    { return "Grupos de Constantes"; }
+
+    /** UNO IDL constant groups */
+    virtual QCString trConstantGroupReference(const QCString &namespaceName)
+    {
+      QCString result = "Referência do grupo de constantes ";
+      result += namespaceName;
+      return result;
+    }
+
+    /** UNO IDL service page title */
+    virtual QCString trServiceReference(const QCString &sName)
+    {
+      QCString result = "Referência do serviço ";
+      result += sName;
+      return result;
+    }
+
+    /** UNO IDL singleton page title */
+    virtual QCString trSingletonReference(const QCString &sName)
+    {
+      QCString result = "Referência do Singleton ";
+      result += sName;
+      return result;
+    }
+
+    /** UNO IDL service page */
+    virtual QCString trServiceGeneratedFromFiles(bool single)
+    {
+      // single is true implies a single file
+      QCString result="A documentação para este serviço "
+                                "foi gerada a partir ";
+      if (single) {
+        result+="do seguinte ficheiro:";
+      } else {
+        result+="dos: seguintes ficheiros:";
+      }
+      return result;
+    }
+
+    /** UNO IDL singleton page */
+    virtual QCString trSingletonGeneratedFromFiles(bool single)
+    {
+      // single is true implies a single file
+      QCString result="A documentação para este singleton "
+                                "foi gerada a partir ";
+      if (single) {
+        result+="do seguinte ficheiro:";
+      } else {
+        result+="dos: seguintes ficheiros:";
+      }
+
+      return result;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.8.15
+    //////////////////////////////////////////////////////////////////////////
+
+    /** VHDL design unit hierarchy */
+    virtual QCString trDesignUnitHierarchy()
+    { return "Hierarquia da Unidade de Design"; }
+    /** VHDL design unit list */
+    virtual QCString trDesignUnitList()
+    { return "Lista de Unidades de Design"; }
+    /** VHDL design unit members */
+    virtual QCString trDesignUnitMembers()
+    { return "Membros da Unidade de Design"; }
+    /** VHDL design unit list description */
+    virtual QCString trDesignUnitListDescription()
+    {
+        return "Esta é uma lista de todos os membros de unidades de design "
+        		"com ligações para as entidades às quais pertencem:";
+    }
+    /** VHDL design unit index */
+    virtual QCString trDesignUnitIndex()
+    { return "Índice de Unidades de Design"; }
+    /** VHDL design units */
+    virtual QCString trDesignUnits()
+    { return "Unidades de Design"; }
+    /** VHDL functions/procedures/processes */
+    virtual QCString trFunctionAndProc()
+    { return "Funções/Procedimentos/Processos"; }
+    /** VHDL type */
+    virtual QCString trVhdlType(uint64 type,bool single)
+    {
+      switch(type)
+      {
+        case VhdlDocGen::LIBRARY:
+          if (single) return "Biblioteca";
+          else        return "Bibliotecas";
+        case VhdlDocGen::PACKAGE:
+          if (single) return "Pacote";
+          else        return "Pacotes";
+        case VhdlDocGen::SIGNAL:
+          if (single) return "Sinal";
+          else        return "Sinais";
+        case VhdlDocGen::COMPONENT:
+          if (single) return "Componente";
+          else        return "Componentes";
+        case VhdlDocGen::CONSTANT:
+          if (single) return "Constante";
+          else        return "Constantes";
+        case VhdlDocGen::ENTITY:
+          if (single) return "Entidade";
+          else        return "Entidades";
+        case VhdlDocGen::TYPE:
+          if (single) return "Tipo";
+          else        return "Tipos";
+        case VhdlDocGen::SUBTYPE:
+          if (single) return "Subtipo";
+          else        return "Subtipos";
+        case VhdlDocGen::FUNCTION:
+          if (single) return "Função";
+          else        return "Funções";
+        case VhdlDocGen::RECORD:
+          if (single) return "Registro";
+          else        return "Registros";
+        case VhdlDocGen::PROCEDURE:
+          if (single) return "Procedimento";
+          else        return "Procedimentos";
+        case VhdlDocGen::ARCHITECTURE:
+          if (single) return "Arquitetura";
+          else        return "Arquiteturas";
+        case VhdlDocGen::ATTRIBUTE:
+          if (single) return "Atributo";
+          else        return "Atributos";
+        case VhdlDocGen::PROCESS:
+          if (single) return "Processo";
+          else        return "Processos";
+        case VhdlDocGen::PORT:
+          if (single) return "Porta";
+          else        return "Portas";
+        case VhdlDocGen::USE:
+          if (single) return "cláusula de uso";
+          else        return "cláusulas de uso";
+        case VhdlDocGen::GENERIC:
+          if (single) return "Generico";
+          else        return "Genericos";
+        case VhdlDocGen::PACKAGE_BODY:
+          return "Corpo do Pacote";
+        case VhdlDocGen::UNITS:
+          return "Unidades";
+        case VhdlDocGen::SHAREDVARIABLE:
+          if (single) return "Variável Compartilhada";
+          else        return "Variáveis Compartilhadas";
+        case VhdlDocGen::VFILE:
+          if (single) return "Ficheiro";
+          else        return "Ficheiros";
+        case VhdlDocGen::GROUP:
+          if (single) return "Grupo";
+          else        return "Grupos";
+        case VhdlDocGen::INSTANTIATION:
+          if (single) return "Instância";
+          else        return "Instâncias";
+        case VhdlDocGen::ALIAS:
+          if (single) return "Apelido";
+          else        return "Apelidos";
+        case VhdlDocGen::CONFIG:
+          if (single) return "Configuração";
+          else        return "Configurações";
+        case VhdlDocGen::MISCELLANEOUS:
+          return "Outros"; // Is this correct for VHDL?
+        case VhdlDocGen::UCF_CONST:
+          return "Restrições";
+        default:
+          return "Classe";
+      }
+    }
+    virtual QCString trCustomReference(const QCString &name)
+    { return "Referência de " + QCString(name); }
+
+    /* Slice */
+    virtual QCString trConstants()
+    {
         return "Constantes";
-    case VhdlDocGen::ENTITY:
-      if (single)
-        return "Entidade";
-      else
-        return "Entidades";
-    case VhdlDocGen::TYPE:
-      if (single)
-        return "Tipo";
-      else
-        return "Tipos";
-    case VhdlDocGen::SUBTYPE:
-      if (single)
-        return "Subtipo";
-      else
-        return "Subtipos";
-    case VhdlDocGen::FUNCTION:
-      if (single)
-        return "Função";
-      else
-        return "Funções";
-    case VhdlDocGen::RECORD:
-      if (single)
-        return "Registro";
-      else
-        return "Registros";
-    case VhdlDocGen::PROCEDURE:
-      if (single)
-        return "Procedimento";
-      else
-        return "Procedimentos";
-    case VhdlDocGen::ARCHITECTURE:
-      if (single)
-        return "Arquitetura";
-      else
-        return "Arquiteturas";
-    case VhdlDocGen::ATTRIBUTE:
-      if (single)
-        return "Atributo";
-      else
-        return "Atributos";
-    case VhdlDocGen::PROCESS:
-      if (single)
-        return "Processo";
-      else
-        return "Processos";
-    case VhdlDocGen::PORT:
-      if (single)
-        return "Porta";
-      else
-        return "Portas";
-    case VhdlDocGen::USE:
-      if (single)
-        return "cláusula de uso";
-      else
-        return "cláusulas de uso";
-    case VhdlDocGen::GENERIC:
-      if (single)
-        return "Generico";
-      else
-        return "Genericos";
-    case VhdlDocGen::PACKAGE_BODY:
-      return "Corpo do Pacote";
-    case VhdlDocGen::UNITS:
-      return "Unidades";
-    case VhdlDocGen::SHAREDVARIABLE:
-      if (single)
-        return "Variável Compartilhada";
-      else
-        return "Variáveis Compartilhadas";
-    case VhdlDocGen::VFILE:
-      if (single)
-        return "Ficheiro";
-      else
-        return "Ficheiros";
-    case VhdlDocGen::GROUP:
-      if (single)
-        return "Grupo";
-      else
-        return "Grupos";
-    case VhdlDocGen::INSTANTIATION:
-      if (single)
-        return "Instância";
-      else
-        return "Instâncias";
-    case VhdlDocGen::ALIAS:
-      if (single)
-        return "Apelido";
-      else
-        return "Apelidos";
-    case VhdlDocGen::CONFIG:
-      if (single)
-        return "Configuração";
-      else
-        return "Configurações";
-    case VhdlDocGen::MISCELLANEOUS:
-      return "Outros"; // Is this correct for VHDL?
-    case VhdlDocGen::UCF_CONST:
-      return "Restrições";
-    default:
-      return "Classe";
     }
-  }
-  virtual QCString trCustomReference(const QCString &name)
-  {
-    return "Referência de " + QCString(name);
-  }
-
-  /* Slice */
-  virtual QCString trConstants()
-  {
-    return "Constantes";
-  }
-  virtual QCString trConstantDocumentation()
-  {
-    return "Constantes";
-  }
-  virtual QCString trSequences()
-  {
-    return "Sequências";
-  }
-  virtual QCString trSequenceDocumentation()
-  {
-    return "Sequências";
-  }
-  virtual QCString trDictionaries()
-  {
-    return "Dicionários";
-  }
-  virtual QCString trDictionaryDocumentation()
-  {
-    return "Dicionários";
-  }
-  virtual QCString trSliceInterfaces()
-  {
-    return "Interfaces";
-  }
-  virtual QCString trInterfaceIndex()
-  {
-    return "Índice de Interfaces";
-  }
-  virtual QCString trInterfaceList()
-  {
-    return "Lista de Interfaces";
-  }
-  virtual QCString trInterfaceListDescription()
-  {
-    return "Estas são as interfaces com suas respectivas descrições:";
-  }
-  virtual QCString trInterfaceHierarchy()
-  {
-    return "Hierarquia de Interfaces";
-  }
-  virtual QCString trInterfaceHierarchyDescription()
-  {
-    return "Esta é a lista parcialmente ordenadas de heranças:";
-  }
-  virtual QCString trInterfaceDocumentation()
-  {
-    return "Interfaces";
-  }
-  virtual QCString trStructs()
-  {
-    return "Estruturas";
-  }
-  virtual QCString trStructIndex()
-  {
-    return "Índice de Estruturas";
-  }
-  virtual QCString trStructList()
-  {
-    return "Lista de Estruturas";
-  }
-  virtual QCString trStructListDescription()
-  {
-    return "Estas são as estruturas com suas respectivas descrições:";
-  }
-  virtual QCString trStructDocumentation()
-  {
-    return "Estruturas";
-  }
-  virtual QCString trExceptionIndex()
-  {
-    return "Índice the Exceções";
-  }
-  virtual QCString trExceptionList()
-  {
-    return "Lista de Exceções";
-  }
-  virtual QCString trExceptionListDescription()
-  {
-    return "Estas são as exceções com suas respectivas descrições:";
-  }
-  virtual QCString trExceptionHierarchy()
-  {
-    return "Hierarquia de Exceções";
-  }
-  virtual QCString trExceptionHierarchyDescription()
-  {
-    return "Esta é a lista parcialmente ordenadas de heranças:";
-  }
-  virtual QCString trExceptionDocumentation()
-  {
-    return "Exceções";
-  }
-  virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
-  {
-    QCString result = "Referência ";
-    switch (compType)
+    virtual QCString trConstantDocumentation()
     {
-    case ClassDef::Class:
-      result += "da Classe ";
-      break;
-    case ClassDef::Struct:
-      result += "da Estrutura ";
-      break;
-    case ClassDef::Union:
-      result += "da União ";
-      break;
-    case ClassDef::Interface:
-      result += "da Interface ";
-      break;
-    case ClassDef::Protocol:
-      result += "do Protocolo ";
-      break;
-    case ClassDef::Category:
-      result += "da Categoria ";
-      break;
-    case ClassDef::Exception:
-      result += "da Exceção ";
-      break;
-    default:
-      break;
+        return "Constantes";
     }
-    if (isLocal)
-      result += "Local ";
-    result += clName;
-    return result;
-  }
-  virtual QCString trOperations()
-  {
-    return "Operações";
-  }
-  virtual QCString trOperationDocumentation()
-  {
-    return "Operações";
-  }
-  virtual QCString trDataMembers()
-  {
-    return "Dados Membros";
-  }
-  virtual QCString trDataMemberDocumentation()
-  {
-    return "Dados Membros";
-  }
+    virtual QCString trSequences()
+    {
+        return "Sequências";
+    }
+    virtual QCString trSequenceDocumentation()
+    {
+        return "Sequências";
+    }
+    virtual QCString trDictionaries()
+    {
+        return "Dicionários";
+    }
+    virtual QCString trDictionaryDocumentation()
+    {
+        return "Dicionários";
+    }
+    virtual QCString trSliceInterfaces()
+    {
+        return "Interfaces";
+    }
+    virtual QCString trInterfaceIndex()
+    {
+        return "Índice de Interfaces";
+    }
+    virtual QCString trInterfaceList()
+    {
+        return "Lista de Interfaces";
+    }
+    virtual QCString trInterfaceListDescription()
+    {
+        return "Estas são as interfaces com suas respectivas descrições:";
+    }
+    virtual QCString trInterfaceHierarchy()
+    {
+        return "Hierarquia de Interfaces";
+    }
+    virtual QCString trInterfaceHierarchyDescription()
+    {
+        return "Esta é a lista parcialmente ordenadas de heranças:";
+    }
+    virtual QCString trInterfaceDocumentation()
+    {
+        return "Interfaces";
+    }
+    virtual QCString trStructs()
+    {
+        return "Estruturas";
+    }
+    virtual QCString trStructIndex()
+    {
+        return "Índice de Estruturas";
+    }
+    virtual QCString trStructList()
+    {
+        return "Lista de Estruturas";
+    }
+    virtual QCString trStructListDescription()
+    {
+        return "Estas são as estruturas com suas respectivas descrições:";
+    }
+    virtual QCString trStructDocumentation()
+    {
+        return "Estruturas";
+    }
+    virtual QCString trExceptionIndex()
+    {
+        return "Índice the Exceções";
+    }
+    virtual QCString trExceptionList()
+    {
+        return "Lista de Exceções";
+    }
+    virtual QCString trExceptionListDescription()
+    {
+        return "Estas são as exceções com suas respectivas descrições:";
+    }
+    virtual QCString trExceptionHierarchy()
+    {
+        return "Hierarquia de Exceções";
+    }
+    virtual QCString trExceptionHierarchyDescription()
+    {
+        return "Esta é a lista parcialmente ordenadas de heranças:";
+    }
+    virtual QCString trExceptionDocumentation()
+    {
+        return "Exceções";
+    }
+    virtual QCString trCompoundReferenceSlice(const QCString &clName, ClassDef::CompoundType compType, bool isLocal)
+    {
+      QCString result="Referência ";
+      switch(compType)
+      {
+        case ClassDef::Class:      result+="da Classe "; break;
+        case ClassDef::Struct:     result+="da Estrutura "; break;
+        case ClassDef::Union:      result+="da União "; break;
+        case ClassDef::Interface:  result+="da Interface "; break;
+        case ClassDef::Protocol:   result+="do Protocolo "; break;
+        case ClassDef::Category:   result+="da Categoria "; break;
+        case ClassDef::Exception:  result+="da Exceção "; break;
+        default: break;
+      }
+      if (isLocal) result+="Local ";
+      result+= clName;
+      return result;
+    }
+    virtual QCString trOperations()
+    {
+        return "Operações";
+    }
+    virtual QCString trOperationDocumentation()
+    {
+        return "Operações";
+    }
+    virtual QCString trDataMembers()
+    {
+        return "Dados Membros";
+    }
+    virtual QCString trDataMemberDocumentation()
+    {
+        return "Dados Membros";
+    }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.8.19
-  //////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.8.19
+    //////////////////////////////////////////////////////////////////////////
 
-  /** VHDL design unit documentation */
-  virtual QCString trDesignUnitDocumentation()
-  {
-    return "Documentação da Unidade de Projeto";
-  }
+    /** VHDL design unit documentation */
+    virtual QCString trDesignUnitDocumentation()
+    {
+        return "Documentação da Unidade de Projeto";
+    }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.9.2
-  //////////////////////////////////////////////////////////////////////////
-  /** C++20 concept */
-  virtual QCString trConcept(bool first_capital, bool singular)
-  {
-    QCString result((first_capital ? "Conceito" : "conceito"));
-    if (!singular)
-      result += "s";
-    return result;
-  }
-  /*! used as the title of the HTML page of a C++20 concept page */
-  virtual QCString trConceptReference(const QCString &conceptName)
-  {
-    QCString result = "Referência do Conceito ";
-    result += conceptName;
-    return result;
-  }
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.9.2
+    //////////////////////////////////////////////////////////////////////////
 
-  /*! used as the title of page containing all the index of all concepts. */
-  virtual QCString trConceptList()
-  {
-    return "Lista de Conceitos";
-  }
+    /** C++20 concept */
+    virtual QCString trConcept(bool first_capital, bool singular)
+    {
+        QCString result((first_capital ? "Conceito" : "conceito"));
+        if (!singular) result+="s";
+        return result;
+    }
+    /*! used as the title of the HTML page of a C++20 concept page */
+    virtual QCString trConceptReference(const QCString &conceptName)
+    {
+        QCString result= "Referência do Conceito ";
+        result+=conceptName;
+        return result;
+    }
 
-  /*! used as the title of chapter containing the index listing all concepts. */
-  virtual QCString trConceptIndex()
-  {
-    return "Índice de Conceitos";
-  }
+    /*! used as the title of page containing all the index of all concepts. */
+    virtual QCString trConceptList()
+    { return "Lista de Conceitos"; }
 
-  /*! used as the title of chapter containing all information about concepts. */
-  virtual QCString trConceptDocumentation()
-  {
-    return "Documentação do Conceito";
-  }
+    /*! used as the title of chapter containing the index listing all concepts. */
+    virtual QCString trConceptIndex()
+    { return "Índice de Conceitos"; }
 
-  /*! used as an introduction to the concept list */
-  virtual QCString trConceptListDescription(bool extractAll)
-  {
-    QCString result = "Esta é a lista de todos os conceitos ";
-    if (!extractAll)
-      result += "documentados ";
-    result += "com suas respectivas descrições:";
-    return result;
-  }
+    /*! used as the title of chapter containing all information about concepts. */
+    virtual QCString trConceptDocumentation()
+    { return "Documentação do Conceito"; }
 
-  /*! used to introduce the definition of the C++20 concept */
-  virtual QCString trConceptDefinition()
-  {
-    return "Definição de conceito";
-  }
+    /*! used as an introduction to the concept list */
+    virtual QCString trConceptListDescription(bool extractAll)
+    {
+        QCString result="Esta é a lista de todos os conceitos ";
+        if (!extractAll) result+="documentados ";
+        result+="com suas respectivas descrições:";
+        return result;
+    }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.9.4
-  //////////////////////////////////////////////////////////////////////////
-  virtual QCString trPackageList()
-  {
-    return "Lista de pacotes";
-  }
+    /*! used to introduce the definition of the C++20 concept */
+    virtual QCString trConceptDefinition()
+    {
+        return "Definição de conceito";
+    }
 
-  //////////////////////////////////////////////////////////////////////////
-  // new since 1.9.6
-  //////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.9.4
+    //////////////////////////////////////////////////////////////////////////
+    virtual QCString trPackageList()
+    { return "Lista de pacotes"; }
+    
+    //////////////////////////////////////////////////////////////////////////
+    // new since 1.9.6
+    //////////////////////////////////////////////////////////////////////////
 
-  /*! This is used for translation of the word that will be
-   *  followed by a single name of the VHDL process flowchart.
-   */
-  virtual QCString trFlowchart()
-  {
-    return "Fluxograma: ";
-  }
+    /*! This is used for translation of the word that will be
+     *  followed by a single name of the VHDL process flowchart.
+     */
+    virtual QCString trFlowchart()
+    {
+        return "Fluxograma: ";
+    }
 
-  /*! Please translate also updated body of the method
-   *  trMemberFunctionDocumentation(), now better adapted for
-   *  VHDL sources documentation.
-   */
+    /*! Please translate also updated body of the method
+     *  trMemberFunctionDocumentation(), now better adapted for
+     *  VHDL sources documentation.
+    */        
 };
 
 #endif


### PR DESCRIPTION
This is the new version of the Portuguese translators updated to 1.9.6. This time, the format has been reverted back to the original one from commit 28ec5dc5a74e0b2cbf66ea0fde2696f9c5c340be. The previous pull request was not suitable to be merged due to an unwanted auto format performed by VS Code.