### PR TITLE
[regression] Double negate

### DIFF
--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -185,7 +185,7 @@ int Portable::system(const QCString &command,const QCString &args,bool commandHa
       WaitForSingleObject(sInfo.hProcess,INFINITE);
       /* get process exit code */
       DWORD exitCode;
-      bool retval = !GetExitCodeProcess(sInfo.hProcess,&exitCode);
+      bool retval = GetExitCodeProcess(sInfo.hProcess,&exitCode);
       CloseHandle(sInfo.hProcess);
       delete[] commandw;
       delete[] argsw;


### PR DESCRIPTION
Due to  #9565 a double negate slipped into the, Windows part of the, code so that a.o. the documentation didn't build.