### PR TITLE
Warning during compilation on Windows systems

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -252,7 +252,7 @@ static QCString escapeObject(yyscan_t yyscanner,const char *s);
 static QCString escapeWord(yyscan_t yyscanner,const char *s);
 static QCString escapeComment(yyscan_t yyscanner,const char *s);
 static bool skipLanguageSpecificKeyword(yyscan_t yyscanner,const char *kw);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static void addVariable(yyscan_t yyscanner,QCString type,QCString name);
 static bool startsWithKeyword(const QCString &str,const QCString &kw);
 
@@ -3839,7 +3839,7 @@ static bool isCastKeyword(const char *keyword)
   return kw=="const_cast" || kw=="static_cast" || kw=="dynamic_cast" || kw=="reinterpret_cast";
 }
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;
@@ -3851,7 +3851,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     c++;
   }
   yyextra->inputPosition += c;
-  return c;
+  return static_cast<int>(c);
 }
 
 

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -116,7 +116,7 @@ static void startCondSection(yyscan_t yyscanner,const QCString &sectId);
 static void endCondSection(yyscan_t yyscanner);
 static void handleCondSectionId(yyscan_t yyscanner,const char *expression);
 static void replaceAliases(yyscan_t yyscanner,const QCString &s);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static void replaceComment(yyscan_t yyscanner,int offset);
 static void clearCommentStack(yyscan_t yyscanner);
 
@@ -1150,14 +1150,14 @@ static void replaceAliases(yyscan_t yyscanner,const QCString &s)
 }
 
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t bytesInBuf = yyextra->inBuf->curPos()-yyextra->inBufPos;
   yy_size_t bytesToCopy = std::min(max_size,bytesInBuf);
   memcpy(buf,yyextra->inBuf->data()+yyextra->inBufPos,bytesToCopy);
   yyextra->inBufPos+=bytesToCopy;
-  return bytesToCopy;
+  return static_cast<int>(bytesToCopy);
 }
 
 static void replaceComment(yyscan_t yyscanner,int offset)

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -461,7 +461,7 @@ static inline void addOutput(yyscan_t yyscanner,const QCString &s);
 static inline void addOutput(yyscan_t yyscanner,char c);
 static void endBrief(yyscan_t yyscanner,bool addToOutput=TRUE);
 static void handleGuard(yyscan_t yyscanner,const QCString &expr);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static void addCite(yyscan_t yyscanner);
 static void addIline(yyscan_t yyscanner,int lineNr);
 static void addIlineBreak(yyscan_t yyscanner,int lineNr);
@@ -3589,7 +3589,7 @@ static void endBrief(yyscan_t yyscanner,bool addToOutput)
   }
 }
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->prevPosition=yyextra->inputPosition;
@@ -3600,7 +3600,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     //printf("%d (%c)\n",*buf,*buf);
     c++; buf++;
   }
-  return c;
+  return static_cast<int>(c);
 }
 
 //----------------------------------------------------------------------------

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -647,24 +647,24 @@ static inline const char *getLexerFILE() {return __FILE__;}
 #define LEX_NO_REENTRANT
 #include "doxygen_lex.h"
 
-static yy_size_t yyread(char *buf,yy_size_t max_size)
+static int yyread(char *buf,yy_size_t max_size)
 {
   // no file included
   if (g_includeStack.empty())
   {
     yy_size_t c=0;
-    if (g_inputString==0) return c;
+    if (g_inputString==0) return static_cast<int>(c);
     while( c < max_size && g_inputString[g_inputPosition] )
     {
       *buf = g_inputString[g_inputPosition++] ;
       c++; buf++;
     }
-    return c;
+    return static_cast<int>(c);
   }
   else
   {
     //assert(g_includeStack.current()->newState==YY_CURRENT_BUFFER);
-    return static_cast<yy_size_t>(fread(buf,1,max_size,g_includeStack.back()->filePtr));
+    return static_cast<int>(fread(buf,1,max_size,g_includeStack.back()->filePtr));
   }
 }
 

--- a/src/constexp.l
+++ b/src/constexp.l
@@ -42,7 +42,7 @@
 static const char *stateToString(int state);
 #endif
 
-static yy_size_t yyread(char *buf,yy_size_t max_size,yyscan_t yyscanner);
+static int yyread(char *buf,yy_size_t max_size,yyscan_t yyscanner);
 
 #undef  YY_INPUT
 #define YY_INPUT(buf,result,max_size) result=yyread(buf,max_size,yyscanner);
@@ -110,7 +110,7 @@ CONSTSUFFIX ([uU][lL]?[lL]?)|([lL][lL]?[uU]?)
 
 %%
 
-static yy_size_t yyread(char *buf,yy_size_t max_size,yyscan_t yyscanner)
+static int yyread(char *buf,yy_size_t max_size,yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = static_cast<struct yyguts_t*>(yyscanner);
   yy_size_t c=0;
@@ -119,7 +119,7 @@ static yy_size_t yyread(char *buf,yy_size_t max_size,yyscan_t yyscanner)
     *buf = yyextra->inputString[yyextra->inputPosition++] ;
     c++; buf++;
   }
-  return c;
+  return static_cast<int>(c);
 }
 
 struct ConstExpressionParser::Private

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -79,7 +79,7 @@ static const char *stateToString(int state);
 
 static void addType(yyscan_t yyscanner);
 static void addTypeName(yyscan_t yyscanner);
-static yy_size_t yyread(char *buf,yy_size_t max_size, yyscan_t yyscanner);
+static int yyread(char *buf,yy_size_t max_size, yyscan_t yyscanner);
 
 /* -----------------------------------------------------------------
  */
@@ -295,7 +295,7 @@ static void addTypeName(yyscan_t yyscanner)
   yyextra->name.resize(0);
 }
 
-static yy_size_t yyread(char *buf,yy_size_t max_size, yyscan_t yyscanner)
+static int yyread(char *buf,yy_size_t max_size, yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
@@ -304,7 +304,7 @@ static yy_size_t yyread(char *buf,yy_size_t max_size, yyscan_t yyscanner)
     *buf = yyextra->inputString[yyextra->inputPosition++] ;
     c++; buf++;
   }
-  return c;
+  return static_cast<int>(c);
 }
 
 /*@ public interface------------------------------------------------------------

--- a/src/defargs.l
+++ b/src/defargs.l
@@ -107,7 +107,7 @@ struct defargsYY_state
 static const char *stateToString(int state);
 #endif
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static bool nameIsActuallyPartOfType(QCString &name);
 
 /* -----------------------------------------------------------------
@@ -620,7 +620,7 @@ CPPC  "/\/"
 /* ----------------------------------------------------------------------------
  */
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
@@ -629,7 +629,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
       *buf = yyextra->inputString[yyextra->inputPosition++] ;
       c++; buf++;
   }
-  return c;
+  return static_cast<int>(c);
 }
 
 /*

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -101,7 +101,7 @@ static const char *stateToString(int state);
 #endif
 
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static void handleHtmlTag(yyscan_t yyscanner,const char *text);
 static void processSection(yyscan_t yyscanner);
 
@@ -1536,14 +1536,14 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 
 //--------------------------------------------------------------------------
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
   const char *p = yyextra->inputString + yyextra->inputPos;
   while ( c < max_size && *p ) { *buf++ = *p++; c++; }
   yyextra->inputPos+=c;
-  return c;
+  return static_cast<int>(c);
 }
 
 static void processSection(yyscan_t yyscanner)

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -210,7 +210,7 @@ static void addUse(yyscan_t yyscanner,const QCString &moduleName);
 static void addLocalVar(yyscan_t yyscanner,const QCString &varName);
 static MemberDef *getFortranDefs(yyscan_t yyscanner,const QCString &memberName, const QCString &moduleName,
                                  const UseMap &useMap);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static inline void pop_state(yyscan_t yyscanner);
 
 
@@ -850,7 +850,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 /*@ ----------------------------------------------------------------------------
  */
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;
@@ -862,7 +862,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     c++;
   }
   yyextra->inputPosition += c;
-  return c;
+  return static_cast<int>(c);
 }
 
 static void endFontClass(yyscan_t yyscanner)

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -217,7 +217,7 @@ static QCString extractFromParens(const QCString &name);
 static QCString extractBind(const QCString &name);
 
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static void startCommentBlock(yyscan_t yyscanner,bool);
 static void handleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief);
 static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief);
@@ -2400,7 +2400,7 @@ static bool endScope(yyscan_t yyscanner,Entry *scope, bool isGlobalRoot)
   return TRUE;
 }
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
@@ -2409,7 +2409,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     *buf = yyextra->inputString[yyextra->inputPosition++] ;
     c++; buf++;
   }
-  return c;
+  return static_cast<int>(c);
 }
 
 static void initParser(yyscan_t yyscanner)

--- a/src/lexcode.l
+++ b/src/lexcode.l
@@ -100,7 +100,7 @@ static void nextCodeLine(yyscan_t yyscanner);
 static void codifyLines(yyscan_t yyscanner,const QCString &text);
 static void startFontClass(yyscan_t yyscanner,const char *s);
 static int countLines(yyscan_t yyscanner);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static void lineCount(yyscan_t yyscanner);
 static void handleCCode(yyscan_t yyscanner);
 
@@ -1110,7 +1110,7 @@ static int countLines(yyscan_t yyscanner)
   return count;
 }
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;
@@ -1122,7 +1122,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     c++;
   }
   yyextra->inputPosition += c;
-  return c;
+  return static_cast<int>(c);
 }
 
 static void lineCount(yyscan_t yyscanner)

--- a/src/lexscanner.l
+++ b/src/lexscanner.l
@@ -97,7 +97,7 @@ static const char *stateToString(int state);
 
 // forward declarations for statefull functions
 static void handleCCode(yyscan_t yyscanner);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 /* ----------------------------------------------------------------- */
 #undef  YY_INPUT
@@ -929,7 +929,7 @@ NONLopt [^\n]*
 %%
 
 //----------------------------------------------------------------------------
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
@@ -939,7 +939,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     //printf("%d (%c)\n",*buf,*buf);
     c++; buf++;
   }
-  return c;
+  return static_cast<int>(c);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/pre.l
+++ b/src/pre.l
@@ -339,7 +339,7 @@ static void      endCondSection(yyscan_t yyscanner);
 static void  addMacroDefinition(yyscan_t yyscanner);
 static void           addDefine(yyscan_t yyscanner);
 static void         setFileName(yyscan_t yyscanner,const QCString &name);
-static yy_size_t         yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int               yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static Define *       isDefined(yyscan_t yyscanner,const QCString &name);
 
 /* ----------------------------------------------------------------- */
@@ -1855,14 +1855,14 @@ WSopt [ \t\r]*
 
 /////////////////////////////////////////////////////////////////////////////////////
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   YY_EXTRA_TYPE state = preYYget_extra(yyscanner);
   yy_size_t bytesInBuf = state->inputBuf->curPos()-state->inputBufPos;
   yy_size_t bytesToCopy = std::min(max_size,bytesInBuf);
   memcpy(buf,state->inputBuf->data()+state->inputBufPos,bytesToCopy);
   state->inputBufPos+=bytesToCopy;
-  return bytesToCopy;
+  return static_cast<int>(bytesToCopy);
 }
 
 static void setFileName(yyscan_t yyscanner,const QCString &name)

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -147,7 +147,7 @@ static bool findMemberLink(yyscan_t yyscanner, CodeOutputInterface &ol,
 static void findMemberLink(yyscan_t yyscanner, CodeOutputInterface &ol,
                            const QCString &symName);
 static void adjustScopesAndSuites(yyscan_t yyscanner,unsigned indentLength);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 static inline void pop_state(yyscan_t yyscanner);
 
 #if 0 // TODO: call me to store local variables and get better syntax highlighting, see code.l
@@ -879,7 +879,7 @@ static void addVariable(yyscan_t yyscanner, QCString type, QCString name)
 
 //-------------------------------------------------------------------------------
 
-static yy_size_t yyread(yyscan_t yyscanner, char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner, char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;
@@ -891,7 +891,7 @@ static yy_size_t yyread(yyscan_t yyscanner, char *buf,yy_size_t max_size)
     c++;
   }
   yyextra->inputPosition += c;
-  return c;
+  return static_cast<int>(c);
 }
 
 //-------------------------------------------------------------------------------

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -142,7 +142,7 @@ static void searchFoundDef(yyscan_t yyscanner);
 static void searchFoundClass(yyscan_t yyscanner);
 static QCString findPackageScope(yyscan_t yyscanner,const QCString &fileName);
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 //-----------------------------------------------------------------------------
 /* ----------------------------------------------------------------- */
@@ -1479,14 +1479,14 @@ STARTDOCSYMS      "##"
 
 //----------------------------------------------------------------------------
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
   const char *p = yyextra->inputString + yyextra->inputPosition;
   while ( c < max_size && *p ) { *buf++ = *p++; c++; }
   yyextra->inputPosition+=c;
-  return c;
+  return static_cast<int>(c);
 }
 
 static void initParser(yyscan_t yyscanner)

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -234,7 +234,7 @@ static bool checkForKnRstyleC(yyscan_t yyscanner);
 static void splitKnRArg(yyscan_t yyscanner,QCString &oldStyleArgPtr,QCString &oldStyleArgName);
 static void addKnRArgInfo(yyscan_t yyscanner,const QCString &type,const QCString &name,
                           const QCString &brief,const QCString &docs);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 /* ----------------------------------------------------------------- */
 #undef  YY_INPUT
@@ -7104,7 +7104,7 @@ NONLopt [^\n]*
 %%
 
 //----------------------------------------------------------------------------
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t c=0;
@@ -7114,7 +7114,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     //printf("%d (%c)\n",*buf,*buf);
     c++; buf++;
   }
-  return c;
+  return static_cast<int>(c);
 }
 
 

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -84,7 +84,7 @@ static void nextCodeLine(yyscan_t yyscanner);
 static void codifyLines(yyscan_t yyscanner,const char *text);
 static void startFontClass(yyscan_t yyscanner,const char *s);
 static int countLines(yyscan_t yyscanner);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 #undef YY_INPUT
 #define YY_INPUT(buf,result,max_size) result=yyread(yyscanner,buf,max_size);
@@ -366,7 +366,7 @@ static int countLines(yyscan_t yyscanner)
   return count;
 }
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;
@@ -378,7 +378,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     c++;
   }
   yyextra->inputPosition += c;
-  return c;
+  return static_cast<int>(c);
 }
 
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6094,8 +6094,8 @@ static QCString expandAliasRec(StringUnorderedSet &aliasesProcessed,const QCStri
   if (result == s)
   {
     std::string orgStr = s.str();
-    int ridx = orgStr.rfind('-');
-    if (ridx != -1) return expandAliasRec(aliasesProcessed,s.left(ridx),allowRecursion) + s.right(s.length() - ridx);
+    size_t ridx = orgStr.rfind('-');
+    if (ridx != std::string::npos) return expandAliasRec(aliasesProcessed,s.left(ridx),allowRecursion) + s.right(s.length() - ridx);
   }
 
   return result;
@@ -7259,7 +7259,7 @@ bool recognizeFixedForm(const QCString &contents, FortranFormat format)
   {
     column++;
 
-    switch(contents[i])
+    switch(contents.at(i))
     {
       case '\n':
         column=0;

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -138,7 +138,7 @@ static void appStringLower(QCString& qcs,const char* text);
 static void codifyMapLines(yyscan_t yyscanner,const QCString &text);
 static void writeFuncProto(yyscan_t yyscanner);
 static void writeProcessProto(yyscan_t yyscanner);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 #if USE_STATE2STRING
 static const char *stateToString(int state);
@@ -921,7 +921,7 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
 /*@ ----------------------------------------------------------------------------
  */
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;
@@ -933,7 +933,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size)
     c++;
   }
   yyextra->inputPosition += c;
-  return c;
+  return static_cast<int>(c);
 }
 
 static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor)

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -100,7 +100,7 @@ static void nextCodeLine(yyscan_t yyscanner);
 static void codifyLines(yyscan_t yyscanner,const char *text);
 static void startFontClass(yyscan_t yyscanner,const char *s);
 static int  countLines(yyscan_t yyscanner);
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
+static int yyread(yyscan_t yyscanner,char *buf,yy_size_t max_size);
 
 #undef YY_INPUT
 #define YY_INPUT(buf,result,max_size) result=yyread(yyscanner,buf,max_size);
@@ -204,7 +204,7 @@ string      \"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
 
 //----------------------------------------------------------------------------------------
 
-static yy_size_t yyread(yyscan_t yyscanner,char *buf,size_t max_size)
+static int yyread(yyscan_t yyscanner,char *buf,size_t max_size)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yy_size_t inputPosition = yyextra->inputPosition;
@@ -216,7 +216,7 @@ static yy_size_t yyread(yyscan_t yyscanner,char *buf,size_t max_size)
     c++;
   }
   yyextra->inputPosition += c;
-  return c;
+  return static_cast<int>(c);
 }
 
 static void codify(yyscan_t yyscanner,const char* text)


### PR DESCRIPTION
This is based on the warning type: 4267 'variable': conversion from 'size_t' to 'type', possible loss of data