### PR TITLE
Usage of steady_clock

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -117,16 +117,16 @@ class Timer
   public:
     void start()
     {
-      m_startTime = std::chrono::system_clock::now();
+      m_startTime = std::chrono::steady_clock::now();
     }
     double elapsedTimeS()
     {
       return (std::chrono::duration_cast<
                   std::chrono::microseconds>(
-                  std::chrono::system_clock::now() - m_startTime).count()) / 1000000.0;
+                  std::chrono::steady_clock::now() - m_startTime).count()) / 1000000.0;
     }
   private:
-    std::chrono::time_point<std::chrono::system_clock> m_startTime;
+    std::chrono::time_point<std::chrono::steady_clock> m_startTime;
 };
 
 static Timer g_runningTime;


### PR DESCRIPTION
Use the steady_clock (like in portable.cpp and doxygen.cpp) as the system_clock can be adjusted (e.g. leap seconds, daylit saving time, user adjusting the clock on the computer).

**steady clock**
Objects of class steady_clock represent clocks for which values of time_point never decrease as physical time advances and for which values of time_point advance at a steady rate relative to real time. That is, the clock may not be adjusted.

**system_clock**
Objects of type system_clock represent wall clock time from the system-wide realtime clock.