### PR TITLE
Spurious characters in Fortran Fixed to free format conversion

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1826,13 +1826,17 @@ const char* prepassFixedForm(const char* contents, int *hasContLine,int fixedCom
     free(newContents);
     return NULL;
   }
-  newContentsSize = (int)strlen(newContents);
-  if (newContents[newContentsSize - 1] != '\n')
+
+  if (newContents[j] == '\n')
   {
-    // to be on the safe side
-    newContents = (char*)realloc(newContents, newContentsSize+2);
-    newContents[newContentsSize] = '\n';
-    newContents[newContentsSize + 1] = '\000';
+    newContents = (char*)realloc(newContents, j+2);
+    newContents[j + 1] = '\000';
+  }
+  else
+  {
+    newContents = (char*)realloc(newContents, j+3);
+    newContents[j + 1] = '\n';
+    newContents[j + 2] = '\000';
   }
   return newContents;
 }

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1827,7 +1827,13 @@ const char* prepassFixedForm(const char* contents, int *hasContLine,int fixedCom
     return NULL;
   }
 
-  if (newContents[j] == '\n')
+  if (sizCont==0)
+  {
+    newContents = (char*)realloc(newContents, 2);
+    newContents[0] = '\n';
+    newContents[1] = '\000';
+  }
+  else if (newContents[j] == '\n')
   {
     newContents = (char*)realloc(newContents, j+2);
     newContents[j + 1] = '\000';


### PR DESCRIPTION
In the Fortran fixed to free format conversion it is possible that the buffer is not closed properly and that left over characters in allocated memory are shown. This results in warnings like:
```
Error in file .../call_sub.f line: 7, state: 10(ModuleBody)
```
and the conversion reveals:
```
======== Fixed to Free format  =========
---- Input fixed form string -------
        subroutine call_sub
          call mysub()
          call my_sub()
        end

---- Resulting free form string -------
        subroutine call_sub
          call mysub()
          call my_sub()
        end
ll my_sub()
     1

********************************************************************
Error in file .../call_sub.f line: 7, state: 10(ModuleBody)
********************************************************************
======== Fixed to Free format  =========
---- Input fixed form string -------
      subroutine my_sub
      end

---- Resulting free form string -------
      subroutine my_sub
      end
outine1

********************************************************************
Error in file .../my_sub.f line: 4, state: 10(ModuleBody)
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9565841/example.tar.gz)

(found by Fossies for the cmake package)
