### PR TITLE
Add building of the doxygen internal documentation to CMake

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -393,9 +393,15 @@ jobs:
       if: matrix.config.name == 'Ubuntu Latest GCC Release'
       
     - name: Generate Internal documentation
-      shell: bash
+      shell: cmake -P {0}
       run: |
-        build/bin/doxygen Doxyfile
+        execute_process(
+          COMMAND cmake --build build --target docs_internal
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Building internal documentation failed")
+        endif()
       if: matrix.config.name == 'Ubuntu Latest GCC Release'
 
     - name: Publish Internal documentation to Github pages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ if (build_doc)
     add_subdirectory(doc)
 endif ()
 
+add_subdirectory(doc_internal)
 add_subdirectory(addon)
 
 enable_testing()

--- a/doc_internal/CMakeLists.txt
+++ b/doc_internal/CMakeLists.txt
@@ -1,0 +1,27 @@
+# vim:ts=4:sw=4:expandtab:autoindent:
+#
+# Copyright (C) 1997-2022 by Dimitri van Heesch.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation under the terms of the GNU General Public License is hereby
+# granted. No representations are made about the suitability of this software
+# for any purpose. It is provided "as is" without express or implied warranty.
+# See the GNU General Public License for more details.
+#
+# Documents produced by Doxygen are derivative works derived from the
+# input used in their production; they are not affected by this license.
+
+if (doxygen_BINARY_DIR)
+    set(DOXYGEN_EXECUTABLE ${doxygen_BINARY_DIR}/bin/doxygen)
+else()
+    # when building only the doxygen_doc, from the doc/ directory, the
+    # doxygen project variables are unknown so look for doxygen in PATH
+    find_package(Doxygen)
+endif()
+
+configure_file(${CMAKE_SOURCE_DIR}/doc_internal/Doxyfile.in "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile" @ONLY)
+
+add_custom_target(docs_internal
+        COMMENT "Generating HTML internal documentation."
+        COMMAND ${CMAKE_COMMAND} -E env VERSION=${VERSION} ${DOXYGEN_EXECUTABLE}
+        )

--- a/doc_internal/Doxyfile.in
+++ b/doc_internal/Doxyfile.in
@@ -8,7 +8,7 @@ PROJECT_NAME           = Doxygen
 PROJECT_NUMBER         =
 PROJECT_BRIEF          =
 PROJECT_LOGO           =
-OUTPUT_DIRECTORY       = doxygen_docs
+OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/doxygen_docs
 CREATE_SUBDIRS         = YES
 CREATE_SUBDIRS_LEVEL   = 8
 ALLOW_UNICODE_NAMES    = NO
@@ -112,13 +112,13 @@ WARN_LOGFILE           =
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = \
-                         doc_internal/commands_history.md \
-                         doc_internal/commands_internal.md \
-                         doc_internal/releases.md \
-                         doc_internal/tags_history.md \
-                         src \
-                         vhdlparser \
-                         libxml
+                         @CMAKE_SOURCE_DIR@/doc_internal/commands_history.md \
+                         @CMAKE_SOURCE_DIR@/doc_internal/commands_internal.md \
+                         @CMAKE_SOURCE_DIR@/doc_internal/releases.md \
+                         @CMAKE_SOURCE_DIR@/doc_internal/tags_history.md \
+                         @CMAKE_SOURCE_DIR@/src \
+                         @CMAKE_SOURCE_DIR@/vhdlparser \
+                         @CMAKE_SOURCE_DIR@/libxml
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.h \
                          *.hpp \
@@ -166,7 +166,7 @@ HTML_FILE_EXTENSION    = .html
 HTML_HEADER            =
 HTML_FOOTER            =
 HTML_STYLESHEET        =
-HTML_EXTRA_STYLESHEET  = doc_internal/doc_internal.css
+HTML_EXTRA_STYLESHEET  = @CMAKE_SOURCE_DIR@/doc_internal/doc_internal.css
 HTML_EXTRA_FILES       =
 HTML_COLORSTYLE        = TOGGLE
 HTML_COLORSTYLE_HUE    = 220
@@ -297,9 +297,9 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
-INCLUDE_PATH           = libmd5 \
-                         liblodepng \
-                         libmscgen
+INCLUDE_PATH           = @CMAKE_SOURCE_DIR@/libmd5 \
+                         @CMAKE_SOURCE_DIR@/liblodepng \
+                         @CMAKE_SOURCE_DIR@/libmscgen
 INCLUDE_FILE_PATTERNS  =
 PREDEFINED             =
 EXPAND_AS_DEFINED      = DOC_NODES DN_SEP DN


### PR DESCRIPTION
The doxygen internal documentation is part of the GitHub actions and is published to http://doxygen.github.io/doxygen, so it is logical create the possibility to build the internal documentation with the aid of CMake and deploy those results.