### PR TITLE
bug 736665 First % in markdown inline code segement a la %PATH% is swallowed

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -310,6 +310,7 @@ static QCString escapeSpecialChars(const QCString &s)
                  break;
       case '\\': if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('\\'); break;
       case '@':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('@'); break;
+      case '%':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('%'); break;
       case '#':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('#'); break;
       case '$':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('$'); break;
       case '&':  if (!insideQuote) { growBuf.addChar('\\'); } growBuf.addChar('&'); break;


### PR DESCRIPTION
The strategy of doxygen is not to tough the the content inside code spans, hence a number of, doxygen, special characters were already escaped though the `%` wasn't.