### PR TITLE
Incorrect handling of escaped ilinebr command

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1478,6 +1478,9 @@ STopt  [^\n@\\]*
 
   /* ----- handle arguments of the relates(also)/addindex commands ----- */
 
+<LineParam>{CMD}{CMD}                   { // escaped command
+                                          addOutput(yyscanner,yytext);
+                                        }
 <LineParam>{DOCNL}                      { // end of argument
                                           //if (*yytext=='\n') yyextra->lineNr++;
                                           //addOutput(yyscanner,'\n');


### PR DESCRIPTION
In case we have code line:
```
\refitem cmdilinebr \\ilinebr
```
the escaped ilinebr command is handled incorrectly first the first `\` is handled and than the `\ilinebr` instead of taking into account that the second `\` has been escaped (same can occur for line continuations).

(found in the doxygen internal commands documentation)