### PR TITLE
Warning (5219) during compilation on Windows systems

### DIFF
--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -1067,8 +1067,8 @@ void ClassDiagram::writeFigure(TextStream &output,const QCString &path,
   uint cols=(std::max(baseMaxX,superMaxX)+gridWidth*2-1)/gridWidth;
 
   // Estimate the image aspect width and height in pixels.
-  float estHeight = rows*40.0f;
-  float estWidth  = cols*(20.0f+std::max(baseMaxLabelWidth,superMaxLabelWidth));
+  float estHeight = static_cast<float>(rows)*40.0f;
+  float estWidth  = static_cast<float>(cols)*(20+static_cast<float>(std::max(baseMaxLabelWidth,superMaxLabelWidth)));
   //printf("Estimated size %d x %d\n",estWidth,estHeight);
 
   const float pageWidth = 14.0f; // estimated page width in cm.


### PR DESCRIPTION
Some more warnings based on the warning type: 5219 implicit conversion from 'type-1' to 'type-2', possible loss of data

On Windows with C/C++ Optimizing Compiler Version 19.28.29914 for x64 we still get (and setting `/W15219`):
```
.../diagram.cpp(1070): warning C5219: implicit conversion from 'uint' to 'float', possible loss of data
.../diagram.cpp(1071): warning C5219: implicit conversion from 'const _Ty' to 'float', possible loss of data
        with
        [
            _Ty=uint
        ]
.../diagram.cpp(1071): warning C5219: implicit conversion from 'uint' to 'float', possible loss of data
```