### PR TITLE
Making the arrows with the `<details>` tag  look like those used in the treeview

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -419,7 +419,6 @@ struct commentscanYY_state
 
   QCString         guardExpr;
   int              roundCount = 0;
-  int              HTMLDetails = 0;
   std::vector<int> HTMLDetailsSummary;
 
   bool             insideParBlock = FALSE;
@@ -638,15 +637,13 @@ STopt  [^\n@\\]*
                                           REJECT;
                                         }
 <Comment>"<"{DETAILS}{ATTR}">"          { // start of a HTML style details description
-                                          yyextra->HTMLDetails++;
                                           yyextra->HTMLDetailsSummary.push_back(0);
                                           setOutput(yyscanner,OutputDoc);
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"</"{DETAILS}">"               { // end of a HTML style details description
-                                          if (yyextra->HTMLDetails)
+                                          if (yyextra->HTMLDetailsSummary.size())
                                           {
-                                            yyextra->HTMLDetails--;
                                             yyextra->HTMLDetailsSummary.pop_back();
                                           }
                                           addOutput(yyscanner,yytext);
@@ -711,10 +708,10 @@ STopt  [^\n@\\]*
                                           yyextra->htmlAnchorStr += yytext;
                                         }
 <Comment>"<"{SUMMARY}">"                { // start of a .NET XML style brief description
-                                          if (!yyextra->HTMLDetails) setOutput(yyscanner,OutputBrief);
+                                          if (!yyextra->HTMLDetailsSummary.size()) setOutput(yyscanner,OutputBrief);
                                           else
                                           {
-                                            int id = yyextra->HTMLDetailsSummary[yyextra->HTMLDetails-1];
+                                            int id = yyextra->HTMLDetailsSummary[yyextra->HTMLDetailsSummary.size()-1];
                                             if (id == 0)
                                             {
                                               addOutput(yyscanner,"\\htmlonly </p> \\endhtmlonly");
@@ -730,9 +727,9 @@ STopt  [^\n@\\]*
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"</"{SUMMARY}">"               { // start of a .NET XML style detailed description
-                                          if (yyextra->HTMLDetails)
+                                          if (yyextra->HTMLDetailsSummary.size())
                                           {
-                                            int id = yyextra->HTMLDetailsSummary[yyextra->HTMLDetails-1];
+                                            int id = yyextra->HTMLDetailsSummary[yyextra->HTMLDetailsSummary.size()-1];
                                             if (id == 1)
                                             {
                                               addOutput(yyscanner,yytext);

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -420,6 +420,7 @@ struct commentscanYY_state
   QCString         guardExpr;
   int              roundCount = 0;
   int              HTMLDetails = 0;
+  std::vector<int> HTMLDetailsSummary;
 
   bool             insideParBlock = FALSE;
   bool             inInternalDocs = FALSE;
@@ -638,11 +639,16 @@ STopt  [^\n@\\]*
                                         }
 <Comment>"<"{DETAILS}{ATTR}">"          { // start of a HTML style details description
                                           yyextra->HTMLDetails++;
+                                          yyextra->HTMLDetailsSummary.push_back(0);
                                           setOutput(yyscanner,OutputDoc);
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"</"{DETAILS}">"               { // end of a HTML style details description
-                                          if (yyextra->HTMLDetails) yyextra->HTMLDetails--;
+                                          if (yyextra->HTMLDetails)
+                                          {
+                                            yyextra->HTMLDetails--;
+                                            yyextra->HTMLDetailsSummary.pop_back();
+                                          }
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"<"{AHTML}                     { // potential start of HTML anchor, see issue 9200
@@ -706,15 +712,35 @@ STopt  [^\n@\\]*
                                         }
 <Comment>"<"{SUMMARY}">"                { // start of a .NET XML style brief description
                                           if (!yyextra->HTMLDetails) setOutput(yyscanner,OutputBrief);
-                                          addOutput(yyscanner,yytext);
+                                          else
+                                          {
+                                            int id = yyextra->HTMLDetailsSummary[yyextra->HTMLDetails-1];
+                                            if (id == 0)
+                                            {
+                                              addOutput(yyscanner,"\\htmlonly </p> \\endhtmlonly");
+                                              addOutput(yyscanner,yytext);
+                                            }
+                                            else addOutput(yyscanner,"<p>");
+                                            yyextra->HTMLDetailsSummary.pop_back();
+                                            yyextra->HTMLDetailsSummary.push_back(id+1);
+                                          }
                                         }
 <Comment>"<"{REMARKS}">"                { // start of a .NET XML style detailed description
                                           setOutput(yyscanner,OutputDoc);
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"</"{SUMMARY}">"               { // start of a .NET XML style detailed description
-                                          addOutput(yyscanner,yytext);
-                                          if (!yyextra->HTMLDetails) setOutput(yyscanner,OutputDoc);
+                                          if (yyextra->HTMLDetails)
+                                          {
+                                            int id = yyextra->HTMLDetailsSummary[yyextra->HTMLDetails-1];
+                                            if (id == 1)
+                                            {
+                                              addOutput(yyscanner,yytext);
+                                              addOutput(yyscanner,"\\htmlonly <p> \\endhtmlonly");
+                                            }
+                                            else addOutput(yyscanner,"</p>");
+                                          }
+                                          else setOutput(yyscanner,OutputDoc);
                                         }
 <Comment>"</"{REMARKS}">"               { // end of a brief or detailed description
                                           setOutput(yyscanner,OutputDoc);

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1641,3 +1641,23 @@ u {
 	text-decoration: underline;
 }
 
+details>summary {
+  list-style-type: none;
+}
+
+details > summary::-webkit-details-marker {
+    display: none;
+}
+
+details>summary::before {
+    content: "\25ba";
+    padding-right:4px;
+    font-size: 80%;
+}
+
+details[open]>summary::before {
+    content: "\25bc";
+    padding-right:4px;
+    font-size: 80%;
+}
+


### PR DESCRIPTION
Making the arrows with the `<details>` tag  look like those used in the treeview, resulting in adding the settings in doxygen.css

There were some problems in the output introduced in the comment scanner
- multiple `<summary>` tags were just left there whilst only the first one is relevant for the `<details>` tag, the other `<summary>` tags are just new paragraphs
- the `<summary>` tag should only remain in case we are in inside a `<details>` section, otherwise it is handled as a brief description (here the `<summary>` was already ignored, but now it is not even added).
- the order of the resulting `<p>` tags in the HTML output was not correct for XHTML (the `<summary>` tag  was inside a `<p>` tag, this has been corrected