### PR TITLE
Fix a number of compiler warnings

### DIFF
--- a/libmscgen/mscgen_lexer.l
+++ b/libmscgen/mscgen_lexer.l
@@ -44,7 +44,6 @@ static Boolean        lex_utf8 = FALSE;
 /* Local function prototypes */
 static void newline(const char *text, unsigned int n);
 static char *trimQstring(char *s);
-static const char *stateToString(int state);
 
 #if USE_STATE2STRING
 static const char *stateToString(int state);

--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -335,7 +335,6 @@ bool DotFilePatcher::run() const
   bool insideHeader=FALSE;
   bool replacedHeader=FALSE;
   bool foundSize=FALSE;
-  int lineNr=1;
   std::string lineStr;
   static const reg::Ex reSVG(R"([\[<]!-- SVG [0-9]+)");
   static const reg::Ex reMAP(R"(<!-- MAP [0-9]+)");
@@ -463,7 +462,6 @@ bool DotFilePatcher::run() const
     {
       t << line;
     }
-    lineNr++;
   }
   fi.close();
   if (isSVGFile && interactiveSVG_local && replacedHeader)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1345,11 +1345,11 @@ static void resolveClassNestingRelations()
   ClassDefSet visitedClasses;
 
   bool done=FALSE;
-  int iteration=0;
+  //int iteration=0;
   while (!done)
   {
     done=TRUE;
-    ++iteration;
+    //++iteration;
     struct ClassAlias
     {
       ClassAlias(const QCString &name,std::unique_ptr<ClassDef> cd,DefinitionMutable *ctx) :

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3055,15 +3055,6 @@ QCString Markdown::processBlocks(const QCString &s,const int indent)
   int i=0,end=0,pi=-1,ref,level;
   QCString id,link,title;
 
-  // get indent for the first line
-  end = i+1;
-  int sp=0;
-  while (end<=size && data[end-1]!='\n')
-  {
-    if (data[end-1]==' ') sp++;
-    end++;
-  }
-
 #if 0 // commented m_out, since starting with a comment block is probably a usage error
       // see also http://stackoverflow.com/q/20478611/784672
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6821,7 +6821,7 @@ NONLopt [^\n]*
                                           }
                                         }
 <DocCopyBlock>^{B}*"*"+/{BN}+           { // start of a comment line
-                                          if ((yyextra->docBlockName=="verbatim") | (yyextra->docBlockName=="code") || (yyextra->docBlockName=="iliteral"))
+                                          if ((yyextra->docBlockName=="verbatim") || (yyextra->docBlockName=="code") || (yyextra->docBlockName=="iliteral"))
                                           {
                                             REJECT;
                                           }


### PR DESCRIPTION
```
.../markdown.cpp(3060,7): warning: variable 'sp' set but not used [-Wunused-but-set-variable]
  int sp=0;

doxygen.cpp(1348,7): warning: variable 'iteration' set but not used [-Wunused-but-set-variable]
  int iteration=0;

dotfilepatcher.cpp(338,7): warning: variable 'lineNr' set but not used
      [-Wunused-but-set-variable]
  int lineNr=1;

scanner.l(6825,47): warning: use of bitwise '|' with boolean operands
      [-Wbitwise-instead-of-logical]
                                          if ((yyextra->docBlockName=="verbatim") | (yyextra->docBlockName=="code") || (yyex...
                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                  ||
scanner.l(6825,47): note: cast one or both operands to int to silence this warning

mscgen_lexer.l(47,20): warning: unused function 'stateToString' [-Wunused-function]
static const char *stateToString(int state);
```

- corrected syntax problem
- removed unused variables
- doxygen.cpp commented as `iteration` was still present in commented `printf` statements