### PR TITLE
Create possibility to disable a user defined xref list

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2085,6 +2085,9 @@ void setPosition(double x,double y,double z,double t)
  cross-referenced between the place of occurrence and a related page,
  which will be generated. On the related page all sections of
  the same type will be collected.
+ A user defined xref list and the corresponding entries can be disabled by setting the
+ correspondig item with the command
+ \ref cfg_generate_xreflist "GENERATE_XREFLIST" to `NO`.
 
  The first argument \<key\> is an
  identifier uniquely representing the type of the section. The second argument

--- a/src/config.xml
+++ b/src/config.xml
@@ -1186,6 +1186,21 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='list' id='GENERATE_XREFLIST' format='string'>
+      <docs>
+<![CDATA[
+ The \c GENERATE_XREFLIST tag can be used to enable (\c YES) or
+ disable (\c NO) a user defined xref list. This list is created by
+ putting \ref cmdxrefitem "\\xrefitem" commands in the documentation.
+ The format is `key=val`, where `key` is the exact `key` as used in the
+ \ref cmdxrefitem "\\xrefitem" command.
+
+ For instance to disable the user defined xref list `reminders`
+ added  by means of  `\xrefitem reminders ...`<br>
+ use: `GENERATE_XREFLIST = reminders=NO`.
+]]>
+      </docs>
+    </option>
     <option type='list' id='ENABLED_SECTIONS' format='string'>
       <docs>
 <![CDATA[

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1921,6 +1921,10 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   }
 
   //------------------------
+  // check GENERATE_XREFLIST
+  checkList(Config_getList(GENERATE_XREFLIST),"GENERATE_XREFLIST",TRUE,TRUE);
+
+  //------------------------
   // check EXTENSION_MAPPING
   checkList(Config_getList(EXTENSION_MAPPING),"EXTENSION_MAPPING",TRUE,TRUE);
 

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -131,6 +131,7 @@ class Doxygen
     static QCString                  verifiedDotPath;
     static volatile bool             terminating;
     static InputFileEncodingList     inputFileEncodingList;
+    static std::vector<std::string>  generateXRefList;
 };
 
 /** Deleter that only deletes an object if doxygen is not already terminating */

--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -20,6 +20,7 @@
 #include "util.h"
 #include "definition.h"
 #include "config.h"
+#include "doxygen.h"
 
 RefList::RefList(const QCString &listName, const QCString &pageTitle, const QCString &secTitle) :
        m_listName(listName), m_fileName(convertNameToFile(listName,FALSE,TRUE)),
@@ -49,6 +50,7 @@ bool RefList::isEnabled() const
   else if (m_listName=="test"       && !Config_getBool(GENERATE_TESTLIST))       return false;
   else if (m_listName=="bug"        && !Config_getBool(GENERATE_BUGLIST))        return false;
   else if (m_listName=="deprecated" && !Config_getBool(GENERATE_DEPRECATEDLIST)) return false;
+  else if (std::find(Doxygen::generateXRefList.begin(), Doxygen::generateXRefList.end(), m_listName.str()) != Doxygen::generateXRefList.end()) return false;
   return true;
 }
 


### PR DESCRIPTION
There is a discrepancy between the standard defined xref lists (bug, todo, test, deprecated) and the user defined defined xref list, as there is no, easy, equivalent for a command like `GENERATE_BUGLIST=NO`. Defining the user defined xref list using the `\noop` doesn't work as here only the first line is removed and not the rest of the lies of a paragraph. Only solution is to have the user defined xref list item embedded in `\if ... endif` and use `ENABLED_SECTIONS`, but this is just a workaround. Introducing the `GENERATE_XREFLIST` creates the possibility to make a user and standard defined xref list behave in the same way.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9777175/example.tar.gz)
