### PR TITLE
Layout, textual, syntactical changes documentation

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -56,6 +56,8 @@ HTML_EXTRA_FILES += translator_report.txt
 ALIASES           = LaTeX="\f({\LaTeX}\f)"
 ALIASES          += TeX="\f({\TeX}\f)"
 ALIASES          += forceNewPage="\latexonly \newpage \endlatexonly"
+ALIASES          += startalign=" \latexonly\noalign{\endlatexonly"
+ALIASES          += endalign=" \latexonly}\endlatexonly"
 LATEX_BATCHMODE   = YES
 LATEX_EXTRA_STYLESHEET = manual.sty
 LATEX_EMOJI_DIRECTORY  = ../doc

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -902,10 +902,8 @@ Structural indicators
   \addindex \\name
 
   This command turns a comment block into a header
-  definition of a member group. The
-  comment block should be followed by a
-  <code>///\@{ ... ///\@}</code> block containing the
-  members of the group.
+  definition of a member group. The comment block should be followed by a
+  `@{` ... `@}` block containing the members of the group.
 
   See section \ref memgroup for an example.
 
@@ -2076,7 +2074,7 @@ void setPosition(double x,double y,double z,double t)
   for an example.
 
 <hr>
-\section cmdxrefitem \\xrefitem <key> "(heading)" "(list title)" { text }
+\section cmdxrefitem \\xrefitem <key> "heading" "list title" { text }
 
  \addindex \\xrefitem
  This command is a generalization of commands such as \ref cmdtodo "\\todo"
@@ -2091,7 +2089,8 @@ void setPosition(double x,double y,double z,double t)
  is a quoted string representing the heading of the section under which
  text passed as the fourth argument is put. The third argument (list title)
  is used as the title for the related page containing all items with the
- same key. The keys \c "todo", \c "test", \c "bug" and \c "deprecated" are predefined.
+ same key. The second and third string argument cannot contain a newline.
+ The keys \c "todo", \c "test", \c "bug" and \c "deprecated" are predefined.
 
  To get an idea on how to use the \c \\xrefitem command and what its effect
  is, consider the todo list, which (for English output) can be seen an

--- a/doc/extsearch.doc
+++ b/doc/extsearch.doc
@@ -278,7 +278,7 @@ The fields have the following meaning:
 - *first*: the index of first result returned: \f$\min(n*p,\mbox{\em hits})\f$.
 - *count*: the actual number of results returned: \f$\min(n,\mbox{\em hits}-\mbox{\em first})\f$
 - *page*:  the page number of the result: \f$p\f$
-- *pages*: the total number of pages: \f$\lceil\frac{\mbox{\em hits}}{n}\rceil\f$.
+- *pages*: the total number of pages: \f$\left\lceil\frac{\mbox{\em hits}}{n}\right\rceil\f$.
 - *items*: an array containing the search data per result.
 
 Here is an example of how the element of the *items* array should look like:

--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -26,104 +26,104 @@ of a HTML tag are passed on to the HTML output only
 
 <table class="markdownTable">
 <tr class="markdownTableHead"><th class="markdownTableHeadLeft">HTML Command</th><th class="markdownTableHeadLeft">Description</th></tr>
-<tr><td valign="top"><tt>\anchor htmltag_A_HREF \addindex "\<A HREF=\"...\"\>"\<A HREF="..."\></tt></td><td valign="top">Starts a hyperlink
+<tr><td valign="top">\startalign\anchor htmltag_A_HREF \addindex "\<A HREF=\"...\"\>"\endalign<tt>\<A HREF="..."\></tt></td><td valign="top">Starts a hyperlink
                        (if supported by the output format).</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_A_ID \addindex "\<A ID=\"...\"\>"\<A ID="..."\></tt></td><td valign="top">Starts a named anchor
+<tr><td valign="top">\startalign\anchor htmltag_A_ID \addindex "\<A ID=\"...\"\>"\endalign<tt>\<A ID="..."\></tt></td><td valign="top">Starts a named anchor
                        (if supported by the output format).</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_A_NAME \addindex "\<A NAME=\"...\"\>"\<A NAME="..."\></tt></td><td valign="top">Starts a named anchor
+<tr><td valign="top">\startalign\anchor htmltag_A_NAME \addindex "\<A NAME=\"...\"\>"\endalign<tt>\<A NAME="..."\></tt></td><td valign="top">Starts a named anchor
                        (if supported by the output format).</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endA \addindex "\</A\>"\</A\></tt></td><td valign="top">Ends a link or anchor</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_B \addindex "\<B\>"\<B\></tt></td><td valign="top">Starts a piece of text displayed in a bold font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endB \addindex "\</B\>"\</B\></tt></td><td valign="top">Ends a \ref htmltag_B "\<B\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_BLOCKQUOTE \addindex "\<BLOCKQUOTE\>"\<BLOCKQUOTE\></tt></td><td valign="top">Starts a quotation block.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endBLOCKQUOTE \addindex "\</BLOCKQUOTE\>"\</BLOCKQUOTE\></tt></td><td valign="top">Ends the quotation block.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_BR \addindex "\<BR\>"\<BR\></tt></td><td valign="top">Forces a line break.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_CENTER \addindex "\<CENTER\>"\<CENTER\></tt></td><td valign="top">starts a section of centered text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endCENTER \addindex "\</CENTER\>"\</CENTER\></tt></td><td valign="top">ends a section of centered text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_CAPTION \addindex "\<CAPTION\>"\<CAPTION\></tt></td><td valign="top">Starts a caption. Use within a table only.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endCAPTION \addindex "\</CAPTION\>"\</CAPTION\></tt></td><td valign="top">Ends a caption. Use within a table only.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_CITE \addindex "\<CITE\>"\<CITE\></tt></td><td valign="top">Starts a section of text displayed in a font specific for citations.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endCITE \addindex "\</CITE\>"\</CITE\></tt></td><td valign="top">Ends a \ref htmltag_CITE "\<CITE\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_CODE \addindex "\<CODE\>"\<CODE\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endA \addindex "\</A\>"\endalign<tt>\</A\></tt></td><td valign="top">Ends a link or anchor</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_B \addindex "\<B\>"\endalign<tt>\<B\></tt></td><td valign="top">Starts a piece of text displayed in a bold font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endB \addindex "\</B\>"\endalign<tt>\</B\></tt></td><td valign="top">Ends a \ref htmltag_B "\<B\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_BLOCKQUOTE \addindex "\<BLOCKQUOTE\>"\endalign<tt>\<BLOCKQUOTE\></tt></td><td valign="top">Starts a quotation block.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endBLOCKQUOTE \addindex "\</BLOCKQUOTE\>"\endalign<tt>\</BLOCKQUOTE\></tt></td><td valign="top">Ends the quotation block.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_BR \addindex "\<BR\>"\endalign<tt>\<BR\></tt></td><td valign="top">Forces a line break.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_CENTER \addindex "\<CENTER\>"\endalign<tt>\<CENTER\></tt></td><td valign="top">starts a section of centered text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endCENTER \addindex "\</CENTER\>"\endalign<tt>\</CENTER\></tt></td><td valign="top">ends a section of centered text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_CAPTION \addindex "\<CAPTION\>"\endalign<tt>\<CAPTION\></tt></td><td valign="top">Starts a caption. Use within a table only.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endCAPTION \addindex "\</CAPTION\>"\endalign<tt>\</CAPTION\></tt></td><td valign="top">Ends a caption. Use within a table only.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_CITE \addindex "\<CITE\>"\endalign<tt>\<CITE\></tt></td><td valign="top">Starts a section of text displayed in a font specific for citations.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endCITE \addindex "\</CITE\>"\endalign<tt>\</CITE\></tt></td><td valign="top">Ends a \ref htmltag_CITE "\<CITE\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_CODE \addindex "\<CODE\>"\endalign<tt>\<CODE\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
                        Note that only for C# code, this command is equivalent to
                        \ref cmdcode "\\code" (see \ref xmltag_code "\<code\>").</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endCODE \addindex "\</CODE\>"\</CODE\></tt></td><td valign="top">Ends a \ref htmltag_CODE "\<CODE\>" section.
+<tr><td valign="top">\startalign\anchor htmltag_endCODE \addindex "\</CODE\>"\endalign<tt>\</CODE\></tt></td><td valign="top">Ends a \ref htmltag_CODE "\<CODE\>" section.
                        Note that only for C# code, this command is equivalent to
                        \ref cmdendcode "\\endcode" (see \ref xmltag_code "\<code\>").</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_DD \addindex "\<DD\>"\<DD\></tt></td><td valign="top">Starts an item description.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endDD \addindex "\</DD\>"\</DD\></tt></td><td valign="top">Ends an item description.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_DEL \addindex "\<DEL\>"\<DEL\></tt></td><td valign="top">Starts a section of deleted text, typically shown strike through text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endDEL \addindex "\</DEL\>"\</DEL\></tt></td><td valign="top">Ends a section of deleted text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_DETAILS \addindex "\<DETAILS\>"\<DETAILS\></tt></td><td valign="top">Starts a section of detailed text that the user can open and close (in HTML output))</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endDETAILS \addindex "\</DETAILS\>"\</DETAILS\></tt></td><td valign="top">Ends a section of detailed text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_DFN \addindex "\<DFN\>"\<DFN\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endDFN \addindex "\</DFN\>"\</DFN\></tt></td><td valign="top">Ends a \ref htmltag_DFN "\<DFN\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_DIV \addindex "\<DIV\>"\<DIV></tt></td><td valign="top">Starts a section with a specific style (HTML only)</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endDIV \addindex "\</DIV\>"\</DIV></tt></td><td valign="top">Ends a section with a specific style (HTML only)</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_DL \addindex "\<DL\>"\<DL\></tt></td><td valign="top">Starts a description list.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endDL \addindex "\</DL\>"\</DL\></tt></td><td valign="top">Ends a description list.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_DT \addindex "\<DT\>"\<DT\></tt></td><td valign="top">Starts an item title.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endDT \addindex "\</DT\>"\</DT\></tt></td><td valign="top">Ends an item title.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_EM \addindex "\<EM\>"\<EM\></tt></td><td valign="top">Starts a piece of text displayed in an italic font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endEM \addindex "\</EM\>"\</EM\></tt></td><td valign="top">Ends a \ref htmltag_EM "\<EM\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_HR \addindex "\<HR\>"\<HR\></tt></td><td valign="top">Writes a horizontal ruler.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_H1 \addindex "\<H1\>"\<H1\></tt></td><td valign="top">Starts an unnumbered section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endH1 \addindex "\</H1\>"\</H1\></tt></td><td valign="top">Ends an unnumbered section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_H2 \addindex "\<H2\>"\<H2\></tt></td><td valign="top">Starts an unnumbered subsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endH2 \addindex "\</H2\>"\</H2\></tt></td><td valign="top">Ends an unnumbered subsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_H3 \addindex "\<H3\>"\<H3\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr></td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endH3 \addindex "\</H3\>"\</H3\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_H4 \addindex "\<H4\>"\<H4\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endH4 \addindex "\</H4\>"\</H4\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_H5 \addindex "\<H5\>"\<H5\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endH5 \addindex "\</H5\>"\</H5\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_H6 \addindex "\<H6\>"\<H6\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endH6 \addindex "\</H6\>"\</H6\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_I \addindex "\<I\>"\<I\></tt></td><td valign="top">Starts a piece of text displayed in an italic font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endI \addindex "\</I\>"\</I\></tt></td><td valign="top">Ends a \ref htmltag_I "\<I\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_IMG \addindex "\<IMG SRC=\"...\"\>"\<IMG SRC="..." ...\></tt></td><td valign="top">This command is written with its attributes to the HTML output only. The SRC attribute is mandatory.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_INS \addindex "\<INS\>"\<INS\></tt></td><td valign="top">Starts a section of inserted text, typically shown as underlined text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endINS \addindex "\</INS\>"\</INS\></tt></td><td valign="top">Ends a section of inserted text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_LI \addindex "\<LI\>"\<LI\></tt></td><td valign="top">Starts a new list item.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endLI \addindex "\</LI\>"\</LI\></tt></td><td valign="top">Ends a list item.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_OL \addindex "\<OL\>"\<OL\></tt></td><td valign="top">Starts a numbered item list.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endOL \addindex "\</OL\>"\</OL\></tt></td><td valign="top">Ends a numbered item list.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_P \addindex "\<P\>"\<P\></tt></td><td valign="top">Starts a new paragraph.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endP \addindex "\</P\>"\</P\></tt></td><td valign="top">Ends a paragraph.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_PRE \addindex "\<PRE\>"\<PRE\></tt></td><td valign="top">Starts a preformatted fragment.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endPRE \addindex "\</PRE\>"\</PRE\></tt></td><td valign="top">Ends a preformatted fragment.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_SMALL \addindex "\<SMALL\>"\<SMALL\></tt></td><td valign="top">Starts a section of text displayed in a smaller font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endSMALL \addindex "\</SMALL\>"\</SMALL\></tt></td><td valign="top">Ends a \ref htmltag_SMALL "\<SMALL\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_SPAN \addindex "\<SPAN\>"\<SPAN></tt></td><td valign="top">Starts an inline text fragment with a specific style (HTML only)</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endSPAN \addindex "\</SPAN\>"\</SPAN></tt></td><td valign="top">Ends an inline text fragment with a specific style (HTML only)</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_S \addindex "\<S\>"\<S\></tt></td><td valign="top">Starts a section of strike through text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endS \addindex "\</S\>"\</S\></tt></td><td valign="top">Ends a section of strike through text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_STRIKE \addindex "\<STRIKE\>"\<STRIKE\></tt></td><td valign="top">Starts a section of strike through text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endSTRIKE \addindex "\</STRIKE\>"\</STRIKE\></tt></td><td valign="top">Ends a section of strike through text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_STRONG \addindex "\<STRONG\>"\<STRONG\></tt></td><td valign="top">Starts a section of bold text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endSTRONG \addindex "\</STRONG\>"\</STRONG\></tt></td><td valign="top">Ends a section of bold text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_SUB \addindex "\<SUB\>"\<SUB\></tt></td><td valign="top">Starts a piece of text displayed in subscript.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endSUB \addindex "\</SUB\>"\</SUB\></tt></td><td valign="top">Ends a \ref htmltag_SUB "\<SUB\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_SUP \addindex "\<SUP\>"\<SUP\></tt></td><td valign="top">Starts a piece of text displayed in superscript.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endSUP \addindex "\</SUP\>"\</SUP\></tt></td><td valign="top">Ends a \ref htmltag_SUP "\<SUP\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_TABLE \addindex "\<TABLE\>"\<TABLE\></tt></td><td valign="top">starts a table.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endTABLE \addindex "\</TABLE\>"\</TABLE\></tt></td><td valign="top">ends a table.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_TD \addindex "\<TD\>"\<TD\></tt></td><td valign="top">Starts a new table data element.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endTD \addindex "\</TD\>"\</TD\></tt></td><td valign="top">Ends a table data element.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_TH \addindex "\<TH\>"\<TH\></tt></td><td valign="top">Starts a new table header.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endTH \addindex "\</TH\>"\</TH\></tt></td><td valign="top">Ends a table header.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_TR \addindex "\<TR\>"\<TR\></tt></td><td valign="top">Starts a new table row.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endTR \addindex "\</TR\>"\</TR\></tt></td><td valign="top">Ends a table row.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_TT \addindex "\<TT\>"\<TT\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endTT \addindex "\</TT\>"\</TT\></tt></td><td valign="top">Ends a \ref htmltag_TT "\<TT\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_KBD \addindex "\<KBD\>"\<KBD\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endKBD \addindex "\</KBD\>"\</KBD\></tt></td><td valign="top">Ends a \ref htmltag_KBD "\<KBD\>" section.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_U \addindex "\<U\>"\<U\></tt></td><td valign="top">Starts a section of underlined text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endU \addindex "\</U\>"\</U\></tt></td><td valign="top">Ends a section of underlined text.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_UL \addindex "\<UL\>"\<UL\></tt></td><td valign="top">Starts an unnumbered item list.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endUL \addindex "\</UL\>"\</UL\></tt></td><td valign="top">Ends an unnumbered item list.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_VAR \addindex "\<VAR\>"\<VAR\></tt></td><td valign="top">Starts a piece of text displayed in an italic font.</td></tr>
-<tr><td valign="top"><tt>\anchor htmltag_endVAR \addindex "\</VAR\>"\</VAR\></tt></td><td valign="top">Ends a \ref htmltag_VAR "\<VAR\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_DD \addindex "\<DD\>"\endalign<tt>\<DD\></tt></td><td valign="top">Starts an item description.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endDD \addindex "\</DD\>"\endalign<tt>\</DD\></tt></td><td valign="top">Ends an item description.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_DEL \addindex "\<DEL\>"\endalign<tt>\<DEL\></tt></td><td valign="top">Starts a section of deleted text, typically shown strike through text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endDEL \addindex "\</DEL\>"\endalign<tt>\</DEL\></tt></td><td valign="top">Ends a section of deleted text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_DETAILS \addindex "\<DETAILS\>"\endalign<tt>\<DETAILS\></tt></td><td valign="top">Starts a section of detailed text that the user can open and close (in HTML output))</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endDETAILS \addindex "\</DETAILS\>"\endalign<tt>\</DETAILS\></tt></td><td valign="top">Ends a section of detailed text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_DFN \addindex "\<DFN\>"\endalign<tt>\<DFN\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endDFN \addindex "\</DFN\>"\endalign<tt>\</DFN\></tt></td><td valign="top">Ends a \ref htmltag_DFN "\<DFN\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_DIV \addindex "\<DIV\>"\endalign<tt>\<DIV></tt></td><td valign="top">Starts a section with a specific style (HTML only)</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endDIV \addindex "\</DIV\>"\endalign<tt>\</DIV></tt></td><td valign="top">Ends a section with a specific style (HTML only)</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_DL \addindex "\<DL\>"\endalign<tt>\<DL\></tt></td><td valign="top">Starts a description list.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endDL \addindex "\</DL\>"\endalign<tt>\</DL\></tt></td><td valign="top">Ends a description list.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_DT \addindex "\<DT\>"\endalign<tt>\<DT\></tt></td><td valign="top">Starts an item title.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endDT \addindex "\</DT\>"\endalign<tt>\</DT\></tt></td><td valign="top">Ends an item title.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_EM \addindex "\<EM\>"\endalign<tt>\<EM\></tt></td><td valign="top">Starts a piece of text displayed in an italic font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endEM \addindex "\</EM\>"\endalign<tt>\</EM\></tt></td><td valign="top">Ends a \ref htmltag_EM "\<EM\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_HR \addindex "\<HR\>"\endalign<tt>\<HR\></tt></td><td valign="top">Writes a horizontal ruler.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_H1 \addindex "\<H1\>"\endalign<tt>\<H1\></tt></td><td valign="top">Starts an unnumbered section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endH1 \addindex "\</H1\>"\endalign<tt>\</H1\></tt></td><td valign="top">Ends an unnumbered section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_H2 \addindex "\<H2\>"\endalign<tt>\<H2\></tt></td><td valign="top">Starts an unnumbered subsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endH2 \addindex "\</H2\>"\endalign<tt>\</H2\></tt></td><td valign="top">Ends an unnumbered subsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_H3 \addindex "\<H3\>"\endalign<tt>\<H3\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr></td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endH3 \addindex "\</H3\>"\endalign<tt>\</H3\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_H4 \addindex "\<H4\>"\endalign<tt>\<H4\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endH4 \addindex "\</H4\>"\endalign<tt>\</H4\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_H5 \addindex "\<H5\>"\endalign<tt>\<H5\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endH5 \addindex "\</H5\>"\endalign<tt>\</H5\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_H6 \addindex "\<H6\>"\endalign<tt>\<H6\></tt></td><td valign="top">Starts an unnumbered subsubsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endH6 \addindex "\</H6\>"\endalign<tt>\</H6\></tt></td><td valign="top">Ends an unnumbered subsubsection.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_I \addindex "\<I\>"\endalign<tt>\<I\></tt></td><td valign="top">Starts a piece of text displayed in an italic font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endI \addindex "\</I\>"\endalign<tt>\</I\></tt></td><td valign="top">Ends a \ref htmltag_I "\<I\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_IMG \addindex "\<IMG SRC=\"...\"\>"\endalign<tt>\<IMG SRC="..." ...\></tt></td><td valign="top">This command is written with its attributes to the HTML output only. The SRC attribute is mandatory.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_INS \addindex "\<INS\>"\endalign<tt>\<INS\></tt></td><td valign="top">Starts a section of inserted text, typically shown as underlined text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endINS \addindex "\</INS\>"\endalign<tt>\</INS\></tt></td><td valign="top">Ends a section of inserted text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_LI \addindex "\<LI\>"\endalign<tt>\<LI\></tt></td><td valign="top">Starts a new list item.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endLI \addindex "\</LI\>"\endalign<tt>\</LI\></tt></td><td valign="top">Ends a list item.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_OL \addindex "\<OL\>"\endalign<tt>\<OL\></tt></td><td valign="top">Starts a numbered item list.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endOL \addindex "\</OL\>"\endalign<tt>\</OL\></tt></td><td valign="top">Ends a numbered item list.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_P \addindex "\<P\>"\endalign<tt>\<P\></tt></td><td valign="top">Starts a new paragraph.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endP \addindex "\</P\>"\endalign<tt>\</P\></tt></td><td valign="top">Ends a paragraph.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_PRE \addindex "\<PRE\>"\endalign<tt>\<PRE\></tt></td><td valign="top">Starts a preformatted fragment.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endPRE \addindex "\</PRE\>"\endalign<tt>\</PRE\></tt></td><td valign="top">Ends a preformatted fragment.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_SMALL \addindex "\<SMALL\>"\endalign<tt>\<SMALL\></tt></td><td valign="top">Starts a section of text displayed in a smaller font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endSMALL \addindex "\</SMALL\>"\endalign<tt>\</SMALL\></tt></td><td valign="top">Ends a \ref htmltag_SMALL "\<SMALL\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_SPAN \addindex "\<SPAN\>"\endalign<tt>\<SPAN></tt></td><td valign="top">Starts an inline text fragment with a specific style (HTML only)</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endSPAN \addindex "\</SPAN\>"\endalign<tt>\</SPAN></tt></td><td valign="top">Ends an inline text fragment with a specific style (HTML only)</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_S \addindex "\<S\>"\endalign<tt>\<S\></tt></td><td valign="top">Starts a section of strike through text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endS \addindex "\</S\>"\endalign<tt>\</S\></tt></td><td valign="top">Ends a section of strike through text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_STRIKE \addindex "\<STRIKE\>"\endalign<tt>\<STRIKE\></tt></td><td valign="top">Starts a section of strike through text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endSTRIKE \addindex "\</STRIKE\>"\endalign<tt>\</STRIKE\></tt></td><td valign="top">Ends a section of strike through text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_STRONG \addindex "\<STRONG\>"\endalign<tt>\<STRONG\></tt></td><td valign="top">Starts a section of bold text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endSTRONG \addindex "\</STRONG\>"\endalign<tt>\</STRONG\></tt></td><td valign="top">Ends a section of bold text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_SUB \addindex "\<SUB\>"\endalign<tt>\<SUB\></tt></td><td valign="top">Starts a piece of text displayed in subscript.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endSUB \addindex "\</SUB\>"\endalign<tt>\</SUB\></tt></td><td valign="top">Ends a \ref htmltag_SUB "\<SUB\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_SUP \addindex "\<SUP\>"\endalign<tt>\<SUP\></tt></td><td valign="top">Starts a piece of text displayed in superscript.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endSUP \addindex "\</SUP\>"\endalign<tt>\</SUP\></tt></td><td valign="top">Ends a \ref htmltag_SUP "\<SUP\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_TABLE \addindex "\<TABLE\>"\endalign<tt>\<TABLE\></tt></td><td valign="top">starts a table.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endTABLE \addindex "\</TABLE\>"\endalign<tt>\</TABLE\></tt></td><td valign="top">ends a table.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_TD \addindex "\<TD\>"\endalign<tt>\<TD\></tt></td><td valign="top">Starts a new table data element.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endTD \addindex "\</TD\>"\endalign<tt>\</TD\></tt></td><td valign="top">Ends a table data element.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_TH \addindex "\<TH\>"\endalign<tt>\<TH\></tt></td><td valign="top">Starts a new table header.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endTH \addindex "\</TH\>"\endalign<tt>\</TH\></tt></td><td valign="top">Ends a table header.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_TR \addindex "\<TR\>"\endalign<tt>\<TR\></tt></td><td valign="top">Starts a new table row.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endTR \addindex "\</TR\>"\endalign<tt>\</TR\></tt></td><td valign="top">Ends a table row.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_TT \addindex "\<TT\>"\endalign<tt>\<TT\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endTT \addindex "\</TT\>"\endalign<tt>\</TT\></tt></td><td valign="top">Ends a \ref htmltag_TT "\<TT\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_KBD \addindex "\<KBD\>"\endalign<tt>\<KBD\></tt></td><td valign="top">Starts a piece of text displayed in a typewriter font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endKBD \addindex "\</KBD\>"\endalign<tt>\</KBD\></tt></td><td valign="top">Ends a \ref htmltag_KBD "\<KBD\>" section.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_U \addindex "\<U\>"\endalign<tt>\<U\></tt></td><td valign="top">Starts a section of underlined text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endU \addindex "\</U\>"\endalign<tt>\</U\></tt></td><td valign="top">Ends a section of underlined text.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_UL \addindex "\<UL\>"\endalign<tt>\<UL\></tt></td><td valign="top">Starts an unnumbered item list.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endUL \addindex "\</UL\>"\endalign<tt>\</UL\></tt></td><td valign="top">Ends an unnumbered item list.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_VAR \addindex "\<VAR\>"\endalign<tt>\<VAR\></tt></td><td valign="top">Starts a piece of text displayed in an italic font.</td></tr>
+<tr><td valign="top">\startalign\anchor htmltag_endVAR \addindex "\</VAR\>"\endalign<tt>\</VAR\></tt></td><td valign="top">Ends a \ref htmltag_VAR "\<VAR\>" section.</td></tr>
 </table>
 
 Finally, to put invisible comments inside comment blocks, HTML style

--- a/doc/install.doc
+++ b/doc/install.doc
@@ -194,7 +194,7 @@ or use the built-in unpack feature of modern Windows systems).
 
 Now your environment is setup to generate the required project files for \c doxygen.
 
-cd into the \c doxygen-x.y.z directory, create and cd to a build directory
+change directory to the \c doxygen-x.y.z directory, create and change to a build directory
 \verbatim
 mkdir build
 cd build

--- a/doc/xmlcmds.doc
+++ b/doc/xmlcmds.doc
@@ -26,56 +26,56 @@ Here is the list of tags supported by doxygen:
 
 <table class="markdownTable" valign="top">
 <tr class="markdownTableHead"><th class="markdownTableHeadLeft">XML Command</th><th class="markdownTableHeadLeft">Description</th></tr>
-<tr><td valign="top"><tt>\anchor xmltag_c \addindex "\<c\>" \<c\></tt></td><td valign="top">Identifies inline text that should be rendered as a 
+<tr><td valign="top">\startalign\anchor xmltag_c \addindex "\<c\>"\endalign<tt> \<c\></tt></td><td valign="top">Identifies inline text that should be rendered as a 
                        piece of code. Similar to using <tt>\<tt\></tt>text<tt>\</tt\></tt>.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_code \addindex "\<code\>" <code\></tt></td><td valign="top">Set one or more lines of source code or program output.
+<tr><td valign="top">\startalign\anchor xmltag_code \addindex "\<code\>"\endalign<tt> <code\></tt></td><td valign="top">Set one or more lines of source code or program output.
                        Note that this command behaves like \ref cmdcode "\\code" ... \ref cmdendcode "\\endcode"
                        for C# code, but it behaves like the HTML equivalent
                        \ref htmltag_CODE "\<CODE\>"...\ref htmltag_endCODE "\</CODE\>" for other languages.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_description \addindex "\<description\>" \<description\></tt></td><td valign="top">Part of a \ref xmltag_list "\<list\>" command, describes an item.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_example \addindex "\<example\>" \<example\></tt></td><td valign="top">Marks a block of text as an example, ignored by doxygen.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_exception \addindex "\<exception\>" \<exception cref="member"\></tt></td><td valign="top">Identifies the exception a 
+<tr><td valign="top">\startalign\anchor xmltag_description \addindex "\<description\>"\endalign<tt> \<description\></tt></td><td valign="top">Part of a \ref xmltag_list "\<list\>" command, describes an item.</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_example \addindex "\<example\>"\endalign<tt> \<example\></tt></td><td valign="top">Marks a block of text as an example, ignored by doxygen.</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_exception \addindex "\<exception\>"\endalign<tt> \<exception cref="member"\></tt></td><td valign="top">Identifies the exception a 
                          method can throw.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_include \addindex "\<include\>" \<include\></tt></td><td valign="top">Can be used to import a piece of XML from an external
+<tr><td valign="top">\startalign\anchor xmltag_include \addindex "\<include\>"\endalign<tt> \<include\></tt></td><td valign="top">Can be used to import a piece of XML from an external
                          file. Ignored by doxygen at the moment.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_inheritdoc \addindex "\<inheritdoc\>" \<inheritdoc\></tt></td><td valign="top">Can be used to insert the documentation of a 
+<tr><td valign="top">\startalign\anchor xmltag_inheritdoc \addindex "\<inheritdoc\>"\endalign<tt> \<inheritdoc\></tt></td><td valign="top">Can be used to insert the documentation of a 
                          member of a base class into the documentation of a 
                          member of a derived class that reimplements it.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_item \addindex "\<item\>" \<item\></tt></td><td valign="top">List item. Can only be used inside a \ref xmltag_list "\<list\>" context.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_list \addindex "\<list\>" \<list type="type"\></tt></td><td valign="top">Starts a list, supported types are <tt>bullet</tt>
+<tr><td valign="top">\startalign\anchor xmltag_item \addindex "\<item\>"\endalign<tt> \<item\></tt></td><td valign="top">List item. Can only be used inside a \ref xmltag_list "\<list\>" context.</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_list \addindex "\<list\>"\endalign<tt> \<list type="type"\></tt></td><td valign="top">Starts a list, supported types are <tt>bullet</tt>
                          or <tt>number</tt> and <tt>table</tt>. 
                          A list consists of a number of <tt>\<item\></tt> tags.
                          A list of type table, is a two column table which can have
                          a header.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_listheader \addindex "\<listheader\>" \<listheader\></tt></td><td valign="top">Starts the header of a list of type "table".</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_para \addindex "\<para\>" \<para\></tt></td><td valign="top">Identifies a paragraph of text.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_param \addindex "\<param\>" \<param name="paramName"\></tt></td><td valign="top">Marks a piece of text as the documentation
+<tr><td valign="top">\startalign\anchor xmltag_listheader \addindex "\<listheader\>"\endalign<tt> \<listheader\></tt></td><td valign="top">Starts the header of a list of type "table".</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_para \addindex "\<para\>"\endalign<tt> \<para\></tt></td><td valign="top">Identifies a paragraph of text.</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_param \addindex "\<param\>"\endalign<tt> \<param name="paramName"\></tt></td><td valign="top">Marks a piece of text as the documentation
                          for parameter "paramName". Similar to 
                          using \ref cmdparam "\\param".</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_paramref \addindex "\<paramref\>" \<paramref name="paramName"\></tt></td><td valign="top">Refers to a parameter with name
+<tr><td valign="top">\startalign\anchor xmltag_paramref \addindex "\<paramref\>"\endalign<tt> \<paramref name="paramName"\></tt></td><td valign="top">Refers to a parameter with name
                          "paramName". Similar to using \ref cmda "\\a".</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_permission \addindex "\<permission\>" \<permission\></tt></td><td valign="top">Identifies the security accessibility of a member.
+<tr><td valign="top">\startalign\anchor xmltag_permission \addindex "\<permission\>"\endalign<tt> \<permission\></tt></td><td valign="top">Identifies the security accessibility of a member.
                          Ignored by doxygen.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_remarks \addindex "\<remarks\>" \<remarks\></tt></td><td valign="top">Identifies the detailed description. </td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_returns \addindex "\<returns\>" \<returns\></tt></td><td valign="top">Marks a piece of text as the return value of a
+<tr><td valign="top">\startalign\anchor xmltag_remarks \addindex "\<remarks\>"\endalign<tt> \<remarks\></tt></td><td valign="top">Identifies the detailed description. </td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_returns \addindex "\<returns\>"\endalign<tt> \<returns\></tt></td><td valign="top">Marks a piece of text as the return value of a
                          function or method. Similar to using \ref cmdreturn "\\return".</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_see \addindex "\<see\>" \<see cref="member"\></tt></td><td valign="top">Refers to a member. Similar to \ref cmdref "\\ref".</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_seealso \addindex "\<seealso\>" \<seealso cref="member"\></tt></td><td valign="top">Starts a "See also" section referring
+<tr><td valign="top">\startalign\anchor xmltag_see \addindex "\<see\>"\endalign<tt> \<see cref="member"\></tt></td><td valign="top">Refers to a member. Similar to \ref cmdref "\\ref".</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_seealso \addindex "\<seealso\>"\endalign<tt> \<seealso cref="member"\></tt></td><td valign="top">Starts a "See also" section referring
                          to "member". Similar to using \ref cmdsa "\\sa" member.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_summary \addindex "\<summary\>" \<summary\></tt></td><td valign="top">
+<tr><td valign="top">\startalign\anchor xmltag_summary \addindex "\<summary\>"\endalign<tt> \<summary\></tt></td><td valign="top">
                          In case this tag is used outside a \ref htmltag_DETAILS "\<DETAILS\>" tag this tag
                          identifies the brief description.
                          Similar to using \ref cmdbrief "\\brief".
                          In case this tag is used inside a \ref htmltag_DETAILS "\<DETAILS\>" tag this tag
                          identifies the heading of the \ref htmltag_DETAILS "\<DETAILS\>" tag.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_term \addindex "\<term\>" \<term\></tt></td><td valign="top">Part of a \ref xmltag_list "\<list\>" command.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_typeparam \addindex "\<typeparam\>" \<typeparam name="paramName"\></tt></td><td valign="top">Marks a piece of text as the documentation
+<tr><td valign="top">\startalign\anchor xmltag_term \addindex "\<term\>"\endalign<tt> \<term\></tt></td><td valign="top">Part of a \ref xmltag_list "\<list\>" command.</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_typeparam \addindex "\<typeparam\>"\endalign<tt> \<typeparam name="paramName"\></tt></td><td valign="top">Marks a piece of text as the documentation
                          for type parameter "paramName". Similar to 
                          using \ref cmdparam "\\param".</td></tr>
-<tr><td valign="top">\anchor xmltag_typeparamref \addindex "\<typeparamref\>"<tt>\<typeparamref name="paramName"\></tt></td><td valign="top">Refers to a parameter with name
+<tr><td valign="top">\startalign\anchor xmltag_typeparamref \addindex "\<typeparamref\>"\endalign<tt>\<typeparamref name="paramName"\></tt></td><td valign="top">Refers to a parameter with name
                          "paramName". Similar to using \ref cmda "\\a".</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_value \addindex "\<value\>" \<value\></tt></td><td valign="top">Identifies a property. Ignored by doxygen.</td></tr>
-<tr><td valign="top"><tt>\anchor xmltag_CDATA \addindex "\<![CDATA[...]]\>" \<![CDATA[...]]\></tt></td><td valign="top">The text inside this tag (on the ...) is  handled as normal
+<tr><td valign="top">\startalign\anchor xmltag_value \addindex "\<value\>"\endalign<tt> \<value\></tt></td><td valign="top">Identifies a property. Ignored by doxygen.</td></tr>
+<tr><td valign="top">\startalign\anchor xmltag_CDATA \addindex "\<![CDATA[...]]\>"\endalign<tt> \<![CDATA[...]]\></tt></td><td valign="top">The text inside this tag (on the ...) is  handled as normal
                          doxygen comment except for the XML special characters `<`, `>` and
                          `&` that are used as if they were escaped.</td></tr>
 </table>


### PR DESCRIPTION
Some layout, textual, syntactical changes in the documentation
- extsearch.doc better left and right ceil (so they span the total vertical part of the formula
- htmldcmds.doc, xmlcmds.doc, Doxyfile Correction of the positioning in the "HTML Command" / "XML Command" filed as the command was positioned properly at the top resulting in more required space for the table.
  Solution based on: https://tex.stackexchange.com/questions/376373/hyperref-inserts-vertical-space-in-tabular-cell