### PR TITLE
bug 751096 Possibility for svg images with \image command in LaTeX

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3592,10 +3592,20 @@ class Receiver
 \endverbatim
 
   \warning The image format for HTML is limited to what your
-           browser supports.<br>For \LaTeX, the image format
+           browser supports.
+           <br>
+           For \LaTeX, the image format
            must be supported by the \LaTeX `\includegraphics` command i.e.
            Encapsulated PostScript (eps), Portable network graphics (png),
            Joint photographic experts group (jpg / jpeg).
+           <br>
+           Besides the formats supported by the `\includegraphics`
+           command it is also posible to use the Scalable Vector Graphics (svg) format.
+           In order for this to work the external program Inkscape (https://inkscape.org/) has
+           to be installed and must be reachable throught the path. Also
+           the configuration parameter `LATEX_CMD_NAME` has to have the name
+           of the \LaTeX processor to be used plus the option to use
+           `shell escape` (normally the option `-enable-write18`).
            <br><br>
            Doxygen does not check if the image is in the correct format.
            So \e you have to make sure this is the case!

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -75,6 +75,7 @@ static void insertDimension(TextStream &t, QCString dimension, const char *orien
 
 static void visitPreStart(TextStream &t, bool hasCaption, QCString name,  QCString width,  QCString height, bool inlineImage = FALSE)
 {
+    bool isSvg = name.right(4)==".svg";
     if (inlineImage)
     {
       t << "\n\\begin{DoxyInlineImage}\n";
@@ -92,10 +93,15 @@ static void visitPreStart(TextStream &t, bool hasCaption, QCString name,  QCStri
       }
     }
 
-    t << "\\includegraphics";
+    if (isSvg)
+      t << "\\includesvg";
+    else 
+      t << "\\includegraphics";
+
     if (!width.isEmpty() || !height.isEmpty())
     {
       t << "[";
+      if (isSvg) t << "inkscapelatex=false,";
     }
     if (!width.isEmpty())
     {
@@ -114,13 +120,27 @@ static void visitPreStart(TextStream &t, bool hasCaption, QCString name,  QCStri
     if (width.isEmpty() && height.isEmpty())
     {
       /* default setting */
-      if (inlineImage)
+      if (isSvg)
       {
-        t << "[height=\\baselineskip,keepaspectratio=true]";
+        if (inlineImage)
+        {
+          t << "[inkscapelatex=false,height=\\baselineskip]";
+        }
+        else
+        {
+          t << "[inkscapelatex=false,width=\\textwidth,height=0.5\\textheight]";
+        }
       }
       else
       {
-        t << "[width=\\textwidth,height=\\textheight/2,keepaspectratio=true]";
+        if (inlineImage)
+        {
+          t << "[height=\\baselineskip,keepaspectratio=true]";
+        }
+        else
+        {
+          t << "[width=\\textwidth,height=\\textheight/2,keepaspectratio=true]";
+        }
       }
     }
     else

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -294,8 +294,8 @@ static void writeLatexMakefile()
   }
   TextStream t(&f);
   // inserted by KONNO Akihisa <konno@researchers.jp> 2002-03-05
-  QCString latex_command = theTranslator->latexCommandName().quoted();
-  QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME).quoted();
+  QCString latex_command = theTranslator->latexCommandName();
+  QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME);
   QCString bibtex_command = "bibtex";
   QCString manual_file = "refman";
   const int latex_count = 8;
@@ -387,8 +387,8 @@ static void writeMakeBat()
 #if defined(_MSC_VER)
   QCString dir=Config_getString(LATEX_OUTPUT);
   QCString fileName=dir+"/make.bat";
-  QCString latex_command = theTranslator->latexCommandName().quoted();
-  QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME).quoted();
+  QCString latex_command = theTranslator->latexCommandName();
+  QCString mkidx_command = Config_getString(MAKEINDEX_CMD_NAME);
   QCString bibtex_command = "bibtex";
   QCString manual_file = "refman";
   const int latex_count = 8;

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -30,6 +30,7 @@
   $extralatexstylesheet
 
   \usepackage{graphicx}
+  \usepackage{svg}
   \usepackage[utf8]{inputenc}
   \usepackage{makeidx}
   \PassOptionsToPackage{warn}{textcomp}

--- a/templates/latex/latexrefman.tpl
+++ b/templates/latex/latexrefman.tpl
@@ -9,6 +9,7 @@
 \usepackage{<{package|stripExtension:'.sty'}>}
 <% endfor %>
 \usepackage{graphicx}
+\usepackage{svg}
 \usepackage[utf8]{inputenc}
 \usepackage{makeidx}
 \usepackage{multicol}


### PR DESCRIPTION
When using a svg image with the \image command in LaTeX we get the message:
```
! LaTeX Error: Unknown graphics extension: .svg.

See the LaTeX manual or LaTeX Companion for explanation.
```
when generating the refman.pdf.

Enabling can be done by:
-    using the svg package
      note:
      - LATEX_CMD should not be quoted in the `make.bat` / `Makefile`
      - properly handle underscores in svg images (see also: https://tex.stackexchange.com/a/525613/44119)
-    installing the external package Inkscape.
-    enabling the shell escape with the LaTeX processor (normally the option -enable-write18).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9820633/example.tar.gz)

Supersedes #7421
