### PR TITLE
Removing hierarchy / namespace from layout file results in incorrect RTF / LaTeX document

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4553,9 +4553,13 @@ static void writeIndex(OutputList &ol)
     }
     if (Config_getBool(SHOW_NAMESPACES) && (documentedNamespaces>0))
     {
-      ol.startIndexSection(isNamespaceIndex);
-      ol.parseText(/*projPrefix+*/(fortranOpt?theTranslator->trModulesIndex():theTranslator->trNamespaceIndex()));
-      ol.endIndexSection(isNamespaceIndex);
+      LayoutNavEntry *lne = LayoutDocManager::instance().rootNavEntry()->find(LayoutNavEntry::Namespaces);
+      if (lne)
+      {
+        ol.startIndexSection(isNamespaceIndex);
+        ol.parseText(/*projPrefix+*/(fortranOpt?theTranslator->trModulesIndex():theTranslator->trNamespaceIndex()));
+        ol.endIndexSection(isNamespaceIndex);
+      }
     }
     if (documentedConcepts>0)
     {
@@ -4571,13 +4575,17 @@ static void writeIndex(OutputList &ol)
     }
     if (hierarchyClasses>0)
     {
-      ol.startIndexSection(isClassHierarchyIndex);
-      ol.parseText(/*projPrefix+*/
-          (fortranOpt ? theTranslator->trCompoundIndexFortran() :
-           vhdlOpt    ? theTranslator->trHierarchicalIndex()    :
-                        theTranslator->trHierarchicalIndex()
-          ));
-      ol.endIndexSection(isClassHierarchyIndex);
+      LayoutNavEntry *lne = LayoutDocManager::instance().rootNavEntry()->find(LayoutNavEntry::ClassHierarchy);
+      if (lne)
+      {
+        ol.startIndexSection(isClassHierarchyIndex);
+        ol.parseText(/*projPrefix+*/
+            (fortranOpt ? theTranslator->trCompoundIndexFortran() :
+             vhdlOpt    ? theTranslator->trHierarchicalIndex()    :
+                          theTranslator->trHierarchicalIndex()
+            ));
+        ol.endIndexSection(isClassHierarchyIndex);
+      }
     }
     if (hierarchyExceptions>0)
     {


### PR DESCRIPTION
When removing from the `DoxygenLayout.xml` the parts
```
    <tab type="namespaces" visible="no" title="">
      <tab type="namespacelist" visible="yes" title="" intro=""/>
      <tab type="namespacemembers" visible="yes" title="" intro=""/>
    </tab>
```
and
```
      <tab type="hierarchy" visible="no" title="" intro=""/>
```
this leads to errors due to missing files `namespaces` and `hierarchy` when building the PDF from the LaTeX files and when combining the RTF files.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9832021/example.tar.gz)
