### PR TITLE
Coverity structural dead code

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -306,8 +306,6 @@ DB_VIS_C
     case DocStyleChange::Ins:        break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-      if (s.enable()) m_t << "<para><emphasis role=\"bold\">";      else m_t << "</emphasis></para>";
-      break;
   }
 }
 

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -378,7 +378,6 @@ void LatexDocVisitor::operator()(const DocStyleChange &s)
       break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-      break;
   }
 }
 

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -286,8 +286,6 @@ void RTFDocVisitor::operator()(const DocStyleChange &s)
       break;
     case DocStyleChange::Div:  /* HTML only */ break;
     case DocStyleChange::Span: /* HTML only */ break;
-      if (s.enable()) m_t << "{\\b ";      else m_t << "}\\par ";
-      break;
   }
 }
 


### PR DESCRIPTION
Coverity reported "structural dead code" as with
```
Commit: 61caf5d22fc908fa39ea2eff460720e545b0637f [61caf5d]
Date: Thursday, October 27, 2022 8:11:43 PM
Improve handling of <details> and <summary> tags
```

these lines were not removed when the `    case DocStyleChange::Summary:` was removed.