### PR TITLE
Handling of text for the `\ref`  command

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1173,8 +1173,12 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          yyextra->token->name = yytext;
                          return TK_SYMBOL;
                        }
-<St_Ref2>"\""|\n|"\\ilinebr" { /* " or \n => end of title */
+<St_Ref2>\n|"\\ilinebr" {
                          lineCount(yytext,yyleng);
+                         yyextra->token->chars=yytext;
+                         return TK_WHITESPACE;
+                       }
+<St_Ref2>"\""          {
                          return 0;
                        }
 <St_Ref2>{SPCMD1}      |


### PR DESCRIPTION
The, optional, text for a `\ref` command has to be, according to the documentation, between double quotes and the text should not s[an lines:
> \ref <name> ["(text)"]

the implementation is so that the text ends either with a double quote or an end of line. When the text runs over the line into the next line we have on the next line just the beginning of a string starting with a double quote. The chosen solution is so that the text now ends at at the closing double quote and that the end of lines are allowed (they are later on seen as whitespace).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9939841/example.tar.gz)

**Before**

![image](https://user-images.githubusercontent.com/5223533/200015228-1fc49daa-e51c-4f1e-9c96-c66a7fa2e3af.png)


**After**

![image](https://user-images.githubusercontent.com/5223533/200015150-0f95dd83-0d96-4e63-920e-33a251336324.png)


Note: An alternative might have been to gather the text till the end of a line and when no closing quote found the text would have been pushed back into the input stream and handled as regular text, though when we would find a closing double quote it would be harder to parse.
