### PR TITLE
Reference to non existing pages with embedded anonymous union / struct

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2466,25 +2466,20 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
       ol.writeDoc(ast.get(),getOuterScope()?getOuterScope():d,this);
       if (detailsVisible) // add More.. link only when both brief and details are visible
       {
-        ol.pushGeneratorState();
-        ol.disableAllBut(OutputGenerator::Html);
-        ol.docify(" ");
-        MemberDefMutable *annMemb = NULL;
         if (!isAnonymous()) // hide anonymous stuff
         {
-          annMemb = toMemberDefMutable(m_impl->annMemb);
+          ol.pushGeneratorState();
+          ol.disableAllBut(OutputGenerator::Html);
+          ol.docify(" ");
+          MemberDefMutable *annMemb = toMemberDefMutable(m_impl->annMemb);
+          if (annMemb)
+          {
+            ol.startTextLink(annMemb->getOutputFileBase(),annMemb->anchor());
+            ol.parseText(theTranslator->trMore());
+            ol.endTextLink();
+          }
+          ol.popGeneratorState();
         }
-        if (annMemb)
-        {
-          ol.startTextLink(annMemb->getOutputFileBase(),annMemb->anchor());
-        }
-        else
-        {
-          ol.startTextLink(getOutputFileBase(),anchor());
-        }
-        ol.parseText(theTranslator->trMore());
-        ol.endTextLink();
-        ol.popGeneratorState();
       }
       // for RTF we need to add an extra empty paragraph
       ol.pushGeneratorState();


### PR DESCRIPTION
When having a simple program like:
```
/// \file

/// the union
union {
  /// the first, struct
  struct {
    /// elem
    int elem1_1;
  };
  /// the second, union
  union {
    /// elem
    int elem2_1;
  };
} U;
```

There are `More...` references shown for the embedded union and struct although there is no detailed section for these parts, a link checker gives a warning like:
```
List of broken links and other issues:
file:///.../html/union_0d0.html
 Lines: 106, 113
  Code: 404 File `.../html/union_0d0.html' does not exist
 To do: The link is broken. Double-check that you have not made any typo,
        or mistake in copy-pasting. If the link points to a resource that
        no longer exists, you may want to remove or fix the link.
Fragments:
        a02cf6b8c764fa94063269490f61cceeb       Line: 106
        a0256ef0243f59885baea0a1ea9bd5064       Line: 113

```

(The problem was found in the fsvs package).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9943914/example.tar.gz)



**Before**

![image](https://user-images.githubusercontent.com/5223533/200121865-00d30d9c-fb47-4e2f-8c26-0e1665eb036b.png)


**After**

![image](https://user-images.githubusercontent.com/5223533/200121690-3f52291b-98e4-402b-bb49-0a0ffa40d187.png)
