### PR TITLE
issue #9319 Doc build fails with cairo 1.17.6

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11962,6 +11962,8 @@ void parseInput()
     {
       Portable::setenv("DOTFONTPATH",qPrint(curFontPath));
     }
+    // issue 9319
+    Portable::setenv("CAIRO_DEBUG_PDF","1");
   }
 
 


### PR DESCRIPTION
Implementing the use of the environment variable so that always the non compressed version is written.