### PR TITLE
HTML `<details>` tag without `<summary>` tag

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -1331,6 +1331,13 @@ int DocHtmlDetails::parse(DocNodeVariant *thisVariant)
   while (retval==TK_NEWPARA);
   if (par) par->markLast();
 
+  if (!summary())
+  {
+    HtmlAttribList summaryAttribs;
+    m_summary = std::make_unique<DocNodeVariant>(DocHtmlSummary(parser(),thisVariant,summaryAttribs));
+    DocHtmlSummary *summary = &std::get<DocHtmlSummary>(*m_summary);
+    summary->children().append<DocWord>(parser(),thisVariant,theTranslator->trDetails());
+  }
   DBG(("DocHtmlDetails::parse() end retval=%s\n",DocTokenizer::retvalToString(retval)));
   return (retval==RetVal_EndHtmlDetails) ? RetVal_OK : retval;
 }

--- a/src/translator.h
+++ b/src/translator.h
@@ -152,6 +152,7 @@ class Translator
     virtual QCString trRelatedFunctions() = 0;
     virtual QCString trRelatedSubscript() = 0;
     virtual QCString trDetailedDescription() = 0;
+    virtual QCString trDetails() = 0;
     virtual QCString trMemberTypedefDocumentation() = 0;
     virtual QCString trMemberEnumerationDocumentation() = 0;
     virtual QCString trMemberFunctionDocumentation() = 0;

--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -56,6 +56,10 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
     virtual QCString trDetailedDescription()
     { return "Մանրամասն նկարագրություն"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Մանրամասներ"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Անդամ տիպի սահմանումներ (typedef)"; }

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -85,6 +85,10 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
     virtual QCString trDetailedDescription()
     { return "وصف تفصيلي"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "التفاصيل"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "توثيق تعريفات النوع الأعضاء"; }

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -102,6 +102,10 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
     virtual QCString trDetailedDescription()
     { return "Подробно описание"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Подробности"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Членове Дефинирани типове Документация"; }

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -117,6 +117,10 @@ class TranslatorBrazilian : public Translator
     virtual QCString trDetailedDescription()
     { return "Descrição detalhada"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detalhes"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Documentação das definições de tipos"; }

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -98,6 +98,10 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
     virtual QCString trDetailedDescription()
     { return "Descripció Detallada"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detalls"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Documentació de les Definicions de Tipus Membre"; }

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -95,6 +95,10 @@ class TranslatorChinese : public TranslatorAdapter_1_9_4
     virtual QCString trDetailedDescription()
     { return "详细描述"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "详细信息"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "成员类型定义说明"; }

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -193,6 +193,10 @@ class TranslatorCzech : public Translator
     virtual QCString trDetailedDescription()
     { return "Detailní popis"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Podrobnosti"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentace členských typů"; }

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -187,6 +187,10 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "Ausführliche Beschreibung"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Details"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentation der benutzerdefinierten Datentypen"; }

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -143,6 +143,10 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     virtual QCString trDetailedDescription()
     { return "Detaljeret beskrivelse"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detaljer"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentation af medlems-typedefinitioner"; }

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -97,6 +97,10 @@ class TranslatorEnglish : public Translator
     virtual QCString trDetailedDescription()
     { return "Detailed Description"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Details"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Member Typedef Documentation"; }

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -100,6 +100,10 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     virtual QCString trDetailedDescription()
     { return "Detala Priskribo"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detaloj"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentado de la Membraj Tipodifinoj"; }

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -91,6 +91,10 @@ class TranslatorSpanish : public TranslatorAdapter_1_8_19
     virtual QCString trDetailedDescription()
     { return "Descripción detallada"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detalles"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Documentación de los 'Typedef' miembros de la clase"; }

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -114,6 +114,10 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
     virtual QCString trDetailedDescription()
     { return "توضيحات جزئی"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "جزئیات"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "مستندات تعریف گونه ها"; }

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -141,6 +141,10 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
     virtual QCString trDetailedDescription()
     { return "Yksityiskohtainen selite"; } // "Detailed Description"
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Yksityiskohdat"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
       // header that is put before the list of typedefs.

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -158,6 +158,10 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
     virtual QCString trDetailedDescription()
     { return "Description détaillée"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Détails"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Documentation des définitions de type membres"; }

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -98,6 +98,10 @@ class TranslatorGreek : public TranslatorAdapter_1_9_4
     virtual QCString trDetailedDescription()
     { return "Λεπτομερής Περιγραφή"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Λεπτομέρειες"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Τεκμηρίωση Μελών Ορισμών Τύπων"; }

--- a/src/translator_hi.h
+++ b/src/translator_hi.h
@@ -203,6 +203,10 @@ class TranslatorHindi : public TranslatorAdapter_1_9_4
     virtual QCString trDetailedDescription()
     { return "विस्तृत विवरण"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "विवरण"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "सदस्य प्ररुप-परिभाषा दस्तावेज़ीकरण"; }

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -104,6 +104,8 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     { return "(To nisu member funkcije.)"; }
     QCString trDetailedDescription()
     { return "Detaljno objašnjenje"; }
+    QCString trDetails()
+    { return "Detalji"; }
     QCString trMemberTypedefDocumentation()
     { return "Dokumentacija typedef članova"; }
     QCString trMemberEnumerationDocumentation()

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -123,6 +123,10 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "Részletes leírás"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Részletek"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Típusdefiníció-tagok dokumentációja"; }

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -81,6 +81,10 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     virtual QCString trDetailedDescription()
     { return "Keterangan Lengkap"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detail"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentasi Anggota: Tipe"; }

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -135,6 +135,10 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     QCString trDetailedDescription()
     { return "Descrizione dettagliata"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Dettagli"; }
+
     /*! header that is put before the list of typedefs. */
     QCString trMemberTypedefDocumentation()
     { return "Documentazione delle ridefinizioni dei tipi (typedef)"; }

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -116,6 +116,10 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "詳解"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "詳細"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "型定義メンバ詳解"; }

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -120,6 +120,10 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "상세한 설명"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "상세"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "멤버 타입정의 문서화"; }

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -88,6 +88,10 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
     virtual QCString trDetailedDescription()
     { return "Smulkus aprašymas"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Išsamiau"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Tipo Aprašymo Dokumentacija"; }

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -103,6 +103,10 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     virtual QCString trDetailedDescription()
     { return "Detalizēts apraksts"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Sīkāka informācija"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Elementa Typedef dokumentācija"; }

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -88,6 +88,10 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
     virtual QCString trDetailedDescription()
     { return "Детален опис"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Детали"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Документација на членови дефиниции на тип"; }

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -48,6 +48,9 @@ class TranslatorDutch : public Translator
     { return "(Merk op dat dit geen member functies zijn.)"; }
     QCString trDetailedDescription()
     { return "Gedetailleerde Beschrijving"; }
+    virtual QCString trDetails()
+    { return "Details"; }
+
     QCString trMemberTypedefDocumentation()
     { return "Documentatie van type definitie members"; }
     QCString trMemberEnumerationDocumentation()

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -98,6 +98,10 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
     virtual QCString trDetailedDescription()
     { return "Detaljert beskrivelse"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detaljar"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Medlemstypedef-dokumentasjon"; }

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -77,6 +77,10 @@ class TranslatorPolish : public TranslatorAdapter_1_8_2
     QCString trDetailedDescription()
     { return "Opis szczegółowy"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Szczegóły"; }
+
     /*! header that is put before the list of typedefs. */
     QCString trMemberTypedefDocumentation()
     { return "Dokumentacja składowych definicji typu"; }

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -127,6 +127,10 @@ class TranslatorPortuguese : public Translator
     QCString trDetailedDescription()
     { return "Descrição detalhada"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detalhes"; }
+
     /*! header that is put before the list of typedefs. */
     QCString trMemberTypedefDocumentation()
     { return "Documentação das definições de tipo"; }

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -97,6 +97,10 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "Descriere Detaliată"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detalii"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Documentaţia Definiţiilor de Tipuri (typedef) Membre"; }

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -58,6 +58,10 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "Подробное описание"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Подробности"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Определения типов"; }

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -101,6 +101,10 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     virtual QCString trDetailedDescription()
     { return "Опширније"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Детаљи"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Документација дефиниције типа"; }

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -45,6 +45,9 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     { return "(To niso metode.)"; }
     QCString trDetailedDescription()
     { return "Podroben opis"; }
+    virtual QCString trDetails()
+    { return "Podrobnosti"; }
+
     QCString trMemberTypedefDocumentation()
     { return "Opis uporabniško definiranih tipov"; }
     QCString trMemberEnumerationDocumentation()

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -71,6 +71,10 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "Detailný popis"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Podrobnosti"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentácia k členským typom"; }

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -83,6 +83,10 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
     virtual QCString trDetailedDescription()
     { return "Opširniji opis"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Podrobnosće"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentacija unutrašnjih definicija tipa"; }

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -205,6 +205,10 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_4
     virtual QCString trDetailedDescription()
     { return "Detaljerad beskrivning"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Detaljer"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Dokumentation av typdefinierade medlemmar"; }

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -96,6 +96,10 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     virtual QCString trDetailedDescription()
     { return "Ayrıntılı tanımlama"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Ayrıntılar"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Üye Typedef Dokümantasyonu"; }

--- a/src/translator_tw.h
+++ b/src/translator_tw.h
@@ -109,6 +109,10 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
     virtual QCString trDetailedDescription()
     { return "詳細描述"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "詳細資訊"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "型態定義成員說明文件"; }

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -54,6 +54,10 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     virtual QCString trDetailedDescription()
     { return "Детальний опис"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Подробиці"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Опис типів користувача"; }

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -117,6 +117,10 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     virtual QCString trDetailedDescription()
     { return "Mô tả chi tiết"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Chi tiết"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Thông tin về Member Typedef"; }

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -82,6 +82,10 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
     virtual QCString trDetailedDescription()
     { return "Detail Beskrywing"; }
 
+    /*! header that is used when the summary tag is missing inside the details tag */
+    virtual QCString trDetails()
+    { return "Besonderhede"; }
+
     /*! header that is put before the list of typedefs. */
     virtual QCString trMemberTypedefDocumentation()
     { return "Lede Typedef Dokumentasie"; }

--- a/testing/060/class_details_without_summary.xml
+++ b/testing/060/class_details_without_summary.xml
@@ -5,7 +5,7 @@
     <briefdescription>
     </briefdescription>
     <detaileddescription>
-      <para>Before details. <details><para>Details body without summary </para></details>After details. </para>
+      <para>Before details. <details><summary>Details</summary><para>Details body without summary </para></details>After details. </para>
     </detaileddescription>
     <location file="060_details.cpp" line="25" column="1" bodyfile="060_details.cpp" bodystart="25" bodyend="25"/>
     <listofallmembers>


### PR DESCRIPTION
When we gave a `<details>` tag without a `<summary>` tag, we see that
- the triangle in front does not match the triangle which is used when doxygen styles the summary
- the default text is in the language that is used by the browser, not by doxygen

In case doxygen sees that there is no `<summary>` tag present doxygen will add the summary tag and use the text according to the doxygen `OUTPUT_LANGUAGE`. The texts have been taken from  the Firefox language packs at https://releases.mozilla.org/pub/firefox/releases/106.0/win64/xpi/, in case there is no text available the text is created with the aid of Google translate.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9952775/example.tar.gz)

Images (I also set the color for the `<summary>` tag to red to show the problem even better)
**before**

![image](https://user-images.githubusercontent.com/5223533/200340799-b600e7bf-fae7-4436-a4a7-4e6c06c6978e.png)

**after**

![image](https://user-images.githubusercontent.com/5223533/200341199-d7cea580-8aa8-4f08-92f1-9d26bf8c4189.png)
