### PR TITLE
Incorrect man code output in respect to backslashes

### DIFF
--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -334,7 +334,7 @@ void ManGenerator::codify(const QCString &str)
                     m_col+=spacesToNextTabStop;
                     break;
         case '\n':  m_t << "\n"; m_firstCol=TRUE; m_col=0; break;
-        case '\\':  m_t << "\\"; m_col++; break;
+        case '\\':  m_t << "\\\\"; m_col++; break;
         case '\"':  // no break!
         default:    p=writeUTF8Char(m_t,p-1); m_firstCol=FALSE; m_col++; break;
       }


### PR DESCRIPTION
When having a simple  code section in the documentation like:
```
/**
 The fie
 \code
 #define X \
   Y
 char *b = "Some \fB string.";
 \endcode
*/
void fie();
```
and looking at the man output we see that the backslashes (`\`) are interpreted by the man interpreter as doxygen din;t properly escape them, resulting in
```
       The fie

       #define X   Y
       char *b = "Some  string.";
```
i.e. joining the `#define` lines and printing the word `string` and the rest of the section in bold.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/9970151/example.tar.gz)
