### PR TITLE
issue #9669 Namespaces in arguments of a method breaks cref resolving in C#

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4497,7 +4497,8 @@ NONLopt [^\n]*
   /*- Function argument reading rules ---------------------------------------*/
 
 <ReadFuncArgType>[^ \/\r\t\n\[\]\)\(\"\'#]+ { *yyextra->copyArgString+=yytext;
-                                          yyextra->fullArgString+=yytext;
+                                          if (yyextra->insideCS) yyextra->fullArgString+=substitute(yytext,".","::");
+                                          else yyextra->fullArgString+=yytext;
                                         }
 <CopyArgString,CopyArgPHPString>[^\n\\\"\']+            { *yyextra->copyArgString+=yytext;
                                           yyextra->fullArgString+=yytext;


### PR DESCRIPTION
In case of CSharp convert the type from the dot notation to the (internally used) double colon notation.