### PR TITLE
issue #9672 doxygen does not interpret Python docstrings when typed next to SLURM directives

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -356,7 +356,8 @@ STARTDOCSYMS      "##"
                         if (yyextra->yyLineNr != 1) REJECT;
                       }
     {POUNDCOMMENT}    { // normal comment
-                        yyextra->packageCommentAllowed = FALSE;
+                        // issue 9672
+                        //yyextra->packageCommentAllowed = FALSE;
                       }
     {IDENTIFIER}      { // some other identifier
                         yyextra->packageCommentAllowed = FALSE;


### PR DESCRIPTION
In case a normal comment was found the possibility for package comments was disabled.