### PR TITLE
Fixed missing line return

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11797,7 +11797,7 @@ void searchInputFiles()
   }
   if (Doxygen::inputNameLinkedMap->empty())
   {
-    warn_uncond("No files to be processed, please check your settings, in particular INPUT, FILE_PATTERNS, and RECURSIVE");
+    warn_uncond("No files to be processed, please check your settings, in particular INPUT, FILE_PATTERNS, and RECURSIVE\n");
   }
   g_s.end();
 }


### PR DESCRIPTION
Fixed a `warn_uncond` function call where a line return was missing