### PR TITLE
Added latex and html folders in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 tags
 
 .idea
+
+/examples/html/*
+/examples/latex/*


### PR DESCRIPTION
The configuration in the `examples` folder is using the root of the project as an output base directory.

When generating the examples individually, the documentation is generated in the `/html/` and `/latex/` folders.

I might not be the only one trying to generate the examples individually while adding some features to the code, so it is maybe worth to add those folders in the `.gitignore` file, if those folders are not used for any other purpose.