### PR TITLE
Small correction of `startGroupHeader` argument (int <-> bool)

### DIFF
--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -623,8 +623,8 @@ void ManGenerator::startSection(const QCString &,const QCString &,SectionType ty
   {
     switch(type)
     {
-      case SectionType::Page:          startGroupHeader(FALSE); break;
-      case SectionType::Section:       startGroupHeader(FALSE); break;
+      case SectionType::Page:          startGroupHeader(0); break;
+      case SectionType::Section:       startGroupHeader(0); break;
       case SectionType::Subsection:    startMemberHeader(QCString(), -1); break;
       case SectionType::Subsubsection: startMemberHeader(QCString(), -1); break;
       case SectionType::Paragraph:     startMemberHeader(QCString(), -1); break;

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -133,7 +133,7 @@ class RTFGenerator : public OutputGenerator
     void endMemberSections() {}
     void startHeaderSection() {}
     void endHeaderSection() {}
-    void startMemberHeader(const QCString &,int) { startGroupHeader(FALSE); }
+    void startMemberHeader(const QCString &,int) { startGroupHeader(0); }
     void endMemberHeader() { endGroupHeader(FALSE); }
     void startMemberSubtitle();
     void endMemberSubtitle();


### PR DESCRIPTION
The argument of `startGroupHeader` is `int` and not `bool`