### PR TITLE
Show "Additional Inherited Members" for LaTeX, RTF, etc.

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -4446,8 +4446,6 @@ void ClassDefImpl::writeInheritedMemberDeclarations(OutputList &ol,ClassDefSet &
                MemberListType lt,int lt2,const QCString &title,
                const ClassDef *inheritedFrom,bool invert,bool showAlways) const
 {
-  ol.pushGeneratorState();
-  ol.disableAllBut(OutputType::Html);
   int count = countMembersIncludingGrouped(lt,inheritedFrom,FALSE);
   bool process = count>0;
   //printf("%s: writeInheritedMemberDec: lt=%d process=%d invert=%d always=%d\n",
@@ -4482,7 +4480,6 @@ void ClassDefImpl::writeInheritedMemberDeclarations(OutputList &ol,ClassDefSet &
       }
     }
   }
-  ol.popGeneratorState();
 }
 
 void ClassDefImpl::writeMemberDeclarations(OutputList &ol,ClassDefSet &visitedClasses,

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -672,21 +672,29 @@ void DocbookGenerator::docify(const QCString &str)
 DB_GEN_C
   m_t << convertToDocBook(str);
 }
-void DocbookGenerator::writeObjectLink(const QCString &, const QCString &f,
-                                     const QCString &anchor, const QCString &text)
+QCString DocbookGenerator::objectLinkToString(const QCString &, const QCString &f,
+                                              const QCString &anchor, const QCString &text)
 {
 DB_GEN_C
+  QCString result;
   if (!anchor.isEmpty())
   {
-    if (!f.isEmpty()) m_t << "<link linkend=\"_" << stripPath(f) << "_1" << anchor << "\">";
-    else   m_t << "<link linkend=\"_" << anchor << "\">";
+    if (!f.isEmpty()) result += "<link linkend=\"_" + stripPath(f) + "_1" + anchor + "\">";
+    else   result += "<link linkend=\"_" + anchor + "\">";
   }
   else
   {
-    m_t << "<link linkend=\"_" << stripPath(f) << "\">";
+    result += "<link linkend=\"_" + stripPath(f) + "\">";
   }
-  docify(text);
-  m_t << "</link>";
+  result += convertToDocBook(text);
+  result += "</link>";
+  return result;
+}
+void DocbookGenerator::writeObjectLink(const QCString &ref, const QCString &f,
+                                     const QCString &anchor, const QCString &text)
+{
+DB_GEN_C
+  m_t << objectLinkToString(ref,f,anchor,text);
 }
 void DocbookGenerator::startMemberList()
 {
@@ -1257,3 +1265,11 @@ void DocbookGenerator::closeAllSections()
   }
 }
 
+void DocbookGenerator::writeInheritedSectionTitle(
+                  const QCString &id,    const QCString &ref,
+                  const QCString &file,  const QCString &anchor,
+                  const QCString &title, const QCString &name)
+{
+DB_GEN_C
+  m_t << theTranslator->trInheritedFrom(convertToDocBook(title), objectLinkToString(ref, file, anchor, name));
+}

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -139,6 +139,7 @@ class DocbookGenerator : public OutputGenerator //: public CodeOutputForwarder<O
     void writeString(const QCString &);
     void startParagraph(const QCString &);
     void endParagraph();
+    QCString objectLinkToString(const QCString &,const QCString &,const QCString &,const QCString &);
     void writeObjectLink(const QCString &,const QCString &,const QCString &,const QCString &);
     void startHtmlLink(const QCString &){DB_GEN_NEW};
     void endHtmlLink(){DB_GEN_NEW};
@@ -238,7 +239,7 @@ class DocbookGenerator : public OutputGenerator //: public CodeOutputForwarder<O
     void endMemberDeclaration(const QCString &,const QCString &){DB_GEN_EMPTY};
     void writeInheritedSectionTitle(const QCString &,const QCString &,
                                     const QCString &,const QCString &,
-                                    const QCString &,const QCString &){DB_GEN_NEW};
+                                    const QCString &,const QCString &);
     void startIndent(){DB_GEN_EMPTY};
     void endIndent(){DB_GEN_EMPTY};
     void writeSynopsis(){DB_GEN_EMPTY};

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -123,6 +123,8 @@ class HtmlGenerator : public OutputGenerator //public CodeOutputForwarder<Output
     void endIndexItem(const QCString &ref,const QCString &file);
     void docify(const QCString &text);
 
+    QCString objectLinkToString(const QCString &ref,const QCString &file,
+                                const QCString &anchor,const QCString &name);
     void writeObjectLink(const QCString &ref,const QCString &file,
                          const QCString &anchor,const QCString &name);
 

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1263,26 +1263,33 @@ void LatexGenerator::endTextLink()
   m_t << "}";
 }
 
-void LatexGenerator::writeObjectLink(const QCString &ref, const QCString &f,
-                                     const QCString &anchor, const QCString &text)
+QCString LatexGenerator::objectLinkToString(const QCString &ref, const QCString &f,
+                                            const QCString &anchor, const QCString &text)
 {
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+  QCString result;
   if (!m_disableLinks && ref.isEmpty() && pdfHyperlinks)
   {
-    m_t << "\\mbox{\\hyperlink{";
-    if (!f.isEmpty()) m_t << stripPath(f);
-    if (!f.isEmpty() && !anchor.isEmpty()) m_t << "_";
-    if (!anchor.isEmpty()) m_t << anchor;
-    m_t << "}{";
-    docify(text);
-    m_t << "}}";
+    result += "\\mbox{\\hyperlink{";
+    if (!f.isEmpty()) result += stripPath(f);
+    if (!f.isEmpty() && !anchor.isEmpty()) result += "_";
+    if (!anchor.isEmpty()) result += anchor;
+    result += "}{";
+    result += convertToLaTeX(text);
+    result += "}}";
   }
   else
   {
-    m_t << "\\textbf{ ";
-    docify(text);
-    m_t << "}";
+    result += "\\textbf{ ";
+    result += convertToLaTeX(text);
+    result += "}";
   }
+  return result;
+}
+void LatexGenerator::writeObjectLink(const QCString &ref, const QCString &f,
+                                     const QCString &anchor, const QCString &text)
+{
+  m_t << objectLinkToString(ref,f,anchor,text);
 }
 
 void LatexGenerator::startPageRef()
@@ -2134,4 +2141,21 @@ void LatexGenerator::writeLabel(const QCString &l,bool isLast)
 
 void LatexGenerator::endLabels()
 {
+}
+
+void LatexGenerator::writeInheritedSectionTitle(
+                  const QCString &id,    const QCString &ref,
+                  const QCString &file,  const QCString &anchor,
+                  const QCString &title, const QCString &name)
+{
+  if (Config_getBool(COMPACT_LATEX))
+  {
+    m_t << "\\doxyparagraph*{";
+  }
+  else
+  {
+    m_t << "\\doxysubsubsection*{";
+  }
+  m_t << theTranslator->trInheritedFrom(convertToLaTeX(title), objectLinkToString(ref, file, anchor, name));
+  m_t << "}\n";
 }

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -132,6 +132,8 @@ class LatexGenerator : public OutputGenerator //: public CodeOutputForwarder<Out
     void startIndexItem(const QCString &ref,const QCString &file);
     void endIndexItem(const QCString &ref,const QCString &file);
     void docify(const QCString &text);
+    QCString objectLinkToString(const QCString &ref,const QCString &file,
+                                const QCString &anchor,const QCString &name);
     void writeObjectLink(const QCString &ref,const QCString &file,
                          const QCString &anchor,const QCString &name);
 
@@ -212,7 +214,7 @@ class LatexGenerator : public OutputGenerator //: public CodeOutputForwarder<Out
     void startMemberDeclaration() {}
     void endMemberDeclaration(const QCString &,const QCString &) {}
     void writeInheritedSectionTitle(const QCString &,const QCString &,const QCString &,
-                      const QCString &,const QCString &,const QCString &) {}
+                      const QCString &,const QCString &,const QCString &);
     void startDescList(SectionTypes)     { m_t << "\\begin{Desc}\n\\item["; }
     void endDescList()       { m_t << "\\end{Desc}\n"; }
     void startExamples();

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -316,10 +316,20 @@ void ManGenerator::writeStartAnnoItem(const QCString &,const QCString &,
 {
 }
 
-void ManGenerator::writeObjectLink(const QCString &,const QCString &,
-                                    const QCString &, const QCString &name)
+QCString ManGenerator::objectLinkToString(const QCString &,const QCString &,
+                                          const QCString &, const QCString &name)
 {
-  startBold(); docify(name); endBold();
+  QCString result;
+  result += "\\fB";
+  result += docifyToString(name);
+  result += "\\fP";
+  m_firstCol=FALSE;
+  return result;
+}
+void ManGenerator::writeObjectLink(const QCString &ref,const QCString &f,
+                                    const QCString &anchor, const QCString &text)
+{
+  m_t << objectLinkToString(ref,f,anchor,text);
 }
 
 void ManGenerator::startHtmlLink(const QCString &)
@@ -359,8 +369,9 @@ void ManGenerator::endMemberHeader()
   m_paragraph=FALSE;
 }
 
-void ManGenerator::docify(const QCString &str)
+QCString ManGenerator::docifyToString(const QCString &str)
 {
+  QCString result;
   if (!str.isEmpty())
   {
     const char *p=str.data();
@@ -369,18 +380,23 @@ void ManGenerator::docify(const QCString &str)
     {
       switch(c)
       {
-        case '-':  m_t << "\\-"; break; // see  bug747780
-        case '.':  m_t << "\\&."; break; // see  bug652277
-        case '\\': m_t << "\\\\"; m_col++; break;
-        case '\n': m_t << "\n"; m_col=0; break;
+        case '-':  result += "\\-"; break; // see  bug747780
+        case '.':  result += "\\&."; break; // see  bug652277
+        case '\\': result += "\\\\"; m_col++; break;
+        case '\n': result += "\n"; m_col=0; break;
         case '\"':  c = '\''; // no break!
-        default: m_t << c; m_col++; break;
+        default: result += c; m_col++; break;
       }
     }
     m_firstCol=(c=='\n');
     //printf("%s",str);fflush(stdout);
   }
   m_paragraph=FALSE;
+  return result;
+}
+void ManGenerator::docify(const QCString &str)
+{
+  m_t << docifyToString(str);
 }
 
 void ManGenerator::writeChar(char c)
@@ -866,3 +882,11 @@ void ManGenerator::endHeaderSection()
 {
 }
 
+void ManGenerator::writeInheritedSectionTitle(
+                  const QCString &id,    const QCString &ref,
+                  const QCString &file,  const QCString &anchor,
+                  const QCString &title, const QCString &name)
+{
+  m_t << "\n\n";
+  m_t << theTranslator->trInheritedFrom(docifyToString(title), objectLinkToString(ref, file, anchor, name));
+}

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -104,7 +104,10 @@ class ManGenerator : public OutputGenerator //public CodeOutputForwarder<OutputG
     void endItemList()    { newParagraph(); }
     void startIndexItem(const QCString &ref,const QCString &file);
     void endIndexItem(const QCString &ref,const QCString &file);
+    QCString docifyToString(const QCString &text);
     void docify(const QCString &text);
+    QCString objectLinkToString(const QCString &ref,const QCString &file,
+                                const QCString &anchor,const QCString &name);
     void writeObjectLink(const QCString &ref,const QCString &file,
                          const QCString &anchor,const QCString &name);
     void startTextLink(const QCString &,const QCString &) {}
@@ -182,7 +185,7 @@ class ManGenerator : public OutputGenerator //public CodeOutputForwarder<OutputG
     void startMemberDeclaration() {}
     void endMemberDeclaration(const QCString &,const QCString &) {}
     void writeInheritedSectionTitle(const QCString &,const QCString &,const QCString &,
-                      const QCString &,const QCString &,const QCString &) {}
+                      const QCString &,const QCString &,const QCString &);
     void startDescList(SectionTypes);
     void endDescList()        {}
     void startExamples();

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -550,8 +550,6 @@ void MemberList::writeDeclarations(OutputList &ol,
     if ( cd && !optimizeVhdl && cd->countMembersIncludingGrouped(
                                       m_listType,inheritedFrom,TRUE)>0 )
     {
-      ol.pushGeneratorState();
-      ol.disableAllBut(OutputType::Html);
       inheritId = substitute(listTypeAsString(lt),"-","_")+"_"+
                   stripPath(cd->getOutputFileBase());
       if (!title.isEmpty())
@@ -560,7 +558,6 @@ void MemberList::writeDeclarations(OutputList &ol,
                                       cd->getOutputFileBase(),
                                       cd->anchor(),title,cd->displayName());
       }
-      ol.popGeneratorState();
     }
   }
   else if (num>numEnumValues)

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -116,6 +116,8 @@ class RTFGenerator : public OutputGenerator
     void startIndexItem(const QCString &ref,const QCString &file);
     void endIndexItem(const QCString &ref,const QCString &file);
     void docify(const QCString &text);
+    QCString objectLinkToString(const QCString &ref,const QCString &file,
+                                const QCString &anchor,const QCString &name);
     void writeObjectLink(const QCString &ref,const QCString &file,
                          const QCString &anchor,const QCString &name);
     void startTextLink(const QCString &f,const QCString &anchor);
@@ -189,7 +191,7 @@ class RTFGenerator : public OutputGenerator
     void startMemberDeclaration() {}
     void endMemberDeclaration(const QCString &,const QCString &) {}
     void writeInheritedSectionTitle(const QCString &,const QCString &,const QCString &,
-                      const QCString &,const QCString &,const QCString &) {}
+                      const QCString &,const QCString &,const QCString &);
     void startDescList(SectionTypes);
     void startExamples();
     void endExamples();


### PR DESCRIPTION
For the HTML output we see a wit the "Additional Inherited Members" we see (in the expandable list) all the additional inherited members, with LaTeX, RTF etc. we only see the header but no members. (Seen with the example code from issue #9678)