### PR TITLE
Incorrect return of getUTF8CharAt giving wrong alphabetical index

### DIFF
--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -129,7 +129,7 @@ std::string getUTF8CharAt(const std::string &input,size_t pos)
   if (input.length()<=pos) return std::string();
   int numBytes=getUTF8CharNumBytes(input[pos]);
   if (input.length()<pos+numBytes) return std::string();
-  return input.substr(pos,pos+numBytes);
+  return input.substr(pos,numBytes);
 }
 
 uint32_t getUnicodeForUTF8CharAt(const std::string &input,size_t pos)


### PR DESCRIPTION
This is a regression on https://github.com/doxygen/doxygen/issues/8375, the `substr` function requires a length and not an end position. Problem was found when looking at https://github.com/doxygen/doxygen/issues/3244