### PR TITLE
Incorrect place of prototype of `dateToString`

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -55,6 +55,7 @@
 #include "searchindex.h"
 #include "resourcemgr.h"
 #include "dir.h"
+#include "datetime.h"
 
 // TODO: pass the current file to Dot*::writeGraph, so the user can put dot graphs in other
 //       files as well

--- a/src/datetime.h
+++ b/src/datetime.h
@@ -70,4 +70,9 @@ std::tm getCurrentDateTime();
 /** Returns the current year as a string */
 QCString yearToString();
 
+/** Returns the current date, when \c includeTime is set also the time is provided.
+ *  @param[in] includeTime include the time in the output
+ */
+QCString dateToString(bool includeTime);
+
 #endif

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -55,6 +55,7 @@
 #include "utf8.h"
 #include "textstream.h"
 #include "indexlist.h"
+#include "datetime.h"
 
 //#define DBG_HTML(x) x;
 #define DBG_HTML(x)

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -44,6 +44,7 @@
 #include "portable.h"
 #include "fileinfo.h"
 #include "utf8.h"
+#include "datetime.h"
 
 static QCString g_header;
 static QCString g_footer;

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -31,6 +31,7 @@
 #include "language.h"
 #include "dir.h"
 #include "utf8.h"
+#include "datetime.h"
 
 static QCString getExtension()
 {

--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -48,6 +48,7 @@
 #include "section.h"
 #include "fileinfo.h"
 #include "dir.h"
+#include "datetime.h"
 
 #include <sys/stat.h>
 #include <string.h>

--- a/src/util.h
+++ b/src/util.h
@@ -102,8 +102,6 @@ void linkifyText(const TextGeneratorIntf &ol,
 
 QCString fileToString(const QCString &name,bool filter=FALSE,bool isSourceCode=FALSE);
 
-QCString dateToString(bool);
-
 bool getDefs(const QCString &scopeName,
                     const QCString &memberName,
                     const QCString &args,


### PR DESCRIPTION
The prototype of `dateToString` was located in `util.h` although the implementation is in `datetime.cpp` and the file `datetime.h` exists. Moved `dateToString` to `datetime.h`