### PR TITLE
MiKTeX timeout

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -77,7 +77,7 @@ jobs:
         Do {
           $attemptCount++;
           Try {
-            $wc.DownloadFile("https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-5.2.0+b8f430f-x64.zip","miktexsetup-5.2.0+b8f430f-x64.zip")
+            $wc.DownloadFile("http://mirror.easyname.at/ctan/systems/win32/miktex/setup/windows-x64/miktexsetup-5.2.0+b8f430f-x64.zip","miktexsetup-5.2.0+b8f430f-x64.zip")
           } Catch [Exception] {
             Write-Host $_.Exception | format-list -force
           }
@@ -143,7 +143,7 @@ jobs:
       run: |
         ./miktexsetup_standalone --verbose \
                       --local-package-repository="C:/miktex-repository" \
-                      --remote-package-repository="https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/" \
+                      --remote-package-repository="http://mirror.easyname.at/ctan/systems/win32/miktex/tm/packages/" \
                       --package-set=essential \
                       download
       if: matrix.config.os == 'windows-latest'


### PR DESCRIPTION
Looks like the mirror runs into a timeout:
```
  ./miktexsetup_standalone --verbose \
                --local-package-repository="C:/miktex-repository" \
                --remote-package-repository="https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/" \
                --package-set=essential \
                download
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
this is MiKTeX Setup Service 5.4 (MiKTeX 22.10)
starting downloader...
miktexsetup_standalone: Timeout was reached
```

Trying different mirror