### PR TITLE
bug 466064 Formatting-options for $datetime

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1951,6 +1951,11 @@ doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFil
  <dt><code>$datetime</code><dd>will be replaced with current the date and time.
  <dt><code>$date</code><dd>will be replaced with the current date.
  <dt><code>$year</code><dd>will be replaces with the current year.
+ <dt><code>$showdate(<format>)</code><dd>will be replaced with the current date
+           and time according to the format as specified by `<format>`. The
+           `<format>` follows the rules as specified for the
+           \ref cmdshowdate "\\showdate" command with the exception that no `)`
+           is allowed in the `<format>`.
  <dt><code>$doxygenversion</code><dd>will be replaced with the version of doxygen
  <dt><code>$projectname</code><dd>will be replaced with the name of
             the project (see \ref cfg_project_name "PROJECT_NAME")
@@ -2944,6 +2949,11 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
  <dt><code>$datetime</code><dd>will be replaced with current the date and time.
  <dt><code>$date</code><dd>will be replaced with the current date.
  <dt><code>$year</code><dd>will be replaces with the current year.
+ <dt><code>$showdate(<format>)</code><dd>will be replaced with the current date
+           and time according to the format as specified by `<format>`. The
+           `<format>` follows the rules as specified for the
+           \ref cmdshowdate "\\showdate" command with the exception that no `)`
+           is allowed in the `<format>`.
  <dt><code>$doxygenversion</code><dd>will be replaced with the version of doxygen
  <dt><code>$projectname</code><dd>will be replaced with the name of
            the project (see \ref cfg_project_name "PROJECT_NAME")

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3419,6 +3419,43 @@ QCString substituteKeywords(const QCString &s,const QCString &title,
   result = substitute(result,"$projectbrief",projBrief);
   result = substitute(result,"$projectlogo",stripPath(Config_getString(PROJECT_LOGO)));
   result = substitute(result,"$langISO",theTranslator->trISOLang());
+
+  static const reg::Ex re(R"(\$showdate\([^\)]*\))");
+  std::string s1 = result.str();
+  reg::Iterator iter(s1,re);
+  reg::Iterator end;
+  result = "";
+  size_t p=0;
+  size_t sl=s1.length();
+  for ( ; iter!=end ; ++iter)
+  {
+    const auto &match = *iter;
+    size_t i = match.position();
+    if (i>p) // add non-matching prefix
+    {
+      result+=s1.substr(p,i-p);
+    }
+    QCString showDate = match.str();
+    showDate = showDate.mid(10,showDate.length()-10-1);
+
+    // get the current date and time
+    std::tm dat{};
+    int specFormat=0;
+    QCString specDate = "";
+    QCString err = dateTimeFromString(specDate,dat,specFormat);
+
+    // do the conversion
+    int usedFormat=0;
+    QCString dateTimeStr = formatDateTime(showDate,dat,usedFormat);
+    result += dateTimeStr;
+
+    p = match.position()+match.length();
+  }
+  if (p<sl) // add trailing remainder
+  {
+    result+=s1.substr(p);
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Adding marker `$showdate` following rules as for the command `\showdate`.