### PR TITLE
issue #9701 Relative Links in Markdown to Anchors do not get translated correctly in HTML output

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -699,9 +699,19 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
   QCString     anchor;
   //printf("DocRef::DocRef(target=%s,context=%s)\n",qPrint(target),qPrint(context));
   ASSERT(!target.isEmpty());
-  SrcLangExt lang = getLanguageFromFileName(target);
+  QCString locTarget = target;
+  QCString locAnchor;
+  int lp = -1;
+  lp = locTarget.findRev('#');
+  if (lp != -1)
+  {
+    locTarget = target.left(lp);
+    locAnchor = target.right(target.length() - lp);
+  }
+  SrcLangExt lang = getLanguageFromFileName(locTarget);
+
   m_relPath = parser->context.relPath;
-  const SectionInfo *sec = SectionManager::instance().find(target);
+  const SectionInfo *sec = SectionManager::instance().find(locTarget);
   if (sec==0 && lang==SrcLangExt_Markdown) // lookup as markdown file
   {
     sec = SectionManager::instance().find(markdownFileNameToId(target));
@@ -711,7 +721,7 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
     PageDef *pd = 0;
     if (sec->type()==SectionType::Page)
     {
-      pd = Doxygen::pageLinkedMap->find(target);
+      pd = Doxygen::pageLinkedMap->find(locTarget);
     }
     m_text         = sec->title();
     if (m_text.isEmpty()) m_text = sec->label();
@@ -732,6 +742,7 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
     }
     m_isSubPage    = pd && pd->hasParentPage();
     if (sec->type()!=SectionType::Page || m_isSubPage) m_anchor = sec->label();
+    if (m_anchor.isEmpty()) m_anchor = locAnchor;
     //printf("m_text=%s,m_ref=%s,m_file=%s,type=%d\n",
     //    qPrint(m_text),qPrint(m_ref),qPrint(m_file),m_refType);
     return;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1524,29 +1524,39 @@ int Markdown::processLink(const char *data,int offset,int size)
   }
   else
   {
-    SrcLangExt lang = getLanguageFromFileName(link);
-    int lp=-1;
+    int lp = -1;
+    QCString locLink = link;
+    QCString locAnchor;
+    lp = locLink.findRev('#');
+    SrcLangExt lang;
+    if (lp != -1)
+    {
+      locLink = link.left(lp);
+      locAnchor = link.right(link.length() - lp);
+    }
+    lang = getLanguageFromFileName(locLink);
+    lp=-1;
     if ((lp=link.find("@ref "))!=-1 || (lp=link.find("\\ref "))!=-1 || (lang==SrcLangExt_Markdown && !isURL(link)))
         // assume doxygen symbol link
     {
       if (lp==-1) // link to markdown page
       {
         m_out.addStr("@ref ");
-        if (!(Portable::isAbsolutePath(link) || isURL(link)))
+        if (!(Portable::isAbsolutePath(locLink) || isURL(locLink)))
         {
-          FileInfo forg(link.str());
+          FileInfo forg(locLink.str());
           if (forg.exists() && forg.isReadable())
           {
-            link = forg.absFilePath();
+            link = forg.absFilePath() + locAnchor;
           }
           else if (!(forg.exists() && forg.isReadable()))
           {
             FileInfo fi(m_fileName.str());
-            QCString mdFile = m_fileName.left(m_fileName.length()-fi.fileName().length()) + link;
+            QCString mdFile = m_fileName.left(m_fileName.length()-fi.fileName().length()) + locLink;
             FileInfo fmd(mdFile.str());
             if (fmd.exists() && fmd.isReadable())
             {
-              link = fmd.absFilePath().data();
+              link = fmd.absFilePath().data() + locAnchor;
             }
           }
         }


### PR DESCRIPTION
Determining the language from the filename should be done without the anchor. Also other operations should be done without the anchor (like absolute path), but we have to append the anchor later on again.