### PR TITLE
Replace MiKTeX by tlmgr for Windows

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -69,21 +69,21 @@ jobs:
     - name: Checkout doxygen
       uses: actions/checkout@v3
       
-    - name: Download MikTex (Windows)
-      run: |
-        $wc = New-Object System.Net.WebClient;
-        $maxAttempts=5;
-        $attemptCount=0;
-        Do {
-          $attemptCount++;
-          Try {
-            $wc.DownloadFile("https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-5.2.0+b8f430f-x64.zip","miktexsetup-5.2.0+b8f430f-x64.zip")
-          } Catch [Exception] {
-            Write-Host $_.Exception | format-list -force
-          }
-        } while (((Test-Path "miktexsetup-5.2.0+b8f430f-x64.zip") -eq $false) -and ($attemptCount -le $maxAttempts))  
-      shell: pwsh
-      if: matrix.config.os == 'windows-latest'
+#    - name: Download MikTex (Windows)
+#      run: |
+#        $wc = New-Object System.Net.WebClient;
+#        $maxAttempts=5;
+#        $attemptCount=0;
+#        Do {
+#          $attemptCount++;
+#          Try {
+#            $wc.DownloadFile("https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-5.2.0+b8f430f-x64.zip","miktexsetup-5.2.0+b8f430f-x64.zip")
+#          } Catch [Exception] {
+#            Write-Host $_.Exception | format-list -force
+#          }
+#        } while (((Test-Path "miktexsetup-5.2.0+b8f430f-x64.zip") -eq $false) -and ($attemptCount -le $maxAttempts))  
+#      shell: pwsh
+#      if: matrix.config.os == 'windows-latest'
       
     - name: Install libiconv (Windows)
       uses: suisei-cn/actions-download-file@v1
@@ -132,40 +132,50 @@ jobs:
         sudo apt install libxapian-dev
       if: matrix.config.os == 'ubuntu-20.04'
           
-    - name: Extract MikTex zip (Windows)
-      shell: bash
-      run: |
-        unzip miktexsetup-5.2.0+b8f430f-x64.zip
-      if: matrix.config.os == 'windows-latest'
+#    - name: Extract MikTex zip (Windows)
+#      shell: bash
+#      run: |
+#        unzip miktexsetup-5.2.0+b8f430f-x64.zip
+#      if: matrix.config.os == 'windows-latest'
+#
+#    - name: Download MikTex packages (Windows)
+#      shell: bash
+#      run: |
+#        ./miktexsetup_standalone --verbose \
+#                      --local-package-repository="C:/miktex-repository" \
+#                      --remote-package-repository="https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/" \
+#                      --package-set=essential \
+#                      download
+#      if: matrix.config.os == 'windows-latest'
+#
+#    - name: Install MikTex packages (Windows)
+#      shell: bash
+#      run: |
+#        ./miktexsetup_standalone --local-package-repository="C:/miktex-repository" \
+#                      --verbose \
+#                      --package-set=essential \
+#                      --shared \
+#                      install
+#      if: matrix.config.os == 'windows-latest'
+#
+#    - name: Setting MikTex paths (Windows)
+#      shell: bash
+#      run: |
+#        echo "C:/Program Files/MiKTeX/miktex/bin/x64/" >> $GITHUB_PATH
+#        export PATH="/c/Program Files/MiKTeX/miktex/bin/x64/:$PATH"
+#        
+#        echo "Configuring MiKTeX to install missing packages on the fly"
+#        initexmf --admin --verbose --set-config-value='[MPM]AutoInstall=1'
+#      if: matrix.config.os == 'windows-latest'
 
-    - name: Download MikTex packages (Windows)
-      shell: bash
-      run: |
-        ./miktexsetup_standalone --verbose \
-                      --local-package-repository="C:/miktex-repository" \
-                      --remote-package-repository="https://ctan.math.illinois.edu/systems/win32/miktex/tm/packages/" \
-                      --package-set=essential \
-                      download
-      if: matrix.config.os == 'windows-latest'
-
-    - name: Install MikTex packages (Windows)
-      shell: bash
-      run: |
-        ./miktexsetup_standalone --local-package-repository="C:/miktex-repository" \
-                      --verbose \
-                      --package-set=essential \
-                      --shared \
-                      install
-      if: matrix.config.os == 'windows-latest'
-
-    - name: Setting MikTex paths (Windows)
-      shell: bash
-      run: |
-        echo "C:/Program Files/MiKTeX/miktex/bin/x64/" >> $GITHUB_PATH
-        export PATH="/c/Program Files/MiKTeX/miktex/bin/x64/:$PATH"
-        
-        echo "Configuring MiKTeX to install missing packages on the fly"
-        initexmf --admin --verbose --set-config-value='[MPM]AutoInstall=1'
+    - name: Install LaTeX (Windows)
+      uses: teatimeguest/setup-texlive-action@v2
+      with:
+        packages: >-
+          scheme-medium
+          babel-dutch
+          cjk
+          bibtex
       if: matrix.config.os == 'windows-latest'
 
     - name: Install Ghostscript (Linux)
@@ -358,7 +368,7 @@ jobs:
         set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
 
         execute_process(
-          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd"
+          COMMAND cmake --build build --target tests TEST_FLAGS="--xml --xmlxsd --xhtml --qhp --docbook --rtf --pdf"
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)
@@ -376,7 +386,6 @@ jobs:
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Building documentation failed")
         endif()
-      if: matrix.config.os != 'windows-latest'
 
     - name: Archive html documentation artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -173,10 +173,10 @@ jobs:
       with:
         packages: >-
           scheme-medium
+          collection-latexextra
           babel-dutch
           cjk
           bibtex
-          tabu
       if: matrix.config.os == 'windows-latest'
 
     - name: Install Ghostscript (Linux)

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -176,6 +176,7 @@ jobs:
           babel-dutch
           cjk
           bibtex
+          tabu
       if: matrix.config.os == 'windows-latest'
 
     - name: Install Ghostscript (Linux)

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -376,15 +376,6 @@ jobs:
           message(FATAL_ERROR "Running tests failed!")
         endif()
       if: matrix.config.os == 'windows-latest'
-    - name: Get log file
-      if: ${{ failure() }}
-      id: package
-      uses: juliangruber/read-file-action@v1
-      with:
-        path: ./build/testing/test_output_001/latex/refman.log
-    - name: Echo log file
-      if: ${{ failure() }}
-      run: echo "${{ steps.package.outputs.content }}"
 
     - name: Generate documentation
       shell: cmake -P {0}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -375,6 +375,15 @@ jobs:
           message(FATAL_ERROR "Running tests failed!")
         endif()
       if: matrix.config.os == 'windows-latest'
+    - name: Get log file
+      if: ${{ failure() }}
+      id: package
+      uses: juliangruber/read-file-action@v1
+      with:
+        path: ./build/testing/test_output_001/latex/refman.log
+    - name: Echo log file
+      if: ${{ failure() }}
+      run: echo "${{ steps.package.outputs.content }}"
 
     - name: Generate documentation
       shell: cmake -P {0}


### PR DESCRIPTION
Due to the fact that MiKTeX is not working (timeout) the latex distribution for windows has been replaced by tlmgr. Added the full test suite for windows, including pdf. Extra packages:
- bibtex for test 012 the `\cite` command (needed for bib2xhtml.pl)
- babel-dutch and cjk needed for test 053 and 065  i.e. the `\~language` command tests