### PR TITLE
Issue #9715 prevent recursion

### DIFF
--- a/src/classdef.h
+++ b/src/classdef.h
@@ -223,7 +223,7 @@ class ClassDef : public Definition
      *  class. This function will recursively traverse all branches of the
      *  inheritance tree.
      */
-    virtual int isBaseClass(const ClassDef *bcd,bool followInstances) const = 0;
+    virtual int isBaseClass(const ClassDef *bcd, bool followInstances, int recursion_depth=0) const = 0;
 
     /** Returns TRUE iff \a bcd is a direct or indirect sub class of this
      *  class.

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -348,7 +348,7 @@ void DiagramRow::insertClass(DiagramItem *parent,const ClassDef *cd,bool doBases
   {
     /* there are base/sub classes */
     ClassDef *ccd=bcd.classDef;
-    if (ccd && ccd->isVisibleInHierarchy()) count++;
+    if (ccd && ccd->isVisibleInHierarchy() && ccd != cd) count++;
   }
   if (count>0 && (prot!=Private || !doBases))
   {
@@ -364,7 +364,7 @@ void DiagramRow::insertClass(DiagramItem *parent,const ClassDef *cd,bool doBases
     for (const auto &bcd : doBases ? cd->baseClasses() : cd->subClasses())
     {
       ClassDef *ccd=bcd.classDef;
-      if (ccd && ccd->isVisibleInHierarchy())
+      if (ccd && ccd->isVisibleInHierarchy() && ccd != cd)
       {
         row->insertClass(di_ptr,ccd,doBases,bcd.prot,
             doBases?bcd.virt:Normal,


### PR DESCRIPTION
Prevent recursion for abstract c# classes that inherit from themselves.
Moved the recursion check in front of the function call in isBaseClass in classdef.cpp since the function call itself could produce an infinite recursion.
Added an equality check to prevent an infinite loop in diagram.cpp