### PR TITLE
issue #9721 \code blocks have blank lines removed in LaTeX/PDF output

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -86,7 +86,7 @@ void LatexCodeGenerator::codify(const QCString &str)
       {
         case 0x0c: p++;  // remove ^L
                    break;
-        case ' ':  m_t <<" ";
+        case ' ':  m_t << (m_doxyCodeLineOpen ? "\\ " : " ");
                    m_col++;
                    p++;
                    break;
@@ -96,7 +96,7 @@ void LatexCodeGenerator::codify(const QCString &str)
                    break;
         case '\t': spacesToNextTabStop =
                          tabSize - (m_col%tabSize);
-                   for (i = 0; i < spacesToNextTabStop; i++) m_t <<" ";
+                   for (i = 0; i < spacesToNextTabStop; i++) m_t << (m_doxyCodeLineOpen ? "\\ " : " ");
                    m_col+=spacesToNextTabStop;
                    p++;
                    break;
@@ -204,11 +204,14 @@ void LatexCodeGenerator::writeLineNumber(const QCString &ref,const QCString &fil
     {
       codify(lineNumber);
     }
-    m_t << " ";
+    m_t << "\\ ";
   }
   else
   {
-    m_t << l << " ";
+    QCString lineNumber;
+    lineNumber.sprintf("%05d",l);
+    codify(lineNumber);
+    m_t << "\\ ";
   }
   m_col=0;
 }

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -105,7 +105,15 @@
 % Necessary for hanging indent
 \newlength{\DoxyCodeWidth}
 
-\newcommand\DoxyCodeLine[1]{\hangpara{\DoxyCodeWidth}{1}{#1}\par}
+\newcommand\DoxyCodeLine[1]{
+  \ifthenelse{\equal{\detokenize{#1}}{}}
+  {
+    \vspace*{\baselineskip}
+  }
+  {
+    \hangpara{\DoxyCodeWidth}{1}{#1}\par
+  }
+}
 
 \newcommand\NiceSpace{%
      \discretionary{}{\kern\fontdimen2\font}{\kern\fontdimen2\font}%


### PR DESCRIPTION
- show spaces as spaces in LaTeX code sections (latexgen.cpp)
- consistency of line number representation (latexgen.cpp)
- show empty lines also in code (doxygen.sty)