### PR TITLE
Creation of internal documentation depends on executable

### DIFF
--- a/doc_internal/CMakeLists.txt
+++ b/doc_internal/CMakeLists.txt
@@ -24,4 +24,5 @@ configure_file(${CMAKE_SOURCE_DIR}/doc_internal/Doxyfile.in "${CMAKE_CURRENT_BIN
 add_custom_target(docs_internal
         COMMENT "Generating HTML internal documentation."
         COMMAND ${CMAKE_COMMAND} -E env VERSION=${VERSION} ${DOXYGEN_EXECUTABLE}
+        DEPENDS doxygen
         )


### PR DESCRIPTION
The internal documentation should be created based on an up to date own executable