### PR TITLE
issue #9719 \ref command does not insert title of referenced page

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2191,11 +2191,14 @@ Commands to create links
   This command adds (text) to the \LaTeX , DocBook and RTF index.
 
 <hr>
-\section cmdanchor \\anchor <word>
+\section cmdanchor \\anchor['{'text'}'] <word>
 
   \addindex \\anchor
   This command places an invisible, named anchor into the documentation
   to which you can refer with the \ref cmdref "\\ref" command.
+
+  The text of the option `text` with the command is the text to be used as
+  `text` with the \ref cmdref "\\ref" command.
 
   \sa section \ref cmdref "\\ref".
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -783,7 +783,7 @@ STopt  [^\n@\\]*
 <Comment>{B}*"\\ilinebr"{B}*            { // preserve spacing around \\ilinebr
                                           addOutput(yyscanner,yytext);
                                         }
-<Comment>{B}*{CMD}[a-z_A-Z]+"{"[a-zA-Z_,:0-9\. %]*"}"{B}*  |
+<Comment>{B}*{CMD}[a-z_A-Z]+"{"[^}]*"}"{B}*  |
 <Comment>{B}*{CMD}[a-z_A-Z]+{B}*        { // potentially interesting command
                                           // the {B}* in the front was added for bug620924
                                           QCString fullMatch = QCString(yytext);

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -429,6 +429,7 @@ struct commentscanYY_state
 
   QCString         raiseWarning;
 
+  QCString         anchorTitle;
   QCString         htmlAnchorStr;
   bool             htmlAnchor = false;
 };
@@ -455,7 +456,7 @@ static QCString addFormula(yyscan_t yyscanner);
 static void checkFormula(yyscan_t yyscanner);
 static void addSection(yyscan_t yyscanner);
 static inline void setOutput(yyscan_t yyscanner,OutputContext ctx);
-static void addAnchor(yyscan_t yyscanner,const QCString &anchor);
+static void addAnchor(yyscan_t yyscanner,const QCString &anchor, const QCString &title="");
 static inline void addOutput(yyscan_t yyscanner,const char *s);
 static inline void addOutput(yyscan_t yyscanner,const QCString &s);
 static inline void addOutput(yyscan_t yyscanner,char c);
@@ -1600,7 +1601,7 @@ STopt  [^\n@\\]*
   /* ----- handle arguments of the anchor command ------- */
 
 <AnchorLabel>{LABELID}                  { // found argument
-                                          addAnchor(yyscanner,QCString(yytext));
+                                          addAnchor(yyscanner,QCString(yytext), yyextra->anchorTitle);
                                           addOutput(yyscanner,yytext);
                                           BEGIN( Comment );
                                         }
@@ -2592,10 +2593,18 @@ static bool handleSubpage(yyscan_t yyscanner,const QCString &s, const StringVect
   return FALSE;
 }
 
-static bool handleAnchor(yyscan_t yyscanner,const QCString &s, const StringVector &)
+static bool handleAnchor(yyscan_t yyscanner,const QCString &s, const StringVector &optList)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   addOutput(yyscanner,"@"+s+" ");
+  if (optList.empty())
+  {
+    yyextra -> anchorTitle = "";
+  }
+  else
+  {
+    yyextra -> anchorTitle = join(optList," ");
+  }
   BEGIN(AnchorLabel);
   return FALSE;
 }
@@ -3518,7 +3527,7 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
 }
 
 
-static void addAnchor(yyscan_t yyscanner,const QCString &anchor)
+static void addAnchor(yyscan_t yyscanner,const QCString &anchor, const QCString &title)
 {
   std::unique_lock<std::mutex> lock(g_sectionMutex);
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
@@ -3545,7 +3554,7 @@ static void addAnchor(yyscan_t yyscanner,const QCString &anchor)
   }
   else
   {
-    si = sm.add(anchor,yyextra->fileName,yyextra->lineNr,QCString(),SectionType::Anchor,0);
+    si = sm.add(anchor,yyextra->fileName,yyextra->lineNr,title,SectionType::Anchor,0);
     yyextra->current->anchors.push_back(si);
   }
 }

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -783,7 +783,7 @@ STopt  [^\n@\\]*
 <Comment>{B}*"\\ilinebr"{B}*            { // preserve spacing around \\ilinebr
                                           addOutput(yyscanner,yytext);
                                         }
-<Comment>{B}*{CMD}[a-z_A-Z]+"{"[a-zA-Z_,:0-9\. ]*"}"{B}*  |
+<Comment>{B}*{CMD}[a-z_A-Z]+"{"[a-zA-Z_,:0-9\. %]*"}"{B}*  |
 <Comment>{B}*{CMD}[a-z_A-Z]+{B}*        { // potentially interesting command
                                           // the {B}* in the front was added for bug620924
                                           QCString fullMatch = QCString(yytext);

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2682,7 +2682,7 @@ void Markdown::writeOneLineHeaderOrRuler(const char *data,int size)
     {
       if (!id.isEmpty())
       {
-        m_out.addStr("\\anchor "+id+"\\ilinebr ");
+        m_out.addStr("\\anchor{" + header + "} "+id+"\\ilinebr ");
       }
       hTag.sprintf("h%d",level);
       m_out.addStr("<"+hTag+">");
@@ -3527,19 +3527,19 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
            FileInfo(mdfileAsMainPage.str()).absFilePath()) // file reference with path
          )
       {
-        docs.prepend("@anchor " + id + "\\ilinebr ");
+        docs.prepend("@anchor{" + title + "} " + id + "\\ilinebr ");
         docs.prepend("@mainpage "+title+"\\ilinebr ");
       }
       else if (id=="mainpage" || id=="index")
       {
         if (title.isEmpty()) title = titleFn;
-        docs.prepend("@anchor " + id + "\\ilinebr ");
+        docs.prepend("@anchor{" + title + "} " + id + "\\ilinebr ");
         docs.prepend("@mainpage "+title+"\\ilinebr ");
       }
       else
       {
         if (title.isEmpty()) {title = titleFn;prepend=0;}
-        if (!wasEmpty) docs.prepend("@anchor " +  markdownFileNameToId(fileName) + "\\ilinebr ");
+        if (!wasEmpty) docs.prepend("@anchor{" + title + "} " +  markdownFileNameToId(fileName) + "\\ilinebr ");
         docs.prepend("@page "+id+" "+title+"\\ilinebr ");
       }
       for (int i = 0; i < prepend; i++) docs.prepend("\n");
@@ -3553,11 +3553,13 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
         if (reg::search(s,match,re))
         {
           QCString orgLabel    = match[1].str();
+          QCString orgTitle    = match[2].str();
+          orgTitle = orgTitle.stripWhiteSpace();
           QCString newLabel    = markdownFileNameToId(fileName);
           docs = docs.left(match[1].position())+               // part before label
                  newLabel+                                     // new label
                  match[2].str()+                               // part between orgLabel and \n
-                 "\\ilinebr @anchor "+orgLabel+"\n"+           // add original anchor plus \n of above
+                 "\\ilinebr @anchor{" + orgTitle + "} "+orgLabel+"\n"+           // add original anchor plus \n of above
                  docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }


### PR DESCRIPTION
Adding the `title` as optional text as option to the `\anchor` command.