### PR TITLE
Consistency of end of program

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -12693,6 +12693,14 @@ void generateOutput()
          Portable::getSysElapsedTime()
         );
     g_s.print();
+    bool restore=FALSE;
+    if (Debug::isFlagSet(Debug::Time))
+    {
+      Debug::clearFlag("time");
+      restore=TRUE;
+    }
+    msg("finished...\n");
+    if (restore) Debug::setFlag("time");
   }
   else
   {


### PR DESCRIPTION
In case `-d time` is used the "finished...` was not printed, made consistent