### PR TITLE
Check debug settings by means of the compiler

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -80,16 +80,21 @@ static int labelToEnumValue(const QCString &l)
   return (it!=s_labels.end()) ? it->second : 0;
 }
 
-int Debug::setFlag(const QCString &lab)
+int Debug::setFlagStr(const QCString &lab)
 {
   int retVal = labelToEnumValue(lab);
   curMask = static_cast<DebugMask>(curMask | retVal);
   return retVal;
 }
 
-void Debug::clearFlag(const QCString &lab)
+void Debug::setFlag(const DebugMask mask)
 {
-  curMask = static_cast<DebugMask>(curMask & ~labelToEnumValue(lab));
+  curMask = static_cast<DebugMask>(curMask | mask);
+}
+
+void Debug::clearFlag(const DebugMask mask)
+{
+  curMask = static_cast<DebugMask>(curMask & ~mask);
 }
 
 void Debug::setPriority(int p)

--- a/src/debug.h
+++ b/src/debug.h
@@ -46,8 +46,9 @@ class Debug
                    };
     static void print(DebugMask mask,int prio,const char *fmt,...);
 
-    static int  setFlag(const QCString &label);
-    static void clearFlag(const QCString &label);
+    static int  setFlagStr(const QCString &label);
+    static void setFlag(const DebugMask mask);
+    static void clearFlag(const DebugMask mask);
     static bool isFlagSet(DebugMask mask);
     static void printFlags();
     static void setPriority(int p);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -229,7 +229,7 @@ class Statistics
       bool restore=FALSE;
       if (Debug::isFlagSet(Debug::Time))
       {
-        Debug::clearFlag("time");
+        Debug::clearFlag(Debug::Time);
         restore=TRUE;
       }
       msg("----------------------\n");
@@ -237,7 +237,7 @@ class Statistics
       {
         msg("Spent %.6f seconds in %s",s.elapsed,s.name);
       }
-      if (restore) Debug::setFlag("time");
+      if (restore) Debug::setFlag(Debug::Time);
     }
   private:
     struct stat
@@ -10926,7 +10926,7 @@ void readConfiguration(int argc, char **argv)
           cleanUpDoxygen();
           exit(0);
         }
-        retVal = Debug::setFlag(debugLabel);
+        retVal = Debug::setFlagStr(debugLabel);
         if (!retVal)
         {
           err("option \"-d\" has unknown debug specifier: \"%s\".\n",qPrint(debugLabel));
@@ -12694,9 +12694,9 @@ void generateOutput()
         );
     g_s.print();
 
-    Debug::clearFlag("time");
+    Debug::clearFlag(Debug::Time);
     msg("finished...\n");
-    Debug::setFlag("time");
+    Debug::setFlag(Debug::Time);
   }
   else
   {


### PR DESCRIPTION
Use as much as possible settings that can be verified on validity by the compiler, so when the developer makes a typing error it is shown directly.