### PR TITLE
issue #9733 doxygen stops parsing a file if one uses latex formulas and //!< or ///< for inline parameter documentation

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4689,13 +4689,16 @@ NONLopt [^\n]*
                                           yyextra->fullArgString+=yytext;
                                           BEGIN(CopyArgVerbatim);
                                         }
-<CopyArgVerbatim>[\\@]("endverbatim"|"endiliteral"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endmsc"|"enduml"|"endcode"|"f$"|"f]"|"f}"|"f)")/[^a-z_A-Z0-9\-] { // end of verbatim block
+<CopyArgVerbatim>[\\@]("endverbatim"|"endiliteral"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endmsc"|"enduml"|"endcode")/[^a-z_A-Z0-9\-] { // end of verbatim block
                                           yyextra->fullArgString+=yytext;
-					  if (yytext[1]=='f' && yyextra->docBlockName==&yytext[1])
+                                          if (&yytext[4]==yyextra->docBlockName)
                                           {
                                             BEGIN(CopyArgCommentLine);
                                           }
-                                          if (&yytext[4]==yyextra->docBlockName)
+                                        }
+<CopyArgVerbatim>[\\@]("f$"|"f]"|"f}"|"f)") { // end of verbatim block
+                                          yyextra->fullArgString+=yytext;
+					  if (yyextra->docBlockName==&yytext[1])
                                           {
                                             BEGIN(CopyArgCommentLine);
                                           }


### PR DESCRIPTION
When copying the data of a formula the formula is ended with the corresponding `\f` command. It makes no real sense to check here for other characters (like `[A-Za-z\-]`) as the formula is terminated with a special end sequence, contrary to other verbatim blocks where we have more general words.