### PR TITLE
Don't show default text in case no default value present

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -223,11 +223,14 @@ static QString getDocsForNode(const QDomElement &child)
       }
       docsVal = docsVal.nextSiblingElement();
     }
-    docs+=SA("<br/>");
-    docs+=SA("<br/>");
-    docs+=SA(" The default value is: <code>")+
-          child.attribute(SA("defval"))+
-          SA("</code>.");
+    if (child.attribute(SA("defval")) != SA(""))
+    {
+      docs+=SA("<br/>");
+      docs+=SA("<br/>");
+      docs+=SA(" The default value is: <code>")+
+            child.attribute(SA("defval"))+
+            SA("</code>.");
+    }
     docs+= SA("<br/>");
   }
   else if (type==SA("int"))


### PR DESCRIPTION
In case an item doesn't have a default value no attempt should be made to write out the default value (consistency with other part in `expert.cpp` and with `configgen.py`).