### PR TITLE
Remove redundant functions and typedef

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -583,7 +583,7 @@ class FilterCache
   private:
     struct FilterCacheItem
     {
-      portable_off_t filePos;
+      size_t filePos;
       size_t fileSize;
     };
     using LineOffsets = std::vector<size_t>;
@@ -742,7 +742,7 @@ class FilterCache
 
     //! Shrinks buffer \a str which should hold the contents of \a fileName to the
     //! fragment starting a line \a startLine and ending at line \a endLine
-    void shrinkBuffer(BufStr &str,const QCString &fileName,int startLine,int endLine)
+    void shrinkBuffer(BufStr &str,const QCString &fileName,size_t startLine,size_t endLine)
     {
       // compute offsets from start for each line
       compileLineOffsets(fileName,str);
@@ -775,7 +775,7 @@ class FilterCache
     std::unordered_map<std::string,FilterCacheItem> m_cache;
     std::unordered_map<std::string,LineOffsets> m_lineOffsets;
     std::mutex m_mutex;
-    portable_off_t m_endPos;
+    size_t m_endPos;
 };
 
 FilterCache &FilterCache::instance()

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -354,28 +354,6 @@ QCString Portable::getenv(const QCString &variable)
 #endif
 }
 
-portable_off_t Portable::fseek(FILE *f,portable_off_t offset, int whence)
-{
-#if defined(__MINGW32__)
-  return fseeko64(f,offset,whence);
-#elif defined(_WIN32) && !defined(__CYGWIN__)
-  return _fseeki64(f,offset,whence);
-#else
-  return fseeko(f,offset,whence);
-#endif
-}
-
-portable_off_t Portable::ftell(FILE *f)
-{
-#if defined(__MINGW32__)
-  return ftello64(f);
-#elif defined(_WIN32) && !defined(__CYGWIN__)
-  return _ftelli64(f);
-#else
-  return ftello(f);
-#endif
-}
-
 FILE *Portable::fopen(const QCString &fileName,const QCString &mode)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)

--- a/src/portable.h
+++ b/src/portable.h
@@ -9,12 +9,6 @@
 
 class Buf;
 
-#if defined(_WIN32)
-typedef __int64 portable_off_t;
-#else
-typedef off_t portable_off_t;
-#endif
-
 /** @file
  *  @brief Portable versions of functions that are platform dependent.
  */
@@ -26,8 +20,6 @@ namespace Portable
   QCString       getenv(const QCString &variable);
   void           setenv(const QCString &variable,const QCString &value);
   void           unsetenv(const QCString &variable);
-  portable_off_t fseek(FILE *f,portable_off_t offset, int whence);
-  portable_off_t ftell(FILE *f);
   FILE *         fopen(const QCString &fileName,const QCString &mode);
   int            fclose(FILE *f);
   void           unlink(const QCString &fileName);


### PR DESCRIPTION
During a windows build the following warning appeared:
```
definition.cpp(626): warning C4244: 'argument': conversion from 'portable_off_t' to 'size_t', possible loss of data
```
investigations lead to:
- fseek and ftell  are not used,
- portable_off_t is misused

removed the mentioned functions and typedefs.

- corrected the possible loss of data for shrinkBuffer