### PR TITLE
Better representation of brief (union / struct) descriptions in HTML

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2411,7 +2411,7 @@ void ClassDefImpl::writeDeclarationLink(OutputList &ol,bool &found,const QCStrin
       found=TRUE;
     }
     ol.startMemberDeclaration();
-    ol.startMemberItem(anchor(),FALSE);
+    ol.startMemberItem(anchor(),0);
     QCString ctype = compoundTypeString();
     QCString cname = displayName(!localNames);
 
@@ -2445,7 +2445,7 @@ void ClassDefImpl::writeDeclarationLink(OutputList &ol,bool &found,const QCStrin
       ol.insertMemberAlign();
       ol.writeString(VhdlDocGen::getProtectionName(VhdlDocGen::convert(protection())));
     }
-    ol.endMemberItem();
+    ol.endMemberItem(0);
 
     // add the brief description if available
     if (!briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
@@ -3280,7 +3280,7 @@ void ClassDefImpl::writeDeclaration(OutputList &ol,const MemberDef *md,bool inGr
     }
   }
   ol.docify(" {");
-  ol.endMemberItem();
+  ol.endMemberItem(1);
 
   // write user defined member groups
   for (const auto &mg : m_impl->memberGroups)

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -613,7 +613,7 @@ void ConceptDefImpl::writeDeclarationLink(OutputList &ol,bool &found,const QCStr
       found=TRUE;
     }
     ol.startMemberDeclaration();
-    ol.startMemberItem(anchor(),FALSE);
+    ol.startMemberItem(anchor(),0);
     ol.writeString("concept ");
     QCString cname = displayName(!localNames);
     ol.insertMemberAlign();
@@ -631,7 +631,7 @@ void ConceptDefImpl::writeDeclarationLink(OutputList &ol,bool &found,const QCStr
       ol.docify(cname);
       ol.endBold();
     }
-    ol.endMemberItem();
+    ol.endMemberItem(0);
     // add the brief description if available
     if (!briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
     {

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -349,7 +349,7 @@ void DirDefImpl::writeSubDirList(OutputList &ol)
         ol.parseText(theTranslator->trDir(FALSE,TRUE)+" ");
         ol.insertMemberAlign();
         ol.writeObjectLink(dd->getReference(),dd->getOutputFileBase(),QCString(),dd->shortName());
-        ol.endMemberItem();
+        ol.endMemberItem(0);
         if (!dd->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
         {
           ol.startMemberDescription(dd->getOutputFileBase());
@@ -426,7 +426,7 @@ void DirDefImpl::writeFileList(OutputList &ol)
           ol.endTextLink();
           ol.popGeneratorState();
         }
-        ol.endMemberItem();
+        ol.endMemberItem(0);
         if (!fd->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
         {
           ol.startMemberDescription(fd->getOutputFileBase());

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -719,7 +719,7 @@ DB_GEN_C
   m_t << "            <listitem><para>";
   m_inListItem[m_levelListItem] = TRUE;
 }
-void DocbookGenerator::endMemberItem()
+void DocbookGenerator::endMemberItem(int)
 {
 DB_GEN_C
   m_t << "</para>\n";

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -208,7 +208,7 @@ class DocbookGenerator : public OutputGenerator //: public CodeOutputForwarder<O
     void startAnonTypeScope(int){DB_GEN_EMPTY};
     void endAnonTypeScope(int){DB_GEN_EMPTY};
     void startMemberItem(const QCString &,int,const QCString &);
-    void endMemberItem();
+    void endMemberItem(int annoType = -1);
     void startMemberTemplateParams();
     void endMemberTemplateParams(const QCString &,const QCString &);
     void startCompoundTemplateParams() { startSubsubsection(); }

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -865,7 +865,7 @@ void GroupDefImpl::writeFiles(OutputList &ol,const QCString &title)
       ol.docify(theTranslator->trFile(FALSE,TRUE)+" ");
       ol.insertMemberAlign();
       ol.writeObjectLink(fd->getReference(),fd->getOutputFileBase(),QCString(),fd->name());
-      ol.endMemberItem();
+      ol.endMemberItem(0);
       if (!fd->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
       {
         ol.startMemberDescription(fd->getOutputFileBase());
@@ -910,7 +910,7 @@ void GroupDefImpl::writeNestedGroups(OutputList &ol,const QCString &title)
         //ol.docify(" ");
         ol.insertMemberAlign();
         ol.writeObjectLink(gd->getReference(),gd->getOutputFileBase(),QCString(),gd->groupTitle());
-        ol.endMemberItem();
+        ol.endMemberItem(0);
         if (!gd->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
         {
           ol.startMemberDescription(gd->getOutputFileBase());
@@ -942,7 +942,7 @@ void GroupDefImpl::writeDirs(OutputList &ol,const QCString &title)
       ol.parseText(theTranslator->trDir(FALSE,TRUE));
       ol.insertMemberAlign();
       ol.writeObjectLink(dd->getReference(),dd->getOutputFileBase(),QCString(),dd->shortName());
-      ol.endMemberItem();
+      ol.endMemberItem(0);
       if (!dd->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
       {
         ol.startMemberDescription(dd->getOutputFileBase());

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1916,8 +1916,12 @@ void HtmlGenerator::startMemberItem(const QCString &anchor,int annoType,const QC
   insertMemberAlignLeft(annoType, true);
 }
 
-void HtmlGenerator::endMemberItem()
+void HtmlGenerator::endMemberItem(int annoType)
 {
+  if (annoType == 1)
+  { 
+    insertMemberAlign(false);
+  }
   m_t << "</td></tr>\n";
 }
 

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -154,7 +154,7 @@ class HtmlGenerator : public OutputGenerator //public CodeOutputForwarder<Output
     void startAnonTypeScope(int) {}
     void endAnonTypeScope(int) {}
     void startMemberItem(const QCString &anchor,int,const QCString &inheritId);
-    void endMemberItem();
+    void endMemberItem(int annoType = -1);
     void startMemberTemplateParams();
     void endMemberTemplateParams(const QCString &anchor,const QCString &inheritId);
     void startCompoundTemplateParams();

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1671,7 +1671,7 @@ void LatexGenerator::startMemberItem(const QCString &,int annoType,const QCStrin
   }
 }
 
-void LatexGenerator::endMemberItem()
+void LatexGenerator::endMemberItem(int)
 {
   if (m_insideTabbing)
   {

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -163,7 +163,7 @@ class LatexGenerator : public OutputGenerator //: public CodeOutputForwarder<Out
     void startAnonTypeScope(int);
     void endAnonTypeScope(int);
     void startMemberItem(const QCString &,int,const QCString &);
-    void endMemberItem();
+    void endMemberItem(int annoType = -1);
     void startMemberTemplateParams();
     void endMemberTemplateParams(const QCString &,const QCString &);
     void startCompoundTemplateParams() { startSubsubsection(); }

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -596,7 +596,7 @@ void ManGenerator::startMemberItem(const QCString &,int,const QCString &)
   m_firstCol=FALSE;
 }
 
-void ManGenerator::endMemberItem()
+void ManGenerator::endMemberItem(int)
 {
   m_t << "\"\n.br";
 }

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -136,7 +136,7 @@ class ManGenerator : public OutputGenerator //public CodeOutputForwarder<OutputG
     void startAnonTypeScope(int);
     void endAnonTypeScope(int);
     void startMemberItem(const QCString &,int,const QCString &);
-    void endMemberItem();
+    void endMemberItem(int annoType = -1);
     void startMemberTemplateParams() {}
     void endMemberTemplateParams(const QCString &,const QCString &) {}
     void startCompoundTemplateParams() { startSubsubsection(); }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2090,10 +2090,8 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
 
   // start a new member declaration
   bool isAnonType = annoClassDef || m_impl->annMemb || m_impl->annEnumType;
-  ol.startMemberItem(anchor(),
-                     isAnonType ? 1 : !m_impl->tArgList.empty() ? 3 : 0,
-                     inheritId
-                    );
+  int anonType = isAnonType ? 1 : !m_impl->tArgList.empty() ? 3 : 0;
+  ol.startMemberItem(anchor(), anonType, inheritId);
 
   // If there is no detailed description we need to write the anchor here.
   bool detailsVisible = hasDetailedDescription();
@@ -2168,7 +2166,8 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
       ol.startAnonTypeScope(indentLevel);
       annoClassDef->writeDeclaration(ol,m_impl->annMemb,inGroup,indentLevel+1,inheritedFrom,inheritId);
       //printf(">>>>>>>>>>>>>> startMemberItem(2)\n");
-      ol.startMemberItem(anchor(),2,inheritId);
+      anonType = 2;
+      ol.startMemberItem(anchor(),anonType,inheritId);
       int j;
       for (j=0;j< indentLevel;j++)
       {
@@ -2443,7 +2442,7 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
 
   //printf("endMember %s annoClassDef=%p annEnumType=%p\n",
   //    qPrint(name()),annoClassDef,annEnumType);
-  ol.endMemberItem();
+  ol.endMemberItem(anonType);
   if (endAnonScopeNeeded)
   {
     ol.endAnonTypeScope(indentLevel);

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -416,7 +416,7 @@ void MemberList::writePlainDeclarations(OutputList &ol, bool inGroup,
               {
                 ol.endDoxyAnchor(md->getOutputFileBase(),md->anchor());
               }
-              ol.endMemberItem();
+              ol.endMemberItem(0);
               if (!md->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
               {
                 auto parser { createDocParser() };

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -1377,7 +1377,7 @@ void NamespaceLinkedRefMap::writeDeclaration(OutputList &ol,const QCString &titl
         name = nd->displayName();
       }
       ol.writeObjectLink(nd->getReference(),nd->getOutputFileBase(),QCString(),name);
-      ol.endMemberItem();
+      ol.endMemberItem(0);
       if (!nd->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
       {
         ol.startMemberDescription(nd->getOutputFileBase());

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -414,7 +414,7 @@ class OutputGenerator : public BaseOutputDocInterface
     virtual void startAnonTypeScope(int) = 0;
     virtual void endAnonTypeScope(int) = 0;
     virtual void startMemberItem(const QCString &,int,const QCString &) = 0;
-    virtual void endMemberItem() = 0;
+    virtual void endMemberItem(int annoType = -1) = 0;
     virtual void startMemberTemplateParams() = 0;
     virtual void endMemberTemplateParams(const QCString &,const QCString &) = 0;
     virtual void startCompoundTemplateParams() = 0;

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -266,8 +266,8 @@ class OutputList : public BaseOutputDocInterface
     { forall(&OutputGenerator::endAnonTypeScope,i1); }
     void startMemberItem(const QCString &anchor,int i1,const QCString &id=QCString())
     { forall(&OutputGenerator::startMemberItem,anchor,i1,id); }
-    void endMemberItem()
-    { forall(&OutputGenerator::endMemberItem); }
+    void endMemberItem(int annoType = -1)
+    { forall(&OutputGenerator::endMemberItem,annoType); }
     void startMemberTemplateParams()
     { forall(&OutputGenerator::startMemberTemplateParams); }
     void endMemberTemplateParams(const QCString &anchor,const QCString &inheritId)

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1807,7 +1807,7 @@ void RTFGenerator::startMemberItem(const QCString &,int,const QCString &)
   m_t << rtf_Style_Reset << rtf_BList_DepthStyle() << "\n"; // set style to appropriate depth
 }
 
-void RTFGenerator::endMemberItem()
+void RTFGenerator::endMemberItem(int)
 {
   DBG_RTF(m_t << "{\\comment endMemberItem }\n")
   newParagraph();

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -146,7 +146,7 @@ class RTFGenerator : public OutputGenerator
     void startAnonTypeScope(int) {}
     void endAnonTypeScope(int) {}
     void startMemberItem(const QCString &,int,const QCString &);
-    void endMemberItem();
+    void endMemberItem(int annoType = -1);
     void startMemberTemplateParams() {}
     void endMemberTemplateParams(const QCString &,const QCString &) {}
     void startCompoundTemplateParams() { startSubsubsection(); }

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2007,7 +2007,7 @@ void VhdlDocGen::writeVHDLDeclaration(const MemberDefMutable* mdef,OutputList &o
     ol.endDoxyAnchor(cfname,mdef->anchor());
   }
 
-  ol.endMemberItem();
+  ol.endMemberItem(isAnonymous);
   if (!mdef->briefDescription().isEmpty() &&   Config_getBool(BRIEF_MEMBER_DESC) /* && !annMemb */)
   {
     QCString s=mdef->briefDescription();


### PR DESCRIPTION
Looking at the brief description of (non documented) elements of structs and unions we see that the "shading" is a bit ragged. The "shading" should be identical for all fields.

(this was seen / a remark with issue #9603).

Example is based on the page doxygen_docs/html/d2/d75/class_c_p_p_value.html of the doxygen internal documentaion (see the union). Colors have been enhanced for better showing the problem.
Old result:

![image](https://user-images.githubusercontent.com/5223533/209470575-b16b4a2f-1297-40d4-9aac-6c34593ec0bf.png)

New result:

![image](https://user-images.githubusercontent.com/5223533/209470563-b1351075-bcbd-476a-8927-19856e4308ff.png)
