### PR TITLE
bug_621171 \relates does not find class if it is in an anonymous namespace

### DIFF
--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -148,7 +148,7 @@ ID	([$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*)|(@[0-9]+)
 <Start>{B}*"::"{B}*		{ // found a yyextra->scope specifier
  				  if (!yyextra->scope.isEmpty() && !yyextra->scope.endsWith("::"))
 				  {
-				    yyextra->scope+="::"+yyextra->name; // add yyextra->name to yyextra->scope
+                                    if (!yyextra->name.isEmpty()) yyextra->scope+="::"+yyextra->name; // add yyextra->name to yyextra->scope
 				  }
 				  else
 				  {


### PR DESCRIPTION
When the name has no value no attempt should be made to add something to the scopename.

(of course `EXTRACT_ANON_NSPACES` should be set).