### PR TITLE
issue #9726 \ref command doesn't perform in LaTeX as described in the documentation

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2257,9 +2257,10 @@ Commands to create links
   the section. For a section or subsection the title of the section will be
   used as the text of the link. For an anchor the optional text between quotes
   will be used or \<name\> if no text is specified.
-  For \LaTeX documentation the reference command will
-  generate a section number for sections or the text followed by a
-  page number if \<name\> refers to an anchor.
+  For \LaTeX documentation the reference command will be the same unless the
+  \ref cfg_pdf_hyperlinks "PDF_HYPERLINKS" option has been set to `NO`, in this case
+  it generates the section title for sections or the text if \<name\> refers to an anchor
+  followed by a page number.
 
   \sa
     Section \ref cmdpage "\\page" for an example of the \c \\ref command.

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -732,6 +732,7 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
     }
     m_isSubPage    = pd && pd->hasParentPage();
     if (sec->type()!=SectionType::Page || m_isSubPage) m_anchor = sec->label();
+    m_sectionType = sec->type();
     //printf("m_text=%s,m_ref=%s,m_file=%s,type=%d\n",
     //    qPrint(m_text),qPrint(m_ref),qPrint(m_file),m_refType);
     return;

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -27,6 +27,7 @@
 #include "htmlattrib.h"
 #include "htmlentity.h"
 #include "growvector.h"
+#include "section.h"
 
 class MemberDef;
 class Definition;
@@ -739,6 +740,7 @@ class DocRef : public DocCompoundNode
     QCString ref() const          { return m_ref; }
     QCString anchor() const       { return m_anchor; }
     QCString targetTitle() const  { return m_text; }
+    SectionType sectionType() const { return m_sectionType; }
     bool hasLinkText() const      { return !children().empty(); }
     bool refToAnchor() const      { return m_refType==Anchor; }
     bool refToSection() const     { return m_refType==Section; }
@@ -747,6 +749,7 @@ class DocRef : public DocCompoundNode
 
   private:
     RefType    m_refType = Unknown;
+    SectionType m_sectionType = SectionType::Anchor;
     bool       m_isSubPage = false;
     QCString   m_file;
     QCString   m_relPath;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1507,7 +1507,7 @@ void LatexDocVisitor::operator()(const DocRef &ref)
   }
   else
   {
-    if (!ref.file().isEmpty()) startLink(ref.ref(),ref.file(),ref.anchor(),ref.refToTable());
+    if (!ref.file().isEmpty()) startLink(ref.ref(),ref.file(),ref.anchor(),ref.refToTable(),ref.refToSection());
   }
   if (!ref.hasLinkText())
   {
@@ -1520,7 +1520,7 @@ void LatexDocVisitor::operator()(const DocRef &ref)
   }
   else
   {
-    if (!ref.file().isEmpty()) endLink(ref.ref(),ref.file(),ref.anchor(),ref.refToTable());
+    if (!ref.file().isEmpty()) endLink(ref.ref(),ref.file(),ref.anchor(),ref.refToTable(),ref.refToSection(),ref.sectionType());
   }
 }
 
@@ -1782,7 +1782,7 @@ void LatexDocVisitor::filter(const QCString &str, const bool retainNewLine)
                    );
 }
 
-void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable)
+void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable,bool refToSection)
 {
   bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
   if (ref.isEmpty() && pdfHyperLinks) // internal PDF link
@@ -1791,14 +1791,22 @@ void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const Q
     {
       m_t << "\\doxytablelink{";
     }
+    else if (refToSection)
+    {
+      m_t << "\\doxysectlink{";
+    }
     else
     {
-      m_t << "\\mbox{\\hyperlink{";
+      m_t << "\\doxylink{";
     }
     if (!file.isEmpty()) m_t << stripPath(file);
     if (!file.isEmpty() && !anchor.isEmpty()) m_t << "_";
     if (!anchor.isEmpty()) m_t << anchor;
     m_t << "}{";
+  }
+  else if (ref.isEmpty() && refToSection)
+  {
+    m_t << "\\doxysectref{";
   }
   else if (ref.isEmpty() && refToTable)
   {
@@ -1814,7 +1822,7 @@ void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const Q
   }
 }
 
-void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable)
+void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable,bool refToSection, SectionType sectionType)
 {
   m_t << "}";
   bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);
@@ -1825,12 +1833,16 @@ void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCS
     m_t << "}{" << file;
     if (!file.isEmpty() && !anchor.isEmpty()) m_t << "_";
     m_t << anchor << "}";
+    if (refToSection)
+    {
+      m_t << "{" << static_cast<int>(sectionType) << "}";
+    }
   }
   if (ref.isEmpty() && pdfHyperLinks) // internal PDF link
   {
-    if (!refToTable)
+    if (refToSection)
     {
-      m_t << "}";
+      m_t << "{" << static_cast<int>(sectionType) << "}";
     }
   }
 }

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -128,9 +128,9 @@ class LatexDocVisitor : public DocVisitor
 
     void filter(const QCString &str, const bool retainNewLine = false);
     void startLink(const QCString &ref,const QCString &file,
-                   const QCString &anchor,bool refToTable=FALSE);
+                   const QCString &anchor,bool refToTable=false,bool refToSection=false);
     void endLink(const QCString &ref,const QCString &file,
-                 const QCString &anchor,bool refToTable=FALSE);
+                 const QCString &anchor,bool refToTable=false,bool refToSection=false, SectionType sectionType = SectionType::Anchor);
     QCString escapeMakeIndexChars(const char *s);
     void startDotFile(const QCString &fileName,const QCString &width,
                       const QCString &height, bool hasCaption,

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -523,8 +523,26 @@
   \end{list}%
 }
 
+% Used when hyperlinks are turned on
+\newcommand{\doxylink}[2]{%
+  \mbox{\hyperlink{#1}{#2}}%
+}
+
+% Used when hyperlinks are turned on
+% Third argument is the SectionType, see the doxygen internal
+% documentation for the values (relevant: Page ... Subsubsection).
+\newcommand{\doxysectlink}[3]{%
+  \mbox{\hyperlink{#1}{#2}}%
+}
 % Used when hyperlinks are turned off
 \newcommand{\doxyref}[3]{%
+  \textbf{#1} (\textnormal{#2}\,\pageref{#3})%
+}
+
+% Used when hyperlinks are turned off
+% Fourth argument is the SectionType, see the doxygen internal
+% documentation for the values (relevant: Page ... Subsubsection).
+\newcommand{\doxysectref}[4]{%
   \textbf{#1} (\textnormal{#2}\,\pageref{#3})%
 }
 


### PR DESCRIPTION
- corrected the documentation to reflect the implementation
- made the LaTeX output more flexible so the user can decide how the references look like (default implementation is so it doesn't change the appearance)