### PR TITLE
Get full history of doxygen

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
     - name: Checkout doxygen
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
       
 #    - name: Download MikTex (Windows)
 #      run: |


### PR DESCRIPTION
Automatic generation of some pats of the internal documentation (cmds_tags.py) requires full history