### PR TITLE
Removed extra space in `UML_LOOK` diagrams for constructor

### DIFF
--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -276,6 +276,10 @@ QCString DotNode::convertLabel(const QCString &l, bool htmlLike)
     charsLeft--;
     pc=c;
   }
+  if (htmlLike)
+  {
+     result = result.stripWhiteSpace();
+  }
   return result;
 }
 


### PR DESCRIPTION
In the issue #9718 and subsequent pull request #9758 the layout of the `UML_LOOK` diagrams was improved, though in case of a constructor an extra space appears  in front (due to the fact that a constructor doesn't have a type. This has been corrected.

This can easily be demonstrated with the following example:
```
/// \file

class Fluid3{
  public:
    Fluid3(double etc, double rho);
    Fluid3(double etc,   double rho);
    Fluid3(double etc,double rho);
    Fluid3(double etc, double etcWithAVeryLongNameVeryGettingOutOfProportions,double rho);
    Fluid3(double etcWithAVeryLongNameVeryGettingOutOfProportions,double rho);
    double get_nue();
};
```

In the **1.9.6** version this gave:

![image](https://user-images.githubusercontent.com/5223533/210529567-b4e84601-1c7a-4ac8-a0a8-5c216ad2ecd1.png)

and in the initially adjusted version:

![image](https://user-images.githubusercontent.com/5223533/210529671-a587a31e-b2d9-419e-991a-f60fe742e39d.png)


note here the staring space in front of `Fluid3` in the last part of the image.

With the current correction we get:

![image](https://user-images.githubusercontent.com/5223533/210529837-fa1a9d45-b4b8-4e3f-95d3-6a7a58859d81.png)

We see now:
- the word `Fluid3` starts at the beginning of the line
- new "words" / arguments start with a space 
- split "words" start again at the beginning of the line to signal the split.


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10343057/example.tar.gz)


