### PR TITLE
Escape `-` sign in fontname settings substring as well

### DIFF
--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -268,7 +268,8 @@ class QCString
       {
         while (i<end && !needsQuotes) // check if the to be quoted part has at least one whitespace character
         {
-          needsQuotes = qisspace(m_rep[i++]);
+          needsQuotes = m_rep[i] =='-';
+          needsQuotes |= qisspace(m_rep[i++]);
         }
       }
       QCString result(m_rep.substr(start,1+end-start));


### PR DESCRIPTION
Not only substrings with white space have to be quoted but also when containing `-`

(Based on the comments https://github.com/doxygen/doxygen/issues/9319#issuecomment-1371783416 and https://github.com/doxygen/doxygen/issues/9319#issuecomment-1372056305)