### PR TITLE
issue #9771 Escaped double-quote in Objective-C string confuses parser

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3046,7 +3046,13 @@ NONLopt [^\n]*
                                             BEGIN(SkipVerbString);
                                           }
                                         }
-<SkipVerbString>[^\n"]+                 {
+<SkipVerbString>[^\n"\\]+               {
+                                          *yyextra->pSkipVerbString << yytext;
+                                        }
+<SkipVerbString>"\\\\"                  { // escaped backslash
+                                          *yyextra->pSkipVerbString << yytext;
+                                        }
+<SkipVerbString>"\\\""                  { // backslash escaped quote
                                           *yyextra->pSkipVerbString << yytext;
                                         }
 <SkipVerbString>"\"\""                  { // quote escape


### PR DESCRIPTION
Also backslash escapes taken into consideration