### PR TITLE
Escape `-` sign in fontname settings substring as well

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2170,7 +2170,6 @@ void Config::checkAndCorrect(bool quiet, const bool check)
 
 static void updateAttribute(DotAttributes& attr, QCString name, ConfigObsolete* value)
 {
-  if (value==0 || value->valueStringRef()->isEmpty()) return;
   attr.updateValue(name,*value->valueStringRef());
 }
 

--- a/src/dotattributes.h
+++ b/src/dotattributes.h
@@ -34,7 +34,7 @@ class DotAttributes
 
     //! update a given attribute with a new value.
     //! If the attribute is not found a new attribute will be appended.
-    void updateValue(const QCString &key,const QCString &value)
+    void updateValue(const QCString &key,const QCString &inpValue)
     {
       // look for key\s*=
       const reg::Ex re = key.str()+R"(\s*=)";
@@ -57,13 +57,25 @@ class DotAttributes
         {
           while (pos<len && s[pos]!=',' && s[pos]!=';' && !qisspace(s[pos])) pos++;
         }
+        QCString value;
+        if (inpValue.isEmpty())
+        {
+          value = m_input.mid(startPos,pos-startPos);
+        }
+        else
+        {
+          value = inpValue;
+        }
         // pos is now the position after the value, so replace the part between [start..pos) with the new value
         m_input=m_input.left(startPos)+value.quoted()+m_input.mid(pos);
       }
       else // append new attribute
       {
-        if (!m_input.isEmpty()) m_input+=",";
-        m_input+=key+"="+value.quoted();
+        if (!inpValue.isEmpty())
+        {
+          if (!m_input.isEmpty()) m_input+=",";
+          m_input+=key+"="+inpValue.quoted();
+        }
       }
     }
 


### PR DESCRIPTION
We also have to correct the string in case it is an user input like in:
```
DOT_COMMON_ATTR        = "fontname=Times-Roman,fontsize=10"
DOT_EDGE_ATTR          = "labelfontname=Times-Roman,labelfontsize=10"
```

See extended discussion at https://github.com/doxygen/doxygen/issues/9319#issuecomment-1372175922

Example test Doxyfiles: [example.tar.gz](https://github.com/doxygen/doxygen/files/10352724/example.tar.gz)
