### PR TITLE
Incorrect line counting for inbody docs

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3741,7 +3741,9 @@ bool CommentScanner::parseCommentBlock(/* in */     OutlineParserInterface *pars
   printlex(yy_flex_debug, TRUE, __FILE__, !fileName.isEmpty() ? qPrint(fileName): NULL);
   if (!yyextra->current->inbodyDocs.isEmpty() && isInbody) // separate in body fragments
   {
-    yyextra->current->inbodyDocs+="\n\n";
+    char cmd[30];
+    sprintf(cmd,"\n\n\\iline %d \\ilinebr ",lineNr);
+    yyextra->current->inbodyDocs+=cmd;
   }
 
   Debug::print(Debug::CommentScan,0,"-----------\nCommentScanner: %s:%d\n"


### PR DESCRIPTION
In case of multiple inbody blocks they are put together, though in case of a warning the line number given is not according to the original file but was calculated from the initial inbody block and the add3ed documentation blocks.

This problem was found through Fossies for the siege project, orignally we got the warning:
```
browser.c:496: warning: Unsupported xml/html tag <meta> found
```
though the offending line is at line 592. This has been corrected, see example.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10359366/example.tar.gz)
