### PR TITLE
Warning to incomplete switch statement

### DIFF
--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -2434,6 +2434,9 @@ class TranslatorEnglish : public Translator
         case FileMemberHighlight::Defines:
           result+="macros";
           break;
+        case FileMemberHighlight::Total:
+          ASSERT(0); // cannot happen, element is just the counter
+          break;
       }
       result+=" with links to ";
       if (extractAll)
@@ -2486,6 +2489,9 @@ class TranslatorEnglish : public Translator
           break;
         case ClassMemberHighlight::Related:
           result+="related symbols";
+          break;
+        case ClassMemberHighlight::Total:
+          ASSERT(0); // cannot happen, element is just the counter
           break;
       }
       result+=" with links to ";
@@ -2547,6 +2553,9 @@ class TranslatorEnglish : public Translator
           break;
         case NamespaceMemberHighlight::EnumValues:
           singularResult="enum value";
+          break;
+        case NamespaceMemberHighlight::Total:
+          ASSERT(0); // cannot happen, element is just the counter
           break;
       }
       result+=(pluralResult.isEmpty() ? singularResult+"s" : pluralResult);

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -2093,6 +2093,9 @@ class TranslatorDutch : public Translator
         case FileMemberHighlight::Defines:
           result+="macros";
           break;
+        case FileMemberHighlight::Total:
+          ASSERT(0); // cannot happen, element is just the counter
+          break;
       }
       result+=" met links naar ";
       if (extractAll) result+="de bestand's documentatie voor elke member:";
@@ -2151,6 +2154,9 @@ class TranslatorDutch : public Translator
           break;
         case ClassMemberHighlight::Related:
           result+="gerelateerde symbolen";
+          break;
+        case ClassMemberHighlight::Total:
+          ASSERT(0); // cannot happen, element is just the counter
           break;
       }
       result+=" met links naar ";
@@ -2220,6 +2226,9 @@ class TranslatorDutch : public Translator
         case NamespaceMemberHighlight::EnumValues:
           singularResult="e enumeratie waarde";
           pluralResult="enumeratie waarden";
+          break;
+        case NamespaceMemberHighlight::Total:
+          ASSERT(0); // cannot happen, element is just the counter
           break;
       }
       result+=pluralResult;


### PR DESCRIPTION
In GitHub Actions (and reported by CGAL) we get warnings like:
```
/home/runner/work/doxygen/doxygen/src/translator_en.h: In member function ‘virtual QCString TranslatorEnglish::trFileMembersDescriptionTotal(FileMemberHighlight::Enum)’:
/home/runner/work/doxygen/doxygen/src/translator_en.h:2401:14: warning: enumeration value ‘Total’ not handled in switch [-Wswitch]
 2401 |       switch (hl)
      |              ^
```

due to the fact that the `Total` i.e. the counter for the number of elements isn't handled here (and should not do anything / cannot be used anyway)