### PR TITLE
Consistency  in HTML output with multiple runs

### DIFF
--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -410,7 +410,7 @@ bool DotFilePatcher::run() const
         {
           err("Problem extracting size from SVG file %s\n",qPrint(map.mapFile));
         }
-        if (e!=-1) t << line.mid(e+3);
+        if (e!=-1 && line.mid(e+3) != "\n") t << line.mid(e+3);
       }
       else // error invalid map id!
       {


### PR DESCRIPTION
When running a project twice on the same source (leaving the HTML output in place) still the resulting HTML output differs slightly between both run. (Necessary is that interactive SVG is enabled)

It is just a cosmetic change in the output files, but helps when looking for differences between the 2 runs (with e.g. diff).
(The problem was found by Fossies)