### PR TITLE
Document missing parameters (for internal documentation)

### DIFF
--- a/libxml/xml.h
+++ b/libxml/xml.h
@@ -77,6 +77,8 @@ class XMLParser : public XMLLocator
      *  @param fileName the name of the file, used for error reporting.
      *  @param inputString the contents of the file as a zero terminated UTF-8 string.
      *  @param debugEnabled indicates if debugging via -d lex is enabled or not.
+     *  @param debugStart handler to print start debug information
+     *  @param debugEnd handler to end print debug information
      */
     void parse(const char *fileName,const char *inputString,bool debugEnabled,
         std::function<void()> debugStart,std::function<void()> debugEnd);


### PR DESCRIPTION
Document missing parameters (for internal documentation)