### PR TITLE
Lexical analyzer extra `(for: )` for some lexers

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -144,7 +144,7 @@ DebugLex::~DebugLex()
 
 void DebugLex::print(Debug::DebugMask mask,const char *state,const char *lexName,const char *fileName)
 {
-  if (fileName)
+  if (fileName && *fileName)
   {
     if (Debug::isFlagSet(mask))
     {


### PR DESCRIPTION
We get with `-d lex:defargs` the messages like:
```
Entering lexical analyzer: .../src/defargs.l (for: )
```
due to the conversion from character to QCString and back an empty string is returned