### PR TITLE
issue #8790 doxyrest command returns "duplicate member id group..."

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -3393,7 +3393,7 @@ class sectiondefType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, kind=None, header=None, description=None, memberdef=None, gds_collector_=None, **kwargs_):
+    def __init__(self, kind=None, header=None, description=None, memberdef=None, member=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -3410,6 +3410,11 @@ class sectiondefType(GeneratedsSuper):
         else:
             self.memberdef = memberdef
         self.memberdef_nsprefix_ = None
+        if member is None:
+            self.member = []
+        else:
+            self.member = member
+        self.member_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -3443,6 +3448,16 @@ class sectiondefType(GeneratedsSuper):
         self.memberdef.insert(index, value)
     def replace_memberdef_at(self, index, value):
         self.memberdef[index] = value
+    def get_member(self):
+        return self.member
+    def set_member(self, member):
+        self.member = member
+    def add_member(self, value):
+        self.member.append(value)
+    def insert_member_at(self, index, value):
+        self.member.insert(index, value)
+    def replace_member_at(self, index, value):
+        self.member[index] = value
     def get_kind(self):
         return self.kind
     def set_kind(self, kind):
@@ -3464,7 +3479,8 @@ class sectiondefType(GeneratedsSuper):
         if (
             self.header is not None or
             self.description is not None or
-            self.memberdef
+            self.memberdef or
+            self.member
         ):
             return True
         else:
@@ -3511,6 +3527,9 @@ class sectiondefType(GeneratedsSuper):
         for memberdef_ in self.memberdef:
             namespaceprefix_ = self.memberdef_nsprefix_ + ':' if (UseCapturedNS_ and self.memberdef_nsprefix_) else ''
             memberdef_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='memberdef', pretty_print=pretty_print)
+        for member_ in self.member:
+            namespaceprefix_ = self.member_nsprefix_ + ':' if (UseCapturedNS_ and self.member_nsprefix_) else ''
+            member_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='member', pretty_print=pretty_print)
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -3545,6 +3564,11 @@ class sectiondefType(GeneratedsSuper):
             obj_.build(child_, gds_collector_=gds_collector_)
             self.memberdef.append(obj_)
             obj_.original_tagname_ = 'memberdef'
+        elif nodeName_ == 'member':
+            obj_ = memberRefType.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.member.append(obj_)
+            obj_.original_tagname_ = 'member'
 # end class sectiondefType
 
 

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -545,7 +545,7 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
   if (md->isHidden()) return;
 
   // group members are only visible in their group
-  //if (def->definitionType()!=Definition::TypeGroup && md->getGroupDef()) return;
+  bool groupMember = md->getGroupDef() && def->definitionType()!=Definition::TypeGroup;
 
   QCString memType;
   bool isFunc=FALSE;
@@ -573,19 +573,24 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
      << "_1" << md->anchor() << "\" kind=\"" << memType << "\"><name>"
      << convertToXML(md->name()) << "</name></member>\n";
 
-  t << "      <memberdef kind=\"";
-  //enum { define_t,variable_t,typedef_t,enum_t,function_t } xmlType = function_t;
-  t << memType << "\" id=\"";
-  if (md->getGroupDef() && def->definitionType()==Definition::TypeGroup)
+  if (groupMember)
   {
-    t << md->getGroupDef()->getOutputFileBase();
+    t << "      <member refid=\""
+      << md->getGroupDef()->getOutputFileBase()
+      << "_1" << md->anchor() << "\" kind=\"" << memType << "\"><name>"
+      << convertToXML(md->name()) << "</name></member>\n";
+    return;
   }
   else
   {
+    t << "      <memberdef kind=\"";
+    t << memType << "\" id=\"";
     t << memberOutputFileBase(md);
+    t << "_1"      // encoded ':' character (see util.cpp:convertNameToFile)
+      << md->anchor();
   }
-  t << "_1"      // encoded ':' character (see util.cpp:convertNameToFile)
-    << md->anchor();
+  //enum { define_t,variable_t,typedef_t,enum_t,function_t } xmlType = function_t;
+
   t << "\" prot=\"";
   switch (md->protection())
   {

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -128,11 +128,38 @@
     </xsd:simpleContent>
   </xsd:complexType>
 
+  <xsd:simpleType name="MemberKind">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="define"/>
+      <xsd:enumeration value="property"/>
+      <xsd:enumeration value="event"/>
+      <xsd:enumeration value="variable"/>
+      <xsd:enumeration value="typedef"/>
+      <xsd:enumeration value="enum"/>
+      <xsd:enumeration value="enumvalue"/>
+      <xsd:enumeration value="function"/>
+      <xsd:enumeration value="signal"/>
+      <xsd:enumeration value="prototype"/>
+      <xsd:enumeration value="friend"/>
+      <xsd:enumeration value="dcop"/>
+      <xsd:enumeration value="slot"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:complexType name="MemberType">
+    <xsd:sequence>
+      <xsd:element name="name" type="xsd:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="refid" type="xsd:string" use="required"/>
+    <xsd:attribute name="kind" type="MemberKind" use="required"/>
+  </xsd:complexType>
+
   <xsd:complexType name="sectiondefType">
     <xsd:sequence>
       <xsd:element name="header" type="xsd:string" minOccurs="0" />
       <xsd:element name="description" type="descriptionType" minOccurs="0" />
-      <xsd:element name="memberdef" type="memberdefType" maxOccurs="unbounded" />
+      <xsd:element name="memberdef" type="memberdefType" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="member" type="MemberType" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="kind" type="DoxSectionKind" />
   </xsd:complexType>


### PR DESCRIPTION
In case a member is a member of a group but we are not in describing a group page we should output only a member reference and not a member definition. (Note there was already a comment indicating that something should be done, though the condition mentioned was not correct and hence probably never implemented)