### PR TITLE
Fix a warning (introduced by 88c1899ae292e)

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -93,7 +93,7 @@ static uint64_t labelToEnumValue(const QCString &l)
   std::string s = l.str();
   std::transform(s.begin(),s.end(),s.begin(),asciiToLower);
   auto it = s_labels.find(s);
-  return (it!=s_labels.end()) ? it->second : 0;
+  return (it!=s_labels.end()) ? it->second : Debug::DebugMask::Quiet;
 }
 
 bool Debug::setFlagStr(const QCString &lab)


### PR DESCRIPTION
Fix the following warning, introduced since 88c1899ae292e:
```
.../Git/doxygen/src/debug.cpp: In function ‘uint64_t labelToEnumValue(const QCString&)’: .../Git/doxygen/src/debug.cpp:96:31: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
   return (it!=s_labels.end()) ? it->second : 0;//Debug::DebugMask::Quiet;
          ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```