### PR TITLE
Option handling in respect to `-t`

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10812,13 +10812,14 @@ void readConfiguration(int argc, char **argv)
       case 't':
         {
 #if ENABLE_TRACING
-          if (optInd+1>=argc)
+          if (optInd+1>=argc || argv[optInd+1][0] == '-')
           {
             traceName="trace.txt";
           }
           else
           {
             traceName=argv[optInd+1];
+            optInd++;
           }
 #else
           err("support for option \"-t\" has not been compiled in (use a debug build or a release build with tracing enabled).\n");


### PR DESCRIPTION
The trace handling (in a debug executable) can be enabled by means of the `-t` option.
- in case no file name is given the filename `trace.txt` is chose, though when having `doxygen -t -d time` a file with the name `-d` was created
- in case e.g. `doxygen -t xx` was given the file `xx` was used as "empty Doxyfile".