### PR TITLE
Prevent list items in section titles

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1599,7 +1599,7 @@ int DocParser::internalValidatingParseDoc(DocNodeVariant *parent,DocNodeList &ch
 
   if (doc.isEmpty()) return retval;
 
-  tokenizer.init(doc.data(),context.fileName,context.markdownSupport);
+  tokenizer.init(doc.data(),context.fileName,context.markdownSupport,context.insideHtmlLink);
 
   // first parse any number of paragraphs
   bool isFirst=TRUE;

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -137,7 +137,7 @@ class DocTokenizer
     // operations on the scanner
     void findSections(const QCString &input,const Definition *d,
         const QCString &fileName);
-    void init(const char *input,const QCString &fileName,bool markdownSupport);
+    void init(const char *input,const QCString &fileName,bool markdownSupport, bool insideHtmlLink = false);
     void cleanup();
     void pushContext();
     bool popContext();

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -80,7 +80,8 @@ struct doctokenizerYY_state
   QCString fileName;
   bool insidePre = false;
   int sharpCount=0;
-  bool markdownSupport=TRUE;
+  bool markdownSupport=true;
+  bool insideHtmlLink=false;
 
   // context for section finding phase
   const Definition  *definition = 0;
@@ -408,6 +409,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 %%
 <St_Para>\r            /* skip carriage return */
 <St_Para>^{LISTITEM}   { /* list item */
+                         if (yyextra->insideHtmlLink) REJECT;
                          lineCount(yytext,yyleng);
                          QCString text(yytext);
                          uint32_t dashPos = static_cast<uint32_t>(text.findRev('-'));
@@ -418,7 +420,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          return TK_LISTITEM;
                        }
 <St_Para>^{MLISTITEM}  { /* list item */
-                         if (!yyextra->markdownSupport || yyextra->insidePre)
+                         if (yyextra->insideHtmlLink || !yyextra->markdownSupport || yyextra->insidePre)
                          {
                            REJECT;
                          }
@@ -438,7 +440,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          }
                        }
 <St_Para>^{OLISTITEM}  { /* numbered list item */
-                         if (!yyextra->markdownSupport || yyextra->insidePre)
+                         if (yyextra->insideHtmlLink || !yyextra->markdownSupport || yyextra->insidePre)
                          {
                            REJECT;
                          }
@@ -463,6 +465,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          }
                        }
 <St_Para>{BLANK}*(\n|"\\ilinebr"){LISTITEM}     { /* list item on next line */
+                         if (yyextra->insideHtmlLink) REJECT;
                          lineCount(yytext,yyleng);
                          QCString text=extractPartAfterNewLine(QCString(yytext));
                          uint32_t dashPos = static_cast<uint32_t>(text.findRev('-'));
@@ -473,7 +476,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          return TK_LISTITEM;
                        }
 <St_Para>{BLANK}*(\n|"\\ilinebr"){MLISTITEM}     { /* list item on next line */
-                         if (!yyextra->markdownSupport || yyextra->insidePre)
+                         if (yyextra->insideHtmlLink || !yyextra->markdownSupport || yyextra->insidePre)
                          {
                            REJECT;
                          }
@@ -493,7 +496,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          }
                        }
 <St_Para>{BLANK}*(\n|"\\ilinebr"){OLISTITEM}     { /* list item on next line */
-                         if (!yyextra->markdownSupport || yyextra->insidePre)
+                         if (yyextra->insideHtmlLink || !yyextra->markdownSupport || yyextra->insidePre)
                          {
                            REJECT;
                          }
@@ -519,12 +522,14 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          }
                        }
 <St_Para>^{ENDLIST}       { /* end list */
+                         if (yyextra->insideHtmlLink) REJECT;
                          lineCount(yytext,yyleng);
                          size_t dotPos = static_cast<size_t>(QCString(yytext).findRev('.'));
                          yyextra->token->indent     = computeIndent(yytext,dotPos);
                          return TK_ENDLIST;
                        }
 <St_Para>{BLANK}*(\n|"\\ilinebr"){ENDLIST}      { /* end list on next line */
+                         if (yyextra->insideHtmlLink) REJECT;
                          lineCount(yytext,yyleng);
                          QCString text=extractPartAfterNewLine(QCString(yytext));
                          size_t dotPos = static_cast<size_t>(text.findRev('.'));
@@ -1758,7 +1763,7 @@ void DocTokenizer::findSections(const QCString &input,const Definition *d,
   doctokenizerYYlex(yyscanner);
 }
 
-void DocTokenizer::init(const char *input,const QCString &fileName,bool markdownSupport)
+void DocTokenizer::init(const char *input,const QCString &fileName,bool markdownSupport, bool insideHtmlLink)
 {
   yyscan_t yyscanner = p->yyscanner;
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
@@ -1768,6 +1773,7 @@ void DocTokenizer::init(const char *input,const QCString &fileName,bool markdown
   yyextra->fileName    = fileName;
   yyextra->insidePre   = FALSE;
   yyextra->markdownSupport = markdownSupport;
+  yyextra->insideHtmlLink = insideHtmlLink;
   BEGIN(St_Para);
 }
 

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1796,6 +1796,7 @@ void DocTokenizer::setStatePara()
 {
   yyscan_t yyscanner = p->yyscanner;
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->insideHtmlLink = false;
   BEGIN(St_Para);
 }
 


### PR DESCRIPTION
When having the, a bit unusual, construct:
```
\section ThePage_subsection 1. The First Sub-Section
```
and we use the reference like:
```
\ref ThePage_subsection
```
we get in the LaTeX generation the error:
```
! LaTeX Error: Something's wrong--perhaps a missing \item.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.4 \end{DoxyEnumerate}}}
```
due to the construct:
```
Check it here \mbox{\hyperlink{_the_page_ThePage_subsection}{
\begin{DoxyEnumerate}
\item The First Sub-\/\+Section
\end{DoxyEnumerate}}}
```

This is all because of the `1.` i.e. a list item in the section title.

(all based on the discussion in:  Doxygen regression when creating PDF output 1.9.6 -> master of 10.01.2023 #9781 )

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10472228/example.tar.gz)
