### PR TITLE
Image appears in the middle of code in the internal documentation

### DIFF
--- a/src/dotgraph.cpp
+++ b/src/dotgraph.cpp
@@ -242,7 +242,7 @@ void DotGraph::generateCode(TextStream &t)
         int mapId = DotManager::instance()->
                createFilePatcher(m_fileName)->
                addSVGObject(m_baseName,absImgName(),m_relPath);
-        t << "<!-- SVG " << mapId << " -->";
+        t << "<!-- " << "SVG " << mapId << " -->";
       }
       if (!m_noDivTag) t << "</div>\n";
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3691,7 +3691,7 @@ void writeGraphInfo(OutputList &ol)
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg" && s!=-1 && e!=-1)
   {
-    legendDocs = legendDocs.left(s+8) + "[!-- SVG 0 --]" + legendDocs.mid(e);
+    legendDocs = legendDocs.left(s+8) + "[!-- " + "SVG 0 --]" + legendDocs.mid(e);
     //printf("legendDocs=%s\n",qPrint(legendDocs));
   }
   FileDef *fd = createFileDef("","graph_legend.dox");


### PR DESCRIPTION
Due to the fact that doxygen searches for a replacement string and this string is also part of the doxygen code we see in the internal documentation the weird behavior that in the middle of some source code of the description there is an image (see https://doxygen.github.io/doxygen/db/d14/index_8cpp.html and search for 3694, function `writeGraphInfo()`). By splitting the string this can be overcome.

As an image:

![image](https://user-images.githubusercontent.com/5223533/213920850-7e9f288d-7400-4bdb-b770-fe88de18d756.png)


Note: I only observed it with a clean run