### PR TITLE
Issue #9802 enumvalueType should not be a mixed type

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -5735,7 +5735,6 @@ class enumvalueType(GeneratedsSuper):
             obj_ = self.mixedclass_(MixedContainer.CategorySimple,
                 MixedContainer.TypeString, 'name', valuestr_)
             self.content_.append(obj_)
-            self.name = valuestr_       # missing assignment that was not auto-generated, fixes self.name always equal to None
             self.name_nsprefix_ = child_.prefix
         elif nodeName_ == 'initializer':
             obj_ = linkedTextType.factory(parent_object_=self)

--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -5735,6 +5735,7 @@ class enumvalueType(GeneratedsSuper):
             obj_ = self.mixedclass_(MixedContainer.CategorySimple,
                 MixedContainer.TypeString, 'name', valuestr_)
             self.content_.append(obj_)
+            self.name = valuestr_       # missing assignment that was not auto-generated, fixes self.name always equal to None
             self.name_nsprefix_ = child_.prefix
         elif nodeName_ == 'initializer':
             obj_ = linkedTextType.factory(parent_object_=self)

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -252,7 +252,7 @@
     </xsd:sequence>
   </xsd:complexType>
 
-  <xsd:complexType name="enumvalueType" mixed="true">
+  <xsd:complexType name="enumvalueType">
     <xsd:sequence>
       <xsd:element name="name" />
       <xsd:element name="initializer" type="linkedTextType" minOccurs="0" />


### PR DESCRIPTION
This will fix a quirk with doxmlparser.py that makes it difficult to parse Enums.