### PR TITLE
Coverity warning

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3934,7 +3934,7 @@ static void handleGuard(yyscan_t yyscanner,const QCString &expr)
   {
     sectionEnabled=prs.parse(yyextra->fileName,yyextra->lineNr,expr.stripWhiteSpace());
   }
-  bool parentEnabled = parentEnabled = yyextra->guards.top().parentVisible();
+  bool parentEnabled = yyextra->guards.top().parentVisible();
   if (parentEnabled)
   {
     if (


### PR DESCRIPTION
The line:
```
  bool parentEnabled = parentEnabled = yyextra->guards.top().parentVisible();
```
should have been
```
  bool parentEnabled = yyextra->guards.top().parentVisible();
```