### PR TITLE
issue #9810  Math in bibliography

### DIFF
--- a/src/cite.h
+++ b/src/cite.h
@@ -18,6 +18,7 @@
 #define CITE_H
 
 #include <memory>
+#include <map>
 
 #include "qcstring.h"
 
@@ -68,6 +69,9 @@ class CitationManager
     /** Create the database, with an expected maximum of \a size entries */
     CitationManager();
     void insertCrossReferencesForBibFile(const QCString &bibFile);
+    QCString getFormulas(const QCString &s);
+    QCString replaceFormulas(const QCString &s);
+    std::map< QCString,QCString > m_formulaCite;
     struct Private;
     std::unique_ptr<Private> p;
 };


### PR DESCRIPTION
Enabled possibility for (LaTeX)- formulas in the bibliography
- replace the (LaTeX)-formulas with placeholders
- run the usual bibliography commands
- substitute back in the bibliography overview page the formulas (now in doxygen format, so with `\f$`)
- run processing on the bibliography overview page so that the formulas are properly gathered

(Note the doxygen LaTeX output is not changed by this as this uses the native LaTeX approach).