### PR TITLE
Windows compilation warnings

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -1267,7 +1267,7 @@ void DocbookGenerator::closeAllSections()
 }
 
 void DocbookGenerator::writeInheritedSectionTitle(
-                  const QCString &id,    const QCString &ref,
+                  const QCString &/*id*/,const QCString &ref,
                   const QCString &file,  const QCString &anchor,
                   const QCString &title, const QCString &name)
 {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1332,7 +1332,7 @@ void HtmlGenerator::writeFooterFile(TextStream &t)
 static std::mutex g_indexLock;
 
 void HtmlGenerator::startFile(const QCString &name,const QCString &,
-                              const QCString &title,int id)
+                              const QCString &title,int /*id*/)
 {
   //printf("HtmlGenerator::startFile(%s)\n",qPrint(name));
   m_relPath = relativePathToRoot(name);

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1823,7 +1823,7 @@ void LatexDocVisitor::startLink(const QCString &ref,const QCString &file,const Q
   }
 }
 
-void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCString &anchor,bool refToTable,bool refToSection, SectionType sectionType)
+void LatexDocVisitor::endLink(const QCString &ref,const QCString &file,const QCString &anchor,bool /*refToTable*/,bool refToSection, SectionType sectionType)
 {
   m_t << "}";
   bool pdfHyperLinks = Config_getBool(PDF_HYPERLINKS);

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2153,7 +2153,7 @@ void LatexGenerator::endLabels()
 }
 
 void LatexGenerator::writeInheritedSectionTitle(
-                  const QCString &id,    const QCString &ref,
+                  const QCString &/*id*/,const QCString &ref,
                   const QCString &file,  const QCString &anchor,
                   const QCString &title, const QCString &name)
 {

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -897,9 +897,9 @@ void ManGenerator::endHeaderSection()
 }
 
 void ManGenerator::writeInheritedSectionTitle(
-                  const QCString &id,    const QCString &ref,
-                  const QCString &file,  const QCString &anchor,
-                  const QCString &title, const QCString &name)
+                  const QCString &/*id*/,    const QCString &/*ref*/,
+                  const QCString &/*file*/,  const QCString &/*anchor*/,
+                  const QCString &title,     const QCString &name)
 {
   m_t << "\n\n";
   m_t << theTranslator->trInheritedFrom(docifyToString(title), objectLinkToString(name));

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2767,7 +2767,7 @@ void RTFGenerator::endLabels()
 }
 
 void RTFGenerator::writeInheritedSectionTitle(
-                  const QCString &id,    const QCString &ref,
+                  const QCString &/*id*/,const QCString &ref,
                   const QCString &file,  const QCString &anchor,
                   const QCString &title, const QCString &name)
 {


### PR DESCRIPTION
Correction of some windows compilation warnings like:
```
warning C4100: 'id': unreferenced formal parameter
```