### PR TITLE
Adding "engine" ebnf for plantuml

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1119,6 +1119,7 @@ class DoxPlantumlEngine(str, Enum):
     FLOW='flow'
     BOARD='board'
     GIT='git'
+    EBNF='ebnf'
 
 
 class DoxProtectionKind(str, Enum):
@@ -23727,7 +23728,7 @@ class docPlantumlType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git']
+            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'ebnf']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxPlantumlEngine' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3189,7 +3189,7 @@ class Receiver
   Not all diagrams can be created with the PlantUML `@startuml` command but need another
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
   the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
-  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board` and `git`.
+  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git` and `ebnf`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -57,7 +57,7 @@ static const std::set<std::string> g_plantumlEngine {
   "uml", "bpm", "wire", "dot", "ditaa",
   "salt", "math", "latex", "gantt", "mindmap",
   "wbs", "yaml", "creole", "json", "flow",
-  "board", "git"
+  "board", "git", "ebnf"
 };
 
 //---------------------------------------------------------------------------

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -1017,6 +1017,7 @@
       <xsd:enumeration value="flow"/>
       <xsd:enumeration value="board"/>
       <xsd:enumeration value="git"/>
+      <xsd:enumeration value="ebnf"/>
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
Add the plantuml "engine" EBNF (Extended Backus Naur Form) . The implementation in plantuml is a basic implementation and like written in the plantuml documentation:

> EBNF allows for self description, so here it is!

```
@startebnf
grammar = { rule };
rule = lhs , "=" (* definition *) , rhs , ";" (* termination *);
lhs = identifier ;
rhs = identifier
     | terminal
     | "[" , rhs (* optional *) , "]"
     | "{" , rhs (* repetition *), "}"
     | "(" , rhs (* grouping *) , ")"
     | "(*" , rhs (* comment *) , "*)"
     | "?" , rhs (* special sequence, aka notation *) , "?"
     | rhs , "|" (* alternation *) , rhs
     | rhs , "," (* concatenation *), rhs ;
identifier = letter , { letter | digit | "_" } ;
terminal = "'" , character , { character } , "'"
         | '"' , character , { character } , '"' ;
character = letter | digit | symbol | "_" ;
symbol = "[" | "]" | "{" | "}" | "(" | ")" | "<" | ">"
       | "'" | '"' | "=" | "|" | "." | "," | ";" ;
digit = ? 0-9 ? ;
letter = ? A-Z or a-z ? ;
@endebnf
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10508727/example.tar.gz)
