### PR TITLE
Windows compilation warnings

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2324,7 +2324,7 @@ static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor)
   }
 }
 
-static void addToSearchIndex(yyscan_t yyscanner,const QCString &text)
+static void addToSearchIndex(yyscan_t /*yyscanner*/,const QCString &text)
 {
   if (Doxygen::searchIndex)
   {

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -900,7 +900,7 @@ static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor)
   }
 }
 
-static void addToSearchIndex(yyscan_t yyscanner,const QCString &text)
+static void addToSearchIndex(yyscan_t /*yyscanner*/,const QCString &text)
 {
   if (Doxygen::searchIndex)
   {

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -950,7 +950,7 @@ static void setCurrentDoc(yyscan_t yyscanner, const QCString &anchor)
 
 //-------------------------------------------------------------------------------
 
-static void addToSearchIndex(yyscan_t yyscanner, const QCString &text)
+static void addToSearchIndex(yyscan_t /* yyscanner */, const QCString &text)
 {
   if (Doxygen::searchIndex)
   {

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -99,7 +99,7 @@ class ThreadPool
         std::unique_lock<std::mutex> l(m_mutex);
         for(auto&& u : m_finished)
         {
-          unused_variable(u);
+          (void)u; //unused_variable, to silence the compiler warning about unused variables
           m_work.push_back({}); // insert empty function object to signal abort
         }
       }
@@ -107,10 +107,6 @@ class ThreadPool
       m_finished.clear();
     }
   private:
-
-    // helper to silence the compiler warning about unused variables
-    template <typename ...Args>
-    void unused_variable(Args&& ...args) { (void)(sizeof...(args)); }
 
     // the work that a worker thread does:
     void threadTask()

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -991,7 +991,7 @@ static bool checkVhdlString(yyscan_t yyscanner,QCString &name)
   return false;
 }
 
-static void addToSearchIndex(yyscan_t yyscanner,const QCString &text)
+static void addToSearchIndex(yyscan_t /*yyscanner*/,const QCString &text)
 {
   if (Doxygen::searchIndex)
   {


### PR DESCRIPTION
Correction of some windows compilation warnings like:
```
warning C4100: '<args_0>': unreferenced formal parameter
```