### PR TITLE
Adding "engine" hcl and regex for plantuml

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1119,6 +1119,8 @@ class DoxPlantumlEngine(str, Enum):
     FLOW='flow'
     BOARD='board'
     GIT='git'
+    HCL='hcl'
+    REGEX='regex'
     EBNF='ebnf'
 
 
@@ -23728,7 +23730,7 @@ class docPlantumlType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'ebnf']
+            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxPlantumlEngine' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3189,7 +3189,7 @@ class Receiver
   Not all diagrams can be created with the PlantUML `@startuml` command but need another
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
   the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
-  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git` and `ebnf`.
+  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex` and `ebnf`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -57,7 +57,7 @@ static const std::set<std::string> g_plantumlEngine {
   "uml", "bpm", "wire", "dot", "ditaa",
   "salt", "math", "latex", "gantt", "mindmap",
   "wbs", "yaml", "creole", "json", "flow",
-  "board", "git", "ebnf"
+  "board", "git", "hcl", "regex", "ebnf"
 };
 
 //---------------------------------------------------------------------------

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -1017,6 +1017,8 @@
       <xsd:enumeration value="flow"/>
       <xsd:enumeration value="board"/>
       <xsd:enumeration value="git"/>
+      <xsd:enumeration value="hcl"/>
+      <xsd:enumeration value="regex"/>
       <xsd:enumeration value="ebnf"/>
     </xsd:restriction>
   </xsd:simpleType>


### PR DESCRIPTION
Add the plantuml "engine" HCL (HCL Configuration Languages. see: https://hcl.readthedocs.io/en/latest/index.html) and REGEX (Regular expression  see: https://en.wikipedia.org/wiki/Regular_expression) The implementation in plantuml is a basic implementation and like written in the plantuml documentation:

Small HCL example:

```
@startuml{hcl}
{
key = "value"
}
@enduml
```

Small Regex example:
```
@startuml{regex}
repetitionZeroOrMore: a*
@enduml
```

Example:
- [example_regex.tar.gz](https://github.com/doxygen/doxygen/files/10517964/example_regex.tar.gz)
- [example_hcl.tar.gz](https://github.com/doxygen/doxygen/files/10517974/example_hcl.tar.gz)

For the plantuml.jar file see example with https://github.com/doxygen/doxygen/pull/9817

