### PR TITLE
Remove common leading space from code snippets

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -2635,9 +2635,11 @@ Commands for displaying examples
  Note also that the [block_id] markers should appear exactly twice in the
  source file.
 
- The `option` can either be `lineno` or `doc`.
- The `option` `lineno` can be used to enable line numbers for the included code if desired.
- The `option` `doc` can be used to treat the file as documentation rather than code.
+ - The `option` can either be `lineno`, `trimleft` or `doc`.
+ - The `option` `lineno` can be used to enable line numbers for the included code if desired.
+ - The `option` `trimleft` can be used to remove the common spacing in front of all lines
+   (also taking in account the setting of the \ref cfg_tab_size "TAB_SIZE" tag).
+ - The `option` `doc` can be used to treat the file as documentation rather than code.
 
  \note When using the `{doc}` option,
        some commands like \ref cmdcond "\\cond" and \ref cmdif "\\if" don't work with

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -482,10 +482,11 @@ DB_VIS_C
       m_t << "</literallayout>";
       break;
     case DocInclude::Snippet:
+    case DocInclude::SnippetTrimLeft:
       m_t << "<literallayout><computeroutput>";
       getCodeParser(inc.extension()).parseCode(m_ci,
                                                 inc.context(),
-                                                extractBlock(inc.text(),inc.blockId()),
+                                                extractBlock(inc.text(),inc.blockId(),inc.type()==DocInclude::SnippetTrimLeft),
                                                 langExt,
                                                 inc.isExample(),
                                                 inc.exampleFile()

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -281,6 +281,7 @@ void DocInclude::parse(DocNodeVariant *)
       parser()->readTextFileByName(m_file,m_text);
       break;
     case Snippet:
+    case SnippetTrimLeft:
     case SnipWithLines:
       parser()->readTextFileByName(m_file,m_text);
       // check here for the existence of the blockId inside the file, so we
@@ -3526,6 +3527,10 @@ void DocPara::handleInclude(DocNodeVariant *thisVariant,const QCString &cmdName,
     {
       t = DocInclude::SnippetDoc;
     }
+    else if (t==DocInclude::Snippet && contains("trimleft"))
+    {
+      t = DocInclude::SnippetTrimLeft;
+    }
     tok=parser()->tokenizer.lex();
     if (tok!=TK_WHITESPACE)
     {
@@ -3565,7 +3570,7 @@ void DocPara::handleInclude(DocNodeVariant *thisVariant,const QCString &cmdName,
   }
   QCString fileName = parser()->context.token->name;
   QCString blockId;
-  if (t==DocInclude::Snippet || t==DocInclude::SnipWithLines || t==DocInclude::SnippetDoc)
+  if (t==DocInclude::Snippet || t==DocInclude::SnipWithLines || t==DocInclude::SnippetDoc || t == DocInclude::SnippetTrimLeft)
   {
     if (fileName == "this") fileName=parser()->context.fileName;
     parser()->tokenizer.setStateSnippet();

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -412,7 +412,8 @@ class DocInclude : public DocNode
   public:
   enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude,
 	      IncWithLines, Snippet , IncludeDoc, SnippetDoc, SnipWithLines,
-	      DontIncWithLines, RtfInclude, ManInclude, DocbookInclude, XmlInclude};
+	      DontIncWithLines, RtfInclude, ManInclude, DocbookInclude, XmlInclude,
+              SnippetTrimLeft};
     DocInclude(DocParser *parser,DocNodeVariant *parent,const QCString &file,
                const QCString &context, Type t,
                bool isExample,const QCString &exampleFile,

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -763,12 +763,13 @@ void HtmlDocVisitor::operator()(const DocInclude &inc)
       forceStartParagraph(inc);
       break;
     case DocInclude::Snippet:
+    case DocInclude::SnippetTrimLeft:
       {
          forceEndParagraph(inc);
          m_ci.startCodeFragment("DoxyCode");
          getCodeParser(inc.extension()).parseCode(m_ci,
                                            inc.context(),
-                                           extractBlock(inc.text(),inc.blockId()),
+                                           extractBlock(inc.text(),inc.blockId(),inc.type()==DocInclude::SnippetTrimLeft),
                                            langExt,
                                            inc.isExample(),
                                            inc.exampleFile(),

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -563,11 +563,12 @@ void LatexDocVisitor::operator()(const DocInclude &inc)
       m_t << "\\end{DoxyVerbInclude}\n";
       break;
     case DocInclude::Snippet:
+    case DocInclude::SnippetTrimLeft:
       {
         m_ci.startCodeFragment("DoxyCodeInclude");
         getCodeParser(inc.extension()).parseCode(m_ci,
                                                   inc.context(),
-                                                  extractBlock(inc.text(),inc.blockId()),
+                                                  extractBlock(inc.text(),inc.blockId(),inc.type()==DocInclude::SnippetTrimLeft),
                                                   langExt,
                                                   inc.isExample(),
                                                   inc.exampleFile()

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -328,12 +328,13 @@ void ManDocVisitor::operator()(const DocInclude &inc)
       m_firstCol=TRUE;
       break;
     case DocInclude::Snippet:
+    case DocInclude::SnippetTrimLeft:
       if (!m_firstCol) m_t << "\n";
       m_t << ".PP\n";
       m_t << ".nf\n";
       getCodeParser(inc.extension()).parseCode(m_ci,
                                         inc.context(),
-                                        extractBlock(inc.text(),inc.blockId()),
+                                        extractBlock(inc.text(),inc.blockId(),inc.type()==DocInclude::SnippetTrimLeft),
                                         langExt,
                                         inc.isExample(),
                                         inc.exampleFile()

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -36,9 +36,9 @@ class Markdown
     QCString process(const QCString &input, int &startNewlines, bool fromParseInput = false);
     QCString extractPageTitle(QCString &docs,QCString &id,int &prepend);
     void setIndentLevel(int level) { m_indentLevel = level; }
+    QCString detab(const QCString &s,int &refIndent);
 
   private:
-    QCString detab(const QCString &s,int &refIndent);
     QCString processQuotations(const QCString &s,int refIndent);
     QCString processBlocks(const QCString &s,int indent);
     QCString isBlockCommand(const char *data,int offset,int size);

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -695,6 +695,7 @@ void PerlModDocVisitor::operator()(const DocInclude &inc)
     case DocInclude::DocbookInclude: type = "docbookonly"; break;
     case DocInclude::VerbInclude:	type = "preformatted"; break;
     case DocInclude::Snippet: return;
+    case DocInclude::SnippetTrimLeft: return;
     case DocInclude::SnipWithLines: return;
     case DocInclude::SnippetDoc:
     case DocInclude::IncludeDoc:

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -212,6 +212,7 @@ class PrintDocVisitor
         case DocInclude::XmlInclude: printf("xmlinclude"); break;
         case DocInclude::VerbInclude: printf("verbinclude"); break;
         case DocInclude::Snippet: printf("snippet"); break;
+        case DocInclude::SnippetTrimLeft: printf("snippettrimleft"); break;
         case DocInclude::SnipWithLines: printf("snipwithlines"); break;
         case DocInclude::SnippetDoc:
         case DocInclude::IncludeDoc:

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -500,12 +500,13 @@ void RTFDocVisitor::operator()(const DocInclude &inc)
       m_t << "}\n";
       break;
     case DocInclude::Snippet:
+    case DocInclude::SnippetTrimLeft:
       m_t << "{\n";
       if (!m_lastIsPara) m_t << "\\par\n";
       m_t << rtf_Style_Reset << getStyle("CodeExample");
       getCodeParser(inc.extension()).parseCode(m_ci,
                                         inc.context(),
-                                        extractBlock(inc.text(),inc.blockId()),
+                                        extractBlock(inc.text(),inc.blockId(),inc.type()==DocInclude::SnippetTrimLeft),
                                         langExt,
                                         inc.isExample(),
                                         inc.exampleFile()

--- a/src/util.h
+++ b/src/util.h
@@ -388,7 +388,8 @@ void writeColoredImgData(const QCString &dir,ColoredImgDataItem data[]);
 QCString replaceColorMarkers(const QCString &str);
 
 bool copyFile(const QCString &src,const QCString &dest);
-QCString extractBlock(const QCString &text,const QCString &marker);
+QCString extractBlock(const QCString &text,const QCString &marker, const bool trimLeft=false);
+
 int lineBlock(const QCString &text,const QCString &marker);
 
 bool isURL(const QCString &url);

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -478,10 +478,11 @@ void XmlDocVisitor::operator()(const DocInclude &inc)
       m_t << "</verbatim>";
       break;
     case DocInclude::Snippet:
+    case DocInclude::SnippetTrimLeft:
       m_t << "<programlisting filename=\"" << inc.file() << "\">";
       getCodeParser(inc.extension()).parseCode(m_ci,
                                         inc.context(),
-                                        extractBlock(inc.text(),inc.blockId()),
+                                        extractBlock(inc.text(),inc.blockId(),inc.type()==DocInclude::SnippetTrimLeft),
                                         langExt,
                                         inc.isExample(),
                                         inc.exampleFile()


### PR DESCRIPTION
Based on the question https://stackoverflow.com/questions/55955554/remove-leading-indentation-white-space-in-doxygen-snippet, the proposed pull request #9819 and the discussion there and alternative approach has been implemented .
- add the option `trimleft` to the command `\snippet`
- remove the common leading spaces after `detab`ing