### PR TITLE
Not documented parameter in case of `const <type>` without argument name

### DIFF
--- a/src/defargs.l
+++ b/src/defargs.l
@@ -445,6 +445,8 @@ CPPC  "/\/"
 						    a.type.mid(sv)=="union"     ||
 						    a.type.mid(sv)=="class"     ||
 						    a.type.mid(sv)=="typename"  ||
+						    a.type=="const"             ||
+						    a.type=="volatile"          ||
 						    nameIsActuallyPartOfType(a.name)
 						   )
 						{


### PR DESCRIPTION
When having an argument in a function definition like `const item` without an argument name and the type is `item` doxygen will see the word `item` as the name of the argument (unless the type is a predefined type from the standard like `int` of `std::size_t`). When the type is found so far is just `const` we should see what is now in `name` as type and process further.

Example:
```
/// a fie
/// @param b2 the param
/// @return the return
int t_c_item2(int b2, const item);
```
giving the warning:
```
bb.h:15: warning: The following parameter of t_c_item2(int b2, const item) is not documented:
  parameter 'item'
```

(same applies for volatile, seen also the code just above)

Also reported in https://github.com/CGAL/cgal/pull/6702#issuecomment-1412482471

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10560331/example.tar.gz)


