### PR TITLE
avoid csp insecure eval on search box.

### DIFF
--- a/templates/html/search.js
+++ b/templates/html/search.js
@@ -156,7 +156,7 @@ function SearchBox(name, resultsPath, extension)
 
   this.OnSearchSelectHide = function()
   {
-    this.hideTimeout = setTimeout(this.name +".CloseSelectionWindow()",
+    this.hideTimeout = setTimeout(this.CloseSelectionWindow.bind(this),
                                   this.closeSelectionTimeout);
   }
 
@@ -211,7 +211,7 @@ function SearchBox(name, resultsPath, extension)
       if (searchValue != "") // non-empty search
       {
         // set timer for search update
-        this.keyTimeout = setTimeout(this.name + '.Search()',
+        this.keyTimeout = setTimeout(this.Search.bind(this),
                                      this.keyTimeoutLength);
       }
       else // empty search field


### PR DESCRIPTION
From the issue [issues/6381](https://github.com/doxygen/doxygen/issues/6381) there was a suggestion on an update to the seach.js template to avoid csp violations for `unsafe-eval` which are currently seeing in our published docs. 

`Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".`

This adds the suggested change from the issue, combing through the comments on the issue, i don't see any blocking comments, rather that other places need to be updated unrelated to search. This is to fix the search issue we are seeing. We have created and are using a fork.