### PR TITLE
issue #9831 @exception description paragraph does not accept @ref tag

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1233,12 +1233,7 @@ void convertCppComments(const BufStr &inBuf,BufStr &outBuf,const QCString &fileN
   clearCommentStack(yyscanner);
   yyextra->vhdl = FALSE;
 
-  if (Debug::isFlagSet(Debug::CommentCnv))
-  {
-    Debug::print(Debug::CommentCnv,0,"-----------\nCommentCnv: %s\n"
-                 "input=[\n%s]\n-----------\n",qPrint(fileName),yyextra->inBuf.data()
-                );
-  }
+  DebugLex debugLex(Debug::Lex_commentcnv,__FILE__, qPrint(fileName));
   yyextra->isFixedForm = FALSE;
   if (yyextra->lang==SrcLangExt_Fortran)
   {

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -221,6 +221,25 @@ SLASHopt [/]*
                                        yyextra->commentStack.push(yyextra->lineNr);
 				     }
                                    }
+<Scan>"\"\"\""                     { /* start of python long comment */
+                                     if (yyextra->lang!=SrcLangExt_Python)
+				     {
+				       REJECT;
+				     }
+                                     else if (Config_getBool(PYTHON_DOCSTRING))
+                                     {
+				       REJECT;
+                                     }
+				     else
+				     { /* handle as if """! */
+                                       yyextra->pythonDocString = TRUE;
+                                       yyextra->nestingCount=1;
+                                       clearCommentStack(yyscanner); /*  to be on the save side */
+                                       copyToOutput(yyscanner,yytext,(int)yyleng);
+				       BEGIN(CComment);
+                                       yyextra->commentStack.push(yyextra->lineNr);
+				     }
+                                   }
 <Scan>![><!]/.*\n	   {
                                      if (yyextra->lang!=SrcLangExt_Fortran)
 				     {
@@ -1214,7 +1233,12 @@ void convertCppComments(const BufStr &inBuf,BufStr &outBuf,const QCString &fileN
   clearCommentStack(yyscanner);
   yyextra->vhdl = FALSE;
 
-  DebugLex debugLex(Debug::Lex_commentcnv,__FILE__, qPrint(fileName));
+  if (Debug::isFlagSet(Debug::CommentCnv))
+  {
+    Debug::print(Debug::CommentCnv,0,"-----------\nCommentCnv: %s\n"
+                 "input=[\n%s]\n-----------\n",qPrint(fileName),yyextra->inBuf.data()
+                );
+  }
   yyextra->isFixedForm = FALSE;
   if (yyextra->lang==SrcLangExt_Fortran)
   {


### PR DESCRIPTION
Handle the `"""` in the comment converter properly in case `PYTHON_DOCSTRING=NO` so e.g. `ALIASES` are converted as well.