### PR TITLE
Debugging documentation

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -242,8 +242,14 @@ utime $now, $now, $file;
 Another way to get rules matching / debugging information
 from the \c flex code is setting \c LEX_FLAGS with \c make (`make LEX_FLAGS=-d`).
 
+By default a debug version of doxygen (i.e. an executable created with the \c CMake
+setting `-DCMAKE_BUILD_TYPE=Debug`) will automatically have the \c flex debugging
+information for all `flex codefile`s.
+
 Note that by running doxygen with `-d lex` you get information about which
 `flex codefile` is used.
+To see the information of the flex parser, which is compiled with the flex debug option,
+you have to specify `-d lex:<flex codefile>` when running doxygen.
 
 <h3>Testing</h3>
 
@@ -263,7 +269,7 @@ are different from the standard doxygen configuration file settings one can run 
 doxygen command: with the `-x` option and the name of the configuration file (default
 is `Doxyfile`). The output will be a list of the not default settings (in `Doxyfile`
 format). Alternatively also `-x_noenv` is possible which is identical to the `-x`
-option but without replacing the environment variables and the CMake type replacement variables.
+option but without replacing the environment variables and the \c CMake type replacement variables.
 
 \htmlonly
 Return to the <a href="index.html">index</a>.


### PR DESCRIPTION
Adding:
- the necessity of using `-d lex:<flex codefile>`
- default that a debug executable contains flex debug information