### PR TITLE
Consistency in used debug terminology

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1575,7 +1575,7 @@ void LayoutDocManager::init()
   QCString layout_default = ResourceMgr::instance().getAsString(layoutFile);
   parser.parse(layoutFile,layout_default.data(),Debug::isFlagSet(Debug::Lex_xml),
                [&]() { DebugLex::print(Debug::Lex_xml,"Entering","libxml/xml.l",layoutFile); },
-               [&]() { DebugLex::print(Debug::Lex_xml,"Leaving", "libxml/xml.l",layoutFile); }
+               [&]() { DebugLex::print(Debug::Lex_xml,"Finished", "libxml/xml.l",layoutFile); }
               );
 }
 
@@ -1621,7 +1621,7 @@ void LayoutDocManager::parse(const QCString &fileName)
   layoutParser.setDocumentLocator(&parser);
   parser.parse(fileName.data(),fileToString(fileName).data(),Debug::isFlagSet(Debug::Lex_xml),
                [&]() { DebugLex::print(Debug::Lex_xml,"Entering","libxml/xml.l",qPrint(fileName)); },
-               [&]() { DebugLex::print(Debug::Lex_xml,"Leaving", "libxml/xml.l",qPrint(fileName)); }
+               [&]() { DebugLex::print(Debug::Lex_xml,"Finished", "libxml/xml.l",qPrint(fileName)); }
               );
 }
 

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -1701,7 +1701,7 @@ void parseTagFile(const std::shared_ptr<Entry> &root,const char *fullName)
   tagFileParser.setDocumentLocator(&parser);
   parser.parse(fullName,inputStr.data(),Debug::isFlagSet(Debug::Lex_xml),
                [&]() { DebugLex::print(Debug::Lex_xml,"Entering","libxml/xml.l",fullName); },
-               [&]() { DebugLex::print(Debug::Lex_xml,"Leaving", "libxml/xml.l",fullName); }
+               [&]() { DebugLex::print(Debug::Lex_xml,"Finished", "libxml/xml.l",fullName); }
               );
   tagFileParser.buildLists(root);
   tagFileParser.addIncludes();


### PR DESCRIPTION
On all places when the lex parser ends the term "Finished" is used except for the settings in `layout.cpp` and `tagreader.cpp` when addressing the `libxml/xml.l` parser. This has been made consistent.