### PR TITLE
Fix variable name collision with clang mingw

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3070,7 +3070,7 @@ static bool handleInternal(yyscan_t yyscanner,const QCString &, const StringVect
 static bool handleStatic(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  yyextra->current->stat = TRUE;
+  yyextra->current->isStatic = TRUE;
   return FALSE;
 }
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1039,7 +1039,7 @@ static void addClassToContext(const Entry *root)
       }
       cd->setRequiresClause(root->req);
       cd->setProtection(root->protection);
-      cd->setIsStatic(root->stat);
+      cd->setIsStatic(root->isStatic);
 
       // file definition containing the class cd
       cd->setBodySegment(root->startLine,root->bodyLine,root->endBodyLine);
@@ -2247,7 +2247,7 @@ static MemberDef *addVariableToClass(
   std::unique_ptr<MemberDefMutable> md { createMemberDef(
       fileName,root->startLine,root->startColumn,
       type,name,args,root->exception,
-      prot,Specifier::Normal,root->stat,related,
+      prot,Specifier::Normal,root->isStatic,related,
       mtype,!root->tArgLists.empty() ? root->tArgLists.back() : ArgumentList(),
       ArgumentList(), root->metaData) };
   md->setTagInfo(root->tagInfo());
@@ -2430,7 +2430,7 @@ static MemberDef *addVariableToFile(
                           md->argsString()!=args &&
                           args.find('[')!=-1;
         bool staticsInDifferentFiles =
-                          root->stat && md->isStatic() &&
+                          root->isStatic && md->isStatic() &&
                           root->fileName!=md->getDefFileName();
 
         if (md->getFileDef() &&
@@ -2472,7 +2472,7 @@ static MemberDef *addVariableToFile(
   std::unique_ptr<MemberDefMutable> md { createMemberDef(
       fileName,root->startLine,root->startColumn,
       type,name,args,QCString(),
-      root->protection, Specifier::Normal,root->stat,Relationship::Member,
+      root->protection, Specifier::Normal,root->isStatic,Relationship::Member,
       mtype,!root->tArgLists.empty() ? root->tArgLists.back() : ArgumentList(),
       root->argList, root->metaData) };
   md->setTagInfo(root->tagInfo());
@@ -3035,7 +3035,7 @@ static void addInterfaceOrServiceToServiceOrSingleton(
   }
   std::unique_ptr<MemberDefMutable> md { createMemberDef(
       fileName, root->startLine, root->startColumn, root->type, rname,
-      "", "", root->protection, root->virt, root->stat, Relationship::Member,
+      "", "", root->protection, root->virt, root->isStatic, Relationship::Member,
       type, ArgumentList(), root->argList, root->metaData) };
   md->setTagInfo(root->tagInfo());
   md->setMemberClass(cd);
@@ -3060,7 +3060,7 @@ static void addInterfaceOrServiceToServiceOrSingleton(
   md->addQualifiers(root->qualifiers);
 
   AUTO_TRACE("Interface member: fileName='{}' type='{}' name='{}' mtype='{}' prot={} virt={} state={} proto={} def='{}'",
-      fileName,root->type,rname,type,root->protection,root->virt,root->stat,root->proto,def);
+      fileName,root->type,rname,type,root->protection,root->virt,root->isStatic,root->proto,def);
 
   // add member to the class cd
   cd->insertMember(md.get());
@@ -3282,7 +3282,7 @@ static void addGlobalFunction(const Entry *root,const QCString &rname,const QCSt
   std::unique_ptr<MemberDefMutable> md { createMemberDef(
       root->fileName,root->startLine,root->startColumn,
       root->type,name,root->args,root->exception,
-      root->protection,root->virt,root->stat,Relationship::Member,
+      root->protection,root->virt,root->isStatic,Relationship::Member,
       MemberType_Function,
       !root->tArgLists.empty() ? root->tArgLists.back() : ArgumentList(),
       root->argList,root->metaData) };
@@ -3459,7 +3459,7 @@ static void buildFunctionList(const Entry *root)
       {
         AUTO_TRACE_ADD("member '{}' of class '{}'", rname,cd->name());
         addMethodToClass(root,cd,root->type,rname,root->args,isFriend,
-                         root->protection,root->stat,root->virt,root->spec,root->relates);
+                         root->protection,root->isStatic,root->virt,root->spec,root->relates);
       }
       else if (!((root->parent()->section & Entry::COMPOUND_MASK)
                  || root->parent()->section==Entry::OBJCIMPL_SEC
@@ -3533,7 +3533,7 @@ static void buildFunctionList(const Entry *root)
               }
 
               bool staticsInDifferentFiles =
-                root->stat && md->isStatic() && root->fileName!=md->getDefFileName();
+                root->isStatic && md->isStatic() && root->fileName!=md->getDefFileName();
 
               if (
                   matchArguments2(md->getOuterScope(),mfd,&mdAl,
@@ -5536,7 +5536,7 @@ static void addLocalObjCMethod(const Entry *root,
     std::unique_ptr<MemberDefMutable> md { createMemberDef(
         root->fileName,root->startLine,root->startColumn,
         funcType,funcName,funcArgs,exceptions,
-        root->protection,root->virt,root->stat,Relationship::Member,
+        root->protection,root->virt,root->isStatic,Relationship::Member,
         MemberType_Function,ArgumentList(),root->argList,root->metaData) };
     md->setTagInfo(root->tagInfo());
     md->setLanguage(root->lang);
@@ -5806,7 +5806,7 @@ static void addMemberFunction(const Entry *root,
         {
           AUTO_TRACE_ADD("add template specialization");
           addMethodToClass(root,ccd,type,md->name(),args,isFriend,
-              root->protection,root->stat,root->virt,spec,relates);
+              root->protection,root->isStatic,root->virt,spec,relates);
           return;
         }
         if (argListToString(md->argumentList(),FALSE,FALSE) ==
@@ -5941,7 +5941,7 @@ static void addMemberSpecialization(const Entry *root,
       root->fileName,root->startLine,root->startColumn,
       funcType,funcName,funcArgs,exceptions,
       declMd ? declMd->protection() : root->protection,
-      root->virt,root->stat,Relationship::Member,
+      root->virt,root->isStatic,Relationship::Member,
       mtype,tArgList,root->argList,root->metaData) };
   //printf("new specialized member %s args='%s'\n",qPrint(md->name()),qPrint(funcArgs));
   md->setTagInfo(root->tagInfo());
@@ -6009,7 +6009,7 @@ static void addOverloaded(const Entry *root,MemberName *mn,
     std::unique_ptr<MemberDefMutable> md { createMemberDef(
         root->fileName,root->startLine,root->startColumn,
         funcType,funcName,funcArgs,exceptions,
-        root->protection,root->virt,root->stat,Relationship::Related,
+        root->protection,root->virt,root->isStatic,Relationship::Related,
         mtype,tArgList ? *tArgList : ArgumentList(),root->argList,root->metaData) };
     md->setTagInfo(root->tagInfo());
     md->setLanguage(root->lang);
@@ -6507,7 +6507,7 @@ static void findMember(const Entry *root,
               root->fileName,root->startLine,root->startColumn,
               funcType,funcName,funcArgs,exceptions,
               root->protection,root->virt,
-              root->stat,
+              root->isStatic,
               isMemberOf ? Relationship::Foreign : Relationship::Related,
               mtype,
               (!root->tArgLists.empty() ? root->tArgLists.back() : ArgumentList()),
@@ -7168,7 +7168,7 @@ static void addEnumValuesToEnums(const Entry *root)
                   std::unique_ptr<MemberDefMutable> fmd { createMemberDef(
                       fileName,e->startLine,e->startColumn,
                       e->type,e->name,e->args,QCString(),
-                      e->protection, Specifier::Normal,e->stat,Relationship::Member,
+                      e->protection, Specifier::Normal,e->isStatic,Relationship::Member,
                       MemberType_EnumValue,ArgumentList(),ArgumentList(),e->metaData) };
                   NamespaceDef *mnd = md->getNamespaceDef();
                   if      (md->getClassDef())

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -58,7 +58,7 @@ Entry::Entry(const Entry &e)
   mtype       = e.mtype;
   spec        = e.spec;
   initLines   = e.initLines;
-  stat        = e.stat;
+  isStatic    = e.isStatic;
   localToc    = e.localToc;
   explicitExternal = e.explicitExternal;
   proto       = e.proto;
@@ -224,7 +224,7 @@ void Entry::reset()
   section = EMPTY_SEC;
   mtype   = MethodTypes::Method;
   virt    = Specifier::Normal;
-  stat    = false;
+  isStatic = false;
   proto   = false;
   explicitExternal = false;
   spec  = 0;

--- a/src/entry.h
+++ b/src/entry.h
@@ -247,7 +247,7 @@ class Entry
     MethodTypes mtype;        //!< signal, slot, (dcop) method, or property?
     uint64_t spec;              //!< class/member specifiers
     int  initLines;           //!< define/variable initializer lines to show
-    bool stat;                //!< static ?
+    bool isStatic;            //!< static ?
     bool explicitExternal;    //!< explicitly defined as external?
     bool proto;               //!< prototype ?
     bool subGrouping;         //!< automatically group class members?

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -2307,7 +2307,7 @@ static void applyModifiers(Entry *ent, const SymbolModifiers& mdfs)
   if (mdfs.nonoverridable)
     ent->spec |= Entry::Final;
   if (mdfs.nopass)
-    ent->stat = TRUE;
+    ent->isStatic = TRUE;
   if (mdfs.deferred)
     ent->virt = Specifier::Pure;
 }
@@ -2649,7 +2649,7 @@ static void initEntry(yyscan_t yyscanner)
   }
   yyextra->current->mtype      = MethodTypes::Method;
   yyextra->current->virt       = Specifier::Normal;
-  yyextra->current->stat       = false;
+  yyextra->current->isStatic   = false;
   yyextra->current->lang       = SrcLangExt_Fortran;
   yyextra->commentScanner.initGroupInfo(yyextra->current.get());
 }

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -82,7 +82,7 @@ struct pyscannerYY_state
   int                     yyLineNr = 1 ;
   QCString                fileName;
   MethodTypes             mtype = MethodTypes::Method;
-  bool                    stat = FALSE;
+  bool                    isStatic = FALSE;
   Specifier               virt = Specifier::Normal;
   int                     docBlockContext = 0;
   QCString                docBlock;
@@ -349,7 +349,7 @@ STARTDOCSYMS      "##"
                         BEGIN( DoubleQuoteString );
                       }
     "@staticmethod"  {
-                        yyextra->stat=TRUE;
+                        yyextra->isStatic=TRUE;
                       }
     "@"{SCOPE}{CALL}? { // decorator
                         lineCount(yyscanner);
@@ -1519,7 +1519,7 @@ static void initParser(yyscan_t yyscanner)
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->protection = Protection::Public;
   yyextra->mtype = MethodTypes::Method;
-  yyextra->stat = FALSE;
+  yyextra->isStatic = FALSE;
   yyextra->virt = Specifier::Normal;
   yyextra->previous = 0;
   yyextra->packageCommentAllowed = TRUE;
@@ -1532,10 +1532,10 @@ static void initEntry(yyscan_t yyscanner)
   yyextra->current->protection = yyextra->protection ;
   yyextra->current->mtype      = yyextra->mtype;
   yyextra->current->virt       = yyextra->virt;
-  yyextra->current->stat       = yyextra->stat;
+  yyextra->current->isStatic   = yyextra->isStatic;
   yyextra->current->lang       = SrcLangExt_Python;
   yyextra->commentScanner.initGroupInfo(yyextra->current.get());
-  yyextra->stat = FALSE;
+  yyextra->isStatic = FALSE;
 }
 
 static void newEntry(yyscan_t yyscanner)
@@ -1561,7 +1561,7 @@ static void newVariable(yyscan_t yyscanner)
   }
   if (yyextra->current_root->section&Entry::COMPOUND_MASK) // mark as class variable
   {
-    yyextra->current->stat = TRUE;
+    yyextra->current->isStatic = TRUE;
   }
   newEntry(yyscanner);
 }
@@ -1807,14 +1807,14 @@ static void searchFoundDef(yyscan_t yyscanner)
   yyextra->current->section = Entry::FUNCTION_SEC;
   yyextra->current->lang = SrcLangExt_Python;
   yyextra->current->virt = Specifier::Normal;
-  yyextra->current->stat = yyextra->stat;
+  yyextra->current->isStatic = yyextra->isStatic;
   yyextra->current->mtype = yyextra->mtype = MethodTypes::Method;
   yyextra->current->type.resize(0);
   yyextra->current->name.resize(0);
   yyextra->current->args.resize(0);
   yyextra->current->argList.clear();
   yyextra->packageCommentAllowed = FALSE;
-  yyextra->stat=FALSE;
+  yyextra->isStatic=FALSE;
   //printf("searchFoundDef at=%d\n",yyextra->yyLineNr);
 }
 
@@ -1897,7 +1897,7 @@ static void parseMain(yyscan_t yyscanner, const QCString &fileName,const char *f
 
   yyextra->protection    = Protection::Public;
   yyextra->mtype         = MethodTypes::Method;
-  yyextra->stat          = false;
+  yyextra->isStatic      = false;
   yyextra->virt          = Specifier::Normal;
   yyextra->current_root  = rt;
   yyextra->specialBlock  = false;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -116,7 +116,7 @@ struct scannerYY_state
   int              yyBegColNr   = 1 ;
   QCString         fileName;
   MethodTypes      mtype = MethodTypes::Method;
-  bool             stat = false;
+  bool             isStatic = false;
   Specifier        virt = Specifier::Normal;
   Specifier        baseVirt = Specifier::Normal;
   QCString         msType;
@@ -820,7 +820,7 @@ NONLopt [^\n]*
                                             yyextra->language = yyextra->current->lang = SrcLangExt_ObjC;
                                             yyextra->insideObjC = TRUE;
                                             yyextra->current->virt = Specifier::Virtual;
-                                            yyextra->current->stat=yytext[0]=='+';
+                                            yyextra->current->isStatic=yytext[0]=='+';
                                             yyextra->current->mtype = yyextra->mtype = MethodTypes::Method;
                                             yyextra->current->type.resize(0);
                                             yyextra->current->name.resize(0);
@@ -1112,22 +1112,22 @@ NONLopt [^\n]*
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"static"{BN}*/"{"      { yyextra->current->type += " static ";
-                                          yyextra->current->stat = TRUE;
+                                          yyextra->current->isStatic = TRUE;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"static"{BN}+          { yyextra->current->type += " static ";
-                                          yyextra->current->stat = TRUE;
+                                          yyextra->current->isStatic = TRUE;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"extern"{BN}+          { if (yyextra->insideJava) REJECT;
-                                          yyextra->current->stat = FALSE;
+                                          yyextra->current->isStatic = FALSE;
                                           yyextra->current->explicitExternal = TRUE;
                                           lineCount(yyscanner);
                                         }
 <FindMembers>{B}*"const"{BN}+           { if (yyextra->insideCS)
                                           {
                                             yyextra->current->type += " const ";
-                                            if (yyextra->insideCS) yyextra->current->stat = TRUE;
+                                            if (yyextra->insideCS) yyextra->current->isStatic = TRUE;
                                             lineCount(yyscanner);
                                           }
                                           else
@@ -2370,7 +2370,7 @@ NONLopt [^\n]*
                                                 yyextra->current->name  = yytext;
                                               else
                                                 yyextra->current->name += yytext;
-                                              yyextra->current->stat = TRUE;
+                                              yyextra->current->isStatic = TRUE;
                                             }
                                             else
                                             {
@@ -2380,7 +2380,7 @@ NONLopt [^\n]*
                                                 yyextra->current->name += yytext;
                                               if (yyextra->current->name.startsWith("static "))
                                               {
-                                                yyextra->current->stat = TRUE;
+                                                yyextra->current->isStatic = TRUE;
                                                 yyextra->current->name= yyextra->current->name.mid(7);
                                               }
                                               else if (yyextra->current->name.startsWith("inline "))
@@ -3499,7 +3499,7 @@ NONLopt [^\n]*
                                           {
                                             yyextra->current->type.prepend("typedef ");
                                           }
-                                          bool stat = yyextra->current->stat;
+                                          bool isStatic = yyextra->current->isStatic;
                                           Protection prot = yyextra->current->protection;
                                           bool isConcept = yyextra->current->section==Entry::CONCEPT_SEC;
                                           if (isConcept) // C++20 concept
@@ -3525,7 +3525,7 @@ NONLopt [^\n]*
                                           }
                                           if ( *yytext == ',')
                                           {
-                                            yyextra->current->stat = stat; // the static attribute holds for all variables
+                                            yyextra->current->isStatic = isStatic; // the static attribute holds for all variables
                                             yyextra->current->protection = prot;
                                             yyextra->current->name.resize(0);
                                             yyextra->current->args.resize(0);
@@ -4261,7 +4261,7 @@ NONLopt [^\n]*
                                               varEntry->protection = yyextra->current->protection ;
                                               varEntry->mtype = yyextra->current->mtype;
                                               varEntry->virt = yyextra->current->virt;
-                                              varEntry->stat = yyextra->current->stat;
+                                              varEntry->isStatic = yyextra->current->isStatic;
                                               varEntry->section = Entry::VARIABLE_SEC;
                                               varEntry->name = yyextra->msName.stripWhiteSpace();
                                               varEntry->type = yyextra->current->type.simplifyWhiteSpace()+" ";
@@ -6575,7 +6575,7 @@ NONLopt [^\n]*
                                             {
                                               // static Java initializer
                                               yyextra->needsSemi = FALSE;
-                                              if (yyextra->current->stat)
+                                              if (yyextra->current->isStatic)
                                               {
                                                 yyextra->current->name="[static initializer]";
                                                 yyextra->current->type.resize(0);
@@ -7186,7 +7186,7 @@ static void initParser(yyscan_t yyscanner)
   yyextra->roundCount = 0;
   yyextra->curlyCount = 0;
   yyextra->mtype = MethodTypes::Method;
-  yyextra->stat = FALSE;
+  yyextra->isStatic = FALSE;
   yyextra->virt = Specifier::Normal;
   yyextra->baseVirt = Specifier::Normal;
   yyextra->isTypedef = FALSE;
@@ -7209,7 +7209,7 @@ static void initEntry(yyscan_t yyscanner)
   yyextra->current->protection = yyextra->protection ;
   yyextra->current->mtype      = yyextra->mtype;
   yyextra->current->virt       = yyextra->virt;
-  yyextra->current->stat       = yyextra->stat;
+  yyextra->current->isStatic   = yyextra->isStatic;
   yyextra->current->lang       = yyextra->language;
   //printf("*** initEntry(yyscanner) yyextra->language=%d\n",yyextra->language);
   yyextra->commentScanner.initGroupInfo(yyextra->current.get());
@@ -7688,7 +7688,7 @@ static void parseCompounds(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
       yyextra->insideObjC = ce->lang==SrcLangExt_ObjC;
       //printf("---> Inner block starts at line %d objC=%d\n",yyextra->yyLineNr,yyextra->insideObjC);
       yyextra->current = std::make_shared<Entry>();
-      yyextra->stat = FALSE;
+      yyextra->isStatic = FALSE;
       initEntry(yyscanner);
 
       // deep copy group list from parent (see bug 727732)
@@ -7734,7 +7734,7 @@ static void parseCompounds(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
       {
         if (ce->section == Entry::NAMESPACE_SEC ) // unnamed namespace
         {
-          yyextra->current->stat = yyextra->stat = TRUE;
+          yyextra->current->isStatic = yyextra->isStatic = TRUE;
         }
         yyextra->current->protection = yyextra->protection = ce->protection;
       }
@@ -7744,7 +7744,7 @@ static void parseCompounds(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
       }
       yyextra->mtype = MethodTypes::Method;
       yyextra->virt = Specifier::Normal;
-      //printf("name=%s yyextra->current->stat=%d yyextra->stat=%d\n",qPrint(ce->name),yyextra->current->stat,yyextra->stat);
+      //printf("name=%s yyextra->current->isStatic=%d yyextra->isStatic=%d\n",qPrint(ce->name),yyextra->current->isStatic,yyextra->isStatic);
 
       //memberGroupId = DOX_NOGROUP;
       //memberGroupRelates.resize(0);
@@ -7791,7 +7791,7 @@ static void parseMain(yyscan_t yyscanner,
   //depthIf       = 0;
   yyextra->protection    = Protection::Public;
   yyextra->mtype         = MethodTypes::Method;
-  yyextra->stat          = FALSE;
+  yyextra->isStatic      = FALSE;
   yyextra->virt          = Specifier::Normal;
   yyextra->current_root  = rt;
   yyextra->yyLineNr      = 1 ;

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -1334,7 +1334,7 @@ void TagFileParser::buildMemberList(const std::shared_ptr<Entry> &ce,const std::
     }
     me->protection = tmi.prot;
     me->virt       = tmi.virt;
-    me->stat       = tmi.isStatic;
+    me->isStatic   = tmi.isStatic;
     me->fileName   = ce->fileName;
     me->id         = tmi.clangId;
     me->startLine  = tmi.lineNr;

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -2506,7 +2506,7 @@ void VhdlDocGen::computeVhdlComponentRelations()
 
   for (const auto &cur : getVhdlInstList())
   {
-    if (cur->stat ) //  was bind
+    if (cur->isStatic ) //  was bind
     {
       continue;
     }
@@ -2581,7 +2581,7 @@ ferr:
       n1,uu,uu, QCString(),
       Protection::Public,
       Specifier::Normal,
-      cur->stat,
+      cur->isStatic,
       Relationship::Member,
       MemberType_Variable,
       ArgumentList(),


### PR DESCRIPTION
    This changes the variable name from 'stat' to 'isStatic'.
    Otherwise the 'stat' name come into conflict with 'stat'
    macro in mingw-w64 headers. This fixes the following error:

    commentscan.l:3074:21: error: no member named '_stat64' in 'Entry'
      yyextra->current->stat = TRUE;
      ~~~~~~~~~~~~~~~~  ^

    The 'stat' macro is defined in sys/stat.h file in mingw-w64
    like this '#define stat _stat64'

