### PR TITLE
Build: Re-enable LEX_FILES_{H,CPP}, streamline

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,53 +94,65 @@ add_custom_command(
 )
 set_source_files_properties(${GENERATED_SRC}/resources.cpp PROPERTIES GENERATED 1)
 
-set(LEX_FILES scanner 
+set(LEX_FILES
     code
-    pyscanner
-    pycode
-    fortranscanner
-    fortrancode
-    vhdlcode
-    pre
+    commentcnv
+    commentscan
+    configimpl
+    constexp
     declinfo
     defargs
     doctokenizer
-    commentcnv
-    commentscan
-    constexp
-    xmlcode
-    sqlcode
+    fortrancode
+    fortranscanner
     lexcode
     lexscanner
-    configimpl)
+    pre
+    pycode
+    pyscanner
+    scanner
+    sqlcode
+    vhdlcode
+    xmlcode
+)
 
 if (NOT depfile_supported)
     # In case the DEPFILE possibility is not supported the complete list of lex include files for the dependency has to be used
     set(LEX_INC_FILES)
 endif()
 
-# unfortunately ${LEX_FILES_H} and ${LEX_FILES_CPP} don't work in older versions of CMake (like 3.6.2) for add_library
+set(LEX_FILES_H)
+set(LEX_FILES_CPP)
+set(_depfile_args)
+
 foreach(lex_file ${LEX_FILES})
-    set(LEX_FILES_H ${LEX_FILES_H} " " ${GENERATED_SRC}/${lex_file}.l.h CACHE INTERNAL "Stores generated files")
-    set(LEX_FILES_CPP ${LEX_FILES_CPP} " " ${GENERATED_SRC}/${lex_file}.cpp CACHE INTERNAL "Stores generated files")
+    # configimpl is handled specially (it's in the static lib)
+    if (NOT lex_file STREQUAL "configimpl")
+        list(APPEND LEX_FILES_H ${GENERATED_SRC}/${lex_file}.l.h)
+        list(APPEND LEX_FILES_CPP ${GENERATED_SRC}/${lex_file}.cpp)
+    endif()
+
+    set(_generated_files
+        ${GENERATED_SRC}/${lex_file}.l
+        ${GENERATED_SRC}/${lex_file}.corr
+        ${GENERATED_SRC}/${lex_file}.d)
 
     if (depfile_supported)
-        add_custom_command(
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.d ${CMAKE_CURRENT_LIST_DIR}
-            DEPENDS ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l
-            DEPFILE ${GENERATED_SRC}/${lex_file}.d
-            OUTPUT  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.d
-        )
-    else()
-        add_custom_command(
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.d ${CMAKE_CURRENT_LIST_DIR}
-            DEPENDS ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l ${LEX_INC_FILES}
-            OUTPUT  ${GENERATED_SRC}/${lex_file}.l ${GENERATED_SRC}/${lex_file}.corr ${GENERATED_SRC}/${lex_file}.d
-        )
+        set(_depfile_args DEPFILE ${GENERATED_SRC}/${lex_file}.d)
     endif()
-    set_source_files_properties(${GENERATED_SRC}/${lex_file}.l PROPERTIES GENERATED 1)
-    set_source_files_properties(${GENERATED_SRC}/${lex_file}.corr PROPERTIES GENERATED 1)
-    set_source_files_properties(${GENERATED_SRC}/${lex_file}.d PROPERTIES GENERATED 1)
+    add_custom_command(
+        OUTPUT ${_generated_files}
+        COMMAND ${PYTHON_EXECUTABLE}
+            ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py
+            ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l
+            ${_generated_files}
+            ${CMAKE_CURRENT_LIST_DIR}
+        DEPENDS
+            ${CMAKE_CURRENT_LIST_DIR}/pre_lex.py
+            ${CMAKE_CURRENT_LIST_DIR}/${lex_file}.l
+        ${_depfile_args}
+    )
+    set_source_files_properties(${_generated_files} PROPERTIES GENERATED 1)
 
     add_custom_command(
         COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scan_states.py ${GENERATED_SRC}/${lex_file}.l > ${GENERATED_SRC}/${lex_file}.l.h
@@ -168,6 +180,12 @@ foreach(lex_file ${LEX_FILES})
         OUTPUT  ${GENERATED_SRC}/${lex_file}.cpp
     )
 endforeach()
+unset(_depfile_args)
+unset(_generated_files)
+
+# Cache generated sources lists
+set(LEX_FILES_H ${LEX_FILES_H} CACHE INTERNAL "Stores generated files")
+set(LEX_FILES_CPP ${LEX_FILES_CPP} CACHE INTERNAL "Stores generated files")
 
 
 BISON_TARGET(constexp
@@ -200,44 +218,8 @@ add_sanitizers(doxycfg)
 
 add_library(doxymain STATIC
     # generated for/by flex/bison
-    #${LEX_FILES_H} #unfortunately doesn't work in older versions of CMake (like 3.6.2)
-    #${LEX_FILES_CPP} #unfortunately doesn't work in older versions of CMake (like 3.6.2)
-    ${GENERATED_SRC}/code.l.h
-    ${GENERATED_SRC}/commentcnv.l.h
-    ${GENERATED_SRC}/commentscan.l.h
-    ${GENERATED_SRC}/constexp.cpp
-    ${GENERATED_SRC}/constexp.l.h
-    ${GENERATED_SRC}/declinfo.l.h
-    ${GENERATED_SRC}/defargs.l.h
-    ${GENERATED_SRC}/doctokenizer.l.h
-    ${GENERATED_SRC}/fortrancode.l.h
-    ${GENERATED_SRC}/fortranscanner.l.h
-    ${GENERATED_SRC}/lexcode.l.h
-    ${GENERATED_SRC}/lexscanner.l.h
-    ${GENERATED_SRC}/pre.l.h
-    ${GENERATED_SRC}/pycode.l.h
-    ${GENERATED_SRC}/pyscanner.l.h
-    ${GENERATED_SRC}/scanner.l.h
-    ${GENERATED_SRC}/sqlcode.l.h
-    ${GENERATED_SRC}/vhdlcode.l.h
-    ${GENERATED_SRC}/xmlcode.l.h
-    ${GENERATED_SRC}/code.cpp
-    ${GENERATED_SRC}/commentcnv.cpp
-    ${GENERATED_SRC}/commentscan.cpp
-    ${GENERATED_SRC}/declinfo.cpp
-    ${GENERATED_SRC}/defargs.cpp
-    ${GENERATED_SRC}/doctokenizer.cpp
-    ${GENERATED_SRC}/fortrancode.cpp
-    ${GENERATED_SRC}/fortranscanner.cpp
-    ${GENERATED_SRC}/lexcode.cpp
-    ${GENERATED_SRC}/lexscanner.cpp
-    ${GENERATED_SRC}/pre.cpp
-    ${GENERATED_SRC}/pycode.cpp
-    ${GENERATED_SRC}/pyscanner.cpp
-    ${GENERATED_SRC}/scanner.cpp
-    ${GENERATED_SRC}/sqlcode.cpp
-    ${GENERATED_SRC}/vhdlcode.cpp
-    ${GENERATED_SRC}/xmlcode.cpp
+    ${LEX_FILES_H}
+    ${LEX_FILES_CPP}
     #
     ${GENERATED_SRC}/ce_parse.cpp
     # custom generated files
@@ -422,4 +404,3 @@ set_project_coverage(doxymain)
 set_project_coverage(doxygen)
 
 install(TARGETS doxygen DESTINATION bin)
-


### PR DESCRIPTION
This PR re-enables use of the CMake `${LEX_FILES_H}` and `${LEX_FILES_CPP}` variables, in a way that's compatible with CMake versions much older than 3.5, even -- this code should work with even CMake 3.0.

Support for older CMake versions is actually a moot point, since `deps/spdlog/CMakeLists.txt` contains this line:

https://github.com/doxygen/doxygen/blob/8887ee5387624fafa7a46dafa6a4f8183d45d1c6/deps/spdlog/CMakeLists.txt#L3

So, since the addition of spdlog the effective minimum CMake version for doxygen's own builds has been CMake 3.10. But I promise you, if that restriction were lifted the code in this PR would still work in much, _much_ older CMake releases.

#### Why?

The problem with older CMake versions wasn't support for listing source files in variables, it was how the variables were being constructed. Examining the `CMakeCache.txt` of a configured build tree made the issue apparent. Configuring a build tree from the current `master` branch produces:

```cmake
LEX_FILES_H:INTERNAL= ;/tmp/_build/generated_src/scanner.l.h; ;/tmp/_build/generated_src/code.l.h; ;/tmp/_build/generated_src/pyscanner.l.h; ;/tmp/_build/generated_src/pycode.l.h; ;/tmp/_build/generated_src/fortranscanner.l.h; ;/tmp/_build/generated_src/fortrancode.l.h; ;/tmp/_build/generated_src/vhdlcode.l.h; ;/tmp/_build/generated_src/pre.l.h; ;/tmp/_build/generated_src/declinfo.l.h; ;/tmp/_build/generated_src/defargs.l.h; ;/tmp/_build/generated_src/doctokenizer.l.h; ;/tmp/_build/generated_src/commentcnv.l.h; ;/tmp/_build/generated_src/commentscan.l.h; ;/tmp/_build/generated_src/constexp.l.h; ;/tmp/_build/generated_src/xmlcode.l.h; ;/tmp/_build/generated_src/sqlcode.l.h; ;/tmp/_build/generated_src/lexcode.l.h; ;/tmp/_build/generated_src/lexscanner.l.h; ;/tmp/_build/generated_src/configimpl.l.h
```

The variables were being constructed as a list of values, but each item of that list had an additional, separate list item in front of it that contained only a single space character.

CMake understands how to explode lists-in-variables into members, when listing arguments to a command, It can even expand a list **of arguments**, when calling a command. (I make use of that in my logic to handle the conditional `DEPFILE` arguments to add_custom_command()`.) But older CMake versions weren't smart enough to handle **empty** list arguments without breaking.

With the code in this PR, `LEX_FILES_H` is generated cleanly:
```cmake
LEX_FILES_H:INTERNAL=/tmp/_build2/generated_src/code.l.h;/tmp/_build2/generated_src/commentcnv.l.h;/tmp/_build2/generated_src/commentscan.l.h;/tmp/_build2/generated_src/constexp.l.h;/tmp/_build2/generated_src/declinfo.l.h;/tmp/_build2/generated_src/defargs.l.h;/tmp/_build2/generated_src/doctokenizer.l.h;/tmp/_build2/generated_src/fortrancode.l.h;/tmp/_build2/generated_src/fortranscanner.l.h;/tmp/_build2/generated_src/lexcode.l.h;/tmp/_build2/generated_src/lexscanner.l.h;/tmp/_build2/generated_src/pre.l.h;/tmp/_build2/generated_src/pycode.l.h;/tmp/_build2/generated_src/pyscanner.l.h;/tmp/_build2/generated_src/scanner.l.h;/tmp/_build2/generated_src/sqlcode.l.h;/tmp/_build2/generated_src/vhdlcode.l.h;/tmp/_build2/generated_src/xmlcode.l.h
```

CMake understands how to process **that** list. So it works everywhere, even ancient CMake 3.0/3.1/3.2.

#### What else?
- I sorted the `LEX_FILES` list out of necessity, so that I could compare it to the list of items I was removing from the `add_target()` call and ensure I removed only the items from the variable(s).
- After discovering that the `configimpl` files weren't on the list (they're added to the static target, instead), added code to keep them out of `LEX_FILES_H` and `LEX_FILES_CPP`.
- Line-wrapped the `add_custom_target()` command I edited, to use more vertical space, and less horizontal. (I can undo that on request. it admittedly amounts to nothing more than a personal preference.)
- With the addition of a couple of temporary CMake variables, I managed to streamline and DRY out the `add_custom_command()` call that processes lexer files (eliminating the nearly-identical duplicate branched on `depfiles_supported`).