### PR TITLE
issue #9845 C# parser reads "$" as "Interpolated string expression" which is not correct

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3277,6 +3277,13 @@ NONLopt [^\n]*
                                             *yyextra->pCopyRoundGString << yytext;
                                           }
                                         }
+<GCopyRound>"@\""                       {
+                                          if (!yyextra->insideCS) REJECT;
+                                          *yyextra->pCopyRoundGString << yytext;
+                                           yyextra->lastSkipVerbStringContext=YY_START;
+                                           yyextra->pSkipVerbString=yyextra->pCopyRoundGString;
+                                           BEGIN(SkipVerbString);
+                                        }
 <GCopyRound>[^"'()\n\/,]+               {
                                           *yyextra->pCopyRoundGString << yytext;
                                         }
@@ -3904,7 +3911,7 @@ NONLopt [^\n]*
                                           yyextra->current->program << yytext ;
                                         }
   /* Interpolated string C# */
-<CopyGString,SkipString,SkipCurly,ReadBody,ReadNSBody,ReadBodyIntf,FindMembers,FindMemberName>$\"   { if (!yyextra->insideCS) REJECT
+<SkipCurly,ReadBody,ReadNSBody,ReadBodyIntf,FindMembers,FindMemberName>$\"   { if (!yyextra->insideCS) REJECT
                                           yyextra->current->program << yytext ;
                                           yyextra->pSkipInterpString = &yyextra->current->program;
                                           yyextra->lastSkipInterpStringContext=YY_START;


### PR DESCRIPTION
- the verbatim string should also be handled inside round brackets
- in case of a "normal string" inside round brackets (i.e. without the `@`) the `$"` hasn't a special meaning either, states `CopyGString` and `SkipString` should not check on `$"`.