### PR TITLE
issue #9846 Python functions with and without type hints displayed inconsistently.

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -666,10 +666,6 @@ STARTDOCSYMS      "##"
 <FunctionDec>{
     {IDENTIFIER}            {
                               //found function name
-                              if (yyextra->current->type.isEmpty())
-                              {
-                                  yyextra->current->type = "def";
-                              }
                               yyextra->current->name = yytext;
                               yyextra->current->name = yyextra->current->name.stripWhiteSpace();
                               newFunction(yyscanner);
@@ -1120,7 +1116,7 @@ STARTDOCSYMS      "##"
                         yyextra->current->initializer << yytext;
                       }
    {INTNUMBER}        { // integer value
-                        if (yyextra->current-> type.isEmpty()) yyextra->current->type = "int";
+                        if (yyextra->current->type.isEmpty()) yyextra->current->type = "int";
                         yyextra->current->initializer << yytext;
                       }
    {FLOATNUMBER}      { // floating point value


### PR DESCRIPTION
The suggestion is that the return type of the function in python is "def" whilst in fact the return type is "unknown", so it is better to leave it away (in the past, 1.8.14 and before,  it made sense to have "def" as at that moment the type hints were not supported and thus for all python functions the return type was "unknown" signaled by the word "def").