### PR TITLE
bug 549438 VERBATIM_HEADERS - only works with header files with file type

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1426,7 +1426,7 @@ bool FileDefImpl::generateSourceFile() const
   bool verbatimHeaders = Config_getBool(VERBATIM_HEADERS);
   return !isReference() &&
          (sourceBrowser ||
-           (verbatimHeaders && guessSection(name())==Entry::HEADER_SEC)
+           (verbatimHeaders && (guessSection(name())==Entry::HEADER_SEC || !m_includedByMap.empty()))
          ) &&
          !isDocumentationFile();
 }


### PR DESCRIPTION
Also check whether the file is included so also files with unknown and without extensions are caught as include files (besides files with a  known header extension).

Extended example: [example_extended.tar.gz](https://github.com/doxygen/doxygen/files/10713915/example_extended.tar.gz)
