### PR TITLE
Handling debug information in in respect to mscgen

### DIFF
--- a/deps/libmscgen/mscgen_lexer.l
+++ b/deps/libmscgen/mscgen_lexer.l
@@ -245,6 +245,11 @@ void lex_resetparser()
   lex_linenum = 1;
   lex_line = NULL;
   lex_utf8 = FALSE;
+#ifdef FLEX_DEBUG
+  // in case of a debug build stll disable debug information
+  // as it disrupts the normal doxygen output
+  yy_flex_debug = 0;
+#endif
 }
 
 #if USE_STATE2STRING


### PR DESCRIPTION
By default there would be debug information in case of a debug build. In the other lexers used by doxygen the information is compiled into the debug executable but only shown upon request (`-d lex:<lexername>`). The result is that when a msc image is generated the debug information will appear and disrupts the output. For the mscgen lexer there is no such mechanism as it is an external lexer, building it into this lexer would make the lexer dependent on e.g. the src directory etc. and this is not wanted.