### PR TITLE
Markdown: Heading auto id

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -704,6 +704,16 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='enum' id='HEADING_AUTO_IDENTIFIER' defval='DOXYGEN' depends='MARKDOWN_SUPPORT'>
+      <docs>
+<![CDATA[
+ The \c HEADING_AUTO_IDENTIFIER tag can be used to specify the behavior used to generate ids for the Markdown headings.
+ Note: Every id is unique.
+]]>
+      </docs>
+      <value name="DOXYGEN" desc="Use autotoc_md + a number starting at 0."/>
+      <value name="GITHUB" desc="Uppercase to lowercase, replace all sort of spaces with '-', remove all punctations."/>
+    </option>
     <option type='bool' id='AUTOLINK_SUPPORT' defval='1'>
       <docs>
 <![CDATA[

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -36,6 +36,7 @@
 #include "utf8.h"
 #include "indexlist.h"
 #include "fileinfo.h"
+#include "markdown.h"
 
 //-----------------------------------------------------------------------------------------
 
@@ -400,7 +401,7 @@ void DefinitionImpl::writeDocAnchorsToTagFile(TextStream &tagFile) const
     //printf("%s: writeDocAnchorsToTagFile(%d)\n",qPrint(name()),m_impl->sectionRef.size());
     for (const SectionInfo *si : m_impl->sectionRefs)
     {
-      if (!si->generated() && si->ref().isEmpty() && !si->label().startsWith("autotoc_md"))
+      if (!si->generated() && si->ref().isEmpty() && !set_contains(Markdown::ids(), si->label()))
       {
         //printf("write an entry!\n");
         if (m_impl->def->definitionType()==Definition::TypeMember) tagFile << "  ";

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -5367,7 +5367,7 @@ endparagraph:
 
 int DocSection::parse(DocNodeVariant *thisVariant)
 {
-  AUTO_TRACE("start {} level={}",parser()->context.token->sectionId,m_level);
+  AUTO_TRACE("start {} level={}", parser()->context.token->sectionId, m_level);
   int retval=RetVal_OK;
   auto ns = AutoNodeStack(parser(),thisVariant);
 
@@ -5442,8 +5442,12 @@ int DocSection::parse(DocNodeVariant *thisVariant)
     }
     else if (retval==RetVal_Subsubsection && m_level<=Doxygen::subpageNestingLevel+2)
     {
-      if ((m_level<=1+Doxygen::subpageNestingLevel) && !parser()->context.token->sectionId.startsWith("autotoc_md"))
-          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected subsubsection command found inside %s!",g_sectionLevelToName[m_level]);
+      if ((m_level <= 1 + Doxygen::subpageNestingLevel)
+          && set_contains(Markdown::ids(), parser()->context.token->sectionId))
+        warn_doc_error(parser()->context.fileName,
+                       parser()->tokenizer.getLineNr(),
+                       "Unexpected subsubsection command found inside %s!",
+                       g_sectionLevelToName[m_level]);
       // then parse any number of nested sections
       while (retval==RetVal_Subsubsection) // more sections follow
       {
@@ -5452,11 +5456,13 @@ int DocSection::parse(DocNodeVariant *thisVariant)
                                 parser()->context.token->sectionId);
         retval = children().get_last<DocSection>()->parse(vDocSection);
       }
-      if (!(m_level<Doxygen::subpageNestingLevel+2 && retval == RetVal_Subsection)) break;
+      if (!(m_level < Doxygen::subpageNestingLevel + 2 && retval == RetVal_Subsection))
+        break;
     }
     else if (retval==RetVal_Paragraph && m_level<=std::min(5,Doxygen::subpageNestingLevel+3))
     {
-      if ((m_level<=2+Doxygen::subpageNestingLevel) && !parser()->context.token->sectionId.startsWith("autotoc_md"))
+      if ((m_level <= 2 + Doxygen::subpageNestingLevel)
+          && set_contains(Markdown::ids(), parser()->context.token->sectionId))
         warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected paragraph command found inside %s!",g_sectionLevelToName[m_level]);
       // then parse any number of nested sections
       while (retval==RetVal_Paragraph) // more sections follow
@@ -5483,7 +5489,7 @@ int DocSection::parse(DocNodeVariant *thisVariant)
                   retval==RetVal_EndInternal
                  );
 
-  AUTO_TRACE_EXIT("retval={}",DocTokenizer::retvalToString(retval));
+  AUTO_TRACE_EXIT("retval={}", DocTokenizer::retvalToString(retval));
   return retval;
 }
 
@@ -5605,7 +5611,7 @@ void DocRoot::parse(DocNodeVariant *thisVariant)
 
   // first parse any number of paragraphs
   bool isFirst=TRUE;
-  DocPara *lastPar=0;
+  DocPara *lastPar = nullptr;
   do
   {
     {
@@ -5622,11 +5628,14 @@ void DocRoot::parse(DocNodeVariant *thisVariant)
         lastPar = par;
       }
     }
-    if (retval==RetVal_Paragraph)
+    if (retval == RetVal_Paragraph)
     {
-      if (!parser()->context.token->sectionId.startsWith("autotoc_md"))
+      if (!set_contains(Markdown::ids(), parser()->context.token->sectionId))
       {
-         warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"found paragraph command (id: '%s') outside of subsubsection context!",qPrint(parser()->context.token->sectionId));
+        warn_doc_error(parser()->context.fileName,
+                       parser()->tokenizer.getLineNr(),
+                       "found paragraph command (id: '%s') outside of subsubsection context!",
+                       qPrint(parser()->context.token->sectionId));
       }
       while (retval==RetVal_Paragraph)
       {
@@ -5655,7 +5664,7 @@ void DocRoot::parse(DocNodeVariant *thisVariant)
     }
     if (retval==RetVal_Subsubsection)
     {
-      if (!(parser()->context.token->sectionId.startsWith("autotoc_md")))
+      if (!set_contains(Markdown::ids(), parser()->context.token->sectionId))
         warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"found subsubsection command (id: '%s') outside of subsection context!",qPrint(parser()->context.token->sectionId));
       while (retval==RetVal_Subsubsection)
       {
@@ -5684,8 +5693,7 @@ void DocRoot::parse(DocNodeVariant *thisVariant)
     }
     if (retval==RetVal_Subsection)
     {
-      if (!parser()->context.token->sectionId.startsWith("autotoc_md"))
-      {
+      if (!set_contains(Markdown::ids(), parser()->context.token->sectionId)) {
         warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"found subsection command (id: '%s') outside of section context!",qPrint(parser()->context.token->sectionId));
       }
       while (retval==RetVal_Subsection)
@@ -5753,6 +5761,4 @@ void DocRoot::parse(DocNodeVariant *thisVariant)
   }
 
   parser()->handleUnclosedStyleCommands();
-
 }
-

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -33,26 +33,24 @@
 
 #include <stdio.h>
 
-#include <unordered_map>
-#include <functional>
+#include <algorithm>
 #include <atomic>
+#include <functional>
+#include <unordered_map>
 
-#include "markdown.h"
-#include "growbuf.h"
-#include "debug.h"
-#include "util.h"
-#include "doxygen.h"
 #include "commentscan.h"
-#include "entry.h"
-#include "commentcnv.h"
 #include "config.h"
-#include "section.h"
+#include "debug.h"
+#include "doxygen.h"
+#include "entry.h"
+#include "fileinfo.h"
+#include "growbuf.h"
+#include "markdown.h"
 #include "message.h"
 #include "portable.h"
 #include "regex.h"
-#include "fileinfo.h"
-#include "utf8.h"
 #include "trace.h"
+#include "util.h"
 
 enum class ExplicitPageResult
 {
@@ -1845,7 +1843,52 @@ static bool isHRuler(const char *data,int size)
   return n>=3; // at least 3 characters needed for a hruler
 }
 
-static QCString extractTitleId(QCString &title, int level)
+QCString doxygenHtmlIdentifier()
+{
+  static int count = 0;
+  QCString result = "autotoc_md";
+  result.append(std::to_string(count));
+  ++count;
+  return result;
+}
+
+std::unordered_map<std::string, int> id_count;
+QCString githubHtmlIdentifier(const std::string &str)
+{
+  std::string result;
+
+  for (auto c : str) {
+    if (std::isspace(c))
+      result.push_back('-');
+    else if (std::ispunct(c))
+      continue;
+    else
+      result.push_back(c);
+  }
+
+  result = convertUTF8ToLower(result);
+
+  if (result.empty())
+    return doxygenHtmlIdentifier();
+
+  // Adding end digits if an identical header already exists
+  int &count = id_count[result];
+  if (count > 0) {
+    result += "-" + std::to_string(count);
+  }
+  count++;
+
+  return result;
+}
+
+// Use set because it has better lookup times and every item is unique
+std::set<QCString> m_ids;
+const std::set<QCString> &Markdown::ids()
+{
+  return m_ids;
+}
+
+QCString Markdown::extractTitleId(QCString &title, int level)
 {
   AUTO_TRACE("title={} level={}",Trace::trunc(title),level);
   // match e.g. '{#id-b11} ' and capture 'id-b11'
@@ -1856,15 +1899,34 @@ static QCString extractTitleId(QCString &title, int level)
   {
     std::string id = match[1].str();
     title = title.left(match.position());
+    int &count = id_count[id];
+    if (count > 0) {
+      warn(m_fileName,
+           m_lineNr,
+           "An automatically generated id already has the name '%s'!",
+           id.c_str());
+    }
     //printf("found match id='%s' title=%s\n",id.c_str(),qPrint(title));
     AUTO_TRACE_EXIT("id={}",id);
-    return QCString(id);
+    return id;
   }
-  if ((level > 0) && (level <= Config_getInt(TOC_INCLUDE_HEADINGS)))
-  {
-    static AtomicInt autoId { 0 };
+  if ((level > 0) && (level <= Config_getInt(TOC_INCLUDE_HEADINGS))) {
+    static HEADING_AUTO_IDENTIFIER_t behavior = Config_getEnum(HEADING_AUTO_IDENTIFIER);
     QCString id;
-    id.sprintf("autotoc_md%d",autoId++);
+
+    switch (behavior)
+    {
+      case HEADING_AUTO_IDENTIFIER_t::DOXYGEN:
+        id = doxygenHtmlIdentifier();
+        break;
+      case HEADING_AUTO_IDENTIFIER_t::GITHUB:
+        id = githubHtmlIdentifier(title.str());
+        break;
+      default:
+        id = doxygenHtmlIdentifier();
+    }
+
+    m_ids.insert(id);
     //printf("auto-generated id='%s' title='%s'\n",qPrint(id),qPrint(title));
     AUTO_TRACE_EXIT("id={}",id);
     return id;
@@ -3144,7 +3206,7 @@ static ExplicitPageResult isExplicitPage(const QCString &docs)
   return ExplicitPageResult::notExplicit;
 }
 
-QCString Markdown::extractPageTitle(QCString &docs,QCString &id, int &prepend)
+QCString Markdown::extractPageTitle(QCString &docs, QCString &id, int &prepend, bool *extractedId)
 {
   AUTO_TRACE("docs={} id={} prepend={}",Trace::trunc(docs),id,prepend);
   // first first non-empty line
@@ -3175,6 +3237,8 @@ QCString Markdown::extractPageTitle(QCString &docs,QCString &id, int &prepend)
       convertStringFragment(title,data+i,end1-i-1);
       docs+="\n\n"+docs_org.mid(end2);
       id = extractTitleId(title, 0);
+      if (extractedId != nullptr)
+        *extractedId = true;
       //printf("extractPageTitle(title='%s' docs='%s' id='%s')\n",title.data(),docs.data(),id.data());
       AUTO_TRACE_EXIT("result={}",Trace::trunc(title));
       return title;
@@ -3189,6 +3253,8 @@ QCString Markdown::extractPageTitle(QCString &docs,QCString &id, int &prepend)
   {
     docs=docs_org;
     id = extractTitleId(title, 0);
+    if (extractedId != nullptr)
+      *extractedId = true;
   }
   AUTO_TRACE_EXIT("result={}",Trace::trunc(title));
   return title;
@@ -3298,9 +3364,11 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
   QCString docs = fileBuf;
   Debug::print(Debug::Markdown,0,"======== Markdown =========\n---- input ------- \n%s\n",qPrint(fileBuf));
   QCString id;
+  bool extractedId = false;
   Markdown markdown(fileName,1,0);
-  QCString title=markdown.extractPageTitle(docs,id,prepend).stripWhiteSpace();
-  if (id.startsWith("autotoc_md")) id = "";
+  QCString title = markdown.extractPageTitle(docs, id, prepend, &extractedId).stripWhiteSpace();
+  if (extractedId)
+    id = "";
   int indentLevel=title.isEmpty() ? 0 : -1;
   markdown.setIndentLevel(indentLevel);
   QCString fn      = FileInfo(fileName.str()).fileName();

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -34,8 +34,12 @@ class Markdown
   public:
     Markdown(const QCString &fileName,int lineNr,int indentLevel=0);
     QCString process(const QCString &input, int &startNewlines, bool fromParseInput = false);
-    QCString extractPageTitle(QCString &docs,QCString &id,int &prepend);
+    QCString extractPageTitle(QCString &docs,
+                              QCString &id,
+                              int &prepend,
+                              bool *extractedId = nullptr);
     void setIndentLevel(int level) { m_indentLevel = level; }
+    static const std::set<QCString> &ids();
 
   private:
     QCString processQuotations(const QCString &s,int refIndent);
@@ -69,7 +73,9 @@ class Markdown
                 int blockStart,int blockEnd);
     int writeBlockQuote(const char *data,int size);
     int writeCodeBlock(const char *data,int size,int refIndent);
-    int writeTableBlock(const char *data,int size);
+    int writeTableBlock(const char *data, int size);
+
+    QCString extractTitleId(QCString &title, int level);
 
   private:
     struct LinkRef
@@ -87,7 +93,6 @@ class Markdown
     GrowBuf        m_out;
     Markdown::Action_t m_actions[256];
 };
-
 
 class MarkdownOutlineParser : public OutlineParserInterface
 {

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -40,6 +40,7 @@
 #include "section.h"
 #include "containers.h"
 #include "debug.h"
+#include "config.h"
 
 // ----------------- private part -----------------------------------------------
 
@@ -457,7 +458,10 @@ class TagFileParser
         case InMember:
         case InPackage:
         case InDir:
-          if (m_curString.endsWith("autotoc_md")) return;
+          static HEADING_AUTO_IDENTIFIER_t behavior = Config_getEnum(HEADING_AUTO_IDENTIFIER);
+          if (behavior == HEADING_AUTO_IDENTIFIER_t::DOXYGEN)
+            if (m_curString.startsWith("autotoc_md"))
+              return;
           break;
         default:
           warn("Unexpected tag 'docanchor' found");

--- a/src/util.h
+++ b/src/util.h
@@ -195,6 +195,12 @@ bool rightScopeMatch(const QCString &scope, const QCString &name);
 
 bool leftScopeMatch(const QCString &scope, const QCString &name);
 
+template<class T>
+inline bool set_contains(const std::set<T> &set, const T &value)
+{
+  return set.find(value) != set.end();
+}
+
 struct KeywordSubstitution
 {
   const char *keyword;


### PR DESCRIPTION
As I mentioned in #9855, I don't like the default title ID. I also didn't want to use commands or give the title an ID as described [here](https://www.doxygen.nl/manual/markdown.html#md_header_id). That's why I created this PR to change the default title id. I have already tested it with HTML and PDF. It worked.