### PR TITLE
qcstring.h: Fix conversion method layout

### DIFF
--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -385,13 +385,13 @@ class QCString
     QCString &replace( size_t index, size_t len, const char *s);
     //QCString &replace( const QRegExp &rx, const char *str );
 
-    short  toShort(  bool *ok=0, int base=10 ) const;
-    uint16_t toUShort( bool *ok=0, int base=10 ) const;
-    int	   toInt(    bool *ok=0, int base=10 ) const;
-    uint32_t   toUInt(   bool *ok=0, int base=10 ) const;
-    long   toLong(   bool *ok=0, int base=10 ) const;
-    unsigned long  toULong(  bool *ok=0, int base=10 ) const;
-    uint64_t toUInt64( bool *ok=0, int base=10 ) const;
+    short         toShort(  bool *ok=0, int base=10 ) const;
+    uint16_t      toUShort( bool *ok=0, int base=10 ) const;
+    int	          toInt(    bool *ok=0, int base=10 ) const;
+    uint32_t      toUInt(   bool *ok=0, int base=10 ) const;
+    long          toLong(   bool *ok=0, int base=10 ) const;
+    unsigned long toULong(  bool *ok=0, int base=10 ) const;
+    uint64_t      toUInt64( bool *ok=0, int base=10 ) const;
 
     QCString &setNum(short n)
     {


### PR DESCRIPTION
Last month's refactoring (6ce8be1ae87f7aa6662f5e62affb7d3e3d3512e1) scrambled the column-aligned layout of this section of the header, a bit.

(Prior to 6ce8be1ae87f7aa6662f5e62affb7d3e3d3512e1):
```c++
    short  toShort(  bool *ok=0, int base=10 ) const;
    ushort toUShort( bool *ok=0, int base=10 ) const;
    int	   toInt(    bool *ok=0, int base=10 ) const;
    uint   toUInt(   bool *ok=0, int base=10 ) const;
    long   toLong(   bool *ok=0, int base=10 ) const;
    ulong  toULong(  bool *ok=0, int base=10 ) const;
    uint64 toUInt64( bool *ok=0, int base=10 ) const;
```

(After):
```c++
    short  toShort(  bool *ok=0, int base=10 ) const;
    uint16_t toUShort( bool *ok=0, int base=10 ) const;
    int	   toInt(    bool *ok=0, int base=10 ) const;
    uint32_t   toUInt(   bool *ok=0, int base=10 ) const;
    long   toLong(   bool *ok=0, int base=10 ) const;
    unsigned long  toULong(  bool *ok=0, int base=10 ) const;
    uint64_t toUInt64( bool *ok=0, int base=10 ) const;
```

(This PR:)
```c++
    short         toShort(  bool *ok=0, int base=10 ) const;
    uint16_t      toUShort( bool *ok=0, int base=10 ) const;
    int	          toInt(    bool *ok=0, int base=10 ) const;
    uint32_t      toUInt(   bool *ok=0, int base=10 ) const;
    long          toLong(   bool *ok=0, int base=10 ) const;
    unsigned long toULong(  bool *ok=0, int base=10 ) const;
    uint64_t      toUInt64( bool *ok=0, int base=10 ) const;
```