### PR TITLE
Fix server based search for PHP 8.1

### DIFF
--- a/templates/html/search_functions.php
+++ b/templates/html/search_functions.php
@@ -62,10 +62,10 @@ function computeIndex($word)
   // Simple hashing that allows for substring search
   if (strlen($word)<2) return -1;
   // high char of the index
-  $hi = ord($word{0});
+  $hi = ord($word[0]);
   if ($hi==0) return -1;
   // low char of the index
-  $lo = ord($word{1});
+  $lo = ord($word[1]);
   if ($lo==0) return -1;
   // return index
   return $hi*256+$lo;
@@ -202,7 +202,7 @@ function combine_results($results,&$docs)
 function filter_results($docs,&$requiredWords,&$forbiddenWords)
 {
   $filteredDocs=array();
-  while (list ($key, $val) = each ($docs)) 
+  foreach ($docs as $key => $val)
   {
     $words = &$docs[$key]["words"];
     $copy=1; // copy entry by default
@@ -322,8 +322,8 @@ function run_query($query)
   $word=strtok($query," ");
   while ($word) // for each word in the search query
   {
-    if (($word{0}=='+')) { $word=substr($word,1); $requiredWords[]=$word; }
-    if (($word{0}=='-')) { $word=substr($word,1); $forbiddenWords[]=$word; }
+    if (($word[0]=='+')) { $word=substr($word,1); $requiredWords[]=$word; }
+    if (($word[0]=='-')) { $word=substr($word,1); $forbiddenWords[]=$word; }
     if (!in_array($word,$foundWords))
     {
       $foundWords[]=$word;


### PR DESCRIPTION
Fixes the following errors when using server based search:
```
 PHP Fatal error:  Array and string offset access syntax with curly \
   braces is no longer supported in search_functions.php on line 65
 PHP Fatal error:  Array and string offset access syntax with curly \
   braces is no longer supported in search_functions.php on line 325
 Uncaught Error: Call to undefined function each() in search_functions.php:205
 #0 search_functions.php(339): filter_results()
 #1 search_functions.php(353): run_query()
 #2 search.php(58): main()
 #3 {main}
   thrown in search_functions.php on line 205
```
Tested with:
```
 $ rpm -qv php-fpm
 php-fpm-8.1.15-1.fc37.x86_64
```