### PR TITLE
issue #9861 Links among markdown files don't work if upstream path element contains space

### DIFF
--- a/doc_internal/commands_internal.md
+++ b/doc_internal/commands_internal.md
@@ -12,6 +12,7 @@ and the version in which they were introduced.
 \refitem cmdiline \\iline
 \refitem cmdilinebr \\ilinebr
 \refitem cmdiliteral \\iliteral
+\refitem cmdiref \\iref
 \refitem cmdiverbatim \\iverbatim
 \endsecreflist
 
@@ -113,5 +114,16 @@ and the version in which they were introduced.
   Ends a block of text that was started with a \ref cmdiverbatim "\\iverbatim" command.
 
 \since doxygen version 1.9.5
+
+<hr>
+\section cmdiref \\iref "<name>" ["(text)"]
+
+  \addindex \\iref
+  
+  This command has a similar syntax and function as the command `\ref`, but is internally used
+  for markdown replacements of links.
+
+
+\since doxygen version 1.9.7
 
 <hr>

--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -78,6 +78,7 @@ CommandMap cmdMap[] =
   { "post",          CMD_POST },
   { "pre",           CMD_PRE },
   { "ref",           CMD_REF },
+  { "iref",          CMD_IREF },
   { "refitem",       CMD_SECREFITEM },
   { "remark",        CMD_REMARK },
   { "remarks",       CMD_REMARK },

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -150,7 +150,8 @@ enum CommandType
   CMD_ISTARTCODE   = 121,
   CMD_ENDICODE     = 122,
   CMD_IVERBATIM    = 123,
-  CMD_ENDIVERBATIM = 124
+  CMD_ENDIVERBATIM = 124,
+  CMD_IREF         = 125
 };
 
 enum HtmlTagType

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -2126,6 +2126,7 @@ int DocHtmlDescTitle::parse(DocNodeVariant *thisVariant)
             switch (Mappers::cmdMapper->map(cmdName))
             {
               case CMD_REF:
+              case CMD_IREF:
                 {
                   tok=parser()->tokenizer.lex();
                   if (tok!=TK_WHITESPACE)
@@ -3463,7 +3464,7 @@ void DocPara::handleLink(DocNodeVariant *thisVariant,const QCString &cmdName,boo
   }
 }
 
-void DocPara::handleRef(DocNodeVariant *thisVariant,const QCString &cmdName)
+void DocPara::handleRef(DocNodeVariant *thisVariant,const QCString &cmdName,const int cmdId)
 {
   AUTO_TRACE("cmdName={}",cmdName);
   QCString saveCmdName = cmdName;
@@ -3475,7 +3476,10 @@ void DocPara::handleRef(DocNodeVariant *thisVariant,const QCString &cmdName)
         qPrint(saveCmdName));
     return;
   }
-  parser()->tokenizer.setStateRef();
+  if (cmdId == CMD_IREF)
+    parser()->tokenizer.setStateIRef();
+  else
+    parser()->tokenizer.setStateRef();
   tok=parser()->tokenizer.lex(); // get the reference id
   if (tok!=TK_WORD)
   {
@@ -4349,8 +4353,9 @@ int DocPara::handleCommand(DocNodeVariant *thisVariant,const QCString &cmdName, 
       handleEmoji(thisVariant);
       break;
     case CMD_REF: // fall through
+    case CMD_IREF: // fall through
     case CMD_SUBPAGE:
-      handleRef(thisVariant,cmdName);
+      handleRef(thisVariant,cmdName,cmdId);
       break;
     case CMD_SECREFLIST:
       {

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -1058,7 +1058,7 @@ class DocPara : public DocCompoundNode
     void handleLink(DocNodeVariant *thisVariant,const QCString &cmdName,bool isJavaLink);
     void handleCite(DocNodeVariant *thisVariant);
     void handleEmoji(DocNodeVariant *thisVariant);
-    void handleRef(DocNodeVariant *thisVariant,const QCString &cmdName);
+    void handleRef(DocNodeVariant *thisVariant,const QCString &cmdName,const int cmdId);
     void handleSection(DocNodeVariant *thisVariant,const QCString &cmdName);
     void handleInheritDoc(DocNodeVariant *thisVariant);
     void handleVhdlFlow(DocNodeVariant *thisVariant);

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -169,6 +169,7 @@ class DocTokenizer
     void setStateLink();
     void setStateCite();
     void setStateRef();
+    void setStateIRef();
     void setStateInternalRef();
     void setStateText();
     void setStateSkipTitle();

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -383,7 +383,9 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 %x St_Link
 %x St_Cite
 %x St_Ref
+%x St_IRef
 %x St_Ref2
+%x St_IRef2
 %x St_IntRef
 %x St_Text
 %x St_SkipTitle
@@ -1139,6 +1141,25 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 <St_Ref>.              { // any other character
                          unput(*yytext);
                          return 0;
+                       }
+<St_IRef>{WS}*"\""     { // white space following by quoted string
+                         lineCount(yytext,yyleng);
+                         BEGIN(St_IRef2);
+                       }
+<St_IRef>.             { // any other character
+                         unput(*yytext);
+                         return 0;
+                       }
+<St_IRef2>"\\\""       { 
+                         yyextra->token->name += yytext;
+                       }
+<St_IRef2>"\""{WS}*"\""{WS}* { 
+                         lineCount(yytext,yyleng);
+                         BEGIN(St_Ref2);
+                         return TK_WORD;
+                       }
+<St_IRef2>.            { 
+                         yyextra->token->name += *yytext;
                        }
 <St_IntRef>[A-Z_a-z0-9.:/#\-\+\(\)]+ {
                          yyextra->token->name = yytext;
@@ -2003,6 +2024,14 @@ void DocTokenizer::setStateRef()
   yyscan_t yyscanner = p->yyscanner;
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   BEGIN(St_Ref);
+}
+
+void DocTokenizer::setStateIRef()
+{
+  yyscan_t yyscanner = p->yyscanner;
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->token->name = "";
+  BEGIN(St_IRef);
 }
 
 void DocTokenizer::setStateInternalRef()

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1395,7 +1395,7 @@ int Markdown::processLink(const char *data,int offset,int size)
     {
       if (lp==-1) // link to markdown page
       {
-        m_out.addStr("@ref ");
+        m_out.addStr("@iref ");
         if (!(Portable::isAbsolutePath(link) || isURL(link)))
         {
           FileInfo forg(link.str());
@@ -1415,7 +1415,7 @@ int Markdown::processLink(const char *data,int offset,int size)
           }
         }
       }
-      m_out.addStr(link);
+      m_out.addStr(link.quoted(true));
       m_out.addStr(" \"");
       if (explicitTitle && !title.isEmpty())
       {

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -250,12 +250,22 @@ class QCString
 
     // Returns a quoted copy of this string, unless it is already quoted.
     // Note that trailing and leading whitespace is removed.
-    QCString quoted() const
+    QCString quoted(const bool force = false) const
     {
       size_t start=0, sl=m_rep.size(), end=sl-1;
       while (start<sl  && qisspace(m_rep[start])) start++; // skip over leading whitespace
-      if (start==sl) return QCString(); // only whitespace
+      if (start==sl) return force ? QCString("\"\"") : QCString(); // only whitespace
       while (end>start && qisspace(m_rep[end]))   end--;   // skip over trailing whitespace
+      if (force)
+      {
+        QCString result1(m_rep.substr(start,1+end-start));
+        if (m_rep[start]!='"')
+        {
+          result1.prepend("\"");
+          result1.append("\"");
+        }
+        return result1;
+      }
       bool needsQuotes=false;
       size_t i=start;
       if (i<end && m_rep[i]!='"') // stripped string has at least non-whitespace unquoted character


### PR DESCRIPTION
Doxygen replaces the given path / filename with the full path and due the the spaces in the path this leads to "problems" during further processing. The problem does not only occur due to the "upstream" part but also to local path / filenames with spaces. By embedding the link name always in double quotes (`"`) the problem can be overcome when the double quotes are handled.

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10766441/example.tar.gz)
