### PR TITLE
Incorrect warning about not matching number of `#if` / `#endif`

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2311,7 +2311,7 @@ static bool replaceFunctionMacro(yyscan_t yyscanner,const QCString &expr,QCStrin
   len=0;
   result.resize(0);
   int cc;
-  while ((cc=getCurrentChar(yyscanner,expr,rest,j))!=EOF && isspace(cc))
+  while ((cc=getCurrentChar(yyscanner,expr,rest,j))!=EOF && cc!='\n' && isspace(cc))
   {
     len++;
     getNextChar(yyscanner,expr,rest,j);


### PR DESCRIPTION
In case we have source code like:
```

#define STRESS_MEMRATE_READ(prefetch)  prefetch(3);

#define no_prefetch(arg2) aa

STRESS_MEMRATE_READ(no_prefetch)

#if defined(HAVE_BUILTIN_PREFETCH)
#endif
int after;
```
we get the, incorrect, warning like:
```
aa.c:7: warning: More #endif's than #if's found.
```
looking at the preprocessor output we see:
```
00001
00002 #define STRESS_MEMRATE_READ(prefetch)
00003
00004 #define no_prefetch(arg2)
00005
00006  aa; #if defined(HAVE_BUILTIN_PREFETCH)
00007
00008 int after;
00009
```
Note the `#if` that remains.
The problem has been introduced between versions 1.6.1 and 1.6.2 where in the function `replaceFunctionMacro` a switch was made from:
```
while ((cc=getCurrentChar(expr,rest,j))!=EOF && cc==' ')
```
to
```
while ((cc=getCurrentChar(expr,rest,j))!=EOF && isspace(cc))
```

Problem was found by Fossies for the package stress-ng.

Example (including original source file): [example.tar.gz](https://github.com/doxygen/doxygen/files/10776702/example.tar.gz)
