### PR TITLE
issue #6737 `*/` inside code block

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4751,6 +4751,7 @@ NONLopt [^\n]*
                                           yyextra->fullArgString+=yytext;
                                           if (&yytext[4]==yyextra->docBlockName)
                                           {
+                                            yyextra->docBlockName="";
                                             BEGIN(CopyArgCommentLine);
                                           }
                                         }
@@ -4758,6 +4759,7 @@ NONLopt [^\n]*
                                           yyextra->fullArgString+=yytext;
 					  if (yyextra->docBlockName==&yytext[1])
                                           {
+                                            yyextra->docBlockName="";
                                             BEGIN(CopyArgCommentLine);
                                           }
                                         }
@@ -6860,6 +6862,7 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                           if (yyextra->docBlockName=="<pre>")
                                           {
+                                            yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
                                         }
@@ -6867,6 +6870,7 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                           if (yyextra->docBlockName=="<code>")
                                           {
+                                            yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
                                         }
@@ -6874,6 +6878,7 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                           if (yyextra->docBlockName==&yytext[1])
                                           {
+                                            yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
                                         }
@@ -6881,6 +6886,7 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                           if (&yytext[4]==yyextra->docBlockName)
                                           {
+                                            yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
                                         }
@@ -6959,14 +6965,17 @@ NONLopt [^\n]*
 <DocCopyBlock>[^\<@/\*\]~\$\\\n]+       { // any character that is not special
                                           yyextra->docBlock << yytext;
                                         }
-<DocCopyBlock>{CCS}|{CCE}|{CPPC}           {
-                                          if (yytext[1]=='*')
+<DocCopyBlock>{CCS}|{CCE}|{CPPC}        {
+                                          if (!((yyextra->docBlockName=="code") || (yyextra->docBlockName=="iliteral")))
                                           {
-                                            yyextra->nestedComment=TRUE;
-                                          }
-                                          else if (yytext[0]=='*')
-                                          {
-                                            yyextra->nestedComment=FALSE;
+                                            if (yytext[1]=='*')
+                                            {
+                                              yyextra->nestedComment=true;
+                                            }
+                                            else if (yytext[0]=='*')
+                                            {
+                                              yyextra->nestedComment=false;
+                                            }
                                           }
                                           yyextra->docBlock << yytext;
                                         }


### PR DESCRIPTION
The warning regarding the nested comment block was already removed, though the `*` in the second and further lines in the block remained (also the one in front of the `end` command was still present small example:
```
 * @code
 * root_group->remove("*/stepper_motor/*");
 * root_group->remove("*/stepper_motor/*");
 * @endcode
```

![image](https://user-images.githubusercontent.com/5223533/220371757-3894fcb3-3225-4282-93d4-5acc07a8bd79.png)


- removed the `*`
- reset the block name when reaching the `end` command.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10794382/example.tar.gz)
