### PR TITLE
Documentation `\ianchor` correction

### DIFF
--- a/doc_internal/commands_internal.md
+++ b/doc_internal/commands_internal.md
@@ -21,7 +21,7 @@ and the version in which they were introduced.
 
   \addindex \\ianchor
   This command has a similar syntax and function as the command `\anchor`, but is internally used
-  for @page command in markdown files. Unlike `\anchor` it has an additional 'title' option that
+  for the `@page` command in markdown files. Unlike `\anchor` it has an additional `title` option that
   is used as the link text in references to the page.
 
 \since doxygen version 1.9.7


### PR DESCRIPTION
the `@page` command should be in backticks as:
- otherwise it is seen as a doxygen command and generates a separate page
- consistency with other references to commands (the used font)