### PR TITLE
Improvement of position of open / closed folder icon

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -897,7 +897,6 @@ div.directory {
     height: 18px;
     margin-bottom: 4px;
     background-image:url('folderopen.png');
-    background-position: 0px -4px;
     background-repeat: repeat-y;
     vertical-align:top;
     display: inline-block;
@@ -908,7 +907,6 @@ div.directory {
     height: 18px;
     margin-bottom: 4px;
     background-image:url('folderclosed.png');
-    background-position: 0px -4px;
     background-repeat: repeat-y;
     vertical-align:top;
     display: inline-block;


### PR DESCRIPTION
Small improvement in the positioning of the open / closed folder icon

Old:

![image](https://user-images.githubusercontent.com/5223533/220940751-cb5e06ca-943a-4806-8631-8c184bcfb006.png)


New:

![image](https://user-images.githubusercontent.com/5223533/220940871-2f8fc392-927c-40b9-8bfc-8004194d9667.png)

Note the fact that the icons moved slightly down.