### PR TITLE
Compilation warning

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -287,7 +287,7 @@ QCString CitationManager::replaceFormulas(const QCString &s)
   {
     t += s.mid(pos,i-pos);
     int markerSize = static_cast<int>( g_formulaMarker.length());
-    size_t markerId = atoi(s.mid(i+markerSize,6).data());
+    int markerId = atoi(s.mid(i+markerSize,6).data());
     auto it = p->formulaCite.find(markerId);
     if (it != p->formulaCite.end()) t += it->second;
     pos = i + markerSize+6;

--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -286,7 +286,7 @@ QCString CitationManager::replaceFormulas(const QCString &s)
   while ((i=s.find(g_formulaMarker.c_str(),pos))!=-1)
   {
     t += s.mid(pos,i-pos);
-    size_t markerSize = g_formulaMarker.length();
+    int markerSize = static_cast<int>( g_formulaMarker.length());
     size_t markerId = atoi(s.mid(i+markerSize,6).data());
     auto it = p->formulaCite.find(markerId);
     if (it != p->formulaCite.end()) t += it->second;

--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -281,8 +281,8 @@ QCString CitationManager::replaceFormulas(const QCString &s)
 {
   if (s.isEmpty()) return s;
   QCString t;
-  size_t pos=0;
-  size_t i;
+  int pos=0;
+  int i;
   while ((i=s.find(g_formulaMarker.c_str(),pos))!=-1)
   {
     t += s.mid(pos,i-pos);


### PR DESCRIPTION
Compilation gives the warning:
```
.../src/cite.cpp:286:49:
warning: comparison of integer expressions of different signedness:
‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
    while ((i=s.find(g_formulaMarker.c_str(),pos))!=-1)
```

this has been corrected.

(also reported by CGAL)