### PR TITLE
Compilation warnings in respect to sprintf

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -210,7 +210,8 @@ QCString CitationManager::getFormulas(const QCString &s)
   GrowBuf formulaBuf;
   bool insideFormula = false;
   int citeFormulaCnt = 1;
-  char tmp[30];
+  const size_t tmpLen = 30;
+  char tmp[tmpLen];
   const char *ps=s.data();
   char c;
   while ((c=*ps++))
@@ -233,7 +234,7 @@ QCString CitationManager::getFormulas(const QCString &s)
           formulaBuf.clear();
           break;
         case '$':
-          sprintf(tmp,"%s%06d",g_formulaMarker.c_str(),citeFormulaCnt);
+          qsnprintf(tmp,tmpLen,"%s%06d",g_formulaMarker.c_str(),citeFormulaCnt);
           formulaBuf.addChar(0);
           p->formulaCite.emplace(citeFormulaCnt,std::string("\\f$") + formulaBuf.get() + "\\f$");
           citeFormulaCnt++;

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3731,14 +3731,14 @@ static inline void addOutput(yyscan_t yyscanner,char c)
 static void addIline(yyscan_t yyscanner,int lineNr)
 {
   char cmd[20];
-  sprintf(cmd,"\\iline %d ",lineNr);
+  qsnprintf(cmd,20,"\\iline %d ",lineNr);
   addOutput(yyscanner, cmd);
 }
 
 static void addIlineBreak(yyscan_t yyscanner,int lineNr)
 {
   char cmd[30];
-  sprintf(cmd,"\\iline %d \\ilinebr ",lineNr);
+  qsnprintf(cmd,30,"\\iline %d \\ilinebr ",lineNr);
   addOutput(yyscanner, cmd);
 }
 
@@ -3863,7 +3863,7 @@ bool CommentScanner::parseCommentBlock(/* in */     OutlineParserInterface *pars
   if (!yyextra->current->inbodyDocs.isEmpty() && isInbody) // separate in body fragments
   {
     char cmd[30];
-    sprintf(cmd,"\n\n\\iline %d \\ilinebr ",lineNr);
+    qsnprintf(cmd,30,"\n\n\\iline %d \\ilinebr ",lineNr);
     yyextra->current->inbodyDocs+=cmd;
   }
 

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -1254,7 +1254,7 @@ int DocHtmlHeader::parse(DocNodeVariant *thisVariant)
           break;
         default:
 	  char tmp[20];
-	  sprintf(tmp,"<h%d>tag",m_level);
+	  qsnprintf(tmp,20,"<h%d>tag",m_level);
           parser()->errorHandleDefaultToken(thisVariant,tok,children(),tmp);
       }
     }

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -249,12 +249,13 @@ void FormulaManager::createLatexFile(const QCString &fileName,Format format,Mode
 static bool createDVIFile(const QCString &fileName)
 {
   QCString latexCmd = "latex";
-  char args[4096];
+  const size_t argsLen = 4096;
+  char args[argsLen];
   int rerunCount=1;
   while (rerunCount<8)
   {
     //printf("Running latex...\n");
-    sprintf(args,"-interaction=batchmode %s >%s",qPrint(fileName),Portable::devNull());
+    qsnprintf(args,argsLen,"-interaction=batchmode %s >%s",qPrint(fileName),Portable::devNull());
     if ((Portable::system(latexCmd,args)!=0) || (Portable::system(latexCmd,args)!=0))
     {
       err("Problems running latex. Check your installation or look "
@@ -275,10 +276,11 @@ static bool createDVIFile(const QCString &fileName)
 
 static bool createPostscriptFile(const QCString &fileName,const QCString &formBase,int pageIndex)
 {
-  char args[4096];
+  const size_t argsLen = 4096;
+  char args[argsLen];
   // run dvips to convert the page with number pageIndex to an
   // postscript file.
-  sprintf(args,"-q -D 600 -n 1 -p %d -o %s_tmp.ps %s.dvi",pageIndex,qPrint(formBase),qPrint(fileName));
+  qsnprintf(args,argsLen,"-q -D 600 -n 1 -p %d -o %s_tmp.ps %s.dvi",pageIndex,qPrint(formBase),qPrint(fileName));
   if (Portable::system("dvips",args)!=0)
   {
     err("Problems running dvips. Check your installation!\n");
@@ -289,9 +291,10 @@ static bool createPostscriptFile(const QCString &fileName,const QCString &formBa
 
 static bool createEPSbboxFile(const QCString &formBase)
 {
-  char args[4096];
+  const size_t argsLen = 4096;
+  char args[argsLen];
   // extract the bounding box for the postscript file
-  sprintf(args,"-q -dBATCH -dNOPAUSE -P- -dNOSAFER -sDEVICE=bbox %s_tmp.ps 2>%s_tmp.epsi",
+  qsnprintf(args,argsLen,"-q -dBATCH -dNOPAUSE -P- -dNOSAFER -sDEVICE=bbox %s_tmp.ps 2>%s_tmp.epsi",
       qPrint(formBase),qPrint(formBase));
   if (Portable::system(Portable::ghostScriptCommand(),args)!=0)
   {
@@ -354,9 +357,10 @@ static double updateFormulaSize(Formula *formula,int x1,int y1,int x2,int y2)
 
 static bool createCroppedPDF(const QCString &formBase,int x1,int y1,int x2,int y2)
 {
-  char args[4096];
+  const size_t argsLen = 4096;
+  char args[argsLen];
   // crop the image to its bounding box
-  sprintf(args,"-q -dBATCH -dNOPAUSE -P- -dNOSAFER -sDEVICE=pdfwrite"
+  qsnprintf(args,argsLen,"-q -dBATCH -dNOPAUSE -P- -dNOSAFER -sDEVICE=pdfwrite"
               " -o %s_tmp.pdf -c \"[/CropBox [%d %d %d %d] /PAGES pdfmark\" -f %s_tmp.ps",
       qPrint(formBase),x1,y1,x2,y2,qPrint(formBase));
   if (Portable::system(Portable::ghostScriptCommand(),args)!=0)
@@ -369,9 +373,10 @@ static bool createCroppedPDF(const QCString &formBase,int x1,int y1,int x2,int y
 
 static bool createCroppedEPS(const QCString &formBase)
 {
-  char args[4096];
+  const size_t argsLen = 4096;
+  char args[argsLen];
   // crop the image to its bounding box
-  sprintf(args,"-q -dBATCH -dNOPAUSE -P- -dNOSAFER -sDEVICE=eps2write"
+  qsnprintf(args,argsLen,"-q -dBATCH -dNOPAUSE -P- -dNOSAFER -sDEVICE=eps2write"
               " -o %s_tmp.eps -f %s_tmp.ps",qPrint(formBase),qPrint(formBase));
   if (Portable::system(Portable::ghostScriptCommand(),args)!=0)
   {
@@ -383,8 +388,9 @@ static bool createCroppedEPS(const QCString &formBase)
 
 static bool createSVGFromPDF(const QCString &formBase,const QCString &outFile)
 {
-  char args[4096];
-  sprintf(args,"%s_tmp.pdf %s",qPrint(formBase),qPrint(outFile));
+  const size_t argsLen = 4096;
+  char args[argsLen];
+  qsnprintf(args,argsLen,"%s_tmp.pdf %s",qPrint(formBase),qPrint(outFile));
   if (Portable::system("pdf2svg",args)!=0)
   {
     err("Problems running pdf2svg. Check your installation!\n");
@@ -395,7 +401,8 @@ static bool createSVGFromPDF(const QCString &formBase,const QCString &outFile)
 
 static bool createSVGFromPDFviaInkscape(const Dir &thisDir,const QCString &formBase,const QCString &outFile)
 {
-  char args[4096];
+  const size_t argsLen = 4096;
+  char args[argsLen];
   int inkscapeVersion = determineInkscapeVersion(thisDir);
   if (inkscapeVersion == -1)
   {
@@ -404,11 +411,11 @@ static bool createSVGFromPDFviaInkscape(const Dir &thisDir,const QCString &formB
   }
   else if (inkscapeVersion == 0)
   {
-    sprintf(args,"-l %s -z %s_tmp.pdf 2>%s",qPrint(outFile),qPrint(formBase),Portable::devNull());
+    qsnprintf(args,argsLen,"-l %s -z %s_tmp.pdf 2>%s",qPrint(outFile),qPrint(formBase),Portable::devNull());
   }
   else // inkscapeVersion >= 1
   {
-    sprintf(args,"--export-type=svg --export-filename=%s %s_tmp.pdf 2>%s",qPrint(outFile),qPrint(formBase),Portable::devNull());
+    qsnprintf(args,argsLen,"--export-type=svg --export-filename=%s %s_tmp.pdf 2>%s",qPrint(outFile),qPrint(formBase),Portable::devNull());
   }
   if (Portable::system("inkscape",args)!=0)
   {
@@ -459,8 +466,9 @@ static bool updateEPSBoundingBox(const QCString &formBase,
 
 static bool createPNG(const QCString &formBase,const QCString &outFile,double scaleFactor)
 {
-  char args[4096];
-  sprintf(args,"-q -dNOSAFER -dBATCH -dNOPAUSE -dEPSCrop -sDEVICE=pnggray -dGraphicsAlphaBits=4 -dTextAlphaBits=4 "
+  const size_t argsLen = 4096;
+  char args[argsLen];
+  qsnprintf(args,argsLen,"-q -dNOSAFER -dBATCH -dNOPAUSE -dEPSCrop -sDEVICE=pnggray -dGraphicsAlphaBits=4 -dTextAlphaBits=4 "
                "-r%d -sOutputFile=%s %s_tmp_corr.eps",static_cast<int>(scaleFactor*72),qPrint(outFile),qPrint(formBase));
   if (Portable::system(Portable::ghostScriptCommand(),args)!=0)
   {

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2173,7 +2173,7 @@ static void encodeForOutput(TextStream &t,const QCString &s)
     if (c>=0x80 || multiByte)
     {
       char esc[10];
-      sprintf(esc,"\\'%X",c);        // escape sequence for SBCS and DBCS(1st&2nd bytes).
+      qsnprintf(esc,10,"\\'%X",c);        // escape sequence for SBCS and DBCS(1st&2nd bytes).
       t << esc;
 
       if (!multiByte)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5737,12 +5737,13 @@ void stackTrace()
 #ifdef TRACINGSUPPORT
   void *backtraceFrames[128];
   int frameCount = backtrace(backtraceFrames, 128);
-  static char cmd[40960];
+  const size_t cmdLen = 40960;
+  static char cmd[cmdLen];
   char *p = cmd;
-  p += sprintf(p,"/usr/bin/atos -p %d ", (int)getpid());
+  p += qsnprintf(p,cmdLen,"/usr/bin/atos -p %d ", (int)getpid());
   for (int x = 0; x < frameCount; x++)
   {
-    p += sprintf(p,"%p ", backtraceFrames[x]);
+    p += qsnprintf(p,cmdLen,"%p ", backtraceFrames[x]);
   }
   fprintf(stderr,"========== STACKTRACE START ==============\n");
   if (FILE *fp = Portable::popen(cmd, "r"))

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -1102,7 +1102,7 @@ static int recordCounter=0;
 QCString VhdlDocGen::getRecordNumber()
 {
   char buf[12];
-  sprintf(buf,"%d",recordCounter++);
+  qsnprintf(buf,12,"%d",recordCounter++);
   QCString qcs(&buf[0]);
   return qcs;
 }
@@ -1114,9 +1114,9 @@ QCString VhdlDocGen::getRecordNumber()
 QCString VhdlDocGen::getProcessNumber()
 {
   static int stringCounter;
-  char buf[8];
   QCString qcs("PROCESS_");
-  sprintf(buf,"%d",stringCounter++);
+  char buf[8];
+  qsnprintf(buf,8,"%d",stringCounter++);
   qcs.append(&buf[0]);
   return qcs;
 }


### PR DESCRIPTION
Compilation under MacOS (through GitHub Actions) gives warnings like:
```
src/cite.cpp:236:11: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
          sprintf(tmp,"%s%06d",g_formulaMarker.c_str(),citeFormulaCnt);
```
to prevent this the calls to `sprintf` are replaced by an appropriate `qsnprintf`.