### PR TITLE
Issue #9883 Performance issues when HAVE_DOT is YES to make \dot work, and CLASS_GRAPH=GRAPH is also used

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -1666,7 +1666,7 @@ void ClassDefImpl::writeInheritanceGraph(OutputList &ol) const
       renderDiagram = TRUE;
     }
   }
-  else if ((classGraph==CLASS_GRAPH_t::YES || classGraph==CLASS_GRAPH_t::GRAPH) && count>0)
+  else if ((classGraph==CLASS_GRAPH_t::YES || classGraph==CLASS_GRAPH_t::GRAPH || classGraph==CLASS_GRAPH_t::INTERNAL_GRAPH) && count>0)
     // write class diagram using built-in generator
   {
     ClassDiagram diagram(this); // create a diagram of this class.

--- a/src/config.xml
+++ b/src/config.xml
@@ -3731,6 +3731,8 @@ to be found in the default search path.
  will generate a graph for each documented class showing the direct and
  indirect inheritance relations. In case \ref cfg_have_dot "HAVE_DOT" is set as well
  `dot` will be used to draw the graph, otherwise the built-in generator will be used.
+ The built-in generator will also be used in case \c CLASS_GRAPH is set to \c INTERNAL_GRAPH
+ irrespective of the setting of \ref cfg_have_dot "HAVE_DOT".
  If the \c CLASS_GRAPH tag is set to \c TEXT the direct and indirect inheritance relations
  will be shown as texts / links.
 ]]>
@@ -3739,6 +3741,7 @@ to be found in the default search path.
       <value name="YES" bool_representation="YES" />
       <value name="TEXT" bool_representation="YES" />
       <value name="GRAPH" bool_representation="YES" />
+      <value name="INTERNAL_GRAPH" bool_representation="YES" />
     </option>
     <option type='bool' id='COLLABORATION_GRAPH' defval='1' depends='HAVE_DOT'>
       <docs>

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1810,7 +1810,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
         DotClassGraphPtr cg = getClassGraph();
         result = !cg->isTrivial() && !cg->isTooBig();
       }
-      else if (classGraphEnabled)
+      else if (classGraphEnabled || classGraph==CLASS_GRAPH_t::INTERNAL_GRAPH)
       {
         result = numInheritanceNodes()>0;
       }
@@ -1853,7 +1853,7 @@ class ClassContext::Private : public DefinitionContext<ClassContext::Private>
         }
         g_globals.dynSectionId++;
       }
-      else if (classGraphEnabled)
+      else if (classGraphEnabled || classGraph==CLASS_GRAPH_t::INTERNAL_GRAPH)
       {
         ClassDiagram d(m_classDef);
         switch (g_globals.outputFormat)


### PR DESCRIPTION
Define `INTERNAL_GRAPH` for the setting `CLASS_GRAPH` which always generates the class graphs with the internal diagram generator irrespective of the setting of `HAVE_DOT`