### PR TITLE
Fix a pedantic warning

### DIFF
--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -140,7 +140,7 @@ namespace PortugueseTranslatorUtils
           return true;
       }
     }
-};
+}
 
 class TranslatorBrazilian : public Translator
 {


### PR DESCRIPTION
```
In file included from.../src/translator_pt.h:75,
                 from .../src/language.cpp:42:
.../src/translator_br.h:143:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
```