### PR TITLE
issue 9855 Markdown: Heading auto id starting with digit of minus sign

### DIFF
--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -84,6 +84,7 @@ std::string AnchorGenerator::generate(const std::string &label)
     }
     else
     {
+      if ((result[0] == '-') || (result[0]>='1' && result[0]<='9')) result = "autotoc_md" + result;
       int &count = p->idCount[result];
       // Add end digits if an identical header already exists
       if (count>0)

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1435,6 +1435,11 @@ int Markdown::processLink(const char *data,int offset,int size)
       if (link.at(0) == '#')
       {
         m_out.addStr("@ref \"");
+        if ((Config_getEnum(MARKDOWN_ID_STYLE) == MARKDOWN_ID_STYLE_t::GITHUB) &&
+            ((link.at(1) == '-') || (link.at(1)>='1' && link.at(1)<='9')))
+        {  
+          m_out.addStr("autotoc_md");
+        }
         m_out.addStr(link.mid(1));
         m_out.addStr("\" \"");
         m_out.addStr(substitute(content.simplifyWhiteSpace(),"\"","&quot;"));


### PR DESCRIPTION
Based on the comment https://github.com/doxygen/doxygen/pull/9858#issuecomment-1447835301:
```
    take the # page / section / ... lines and translate (as done now under MARKDOWN_ID_STYLE=GITHUB) to a label. In case the resulting label starts with a digit or a - sign the generated label should be prepended by a reserved word (like autotoc_md).

    take the lines like [...](...) (as this is how GitHub refers to sections etc. where the part between ( and )is taken and when it starts with a # it is stripped away (might be more than one, I saw it once so far but I think this is actually a typo in the code but it works) and when the remaining string (i.e. the label) starts with a digit or a - sign the label should be prepended by the reserved word
```

this feature has been implemented.


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10859639/example.tar.gz)
