### PR TITLE
Text on start line of fenced code block should not be ignored.

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2094,7 +2094,9 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
   } // not enough tildes
   if (i<size && data[i]=='{') i++; // skip over optional {
   int startLang=i;
-  if (data[i] != ' ')
+  lang = "";
+  char c = data[i];
+  if (c == '{' || (c>='A' && c<='Z') || (c>='a' && c<='z'))
   {
     while (i<size && (data[i]!='\n' && data[i]!='}' && data[i]!=' ')) i++;
     convertStringFragment(lang,data+startLang,i-startLang);
@@ -2109,7 +2111,6 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
       int endTildes=0;
       while (i<size && data[i]==tildaChar) endTildes++,i++;
       while (i<size && data[i]==' ') i++;
-      if (i==size || data[i]=='\n')
       {
         if (endTildes==startTildes)
         {
@@ -2776,8 +2777,9 @@ void Markdown::writeFencedCodeBlock(const char *data,const char *lng,
   {
     m_out.addStr("{"+lang+"}");
   }
+  m_out.addStr(" ");
   addStrEscapeUtf8Nbsp(data+blockStart,blockEnd-blockStart);
-  m_out.addStr("@endicode");
+  m_out.addStr("@endicode ");
 }
 
 QCString Markdown::processQuotations(const QCString &s,int refIndent)

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2094,9 +2094,12 @@ static bool isFencedCodeBlock(const char *data,int size,int refIndent,
   } // not enough tildes
   if (i<size && data[i]=='{') i++; // skip over optional {
   int startLang=i;
-  while (i<size && (data[i]!='\n' && data[i]!='}' && data[i]!=' ')) i++;
-  convertStringFragment(lang,data+startLang,i-startLang);
-  while (i<size && data[i]!='\n') i++; // proceed to the end of the line
+  if (data[i] != ' ')
+  {
+    while (i<size && (data[i]!='\n' && data[i]!='}' && data[i]!=' ')) i++;
+    convertStringFragment(lang,data+startLang,i-startLang);
+    if (data[i] == '}')i++;
+  }
   start=i;
   while (i<size)
   {


### PR DESCRIPTION
When having code like:
~~~
# Releasing PyTorch

  - [Cutting release branches](#cutting-release-branches)

``` python github_analyze.py --repo-path ~/local/pytorch --remote upstream  --branch release/1.11 --milestone-id 26 --missing-in-branch ```

## Cutting release branches

```bash
git clone git@github.com:pytorch/pytorch.git
```
~~~

and setting:
```
MARKDOWN_ID_STYLE = GITHUB
```

we get a warning like:
```
RELEASE.md:3: warning: unable to resolve reference to 'cutting-release-branches' for \ref command
```

This is due to the fact that the parts after the first ` ``` ` is ignored
- in case a space follows the ` ``` ` it should be considered as a fenced comment block without language specifier
- the rest of the line should not be ignored (as this would automatically mean the the closing ` ``` ` isn't seen.
- closing `}` should be skipped from output.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10872063/example.tar.gz)

(Found by Fossies for pytorch package)
