### PR TITLE
issue #9899 Error on commenting function parameters

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3694,7 +3694,7 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
       {
         QCString docsWithoutDir = a.docs;
         QCString direction = extractDirection(docsWithoutDir);
-        paramDocs+="@param"+direction+" "+a.name+" "+docsWithoutDir;
+        paramDocs+=" \\ilinebr @param"+direction+" "+a.name+" "+docsWithoutDir;
       }
     }
     // feed the result to the documentation parser


### PR DESCRIPTION
The `@param` should not be appended directly after the already present information but there should be a, non-counting, linebreak in between