### PR TITLE
Fix a warning in dotgroupcollaboration.cpp

### DIFF
--- a/src/dotgroupcollaboration.cpp
+++ b/src/dotgroupcollaboration.cpp
@@ -53,7 +53,7 @@ static void makeURL(const Definition *def,QCString &url)
   {
     url+="#"+def->anchor();
   }
-};
+}
 
 void DotGroupCollaboration::buildGraph(const GroupDef* gd)
 {


### PR DESCRIPTION
Fix a warning:
```
doxygen_master/src/dotgroupcollaboration.cpp:56:2: warning: extra ‘;’ [-Wpedantic]
```