### PR TITLE
Don't show `__pad*__` for unnamed bitfields

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2290,7 +2290,8 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
   }
 
   // *** write name
-  if (!isAnonymous()) // hide anonymous stuff
+  if (!(isAnonymous() || // hide anonymous stuff
+       (!m_impl->bitfields.isEmpty() && name().startsWith("__pad")))) // anonymous bitfield
   {
     bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
     bool extractStatic  = Config_getBool(EXTRACT_STATIC);
@@ -3925,6 +3926,7 @@ void MemberDefImpl::warnIfUndocumented() const
   if ((!hasUserDocumentation() && !extractAll) &&
       !isFriendClass() &&
       name().find('@')==-1 && d && d->name().find('@')==-1 &&
+      !(!m_impl->bitfields.isEmpty() && name().startsWith("__pad")) && // anonymous bitfield
       protectionLevelVisible(m_impl->prot) &&
       !isReference() && !isDeleted()
      )


### PR DESCRIPTION
Based on the stack overflow question:https://stackoverflow.com/questions/75658310/doxygen-unnamed-bitfields remove the warning and the `__pad*__` in the structure definition.

the example:
```
/** @brief Struct to document */
struct mystruct {
    /** @brief Member to document */
    U32 FlagA : 1;
    U32 : 31;
};
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10942646/example.tar.gz)
