### PR TITLE
Issue #7386 Method parameters documented inline are not present in documentation when using `@copydoc`

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1831,6 +1831,14 @@ QCString DocParser::processCopyDoc(const char *data,uint32_t &len)
               buf.addStr("\\iline "+QCString().setNum(def->docLine())+" ");
               uint32_t l=static_cast<uint32_t>(doc.length());
               buf.addStr(processCopyDoc(doc.data(),l));
+              if (def->definitionType() == Definition::TypeMember)
+              {
+                const MemberDef *md = static_cast<const MemberDef *>(def);
+                const ArgumentList &docArgList = md->templateMaster() ?
+                                   md->templateMaster()->argumentList() :
+                                   md->argumentList();
+                buf.addStr(inlineArgListToDoc(docArgList));
+              }
             }
             context.copyStack.pop_back();
             buf.addStr(" \\ilinebr\\ifile \""+context.fileName+"\" ");

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3691,30 +3691,15 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
   const ArgumentList &docArgList = m_impl->templateMaster ?
                                    m_impl->templateMaster->argumentList() :
                                    m_impl->defArgList;
-  if (docArgList.hasDocumentation())
-  {
-    QCString paramDocs;
-    for (const Argument &a : docArgList)
-    {
-      if (a.hasDocumentation())
-      {
-        QCString docsWithoutDir = a.docs;
-        QCString direction = extractDirection(docsWithoutDir);
-        paramDocs+="@param"+direction+" "+a.name+" "+docsWithoutDir;
-      }
-    }
-    // feed the result to the documentation parser
-    ol.generateDoc(
+  ol.generateDoc(
         docFile(),docLine(),
         scopedContainer,
         this,         // memberDef
-        paramDocs,    // docStr
+        inlineArgListToDoc(docArgList),    // docStr
         TRUE,         // indexWords
         FALSE,        // isExample
         QCString(),FALSE,FALSE,Config_getBool(MARKDOWN_SUPPORT)
         );
-
-  }
 
   _writeEnumValues(ol,scopedContainer,cfname,ciname,cname);
   _writeReimplements(ol);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1143,6 +1143,24 @@ void writeExamples(OutputList &ol,const ExampleList &list)
 }
 
 
+QCString inlineArgListToDoc(const ArgumentList &al)
+{
+  QCString paramDocs;
+  if (al.hasDocumentation())
+  {
+    for (const Argument &a : al)
+    {
+      if (a.hasDocumentation())
+      {
+        QCString docsWithoutDir = a.docs;
+        QCString direction = extractDirection(docsWithoutDir);
+        paramDocs+=" \\ilinebr @param"+direction+" "+a.name+" "+docsWithoutDir;
+      }
+    }
+  }
+  return paramDocs;
+}
+
 QCString argListToString(const ArgumentList &al,bool useCanonicalType,bool showDefVals)
 {
   QCString result;

--- a/src/util.h
+++ b/src/util.h
@@ -196,6 +196,8 @@ inline bool isIdJS(int c)
 
 QCString removeRedundantWhiteSpace(const QCString &s);
 
+QCString inlineArgListToDoc(const ArgumentList &al);
+
 QCString argListToString(const ArgumentList &al,bool useCanonicalType=FALSE,bool showDefVals=TRUE);
 
 QCString tempArgListToString(const ArgumentList &al,SrcLangExt lang,bool includeDefaults=true);


### PR DESCRIPTION
Adding the inline conversion also in case of `\copydoc` / `\copydetails`