### PR TITLE
The CDATA sections in xml code representation should not be interpreted

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1028,6 +1028,7 @@ class DoxHighlightClass(str, Enum):
     KEYWORDTYPE='keywordtype'
     KEYWORDFLOW='keywordflow'
     STRINGLITERAL='stringliteral'
+    XMLCDATA='xmlcdata'
     CHARLITERAL='charliteral'
     VHDLKEYWORD='vhdlkeyword'
     VHDLLOGIC='vhdllogic'
@@ -7493,7 +7494,7 @@ class highlightType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['comment', 'normal', 'preprocessor', 'keyword', 'keywordtype', 'keywordflow', 'stringliteral', 'charliteral', 'vhdlkeyword', 'vhdllogic', 'vhdlchar', 'vhdldigit']
+            enumerations = ['comment', 'normal', 'preprocessor', 'keyword', 'keywordtype', 'keywordflow', 'stringliteral', 'xmlcdata', 'charliteral', 'vhdlkeyword', 'vhdllogic', 'vhdlchar', 'vhdldigit']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxHighlightClass' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -121,6 +121,7 @@ namechar    [:A-Za-z\200-\377_0-9.-]
 esc         "&#"[0-9]+";"|"&#x"[0-9a-fA-F]+";"
 name        {namestart}{namechar}*
 comment     {open}"!--"([^-]|"-"[^-])*"--"{close}
+cdata       {open}"![CDATA["([^\]]|"\]"[^\]])*"]]"{close}
 data        "random string"
 string      \"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
 
@@ -151,6 +152,11 @@ string      \"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
                     }
 <INITIAL>{string}   {
                         startFontClass(yyscanner,"stringliteral");
+                        codifyLines(yyscanner,yytext);
+                        endFontClass(yyscanner);
+                    }
+{cdata}             {
+                        startFontClass(yyscanner,"xmlcdata");
                         codifyLines(yyscanner,yytext);
                         endFontClass(yyscanner);
                     }

--- a/templates/html/darkmode_settings.css
+++ b/templates/html/darkmode_settings.css
@@ -122,6 +122,7 @@
 --code-preprocessor-color: #65CABE;
 --code-string-literal-color: #7EC699;
 --code-char-literal-color: #00E0F0;
+--code-xml-cdata-color: #C9D1D9;
 --code-vhdl-digit-color: #FF00FF;
 --code-vhdl-char-color: #000000;
 --code-vhdl-keyword-color: #700070;

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -482,6 +482,10 @@ span.charliteral {
 	color: var(--code-char-literal-color);
 }
 
+span.xmlcdata {
+	color: var(--code-xml-cdata-color);
+}
+
 span.vhdldigit { 
 	color: var(--code-vhdl-digit-color);
 }

--- a/templates/html/lightmode_settings.css
+++ b/templates/html/lightmode_settings.css
@@ -122,6 +122,7 @@
 --code-preprocessor-color: #806020;
 --code-string-literal-color: #002080;
 --code-char-literal-color: #008080;
+--code-xml-cdata-color: black;
 --code-vhdl-digit-color: #FF00FF;
 --code-vhdl-char-color: #000000;
 --code-vhdl-keyword-color: #700070;

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -568,6 +568,7 @@
 \definecolor{preprocessor}{rgb}{0.5,0.38,0.125}
 \definecolor{stringliteral}{rgb}{0.0,0.125,0.25}
 \definecolor{charliteral}{rgb}{0.0,0.5,0.5}
+\definecolor{xmlcdata}{rgb}{0.0,0.0,0.0}
 \definecolor{vhdldigit}{rgb}{1.0,0.0,1.0}
 \definecolor{vhdlkeyword}{rgb}{0.43,0.0,0.43}
 \definecolor{vhdllogic}{rgb}{1.0,0.0,0.0}

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -952,6 +952,7 @@
       <xsd:enumeration value="keywordtype" />
       <xsd:enumeration value="keywordflow" />
       <xsd:enumeration value="stringliteral" />
+      <xsd:enumeration value="xmlcdata" />
       <xsd:enumeration value="charliteral" />
       <xsd:enumeration value="vhdlkeyword" />
       <xsd:enumeration value="vhdllogic" />


### PR DESCRIPTION
The CDATA sections in xml code representation should not be interpreted, but just literally be shown.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/10950785/example.tar.gz)
