### PR TITLE
doxygen should use grep -E instead obsolescent egrep.

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -377,7 +377,7 @@ static void writeLatexMakefile()
     t << "\techo \"Rerunning latex....\"\n"
       << "\t$(LATEX_CMD) $(MANUAL_FILE).tex\n"
       << "\tlatex_count=$(LATEX_COUNT) ; \\\n"
-      << "\twhile egrep -s 'Rerun (LaTeX|to get cross-references right|to get bibliographical references right)' $(MANUAL_FILE).log && [ $$latex_count -gt 0 ] ;\\\n"
+      << "\twhile grep -E -s 'Rerun (LaTeX|to get cross-references right|to get bibliographical references right)' $(MANUAL_FILE).log && [ $$latex_count -gt 0 ] ;\\\n"
       << "\t    do \\\n"
       << "\t      echo \"Rerunning latex....\" ;\\\n"
       << "\t      $(LATEX_CMD) $(MANUAL_FILE).tex ; \\\n"
@@ -405,7 +405,7 @@ static void writeLatexMakefile()
     }
     t << "\t$(LATEX_CMD) $(MANUAL_FILE)\n"
       << "\tlatex_count=$(LATEX_COUNT) ; \\\n"
-      << "\twhile egrep -s 'Rerun (LaTeX|to get cross-references right|to get bibliographical references right)' $(MANUAL_FILE).log && [ $$latex_count -gt 0 ] ;\\\n"
+      << "\twhile grep -E -s 'Rerun (LaTeX|to get cross-references right|to get bibliographical references right)' $(MANUAL_FILE).log && [ $$latex_count -gt 0 ] ;\\\n"
       << "\t    do \\\n"
       << "\t      echo \"Rerunning latex....\" ;\\\n"
       << "\t      $(LATEX_CMD) $(MANUAL_FILE) ;\\\n"

--- a/templates/latex/latexmakefile.tpl
+++ b/templates/latex/latexmakefile.tpl
@@ -9,7 +9,7 @@ refman.pdf: clean refman.tex
 {# TODO: generateBib #}
 	pdflatex refman
 	latex_count=8 ; \
-	while egrep -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$latex_count -gt 0 ] ;\
+	while grep -E -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$latex_count -gt 0 ] ;\
 	    do \
 	      echo "Rerunning latex...." ;\
 	      pdflatex refman ;\
@@ -43,7 +43,7 @@ refman.dvi: clean refman.tex doxygen.sty
 	echo "Rerunning latex...."
 	{{ config.LATEX_CMD_NAME }} refman.tex
 	latex_count=8 ; \
-	while egrep -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$latex_count -gt 0 ] ;\
+	while grep -E -s 'Rerun (LaTeX|to get cross-references right)' refman.log && [ $$latex_count -gt 0 ] ;\
 	    do \
 	      echo "Rerunning latex...." ;\
 	      {{ config.LATEX_CMD_NAME }} refman.tex ;\


### PR DESCRIPTION
Steps to reproduce on fedora:
1. run doxygen on a Doxyfile
2. the Makefile it generates refers to egrep

Actual results:
running the Makefile emits a warning that egrep is obsolescent

More details on GNU Grep 3.8 via release announcement. https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html