### PR TITLE
Limit index fields in hhk file of chm file.

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -212,6 +212,14 @@ static QCString field2URL(const IndexField *f,bool checkReversed)
  */
 void HtmlHelpIndex::writeFields(std::ostream &t)
 {
+  /* to prevent 
+   *  Warning: Keyword string:
+   *    ...
+   *  is too long.  The maximum size is 488 characters.
+   */
+  size_t maxLen = 400;
+  QCString contStr = "...";
+
   std::sort(std::begin(m_map),
             std::end(m_map),
             [](const auto &e1,const auto &e2) { return e1->name < e2->name; }
@@ -265,7 +273,7 @@ void HtmlHelpIndex::writeFields(std::ostream &t)
         t << "  <LI><OBJECT type=\"text/sitemap\">";
         t << "<param name=\"Local\" value=\"" << field2URL(f.get(),FALSE);
         t << "\">";
-        t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">"
+        t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE,maxLen,contStr) << "\">"
            "</OBJECT>\n";
       }
       else
@@ -275,14 +283,14 @@ void HtmlHelpIndex::writeFields(std::ostream &t)
           t << "  <LI><OBJECT type=\"text/sitemap\">";
           t << "<param name=\"Local\" value=\"" << field2URL(f.get(),TRUE);
           t << "\">";
-          t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">"
+          t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE,maxLen,contStr) << "\">"
                "</OBJECT>\n";
         }
         else
         {
           t << "  <LI><OBJECT type=\"text/sitemap\">";
           t << "<param name=\"See Also\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">";
-          t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE) << "\">"
+          t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level1),TRUE,maxLen,contStr) << "\">"
                "</OBJECT>\n";
         }
       }
@@ -302,7 +310,7 @@ void HtmlHelpIndex::writeFields(std::ostream &t)
       t << "    <LI><OBJECT type=\"text/sitemap\">";
       t << "<param name=\"Local\" value=\"" << field2URL(f.get(),FALSE);
       t << "\">";
-      t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level2),TRUE) << "\">"
+      t << "<param name=\"Name\" value=\"" << convertToHtml(m_recoder.recode(level2),TRUE,maxLen,contStr) << "\">"
          "</OBJECT>\n";
     }
   }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4097,7 +4097,7 @@ QCString convertToXML(const QCString &s, bool keepEntities)
 }
 
 /*! Converts a string to a HTML-encoded string */
-QCString convertToHtml(const QCString &s,bool keepEntities)
+QCString convertToHtml(const QCString &s,bool keepEntities, size_t maxLen, QCString contStr)
 {
   if (s.isEmpty()) return s;
   GrowBuf growBuf;
@@ -4151,6 +4151,11 @@ QCString convertToHtml(const QCString &s,bool keepEntities)
           }
         }
         break;
+    }
+    if (maxLen != 0 && growBuf.getPos() >= maxLen)
+    {
+      growBuf.addStr(contStr);
+      break;
     }
   }
   growBuf.addChar(0);

--- a/src/util.h
+++ b/src/util.h
@@ -248,7 +248,7 @@ QCString stripScope(const QCString &name);
 QCString convertToId(const QCString &s);
 QCString correctId(const QCString &s);
 
-QCString convertToHtml(const QCString &s,bool keepEntities=TRUE);
+QCString convertToHtml(const QCString &s,bool keepEntities=TRUE,size_t maxLen = 0, QCString contStr = QCString());
 
 QCString convertToXML(const QCString &s, bool keepEntities=FALSE);
 


### PR DESCRIPTION
Based on some comments in #9894 where a warning was shown like
```
Warning: Keyword string:
...
is too long.  The maximum size is 488 characters.
```
tit was found that this was due to an extremely long `value` field in the `index.hhk` (index file), limiting this field and placing an ellipse when necessary