### PR TITLE
Hyperlinks in help information of doxywizard

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -485,6 +485,8 @@ static QString getDocsForNode(const QDomElement &child)
   docs.replace(SA("\\>"),SA("&gt;"));
   regexp.setPattern(SA(" (http:[^ \\)]*)([ \\)])"));
   docs.replace(regexp,SA(" <a href=\"\\1\">\\1</a>\\2"));
+  regexp.setPattern(SA(" (https:[^ \\)]*)([ \\)])"));
+  docs.replace(regexp,SA(" <a href=\"\\1\">\\1</a>\\2"));
   // LaTeX name as formula -> LaTeX
   regexp.setPattern(SA("\\\\f\\$\\\\mbox\\{\\\\LaTeX\\}\\\\f\\$"));
   docs.replace(regexp,SA("LaTeX"));


### PR DESCRIPTION
The hyperlinks starting with "https:"  were not hyperlinked in the help information of the settings in the doxywizard (see e.g. `DOXYFILE_ENCODING`