### PR TITLE
fix negative return value of getFragmentLocation()

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -747,13 +747,16 @@ class FilterCache
     }
 
     //! Returns the byte offset and size within a file of a fragment given the array of
-    //! line offsets and the start emd end line of the fragment.
+    //! line offsets and the start and end line of the fragment.
     auto getFragmentLocation(const LineOffsets &lineOffsets,
                              size_t startLine,size_t endLine) -> std::tuple<size_t,size_t>
     {
-      size_t startLineOffset = lineOffsets[std::min(startLine-1,lineOffsets.size()-1)];
-      size_t endLineOffset   = lineOffsets[std::min(endLine,    lineOffsets.size()-1)];
-      size_t fragmentSize = endLineOffset-startLineOffset;
+      if (startLine > 0) { --startLine; }
+      assert(startLine <= endLine);
+      const size_t startLineOffset = lineOffsets[std::min(startLine,lineOffsets.size()-1)];
+      const size_t endLineOffset   = lineOffsets[std::min(endLine,  lineOffsets.size()-1)];
+      assert(startLineOffset <= endLineOffset);
+      const size_t fragmentSize = endLineOffset-startLineOffset;
       return std::tie(startLineOffset,fragmentSize);
     };
 


### PR DESCRIPTION
Fix the array lookup in the getFragmentLocation() function to not use a -1 value. This would cause a negative value to be set in the tuple returned by getFragmentLocation(), but since the tuple uses the unsigned size_t data type, this would be casted to an unreasonable large positive integer value, which causes a realloc() to fail and return NULL.

The crash backtrace looks like:
```
#0  __memset_avx2_erms () at ../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:145
#1  0x00005555557f5f34 in BufStr::resize (this=0x7fffffffc550, newlen=18446744073709542287) at /tmp/doxygen/src/bufstr.h:73
#2  0x00005555560d186f in FilterCache::shrinkBuffer (this=0x5555572e3980 <FilterCache::instance()::theInstance>, str=...,
    fileName=..., startLine=0, endLine=4) at /tmp/doxygen/src/definition.cpp:773
#3  0x00005555560d1266 in FilterCache::getFileContentsDisk (this=0x5555572e3980 <FilterCache::instance()::theInstance>,
    fileName=..., startLine=0, endLine=4, str=...) at /tmp/doxygen/src/definition.cpp:721
#4  0x00005555560d0824 in FilterCache::getFileContents (this=0x5555572e3980 <FilterCache::instance()::theInstance>,
    fileName=..., startLine=0, endLine=4, str=...) at /tmp/doxygen/src/definition.cpp:621
#5  0x00005555560c389d in readCodeFragment (fileName=..., startLine=@0x7fffffffd650: 0, endLine=@0x7fffffffd654: 4, result=...)
    at /tmp/doxygen/src/definition.cpp:828
#6  0x00005555560c4c42 in DefinitionImpl::writeInlineCode (this=0x555624669360, ol=..., scopeName=...)
    at /tmp/doxygen/src/definition.cpp:1065
#7  0x0000555555c128f7 in DefinitionMixin<MemberDefMutable>::writeInlineCode (this=0x555624669350, ol=..., scopeName=...)
    at /tmp/doxygen/src/definitionimpl.h:247
#8  0x0000555555bf008e in MemberDefImpl::writeDocumentation (this=0x555624669350, ml=0x555624667340, memCount=1, memTotal=1,
    ol=..., scName=..., container=0x5555585d6e68, inGroup=false, showInline=false) at /tmp/doxygen/src/memberdef.cpp:3726
#9  0x0000555555c29a7e in MemberList::writeDocumentation (this=0x555624667340, ol=..., scopeName=..., container=0x5555585d6e68,
    title=..., showEnumValues=false, showInline=false) at /tmp/doxygen/src/memberlist.cpp:679
#10 0x00005555558f38c8 in FileDefImpl::writeMemberDocumentation (this=0x5555585d6e60, ol=..., lt=MemberListType_docFuncMembers,
    title=...) at /tmp/doxygen/src/filedef.cpp:1652
#11 0x00005555558eeb00 in FileDefImpl::writeDocumentation (this=0x5555585d6e60, ol=...) at /tmp/doxygen/src/filedef.cpp:927
#12 0x00005555557a71e7 in generateFileDocs () at /tmp/doxygen/src/doxygen.cpp:8046
#13 0x00005555557c0710 in generateOutput () at /tmp/doxygen/src/doxygen.cpp:12416
#14 0x000055555576eb53 in main (argc=2, argv=0x7fffffffe2e8) at /tmp/doxygen/src/main.cpp:38
```
the "newlen" parameter for the BufStr::resize() function has an unreasonable large size, which caused the realloc() to return NULL.
```
(gdb) fr 1
#1  0x00005555557f5f34 in BufStr::resize (this=0x7fffffffc550, newlen=18446744073709542287) at /tmp/doxygen/src/bufstr.h:73
73	        memset(m_buf+oldsize,0,m_size-oldsize);
(gdb) list
68	        m_size=m_writeOffset+m_spareRoom;
69	      }
70	      m_buf = static_cast<char *>(realloc(m_buf,m_size));
71	      if (m_size>oldsize)
72	      {
73	        memset(m_buf+oldsize,0,m_size-oldsize);
74	      }
75	    }
76	    size_t size() const
77	    {
(gdb) p m_buf
$1 = 0x0
```
This was caused by a negative integer value, which was casted to the unsigned size_t return type of getFragmentLocation()
```
(gdb) fr 2
#2  0x00005555560d186f in FilterCache::shrinkBuffer (this=0x5555572e3980 <FilterCache::instance()::theInstance>, str=...,
    fileName=..., startLine=0, endLine=4) at /tmp/doxygen/src/definition.cpp:773
773	      str.resize(fragmentSize+1);
(gdb) list
768	      const LineOffsets &lineOffsets = it->second;
769	      auto [ startLineOffset, fragmentSize] = getFragmentLocation(lineOffsets,startLine,endLine);
770	      //printf("%s: new file [%zu-%zu]->[%zu-%zu] size=%zu\n",
771	      //    qPrint(fileName),startLine,endLine,startLineOffset,endLineOffset,fragmentSize);
772	      str.dropFromStart(startLineOffset);
773	      str.resize(fragmentSize+1);
774	      str.at(fragmentSize)='\0';
775	    }
776
777	    //! Reads the fragment start at byte offset \a startOffset of file \a fileName into buffer \a str.
(gdb) p startLineOffset
$2 = (std::tuple_element<0, std::tuple<unsigned long, unsigned long> >::type &&) @0x7fffffffc398: 9415
(gdb) p fragmentSize
$3 = (std::tuple_element<0, std::tuple<unsigned long> >::type &&) @0x7fffffffc390: 18446744073709542286
(gdb) p startLine
$4 = 0
(gdb) p endLine
$5 = 4
(gdb) p lineOffsets
$6 = std::vector of length 207, capacity 256 = {0, 13, 14, 58, 85, 109, 128, 129, 132, 246, 302, 306, 307, 330, 331, 440, 480,
  481, 495, 549, 579, 595, 609, 619, 622, 623, 691, 717, 778, 848, 918, 944, 945, 946, 947, 1037, 1080, 1143, 1210, 1237, 1266,
  1387, 1436, 1440, 1482, 1484, 1485, 1604, 1683, 1696, 1708, 1711, 1712, 1713, 1716, 1757, 1825, 1829, 1862, 1945, 2026, 2102,
  2179, 2183, 2184, 2268, 2356, 2402, 2460, 2486, 2487, 2488, 2489, 2540, 2583, 2660, 2725, 2788, 2790, 2791, 2910, 3029, 3057,
  3100, 3168, 3245, 3391, 3393, 3394, 3490, 3527, 3570, 3699, 3773, 3911, 3913, 3914, 3915, 3990, 4030, 4135, 4179, 4284, 4286,
  4287, 4405, 4467, 4528, 4554, 4597, 4677, 4678, 4679, 4735, 4775, 4818, 4852, 4923, 4924, 4925, 5043, 5081, 5132, 5175, 5231,
  5316, 5317, 5437, 5523, 5585, 5641, 5690, 5735, 5779, 5813, 5969, 5970, 5971, 5998, 5999, 6156, 6191, 6348, 6349, 6391, 6448,
  6506, 6575, 6638, 6683, 6779, 6816, 6861, 6932, 7026, 7062, 7096, 7186, 7233, 7341, 7415, 7566, 7667, 7671, 7735, 7785, 7818,
  7848, 7876, 7945, 8068, 8101, 8105, 8172, 8195, 8209, 8237, 8265, 8302, 8352, 8415, 8452, 8467, 8482, 8497, 8512, 8551, 8585,
  8604, 8651, 8716, 8843, 8874, 8878, 9014, 9065, 9120, 9218, 9269, 9339...}
```

Now I don't know if this is the "correct" way to fix this issue, as I don't understand any of the data structures used by doxygen. Looking at the getFragmentLocation() function, it is making the following call:
```
size_t startLineOffset = lineOffsets[std::min(startLine-1,lineOffsets.size()-1)];
```
with the "startLine" parameter being 0, this would make an array derefence of:
lineOffsets[-1]

which may also be a problem.