### PR TITLE
issue #9921 HIDE_SCOPE_NAMES does not hide names in  treeview

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -532,7 +532,9 @@ static void generateJSLink(TextStream &t,const FTVNodePtr &n)
   }
   else // link into other page
   {
-    t << "\"" << convertToJSString(n->name) << "\", \"";
+    QCString result = n->name;
+    if (Config_getBool(HIDE_SCOPE_NAMES)) result=stripScope(result);
+    t << "\"" << convertToJSString(result) << "\", \"";
     t << externalRef("",n->ref,TRUE);
     t << node2URL(n);
     t << "\", ";


### PR DESCRIPTION
Strip the scope also in the treeview in case of `HIDE_SCOPE_NAMES`