### PR TITLE
Fix enum field association for global enums

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7231,7 +7231,7 @@ static void addEnumValuesToEnums(const Entry *root)
                         if (!fmd->isStrongEnumValue()) // only non strong enum values can be globally added
                         {
                           const FileDef *ffd=fmd->getFileDef();
-                          if (ffd==fd) // enum value has file scope
+                          if (ffd==fd && ffd==md->getFileDef()) // enum value has file scope
                           {
                             md->insertEnumField(fmd);
                             fmd->setEnumScope(md);

--- a/testing/099/099__a_8c.xml
+++ b/testing/099/099__a_8c.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="099__a_8c" kind="file" language="C++">
+    <compoundname>099_a.c</compoundname>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
+        <type/>
+        <name>E</name>
+        <enumvalue id="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+          <name>A</name>
+          <briefdescription>
+            <para>A in a.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+          <name>B</name>
+          <briefdescription>
+            <para>B in a.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+          <name>A</name>
+          <briefdescription>
+            <para>A in b.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+          <name>B</name>
+          <briefdescription>
+            <para>B in b.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+          <para>E in a.c. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="099_a.c" line="15" column="1" bodyfile="099_a.c" bodystart="15" bodyend="25"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>a.c </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="099_a.c"/>
+  </compounddef>
+</doxygen>

--- a/testing/099/099__a_8c.xml
+++ b/testing/099/099__a_8c.xml
@@ -22,22 +22,6 @@
           <detaileddescription>
           </detaileddescription>
         </enumvalue>
-        <enumvalue id="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
-          <name>A</name>
-          <briefdescription>
-            <para>A in b.c. </para>
-          </briefdescription>
-          <detaileddescription>
-          </detaileddescription>
-        </enumvalue>
-        <enumvalue id="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
-          <name>B</name>
-          <briefdescription>
-            <para>B in b.c. </para>
-          </briefdescription>
-          <detaileddescription>
-          </detaileddescription>
-        </enumvalue>
         <briefdescription>
           <para>E in a.c. </para>
         </briefdescription>

--- a/testing/099/more__099__b_8c.xml
+++ b/testing/099/more__099__b_8c.xml
@@ -9,22 +9,6 @@
         <enumvalue id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
           <name>A</name>
           <briefdescription>
-            <para>A in a.c. </para>
-          </briefdescription>
-          <detaileddescription>
-          </detaileddescription>
-        </enumvalue>
-        <enumvalue id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
-          <name>B</name>
-          <briefdescription>
-            <para>B in a.c. </para>
-          </briefdescription>
-          <detaileddescription>
-          </detaileddescription>
-        </enumvalue>
-        <enumvalue id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
-          <name>A</name>
-          <briefdescription>
             <para>A in b.c. </para>
           </briefdescription>
           <detaileddescription>

--- a/testing/099/more__099__b_8c.xml
+++ b/testing/099/more__099__b_8c.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="more__099__b_8c" kind="file" language="C++">
+    <compoundname>more_099_b.c</compoundname>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
+        <type/>
+        <name>E</name>
+        <enumvalue id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+          <name>A</name>
+          <briefdescription>
+            <para>A in a.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+          <name>B</name>
+          <briefdescription>
+            <para>B in a.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+          <name>A</name>
+          <briefdescription>
+            <para>A in b.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="more__099__b_8c_1aa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+          <name>B</name>
+          <briefdescription>
+            <para>B in b.c. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+          <para>E in b.c. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="more_099_b.c" line="10" column="1" bodyfile="more_099_b.c" bodystart="10" bodyend="20"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>b.c </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="more_099_b.c"/>
+  </compounddef>
+</doxygen>

--- a/testing/099_a.c
+++ b/testing/099_a.c
@@ -1,0 +1,25 @@
+!// objective: test enum field association
+!// input: more_099_b.c
+!// check: 099__a_8c.xml
+!// check: more__099__b_8c.xml
+
+/**
+ * @file
+ *
+ * @brief a.c
+ */
+
+/**
+ * @brief E in a.c
+ */
+enum E {
+  /**
+   * @brief A in a.c
+   */
+  A,
+
+  /**
+   * @brief B in a.c
+   */
+  B
+};

--- a/testing/more_099_b.c
+++ b/testing/more_099_b.c
@@ -1,0 +1,20 @@
+/**
+ * @file
+ *
+ * @brief b.c
+ */
+
+/**
+ * @brief E in b.c
+ */
+enum E {
+  /**
+   * @brief A in b.c
+   */
+  A,
+
+  /**
+   * @brief B in b.c
+   */
+  B
+};

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -137,8 +137,11 @@ class Tester:
         shutil.rmtree(self.test_out,ignore_errors=True)
         os.mkdir(self.test_out)
         shutil.copy(self.args.inputdir+'/Doxyfile',self.test_out)
+        inputs = '%s/%s' % (self.args.inputdir,self.test)
+        for i in self.config.get('input', []):
+            inputs += ' %s/%s' % (self.args.inputdir,i)
         with xopen(self.test_out+'/Doxyfile','a') as f:
-            print('INPUT=%s/%s' % (self.args.inputdir,self.test), file=f)
+            print('INPUT=%s' % inputs, file=f)
             print('STRIP_FROM_PATH=%s' % self.args.inputdir, file=f)
             print('EXAMPLE_PATH=%s' % self.args.inputdir, file=f)
             print('WARN_LOGFILE=%s/warnings.log' % self.test_out, file=f)


### PR DESCRIPTION
Make sure that the enum and contained enum fields originate from the  same file.  This fixes the following test case:

File "a.c":
```
/**
 * @file
 *
 * @brief a.c 
 */

/**
 * @brief E in a.c 
 */
enum E { 
  /** 
   * @brief A in a.c 
   */  
  A
};
```
File "b.c":
```
/**
 * @file
 *
 * @brief b.c 
 */

/**
 * @brief E in b.c 
 */
enum E { 
  /** 
   * @brief B in b.c 
   */  
  B
};
```
Without this fix, each enum E documentation contained the enum fields A and B.
