### PR TITLE
Unknown generated markdown id

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3365,6 +3365,11 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
         {
           docs.prepend("@ianchor " +  generatedId + "\\ilinebr ");
         }
+        else
+        {
+          QCString autoId = AnchorGenerator::instance().generate(title.str());
+          docs.prepend("@ianchor " +  autoId + "\\ilinebr ");
+        }
         docs.prepend("@page "+id+" "+title+"\\ilinebr ");
       }
       for (int i = 0; i < prepend; i++) docs.prepend("\n");

--- a/testing/055/md_055__markdown.xml
+++ b/testing/055/md_055__markdown.xml
@@ -6,9 +6,12 @@
     <briefdescription>
     </briefdescription>
     <detaileddescription>
-      <sect1 id="md_055__markdown_1autotoc_md0">
+      <para>
+        <anchor id="md_055__markdown_1autotoc_md0"/>
+      </para>
+      <sect1 id="md_055__markdown_1autotoc_md1">
         <title>Foo</title>
-        <sect2 id="md_055__markdown_1autotoc_md1">
+        <sect2 id="md_055__markdown_1autotoc_md2">
           <title>Bar</title>
           <para>
             <ulink url="http://example.com/inline">Inline link</ulink>
@@ -17,7 +20,7 @@
             <ulink url="http://example.com/reference">Reference link</ulink>
           </para>
         </sect2>
-        <sect2 id="md_055__markdown_1autotoc_md2">
+        <sect2 id="md_055__markdown_1autotoc_md3">
           <title>Baz</title>
           <para>More text</para>
           <para>
@@ -25,7 +28,7 @@
           </para>
           <para>Dash - NDash <ndash/> MDash <mdash/> EDash - ENDash -- EMDash --- E3Dash ---</para>
         </sect2>
-        <sect2 id="md_055__markdown_1autotoc_md3">
+        <sect2 id="md_055__markdown_1autotoc_md4">
           <title>Markdown in HTML</title>
           <para>
             <heading level="3"><bold>Header3</bold> blah <emphasis>blah</emphasis> <computeroutput>blah</computeroutput></heading>


### PR DESCRIPTION
When having an example like:
```
Pipenv: Python Development Workflow for Humans
==============================================

- @ref "pipenv-python-development-workflow-for-humans" "Pipenv"
```
and the settings:
```
QUIET = YES
MARKDOWN_ID_STYLE = GITHUB
```
we get a warning like:
```
README.md:4: warning: unable to resolve reference to 'pipenv-python-development-workflow-for-humans' for \ref command
```
this is due to the fact that a markdown `===` type of header doesn't get an automatic header when promoted to a page

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11010927/example.tar.gz)


(Found by Fossies for the pipenv package)