### PR TITLE
Incorrect handling of `ianchor` in markdown files

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -479,6 +479,7 @@ int Markdown::isSpecialCommand(const char *data,int offset,int size)
     { "fn",             endOfFunc  },
     { "headerfile",     endOfLine  },
     { "htmlinclude",    endOfLine  },
+    { "ianchor",        endOfLabel },
     { "idlexcept",      endOfLine  },
     { "if",             endOfGuard },
     { "ifnot",          endOfGuard },


### PR DESCRIPTION
When having a file with:
```
# OpenProject development style guide - frontend
```
and a file with:
```
# OpenProject development style guide
```
we get a warning like:
```
.../README.md:1: warning: multiple use of section label 'openproject-development-style-guide' while adding anchor, (first occurrence: .../frontend/README.md, line 1)
```
due to the fact that the label of the `\ianchor` command is translated by e.g. the "mdash" processing, the `ianchor` should be handled in the same way as the `\anchor`

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11017034/example.tar.gz)

(Found by Fossies for the openproject package)
