### PR TITLE
Incorrect link in ref list of internal documentation

### DIFF
--- a/doc_internal/commands_internal.md
+++ b/doc_internal/commands_internal.md
@@ -7,7 +7,7 @@ and the version in which they were introduced.
 \refitem cmdendicode \\endicode
 \refitem cmdendiliteral \\endiliteral
 \refitem cmdendiverbatim \\endiverbatim
-\refitem cmdicode \\ianchor
+\refitem cmdianchor \\ianchor
 \refitem cmdicode \\icode
 \refitem cmdifile \\ifile
 \refitem cmdiline \\iline


### PR DESCRIPTION
Corrected link for `\ianchor` in reference list of internal commands in the internal documentation