### PR TITLE
Unknown generated markdown id

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1338,15 +1338,16 @@ STopt  [^\n@\\]*
 
   /* --------- handle arguments of page/mainpage command ------------------- */
 
-<PageDocArg1>[^\n]*"\\ilinebr @ianchor"\{[^\]\n]*\}{B}{FILE} { // special case where the Markdown processor has rewritten
+<PageDocArg1>[^\n]*"\\ilinebr @ianchor/"\{[^\]\n]*\}{B}{FILE} { // special case where the Markdown processor has rewritten
                                                                // "@page label Title" as
                                                                // "@page md_label Title\ilinebr @ianchor{Title} label"
-                                          QCString text = yytext;
-                                          int start = text.find('{');
-                                          int end   = text.find('}',start+1);
-                                          yyextra->current->name = text.mid(end+2);
-                                          yyextra->current->args = text.mid(start+1,end-start-1);
+                                          //QCString text = yytext;
+                                          //int start = text.find('{');
+                                          //int end   = text.find('}',start+1);
+                                          //yyextra->current->name = text.mid(end+2);
+                                          //yyextra->current->args = text.mid(start+1,end-start-1);
                                           //printf("name='%s' title='%s'\n",qPrint(yyextra->current->name),qPrint(yyextra->current->args));
+                                          unput_string("@ianchor",8);
                                           BEGIN( PageDocArg2 );
                                         }
 <PageDocArg1>{FILE}                     { // first argument; page name

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -383,6 +383,25 @@ int Markdown::isSpecialCommand(const char *data,int offset,int size)
     return 0;
   };
 
+  static const auto endOfLabelOpt = [](const char *data_,int offset_,int size_) -> int
+  {
+    int index=offset_;
+    if (index<size_ && data_[index]==' ') // skip over optional spaces
+    {
+      index++;
+      while (index<size_ && data_[index]==' ') index++;
+    }
+    if (index<size_ && data_[index]=='{') // find matching '}'
+    {
+      index++;
+      char c;
+      while (index<size_ && (c=data_[index])!='}' && c!='\\' && c!='@' && c!='\n') index++;
+      if (index==size_ || data_[index]!='}') return 0; // invalid option
+      offset_=index+1; // part after {...} is the option
+    }
+    return endOfLabel(data_,offset_,size_);
+  };
+
   static const auto endOfParam = [](const char *data_,int offset_,int size_) -> int
   {
     int index=offset_;
@@ -479,7 +498,7 @@ int Markdown::isSpecialCommand(const char *data,int offset,int size)
     { "fn",             endOfFunc  },
     { "headerfile",     endOfLine  },
     { "htmlinclude",    endOfLine  },
-    { "ianchor",        endOfLabel },
+    { "ianchor",        endOfLabelOpt },
     { "idlexcept",      endOfLine  },
     { "if",             endOfGuard },
     { "ifnot",          endOfGuard },
@@ -3365,6 +3384,11 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
         else if (!generatedId.isEmpty())
         {
           docs.prepend("@ianchor " +  generatedId + "\\ilinebr ");
+        }
+        else
+        {
+          QCString autoId = AnchorGenerator::instance().generate(title.str());
+          docs.prepend("@ianchor{" + title + "} " +  autoId + "\\ilinebr ");
         }
         docs.prepend("@page "+id+" "+title+"\\ilinebr ");
       }


### PR DESCRIPTION
When having an example like:
```
Pipenv: Python Development Workflow for Humans
==============================================

- @ref "pipenv-python-development-workflow-for-humans" "Pipenv"
```

Based on review
- added optional text label to new `\ianchor`
- properly skipping `@ianchor `
- adjusting handling of page command in combination with `@ianchor` (in commentscan.l)