### PR TITLE
issue #9932 Incomplete Style.css

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9552,6 +9552,7 @@ static void generateConfigFile(const QCString &configFile,bool shortList,
       {
         msg("\n\nConfiguration file '%s' updated.\n\n",qPrint(configFile));
       }
+      f.close();
     }
   }
   else
@@ -10868,6 +10869,7 @@ void readConfiguration(int argc, char **argv)
             TextStream t(&f);
             RTFGenerator::writeExtensionsFile(t);
           }
+          f.close();
           cleanUpDoxygen();
           exit(0);
         }
@@ -10897,6 +10899,7 @@ void readConfiguration(int argc, char **argv)
             TextStream t(&f);
             EmojiEntityMapper::instance().writeEmojiFile(t);
           }
+          f.close();
           cleanUpDoxygen();
           exit(0);
         }
@@ -10932,6 +10935,7 @@ void readConfiguration(int argc, char **argv)
             cleanUpDoxygen();
             exit(1);
           }
+          f.close();
           cleanUpDoxygen();
           exit(0);
         }
@@ -10979,6 +10983,7 @@ void readConfiguration(int argc, char **argv)
             TextStream t(&f);
             HtmlGenerator::writeStyleSheetFile(t);
           }
+          f.close();
           cleanUpDoxygen();
           exit(0);
         }
@@ -11025,6 +11030,7 @@ void readConfiguration(int argc, char **argv)
             TextStream t(&f);
             LatexGenerator::writeStyleSheetFile(t);
           }
+          f.close();
           cleanUpDoxygen();
           exit(0);
         }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -122,6 +122,7 @@ static void format_warn(const QCString &file,int line,const QCString &text)
   }
   if (g_warnBehavior == WARN_AS_ERROR_t::YES)
   {
+    if (g_warnFile != stderr && g_warnFile != stdout) Portable::fclose(g_warnFile);
     Doxygen::terminating=true;
     exit(1);
   }
@@ -137,6 +138,7 @@ static void handle_warn_as_error()
       QCString msgText = " (warning treated as error, aborting now)\n";
       fwrite(msgText.data(),1,msgText.length(),g_warnFile);
     }
+    if (g_warnFile != stderr && g_warnFile != stdout) Portable::fclose(g_warnFile);
     Doxygen::terminating=true;
     exit(1);
   }
@@ -268,6 +270,7 @@ void term(const char *fmt, ...)
       fprintf(g_warnFile, "%s\n", "Exiting...");
     }
   }
+  if (g_warnFile != stderr && g_warnFile != stdout) Portable::fclose(g_warnFile);
   Doxygen::terminating=true;
   exit(1);
 }
@@ -310,6 +313,7 @@ extern void finishWarnExit()
   if (g_warnStat && (g_warnBehavior == WARN_AS_ERROR_t::FAIL_ON_WARNINGS ||
                      g_warnBehavior == WARN_AS_ERROR_t::FAIL_ON_WARNINGS_PRINT))
   {
+    if (g_warnFile != stderr && g_warnFile != stdout) Portable::fclose(g_warnFile);
     Doxygen::terminating=true;
     exit(1);
   }


### PR DESCRIPTION
In case of writing files to a network disk it is possible that the not-closed files are not completely written to disk, explicitly closing files.