### PR TITLE
Latex incorrect handling of backticks in code fragments

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -95,6 +95,10 @@ void LatexCodeGenerator::codify(const QCString &str)
                    m_col++;
                    p++;
                    break;
+        case '`':  *m_t <<"\\`{}";
+                   m_col++;
+                   p++;
+                   break;
         case '\t': spacesToNextTabStop =
                          tabSize - (m_col%tabSize);
                    for (i = 0; i < spacesToNextTabStop; i++) *m_t << (m_doxyCodeLineOpen ? "\\ " : " ");


### PR DESCRIPTION
In case we have a code fragment  with backticks they are translated in "inverted commas".

(this can be seen in the doxygen manual at the bottom of the paragraph 5.2.3 Fenced Code Blocks)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11049208/example.tar.gz)

**Old**:
![image](https://user-images.githubusercontent.com/5223533/227161949-369bf818-1230-432f-909f-f312d2539352.png)


**new**:
![image](https://user-images.githubusercontent.com/5223533/227162068-5185ba89-8c24-4bba-b9ed-3914cfeeef00.png)

