### PR TITLE
Use groups to associate documentation entries

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8786,6 +8786,21 @@ static void flushUnresolvedRelations()
 }
 
 //----------------------------------------------------------------------------
+// Returns TRUE if the entry and member definition have equal file names,
+// otherwise FALSE.
+
+static bool haveEqualFileNames(const Entry *root,const MemberDef *md)
+{
+  const FileDef *fd = md->getFileDef();
+  if (!fd)
+  {
+    return FALSE;
+  }
+
+  return fd->absFilePath() == root->fileName;
+}
+
+//----------------------------------------------------------------------------
 
 static void findDefineDocumentation(Entry *root)
 {
@@ -8856,8 +8871,7 @@ static void findDefineDocumentation(Entry *root)
           MemberDefMutable *md = toMemberDefMutable(imd.get());
           if (md && md->memberType()==MemberType_Define)
           {
-            const FileDef *fd=md->getFileDef();
-            if (fd && fd->absFilePath()==root->fileName)
+            if (haveEqualFileNames(root, md))
               // doc and define in the same file assume they belong together.
             {
               md->setDocumentation(root->doc,root->docFile,root->docLine);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5222,6 +5222,12 @@ static bool findGlobalMember(const Entry *root,
     bool found=FALSE;
     for (const auto &md : *mn)
     {
+      // If the entry has groups, then restrict the search to members which are
+      // in one of the groups of the entry.
+      if (!root->groups.empty() && !isEntryInGroupOfMember(root, md.get()))
+      {
+        continue;
+      }
       const NamespaceDef *nd=0;
       if (md->isAlias() && md->getOuterScope() &&
           md->getOuterScope()->definitionType()==Definition::TypeNamespace)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5169,6 +5169,28 @@ static const ClassDef *findClassDefinition(FileDef *fd,NamespaceDef *nd,
   return tcd;
 }
 
+//----------------------------------------------------------------------------
+// Returns TRUE, if the entry belongs to the group of the member definition,
+// otherwise FALSE.
+
+static bool isEntryInGroupOfMember(const Entry *root,const MemberDef *md)
+{
+  const GroupDef *gd = md->getGroupDef();
+  if (!gd)
+  {
+    return FALSE;
+  }
+
+  for (const auto &g : root->groups)
+  {
+    if (g.groupname == gd->name())
+    {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
 
 //----------------------------------------------------------------------
 // Adds the documentation contained in 'root' to a global function
@@ -8871,8 +8893,8 @@ static void findDefineDocumentation(Entry *root)
           MemberDefMutable *md = toMemberDefMutable(imd.get());
           if (md && md->memberType()==MemberType_Define)
           {
-            if (haveEqualFileNames(root, md))
-              // doc and define in the same file assume they belong together.
+            if (haveEqualFileNames(root, md) || isEntryInGroupOfMember(root, md))
+              // doc and define in the same file or group assume they belong together.
             {
               md->setDocumentation(root->doc,root->docFile,root->docLine);
               md->setDocsForDefinition(!root->proto);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5323,13 +5323,16 @@ static bool findGlobalMember(const Entry *root,
         //    qPrint(argListToString(md->argumentList())),
         //    qPrint(argListToString(root->argList)));
 
-        // for static members we also check if the comment block was found in
+        // For static members we also check if the comment block was found in
         // the same file. This is needed because static members with the same
         // name can be in different files. Thus it would be wrong to just
-        // put the comment block at the first syntactically matching member.
+        // put the comment block at the first syntactically matching member. If
+        // the comment block belongs to a group of the static member, then add
+        // the documentation even if it is in a different file.
         if (matching && md->isStatic() &&
             md->getDefFileName()!=root->fileName &&
-            mn->size()>1)
+            mn->size()>1 &&
+            !isEntryInGroupOfMember(root,md.get()))
         {
           matching = FALSE;
         }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -8833,6 +8833,29 @@ static bool haveEqualFileNames(const Entry *root,const MemberDef *md)
 
 //----------------------------------------------------------------------------
 
+static void addDefineDoc(const Entry *root, MemberDefMutable *md)
+{
+  md->setDocumentation(root->doc,root->docFile,root->docLine);
+  md->setDocsForDefinition(!root->proto);
+  md->setBriefDescription(root->brief,root->briefFile,root->briefLine);
+  if (md->inbodyDocumentation().isEmpty())
+  {
+    md->setInbodyDocumentation(root->inbodyDocs,root->inbodyFile,root->inbodyLine);
+  }
+  if (md->getStartBodyLine()==-1 && root->bodyLine!=-1)
+  {
+    md->setBodySegment(root->startLine,root->bodyLine,root->endBodyLine);
+    md->setBodyDef(root->fileDef());
+  }
+  md->addSectionsToDefinition(root->anchors);
+  md->setMaxInitLines(root->initLines);
+  md->setRefItems(root->sli);
+  if (root->mGrpId!=-1) md->setMemberGroupId(root->mGrpId);
+  addMemberToGroups(root,md);
+}
+
+//----------------------------------------------------------------------------
+
 static void findDefineDocumentation(Entry *root)
 {
   if ((root->section==Entry::DEFINEDOC_SEC ||
@@ -8871,20 +8894,7 @@ static void findDefineDocumentation(Entry *root)
           MemberDefMutable *md = toMemberDefMutable(imd.get());
           if (md && md->memberType()==MemberType_Define)
           {
-            md->setDocumentation(root->doc,root->docFile,root->docLine);
-            md->setDocsForDefinition(!root->proto);
-            md->setBriefDescription(root->brief,root->briefFile,root->briefLine);
-            if (md->inbodyDocumentation().isEmpty())
-            {
-              md->setInbodyDocumentation(root->inbodyDocs,root->inbodyFile,root->inbodyLine);
-            }
-            md->setBodySegment(root->startLine,root->bodyLine,root->endBodyLine);
-            md->setBodyDef(root->fileDef());
-            md->addSectionsToDefinition(root->anchors);
-            md->setMaxInitLines(root->initLines);
-            md->setRefItems(root->sli);
-            if (root->mGrpId!=-1) md->setMemberGroupId(root->mGrpId);
-            addMemberToGroups(root,md);
+            addDefineDoc(root,md);
           }
         }
       }
@@ -8905,20 +8915,7 @@ static void findDefineDocumentation(Entry *root)
             if (haveEqualFileNames(root, md) || isEntryInGroupOfMember(root, md))
               // doc and define in the same file or group assume they belong together.
             {
-              md->setDocumentation(root->doc,root->docFile,root->docLine);
-              md->setDocsForDefinition(!root->proto);
-              md->setBriefDescription(root->brief,root->briefFile,root->briefLine);
-              if (md->inbodyDocumentation().isEmpty())
-              {
-                md->setInbodyDocumentation(root->inbodyDocs,root->inbodyFile,root->inbodyLine);
-              }
-              md->setBodySegment(root->startLine,root->bodyLine,root->endBodyLine);
-              md->setBodyDef(root->fileDef());
-              md->addSectionsToDefinition(root->anchors);
-              md->setRefItems(root->sli);
-              md->setLanguage(root->lang);
-              if (root->mGrpId!=-1) md->setMemberGroupId(root->mGrpId);
-              addMemberToGroups(root,md);
+              addDefineDoc(root,md);
             }
           }
         }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -512,9 +512,12 @@ static void buildFileList(const Entry *root)
         GroupDef *gd=0;
         if (!g.groupname.isEmpty() && (gd=Doxygen::groupLinkedMap->find(g.groupname)))
         {
-          gd->addFile(fd);
-          fd->makePartOfGroup(gd);
-          //printf("File %s: in group %s\n",qPrint(fd->name()),qPrint(gd->name()));
+          if (!gd->containsFile(fd))
+          {
+            gd->addFile(fd);
+            fd->makePartOfGroup(gd);
+            //printf("File %s: in group %s\n",qPrint(fd->name()),qPrint(gd->name()));
+          }
         }
       }
     }

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -64,6 +64,7 @@ class GroupDefImpl : public DefinitionMixin<GroupDef>
     virtual void setGroupTitle( const QCString &newtitle );
     virtual bool hasGroupTitle( ) const { return m_titleSet; }
     virtual void addFile(FileDef *def);
+    virtual bool containsFile(const FileDef *def) const;
     virtual bool addClass(ClassDef *def);
     virtual bool addConcept(ConceptDef *def);
     virtual bool addNamespace(NamespaceDef *def);
@@ -246,6 +247,11 @@ void GroupDefImpl::addFile(FileDef *def)
                        def);
   else
     m_fileList.push_back(def);
+}
+
+bool GroupDefImpl::containsFile(const FileDef *def) const
+{
+  return std::find(m_fileList.cbegin(),m_fileList.cend(), def) != m_fileList.cend();
 }
 
 bool GroupDefImpl::addClass(ClassDef *cd)

--- a/src/groupdef.h
+++ b/src/groupdef.h
@@ -57,6 +57,7 @@ class GroupDef : public DefinitionMutable, public Definition
     virtual void setGroupTitle( const QCString &newtitle ) = 0;
     virtual bool hasGroupTitle( ) const = 0;
     virtual void addFile(FileDef *def) = 0;
+    virtual bool containsFile(const FileDef *def) const = 0;
     virtual bool addClass(ClassDef *def) = 0;
     virtual bool addConcept(ConceptDef *def) = 0;
     virtual bool addNamespace(NamespaceDef *def) = 0;

--- a/src/memberlist.h
+++ b/src/memberlist.h
@@ -88,6 +88,16 @@ class MemberVector
     {
       return std::find(m_members.begin(),m_members.end(),md)!=m_members.end();
     }
+    MemberDef *find(const QCString &name)
+    {
+      auto it = std::find_if(m_members.begin(),m_members.end(),[name=name](auto &el) { return el->name()==name; });
+      if (it != m_members.end())
+      {
+        return *it;
+      }
+
+      return nullptr;
+    }
   protected:
     Vec m_members;
 };

--- a/testing/018/018__def_8c.xml
+++ b/testing/018/018__def_8c.xml
@@ -13,7 +13,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="018_def.c" line="8" column="9"/>
+        <location file="018_def.c" line="8" column="9" bodyfile="018_def.c" bodystart="8" bodyend="-1"/>
       </memberdef>
       <memberdef kind="define" id="018__def_8c_1adc4f42710326718e200d81a0c68cd1f0" prot="public" static="no">
         <name>MACRO4</name>

--- a/testing/018/018__def_8c.xml
+++ b/testing/018/018__def_8c.xml
@@ -15,6 +15,18 @@
         </inbodydescription>
         <location file="018_def.c" line="8" column="9"/>
       </memberdef>
+      <memberdef kind="define" id="018__def_8c_1adc4f42710326718e200d81a0c68cd1f0" prot="public" static="no">
+        <name>MACRO4</name>
+        <initializer>2</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>Another macro definition. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="018_def.c" line="21" column="9" bodyfile="018_def.c" bodystart="21" bodyend="-1"/>
+      </memberdef>
     </sectiondef>
     <sectiondef kind="enum">
       <memberdef kind="enum" id="018__def_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">

--- a/testing/018_def.c
+++ b/testing/018_def.c
@@ -16,6 +16,10 @@ enum E { E1, E2 };
  *  A macro definition 
  */
 
+/** Another macro definition.
+ */
+#define MACRO4 2
+
 /** \var var
  *  A variable
  */

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -4,6 +4,7 @@
     <compoundname>A</compoundname>
     <title>A</title>
     <innerfile refid="100__a_8c">100_a.c</innerfile>
+    <innerclass refid="structs" prot="public">s</innerclass>
     <sectiondef kind="enum">
       <memberdef kind="enum" id="group___a_1gaa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
         <type/>
@@ -36,7 +37,25 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="21" column="1" bodyfile="100_a.c" bodystart="21" bodyend="31"/>
+        <location file="100_a.c" line="22" column="1" bodyfile="100_a.c" bodystart="22" bodyend="32"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="group___a_1ga4ed70e44cd9d80a2082e1ae033eb7fc3" prot="public" static="no">
+        <type>struct <ref refid="structs" kindref="compound">s</ref></type>
+        <definition>struct s T</definition>
+        <argsstring/>
+        <name>T</name>
+        <briefdescription>
+          <para>T in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>More for T in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
+          <para>More for T in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="72" column="16" bodyfile="100_a.c" bodystart="72" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="func">
@@ -56,7 +75,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="45" column="13" bodyfile="100_a.c" bodystart="45" bodyend="45"/>
+        <location file="100_a.c" line="46" column="13" bodyfile="100_a.c" bodystart="46" bodyend="46"/>
       </memberdef>
       <memberdef kind="function" id="group___a_1ga5806fbe7d2114068e8085236b6f8098d" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>
@@ -74,7 +93,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="52" column="6" bodyfile="100_a.c" bodystart="52" bodyend="52"/>
+        <location file="100_a.c" line="53" column="6" bodyfile="100_a.c" bodystart="53" bodyend="53"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="define">
@@ -89,7 +108,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="38" column="9"/>
+        <location file="100_a.c" line="39" column="9"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -43,10 +43,11 @@
           <para>D in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for D in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="38" column="9" bodyfile="100_a.c" bodystart="38" bodyend="-1"/>
+        <location file="100_a.c" line="38" column="9"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -28,6 +28,7 @@
           <para>E in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for E in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -4,6 +4,7 @@
     <compoundname>A</compoundname>
     <title>A</title>
     <innerfile refid="100__a_8c">100_a.c</innerfile>
+    <innerfile refid="100__a_8c">100_a.c</innerfile>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -4,7 +4,6 @@
     <compoundname>A</compoundname>
     <title>A</title>
     <innerfile refid="100__a_8c">100_a.c</innerfile>
-    <innerfile refid="100__a_8c">100_a.c</innerfile>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___a" kind="group">
+    <compoundname>A</compoundname>
+    <title>A</title>
+    <innerfile refid="100__a_8c">100_a.c</innerfile>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -58,6 +58,39 @@
         <location file="100_a.c" line="72" column="16" bodyfile="100_a.c" bodystart="72" bodyend="-1"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="var">
+      <memberdef kind="variable" id="group___a_1ga7e98b8a17c0aad30ba64d47b74e2a6c1" prot="public" static="no" mutable="no">
+        <type>int</type>
+        <definition>i</definition>
+        <argsstring/>
+        <name>i</name>
+        <briefdescription>
+          <para>i in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>More for i in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
+          <para>More for i in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="76" column="5" bodyfile="100_a.c" bodystart="76" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="group___a_1gabf2bc2545a4a5f5683d9ef3ed0d977e0" prot="public" static="yes" mutable="no">
+        <type>int</type>
+        <definition>j</definition>
+        <argsstring/>
+        <name>j</name>
+        <briefdescription>
+          <para>j in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>More for j in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="83" column="12" bodyfile="100_a.c" bodystart="83" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
     <sectiondef kind="func">
       <memberdef kind="function" id="group___a_1gabc536d5f4f9a56b7edcce32ed3a06140" prot="public" static="yes" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -15,8 +15,7 @@
             <para>A in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
           </briefdescription>
           <detaileddescription>
-            <para>More for A in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
-            <para>More for A in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+            <para>More for A in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
           </detaileddescription>
         </enumvalue>
         <enumvalue id="group___a_1ggaa57b8491d1d8fc1014dd54bcf83b130aa1d5389f0fe7d7497267c2a70ae6a4881" prot="public">
@@ -25,8 +24,7 @@
             <para>B in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
           </briefdescription>
           <detaileddescription>
-            <para>More for B in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
-            <para>More for B in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+            <para>More for B in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
           </detaileddescription>
         </enumvalue>
         <briefdescription>
@@ -50,8 +48,7 @@
           <para>T in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
-          <para>More for T in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
-          <para>More for T in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+          <para>More for T in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
@@ -68,12 +65,11 @@
           <para>i in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
-          <para>More for i in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
-          <para>More for i in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+          <para>More for i in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="76" column="5" bodyfile="100_a.c" bodystart="76" bodyend="-1"/>
+        <location file="100_a.c" line="79" column="5" bodyfile="100_a.c" bodystart="79" bodyend="-1"/>
       </memberdef>
       <memberdef kind="variable" id="group___a_1gabf2bc2545a4a5f5683d9ef3ed0d977e0" prot="public" static="yes" mutable="no">
         <type>int</type>
@@ -88,7 +84,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="83" column="12" bodyfile="100_a.c" bodystart="83" bodyend="-1"/>
+        <location file="100_a.c" line="86" column="12" bodyfile="100_a.c" bodystart="86" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="func">

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -35,6 +35,20 @@
         <location file="100_a.c" line="21" column="1" bodyfile="100_a.c" bodystart="21" bodyend="31"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="define">
+      <memberdef kind="define" id="group___a_1gaf316c33cc298530f245e8b55330e86b5" prot="public" static="no">
+        <name>D</name>
+        <initializer>1</initializer>
+        <briefdescription>
+          <para>D in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="38" column="9" bodyfile="100_a.c" bodystart="38" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -8,20 +8,24 @@
       <memberdef kind="enum" id="group___a_1gaa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
         <type/>
         <name>E</name>
-        <enumvalue id="group___a_1ggaa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+        <enumvalue id="group___a_1ggaa57b8491d1d8fc1014dd54bcf83b130aac7b0fd14a12d3b1941ee5f10c795c648" prot="public">
           <name>A</name>
           <briefdescription>
             <para>A in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
           </briefdescription>
           <detaileddescription>
+            <para>More for A in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
+            <para>More for A in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
           </detaileddescription>
         </enumvalue>
-        <enumvalue id="group___a_1ggaa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+        <enumvalue id="group___a_1ggaa57b8491d1d8fc1014dd54bcf83b130aa1d5389f0fe7d7497267c2a70ae6a4881" prot="public">
           <name>B</name>
           <briefdescription>
             <para>B in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
           </briefdescription>
           <detaileddescription>
+            <para>More for B in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>.</para>
+            <para>More for B in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
           </detaileddescription>
         </enumvalue>
         <briefdescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -35,6 +35,43 @@
         <location file="100_a.c" line="21" column="1" bodyfile="100_a.c" bodystart="21" bodyend="31"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="group___a_1gabc536d5f4f9a56b7edcce32ed3a06140" prot="public" static="yes" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>static void f</definition>
+        <argsstring>(void)</argsstring>
+        <name>f</name>
+        <param>
+          <type>void</type>
+        </param>
+        <briefdescription>
+          <para>f() in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="45" column="13" bodyfile="100_a.c" bodystart="45" bodyend="45"/>
+      </memberdef>
+      <memberdef kind="function" id="group___a_1ga5806fbe7d2114068e8085236b6f8098d" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void g</definition>
+        <argsstring>(void)</argsstring>
+        <name>g</name>
+        <param>
+          <type>void</type>
+        </param>
+        <briefdescription>
+          <para><ref refid="group___a_1ga5806fbe7d2114068e8085236b6f8098d" kindref="member">g()</ref> in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>More for <ref refid="group___a_1ga5806fbe7d2114068e8085236b6f8098d" kindref="member">g()</ref> in more_100_a.c from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="52" column="6" bodyfile="100_a.c" bodystart="52" bodyend="52"/>
+      </memberdef>
+    </sectiondef>
     <sectiondef kind="define">
       <memberdef kind="define" id="group___a_1gaf316c33cc298530f245e8b55330e86b5" prot="public" static="no">
         <name>D</name>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -4,6 +4,36 @@
     <compoundname>A</compoundname>
     <title>A</title>
     <innerfile refid="100__a_8c">100_a.c</innerfile>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="group___a_1gaa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
+        <type/>
+        <name>E</name>
+        <enumvalue id="group___a_1ggaa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+          <name>A</name>
+          <briefdescription>
+            <para>A in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="group___a_1ggaa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+          <name>B</name>
+          <briefdescription>
+            <para>B in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+          <para>E in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="21" column="1" bodyfile="100_a.c" bodystart="21" bodyend="31"/>
+      </memberdef>
+    </sectiondef>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -137,7 +137,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="100_a.c" line="39" column="9"/>
+        <location file="100_a.c" line="39" column="9" bodyfile="100_a.c" bodystart="39" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/100/group___a.xml
+++ b/testing/100/group___a.xml
@@ -48,6 +48,7 @@
           <para>f() in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for f() in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -28,6 +28,7 @@
           <para>E in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for E in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -35,6 +35,22 @@
         <location file="more_100_b.c" line="14" column="1" bodyfile="more_100_b.c" bodystart="14" bodyend="24"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="group___b_1ga5a6fd16639bb7ebdbd75952dc246cf51" prot="public" static="no">
+        <type>struct <ref refid="structs" kindref="compound">s</ref></type>
+        <definition>typedef struct s T</definition>
+        <argsstring/>
+        <name>T</name>
+        <briefdescription>
+          <para>T in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="more_100_b.c" line="45" column="16" bodyfile="more_100_b.c" bodystart="45" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
     <sectiondef kind="func">
       <memberdef kind="function" id="group___b_1gabc536d5f4f9a56b7edcce32ed3a06140" prot="public" static="yes" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___b" kind="group">
+    <compoundname>B</compoundname>
+    <title>B</title>
+    <innerfile refid="more__100__b_8c">more_100_b.c</innerfile>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -4,6 +4,7 @@
     <compoundname>B</compoundname>
     <title>B</title>
     <innerfile refid="more__100__b_8c">more_100_b.c</innerfile>
+    <innerfile refid="more__100__b_8c">more_100_b.c</innerfile>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -35,6 +35,20 @@
         <location file="more_100_b.c" line="14" column="1" bodyfile="more_100_b.c" bodystart="14" bodyend="24"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="define">
+      <memberdef kind="define" id="group___b_1gaf316c33cc298530f245e8b55330e86b5" prot="public" static="no">
+        <name>D</name>
+        <initializer>1</initializer>
+        <briefdescription>
+          <para>D in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="more_100_b.c" line="31" column="9" bodyfile="more_100_b.c" bodystart="31" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -4,7 +4,6 @@
     <compoundname>B</compoundname>
     <title>B</title>
     <innerfile refid="more__100__b_8c">more_100_b.c</innerfile>
-    <innerfile refid="more__100__b_8c">more_100_b.c</innerfile>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -103,7 +103,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="more_100_b.c" line="31" column="9"/>
+        <location file="more_100_b.c" line="31" column="9" bodyfile="more_100_b.c" bodystart="31" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -51,6 +51,22 @@
         <location file="more_100_b.c" line="45" column="16" bodyfile="more_100_b.c" bodystart="45" bodyend="-1"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="var">
+      <memberdef kind="variable" id="group___b_1gacb559820d9ca11295b4500f179ef6392" prot="public" static="yes" mutable="no">
+        <type>int</type>
+        <definition>int i</definition>
+        <argsstring/>
+        <name>i</name>
+        <briefdescription>
+          <para>i in more_100_a.c. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="more_100_b.c" line="50" column="12" bodyfile="more_100_b.c" bodystart="50" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
     <sectiondef kind="func">
       <memberdef kind="function" id="group___b_1gabc536d5f4f9a56b7edcce32ed3a06140" prot="public" static="yes" const="no" explicit="no" inline="no" virt="non-virtual">
         <type>void</type>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -43,10 +43,11 @@
           <para>D in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for D in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="more_100_b.c" line="31" column="9" bodyfile="more_100_b.c" bodystart="31" bodyend="-1"/>
+        <location file="more_100_b.c" line="31" column="9"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -35,6 +35,25 @@
         <location file="more_100_b.c" line="14" column="1" bodyfile="more_100_b.c" bodystart="14" bodyend="24"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="group___b_1gabc536d5f4f9a56b7edcce32ed3a06140" prot="public" static="yes" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>static void f</definition>
+        <argsstring>(void)</argsstring>
+        <name>f</name>
+        <param>
+          <type>void</type>
+        </param>
+        <briefdescription>
+          <para>f() in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="more_100_b.c" line="38" column="13" bodyfile="more_100_b.c" bodystart="38" bodyend="38"/>
+      </memberdef>
+    </sectiondef>
     <sectiondef kind="define">
       <memberdef kind="define" id="group___b_1gaf316c33cc298530f245e8b55330e86b5" prot="public" static="no">
         <name>D</name>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -8,20 +8,22 @@
       <memberdef kind="enum" id="group___b_1gaa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
         <type/>
         <name>E</name>
-        <enumvalue id="group___b_1ggaa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+        <enumvalue id="group___b_1ggaa57b8491d1d8fc1014dd54bcf83b130aac7b0fd14a12d3b1941ee5f10c795c648" prot="public">
           <name>A</name>
           <briefdescription>
             <para>A in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
           </briefdescription>
           <detaileddescription>
+            <para>More for A in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
           </detaileddescription>
         </enumvalue>
-        <enumvalue id="group___b_1ggaa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+        <enumvalue id="group___b_1ggaa57b8491d1d8fc1014dd54bcf83b130aa1d5389f0fe7d7497267c2a70ae6a4881" prot="public">
           <name>B</name>
           <briefdescription>
             <para>B in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
           </briefdescription>
           <detaileddescription>
+            <para>More for B in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
           </detaileddescription>
         </enumvalue>
         <briefdescription>
@@ -36,15 +38,16 @@
       </memberdef>
     </sectiondef>
     <sectiondef kind="typedef">
-      <memberdef kind="typedef" id="group___b_1ga5a6fd16639bb7ebdbd75952dc246cf51" prot="public" static="no">
+      <memberdef kind="typedef" id="group___b_1ga4ed70e44cd9d80a2082e1ae033eb7fc3" prot="public" static="no">
         <type>struct <ref refid="structs" kindref="compound">s</ref></type>
-        <definition>typedef struct s T</definition>
+        <definition>struct s T</definition>
         <argsstring/>
         <name>T</name>
         <briefdescription>
           <para>T in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for T in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
@@ -52,19 +55,20 @@
       </memberdef>
     </sectiondef>
     <sectiondef kind="var">
-      <memberdef kind="variable" id="group___b_1gacb559820d9ca11295b4500f179ef6392" prot="public" static="yes" mutable="no">
+      <memberdef kind="variable" id="group___b_1ga7e98b8a17c0aad30ba64d47b74e2a6c1" prot="public" static="yes" mutable="no">
         <type>int</type>
-        <definition>int i</definition>
+        <definition>i</definition>
         <argsstring/>
         <name>i</name>
         <briefdescription>
           <para>i in more_100_a.c. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for i in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="more_100_b.c" line="50" column="12" bodyfile="more_100_b.c" bodystart="50" bodyend="-1"/>
+        <location file="more_100_b.c" line="52" column="12" bodyfile="more_100_b.c" bodystart="52" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="func">

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -48,6 +48,7 @@
           <para>f() in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
         </briefdescription>
         <detaileddescription>
+          <para>More for f() in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>

--- a/testing/100/group___b.xml
+++ b/testing/100/group___b.xml
@@ -4,6 +4,36 @@
     <compoundname>B</compoundname>
     <title>B</title>
     <innerfile refid="more__100__b_8c">more_100_b.c</innerfile>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="group___b_1gaa57b8491d1d8fc1014dd54bcf83b130a" prot="public" static="no" strong="no">
+        <type/>
+        <name>E</name>
+        <enumvalue id="group___b_1ggaa57b8491d1d8fc1014dd54bcf83b130aa42a4ade1acd55a49164099104990e09f" prot="public">
+          <name>A</name>
+          <briefdescription>
+            <para>A in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="group___b_1ggaa57b8491d1d8fc1014dd54bcf83b130aa3f2a77ecd272aa6d6b5902faa5e5fc68" prot="public">
+          <name>B</name>
+          <briefdescription>
+            <para>B in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+          <para>E in <ref refid="more__100__b_8c" kindref="compound">more_100_b.c</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="more_100_b.c" line="14" column="1" bodyfile="more_100_b.c" bodystart="14" bodyend="24"/>
+      </memberdef>
+    </sectiondef>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/group___c.xml
+++ b/testing/100/group___c.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___c" kind="group">
+    <compoundname>C</compoundname>
+    <title>C</title>
+    <innerfile refid="more__100__c_8c">more_100_c.c</innerfile>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/100/group___c.xml
+++ b/testing/100/group___c.xml
@@ -4,6 +4,7 @@
     <compoundname>C</compoundname>
     <title>C</title>
     <innerfile refid="more__100__c_8c">more_100_c.c</innerfile>
+    <innerclass refid="structs" prot="public">s</innerclass>
     <briefdescription>
     </briefdescription>
     <detaileddescription>

--- a/testing/100/structs.xml
+++ b/testing/100/structs.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="structs" kind="struct" language="C++" prot="public">
+    <compoundname>s</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="structs_1afbd4a62a1d1e5d85ea3fcb5954434f29" prot="public" static="no" mutable="no">
+        <type>int</type>
+        <definition>int s::s</definition>
+        <argsstring/>
+        <name>s</name>
+        <qualifiedname>s::s</qualifiedname>
+        <briefdescription>
+          <para>Member s. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="100_a.c" line="64" column="7" bodyfile="100_a.c" bodystart="64" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>Struct s in <ref refid="100__a_8c" kindref="compound">100_a.c</ref>. </para>
+    </briefdescription>
+    <detaileddescription>
+      <para>More for s in <ref refid="100__a_8c" kindref="compound">100_a.c</ref> from <ref refid="more__100__c_8c" kindref="compound">more_100_c.c</ref>. </para>
+    </detaileddescription>
+    <location file="100_a.c" line="60" column="1" bodyfile="100_a.c" bodystart="60" bodyend="65"/>
+    <listofallmembers>
+      <member refid="structs_1afbd4a62a1d1e5d85ea3fcb5954434f29" prot="public" virt="non-virtual">
+        <scope>s</scope>
+        <name>s</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/100_a.c
+++ b/testing/100_a.c
@@ -1,0 +1,14 @@
+!// objective: test documentation entry association with groups
+!// input: more_100_b.c
+!// input: more_100_c.c
+!// check: group___a.xml
+!// check: group___b.xml
+!// check: group___c.xml
+
+/**
+ * @file
+ *
+ * @ingroup A
+ *
+ * @brief 100_a.c
+ */

--- a/testing/100_a.c
+++ b/testing/100_a.c
@@ -70,3 +70,17 @@ struct s {
  * @ingroup A
  */
 typedef struct s T;
+
+/**
+ * @brief i in 100_a.c.
+ *
+ * @ingroup A
+ */
+int i;
+
+/**
+ * @brief j in 100_a.c.
+ *
+ * @ingroup A
+ */
+static int j;

--- a/testing/100_a.c
+++ b/testing/100_a.c
@@ -4,6 +4,7 @@
 !// check: group___a.xml
 !// check: group___b.xml
 !// check: group___c.xml
+!// check: structs.xml
 
 /**
  * @file
@@ -50,3 +51,22 @@ static void f(void) {};
  * @ingroup A
  */
 void g(void) {};
+
+/**
+ * @brief Struct s in 100_a.c.
+ *
+ * @ingroup A
+ */
+struct s {
+  /**
+   * @brief Member s.
+   */
+  int s;
+};
+
+/**
+ * @brief T in 100_a.c.
+ *
+ * @ingroup A
+ */
+typedef struct s T;

--- a/testing/100_a.c
+++ b/testing/100_a.c
@@ -29,3 +29,10 @@ enum E {
    */
   B
 };
+
+/**
+ * @brief D in 100_a.c.
+ *
+ * @ingroup A
+ */
+#define D 1

--- a/testing/100_a.c
+++ b/testing/100_a.c
@@ -12,3 +12,20 @@
  *
  * @brief 100_a.c
  */
+
+/**
+ * @brief E in 100_a.c
+ *
+ * @ingroup A
+ */
+enum E {
+  /**
+   * @brief A in 100_a.c
+   */
+  A,
+
+  /**
+   * @brief B in 100_a.c
+   */
+  B
+};

--- a/testing/100_a.c
+++ b/testing/100_a.c
@@ -36,3 +36,17 @@ enum E {
  * @ingroup A
  */
 #define D 1
+
+/**
+ * @brief f() in 100_a.c.
+ *
+ * @ingroup A
+ */
+static void f(void) {};
+
+/**
+ * @brief g() in 100_a.c.
+ *
+ * @ingroup A
+ */
+void g(void) {};

--- a/testing/more_100_b.c
+++ b/testing/more_100_b.c
@@ -29,3 +29,10 @@ enum E {
  * @ingroup B
  */
 #define D 1
+
+/**
+ * @brief f() in more_100_b.c.
+ *
+ * @ingroup B
+ */
+static void f(void) {};

--- a/testing/more_100_b.c
+++ b/testing/more_100_b.c
@@ -1,0 +1,7 @@
+/**
+ * @file
+ *
+ * @ingroup B
+ *
+ * @brief more_100_b.c
+ */

--- a/testing/more_100_b.c
+++ b/testing/more_100_b.c
@@ -22,3 +22,10 @@ enum E {
    */
   B
 };
+
+/**
+ * @brief D in more_100_b.c.
+ *
+ * @ingroup B
+ */
+#define D 1

--- a/testing/more_100_b.c
+++ b/testing/more_100_b.c
@@ -43,3 +43,10 @@ static void f(void) {};
  * @ingroup B
  */
 typedef struct s T;
+
+/**
+ * @brief i in more_100_a.c.
+ *
+ * @ingroup B
+ */
+static int i;

--- a/testing/more_100_b.c
+++ b/testing/more_100_b.c
@@ -5,3 +5,20 @@
  *
  * @brief more_100_b.c
  */
+
+/**
+ * @brief E in more_100_b.c
+ *
+ * @ingroup B
+ */
+enum E {
+  /**
+   * @brief A in more_100_b.c
+   */
+  A,
+
+  /**
+   * @brief B in more_100_b.c
+   */
+  B
+};

--- a/testing/more_100_b.c
+++ b/testing/more_100_b.c
@@ -36,3 +36,10 @@ enum E {
  * @ingroup B
  */
 static void f(void) {};
+
+/**
+ * @brief T in more_100_b.c.
+ *
+ * @ingroup B
+ */
+typedef struct s T;

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -53,3 +53,19 @@
  *
  * More for E in more_100_b.c from more_100_c.c.
  */
+
+/**
+ * @def D
+ *
+ * @ingroup A
+ *
+ * More for D in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @def D
+ *
+ * @ingroup B
+ *
+ * More for D in more_100_b.c from more_100_c.c.
+ */

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -55,6 +55,38 @@
  */
 
 /**
+ * @var E::A
+ *
+ * @ingroup A
+ *
+ * More for A in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @var E::B
+ *
+ * @ingroup A
+ *
+ * More for B in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @var E::A
+ *
+ * @ingroup B
+ *
+ * More for A in more_100_b.c from more_100_c.c.
+ */
+
+/**
+ * @var E::B
+ *
+ * @ingroup B
+ *
+ * More for B in more_100_b.c from more_100_c.c.
+ */
+
+/**
  * @def D
  *
  * @ingroup A

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -17,3 +17,19 @@
 /**
  * @defgroup C C
  */
+
+/**
+ * @file 100_a.c
+ *
+ * @ingroup A
+ *
+ * More for 100_a.c from more_100_c.c
+ */
+
+/**
+ * @file more_100_b.c
+ *
+ * @ingroup B
+ *
+ * More for more_100_b.c from more_100_c.c
+ */

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -33,3 +33,23 @@
  *
  * More for more_100_b.c from more_100_c.c
  */
+
+/**
+ * @enum E
+ *
+ * @ingroup A
+ *
+ * @ingroup C
+ *
+ * More for E in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @enum E
+ *
+ * @ingroup B
+ *
+ * @ingroup C
+ *
+ * More for E in more_100_b.c from more_100_c.c.
+ */

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -151,3 +151,27 @@
  *
  * More for T in more_100_b.c from more_100_c.c.
  */
+
+/**
+ * @var i
+ *
+ * @ingroup A
+ *
+ * More for i in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @var i
+ *
+ * @ingroup B
+ *
+ * More for i in more_100_b.c from more_100_c.c.
+ */
+
+/**
+ * @var j
+ *
+ * @ingroup A
+ *
+ * More for j in 100_a.c from more_100_c.c.
+ */

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -1,0 +1,19 @@
+/**
+ * @file
+ *
+ * @ingroup C
+ *
+ * @brief more_100_c.c
+ */
+
+/**
+ * @defgroup A A
+ */
+
+/**
+ * @defgroup B B
+ */
+
+/**
+ * @defgroup C C
+ */

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -69,3 +69,27 @@
  *
  * More for D in more_100_b.c from more_100_c.c.
  */
+
+/**
+ * @fn static void f(void)
+ *
+ * @ingroup A
+ *
+ * More for f() in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @fn static void f(void)
+ *
+ * @ingroup B
+ *
+ * More for f() in more_100_b.c from more_100_c.c.
+ */
+
+/**
+ * @fn void g(void)
+ *
+ * @ingroup A
+ *
+ * More for g() in more_100_a.c from more_100_c.c.
+ */

--- a/testing/more_100_c.c
+++ b/testing/more_100_c.c
@@ -125,3 +125,29 @@
  *
  * More for g() in more_100_a.c from more_100_c.c.
  */
+
+/**
+ * @struct s
+ *
+ * @ingroup A
+ *
+ * @ingroup C
+ *
+ * More for s in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @typedef struct s T
+ *
+ * @ingroup A
+ *
+ * More for T in 100_a.c from more_100_c.c.
+ */
+
+/**
+ * @typedef struct s T
+ *
+ * @ingroup B
+ *
+ * More for T in more_100_b.c from more_100_c.c.
+ */


### PR DESCRIPTION
This patch set enables the documentation of static functions, enums, enum fields, typedefs, defines, and variables though documentation entries in a separate file using group membership relations. This can be used to augment the Doxygen produced documentation with outputs from other tools (code metrics, test results, static analysis, design to requirements traceability). In a first Doxygen run only the tagfile is produced. Then the tagfile is used to associate tool generated results with documentation items and a Doxygen documentation file is generated. This file is added to a second Doxygen run which now contains the augmented documentation.