### PR TITLE
Incorrect translator adapter version

### DIFF
--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -48,7 +48,7 @@
 #ifndef TRANSLATOR_GR_H
 #define TRANSLATOR_GR_H
 
-class TranslatorGreek : public TranslatorAdapter_1_9_4
+class TranslatorGreek : public Translator
 {
   public:
 


### PR DESCRIPTION
As indicated with the original pull request (see https://github.com/doxygen/doxygen/pull/9954#issuecomment-1484718674) the translation is now up to date and the Greek translator class should directly inherit from Translator. Due to the wrong adapter also the, automatically, generated documentation was wrong (showing 9.9.99 on a red field).
We will also get the warning:
```
The selected output language "greek" has not been updated
since release 1.9.4.  As a result some sentences may appear in English.
```
when selecting `Greek` as `OUTPUT_LANGUAGE`.