### PR TITLE
Remove obsolete parts from translator.py

### DIFF
--- a/doc/translator.py
+++ b/doc/translator.py
@@ -1237,18 +1237,9 @@ class TrManager:
         #  Normally the original sources aren't in the current directory
         # (as we are in the build directory) so we have to specify the
         # original source /documentation / ... directory.
-        self.org_src_path = self.src_path
-        self.org_doc_path = self.doc_path
-        self.org_doxy_path = self.doxy_path
-        if (len(sys.argv) > 1 and os.path.isdir(os.path.join(sys.argv[1], 'src'))):
-            self.org_src_path = os.path.join(sys.argv[1], 'src')
-            self.org_doc_path = os.path.join(sys.argv[1], 'doc')
-            self.org_doxy_path = sys.argv[1]
-            # Get the explicit arguments of the script.
-            self.script_argLst = sys.argv[2:]
-        else:
-            # Get the explicit arguments of the script.
-            self.script_argLst = sys.argv[1:]
+        self.org_src_path = os.path.join(sys.argv[1], 'src')
+        self.org_doc_path = os.path.join(sys.argv[1], 'doc')
+        self.org_doxy_path = sys.argv[1]
 
         # Create the empty dictionary for Transl object identified by the
         # class identifier of the translator.
@@ -1314,19 +1305,10 @@ class TrManager:
             self.lastModificationTime = tim
 
         # Create the list of the filenames with language translator sources.
-        # If the explicit arguments of the script were typed, process only
-        # those files.
-        if self.script_argLst:
-            lst = ['translator_' + x + '.h' for x in self.script_argLst]
-            for fname in lst:
-                if not os.path.isfile(os.path.join(self.org_src_path, fname)):
-                    sys.stderr.write("\a\nFile '%s' not found!\n" % fname)
-                    sys.exit(1)
-        else:
-            lst = os.listdir(self.org_src_path)
-            lst = [x for x in lst if x[:11] == 'translator_'
-                                   and x[-2:] == '.h'
-                                   and x != 'translator_adapter.h']
+        lst = os.listdir(self.org_src_path)
+        lst = [x for x in lst if x[:11] == 'translator_'
+                               and x[-2:] == '.h'
+                               and x != 'translator_adapter.h']
 
         # Build the object for the translator_xx.h files, and process the
         # content of the file. Then insert the object to the dictionary
@@ -1546,24 +1528,18 @@ class TrManager:
         f.write('(' + self.doxVersion + ')\n\n')
 
         # Output the information about the number of the supported languages
-        # and the list of the languages, or only the note about the explicitly
-        # given languages to process.
-        if self.script_argLst:
-            f.write('The report was generated for the following, explicitly')
-            f.write(' identified languages:\n\n')
-            f.write(self.supportedLangReadableStr + '\n\n')
-        else:
-            f.write('Doxygen supports the following ')
-            f.write(str(self.numLang))
-            f.write(' languages (sorted alphabetically):\n\n')
-            f.write(self.supportedLangReadableStr + '\n\n')
+        # and the list of the languages.
+        f.write('Doxygen supports the following ')
+        f.write(str(self.numLang))
+        f.write(' languages (sorted alphabetically):\n\n')
+        f.write(self.supportedLangReadableStr + '\n\n')
 
-            # Write the summary about the status of language translators (how
-            # many translators) are up-to-date, etc.
-            s = 'Of them, %d translators are up-to-date, ' % len(self.upToDateIdLst)
-            s += '%d translators are based on some adapter class, ' % len(self.adaptIdLst)
-            s += 'and %d are English based.' % len(self.EnBasedIdLst)
-            f.write(fill(s) + '\n\n')
+        # Write the summary about the status of language translators (how
+        # many translators) are up-to-date, etc.
+        s = 'Of them, %d translators are up-to-date, ' % len(self.upToDateIdLst)
+        s += '%d translators are based on some adapter class, ' % len(self.adaptIdLst)
+        s += 'and %d are English based.' % len(self.EnBasedIdLst)
+        f.write(fill(s) + '\n\n')
 
         # The e-mail addresses of the maintainers will be collected to
         # the auxiliary file in the order of translator classes listed
@@ -1647,28 +1623,25 @@ class TrManager:
             fmail.write('; '.join(mailtoLst))
 
             # Set the note if some old translator adapters are not needed
-            # any more. Do it only when the script is called without arguments,
-            # i.e. all languages were checked against the needed translator
-            # adapters.
-            if not self.script_argLst:
-                to_remove = {}
-                for version, adaptClassId in list(self.adaptMethodsDic.values()):
-                    if version < adaptMinVersion:
-                        to_remove[adaptClassId] = True
+            # any more.
+            to_remove = {}
+            for version, adaptClassId in list(self.adaptMethodsDic.values()):
+                if version < adaptMinVersion:
+                    to_remove[adaptClassId] = True
 
-                if to_remove:
-                    lst = list(to_remove.keys())
-                    lst.sort()
-                    plural = len(lst) > 1
-                    note = 'Note: The adapter class'
-                    if plural: note += 'es'
-                    note += ' ' + ', '.join(lst)
-                    if not plural:
-                        note += ' is'
-                    else:
-                        note += ' are'
-                    note += ' not used and can be removed.'
-                    f.write('\n' + fill(note) + '\n')
+            if to_remove:
+                lst = list(to_remove.keys())
+                lst.sort()
+                plural = len(lst) > 1
+                note = 'Note: The adapter class'
+                if plural: note += 'es'
+                note += ' ' + ', '.join(lst)
+                if not plural:
+                    note += ' is'
+                else:
+                    note += ' are'
+                note += ' not used and can be removed.'
+                f.write('\n' + fill(note) + '\n')
 
         # Write the list of the English-based classes.
         if self.EnBasedIdLst:
@@ -1689,25 +1662,23 @@ class TrManager:
                 f.write('\n')
 
         # Check for not used translator methods and generate warning if found.
-        # The check is rather time consuming, so it is not done when report
-        # is restricted to explicitly given language identifiers.
-        if not self.script_argLst:
-            dic = self.__checkForNotUsedTrMethods()
-            if dic:
-                s = '''WARNING: The following translator methods are declared
-                    in the Translator class but their identifiers do not appear
-                    in source files. The situation should be checked. The .cpp
-                    files and .h files excluding the '*translator*' files
-                    in doxygen/src directory were simply searched for occurrence
-                    of the method identifiers:'''
-                f.write('\n' + '=' * 70 + '\n')
-                f.write(fill(s) + '\n\n')
+        # The check is rather time consuming.
+        dic = self.__checkForNotUsedTrMethods()
+        if dic:
+            s = '''WARNING: The following translator methods are declared
+                in the Translator class but their identifiers do not appear
+                in source files. The situation should be checked. The .cpp
+                files and .h files excluding the '*translator*' files
+                in doxygen/src directory were simply searched for occurrence
+                of the method identifiers:'''
+            f.write('\n' + '=' * 70 + '\n')
+            f.write(fill(s) + '\n\n')
 
-                keys = list(dic.keys())
-                keys.sort()
-                for key in keys:
-                    f.write('  ' + dic[key] + '\n')
-                f.write('\n')
+            keys = list(dic.keys())
+            keys.sort()
+            for key in keys:
+                f.write('  ' + dic[key] + '\n')
+            f.write('\n')
 
         # Write the details for the translators.
         f.write('\n' + '=' * 70)


### PR DESCRIPTION
In the past it was possible only to select a number of output languages, nowadays all output languages are automatically included. In the report generation etc. part there were still some parts that were that supported his mechanism but disrupted the flow in the script. The obsolete parts have been removed