### PR TITLE
Make the translator report available in the internal documentation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -169,7 +169,7 @@ configure_file(${PROJECT_SOURCE_DIR}/doc/doxyindexer.1      ${PROJECT_BINARY_DIR
 
 # doc/language.doc (see tag Doxyfile:INPUT)
 add_custom_command(
-        COMMAND ${PYTHON_EXECUTABLE} translator.py ${PROJECT_SOURCE_DIR}
+        COMMAND ${PYTHON_EXECUTABLE} translator.py --doc ${PROJECT_SOURCE_DIR}
         DEPENDS ${PROJECT_SOURCE_DIR}/VERSION ${PROJECT_SOURCE_DIR}/doc/maintainers.txt ${PROJECT_SOURCE_DIR}/doc/language.tpl ${PROJECT_BINARY_DIR}/doc/translator.py ${LANG_FILES}
         OUTPUT language.doc
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc

--- a/doc/translator.py
+++ b/doc/translator.py
@@ -1231,15 +1231,24 @@ class TrManager:
         doxy_default = os.path.join(self.script_path, '..')
         self.doxy_path = os.path.abspath(os.getenv('DOXYGEN', doxy_default))
 
+        self.internal = False
+        if sys.argv[1] == '--doc':
+            self.internal = False
+        elif sys.argv[1] == '--doc_internal':
+            self.internal = True
+
         # Build the path names based on the Doxygen's root knowledge.
-        self.doc_path = os.path.join(self.doxy_path, 'doc')
+        if self.internal:
+            self.doc_path = os.path.join(self.doxy_path, 'doc_internal')
+        else:
+            self.doc_path = os.path.join(self.doxy_path, 'doc')
         self.src_path = os.path.join(self.doxy_path, 'src')
         #  Normally the original sources aren't in the current directory
         # (as we are in the build directory) so we have to specify the
         # original source /documentation / ... directory.
-        self.org_src_path = os.path.join(sys.argv[1], 'src')
-        self.org_doc_path = os.path.join(sys.argv[1], 'doc')
-        self.org_doxy_path = sys.argv[1]
+        self.org_src_path = os.path.join(sys.argv[2], 'src')
+        self.org_doc_path = os.path.join(sys.argv[2], 'doc')
+        self.org_doxy_path = sys.argv[2]
 
         # Create the empty dictionary for Transl object identified by the
         # class identifier of the translator.
@@ -1265,7 +1274,11 @@ class TrManager:
         # Set the names of the translator report text file, of the template
         # for generating "Internationalization" document, for the generated
         # file itself, and for the maintainers list.
-        self.translatorReportFileName = 'translator_report.txt'
+
+        if self.internal:
+            self.translatorReportFileName = 'translator_report.md'
+        else:
+            self.translatorReportFileName = 'translator_report.txt'
         self.maintainersFileName = 'maintainers.txt'
         self.languageTplFileName = 'language.tpl'
         self.languageDocFileName = 'language.doc'
@@ -1525,7 +1538,11 @@ class TrManager:
         f = xopen(output, 'w')
 
         # Output the information about the version.
-        f.write('(' + self.doxVersion + ')\n\n')
+        if self.internal:
+            f.write('@page pg_trans Translator report\n\n')
+            f.write('@verbatim\n\n')
+        else:
+            f.write('(' + self.doxVersion + ')\n\n')
 
         # Output the information about the number of the supported languages
         # and the list of the languages.
@@ -1691,6 +1708,9 @@ class TrManager:
             obj = self.__translDic[c]
             assert(obj.classId != 'Translator')
             obj.report(f)
+
+        if self.internal:
+            f.write('\n\n@endverbatim\n')
 
         # Close the report file and the auxiliary file with e-mails.
         f.close()

--- a/doc_internal/CMakeLists.txt
+++ b/doc_internal/CMakeLists.txt
@@ -21,6 +21,20 @@ endif()
 
 configure_file(${CMAKE_SOURCE_DIR}/doc_internal/Doxyfile.in "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile" @ONLY)
 
+set(DOC_FILES
+        language.tpl
+        maintainers.txt
+        translator.py
+)
+
+foreach (f  ${DOC_FILES})
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/doc_internal/${f}
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doc/${f} ${PROJECT_BINARY_DIR}/doc_internal/
+    DEPENDS ${PROJECT_SOURCE_DIR}/doc/${f}
+    )
+set_source_files_properties(${PROJECT_BINARY_DIR}/doc_internal/${f} PROPERTIES GENERATED 1)
+endforeach()
+
 add_custom_command(
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/doc_internal/cmds_tags.py -cmds ${CMAKE_SOURCE_DIR}/doc_internal ${CMAKE_SOURCE_DIR}/doc_internal/commands_history.md ${PROJECT_BINARY_DIR}/doc_internal/commands_history.md
     DEPENDS ${CMAKE_CURRENT_LIST_DIR}/cmds_tags.py ${CMAKE_SOURCE_DIR}/doc_internal/commands_history.md
@@ -33,10 +47,18 @@ add_custom_command(
     OUTPUT ${PROJECT_BINARY_DIR}/doc_internal/tags_history.md
 )
 
+add_custom_command(
+        COMMAND ${PYTHON_EXECUTABLE} translator.py --doc_internal ${PROJECT_SOURCE_DIR}
+        DEPENDS ${PROJECT_SOURCE_DIR}/VERSION ${PROJECT_SOURCE_DIR}/doc/maintainers.txt ${PROJECT_SOURCE_DIR}/doc/language.tpl ${PROJECT_BINARY_DIR}/doc_internal/translator.py ${LANG_FILES}
+        OUTPUT translator_report.md
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc_internal
+)
+
 add_custom_target(docs_internal
         COMMENT "Generating HTML internal documentation."
         COMMAND ${CMAKE_COMMAND} -E env VERSION=${VERSION} ${DOXYGEN_EXECUTABLE}
         DEPENDS doxygen
         DEPENDS ${PROJECT_BINARY_DIR}/doc_internal/commands_history.md
         DEPENDS ${PROJECT_BINARY_DIR}/doc_internal/tags_history.md
+        DEPENDS ${PROJECT_BINARY_DIR}/doc_internal/translator_report.md
         )

--- a/doc_internal/Doxyfile.in
+++ b/doc_internal/Doxyfile.in
@@ -117,6 +117,7 @@ INPUT                  = \
                          @CMAKE_SOURCE_DIR@/doc_internal/commands_internal.md \
                          @CMAKE_SOURCE_DIR@/doc_internal/releases.md \
                          @PROJECT_BINARY_DIR@/doc_internal/tags_history.md \
+                         @PROJECT_BINARY_DIR@/doc_internal/translator_report.md \
                          @CMAKE_SOURCE_DIR@/src \
                          @CMAKE_SOURCE_DIR@/vhdlparser \
                          @CMAKE_SOURCE_DIR@/libxml


### PR DESCRIPTION
In the doxygen manual there is an overview of the status of the different translators, though there is a more detailed report available as well, this report has been made accessible in the internal documentation (so it is easier to find).