### PR TITLE
Add test case for enum typedef

### DIFF
--- a/testing/099/099__a_8c.xml
+++ b/testing/099/099__a_8c.xml
@@ -32,6 +32,22 @@
         <location file="099_a.c" line="15" column="1" bodyfile="099_a.c" bodystart="15" bodyend="25"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="099__a_8c_1a620c373f942e951632e076054ad2d057" prot="public" static="no">
+        <type>enum <ref refid="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" kindref="member">E</ref></type>
+        <definition>typedef enum E E</definition>
+        <argsstring/>
+        <name>E</name>
+        <briefdescription>
+          <para>E in a.c. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="099_a.c" line="25" column="3"/>
+      </memberdef>
+    </sectiondef>
     <briefdescription>
       <para>a.c </para>
     </briefdescription>

--- a/testing/099/more__099__b_8c.xml
+++ b/testing/099/more__099__b_8c.xml
@@ -32,6 +32,22 @@
         <location file="more_099_b.c" line="10" column="1" bodyfile="more_099_b.c" bodystart="10" bodyend="20"/>
       </memberdef>
     </sectiondef>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="more__099__b_8c_1a620c373f942e951632e076054ad2d057" prot="public" static="no">
+        <type>enum <ref refid="099__a_8c_1aa57b8491d1d8fc1014dd54bcf83b130a" kindref="member">E</ref></type>
+        <definition>typedef enum E E</definition>
+        <argsstring/>
+        <name>E</name>
+        <briefdescription>
+          <para>E in b.c. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="more_099_b.c" line="20" column="3"/>
+      </memberdef>
+    </sectiondef>
     <briefdescription>
       <para>b.c </para>
     </briefdescription>

--- a/testing/099_a.c
+++ b/testing/099_a.c
@@ -12,7 +12,7 @@
 /**
  * @brief E in a.c
  */
-enum E {
+typedef enum E {
   /**
    * @brief A in a.c
    */
@@ -22,4 +22,4 @@ enum E {
    * @brief B in a.c
    */
   B
-};
+} E;

--- a/testing/more_099_b.c
+++ b/testing/more_099_b.c
@@ -7,7 +7,7 @@
 /**
  * @brief E in b.c
  */
-enum E {
+typedef enum E {
   /**
    * @brief A in b.c
    */
@@ -17,4 +17,4 @@ enum E {
    * @brief B in b.c
    */
   B
-};
+} E;


### PR DESCRIPTION
This test case shows a bug.  The typedef in file more_099_b.c wrongly references the enum in file 099_a.c.

See also: #3728, #9926.