### PR TITLE
issue #7087 Invalid (X)HTML in case of \mscfile, \dotfile, \diafile

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1785,6 +1785,7 @@ void HtmlDocVisitor::operator()(const DocDotFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
+  m_t << "</p>";
   m_t << "<div class=\"dotgraph\">\n";
   writeDotFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
   if (df.hasCaption())
@@ -1797,12 +1798,14 @@ void HtmlDocVisitor::operator()(const DocDotFile &df)
     m_t << "</div>\n";
   }
   m_t << "</div>\n";
+  m_t << "<p>";
 }
 
 void HtmlDocVisitor::operator()(const DocMscFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
+  m_t << "</p>";
   m_t << "<div class=\"mscgraph\">\n";
   writeMscFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
   if (df.hasCaption())
@@ -1815,12 +1818,14 @@ void HtmlDocVisitor::operator()(const DocMscFile &df)
     m_t << "</div>\n";
   }
   m_t << "</div>\n";
+  m_t << "<p>";
 }
 
 void HtmlDocVisitor::operator()(const DocDiaFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
+  m_t << "</p>";
   m_t << "<div class=\"diagraph\">\n";
   writeDiaFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
   if (df.hasCaption())
@@ -1833,6 +1838,7 @@ void HtmlDocVisitor::operator()(const DocDiaFile &df)
     m_t << "</div>\n";
   }
   m_t << "</div>\n";
+  m_t << "<p>";
 }
 
 void HtmlDocVisitor::operator()(const DocLink &lnk)

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -120,6 +120,9 @@ static bool mustBeOutsideParagraph(const DocNodeVariant &n)
                                  /* <hr> */         DocHorRuler,
                                  /* <blockquote> */ DocHtmlBlockQuote,
                                  /* \parblock */    DocParBlock,
+                                 /* \dotfile */     DocDotFile,
+                                 /* \mscfile */     DocMscFile,
+                                 /* \diafile */     DocDiaFile,
                                  /* <details> */    DocHtmlDetails,
                                  /* <summary> */    DocHtmlSummary,
                                                     DocIncOperator >(n))
@@ -1785,7 +1788,7 @@ void HtmlDocVisitor::operator()(const DocDotFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
-  m_t << "</p>";
+  forceEndParagraph(df);
   m_t << "<div class=\"dotgraph\">\n";
   writeDotFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
   if (df.hasCaption())
@@ -1798,14 +1801,14 @@ void HtmlDocVisitor::operator()(const DocDotFile &df)
     m_t << "</div>\n";
   }
   m_t << "</div>\n";
-  m_t << "<p>";
+  forceStartParagraph(df);
 }
 
 void HtmlDocVisitor::operator()(const DocMscFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
-  m_t << "</p>";
+  forceEndParagraph(df);
   m_t << "<div class=\"mscgraph\">\n";
   writeMscFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
   if (df.hasCaption())
@@ -1818,14 +1821,14 @@ void HtmlDocVisitor::operator()(const DocMscFile &df)
     m_t << "</div>\n";
   }
   m_t << "</div>\n";
-  m_t << "<p>";
+  forceStartParagraph(df);
 }
 
 void HtmlDocVisitor::operator()(const DocDiaFile &df)
 {
   if (m_hide) return;
   if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
-  m_t << "</p>";
+  forceEndParagraph(df);
   m_t << "<div class=\"diagraph\">\n";
   writeDiaFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
   if (df.hasCaption())
@@ -1838,7 +1841,7 @@ void HtmlDocVisitor::operator()(const DocDiaFile &df)
     m_t << "</div>\n";
   }
   m_t << "</div>\n";
-  m_t << "<p>";
+  forceStartParagraph(df);
 }
 
 void HtmlDocVisitor::operator()(const DocLink &lnk)


### PR DESCRIPTION
Adding closing and opening paragraph tag before / after the  `\mscfile` etc. as a `\mscfile` can only appear inside a paragraph and would always be a "new" paragraph.

(Extended example: [example_2.tar.gz](https://github.com/doxygen/doxygen/files/11170345/example_2.tar.gz))
