### PR TITLE
Incorrect line count in markdown 

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2888,13 +2888,17 @@ QCString Markdown::processQuotations(const QCString &s,int refIndent)
           uint32_t ii = 0;
           // check for absence of start command, either @start<cmd>, or \\start<cmd>
           while (ii<pl.length() && qisspace(pl[ii])) ii++; // skip leading whitespace
+          bool addNewLines = true;
           if (ii+startCmd.length()>=pl.length() || // no room for start command
               (pl[ii]!='\\' && pl[ii]!='@') ||     // no @ or \ after whitespace
               qstrncmp(pl.data()+ii+1,startCmd.data(),startCmd.length())!=0) // no start command
           {
             pl = "@"+startCmd+"\\ilinebr " + pl + " @"+endCmd;
+            addNewLines = false;
           }
+          if (addNewLines) m_out.addChar('\n');
           processSpecialCommand(pl.data(),0,pl.length());
+          if (addNewLines) m_out.addChar('\n');
         };
 
         if (!Config_getString(PLANTUML_JAR_PATH).isEmpty() && lang=="plantuml")


### PR DESCRIPTION
In case a start / end command is present in a markdown code block regarding plantuml the line count is incorrect, e.g.

```
Test on plantuml code
=================

```
@startuml
A -> B
@enduml
```

```{plantuml}
@startuml
A -> B
@enduml
```
@error_16

```{plantuml}
A -> B
```
@error_21
```
results in the warnings:
```
aa.md:14: warning: Found unknown command '@error_16'
aa.md:19: warning: Found unknown command '@error_21'
```
giving the wrong line numbers.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11178790/example.tar.gz)
