### PR TITLE
Allow multiple newlines in a code span.

### DIFF
--- a/doc/markdown.doc
+++ b/doc/markdown.doc
@@ -189,7 +189,7 @@ emphasis / strikethrough spans slightly different than standard Markdown / GitHu
 
 \subsection md_codespan code spans
 
-To indicate a span of code, you should wrap it in backticks (`). Unlike code blocks,
+To indicate a span of code, you should wrap it in backticks (`` ` ``). Unlike code blocks,
 code spans appear inline in a paragraph. An example:
 
     Use the `printf()` function.

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1504,8 +1504,8 @@ int Markdown::processCodeSpan(const char *data, int /*offset*/, int size)
 
   /* finding the next delimiter */
   i = 0;
-  int nl=0;
-  for (end=nb; end<size && i<nb && nl<2; end++)
+  char pc = '`';
+  for (end=nb; end<size && i<nb; end++)
   {
     if (data[end]=='`')
     {
@@ -1513,8 +1513,10 @@ int Markdown::processCodeSpan(const char *data, int /*offset*/, int size)
     }
     else if (data[end]=='\n')
     {
-      i=0;
-      nl++;
+      // consecutive newlines
+      if (pc == '\n') return 0;
+      pc = '\n';
+      i = 0;
     }
     else if (data[end]=='\'' && nb==1 && (end==size-1 || (end<size-1 && !isIdChar(end+1))))
     { // look for quoted strings like 'some word', but skip strings like `it's cool`
@@ -1527,16 +1529,13 @@ int Markdown::processCodeSpan(const char *data, int /*offset*/, int size)
     }
     else
     {
+      if (data[end]!=' ') pc = data[end];
       i=0;
     }
   }
   if (i < nb && end >= size)
   {
     return 0;  // no matching delimiter
-  }
-  if (nl==2) // too many newlines inside the span
-  {
-    return 0;
   }
 
   // trimming outside whitespaces


### PR DESCRIPTION
Currently a maximum of 1 newline is allowed in a code span, so something like:
```
`void fie(int t,
 int x,
 int y,
 int z)`
```
results in a warning.
With this patch multiple newlines are allowed, though a newline followed a new newline or a line with with just spaces  will terminate the code span as an incomplete code span.