### PR TITLE
Warnings in LaTeX output

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -13,6 +13,8 @@
 % input used in their production; they are not affected by this license.
 
 \batchmode
+\pdfminorversion=7
+\pdfsuppresswarningpagegroup=1
 \documentclass{book}
 %% moved from doxygen.sty due to workaround for LaTex 2019 version and unmaintained tabu package
 \usepackage{ifthen}

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -935,12 +935,21 @@ void LatexDocVisitor::operator()(const DocSimpleListItem &li)
 void LatexDocVisitor::operator()(const DocSection &s)
 {
   if (m_hide) return;
-  if (Config_getBool(PDF_HYPERLINKS))
+  bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
+  if (pdfHyperlinks)
   {
     m_t << "\\hypertarget{" << stripPath(s.file()) << "_" << s.anchor() << "}{}";
   }
   m_t << "\\" << getSectionName(s.level()) << "{";
+  if (pdfHyperlinks)
+  {
+    m_t << "\\texorpdfstring{";
+  }
   filter(convertCharEntitiesToUTF8(s.title()));
+  if (pdfHyperlinks)
+  {
+    m_t << "}{" << latexEscapePDFString(convertCharEntitiesToUTF8(s.title())) << "}";
+  }
   m_t << "}\\label{" << stripPath(s.file()) << "_" << s.anchor() << "}\n";
   visitChildren(s);
 }

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2302,7 +2302,7 @@ void filterLatexString(TextStream &t,const QCString &str,
                    break;
         case '\\': t << "\\textbackslash{}";
                    break;
-        case '"':  t << "\\char`\\\"{}";
+        case '"':  t << "\\\"{}";
                    break;
         case '`':  t << "\\`{}";
                    break;
@@ -2447,6 +2447,9 @@ QCString latexEscapePDFString(const QCString &s)
       case '_':  t << "\\_"; break;
       case '%':  t << "\\%"; break;
       case '&':  t << "\\&"; break;
+      case '#':  t << "\\#"; break;
+      case '$':  t << "\\$"; break;
+      case '~':  t << "\\string~";    break;
       default:
         t << c;
         break;

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -6,6 +6,8 @@
   % to overcome problems with too many open files
   \let\mypdfximage\pdfximage\def\pdfximage{\immediate\mypdfximage}
 
+  \pdfminorversion=7
+
   % Set document class depending on configuration
 %%BEGIN COMPACT_LATEX
   \documentclass[twoside]{article}
@@ -24,7 +26,12 @@
   %%
 
   % Packages required by doxygen
-  \usepackage{fixltx2e} % for \textsubscript
+  \makeatletter
+  \providecommand\IfFormatAtLeastTF{\@ifl@t@r\fmtversion}
+  \makeatother
+  \IfFormatAtLeastTF{2016/01/01}{}{\usepackage{fixltx2e}} % for \textsubscript
+  \IfFormatAtLeastTF{2015/01/01}{\pdfsuppresswarningpagegroup=1}{}
+
   \usepackage{doxygen}
 
   $extralatexstylesheet

--- a/templates/latex/latexrefman.tpl
+++ b/templates/latex/latexrefman.tpl
@@ -1,7 +1,12 @@
+\pdfminorversion=7
 \documentclass[twoside]{<% if config.COMPACT_LATEX %>article<% else %>book<% endif %>}
 
 % Packages required by doxygen
-\usepackage{fixltx2e}
+\makeatletter
+\providecommand\IfFormatAtLeastTF{\@ifl@t@r\fmtversion}
+\makeatother
+\IfFormatAtLeastTF{2016/01/01}{}{\usepackage{fixltx2e}} % for \textsubscript
+\IfFormatAtLeastTF{2015/01/01}{\pdfsuppresswarningpagegroup=1}{}
 \usepackage{calc}
 \usepackage{doxygen}
 \usepackage[export]{adjustbox} % also loads graphicx


### PR DESCRIPTION
When looking at the doxygen PDF / LaTeX doxcumentatioon we see quite a few warnings like:
```
Package hyperref Warning: Token not allowed in a PDF string (Unicode):
(hyperref)                removing `\char' on input line 103.
```
This also results in an extra `` ` `` in the LaTeX bookmarks

```
Package hyperref Warning: Token not allowed in a PDF string (Unicode):
(hyperref)                removing `math shift' on input line 227.
```
on another place we already have the usage of `texorpdfstring`, this is now added for other sections as well. This required that some characters were properly defined and especially the `~` as with the `\~[LanguageId]` in the bookmarks the `~` was not present and now it is.

During testing we also got the following warning:
```
Package: fixltx2e 2016/12/29 v2.1a fixes to LaTeX (obsolete)
Applying: [2015/01/01] Old fixltx2e package on input line 46.

Package fixltx2e Warning: fixltx2e is not required with releases after 2015
(fixltx2e)                All fixes are now in the LaTeX kernel.
(fixltx2e)                See the latexrelease package for details.
```
Now the package `fixltx2e` is only included for the older versions , see also https://tex.stackexchange.com/q/682754/44119

```
pdfTeX warning: pdflatex.exe (file ./infoflow.pdf): PDF inclusion: found PDF version <1.7>, but at most version <1.5> allowed
```
Setting the pdfminor version to 7, see also https://tex.stackexchange.com/a/542352/44119

```
pdfTeX warning: pdflatex.exe (file ./examples/diagrams/latex//class_a__coll__graph.pdf):
 PDF inclusion: multiple pdfs with page group included in a single page
```
Just suppress the warnings for the newer versions of LaTeX, see also https://tex.stackexchange.com/a/78020/44119