### PR TITLE
Warnings in LaTeX output (2)

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -62,7 +62,6 @@
 \usepackage{mathptmx}
 \usepackage[scaled=.90]{helvet}
 \usepackage{courier}
-\usepackage{sectsty}
 \usepackage[titles]{tocloft}
 \usepackage{amssymb}
 \usepackage{doxygen}

--- a/doc/manual.sty
+++ b/doc/manual.sty
@@ -1,6 +1,5 @@
 % Use helvetica font instead of times roman
 \RequirePackage{helvet}
-\RequirePackage{sectsty}
 \RequirePackage{tocloft}
 \providecommand{\rmdefault}{phv}
 \providecommand{\bfdefault}{bc}

--- a/src/htmlentity.cpp
+++ b/src/htmlentity.cpp
@@ -52,7 +52,7 @@ static const std::vector<HtmlEntityInfo> g_htmlEntities
   { SYM(yen),      "\xc2\xa5",     "&yen;",      "<yen/>",               "&#165;",        "{$\\yen$}",              NULL,     "\\'A5",       { NULL,         HtmlEntityMapper::Perl_unknown }},
   { SYM(brvbar),   "\xc2\xa6",     "&brvbar;",   "<brvbar/>",            "&#166;",        "\\textbrokenbar{}",      NULL,     "\\'A6",       { NULL,         HtmlEntityMapper::Perl_unknown }},
   { SYM(sect),     "\xc2\xa7",     "&sect;",     "<sect/>",              "<simplesect/>", "{$\\S$}",                NULL,     "\\'A7",       { "sect",       HtmlEntityMapper::Perl_symbol  }},
-  { SYM(uml),      "\xc2\xa8",     "&uml;",      "<umlaut/>",            "&#168;",        "\\textasciidieresis{}",  " \\*(4", "\\'A8",       { " ",          HtmlEntityMapper::Perl_umlaut  }},
+  { SYM(uml),      "\xc2\xa8",     "&uml;",      "<umlaut/>",            "&#168;",        "\\\"{ }",                " \\*(4", "\\'A8",       { " ",          HtmlEntityMapper::Perl_umlaut  }},
   { SYM(copy),     "\xc2\xa9",     "&copy;",     "<copy/>",              "&#169;",        "\\copyright{}",          "(C)",    "\\'A9",       { "copyright",  HtmlEntityMapper::Perl_symbol  }},
   { SYM(ordf),     "\xc2\xaa",     "&ordf;",     "<ordf/>",              "&#170;",        "\\textordfeminine{}",    NULL,     "\\'AA",       { NULL,         HtmlEntityMapper::Perl_unknown }},
   { SYM(laquo),    "\xc2\xab",     "&laquo;",    "<laquo/>",             "&#171;",        "\\guillemotleft{}",      NULL,     "\\'AB",       { NULL,         HtmlEntityMapper::Perl_unknown }},

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2172,10 +2172,28 @@ void writeLatexSpecialFormulaChars(TextStream &t)
     sup3[1]= 0xB3;
     sup3[2]= 0;
 
-    t << "\\usepackage{newunicodechar}\n"
-         "  \\newunicodechar{" << minus << "}{${}^{-}$}% Superscript minus\n"
-         "  \\newunicodechar{" << sup2  << "}{${}^{2}$}% Superscript two\n"
-         "  \\newunicodechar{" << sup3  << "}{${}^{3}$}% Superscript three\n"
+    t << "\\usepackage{newunicodechar}\n";
+    // taken from the newunicodechar package and removed the warning message
+    // actually forcing to redefine the unicode character
+    t << "  \\makeatletter\n"
+         "    \\def\\doxynewunicodechar#1#2{%\n"
+         "    \\@tempswafalse\n"
+         "    \\edef\\nuc@tempa{\\detokenize{#1}}%\n"
+         "    \\if\\relax\\nuc@tempa\\relax\n"
+         "      \\nuc@emptyargerr\n"
+         "    \\else\n"
+         "      \\edef\\@tempb{\\expandafter\\@car\\nuc@tempa\\@nil}%\n"
+         "      \\nuc@check\n"
+         "      \\if@tempswa\n"
+         "        \\@namedef{u8:\\nuc@tempa}{#2}%\n"
+         "      \\fi\n"
+         "    \\fi\n"
+         "  }\n"
+         "  \\makeatother\n";
+
+    t << "  \\doxynewunicodechar{" << minus << "}{${}^{-}$}% Superscript minus\n"
+         "  \\doxynewunicodechar{" << sup2  << "}{${}^{2}$}% Superscript two\n"
+         "  \\doxynewunicodechar{" << sup3  << "}{${}^{3}$}% Superscript three\n"
          "\n";
 }
 

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -604,6 +604,36 @@
                                      {1.5ex \@plus .2ex}%
                                      {\raggedright\normalfont\normalsize\bfseries}}
 \makeatother
+% the sectsty doesn't look to be maintained but gives, in our case, some warning like:
+% LaTeX Warning: Command \underline  has changed.
+%               Check if current package is valid.
+% unfortunately had to copy the relevant part
+\newcommand*{\doxypartfont}          [1]
+   {\gdef\SS@partnumberfont{\SS@sectid{0}\SS@nopart\SS@makeulinepartchap#1}
+    \gdef\SS@parttitlefont{\SS@sectid{0}\SS@titlepart\SS@makeulinepartchap#1}}
+\newcommand*{\doxychapterfont}       [1]
+   {\gdef\SS@chapnumfont{\SS@sectid{1}\SS@nopart\SS@makeulinepartchap#1}
+    \gdef\SS@chaptitlefont{\SS@sectid{1}\SS@titlepart\SS@makeulinepartchap#1}}
+\newcommand*{\doxysectionfont}       [1]
+   {\gdef\SS@sectfont{\SS@sectid{2}\SS@rr\SS@makeulinesect#1}}
+\newcommand*{\doxysubsectionfont}    [1]
+   {\gdef\SS@subsectfont{\SS@sectid{3}\SS@rr\SS@makeulinesect#1}}
+\newcommand*{\doxysubsubsectionfont} [1]
+   {\gdef\SS@subsubsectfont{\SS@sectid{4}\SS@rr\SS@makeulinesect#1}}
+\newcommand*{\doxyparagraphfont}     [1]
+   {\gdef\SS@parafont{\SS@sectid{5}\SS@rr\SS@makeulinesect#1}}
+\newcommand*{\doxysubparagraphfont}  [1]
+   {\gdef\SS@subparafont{\SS@sectid{6}\SS@rr\SS@makeulinesect#1}}
+\newcommand*{\doxyminisecfont}  [1]
+   {\gdef\SS@minisecfont{\SS@sectid{7}\SS@rr\SS@makeulinepartchap#1}}
+\newcommand*{\doxyallsectionsfont}   [1] {\doxypartfont{#1}%
+                                          \doxychapterfont{#1}%
+                                          \doxysectionfont{#1}%
+                                          \doxysubsectionfont{#1}%
+                                          \doxysubsubsectionfont{#1}%
+                                          \doxyparagraphfont{#1}%
+                                          \doxysubparagraphfont{#1}%
+                                          \doxyminisecfont{#1}}%
 % Define caption that is also suitable in a table
 \makeatletter
 \def\doxyfigcaption{%

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -56,8 +56,7 @@
   % set main and monospaced font
   $latexfont
 
-  \usepackage{sectsty}
-  \allsectionsfont{%
+  \doxyallsectionsfont{%
     \fontseries{bc}\selectfont%
     \color{darkgray}%
   }

--- a/templates/latex/latexrefman.tpl
+++ b/templates/latex/latexrefman.tpl
@@ -30,9 +30,8 @@
 \usepackage[scaled=.90]{helvet}
 \usepackage{courier}
 \usepackage{amssymb}
-\usepackage{sectsty}
 \renewcommand{\familydefault}{\sfdefault}
-\allsectionsfont{
+\doxyallsectionsfont{
   \fontseries{bc}\selectfont
   \color{darkgray}
 }

--- a/templates/latex/longtable_doxygen.sty
+++ b/templates/latex/longtable_doxygen.sty
@@ -438,7 +438,15 @@
   \the\LT@p@ftn
   \global\LT@p@ftn{}%
   \hfil}
-\def\LT@p@ftntext#1{%
+%% added \long to prevent:
+% LaTeX Warning: Command \LT@p@ftntext  has changed.
+%
+% from the original repository (https://github.com/latex3/latex2e/blob/develop/required/tools/longtable.dtx):
+% \changes{v4.15}{2021/03/28}
+%      {make long for gh/364}
+% Inside the `p' column, just save up the footnote text in a token
+% register.
+\long\def\LT@p@ftntext#1{%
   \edef\@tempa{\the\LT@p@ftn\noexpand\footnotetext[\the\c@footnote]}%
   \global\LT@p@ftn\expandafter{\@tempa{#1}}}%
 


### PR DESCRIPTION
When looking at the doxygen PDF / LaTeX documentation we see  warnings like:
```
LaTeX Warning: Command \underbar  has changed.
               Check if current package is valid.

LaTeX Warning: Command \underline  has changed.
               Check if current package is valid.
```
this is due to the `sectsty` package (looks like to be unmaintained), we only use from this package the `allsectionsfont`, included relevant part in doxygen and renamed parts.

```
Package newunicodechar Warning: Redefining Unicode character
```
We want to (re)define some unicode characters, so taking the relevant part from the package `newunicodechar` and created the command `doxynewunicodechar` without the warning (had to be done in latexgen.cpp as the code is used in the formulas and the "normal" output).

```
LaTeX Warning: Command \LT@p@ftntext  has changed.
               Check if current package is valid.
```
the `longtable` package as used by doxygen missed a small update that prevented this warning.

```
Package textcomp Warning: Symbol \textasciidieresis not provided by
(textcomp)                font family phv in TS1 encoding
```
redefining the "pure" umlaut character in more "native" LaTeX