### PR TITLE
Confusing entries in legend explanation

### DIFF
--- a/src/dotlegendgraph.cpp
+++ b/src/dotlegendgraph.cpp
@@ -48,22 +48,22 @@ void DotLegendGraph::computeTheGraph()
   writeGraphHeader(md5stream,theTranslator->trLegendTitle());
 
   DotNode{this,"Inherited", "", "", TRUE}.setNodeId(9).writeBox(md5stream, CallGraph, GOF_BITMAP, false);
-  md5stream << "  Node10 -> Node9 [dir=\"back\",color=\"steelblue1\",style=\"solid\"];\n";
-  DotNode{this,"PublicBase", "", "url"}.setNodeId(10).markHasDocumentation().writeBox(md5stream, CallGraph, GOF_BITMAP, false);
-  md5stream << "  Node11 -> Node10 [dir=\"back\",color=\"steelblue1\",style=\"solid\"];\n";
-  DotNode{this,"Truncated", "", "url"}.setNodeId(11).markAsTruncated().markHasDocumentation().writeBox(md5stream, CallGraph, GOF_BITMAP, true);
-  md5stream << "  Node13 -> Node9 [dir=\"back\",color=\"darkgreen\",style=\"solid\"];\n";
-  md5stream << "  Node13 [label=\"ProtectedBase\",color=\"gray40\",fillcolor=\"white\",style=\"filled\"];\n";
-  md5stream << "  Node14 -> Node9 [dir=\"back\",color=\"firebrick4\",style=\"solid\"];\n";
-  md5stream << "  Node14 [label=\"PrivateBase\",color=\"gray40\",fillcolor=\"white\",style=\"filled\"];\n";
-  md5stream << "  Node15 -> Node9 [dir=\"back\",color=\"steelblue1\",style=\"solid\"];\n";
+  md5stream << "  Node10 -> Node9 [dir=\"back\",color=\"steelblue1\",style=\"solid\" tooltip=\" \"];\n";
+  DotNode{this,"PublicBase", "", "doxygen_dummy_url"}.setNodeId(10).markHasDocumentation().writeBox(md5stream, CallGraph, GOF_BITMAP, false);
+  md5stream << "  Node11 -> Node10 [dir=\"back\",color=\"steelblue1\",style=\"solid\" tooltip=\" \"];\n";
+  DotNode{this,"Truncated", "", "doxygen_dummy_url"}.setNodeId(11).markAsTruncated().markHasDocumentation().writeBox(md5stream, CallGraph, GOF_BITMAP, true);
+  md5stream << "  Node13 -> Node9 [dir=\"back\",color=\"darkgreen\",style=\"solid\" tooltip=\" \"];\n";
+  md5stream << "  Node13 [label=\"ProtectedBase\",color=\"gray40\",fillcolor=\"white\",style=\"filled\" tooltip=\" \"];\n";
+  md5stream << "  Node14 -> Node9 [dir=\"back\",color=\"firebrick4\",style=\"solid\" tooltip=\" \"];\n";
+  md5stream << "  Node14 [label=\"PrivateBase\",color=\"gray40\",fillcolor=\"white\",style=\"filled\" tooltip=\" \"];\n";
+  md5stream << "  Node15 -> Node9 [dir=\"back\",color=\"steelblue1\",style=\"solid\" tooltip=\" \"];\n";
   DotNode{this,"Undocumented", "", ""}.setNodeId(15).writeBox(md5stream, CallGraph, GOF_BITMAP, false);
-  md5stream << "  Node16 -> Node9 [dir=\"back\",color=\"steelblue1\",style=\"solid\"];\n";
-  md5stream << "  Node16 [label=\"Templ\\< int \\>\",color=\"gray40\",fillcolor=\"white\",style=\"filled\"];\n";
-  md5stream << "  Node17 -> Node16 [dir=\"back\",color=\"orange\",style=\"dashed\",label=\"< int >\",fontcolor=\"grey\"];\n";
-  md5stream << "  Node17 [label=\"Templ\\< T \\>\",color=\"gray40\",fillcolor=\"white\",style=\"filled\"];\n";
-  md5stream << "  Node18 -> Node9 [dir=\"back\",color=\"darkorchid3\",style=\"dashed\",label=\"m_usedClass\",fontcolor=\"grey\"];\n";
-  md5stream << "  Node18 [label=\"Used\",color=\"gray40\",fillcolor=\"white\",style=\"filled\"];\n";
+  md5stream << "  Node16 -> Node9 [dir=\"back\",color=\"steelblue1\",style=\"solid\" tooltip=\" \"];\n";
+  md5stream << "  Node16 [label=\"Templ\\< int \\>\",color=\"gray40\",fillcolor=\"white\",style=\"filled\" tooltip=\" \"];\n";
+  md5stream << "  Node17 -> Node16 [dir=\"back\",color=\"orange\",style=\"dashed\",label=\"< int >\",fontcolor=\"grey\" tooltip=\" \"];\n";
+  md5stream << "  Node17 [label=\"Templ\\< T \\>\",color=\"gray40\",fillcolor=\"white\",style=\"filled\" tooltip=\" \"];\n";
+  md5stream << "  Node18 -> Node9 [dir=\"back\",color=\"darkorchid3\",style=\"dashed\",label=\"m_usedClass\",fontcolor=\"grey\" tooltip=\" \"];\n";
+  md5stream << "  Node18 [label=\"Used\",color=\"gray40\",fillcolor=\"white\",style=\"filled\" tooltip=\" \"];\n";
   writeGraphFooter(md5stream);
   m_theGraph = md5stream.str();
 }

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -489,8 +489,7 @@ void DotNode::writeLabel(TextStream &t, GraphType gt) const
 
 void DotNode::writeUrl(TextStream &t) const
 {
-  if (m_url.isEmpty())
-    return;
+  if (m_url.isEmpty() || m_url == "doxygen_dummy_url") return;
   int tagPos = m_url.findRev('$');
   t << ",URL=\"";
   QCString noTagURL = m_url;


### PR DESCRIPTION
- tooltips with node numbers, removed by means tooltip with just a space (see also #9970)
- for Truncated and PublicBase an non existing url was defined, this has now been removed by means of a dedicated name

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11241925/example.tar.gz)
