### PR TITLE
Undefined references in pdf documents

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1332,9 +1332,14 @@ void LatexGenerator::startTitleHead(const QCString &fileName)
 void LatexGenerator::endTitleHead(const QCString &fileName,const QCString &name)
 {
   m_t << "}\n";
+  QCString fn = stripPath(fileName);
+  if (!fn.isEmpty())
+  {
+    m_t << "\\label{" << fn << "}";
+  }
   if (!name.isEmpty())
   {
-    m_t << "\\label{" << stripPath(fileName) << "}\\index{";
+    m_t << "\\index{";
     m_t << latexEscapeLabelName(name);
     m_t << "@{";
     m_t << latexEscapeIndexChars(name);


### PR DESCRIPTION
In the doxygen test suite we see warnings like:
```
LaTeX Warning: Reference `013__class_8h_source' on page 3 undefined on input line 3.
```
which result in `??` in the resulting pdf file.
(looks like to happen mostly occurs for source files without file description).

By splitting the label and index part (analogous to what is done in rtfgen.cpp) the problem is resolved.