### PR TITLE
Fix warnings

### DIFF
--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -248,7 +248,7 @@ namespace Mappers
 {
   extern const Mapper *cmdMapper;
   extern const Mapper *htmlTagMapper;
-};
+}
 
 
 #endif

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -62,8 +62,8 @@ class DeepCopyUniquePtr : public std::unique_ptr<T>
   public:
     using std::unique_ptr<T>::unique_ptr;
     DeepCopyUniquePtr(const DeepCopyUniquePtr &other)
+       : std::unique_ptr<T>(other ? new T(*other) : nullptr)
     {
-      this->reset(other ? new T(*other) : nullptr);
     }
     DeepCopyUniquePtr &operator=(const DeepCopyUniquePtr &other)
     {


### PR DESCRIPTION
fix new warnings:

```
.../src/definition.cpp: In instantiation of ‘DeepCopyUniquePtr<T>::DeepCopyUniquePtr(const DeepCopyUniquePtr<T>&) [with T = BodyInfo]’:
.../src/definition.cpp:83:23:   required from ‘typename std::_MakeUniq<_Tp>::__single_object std::make_unique(_Args&& ...) [with _Tp = DefinitionImpl::IMPL; _Args = {DefinitionImpl::IMPL&}; typename std::_MakeUniq<_Tp>::__single_object = std::unique_ptr<DefinitionImpl::IMPL>]’
.../src/definition.cpp:278:60:   required from here
.../src/definition.cpp:64:5: warning: base class ‘class std::unique_ptr<BodyInfo, std::default_delete<BodyInfo> >’ should be explicitly initialized in the copy constructor [-Wextra]
```

```
In file included from .../src/docnode.cpp:31:
.../src/cmdmapper.h:251:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
