### PR TITLE
Adding some attributes to dtd validation

### DIFF
--- a/testing/dtd/xhtml1-transitional.dtd
+++ b/testing/dtd/xhtml1-transitional.dtd
@@ -36,6 +36,8 @@
        - added source tag
      - adjusted possible children of a number of elements so they support the picture tag
      - added details and summary tag
+     - added placeholder to input tag
+     - added allowfullscreen to iframe tag
 -->
 
 <!--================ Character mnemonic entities =========================-->
@@ -417,6 +419,7 @@
   align       %ImgAlign;     #IMPLIED
   height      %Length;       #IMPLIED
   width       %Length;       #IMPLIED
+  allowfullscreen (true|false)   "true"
   >
 
 <!-- alternate content container for non frame-based rendering -->
@@ -976,6 +979,7 @@
   onchange    %Script;       #IMPLIED
   accept      %ContentTypes; #IMPLIED
   align       %ImgAlign;     #IMPLIED
+  placeholder CDATA          #IMPLIED
   >
 
 <!ELEMENT select (optgroup|option)+>  <!-- option selector -->


### PR DESCRIPTION
Adding:
- `allowfullscreen` attribute to `iframe` tag validation (see: https://www.w3schools.com/tags/tag_iframe.asp)
- `placeholder` attribute to `input` tag validation (it is already used in menu.js, see: https://www.w3schools.com/tags/tag_input.asp)

(Both problems were found through CGAL)