### PR TITLE
fix sqlite3gen regressions from 592aaa4f17

### DIFF
--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -859,14 +859,14 @@ class TextGeneratorSqlite3Impl : public TextGeneratorIntf
 };
 
 
-static bool bindTextParameter(SqlStmt &s,const char *name,const QCString &value, bool _static=FALSE)
+static bool bindTextParameter(SqlStmt &s,const char *name,const QCString &value)
 {
   int idx = sqlite3_bind_parameter_index(s.stmt, name);
   if (idx==0) {
     err("sqlite3_bind_parameter_index(%s)[%s] failed: %s\n", name, s.query, sqlite3_errmsg(s.db));
     return false;
   }
-  int rv = sqlite3_bind_text(s.stmt, idx, value.data(), -1, _static==TRUE?SQLITE_STATIC:SQLITE_TRANSIENT);
+  int rv = sqlite3_bind_text(s.stmt, idx, value.data(), -1, SQLITE_TRANSIENT);
   if (rv!=SQLITE_OK) {
     err("sqlite3_bind_text(%s)[%s] failed: %s\n", name, s.query, sqlite3_errmsg(s.db));
     return false;
@@ -930,7 +930,7 @@ static int insertPath(QCString name, bool local=TRUE, bool found=TRUE, int type=
 static void recordMetadata()
 {
   bindTextParameter(meta_insert,":doxygen_version",getFullVersion());
-  bindTextParameter(meta_insert,":schema_version","0.2.1",TRUE); //TODO: this should be a constant somewhere; not sure where
+  bindTextParameter(meta_insert,":schema_version","0.2.1"); //TODO: this should be a constant somewhere; not sure where
   bindTextParameter(meta_insert,":generated_at",dateToString(DateTimeType::DateTime));
   bindTextParameter(meta_insert,":generated_on",dateToString(DateTimeType::Date));
   bindTextParameter(meta_insert,":project_name",Config_getString(PROJECT_NAME));
@@ -2437,7 +2437,7 @@ static void generateSqlite3ForPage(const PageDef *pd,bool isExample)
   // + title
   bindTextParameter(compounddef_insert,":title",title);
 
-  bindTextParameter(compounddef_insert,":kind", isExample ? "example" : "page",TRUE);
+  bindTextParameter(compounddef_insert,":kind", isExample ? "example" : "page");
 
   int file_id = insertPath(pd->getDefFileName());
 


### PR DESCRIPTION
This removes the `_static` argument from `bindTextParameter` and last two call sites using it.

While SQLITE_STATIC (which tells sqlite it doesn't need to copy the value) was fine for string literals, it looks like we should always pass SQLITE_TRANSIENT (which tells sqlite to copy the value at bind time) when using QCString.

(Without this, sqlite could end up inserting junk data into fields that were still using the `TRUE` value for this argument.)

I noticed these causing errors like the below in Python (here's the [CI build](https://github.com/abathur/doxy_db/actions/runs/4761192056/jobs/8462203813#step:4:1224) it came from):

```
    self._meta = sql.Statement(self).table("meta", "id").prepare()().fetchone()
E   sqlite3.OperationalError: Could not decode to UTF-8 column 'schema_version' with text '�'
```

I confirmed in CI (https://github.com/abathur/doxy_db/actions/runs/4767390612/jobs/8475561221) that applying this change on top of 1.9.6 fixes the error.