### PR TITLE
Remove the package identification of `infwarerr`

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -24,6 +24,14 @@
 \usepackage{array}[=2016-10-06]
 \fi
 %%
+\makeatletter
+% suppress package identification of infwarerr as it contains the word "warning"
+\let\@@protected@wlog\protected@wlog
+\def\protected@wlog#1{\wlog{package info suppressed}}
+\RequirePackage{infwarerr}
+\let\protected@wlog\@@protected@wlog
+\makeatother
+%%
 \usepackage[a4paper,left=2.5cm,right=2.5cm,top=2.5cm,bottom=2.5cm]{geometry}
 \usepackage{makeidx}
 \usepackage{natbib}

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -28,6 +28,11 @@
   % Packages required by doxygen
   \makeatletter
   \providecommand\IfFormatAtLeastTF{\@ifl@t@r\fmtversion}
+  % suppress package identification of infwarerr as it contains the word "warning"
+  \let\@@protected@wlog\protected@wlog
+  \def\protected@wlog#1{\wlog{package info suppressed}}
+  \RequirePackage{infwarerr}
+  \let\protected@wlog\@@protected@wlog
   \makeatother
   \IfFormatAtLeastTF{2016/01/01}{}{\usepackage{fixltx2e}} % for \textsubscript
   \IfFormatAtLeastTF{2015/01/01}{\pdfsuppresswarningpagegroup=1}{}


### PR DESCRIPTION
The `infwarerr` package identifies itself as
```
Package: infwarerr 2019/12/03 v1.5 Providing info/warning/error messages (HO)
```
in the log file. As this contains the words "warning" and "error" this can lead to false positives when checking the log file for warnings / errors

The solution is to suppress the message for the package, see also: https://tex.stackexchange.com/a/683451/44119