### PR TITLE
Hide undocumented group members when `HIDE_UNDOC_MEMBERS=YES`

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1917,7 +1917,7 @@ bool MemberDefImpl::isBriefSectionVisible() const
     auto &info = it->second;
     //printf("name=%s m_impl->grpId=%d info=%p\n",qPrint(name()),m_impl->grpId,info);
     //QCString *pMemGrp = Doxygen::memberDocDict[grpId];
-    hasDocs = hasDocs ||
+    hasDocs = hasDocs &&
                   // part of a documented member group
                  (m_impl->grpId!=-1 && !(info->doc.isEmpty() && info->header.isEmpty()));
   }


### PR DESCRIPTION
In case a non documented function is added to a documented group is was shown even though `HIDE_UNDOC_MEMBERS=YES`

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11295081/example.tar.gz)

Based on: https://stackoverflow.com/questions/76071353/omit-functions-not-included-in-group
