### PR TITLE
Remove font warning for test 65 (i.e. Japanes-en)

### DIFF
--- a/testing/065_tilde.dox
+++ b/testing/065_tilde.dox
@@ -1,6 +1,7 @@
 // objective: test \~ command with non default OUTPUT_LANGUAGE which contains '-' letter
 // check: indexpage.xml
 // config: OUTPUT_LANGUAGE = Japanese-en
+// config: LATEX_EXTRA_STYLESHEET = $INPUTDIR/latex_065.sty
 /** 
 \mainpage 
 \~english This is English.

--- a/testing/latex_065.sty
+++ b/testing/latex_065.sty
@@ -1,0 +1,5 @@
+% Remove warnnigs about fonts
+% based on https://tex.stackexchange.com/a/398856/44119
+\makeatletter
+\renewcommand{\@font@warning}[1]{}% Remove font warning
+\makeatother


### PR DESCRIPTION
Remove the font warning in LaTeX:
```
LaTeX Font Warning: Font shape `C70/min/m/n' undefined
LaTeX Font Warning: Some font shapes were not available, defaults substituted.
```

Solution based on: https://tex.stackexchange.com/a/398856/44119

The removal has to be global, so we need an `LATEX_EXTRA_STYLESHEET`