### PR TITLE
No anchor should be created for inherited members

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2104,7 +2104,8 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
   // If there is no detailed description we need to write the anchor here.
   bool detailsVisible = hasDetailedDescription();
   bool writeAnchor = (inGroup || getGroupDef()==0) &&     // only write anchors for member that have no details and are
-                     !detailsVisible && !m_annMemb; // rendered inside the group page or are not grouped at all
+                     !detailsVisible && !m_annMemb && // rendered inside the group page or are not grouped at all
+                     inheritId.isEmpty();
   if (writeAnchor)
   {
     QCString doxyArgs=argsString();
@@ -2113,7 +2114,7 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
     {
       doxyName.prepend(cdname+getLanguageSpecificSeparator(getLanguage()));
     }
-    if (inheritId.isEmpty()) ol.startDoxyAnchor(cfname,cname,anchor(),doxyName,doxyArgs);
+    ol.startDoxyAnchor(cfname,cname,anchor(),doxyName,doxyArgs);
   }
 
   if (!detailsVisible)

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2113,7 +2113,7 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
     {
       doxyName.prepend(cdname+getLanguageSpecificSeparator(getLanguage()));
     }
-    ol.startDoxyAnchor(cfname,cname,anchor(),doxyName,doxyArgs);
+    if (inheritId.isEmpty()) ol.startDoxyAnchor(cfname,cname,anchor(),doxyName,doxyArgs);
   }
 
   if (!detailsVisible)


### PR DESCRIPTION
In case a member is inherited no anchor should be created, this is especially shown by means of the LaTeX / PDF of output for test 27 where there are warnings like:
```
pdfTeX warning (ext4): destination with the same identifier (name{struct_vehicl
e_ad7970f528d429f6fc1725173e93a77c2}) has been already used, duplicate ignored
<to be read again>
                   \relax
l.18 ...vehicle_ad7970f528d429f6fc1725173e93a77c2}
                                                  \label{struct_vehicle_ad79...
) (struct_vehicle.tex <./struct_vehicle.pdf>
<struct_vehicle.pdf, id=283, 501.875pt x 478.78876pt>
File: struct_vehicle.pdf Graphic file (type pdf)
<use struct_vehicle.pdf>
Package pdftex.def Info: struct_vehicle.pdf  used on input line 6.
(pdftex.def)             Requested size: 89.46825pt x 85.35826pt.
[9]
pdfTeX warning (ext4): destination with the same identifier (name{struct_vehicl
e_ad7970f528d429f6fc1725173e93a77c2}) has been already used, duplicate ignored
<to be read again>
                   \relax
l.19 ...vehicle_ad7970f528d429f6fc1725173e93a77c2}
                                                  \label{struct_vehicle_ad79...
) [10]
```