### PR TITLE
Incorrect links in tooltip

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -945,6 +945,8 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
     *m_t << "<div class=\"ttdef\"><b>Definition:</b> ";
     if (!defInfo.url.isEmpty())
     {
+      url = defInfo.url;
+      addHtmlExtensionIfMissing(url);
       *m_t << "<a href=\"";
       *m_t << externalRef(m_relPath,defInfo.ref,TRUE);
       *m_t << url;
@@ -966,6 +968,8 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
     *m_t << "<div class=\"ttdecl\"><b>Declaration:</b> ";
     if (!declInfo.url.isEmpty())
     {
+      url = declInfo.url;
+      addHtmlExtensionIfMissing(url);
       *m_t << "<a href=\"";
       *m_t << externalRef(m_relPath,declInfo.ref,TRUE);
       *m_t << url;


### PR DESCRIPTION
For test 85 we got, when running a link checker, the warning:
```
List of broken links and other issues:
file:///.../testing/test_output_085/html/085__tooltip_8cpp.xhtml
 Lines: 75, 91
  Code: 200 (no message)
 To do: Some of the links to this resource point to broken URI fragments
        (such as index.html#fragment).
The following fragments need to be fixed:
        l00008                          Line: 91

```
(and a lot of similar warnings for the internal documentation).

The links in the tooltip for definition (and declaration) pointed to the documentation instead of to the source code.