### PR TITLE
Translation of terms in tooltip

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -942,7 +942,7 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
   }
   if (!defInfo.file.isEmpty())
   {
-    *m_t << "<div class=\"ttdef\"><b>Definition:</b> ";
+    *m_t << "<div class=\"ttdef\"><b>" << theTranslator->trDefinition() << "</b> ";
     if (!defInfo.url.isEmpty())
     {
       *m_t << "<a href=\"";
@@ -963,7 +963,7 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
   }
   if (!declInfo.file.isEmpty())
   {
-    *m_t << "<div class=\"ttdecl\"><b>Declaration:</b> ";
+    *m_t << "<div class=\"ttdecl\"><b>" << theTranslator->trDeclaration() << "</b> ";
     if (!declInfo.url.isEmpty())
     {
       *m_t << "<a href=\"";

--- a/src/translator.h
+++ b/src/translator.h
@@ -749,6 +749,8 @@ class Translator
     virtual QCString trFileMembersDescriptionTotal(FileMemberHighlight::Enum hl) = 0;
     virtual QCString trCompoundMembersDescriptionTotal(ClassMemberHighlight::Enum hl) = 0;
     virtual QCString trNamespaceMembersDescriptionTotal(NamespaceMemberHighlight::Enum hl) = 0;
+    virtual QCString trDefinition() = 0;
+    virtual QCString trDeclaration() = 0;
 };
 
 #endif

--- a/src/translator_adapter.h
+++ b/src/translator_adapter.h
@@ -96,6 +96,11 @@ class TranslatorAdapter_1_9_6 : public TranslatorAdapterBase
         return "&nbsp;";
       }
     }
+
+    virtual QCString trDefinition()
+    { return english.trDefinition(); }
+    virtual QCString trDeclaration()
+    { return english.trDeclaration(); }
 };
 
 class TranslatorAdapter_1_9_5 : public TranslatorAdapter_1_9_6

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -142,7 +142,7 @@ namespace PortugueseTranslatorUtils
     }
 }
 
-class TranslatorBrazilian : public Translator
+class TranslatorBrazilian : public TranslatorAdapter_1_9_6
 {
   public:
 

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -2563,6 +2563,8 @@ class TranslatorEnglish : public Translator
         result+="the namespaces they belong to:";
       return result;
     }
+    virtual QCString trDefinition()  { return "Definition:";}
+    virtual QCString trDeclaration() { return "Declaration:";}
 };
 
 #endif

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -118,7 +118,7 @@ namespace SpanishTranslatorUtils
     }
 }
 
-class TranslatorSpanish : public Translator
+class TranslatorSpanish : public TranslatorAdapter_1_9_6
 {
   public:
 

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -48,7 +48,7 @@
 #ifndef TRANSLATOR_GR_H
 #define TRANSLATOR_GR_H
 
-class TranslatorGreek : public Translator
+class TranslatorGreek : public TranslatorAdapter_1_9_6
 {
   public:
 

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -2236,6 +2236,9 @@ class TranslatorDutch : public Translator
         result+="de namespaces waartoe ze behoren:";
       return result;
     }
+
+    virtual QCString trDefinition()  { return "Definitie:";}
+    virtual QCString trDeclaration() { return "Declaratie:";}
 };
 
 #endif

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -74,7 +74,7 @@
 
 #include "translator_br.h"
 
-class TranslatorPortuguese : public Translator
+class TranslatorPortuguese : public TranslatorAdapter_1_9_6
 {
   public:
 


### PR DESCRIPTION
In the tooltip code we see that the English texts "Definition:" and "Declaration:" are used even when another output language is specified, this has been correc6ted by the functions `trDefinition` and `trDeclaration`