### PR TITLE
Waning generating doxygen documentation (LaTeX) regarding longtable

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -210,6 +210,8 @@ add_custom_target(doxygen_pdf
         COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex
         COMMAND ${MAKEINDEX} doxygen_manual.idx
         COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex
+        COMMAND ${MAKEINDEX} doxygen_manual.idx
+        COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex
         DEPENDS run_doxygen
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/latex
 )


### PR DESCRIPTION
When generating the doxygen documentation the LaTeX version gives:
```
Package longtable Warning: Table widths have changed. Rerun LaTeX.
```
to prevent this an extra run of makeindex and pdflatex is required.