### PR TITLE
Incorrect line number for ATX header

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1382,7 +1382,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 
 <St_SkipTitle>.
 <St_SkipTitle>(\n|"\\ilinebr") {
-                         lineCount(yytext,yyleng);
+                         if (*yytext == '\n') unput('\n');
                          return 0;
                          }
 


### PR DESCRIPTION
In case we have source code like:
```
\page pg1 The page 1

\error_3 \ilinebr # Changelog

\error_5 \ilinebr ### Changed
\error_6
```
we get the warning:
```
aa.md:6: warning: Unexpected subsubsection command found inside section!
```
but the line number should be 5 this is due to the fact that the end of line was already read

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11332793/example.tar.gz)

(Found by Fossies for the nushell package).
