### PR TITLE
issue #10006 Problem with generated documentation when a method is named 'exception'

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1413,7 +1413,7 @@ NONLopt [^\n]*
                                           BEGIN( CompoundName );
                                         }
 <FindMembers>{B}*"exception"{BN}+       { // Corba IDL/Slice exception
-                                          if (yyextra->insideJava) REJECT;
+                                          if (yyextra->insideJava || yyextra->insideCpp) REJECT;
                                           yyextra->isTypedef=FALSE;
                                           yyextra->current->section = Entry::CLASS_SEC;
                                           // preserve UNO IDL, Slice local


### PR DESCRIPTION
The Corba / Slice word exception should not be recognized in Cpp as special word.