### PR TITLE
Better warning from constant expression evaluation

### DIFF
--- a/src/constexp.h
+++ b/src/constexp.h
@@ -25,7 +25,7 @@ class ConstExpressionParser
   public:
     ConstExpressionParser();
    ~ConstExpressionParser();
-    bool parse(const char *fileName,int line,const std::string &expression);
+    bool parse(const char *fileName,int line,const std::string &expression,const std::string &orgExpression);
   private:
     struct Private;
     std::unique_ptr<Private> p;

--- a/src/constexp.l
+++ b/src/constexp.l
@@ -140,7 +140,7 @@ ConstExpressionParser::~ConstExpressionParser()
   constexpYYlex_destroy(p->yyscanner);
 }
 
-bool ConstExpressionParser::parse(const char *fileName,int lineNr,const std::string &s)
+bool ConstExpressionParser::parse(const char *fileName,int lineNr,const std::string &s, const std::string &orgStr)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)p->yyscanner;
 
@@ -150,6 +150,7 @@ bool ConstExpressionParser::parse(const char *fileName,int lineNr,const std::str
 
   yyextra->constExpFileName = fileName;
   yyextra->constExpLineNr = lineNr;
+  yyextra->orgString = orgStr;
   yyextra->inputString = s;
   yyextra->inputPosition = 0;
   constexpYYrestart( yyin, p->yyscanner );

--- a/src/constexp.y
+++ b/src/constexp.y
@@ -26,7 +26,8 @@ int constexpYYerror(yyscan_t yyscanner, const char *s)
 {
   struct constexpYY_state* yyextra = constexpYYget_extra(yyscanner);
   warn(yyextra->constExpFileName.c_str(), yyextra->constExpLineNr,
-       "preprocessing issue while doing constant expression evaluation: %s: input='%s'",s,yyextra->inputString.c_str());
+       "preprocessing issue while doing constant expression evaluation: %s:\n    input='%s'\n    doxygen interpretation '%s'",
+       s,yyextra->orgString.c_str(),yyextra->inputString.c_str());
   return 0;
 }
 

--- a/src/constexp_p.h
+++ b/src/constexp_p.h
@@ -34,6 +34,7 @@ struct constexpYY_state
   int          constExpLineNr;
   std::string  constExpFileName;
 
+  std::string orgString;
   std::string inputString;
   int         inputPosition;
 };

--- a/src/pre.l
+++ b/src/pre.l
@@ -3067,13 +3067,15 @@ static bool computeExpression(yyscan_t yyscanner,const QCString &expr)
 {
   YY_EXTRA_TYPE state = preYYget_extra(yyscanner);
   QCString e=expr;
+  QCString ee=expr;
+  ee = removeMarkers(ee);
   state->expanded.clear();
   expandExpression(yyscanner,e,0,0,0);
   //printf("after expansion '%s'\n",qPrint(e));
   e = removeIdsAndMarkers(e);
   if (e.isEmpty()) return FALSE;
   //printf("parsing '%s'\n",qPrint(e));
-  return state->constExpParser.parse(state->fileName.data(),state->yyLineNr,e.str());
+  return state->constExpParser.parse(state->fileName.data(),state->yyLineNr,e.str(),ee.str());
 }
 
 /*! expands the macro definition in \a name


### PR DESCRIPTION
The constant expression evaluation gives hard to understand error messages as it shows the doxygen interpretation of the expression instead of the original expression. We now show both expressions.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11353520/example.tar.gz)
