### PR TITLE
issue #10010 SHOW_HEADERFILE doesn't work well for headers with no file extension

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -358,6 +358,10 @@ int guessSection(const QCString &name)
       return Entry::HEADER_SEC;
     }
   }
+  else
+  {
+    if (getLanguageFromFileName(name,SrcLangExt_Unknown) == SrcLangExt_Cpp) return Entry::HEADER_SEC;
+  }
   return 0;
 }
 


### PR DESCRIPTION
Implemented that when a file has no extension and the mapping for files without extension is set to C++ such a file is seen as header file (thanks @jwakely )