### PR TITLE
search: Fix incorrect result count in opensearch suggestions

### DIFF
--- a/templates/html/search_functions.php
+++ b/templates/html/search_functions.php
@@ -301,6 +301,16 @@ function report_results(&$docs)
   echo "</div>\n";
 }
 
+/**
+ * @param string $query
+ * @return array[] List of matched documents, with each array value
+ * in the shape:
+ *  - string url
+ *  - string name
+ *  - float rank
+ *  - array[] words List of word arrays, each word array
+ *    holding properties "word" (string), "match" (string) and "freq" (int)
+ */
 function run_query($query)
 {
   if(strcmp('4.1.0', phpversion()) > 0) 

--- a/templates/html/search_opensearch.php
+++ b/templates/html/search_opensearch.php
@@ -61,7 +61,7 @@ function opensearch_xml_results($query, array $results)
   {
     foreach ($val['words'] as $j => $word)
     {
-      if (array_key_exists($word, $qs_results))
+      if (array_key_exists($word['word'], $qs_results))
         $qs_results[$word['match']]++;
       else
         $qs_results[$word['match']] = 1;
@@ -96,7 +96,7 @@ function opensearch_json_results($query, array $results)
   {
     foreach ($val['words'] as $j => $word)
     {
-      if (array_key_exists($word, $qs_results))
+      if (array_key_exists($word['word'], $qs_results))
         $qs_results[$word['match']]++;
       else
         $qs_results[$word['match']] = 1;


### PR DESCRIPTION
The descriptions displayed under the OpenSearch suggestions in a web browser always said "1 result". This also emitted a warning on the server-side:

> PHP Warning:  array_key_exists(): The first argument should be either a string or an integer)

See also https://github.com/doxygen/doxygen/issues/10017.