### PR TITLE
Portuguese translators updated to 1.9.7

### DIFF
--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -19,7 +19,7 @@
  *    Thanks to Jorge Ramos, Fernando Carijo and others for their contributions.
  *
  * History:
- * 20230225:
+ * 20230430:
  *  - Updated to 1.9.7;
  *  - Adding the namespace PortugueseTranslatorUtils to hold common 
  *    functions shared by both Portuguese translators;

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -140,9 +140,9 @@ namespace PortugueseTranslatorUtils
           return true;
       }
     }
-}
+};
 
-class TranslatorBrazilian : public TranslatorAdapter_1_9_6
+class TranslatorBrazilian : public Translator
 {
   public:
 
@@ -2753,7 +2753,9 @@ class TranslatorBrazilian : public TranslatorAdapter_1_9_6
       else
         result+="o namespace a que pertencem:";
       return result;
-    }    
+    }
+    virtual QCString trDefinition()  { return "Definição";}
+    virtual QCString trDeclaration() { return "Declaração";}        
 };
 
 #endif

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -26,7 +26,7 @@
  * VERSION HISTORY
  * ---------------
  * History:
- * 20230225:
+ * 20230430:
  *  - Updated to 1.9.7;
  *  - Inclusion of translator_br.h's PortugueseTranslatorUtils namespace;
  *  - All entries of "Directório" has been replaced by "Diretório";

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -74,7 +74,7 @@
 
 #include "translator_br.h"
 
-class TranslatorPortuguese : public TranslatorAdapter_1_9_6
+class TranslatorPortuguese : public Translator
 {
   public:
 
@@ -2635,6 +2635,8 @@ class TranslatorPortuguese : public TranslatorAdapter_1_9_6
         result+="o namespace a que pertencem:";
       return result;
     }
+    virtual QCString trDefinition()  { return "Definição";}
+    virtual QCString trDeclaration() { return "Declaração";}        
 };
 
 #endif


### PR DESCRIPTION
This pull request contains the new methods required to upgrade the translators to 1.9.7. 

The missing methods:

- `QCString trDefinition()`;
- `QCString trDeclaration()`;

have been added to both translators.

Please squash the commits on merge because the second commit is a mere fix to the internal release date information.