### PR TITLE
Enable possible other LaTeX error modes

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3164,15 +3164,18 @@ The following block name is set based on whether or not a feature is used in the
 ]]>
       </docs>
     </option>
-    <option type='bool' id='LATEX_BATCHMODE' defval='0' depends='GENERATE_LATEX'>
+    <option type='enum' id='LATEX_BATCHMODE' defval='NO' depends='GENERATE_LATEX'>
       <docs>
 <![CDATA[
- If the \c LATEX_BATCHMODE tag is set to \c YES, doxygen will add the \c \\batchmode
- command to the generated \f$\mbox{\LaTeX}\f$ files. This will
- instruct \f$\mbox{\LaTeX}\f$ to keep running if errors occur, instead of
- asking the user for help.
+ The \c LATEX_BATCHMODE tag ignals the behavior of \f$\mbox{\LaTeX}\f$ in case of an error.
 ]]>
       </docs>
+      <value name="NO" desc='same as ERRORSTOP' />
+      <value name="YES" desc='same as BATCHMODE' />
+      <value name="BATCHMODE" desc='In batch mode nothing is printed on the terminal, errors are scrolled as if \&lt;return\&gt; is hit at every error; missing files that TeX tries to input or request from keyboard input (\\read on a not open input stream) cause the job to abort' />
+      <value name="NONSTOPMODE" desc='In nonstop mode the diagnostic message will appear on the terminal, but there is no possibility of user interaction just like in batch mode' />
+      <value name="SCROLLMODE" desc='In scroll mode, TeX will stop only for missing files to input or if keyboard input is necessary' />
+      <value name="ERRORSTOPMODE" desc='In errorstop mode, TeX will stop at each error, asking for user intervention' />
     </option>
     <option type='bool' id='LATEX_HIDE_INDICES' defval='0' depends='GENERATE_LATEX'>
       <docs>

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -681,13 +681,26 @@ static QCString makeIndex()
   return result;
 }
 
+static QCString latex_batchmode()
+{
+  switch Config_getEnum(LATEX_BATCHMODE)
+  {
+    case LATEX_BATCHMODE_t::NO:            return "";
+    case LATEX_BATCHMODE_t::YES:           return "\\batchmode";
+    case LATEX_BATCHMODE_t::BATCHMODE:     return "\\batchmode";
+    case LATEX_BATCHMODE_t::NONSTOPMODE:   return "\\nonstopmode";
+    case LATEX_BATCHMODE_t::SCROLLMODE:    return "\\scrollmode";
+    case LATEX_BATCHMODE_t::ERRORSTOPMODE: return "\\errorstopmode";
+  }
+  return "";
+}
+
 static QCString substituteLatexKeywords(const QCString &str,
                                         const QCString &title)
 {
   bool compactLatex = Config_getBool(COMPACT_LATEX);
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   bool usePdfLatex = Config_getBool(USE_PDFLATEX);
-  bool latexBatchmode = Config_getBool(LATEX_BATCHMODE);
   QCString paperType = Config_getEnumAsString(PAPER_TYPE);
 
   QCString style = Config_getString(LATEX_BIB_STYLE);
@@ -768,7 +781,8 @@ static QCString substituteLatexKeywords(const QCString &str,
     { "$makeindex",                [&]() { return makeIndex();                                  } },
     { "$extralatexpackages",       [&]() { return extraLatexPackages;                           } },
     { "$latexspecialformulachars", [&]() { return latexSpecialFormulaChars;                     } },
-    { "$formulamacrofile",         [&]() { return stripMacroFile;                               } }
+    { "$formulamacrofile",         [&]() { return stripMacroFile;                               } },
+    { "$latex_batchmode",          [&]() { return latex_batchmode();                            } }
   });
 
   static const SelectionMarkerInfo latexMarkerInfo = { '%', "%%BEGIN ",8 ,"%%END ",6, "",0 };
@@ -782,7 +796,6 @@ static QCString substituteLatexKeywords(const QCString &str,
     { "PDF_HYPERLINKS",    pdfHyperlinks                          },
     { "USE_PDFLATEX",      usePdfLatex                            },
     { "LATEX_TIMESTAMP",   timeStamp                              },
-    { "LATEX_BATCHMODE",   latexBatchmode                         },
     { "LATEX_FONTENC",     !latexFontenc.isEmpty()                },
     { "FORMULA_MACROFILE", !formulaMacrofile.isEmpty()            },
     { "PROJECT_NUMBER",    !projectNumber.isEmpty()               }

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -683,7 +683,7 @@ static QCString makeIndex()
 
 static QCString latex_batchmode()
 {
-  switch Config_getEnum(LATEX_BATCHMODE)
+  switch (Config_getEnum(LATEX_BATCHMODE))
   {
     case LATEX_BATCHMODE_t::NO:            return "";
     case LATEX_BATCHMODE_t::YES:           return "\\batchmode";

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -1,7 +1,5 @@
   % Handle batch mode
-%%BEGIN LATEX_BATCHMODE
-  \batchmode
-%%END LATEX_BATCHMODE
+  $latex_batchmode
 
   % to overcome problems with too many open files
   \let\mypdfximage\pdfximage\def\pdfximage{\immediate\mypdfximage}


### PR DESCRIPTION
Besides the supported `\batchmode` there are a number of other "error" modes for LaTeX available, they can be enabled as well.