### PR TITLE
Incorrect svg file generated

### DIFF
--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -111,7 +111,7 @@ static const char svgZoomFooter2[] = R"svg(
 [data-mouse-over-selected='true']  { opacity: 1.0; }
 ]]>
 </style>
-<script><![CDATA[
+<script xlink:type="simple"><![CDATA[
 document.addEventListener('DOMContentLoaded', (event) => {
   highlightEdges();
   highlightAdjacentNodes();
@@ -380,7 +380,7 @@ bool DotFilePatcher::run() const
           }
           if (useNagivation)
           {
-            t << "<script type=\"text/javascript\">\n";
+            t << "<script xlink:type=\"simple\">\n";
             t << "var viewWidth = " << width << ";\n";
             t << "var viewHeight = " << height << ";\n";
             if (graphId>=0)
@@ -389,7 +389,7 @@ bool DotFilePatcher::run() const
             }
             t << "</script>\n";
           }
-          t << "<script xlink:href=\"" << relPath << "svg.min.js\"/>\n";
+          t << "<script xlink:type=\"simple\" xlink:href=\"" << relPath << "svg.min.js\"/>\n";
           t << "<svg id=\"graph\" class=\"graph\">\n";
 
           if (useNagivation)
@@ -489,6 +489,8 @@ bool DotFilePatcher::run() const
       t << line;
     }
   }
+  if (isSVGFile && interactiveSVG && !useNagivation) t << "</svg>\n";
+
   fi.close();
   if (isSVGFile && interactiveSVG && replacedHeader)
   {


### PR DESCRIPTION
- a number of, simple, svg files were missing missing the closing `</svg>` tag giving an invalid svg file (see e.g. https://doxygen.github.io/doxygen/dir_534aeb5b2351b2c83787cc7391511c04.html when using Chrome)
- added `type` attribute to `script` tag (more svg standard conforming)