### PR TITLE
Add `point` as email separator

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -271,7 +271,7 @@ CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{C
 DOXYCFG   [A-Z][A-Z_0-9]*
 MAILADDR  ("mailto:")?[a-z_A-Z0-9\x80-\xFF.+-]+"@"[a-z_A-Z0-9\x80-\xFf-]+("."[a-z_A-Z0-9\x80-\xFf\-]+)+[a-z_A-Z0-9\x80-\xFf\-]+
 MAILWS    [\t a-z_A-Z0-9\x80-\xFF+-]
-MAILADDR2 {MAILWS}+{BLANK}+("at"|"AT"|"_at_"|"_AT_"){BLANK}+{MAILWS}+("dot"|"DOT"|"_dot_"|"_DOT_"){BLANK}+{MAILWS}+
+MAILADDR2 {MAILWS}+{BLANK}+("at"|"AT"|"_at_"|"_AT_"){BLANK}+{MAILWS}+("dot"|"DOT"|"_dot_"|"_DOT_"|"point"|"POINT"|"_point_"|"_POINT_"){BLANK}+{MAILWS}+
 OPTSTARS  ("/""/"{BLANK}*)?"*"*{BLANK}*
 LISTITEM  {BLANK}*[-]("#")?{WS}
 MLISTITEM {BLANK}*[+*]{WS}


### PR DESCRIPTION
When having an example like:
```
Some email

* Someone <someone_point AT somewhere POINT com>
* Someone <someone_dot AT somewhere DOT com>
```
we get the warning:
```
aa.md:4: warning: Unsupported xml/html tag <someone_point> found
```

Adding `point` (etc.) analogous to `dot`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11396279/example.tar.gz)
 (Found by Fossies for manpages-l10n package)