### PR TITLE
Removing warnings when running xmllint on svg files

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -256,6 +256,10 @@ bool DotManager::run() const
       i++;
     }
   }
+  if (Config_getBool(GENERATE_HTML) && Config_getString(DOT_IMAGE_FORMAT) == DOT_IMAGE_FORMAT_t::svg)
+  {
+    DotFilePatcher::makeStdSVG(Config_getString(HTML_OUTPUT) + "/graph_legend.svg");
+  }
   return TRUE;
 }
 

--- a/src/dotfilepatcher.h
+++ b/src/dotfilepatcher.h
@@ -50,6 +50,7 @@ class DotFilePatcher
 
     static bool writeVecGfxFigure(TextStream& out, const QCString& baseName,
                                   const QCString& figureName);
+    static bool DotFilePatcher::makeStdSVG(QCString patchFile);
 
   private:
     struct Map

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -565,7 +565,10 @@ void DotNode::writeBox(TextStream &t,
   }
   else
   {
+   if (!m_isRoot && !m_url.isEmpty() && (m_url != DotNode::placeholderUrl))
+   {
     t << ",tooltip=\" \""; // space in tooltip is required otherwise still something like 'Node0' is used
+  }
   }
   t << "];\n";
 }
@@ -600,7 +603,7 @@ void DotNode::writeArrow(TextStream &t,
   if (pointBack && !umlUseArrow) t << "dir=\"back\",";
   t << "color=\"" << eProps->edgeColorMap[ei->color()] << "\",";
   t << "style=\"" << eProps->edgeStyleMap[ei->style()] << "\"";
-  t << ",tooltip=\" \""; // space in tooltip is required otherwise still something like 'Node0 -> Node1' is used
+  // t << ",tooltip=\" \""; // space in tooltip is required otherwise still something like 'Node0 -> Node1' is used
   if (!ei->label().isEmpty())
   {
     t << ",label=\" " << convertLabel(ei->label()) << "\",fontcolor=\"grey\" ";


### PR DESCRIPTION
Removing warnings when running xmllint:
- `I/O error : Attempt to load network entity http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd` Replaced `http` by `https`
- `element a: validity error : Element a does not carry attribute xlink:href`
  - in case no brief description (i.e. tooltip) and no URL see to it that `<title>` in svg to empty string
  - in case of a brief description see to it that there is no `<a>` present and that the tooltip is in the `<title>`