### PR TITLE
Silently ignore `</img>` tag

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -5123,7 +5123,6 @@ int DocPara::handleHtmlEndTag(const QCString &tagName)
       warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </h6> found");
       break;
     case HTML_IMG:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </img> found");
       break;
     case HTML_HR:
       warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </hr> tag found\n");


### PR DESCRIPTION
When having:
```
<img src="dd.svg" alt="logo"></img>
```
we get the warning like:
```
warning: Unexpected tag </img> found
```

better is to silently ignore the tag (now it is ignored with warning).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11441741/example.tar.gz)

(Found by Fossied for aesara package)

