### PR TITLE
bug 784736 Words that are the same to class names are hyperlinked in references in the HTML output

### DIFF
--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -172,6 +172,10 @@ void PageDefImpl::writeTagFile(TextStream &tagFile)
 
 void PageDefImpl::writeDocumentation(OutputList &ol)
 {
+  bool foundCiteList = name()=="citelist";
+  bool autoLinkSave = Config_getBool(AUTOLINK_SUPPORT);
+  if (foundCiteList) Config_updateBool(AUTOLINK_SUPPORT, false);
+
   bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   int hierarchyLevel = -1; // Pages start at the root
   PageDef *pd = this;
@@ -286,6 +290,7 @@ void PageDefImpl::writeDocumentation(OutputList &ol)
 
   ol.popGeneratorState();
   //1.}
+  if (foundCiteList) Config_updateBool(AUTOLINK_SUPPORT, autoLinkSave);
 }
 
 void PageDefImpl::writePageDocumentation(OutputList &ol) const


### PR DESCRIPTION
Temporary disable the `AUTOLINK_SUPPORT` for the "citelist" page so information is consistent between LaTeX (PDF) output and other output formats (and no automatic hyperlinks appear in the bibliography).