### PR TITLE
Check and copy logo file for rtf output

### DIFF
--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -451,6 +451,23 @@ void RTFGenerator::init()
   if (!rtfExtensionsFile.isEmpty())
   {
     loadExtensions(rtfExtensionsFile);
+
+    if (!rtf_logoFilename.isEmpty())
+    {
+      FileInfo fi(rtf_logoFilename.str());
+      if (!fi.exists())
+      {
+        err("Logo '%s' specified by 'LogoFilename' in the rtf extension file '%s' does not exist!\n",
+            qPrint(rtf_logoFilename), qPrint(rtfExtensionsFile));
+        rtf_logoFilename = "";
+      }
+      else
+      {
+        QCString destFileName = Config_getString(RTF_OUTPUT)+"/"+fi.fileName();
+        copyFile(rtf_logoFilename,destFileName);
+        rtf_logoFilename = fi.fileName();
+      }
+    }
   }
 
   createSubDirs(d);


### PR DESCRIPTION
The logo to be used in the RTF output can be defined in the rtf extension file though
- it was not checked whether or not it exists
- it was not copied to the output directory

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11462909/example.tar.gz)
