### PR TITLE
Regression: Refactoring: make use of C++17 structured bindings

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10523,7 +10523,7 @@ static void escapeAliases()
       p=in+2;
     }
     newValue+=value.mid(p,value.length()-p);
-    value=newValue.str();
+    definition=newValue.str();
     //printf("Alias %s has value %s\n",name.c_str(),qPrint(newValue));
   }
 }


### PR DESCRIPTION
Writing back should be into `definition` (i.e. the old `kv.second`) and not into the local variable.