### PR TITLE
Setting correct version in LaTeX documentation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -206,11 +206,11 @@ add_custom_target(doxygen_pdf
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/doc/doxygen_manual.tex  .
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/doc/manual.sty  .
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doc/doxygen_logo.pdf  .
-        COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex
+        COMMAND ${CMAKE_COMMAND} -E env VERSION=${VERSION} ${PDFLATEX}  -shell-escape doxygen_manual.tex
         COMMAND ${MAKEINDEX} doxygen_manual.idx
-        COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex
+        COMMAND ${CMAKE_COMMAND} -E env VERSION=${VERSION} ${PDFLATEX}  -shell-escape doxygen_manual.tex
         COMMAND ${MAKEINDEX} doxygen_manual.idx
-        COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex
+        COMMAND ${CMAKE_COMMAND} -E env VERSION=${VERSION} ${PDFLATEX}  -shell-escape doxygen_manual.tex
         DEPENDS run_doxygen
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/latex
 )

--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -74,6 +74,19 @@
 \usepackage{amssymb}
 \usepackage{doxygen}
 \usepackage{manual}
+
+\ExplSyntaxOn
+\NewDocumentCommand{\getenv}{om}%
+  {%
+    \sys_get_shell:nnN { kpsewhich ~ --var-value ~ #2 }%
+      { \cctab_select:N \c_str_cctab } \l_tmpa_tl
+    \tl_trim_spaces:N \l_tmpa_tl
+    \IfNoValueTF { #1 }
+      { \tl_use:N \l_tmpa_tl }
+      { \tl_set_eq:NN #1 \l_tmpa_tl }
+  }
+\ExplSyntaxOff
+\getenv[\VERSION]{VERSION}
 %%
 %gave problems when in doxygen.sty
 \makeatletter
@@ -145,7 +158,7 @@
 \begin{titlepage}
 \includegraphics[width=\textwidth]{doxygen_logo}
 \begin{center}
-Manual for version @VERSION@\\[2ex]
+Manual for version \VERSION\\[2ex]
 Written by Dimitri van Heesch\\[2ex]
 \copyright 1997-\thisyear
 \end{center}

--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -12,7 +12,7 @@
 % Documents produced by Doxygen are derivative works derived from the
 % input used in their production; they are not affected by this license.
 
-\batchmode
+\nonstopmode
 \pdfminorversion=7
 \pdfsuppresswarningpagegroup=1
 \documentclass{book}


### PR DESCRIPTION
Due to the fact that on `tex` files it is not possible to use the normal environment replacement strategy of cmake the `@VERSION@` does not get replaced anymore. Using the possibility of retrieving environment variables (see also: https://tex.stackexchange.com/a/583976/44119)