### PR TITLE
Setting correct version in LaTeX documentation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -202,9 +202,9 @@ add_custom_target(run_doxygen
 add_custom_target(doxygen_pdf
         COMMENT "Generating Doxygen Manual PDF."
         COMMAND ${CMAKE_COMMAND} -E remove refman.tex
-        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/doc/doxygen_manual.tex  .
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/doc/manual.sty  .
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doc/doxygen_logo.pdf  .
+        COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR}/latex ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/doc/doxygen_manual_latex.py "${VERSION}" "${PROJECT_BINARY_DIR}/doc/doxygen_manual.tex" "${PROJECT_BINARY_DIR}/latex/doxygen_manual.tex"
         COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex
         COMMAND ${MAKEINDEX} doxygen_manual.idx
         COMMAND ${PDFLATEX}  -shell-escape doxygen_manual.tex

--- a/doc/doxygen_manual_latex.py
+++ b/doc/doxygen_manual_latex.py
@@ -1,0 +1,10 @@
+import sys
+
+version = sys.argv[1]
+inputFile = sys.argv[2]
+outputFile = sys.argv[3]
+
+with open(outputFile,"w") as out_file:
+    with open(inputFile,"r") as in_file:
+        for line in in_file:
+            out_file.write(line.replace("@VERSION@",version))


### PR DESCRIPTION
Due to the fact that on `tex` files it is not possible to use the normal environment replacement strategy of cmake the `@VERSION@` does not get replaced anymore. An internal LaTeX possibility (see: https://tex.stackexchange.com/a/583976/44119) looks like to be LaTeX version dependent, so a Cmake-Python solution