### PR TITLE
cleanup qcstring indentation and style

### DIFF
--- a/src/qcstring.cpp
+++ b/src/qcstring.cpp
@@ -433,12 +433,12 @@ void qstrfree( const char *str )
 
 char *qstrncpy( char *dst, const char *src, size_t len )
 {
-    if ( !src )
-	return 0;
-    strncpy( dst, src, len );
-    if ( len > 0 )
-	dst[len-1] = '\0';
-    return dst;
+  if ( !src )
+    return nullptr;
+  strncpy( dst, src, len );
+  if ( len > 0 )
+    dst[len-1] = '\0';
+  return dst;
 }
 
 int qstricmp( const char *s1, const char *s2 )

--- a/src/qcstring.cpp
+++ b/src/qcstring.cpp
@@ -443,36 +443,36 @@ char *qstrncpy( char *dst, const char *src, size_t len )
 
 int qstricmp( const char *s1, const char *s2 )
 {
-    if ( !s1 || !s2 )
-    {
-      return s1 == s2 ? 0 : static_cast<int>(s2 - s1);
-    }
-    int res;
-    char c;
-    for ( ; !(res = ((c=toLowerChar(*s1)) - toLowerChar(*s2))); s1++, s2++ )
-    {
-      if ( !c )				// strings are equal
-        break;
-    }
-    return res;
+  if ( !s1 || !s2 )
+  {
+    return s1 == s2 ? 0 : static_cast<int>(s2 - s1);
+  }
+  int res;
+  char c;
+  for ( ; !(res = ((c=toLowerChar(*s1)) - toLowerChar(*s2))); s1++, s2++ )
+  {
+    if ( !c ) // strings are equal
+      break;
+  }
+  return res;
 }
 
 int qstrnicmp( const char *s1, const char *s2, size_t len )
 {
-    if ( !s1 || !s2 )
-    {
-      return static_cast<int>(s2 - s1);
-    }
-    for ( ; len--; s1++, s2++ )
-    {
-        char c = toLowerChar(*s1);
-        int res = c-toLowerChar(*s2);
-	if ( res!=0 ) // strings are not equal
-	    return res;
-	if ( c==0 ) // strings are equal
-	    break;
-    }
-    return 0;
+  if ( !s1 || !s2 )
+  {
+    return static_cast<int>(s2 - s1);
+  }
+  for ( ; len--; s1++, s2++ )
+  {
+    char c = toLowerChar(*s1);
+    int res = c-toLowerChar(*s2);
+    if ( res!=0 ) // strings are not equal
+      return res;
+    if ( c==0 ) // strings are equal
+      break;
+  }
+  return 0;
 }
 
 /// substitute all occurrences of \a src in \a s by \a dst

--- a/src/qcstring.cpp
+++ b/src/qcstring.cpp
@@ -401,20 +401,21 @@ bye:
 
 void *qmemmove( void *dst, const void *src, size_t len )
 {
-    char *d;
-    const char *s;
-    if ( dst > src ) {
-	d = static_cast<char *>(dst) + len - 1;
-	s = static_cast<const char *>(src) + len - 1;
-	while ( len-- )
-	    *d-- = *s--;
-    } else if ( dst < src ) {
-	d = static_cast<char *>(dst);
-	s = static_cast<const char *>(src);
-	while ( len-- )
-	    *d++ = *s++;
-    }
-    return dst;
+  char *d;
+  const char *s;
+  if ( dst > src ) {
+    d = static_cast<char *>(dst) + len - 1;
+    s = static_cast<const char *>(src) + len - 1;
+    while ( len-- )
+      *d-- = *s--;
+  }
+  else if ( dst < src ) {
+    d = static_cast<char *>(dst);
+    s = static_cast<const char *>(src);
+    while ( len-- )
+      *d++ = *s++;
+  }
+  return dst;
 }
 
 char *qstrdup( const char *str )

--- a/src/qcstring.cpp
+++ b/src/qcstring.cpp
@@ -53,7 +53,7 @@ int QCString::find( char c, int index, bool cs ) const
     pos = data()+index;
     c = toLowerChar(c);
     while (*pos && toLowerChar(*pos)!=c) pos++;
-    if (!*pos && c) pos=0; // not found
+    if (!*pos && c) pos=nullptr; // not found
   }
   return pos ? static_cast<int>(pos - data()) : -1;
 }
@@ -78,7 +78,7 @@ int QCString::find( const char *str, int index, bool cs ) const
       if (qstrnicmp(pos,str,len)==0) break;
       pos++;
     }
-    if (!*pos) pos = 0; // not found
+    if (!*pos) pos = nullptr; // not found
   }
   return pos ? static_cast<int>(pos - data()) : -1;
 }

--- a/src/qcstring.cpp
+++ b/src/qcstring.cpp
@@ -420,10 +420,10 @@ void *qmemmove( void *dst, const void *src, size_t len )
 
 char *qstrdup( const char *str )
 {
-    if ( !str )
-	return 0;
-    char *dst = new char[qstrlen(str)+1];
-    return strcpy( dst, str );
+  if ( !str )
+    return 0;
+  char *dst = new char[qstrlen(str)+1];
+  return strcpy( dst, str );
 }
 
 void qstrfree( const char *str )

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -58,7 +58,7 @@ inline uint32_t qstrlen( const char *str )
 { return str ? static_cast<uint32_t>(strlen(str)) : 0; }
 
 inline char *qstrcpy( char *dst, const char *src )
-{ return src ? strcpy(dst, src) : 0; }
+{ return src ? strcpy(dst, src) : nullptr; }
 
 char * qstrncpy(char *dst,const char *src, size_t len);
 

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -60,7 +60,7 @@ inline uint32_t qstrlen( const char *str )
 inline char *qstrcpy( char *dst, const char *src )
 { return src ? strcpy(dst, src) : nullptr; }
 
-char * qstrncpy(char *dst,const char *src, size_t len);
+char *qstrncpy(char *dst,const char *src, size_t len);
 
 inline bool qisempty( const char *s)
 { return s==0 || *s==0; }

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -63,7 +63,7 @@ inline char *qstrcpy( char *dst, const char *src )
 char *qstrncpy(char *dst,const char *src, size_t len);
 
 inline bool qisempty( const char *s)
-{ return s==0 || *s==0; }
+{ return s==nullptr || *s=='\0'; }
 
 inline int qstrcmp( const char *str1, const char *str2 )
 { return (str1 && str2) ? strcmp(str1,str2) :     // both non-empty

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -45,11 +45,7 @@
 
 void *qmemmove( void *dst, const void *src, size_t len );
 
-#if defined(_OS_WIN32_)
-#define qsnprintf _snprintf
-#else
 #define qsnprintf snprintf
-#endif
 
 //! Returns a copy of a string \a s.
 //! Note that memory is passed to the caller, use qstrfree() to release.


### PR DESCRIPTION
This PR try cleanup work in qcstring.h and qcstring.cpp, by:
- indentation adjusted, use 2 space, keep the same as most of other c/cpp code
- replace `0` with `nullptr` for better readability