### PR TITLE
Correct spelling and grammar in MARKDOWN_ID_STYLE docs

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -711,8 +711,8 @@ Go to the <a href="commands.html">next</a> section or return to the
  Note: Every identifier is unique.
 ]]>
       </docs>
-      <value name="DOXYGEN" desc="Use a fixed 'autotoc_md' string followed by a sequence number starting at 0."/>
-      <value name="GITHUB" desc="Use the lower case version of title with any whitespace replaced by '-' and punctations characters removed."/>
+      <value name="DOXYGEN" desc="use a fixed 'autotoc_md' string followed by a sequence number starting at 0"/>
+      <value name="GITHUB" desc="use the lower case version of title with any whitespace replaced by '-' and punctuation characters removed"/>
     </option>
     <option type='bool' id='AUTOLINK_SUPPORT' defval='1'>
       <docs>


### PR DESCRIPTION
Specifically,
1. corrected the misspelling of `punctuation`;
2. dropped the trailing `.` characters; and
3. lower-cased the first characters.

(2) and (3) make the descriptions consistent with (most) other config options.

(2) in particular (dropping the `.`) stops erroneous `.` chars appearing in the default doxyfile.  For example, the current (1.9.7) doxyfile includes:

```
# Possible values are: DOXYGEN Use a fixed 'autotoc_md' string followed by a
# sequence number starting at 0. and GITHUB Use the lower case version of title
# with any whitespace replaced by '-' and punctations characters removed..
```

Note the double dots (`..`) at the end, and the misplaced dot breaking mid-sentence after the `0`.

Cheers.