### PR TITLE
Consistent use of TIMESTAMP

### DIFF
--- a/doc_internal/Doxyfile.in
+++ b/doc_internal/Doxyfile.in
@@ -52,6 +52,7 @@ INLINE_SIMPLE_STRUCTS  = NO
 TYPEDEF_HIDES_STRUCT   = NO
 LOOKUP_CACHE_SIZE      = 1
 NUM_PROC_THREADS       = 0
+TIMESTAMP              = NO
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
@@ -174,7 +175,6 @@ HTML_COLORSTYLE        = TOGGLE
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100
 HTML_COLORSTYLE_GAMMA  = 80
-HTML_TIMESTAMP         = NO
 HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = YES
 HTML_INDEX_NUM_ENTRIES = 100
@@ -244,7 +244,6 @@ USE_PDFLATEX           = NO
 LATEX_BATCHMODE        = NO
 LATEX_HIDE_INDICES     = NO
 LATEX_BIB_STYLE        = plain
-LATEX_TIMESTAMP        = NO
 LATEX_EMOJI_DIRECTORY  =
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -801,7 +801,7 @@ static QCString substituteLatexKeywords(const QCString &str,
     { "COMPACT_LATEX",     compactLatex                           },
     { "PDF_HYPERLINKS",    pdfHyperlinks                          },
     { "USE_PDFLATEX",      usePdfLatex                            },
-    { "LATEX_TIMESTAMP",   timeStamp!=TIMESTAMP_t::NO             },
+    { "TIMESTAMP",         timeStamp!=TIMESTAMP_t::NO             },
     { "LATEX_FONTENC",     !latexFontenc.isEmpty()                },
     { "FORMULA_MACROFILE", !formulaMacrofile.isEmpty()            },
     { "PROJECT_NUMBER",    !projectNumber.isEmpty()               }

--- a/templates/html/htmlbase.tpl
+++ b/templates/html/htmlbase.tpl
@@ -271,7 +271,7 @@ $(document).ready(function(){initNavTree('{{ page.fileName }}{% if page_postfix 
       {% endfor %}
     {% endif %}
     <li class="footer">
-{% if config.HTML_TIMESTAMP %}
+{% if config.TIMESTAMP %}
 {{ tr.generatedAt:doxygen.date,config.PROJECT_NAME }}
 {% else %}
 {{ tr.generatedBy }}
@@ -281,7 +281,7 @@ $(document).ready(function(){initNavTree('{{ page.fileName }}{% if page_postfix 
 </div>
 {% else %}
   <hr class="footer"/><address class="footer"><small>
-{% if config.HTML_TIMESTAMP %}{{ tr.generatedAt:doxygen.date,config.PROJECT_NAME }}{% else %}{{ tr.generatedBy }}{% endif %}&#160;<a href="https://www.doxygen.org/index.html"><img class="footer" src="{{ page.relPath }}doxygen.svg" width="104" height="31" alt="doxygen"/></a> {{ doxygen.version }}
+{% if config.TIMESTAMP %}{{ tr.generatedAt:doxygen.date,config.PROJECT_NAME }}{% else %}{{ tr.generatedBy }}{% endif %}&#160;<a href="https://www.doxygen.org/index.html"><img class="footer" src="{{ page.relPath }}doxygen.svg" width="104" height="31" alt="doxygen"/></a> {{ doxygen.version }}
 </small></address>
 {% endif %}
 </body>

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -241,10 +241,10 @@
 %%END PROJECT_NUMBER
   \vspace*{1cm}
   {\large $generatedby Doxygen $doxygenversion}\\
-%%BEGIN LATEX_TIMESTAMP
+%%BEGIN TIMESTAMP
     \vspace*{0.5cm}
     {\small $datetime}
-%%END LATEX_TIMESTAMP
+%%END TIMESTAMP
   \end{center}
   \end{titlepage}
 


### PR DESCRIPTION
Removing references to `HTML_TIMESTAMP` and `LATEX_TIMESTAMP`  that were left after issue #5797 and pull request #10045