### PR TITLE
issue #10076 \include and Python

### DIFF
--- a/src/pycode.l
+++ b/src/pycode.l
@@ -694,6 +694,9 @@ TARGET            ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBU
     \n                              {
                                       codifyLines(yyscanner,yytext);
                                     }
+    [ \t]+                          {
+                                      codify(yyscanner,yytext);
+                                    }
     .                               {
                                       codify(yyscanner,yytext);
                                     }


### PR DESCRIPTION
In general the source browser for python code showed some strange effects in case of a number of spaces at the beginning of a line inside a triple quoted block. Instead of staying inside the triple quoted block a jump was done to the outside of the block as  the general rule `<*>[ \t]+` was executed (and a jump to condition `Body` occurred) instead  of the a handling inside the triple quoted block.

Constructed example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11546627/example.tar.gz)
