### PR TITLE
Correct warning in case automatic setting of doxygen settings

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1672,7 +1672,7 @@ static void adjustBoolSetting(const char *depOption, const char *optionName,bool
   {
     if (ConfigValues::instance().*(option->value.b)!=expectedValue) // current value differs from expectation
     {
-      err("When enabling %s the %s option should be disabled. I'll adjust it for you.\n",depOption,optionName);
+      err("When enabling %s the %s option should be %s. I'll adjust it for you.\n",depOption,optionName,expectedValue? "enabled" : "disabled");
       ConfigValues::instance().*(option->value.b)=expectedValue; // adjust option
     }
   }


### PR DESCRIPTION
When having a Doxyfile like:
```
OPTIMIZE_OUTPUT_VHDL = YES
```
we get the warnings:
```
error: When enabling OPTIMIZE_OUTPUT_VHDL the INHERIT_DOCS option should be disabled. I'll adjust it for you.
error: When enabling OPTIMIZE_OUTPUT_VHDL the HIDE_SCOPE_NAMES option should be disabled. I'll adjust it for you.
error: When enabling OPTIMIZE_OUTPUT_VHDL the EXTRACT_PRIVATE option should be disabled. I'll adjust it for you.
error: When enabling OPTIMIZE_OUTPUT_VHDL the ENABLE_PREPROCESSING option should be disabled. I'll adjust it for you.
error: When enabling OPTIMIZE_OUTPUT_VHDL the EXTRACT_PACKAGE option should be disabled. I'll adjust it for you.
```
when complying to this we still get the warnings about `HIDE_SCOPE_NAMES`, `EXTRACT_PACKAGE` and `EXTRACT_PRIVATE` as these should be enabled.