### PR TITLE
Variable names seen as keywords in C++

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1106,7 +1106,7 @@ NONLopt [^\n]*
                                           yyextra->curlyCount=0;
                                           BEGIN( ReadNSBody );
                                         }
-<FindMembers>{B}*"initonly"{BN}+        { if (yyextra->insideJava) REJECT;
+<FindMembers>{B}*"initonly"{BN}+        { if (yyextra->insideJava || yyextra->insideCpp) REJECT;
                                           yyextra->current->type += " initonly ";
                                           if (yyextra->insideCli) yyextra->current->spec |= Entry::Initonly;
                                           lineCount(yyscanner);
@@ -1161,6 +1161,7 @@ NONLopt [^\n]*
 <FindMembers>{B}*"abstract"{BN}+        {
                                           if (!yyextra->insidePHP)
                                           {
+                                            if (yyextra->insideCpp) REJECT;
                                             yyextra->current->type += " abstract ";
                                             if (!yyextra->insideJava)
                                             {
@@ -1189,7 +1190,7 @@ NONLopt [^\n]*
                                           yyextra->current->spec|=Entry::Explicit;
                                           lineCount(yyscanner);
                                         }
-<FindMembers>{B}*"local"{BN}+           { if (yyextra->insideJava) REJECT;
+<FindMembers>{B}*"local"{BN}+           { if (yyextra->insideJava || yyextra->insideCpp) REJECT;
                                           yyextra->current->spec|=Entry::Local;
                                           lineCount(yyscanner);
                                         }


### PR DESCRIPTION
`abstract`, `local` and `initonly` are no C / C++  keywords but the types of the variables would be shown as names. This is easily shown by an example like:
```
/*! \brief brief */
int local = 42;
/*! \brief brief */
float initonly = 42;
/*! \brief brief */
double abstract = 42;
/*! \brief brief */
int local0 = 7;
```

the result  is:
![image](https://github.com/doxygen/doxygen/assets/5223533/23a677e3-98b0-4c58-8836-9ac5dfdd2214)

instead of
![image](https://github.com/doxygen/doxygen/assets/5223533/845cbed8-8da3-48bd-b38d-2dfb2bf61c63)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11557050/example.tar.gz)
