### PR TITLE
Possibility to see the temporary files used for formulas

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -32,6 +32,7 @@ static std::map< std::string, Debug::DebugMask > s_labels =
   { "nolineno",           Debug::NoLineNo           },
   { "commentcnv",         Debug::CommentCnv         },
   { "commentscan",        Debug::CommentScan        },
+  { "formula",            Debug::Formula            },
   { "printtree",          Debug::PrintTree          },
   { "time",               Debug::Time               },
   { "extcmd",             Debug::ExtCmd             },

--- a/src/debug.h
+++ b/src/debug.h
@@ -28,6 +28,7 @@ class Debug
                      Preprocessor      = 0x0001,
                      CommentCnv        = 0x0002,
                      CommentScan       = 0x0004,
+                     Formula           = 0x0008,
                      PrintTree         = 0x0010,
                      Time              = 0x0020,
                      ExtCmd            = 0x0040,

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -31,16 +31,13 @@
 #include "threadpool.h"
 #include "portable.h"
 #include "latexgen.h"
+#include "debug.h"
 
 // TODO: remove these dependencies
 #include "doxygen.h"   // for Doxygen::indexList
 #include "indexlist.h" // for Doxygen::indexList
 
 static int determineInkscapeVersion(const Dir &thisDir);
-
-// Remove the temporary files
-#define RM_TMP_FILES (true)
-//#define RM_TMP_FILES (false)
 
 struct FormulaManager::Private
 {
@@ -663,7 +660,7 @@ void FormulaManager::generateImages(const QCString &path,Format format,HighDPI h
   }
 
   // clean up temporary files
-  if (RM_TMP_FILES)
+  if (!Debug::isFlagSet(Debug::Formula))
   {
     for (const auto &file : p->tempFiles)
     {
@@ -761,7 +758,7 @@ static int determineInkscapeVersion(const Dir &thisDir)
     {
       return -1;
     }
-    if (RM_TMP_FILES)
+    if (!Debug::isFlagSet(Debug::Formula))
     {
       thisDir.remove(inkscapeVersionFile.str());
     }


### PR DESCRIPTION
In the issue #10096 there was a problem with the bounding box of the formulas, to inspect the temporary files it would need a rebuild  with the remove flag unset. With the -option `-d formula` it is now possible to get the these files.