### PR TITLE
Adding Parsing file... for vhdl

### DIFF
--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -140,6 +140,8 @@ void VHDLOutlineParser::parseInput(const QCString &fileName,const char *fileBuf,
 
   bool inLine = fileName.isEmpty();
 
+  if (!inLine) msg("Parsing file %s...\n",qPrint(fileName));
+
   p->yyFileName=fileName;
 
   bool xilinx_ucf=isConstraintFile(p->yyFileName,".ucf");


### PR DESCRIPTION
When parsing files for cpp, python, Fortran, we get a line with `Parsing file <fileName>...` but this was not present for vhdl files.