### PR TITLE
Corrections for vhdl comment

### DIFF
--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -963,19 +963,37 @@ void VhdlDocGen::writeVhdlLink(const ClassDef* ccd ,OutputList& ol,QCString& typ
 
 
 /*!
- * strips the "--" prefixes of vhdl comments
+ * strips the "--!" prefixes of vhdl comments
  */
 void VhdlDocGen::prepareComment(QCString& qcs)
 {
-  const char* s="--!";
-  int index=0;
+  qcs=qcs.stripWhiteSpace();
+  if (qcs.isEmpty()) return;
 
-  while (TRUE)
+  const char* sc="--!";
+  if (qcs.startsWith(sc)) qcs = qcs.mid(qstrlen(sc));
+  static const reg::Ex re(R"(\n[ \t]*--!)");
+  std::string s = qcs.str();
+  reg::Iterator iter(s,re);
+  reg::Iterator end;
+  std::string result;
+  size_t p=0;
+  size_t sl=s.length();
+  for ( ; iter!=end ; ++iter)
   {
-    index=qcs.find(s,0,TRUE);
-    if (index<0) break;
-    qcs=qcs.remove(index,qstrlen(s));
+    const auto &match = *iter;
+    size_t i = match.position();
+    result+="\n";
+    result+=s.substr(p,i-p);
+    p = match.position()+match.length();
   }
+  if (p<sl)
+  {
+    result+="\n";
+    result+=s.substr(p);
+  }
+
+  qcs = result;
   qcs=qcs.stripWhiteSpace();
 }
 

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -403,6 +403,7 @@ void VHDLOutlineParser::handleCommentBlock(const QCString &doc1, bool brief)
 
   Protection protection = Protection::Public;
   VhdlDocGen::prepareComment(doc);
+  if (doc.isEmpty()) return;
 
   if (p->oldEntry == s->current.get())
   {


### PR DESCRIPTION
Based on the example from #5454 (comments had to be rewriten due to #10104):
- empty comment blocks (also after removing the `@cond` parts) should not be taken into account at all (otherwise subsequent comments can land in the wrong place).
- the white space before the  vhdl comment (`--!`) should also be removed (otherwise it can lead to code blocs)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11614866/example.tar.gz)

**old output**:
![image](https://github.com/doxygen/doxygen/assets/5223533/38c2ae69-52e2-42c2-904e-e5f1597a8cf5)

**new output**:

![image](https://github.com/doxygen/doxygen/assets/5223533/ccae360a-3cd4-43f5-a441-d1506e41333f)
