### PR TITLE
issue #10110 Regression: Specified markdown mainpage '...md' has not been defined as input file

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11712,7 +11712,7 @@ static void checkMarkdownMainfile()
       return;
     }
     bool ambig = false;
-    if (findFileDef(Doxygen::inputNameLinkedMap,mdfileAsMainPage,ambig)==0)
+    if (findFileDef(Doxygen::inputNameLinkedMap,fi.absFilePath(),ambig)==0)
     {
       warn_uncond("Specified markdown mainpage '%s' has not been defined as input file\n",qPrint(mdfileAsMainPage));
       return;


### PR DESCRIPTION
The filename to be used should be the full qualified filename / filename with absolute path as otherwise the file is not found.