### PR TITLE
Switch dark / light mode on ESC key

### DIFF
--- a/templates/html/darkmode_toggle.js
+++ b/templates/html/darkmode_toggle.js
@@ -100,6 +100,11 @@ class DarkModeToggle extends HTMLElement {
                 $(window).resize(function(){
                     addButton();
                 })
+                $(document).keyup(function(e) {
+                    if (e.key === "Escape") { // escape key maps to keycode `27`
+                       DarkModeToggle.userPreference = !DarkModeToggle.userPreference
+                   }
+                })
                 DarkModeToggle.setDarkModeVisibility(DarkModeToggle.darkModeEnabled)
             })
         })

--- a/templates/html/darkmode_toggle.js
+++ b/templates/html/darkmode_toggle.js
@@ -102,6 +102,7 @@ class DarkModeToggle extends HTMLElement {
                 })
                 $(document).keyup(function(e) {
                     if (e.key === "Escape") { // escape key maps to keycode `27`
+                       e.stopPropagation();
                        DarkModeToggle.userPreference = !DarkModeToggle.userPreference
                    }
                 })

--- a/templates/html/search.js
+++ b/templates/html/search.js
@@ -195,6 +195,7 @@ function SearchBox(name, resultsPath, extension)
     }
     else if (e.keyCode==27) // Escape out of the search field
     {
+      e.stopPropagation();
       this.DOMSearchField().blur();
       this.DOMPopupSearchResultsWindow().style.display = 'none';
       this.DOMSearchClose().style.display = 'none';
@@ -289,6 +290,7 @@ function SearchBox(name, resultsPath, extension)
     }
     else if (e.keyCode==13 || e.keyCode==27)
     {
+      e.stopPropagation();
       this.OnSelectItem(this.searchIndex);
       this.CloseSelectionWindow();
       this.DOMSearchField().focus();
@@ -670,6 +672,7 @@ function SearchResults(name)
       }
       else if (this.lastKey==27) // Escape
       {
+        e.stopPropagation();
         searchBox.CloseResultsWindow();
         document.getElementById("MSearchField").focus();
       }
@@ -713,6 +716,7 @@ function SearchResults(name)
       }
       else if (this.lastKey==27) // Escape
       {
+        e.stopPropagation();
         searchBox.CloseResultsWindow();
         document.getElementById("MSearchField").focus();
       }


### PR DESCRIPTION
In the darkmode some users have a problem to find the possibility to switch back to the light mode. Adding a key release event on the ESC-key that toggles between the dark and light mode.