### PR TITLE
Unclear / double path for file names

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -816,14 +816,16 @@ void FileDefImpl::writeDocumentation(OutputList &ol)
       getDirDef()->writeNavigationPath(ol);
       ol.endQuickIndices();
     }
-    QCString pageTitleShort=theTranslator->trFileReference(name());
     startTitle(ol,getOutputFileBase(),this);
     ol.pushGeneratorState();
       ol.disableAllBut(OutputType::Html);
-      ol.parseText(pageTitleShort); // Html only
+      ol.parseText(theTranslator->trFileReference(displayName())); // Html only
       ol.enableAll();
       ol.disable(OutputType::Html);
-      ol.parseText(pageTitle); // other output formats
+      if (Config_getBool(FULL_PATH_NAMES))
+        ol.parseText(theTranslator->trFileReference(m_docname)); // other output formats
+      else
+        ol.parseText(theTranslator->trFileReference(name())); // other output formats
     ol.popGeneratorState();
     addGroupListToTitle(ol,this);
     endTitle(ol,getOutputFileBase(),title);


### PR DESCRIPTION
Based on #10120  some more path problems were found
- HTML in case of `FULL_PATH_NAMES=NO` there was still a path shown
- other formats, in the file index it was unclear `FULL_PATH_NAMES=NO` which file was intended

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11721647/example.tar.gz)
