### PR TITLE
Mention "Source File" in file index.

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1064,7 +1064,12 @@ void FileDefImpl::writeSourceHeader(OutputList &ol)
       ol.endQuickIndices();
     }
     startTitle(ol,getSourceFileBase());
-    ol.parseText(name());
+    QCString nam;
+    if (Config_getBool(FULL_PATH_NAMES))
+      nam = m_docname;
+    else
+      nam = name();
+    ol.parseText(theTranslator->trSourceFile(nam));
     endTitle(ol,getSourceFileBase(),title);
   }
   else


### PR DESCRIPTION
In the file index (e.g. LaTeX) we for the source files just the filename, so in the index it is unclear what is the case here. (In the HTML output the words "Source File" were already present).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11723493/example.tar.gz)
