### PR TITLE
Position of first line of source browser for RTF output

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1083,6 +1083,11 @@ void FileDefImpl::writeSourceHeader(OutputList &ol)
     ol.startTextLink(getOutputFileBase(),QCString());
     ol.parseText(theTranslator->trGotoDocumentation());
     ol.endTextLink();
+
+    ol.pushGeneratorState();
+    ol.disableAllBut(OutputType::RTF);
+    ol.writeString("\\par\n");
+    ol.popGeneratorState();
   }
 }
 


### PR DESCRIPTION
In case of RTF output the line "Go to the documentation of this file." is directly followed by the first line of the source code instead of that the source code start at the next line.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11748558/example.tar.gz)
