### PR TITLE
Detection of missing / superfluous `\n` in warnings

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1723,7 +1723,7 @@ STopt  [^\n@\\]*
                                               QCString endTag = "end"+yyextra->blockName;
                                               if (yyextra->blockName=="startuml") endTag="enduml";
                                               warn(yyextra->fileName,yyextra->lineNr,
-                                                 "found */ without matching /* while inside a \\%s block! Perhaps a missing \\%s?\n",qPrint(yyextra->blockName),qPrint(endTag));
+                                                 "found */ without matching /* while inside a \\%s block! Perhaps a missing \\%s?",qPrint(yyextra->blockName),qPrint(endTag));
                                             }
                                           }
                                         }

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1738,7 +1738,7 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   }
   if (warnFormat.find("$text")==-1)
   {
-    warn_uncond("warning format foes not contain a $text tag!\n");
+    warn_uncond("warning format does not contain a $text tag!\n");
   }
 
   //------------------------

--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -62,7 +62,7 @@ void writeDiaGraphFromFile(const QCString &inFile,const QCString &outDir,
   //printf("*** running: %s %s outDir:%s %s\n",qPrint(diaExe),qPrint(diaArgs),outDir,outFile);
   if (Portable::system(diaExe,diaArgs,FALSE)!=0)
   {
-    err_full(srcFile,srcLine,"Problems running %s. Check your installation or look typos in you dia file %s\n",
+    err_full(srcFile,srcLine,"Problems running %s. Check your installation or look typos in you dia file %s",
         qPrint(diaExe),qPrint(inFile));
     goto error;
   }

--- a/src/docgroup.cpp
+++ b/src/docgroup.cpp
@@ -37,7 +37,7 @@ void DocGroup::leaveFile(const QCString &fileName,int line)
 {
   //if (m_memberGroupId!=DOX_NOGROUP)
   //{
-  //  warn(fileName,line,"end of file while inside a member group\n");
+  //  warn(fileName,line,"end of file while inside a member group");
   //}
   m_memberGroupId=DOX_NOGROUP;
   m_memberGroupRelates.resize(0);
@@ -56,7 +56,7 @@ void DocGroup::enterCompound(const QCString &fileName,int line,const QCString &n
 {
   if (m_memberGroupId!=DOX_NOGROUP)
   {
-    warn(fileName,line,"try to put compound %s inside a member group\n",qPrint(name));
+    warn(fileName,line,"try to put compound %s inside a member group",qPrint(name));
   }
   m_memberGroupId=DOX_NOGROUP;
   m_memberGroupRelates.resize(0);

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -158,7 +158,7 @@ DocEmoji::DocEmoji(DocParser *parser,DocNodeVariant *parent,const QCString &symN
   m_index = EmojiEntityMapper::instance().symbol2index(m_symName.str());
   if (m_index==-1)
   {
-    warn_doc_error(parser->context.fileName,parser->tokenizer.getLineNr(),"Found unsupported emoji symbol '%s'\n",qPrint(m_symName));
+    warn_doc_error(parser->context.fileName,parser->tokenizer.getLineNr(),"Found unsupported emoji symbol '%s'",qPrint(m_symName));
   }
 }
 
@@ -294,7 +294,7 @@ void DocInclude::parse()
       {
         warn_doc_error(parser()->context.fileName,
                        parser()->tokenizer.getLineNr(),
-                       "block marked with %s for \\snippet should appear twice in file %s, found it %d times\n",
+                       "block marked with %s for \\snippet should appear twice in file %s, found it %d times",
                        qPrint(m_blockId),qPrint(m_file),count);
       }
       break;
@@ -980,7 +980,7 @@ QCString DocLink::parse(bool isJavaLink,bool isXmlLink)
   {
     warn_doc_error(parser()->context.fileName,
                    parser()->tokenizer.getLineNr(),
-                   "Unexpected end of comment while inside link command\n");
+                   "Unexpected end of comment while inside link command");
   }
 endlink:
 
@@ -1264,7 +1264,7 @@ int DocHtmlHeader::parse()
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected end of comment while inside"
-           " <h%d> tag\n",m_level);
+           " <h%d> tag",m_level);
   }
 endheader:
   parser()->handlePendingStyleCommands(thisVariant(),children());
@@ -3160,7 +3160,7 @@ void DocPara::handleCite()
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command %s\n", qPrint("cite"));
+        "argument of command %s", qPrint("cite"));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
@@ -3221,7 +3221,7 @@ void DocPara::handleDoxyConfig()
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command \\doxyconfig\n");
+        "argument of command \\doxyconfig");
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
@@ -3399,7 +3399,7 @@ void DocPara::handleILine()
   int tok = parser()->tokenizer.lex();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid argument for command '\\iline'\n");
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid argument for command '\\iline'");
     return;
   }
   parser()->tokenizer.setStatePara();
@@ -3697,7 +3697,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
        int count;
        if (!blockId.isEmpty() && (count=inc_text.contains(blockId.data()))!=2)
        {
-          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"block marked with %s for \\snippet should appear twice in file %s, found it %d times\n",
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"block marked with %s for \\snippet should appear twice in file %s, found it %d times",
             qPrint(blockId),qPrint(fileName),count);
        }
        inc_line = lineBlock(inc_text, blockId);
@@ -3741,7 +3741,7 @@ void DocPara::handleSection(const QCString &cmdName)
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command %s\n", qPrint(saveCmdName));
+        "argument of command %s", qPrint(saveCmdName));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
@@ -4968,7 +4968,7 @@ int DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &ta
       break;
   default:
       // we should not get here!
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected start tag %s\n",qPrint(tagName));
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected start tag %s",qPrint(tagName));
       ASSERT(0);
       break;
   }
@@ -5102,7 +5102,7 @@ int DocPara::handleHtmlEndTag(const QCString &tagName)
       warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </caption> found");
       break;
     case HTML_BR:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </br> tag found\n");
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </br> tag found");
       break;
     case HTML_H1:
       warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </h1> found");
@@ -5125,7 +5125,7 @@ int DocPara::handleHtmlEndTag(const QCString &tagName)
     case HTML_IMG:
       break;
     case HTML_HR:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </hr> tag found\n");
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </hr> tag found");
       break;
     case HTML_A:
       //warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </a> found");
@@ -5169,7 +5169,7 @@ int DocPara::handleHtmlEndTag(const QCString &tagName)
       break;
     default:
       // we should not get here!
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected end tag %s\n",qPrint(tagName));
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected end tag %s",qPrint(tagName));
       ASSERT(0);
       break;
   }
@@ -5453,7 +5453,7 @@ reparsetoken:
         break;
       default:
         warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),
-            "Found unexpected token (id=%s)\n",DocTokenizer::tokToString(tok));
+            "Found unexpected token (id=%s)",DocTokenizer::tokToString(tok));
         break;
     }
   }

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1350,10 +1350,10 @@ reparsetoken:
         switch (Mappers::htmlTagMapper->map(tokenName))
         {
           case HTML_DIV:
-            warn_doc_error(context.fileName,tokenizer.getLineNr(),"found <div> tag in heading\n");
+            warn_doc_error(context.fileName,tokenizer.getLineNr(),"found <div> tag in heading");
             break;
           case HTML_PRE:
-            warn_doc_error(context.fileName,tokenizer.getLineNr(),"found <pre> tag in heading\n");
+            warn_doc_error(context.fileName,tokenizer.getLineNr(),"found <pre> tag in heading");
             break;
           case HTML_BOLD:
             if (!context.token->endTag)
@@ -1576,7 +1576,7 @@ void DocParser::handleImg(DocNodeVariant *parent, DocNodeList &children,const Ht
   }
   if (!found)
   {
-    warn_doc_error(context.fileName,tokenizer.getLineNr(),"IMG tag does not have a SRC attribute!\n");
+    warn_doc_error(context.fileName,tokenizer.getLineNr(),"IMG tag does not have a SRC attribute!");
   }
 }
 
@@ -1847,7 +1847,7 @@ QCString DocParser::processCopyDoc(const char *data,size_t &len)
           else
           {
             warn_doc_error(context.fileName,tokenizer.getLineNr(),
-	         "Found recursive @copy%s or @copydoc relation for argument '%s'.\n",
+	         "Found recursive @copy%s or @copydoc relation for argument '%s'.",
                  isBrief?"brief":"details",qPrint(id));
           }
         }

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1590,7 +1590,7 @@ static void processSection(yyscan_t yyscanner)
   }
   else
   {
-    warn(yyextra->fileName,yyextra->yyLineNr,"Found section/anchor %s without context\n",qPrint(yyextra->secLabel));
+    warn(yyextra->fileName,yyextra->yyLineNr,"Found section/anchor %s without context",qPrint(yyextra->secLabel));
   }
   SectionInfo *si = SectionManager::instance().find(yyextra->secLabel);
   if (si)

--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -356,7 +356,7 @@ bool DotRunner::run()
   }
   return TRUE;
 error:
-  err_full(srcFile,srcLine,"Problems running dot: exit code=%d, command='%s', arguments='%s'\n",
+  err_full(srcFile,srcLine,"Problems running dot: exit code=%d, command='%s', arguments='%s'",
     exitCode,qPrint(m_dotExe),qPrint(dotArgs));
   return FALSE;
 }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -358,7 +358,7 @@ static void buildGroupListFiltered(const Entry *root,bool additional, bool inclu
         else if ( root->type.length() > 0 && root->name != root->type && gd->groupTitle() != root->type )
         {
           warn( root->fileName,root->startLine,
-              "group %s: ignoring title \"%s\" that does not match old title \"%s\"\n",
+              "group %s: ignoring title \"%s\" that does not match old title \"%s\"",
               qPrint(root->name), qPrint(root->type), qPrint(gd->groupTitle()) );
         }
         gd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
@@ -4660,7 +4660,7 @@ static bool findClassRelation(
         {
           warn(root->fileName,root->startLine,
               "Detected potential recursive class relation "
-              "between class %s and base class %s!\n",
+              "between class %s and base class %s!",
               qPrint(root->name),qPrint(baseClassName)
               );
         }
@@ -8947,7 +8947,7 @@ static void findDefineDocumentation(Entry *root)
       if (preEnabled)
       {
         warn(root->fileName,root->startLine,
-             "documentation for unknown define %s found.\n",
+             "documentation for unknown define %s found.",
              qPrint(root->name)
             );
       }
@@ -8955,7 +8955,7 @@ static void findDefineDocumentation(Entry *root)
       {
         warn(root->fileName,root->startLine,
              "found documented #define %s but ignoring it because "
-             "ENABLE_PREPROCESSING is NO.\n",
+             "ENABLE_PREPROCESSING is NO.",
              qPrint(root->name)
             );
       }
@@ -8997,7 +8997,7 @@ static void findDirDocumentation(const Entry *root)
            warn(root->fileName,root->startLine,
              "\\dir command matches multiple directories.\n"
              "  Applying the command for directory %s\n"
-             "  Ignoring the command for directory %s\n",
+             "  Ignoring the command for directory %s",
              qPrint(matchingDir->name()),qPrint(dir->name())
            );
         }
@@ -9018,7 +9018,7 @@ static void findDirDocumentation(const Entry *root)
     else
     {
       warn(root->fileName,root->startLine,"No matching "
-          "directory found for command \\dir %s\n",qPrint(normalizedName));
+          "directory found for command \\dir %s",qPrint(normalizedName));
     }
   }
   for (const auto &e : root->children()) findDirDocumentation(e.get());

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -316,7 +316,7 @@ static bool extractBoundingBox(const QCString &formBase,
     }
     else
     {
-      err("Couldn't extract bounding box from %s_tmp.epsi",qPrint(formBase));
+      err("Couldn't extract bounding box from %s_tmp.epsi\n",qPrint(formBase));
       return false;
     }
     i = eps.find("%%HiResBoundingBox:");
@@ -326,7 +326,7 @@ static bool extractBoundingBox(const QCString &formBase,
     }
     else
     {
-      err("Couldn't extract high resolution bounding box from %s_tmp.epsi",qPrint(formBase));
+      err("Couldn't extract high resolution bounding box from %s_tmp.epsi\n",qPrint(formBase));
       return false;
     }
   }

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1432,7 +1432,7 @@ void addGroupToGroups(const Entry *root,GroupDef *subGroup)
       else if (subGroup->findGroup(gd))
       {
         warn(root->fileName,root->startLine,"Refusing to add group %s to group %s, since the latter is already a "
-                                            "subgroup of the former\n", qPrint(subGroup->name()),qPrint(gd->name()));
+                                            "subgroup of the former", qPrint(subGroup->name()),qPrint(gd->name()));
       }
       else if (!gd->findGroup(subGroup))
       {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -169,7 +169,7 @@ static QCString getConvertLatexMacro()
     // check for \newcommand or \renewcommand
     if (data[i] != '\\')
     {
-      warn(macrofile,line, "file contains non valid code, expected '\\' got '%c'\n",data[i]);
+      warn(macrofile,line, "file contains non valid code, expected '\\' got '%c'",data[i]);
       return "";
     }
     i++;
@@ -189,13 +189,13 @@ static QCString getConvertLatexMacro()
     // handle {cmd}
     if (data[i] != '{')
     {
-      warn(macrofile,line, "file contains non valid code, expected '{' got '%c'\n",data[i]);
+      warn(macrofile,line, "file contains non valid code, expected '{' got '%c'",data[i]);
       return "";
     }
     i++;
     if (data[i] != '\\')
     {
-      warn(macrofile,line, "file contains non valid code, expected '\\' got '%c'\n",data[i]);
+      warn(macrofile,line, "file contains non valid code, expected '\\' got '%c'",data[i]);
       return "";
     }
     i++;
@@ -227,14 +227,14 @@ static QCString getConvertLatexMacro()
     }
     else if (data[i] != '{')
     {
-      warn(macrofile,line, "file contains non valid code, expected '[' or '{' got '%c'\n",data[i]);
+      warn(macrofile,line, "file contains non valid code, expected '[' or '{' got '%c'",data[i]);
       return "";
     }
     // handle {replacement}
     // retest as the '[' part might have advanced so we can have a new '{'
     if (data[i] != '{')
     {
-      warn(macrofile,line, "file contains non valid code, expected '{' got '%c'\n",data[i]);
+      warn(macrofile,line, "file contains non valid code, expected '{' got '%c'",data[i]);
       return "";
     }
     out.addChar('"');
@@ -1548,7 +1548,7 @@ void HtmlGenerator::writeStyleInfo(int part)
         FileInfo cssfi(cssName.str());
         if (!cssfi.exists() || !cssfi.isFile() || !cssfi.isReadable())
         {
-          err("style sheet %s does not exist or is not readable!", qPrint(Config_getString(HTML_STYLESHEET)));
+          err("style sheet %s does not exist or is not readable!\n", qPrint(Config_getString(HTML_STYLESHEET)));
         }
         else
         {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -698,7 +698,7 @@ static void writeDirTreeNode(OutputList &ol, const DirDef *dd, int level, FTVHel
   {
     warn(dd->getDefFileName(),dd->getDefLine(),
         "maximum nesting level exceeded for directory %s: "
-        "check for possible recursive directory relation!\n",qPrint(dd->name())
+        "check for possible recursive directory relation!",qPrint(dd->name())
         );
     return;
   }
@@ -3715,7 +3715,7 @@ static void writeGroupTreeNode(OutputList &ol, const GroupDef *gd, int level, FT
   if (level>20)
   {
     warn(gd->getDefFileName(),gd->getDefLine(),
-        "maximum nesting level exceeded for group %s: check for possible recursive group relation!\n",qPrint(gd->name())
+        "maximum nesting level exceeded for group %s: check for possible recursive group relation!",qPrint(gd->name())
         );
     return;
   }

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -188,7 +188,7 @@ class LayoutParser
     }
     void error( const std::string &fileName,int lineNr,const std::string &msg)
     {
-      ::warn(fileName.c_str(),lineNr,"%s",msg.c_str());
+      warn(fileName.c_str(),lineNr,"%s",msg.c_str());
     }
     void startElement( const std::string &name, const XMLHandlers::Attributes& attrib );
     void endElement( const std::string &name );
@@ -515,11 +515,11 @@ class LayoutParser
         std::string fileName = m_locator->fileName();
         if (type.isEmpty())
         {
-          ::warn(fileName.c_str(),m_locator->lineNr(),"an entry tag within a navindex has no type attribute! Check your layout file!\n");
+          warn(fileName.c_str(),m_locator->lineNr(),"an entry tag within a navindex has no type attribute! Check your layout file!");
         }
         else
         {
-          ::warn(fileName.c_str(),m_locator->lineNr(),"the type '%s' is not supported for the entry tag within a navindex! Check your layout file!\n",qPrint(type));
+          warn(fileName.c_str(),m_locator->lineNr(),"the type '%s' is not supported for the entry tag within a navindex! Check your layout file!",qPrint(type));
         }
         m_invalidEntry=TRUE;
         return;
@@ -1278,7 +1278,7 @@ void LayoutParser::startElement( const std::string &name, const XMLHandlers::Att
   else
   {
     std::string fileName = m_locator->fileName();
-    ::warn(fileName.c_str(),m_locator->lineNr(),"Unexpected start tag '%s' found in scope='%s'!\n",
+    warn(fileName.c_str(),m_locator->lineNr(),"Unexpected start tag '%s' found in scope='%s'!",
         qPrint(name),qPrint(m_scope));
   }
 }

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -171,7 +171,7 @@ void MemberList::countDecMembers()
                                      m_numDecMembers++;
                                      break;
         default:
-          err("Unknown member type found for member '%s'\n!",qPrint(md->name()));
+          err("Unknown member type found for member '%s'!\n",qPrint(md->name()));
       }
     }
   }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -207,7 +207,7 @@ QCString warn_line(const QCString &file,int line)
             "$line",lineSubst
           );
 }
-void warn(const QCString &file,int line,const char *fmt, ...)
+void warn_(const QCString &file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -226,7 +226,7 @@ void warn_simple(const QCString &file,int line,const char *text)
   format_warn(file,line,QCString(g_warningStr) + text);
 }
 
-void warn_undoc(const QCString &file,int line,const char *fmt, ...)
+void warn_undoc_(const QCString &file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -234,7 +234,7 @@ void warn_undoc(const QCString &file,int line,const char *fmt, ...)
   va_end(args);
 }
 
-void warn_incomplete_doc(const QCString &file,int line,const char *fmt, ...)
+void warn_incomplete_doc_(const QCString &file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -242,7 +242,7 @@ void warn_incomplete_doc(const QCString &file,int line,const char *fmt, ...)
   va_end(args);
 }
 
-void warn_doc_error(const QCString &file,int line,const char *fmt, ...)
+void warn_doc_error_(const QCString &file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -250,7 +250,7 @@ void warn_doc_error(const QCString &file,int line,const char *fmt, ...)
   va_end(args);
 }
 
-void warn_uncond(const char *fmt, ...)
+void warn_uncond_(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -259,7 +259,7 @@ void warn_uncond(const char *fmt, ...)
   handle_warn_as_error();
 }
 
-void err(const char *fmt, ...)
+void err_(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -268,7 +268,7 @@ void err(const char *fmt, ...)
   handle_warn_as_error();
 }
 
-extern void err_full(const QCString &file,int line,const char *fmt, ...)
+extern void err_full_(const QCString &file,int line,const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -276,7 +276,7 @@ extern void err_full(const QCString &file,int line,const char *fmt, ...)
   va_end(args);
 }
 
-void term(const char *fmt, ...)
+void term_(const char *fmt, ...)
 {
   {
     std::unique_lock<std::mutex> lock(g_mutex);

--- a/src/message.h
+++ b/src/message.h
@@ -56,6 +56,7 @@ constexpr bool has_newline_at_end(const char (&str)[N])
 #define msg_newline_required(x) \
    static_assert(has_newline_at_end(x),"text: \"" x "\" should have \\n at end");
 
+#if __GNUC__
 #define warn(file,line,fmt,...) do { \
    msg_no_newline_allowed(fmt);      \
    warn_(file,line,fmt,##__VA_ARGS__); \
@@ -95,5 +96,49 @@ constexpr bool has_newline_at_end(const char (&str)[N])
    msg_newline_required(fmt); \
    term_(fmt,##__VA_ARGS__);    \
    } while(0)
+
+#else
+
+#define warn(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);      \
+   warn_(file,line,fmt,__VA_ARGS__); \
+   } while(0)
+
+#define warn_undoc(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);            \
+   warn_undoc_(file,line,fmt,__VA_ARGS__); \
+   } while(0)
+
+#define warn_incomplete_doc(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);                     \
+   warn_incomplete_doc_(file,line,fmt,__VA_ARGS__); \
+   } while(0)
+
+#define warn_doc_error(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);                \
+   warn_doc_error_(file,line,fmt,__VA_ARGS__); \
+   } while(0)
+
+#define warn_uncond(fmt,...) do { \
+   msg_newline_required(fmt);     \
+   warn_uncond_(fmt,__VA_ARGS__); \
+   } while(0)
+
+#define err(fmt,...) do {     \
+   msg_newline_required(fmt); \
+   err_(fmt,__VA_ARGS__);     \
+   } while(0)
+
+#define err_full(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);          \
+   err_full_(file,line,fmt,__VA_ARGS__); \
+   } while(0)
+
+#define term(fmt,...) do {    \
+   msg_newline_required(fmt); \
+   term_(fmt,__VA_ARGS__);    \
+   } while(0)
+
+#endif
 
 #endif

--- a/src/message.h
+++ b/src/message.h
@@ -56,7 +56,7 @@ constexpr bool has_newline_at_end(const char (&str)[N])
 #define msg_newline_required(x) \
    static_assert(has_newline_at_end(x),"text: \"" x "\" should have \\n at end");
 
-#if __GNUC__
+#if (defined(__GNUC__) && !defined(__clang__))
 #define warn(file,line,fmt,...) do { \
    msg_no_newline_allowed(fmt);      \
    warn_(file,line,fmt,##__VA_ARGS__); \

--- a/src/message.h
+++ b/src/message.h
@@ -56,7 +56,16 @@ constexpr bool has_newline_at_end(const char (&str)[N])
 #define msg_newline_required(x) \
    static_assert(has_newline_at_end(x),"text: \"" x "\" should have \\n at end");
 
-#if (defined(__GNUC__) && !defined(__clang__))
+#if defined(__clang__)
+#define  warn warn_
+#define  warn_undoc warn_undoc_
+#define  warn_incomplete_doc warn_incomplete_doc_
+#define  warn_doc_error warn_doc_error_
+#define  warn_uncond warn_uncond_
+#define  err err_
+#define  err_full err_full_
+#define  term term_
+#else
 #define warn(file,line,fmt,...) do { \
    msg_no_newline_allowed(fmt);      \
    warn_(file,line,fmt,##__VA_ARGS__); \
@@ -96,49 +105,6 @@ constexpr bool has_newline_at_end(const char (&str)[N])
    msg_newline_required(fmt); \
    term_(fmt,##__VA_ARGS__);    \
    } while(0)
-
-#else
-
-#define warn(file,line,fmt,...) do { \
-   msg_no_newline_allowed(fmt);      \
-   warn_(file,line,fmt,__VA_ARGS__); \
-   } while(0)
-
-#define warn_undoc(file,line,fmt,...) do { \
-   msg_no_newline_allowed(fmt);            \
-   warn_undoc_(file,line,fmt,__VA_ARGS__); \
-   } while(0)
-
-#define warn_incomplete_doc(file,line,fmt,...) do { \
-   msg_no_newline_allowed(fmt);                     \
-   warn_incomplete_doc_(file,line,fmt,__VA_ARGS__); \
-   } while(0)
-
-#define warn_doc_error(file,line,fmt,...) do { \
-   msg_no_newline_allowed(fmt);                \
-   warn_doc_error_(file,line,fmt,__VA_ARGS__); \
-   } while(0)
-
-#define warn_uncond(fmt,...) do { \
-   msg_newline_required(fmt);     \
-   warn_uncond_(fmt,__VA_ARGS__); \
-   } while(0)
-
-#define err(fmt,...) do {     \
-   msg_newline_required(fmt); \
-   err_(fmt,__VA_ARGS__);     \
-   } while(0)
-
-#define err_full(file,line,fmt,...) do { \
-   msg_no_newline_allowed(fmt);          \
-   err_full_(file,line,fmt,__VA_ARGS__); \
-   } while(0)
-
-#define term(fmt,...) do {    \
-   msg_newline_required(fmt); \
-   term_(fmt,__VA_ARGS__);    \
-   } while(0)
-
 #endif
 
 #endif

--- a/src/message.h
+++ b/src/message.h
@@ -26,21 +26,74 @@
 #endif
 
 extern void msg(const char *fmt, ...) PRINTFLIKE(1,2);
-extern void warn(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void warn_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void va_warn(const QCString &file, int line, const char* fmt, va_list args);
 extern void warn_simple(const QCString &file,int line,const char *text);
-extern void warn_undoc(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
-extern void warn_incomplete_doc(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
-extern void warn_doc_error(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
-extern void warn_uncond(const char *fmt, ...) PRINTFLIKE(1, 2);
-extern void err(const char *fmt, ...) PRINTFLIKE(1, 2);
-extern void err_full(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
-extern void term(const char *fmt, ...) PRINTFLIKE(1, 2);
+extern void warn_undoc_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void warn_incomplete_doc_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void warn_doc_error_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void warn_uncond_(const char *fmt, ...) PRINTFLIKE(1, 2);
+extern void err_(const char *fmt, ...) PRINTFLIKE(1, 2);
+extern void err_full_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void term_(const char *fmt, ...) PRINTFLIKE(1, 2);
 extern QCString warn_line(const QCString &file,int line);
 void initWarningFormat();
 void warn_flush();
 extern void finishWarnExit();
 
 #undef PRINTFLIKE
+
+// N is size including 0-terminal
+template<std::size_t N>
+constexpr bool has_newline_at_end(const char (&str)[N])
+{
+  return str[N-2]=='\n';
+}
+
+#define msg_no_newline_allowed(x) \
+   static_assert(!has_newline_at_end(x),"text: \"" x "\" should not have \\n at end");
+
+#define msg_newline_required(x) \
+   static_assert(has_newline_at_end(x),"text: \"" x "\" should have \\n at end");
+
+#define warn(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);      \
+   warn_(file,line,fmt,##__VA_ARGS__); \
+   } while(0)
+
+#define warn_undoc(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);            \
+   warn_undoc_(file,line,fmt,##__VA_ARGS__); \
+   } while(0)
+
+#define warn_incomplete_doc(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);                     \
+   warn_incomplete_doc_(file,line,fmt,##__VA_ARGS__); \
+   } while(0)
+
+#define warn_doc_error(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);                \
+   warn_doc_error_(file,line,fmt,##__VA_ARGS__); \
+   } while(0)
+
+#define warn_uncond(fmt,...) do { \
+   msg_newline_required(fmt);     \
+   warn_uncond_(fmt,##__VA_ARGS__); \
+   } while(0)
+
+#define err(fmt,...) do {     \
+   msg_newline_required(fmt); \
+   err_(fmt,##__VA_ARGS__);     \
+   } while(0)
+
+#define err_full(file,line,fmt,...) do { \
+   msg_no_newline_allowed(fmt);          \
+   err_full_(file,line,fmt,##__VA_ARGS__); \
+   } while(0)
+
+#define term(fmt,...) do {    \
+   msg_newline_required(fmt); \
+   term_(fmt,##__VA_ARGS__);    \
+   } while(0)
 
 #endif

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -135,7 +135,7 @@ static bool do_mscgen_generate(const QCString& inFile,const QCString& outFile,ms
     int code = mscgen_generate(inFile.data(),outFile.data(),msc_format);
     if (code!=0)
     {
-      err_full(srcFile,srcLine,"Problems generating msc output (error=%s). Look for typos in you msc file %s\n",
+      err_full(srcFile,srcLine,"Problems generating msc output (error=%s). Look for typos in you msc file '%s'",
           mscgen_error2str(code),qPrint(inFile));
       return false;
     }
@@ -183,7 +183,7 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
                          qPrint(absOutFile),qPrint(absOutFile));
     if (Portable::system("epstopdf",epstopdfArgs)!=0)
     {
-      err_full(srcFile,srcLine,"Problems running epstopdf when processing '%s.eps'. Check your TeX installation!\n",
+      err_full(srcFile,srcLine,"Problems running epstopdf when processing '%s.eps'. Check your TeX installation!",
           qPrint(absOutFile));
     }
   }

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -269,7 +269,7 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
       std::ofstream file = Portable::openOutputStream(puFileName);
       if (!file.is_open())
       {
-        err_full(nb.srcFile,nb.srcLine,"Could not open file %s for writing\n",puFileName.data());
+        err_full(nb.srcFile,nb.srcLine,"Could not open file %s for writing",puFileName.data());
       }
       file.write( nb.content.data(), nb.content.length() );
       file.close();
@@ -279,7 +279,7 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
 
       if ((exitCode=Portable::system(pumlExe.data(),pumlArguments.data(),TRUE))!=0)
       {
-        err_full(nb.srcFile,nb.srcLine,"Problems running PlantUML. Verify that the command 'java -jar \"%s\" -h' works from the command line. Exit code: %d\n",
+        err_full(nb.srcFile,nb.srcLine,"Problems running PlantUML. Verify that the command 'java -jar \"%s\" -h' works from the command line. Exit code: %d.",
             plantumlJarPath.data(),exitCode);
       }
 
@@ -297,7 +297,7 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
                 pumlOutDir.data(),str.c_str(), pumlOutDir.data(),str.c_str());
             if ((exitCode=Portable::system("epstopdf",epstopdfArgs.data()))!=0)
             {
-              err_full(nb.srcFile,nb.srcLine,"Problems running epstopdf. Check your TeX installation! Exit code: %d\n",exitCode);
+              err_full(nb.srcFile,nb.srcLine,"Problems running epstopdf. Check your TeX installation! Exit code: %d.",exitCode);
             }
           }
         }

--- a/src/pre.l
+++ b/src/pre.l
@@ -1960,7 +1960,7 @@ static void decrLevel(yyscan_t yyscanner)
   }
   else
   {
-    warn(state->fileName,state->yyLineNr,"More #endif's than #if's found.\n");
+    warn(state->fileName,state->yyLineNr,"More #endif's than #if's found.");
   }
 }
 
@@ -1969,7 +1969,7 @@ static bool otherCaseDone(yyscan_t yyscanner)
   YY_EXTRA_TYPE state = preYYget_extra(yyscanner);
   if (state->levelGuard.empty())
   {
-    warn(state->fileName,state->yyLineNr,"Found an #else without a preceding #if.\n");
+    warn(state->fileName,state->yyLineNr,"Found an #else without a preceding #if.");
     return TRUE;
   }
   else

--- a/src/rtfstyle.cpp
+++ b/src/rtfstyle.cpp
@@ -254,7 +254,7 @@ bool StyleData::setStyle(const std::string &command, const std::string &styleNam
   reg::Match match;
   if (!reg::search(command,match,s_clause))
   {
-    err("Style sheet '%s' contains no '\\s' clause.\n{%s}", styleName.c_str(), command.c_str());
+    err("Style sheet '%s' contains no '\\s' clause.\n{%s}\n", styleName.c_str(), command.c_str());
     return false;
   }
   m_index = static_cast<int>(std::stoul(match[1].str()));
@@ -275,7 +275,7 @@ void loadStylesheet(const QCString &name, StyleDataMap& map)
   std::ifstream file(name.str());
   if (!file.is_open())
   {
-    err("Can't open RTF style sheet file %s. Using defaults.",qPrint(name));
+    err("Can't open RTF style sheet file %s. Using defaults.\n",qPrint(name));
     return;
   }
   msg("Loading RTF style sheet %s...\n",qPrint(name));
@@ -317,7 +317,7 @@ void loadExtensions(const QCString &name)
   std::ifstream file(name.str());
   if (!file.is_open())
   {
-    err("Can't open RTF extensions file %s. Using defaults.",qPrint(name));
+    err("Can't open RTF extensions file %s. Using defaults.\n",qPrint(name));
     return;
   }
   msg("Loading RTF extensions %s...\n",qPrint(name));

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6952,7 +6952,7 @@ NONLopt [^\n]*
 <DocCopyBlock><<EOF>>                   {
                                           warn(yyextra->fileName,yyextra->yyLineNr,
                                               "reached end of file while inside a '%s' block!\n"
-                                              "The command that should end the block seems to be missing!\n",
+                                              "The command that should end the block seems to be missing!",
                                               qPrint(yyextra->docBlockName));
                                           yyterminate();
                                         }

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -329,7 +329,7 @@ class TagFileParser
     void characters ( const QCString & ch ) { m_curString+=ch; }
     void error( const QCString &fileName,int lineNr,const QCString &msg)
     {
-      ::warn(fileName,lineNr,"%s",qPrint(msg));
+      ::warn_(fileName,lineNr,"%s",qPrint(msg));
     }
 
     void dump();
@@ -352,7 +352,7 @@ class TagFileParser
           m_tagFileCompounds.push_back(std::move(m_curCompound));
           break;
         default:
-          warn("tag 'compound' was not expected!");
+          p_warn("tag 'compound' was not expected!");
           break;
       }
     }
@@ -409,7 +409,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'member' found");
+          p_warn("Unexpected tag 'member' found");
           break;
       }
     }
@@ -428,7 +428,7 @@ class TagFileParser
       }
       else
       {
-        warn("Found 'enumvalue' tag outside of member tag");
+        p_warn("Found 'enumvalue' tag outside of member tag");
       }
     }
 
@@ -461,7 +461,7 @@ class TagFileParser
           if (AnchorGenerator::looksGenerated(m_curString.str())) return;
           break;
         default:
-          warn("Unexpected tag 'docanchor' found");
+          p_warn("Unexpected tag 'docanchor' found");
           return;
       }
       switch(m_state)
@@ -524,7 +524,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'class' found");
+          p_warn("Unexpected tag 'class' found");
           break;
       }
     }
@@ -552,7 +552,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'concept' found");
+          p_warn("Unexpected tag 'concept' found");
           break;
       }
     }
@@ -580,7 +580,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'namespace' found");
+          p_warn("Unexpected tag 'namespace' found");
           break;
       }
     }
@@ -602,7 +602,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'file' found");
+          p_warn("Unexpected tag 'file' found");
           break;
       }
     }
@@ -618,7 +618,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'page' found");
+          p_warn("Unexpected tag 'page' found");
           break;
       }
     }
@@ -634,7 +634,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'dir' found");
+          p_warn("Unexpected tag 'dir' found");
           break;
       }
     }
@@ -659,7 +659,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'type' found");
+        p_warn("Unexpected tag 'type' found");
       }
     }
 
@@ -684,7 +684,7 @@ class TagFileParser
           m_curMember.name = m_curString;
           break;
         default:
-          warn("Unexpected tag 'name' found");
+          p_warn("Unexpected tag 'name' found");
           break;
       }
     }
@@ -715,7 +715,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'base' found");
+        p_warn("Unexpected tag 'base' found");
       }
     }
 
@@ -728,7 +728,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'base' found");
+        p_warn("Unexpected tag 'base' found");
       }
     }
 
@@ -752,7 +752,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'includes' found");
+        p_warn("Unexpected tag 'includes' found");
       }
     }
 
@@ -765,7 +765,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'templarg' found");
+        p_warn("Unexpected tag 'templarg' found");
       }
     }
 
@@ -787,7 +787,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'filename' found");
+          p_warn("Unexpected tag 'filename' found");
           break;
       }
     }
@@ -809,7 +809,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'path' found");
+          p_warn("Unexpected tag 'path' found");
           break;
       }
     }
@@ -827,7 +827,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'anchor' found");
+        p_warn("Unexpected tag 'anchor' found");
       }
     }
 
@@ -849,7 +849,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'clangid' found");
+        p_warn("Unexpected tag 'clangid' found");
       }
     }
 
@@ -863,7 +863,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'anchorfile' found");
+        p_warn("Unexpected tag 'anchorfile' found");
       }
     }
 
@@ -875,7 +875,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'arglist' found");
+        p_warn("Unexpected tag 'arglist' found");
       }
     }
 
@@ -896,7 +896,7 @@ class TagFileParser
           }
           break;
         default:
-          warn("Unexpected tag 'title' found");
+          p_warn("Unexpected tag 'title' found");
           break;
       }
     }
@@ -910,7 +910,7 @@ class TagFileParser
       }
       else
       {
-        warn("Unexpected tag 'subgroup' found");
+        p_warn("Unexpected tag 'subgroup' found");
       }
     }
 
@@ -941,16 +941,16 @@ class TagFileParser
                };
   private:
 
-    void warn(const char *fmt)
+    void p_warn(const char *fmt)
     {
       QCString fileName = m_locator->fileName();
-      ::warn(fileName,m_locator->lineNr(),"%s", fmt);
+      ::warn_(fileName,m_locator->lineNr(),"%s", fmt);
     }
 
-    void warn(const char *fmt,const char *s)
+    void p_warn(const char *fmt,const char *s)
     {
       QCString fileName = m_locator->fileName();
-      ::warn(fileName,m_locator->lineNr(),fmt,s);
+      ::warn_(fileName,m_locator->lineNr(),fmt,s);
     }
 
 
@@ -1066,7 +1066,7 @@ void TagFileParser::startElement( const QCString &name, const XMLHandlers::Attri
   }
   else
   {
-    warn("Unknown start tag '%s' found!",qPrint(name));
+    p_warn("Unknown start tag '%s' found!",qPrint(name));
   }
 }
 
@@ -1080,7 +1080,7 @@ void TagFileParser::endElement( const QCString &name )
   }
   else
   {
-    warn("Unknown end tag '%s' found!",qPrint(name));
+    p_warn("Unknown end tag '%s' found!",qPrint(name));
   }
 }
 
@@ -1100,7 +1100,7 @@ void TagFileParser::startCompound( const XMLHandlers::Attributes& attrib )
   }
   else
   {
-    warn("Unknown compound attribute '%s' found!",kind.c_str());
+    p_warn("Unknown compound attribute '%s' found!",kind.c_str());
     m_state = Invalid;
   }
 
@@ -1299,7 +1299,7 @@ void TagFileParser::addDocAnchors(const std::shared_ptr<Entry> &e,const std::vec
     }
     else
     {
-      warn("Duplicate anchor %s found",qPrint(ta.label));
+      p_warn("Duplicate anchor %s found",qPrint(ta.label));
     }
   }
 }

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -32,6 +32,10 @@
 #include "latexgen.h"
 #include "trace.h"
 
+
+#undef warn
+#define warn warn_
+
 class TemplateToken;
 
 //-------------------------------------------------------------------
@@ -2566,7 +2570,7 @@ void TemplateContextImpl::setEncoding(const QCString &templateName,int line,cons
     m_fromUtf8 = portable_iconv_open(enc.data(),"UTF-8");
     if (m_fromUtf8==reinterpret_cast<void*>(-1))
     {
-      warn(templateName,line,"unsupported character conversion: '%s'->'UTF-8'\n", qPrint(enc));
+      warn(templateName,line,"unsupported character conversion: '%s'->'UTF-8'", qPrint(enc));
     }
   }
   //printf("TemplateContextImpl::setEncoding(%s)\n",qPrint(enc));
@@ -2723,7 +2727,7 @@ void TemplateContextImpl::pop()
   //printf("TemplateContextImpl::pop() #stacks=%lu\n",m_contextStack.size());
   if (m_contextStack.empty())
   {
-    warn(m_templateName,m_line,"pop() called on empty context stack!\n");
+    warn(m_templateName,m_line,"pop() called on empty context stack!");
   }
   else
   {
@@ -3739,7 +3743,7 @@ class TemplateNodeInclude : public TemplateNodeCreator<TemplateNodeInclude>
         QCString includeFile = m_includeExpr->resolve(c).toString();
         if (includeFile.isEmpty())
         {
-          ci->warn(m_templateName,m_line,"invalid parameter for include command\n");
+          ci->warn(m_templateName,m_line,"invalid parameter for include command");
         }
         else
         {
@@ -3830,11 +3834,11 @@ class TemplateNodeCreate : public TemplateNodeCreator<TemplateNodeCreate>
         QCString outputFile = m_fileExpr->resolve(c).toString();
         if (templateFile.isEmpty())
         {
-          ci->warn(m_templateName,m_line,"empty template name parameter for create command\n");
+          ci->warn(m_templateName,m_line,"empty template name parameter for create command");
         }
         else if (outputFile.isEmpty())
         {
-          ci->warn(m_templateName,m_line,"empty file name parameter for create command\n");
+          ci->warn(m_templateName,m_line,"empty file name parameter for create command");
         }
         else
         {
@@ -3957,7 +3961,7 @@ class TemplateNodeTree : public TemplateNodeCreator<TemplateNodeTree>
             }
             else if (list==0)
             {
-              ci->warn(m_templateName,m_line,"recursetree: children attribute has type '%s' instead of list\n",qPrint(v.typeAsString()));
+              ci->warn(m_templateName,m_line,"recursetree: children attribute has type '%s' instead of list",qPrint(v.typeAsString()));
             }
           }
           //else
@@ -4542,7 +4546,7 @@ class TemplateNodeResource : public TemplateNodeCreator<TemplateNodeResource>
         QCString resourceFile = m_resExpr->resolve(c).toString();
         if (resourceFile.isEmpty())
         {
-          ci->warn(m_templateName,m_line,"invalid parameter for resource command\n");
+          ci->warn(m_templateName,m_line,"invalid parameter for resource command");
         }
         else
         {
@@ -4553,7 +4557,7 @@ class TemplateNodeResource : public TemplateNodeCreator<TemplateNodeResource>
             mkpath(ci,targetFile.str());
             if (targetFile.isEmpty())
             {
-              ci->warn(m_templateName,m_line,"invalid parameter at right side of '%s' for resource command\n", m_append ? "append" : "as");
+              ci->warn(m_templateName,m_line,"invalid parameter at right side of '%s' for resource command", m_append ? "append" : "as");
             }
             else
             {

--- a/src/trace.h
+++ b/src/trace.h
@@ -29,7 +29,11 @@
 #else
 #define SPELOG_ACTIVE_LEVEL SPDLOG_LEVEL_INFO  // release build (hide trace/debug levels)
 #endif
+
+#pragma push_macro("warn")
+#undef warn
 #include "spdlog/spdlog.h"
+#pragma pop_macro("warn")
 
 #include "types.h"
 #include "qcstring.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3210,7 +3210,7 @@ bool generateLink(OutputList &ol,const QCString &clName,
     }
     else
     {
-      err("%s:%d: Internal error: resolveLink successful but no compound found!",__FILE__,__LINE__);
+      err("%s:%d: Internal error: resolveLink successful but no compound found!\n",__FILE__,__LINE__);
     }
     return TRUE;
   }

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -166,7 +166,7 @@ static void createSVG()
 
     if (Portable::system(Doxygen::verifiedDotPath,vlargs)!=0)
     {
-      err("could not create dot file");
+      err("could not create dot file\n");
     }
 }
 
@@ -3435,7 +3435,7 @@ void FlowChart::createSVG()
 
   if (Portable::system(Doxygen::verifiedDotPath,vlargs)!=0)
   {
-    err("could not create dot file");
+    err("could not create dot file\n");
   }
 }
 
@@ -3729,7 +3729,7 @@ size_t FlowChart::findLabel(size_t index,const QCString &label)
       return j;
     }
   }
-  err("could not find label: %s",qPrint(label));
+  err("could not find label: '%s'\n",qPrint(label));
   return 0;
 }
 

--- a/vhdlparser/VhdlParser.cc
+++ b/vhdlparser/VhdlParser.cc
@@ -12524,7 +12524,7 @@ QCString VhdlParser::simple_expression() {QCString s,s1,s2;
     }
     }
     if (!hasError) {
-    s1 = term();
+    s1 = simpleTerm();
     }
     if (!hasError) {
 s+=s1;
@@ -12540,7 +12540,7 @@ s+=s1;
       s1 = adding_operator();
       }
       if (!hasError) {
-      s2 = term();
+      s2 = simpleTerm();
       }
       if (!hasError) {
 s+=s1;s+=s2;
@@ -13378,7 +13378,7 @@ assert(false);
 }
 
 
-QCString VhdlParser::term() {QCString s,s1,s2;
+QCString VhdlParser::simpleTerm() {QCString s,s1,s2;
     if (!hasError) {
     s = factor();
     }

--- a/vhdlparser/VhdlParser.h
+++ b/vhdlparser/VhdlParser.h
@@ -353,7 +353,7 @@ QCString subtype_declaration();
 QCString subtype_indication();
 QCString suffix();
 QCString target();
-QCString term();
+QCString simpleTerm();
 QCString timeout_clause();
 QCString type_conversion();
 QCString type_declaration();
@@ -1781,10 +1781,10 @@ void parseInline();
     Token * xsp;
     xsp = jj_scanpos;
     if (jj_3R_simple_expression_3039_3_199()) jj_scanpos = xsp;
-    if (jj_3R_term_3219_2_169()) return true;
+    if (jj_3R_simpleTerm_3220_2_169()) return true;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_simple_expression_3039_35_200()) { jj_scanpos = xsp; break; }
+      if (jj_3R_simple_expression_3039_41_200()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
@@ -1844,7 +1844,7 @@ void parseInline();
     if (jj_scan_token(TYPE_T)) return true;
     if (jj_3R_identifier_1646_3_82()) return true;
     if (jj_scan_token(IS_T)) return true;
-    if (jj_3R_type_definition_3244_1_691()) return true;
+    if (jj_3R_type_definition_3245_1_691()) return true;
     if (jj_scan_token(SEMI_T)) return true;
     return false;
   }
@@ -2010,7 +2010,7 @@ void parseInline();
     if (jj_done) return true;
     if (jj_scan_token(FILE_T)) return true;
     if (jj_scan_token(OF_T)) return true;
-    if (jj_3R_type_mark_3264_3_195()) return true;
+    if (jj_3R_type_mark_3265_3_195()) return true;
     return false;
   }
 
@@ -2033,7 +2033,7 @@ void parseInline();
     if (jj_done) return true;
     if (jj_scan_token(FILE_T)) return true;
     if (jj_scan_token(OF_T)) return true;
-    if (jj_3R_type_mark_3264_3_195()) return true;
+    if (jj_3R_type_mark_3265_3_195()) return true;
     return false;
   }
 
@@ -2062,7 +2062,7 @@ void parseInline();
     if (jj_scan_token(LESSTHAN_T)) return true;
     xsp = jj_scanpos;
     if (jj_3R_signal_assignment_statement_2988_3_665()) jj_scanpos = xsp;
-    if (jj_3R_waveform_3352_1_382()) return true;
+    if (jj_3R_waveform_3353_1_382()) return true;
     if (jj_scan_token(SEMI_T)) return true;
     return false;
   }
@@ -2796,7 +2796,7 @@ void parseInline();
  inline bool jj_3R_sequential_statement_2896_5_320()
  {
     if (jj_done) return true;
-    if (jj_3R_variable_assignment_statement_3302_1_461()) return true;
+    if (jj_3R_variable_assignment_statement_3303_1_461()) return true;
     return false;
   }
 
@@ -2814,7 +2814,7 @@ void parseInline();
  inline bool jj_3_140()
  {
     if (jj_done) return true;
-    if (jj_3R_wait_statement_3343_1_153()) return true;
+    if (jj_3R_wait_statement_3344_1_153()) return true;
     return false;
   }
 
@@ -3059,7 +3059,7 @@ void parseInline();
  inline bool jj_3R_sel_wave_list_2866_4_565()
  {
     if (jj_done) return true;
-    if (jj_3R_waveform_element_3360_2_562()) return true;
+    if (jj_3R_waveform_element_3361_2_562()) return true;
     if (jj_scan_token(WHEN_T)) return true;
     if (jj_3R_choices_771_3_106()) return true;
     Token * xsp;
@@ -3214,7 +3214,7 @@ void parseInline();
  {
     if (jj_done) return true;
     if (jj_scan_token(COMMA_T)) return true;
-    if (jj_3R_waveform_3352_1_382()) return true;
+    if (jj_3R_waveform_3353_1_382()) return true;
     if (jj_scan_token(WHEN_T)) return true;
     if (jj_3R_choices_771_3_106()) return true;
     return false;
@@ -3329,7 +3329,7 @@ void parseInline();
  inline bool jj_3R_selected_waveforms_2812_2_209()
  {
     if (jj_done) return true;
-    if (jj_3R_waveform_3352_1_382()) return true;
+    if (jj_3R_waveform_3353_1_382()) return true;
     if (jj_scan_token(WHEN_T)) return true;
     if (jj_3R_choices_771_3_106()) return true;
     Token * xsp;
@@ -4529,7 +4529,7 @@ void parseInline();
  inline bool jj_3R_protected_type_declarative_item_2623_7_887()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -4763,7 +4763,7 @@ void parseInline();
  inline bool jj_3R_protected_type_body_declarative_item_2588_7_881()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -4805,7 +4805,7 @@ void parseInline();
  inline bool jj_3R_context_item_1054_3_225()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -4848,7 +4848,7 @@ void parseInline();
  inline bool jj_3R_protected_type_body_declarative_item_2581_7_876()
  {
     if (jj_done) return true;
-    if (jj_3R_variable_declaration_3311_1_420()) return true;
+    if (jj_3R_variable_declaration_3312_1_420()) return true;
     return false;
   }
 
@@ -4876,7 +4876,7 @@ void parseInline();
  inline bool jj_3R_protected_type_body_declarative_item_2578_7_873()
  {
     if (jj_done) return true;
-    if (jj_3R_type_declaration_3237_1_415()) return true;
+    if (jj_3R_type_declaration_3238_1_415()) return true;
     return false;
   }
 
@@ -5214,7 +5214,7 @@ void parseInline();
     if (jj_scan_token(WHEN_T)) return true;
     if (jj_3R_condition_901_3_100()) return true;
     if (jj_scan_token(ELSE_T)) return true;
-    if (jj_3R_waveform_3352_1_382()) return true;
+    if (jj_3R_waveform_3353_1_382()) return true;
     return false;
   }
 
@@ -5257,7 +5257,7 @@ void parseInline();
  inline bool jj_3R_conditional_waveforms_971_1_207()
  {
     if (jj_done) return true;
-    if (jj_3R_waveform_3352_1_382()) return true;
+    if (jj_3R_waveform_3353_1_382()) return true;
     Token * xsp;
     while (true) {
       xsp = jj_scanpos;
@@ -5271,7 +5271,7 @@ void parseInline();
  inline bool jj_3R_process_declarative_item_2502_3_634()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -5337,7 +5337,7 @@ void parseInline();
  inline bool jj_3R_process_declarative_item_2495_3_630()
  {
     if (jj_done) return true;
-    if (jj_3R_variable_declaration_3311_1_420()) return true;
+    if (jj_3R_variable_declaration_3312_1_420()) return true;
     return false;
   }
 
@@ -5365,7 +5365,7 @@ void parseInline();
  inline bool jj_3R_process_declarative_item_2493_3_628()
  {
     if (jj_done) return true;
-    if (jj_3R_type_declaration_3237_1_415()) return true;
+    if (jj_3R_type_declaration_3238_1_415()) return true;
     return false;
   }
 
@@ -5623,7 +5623,7 @@ void parseInline();
     Token * xsp;
     xsp = jj_scanpos;
     if (jj_3R_conditional_waveform_assignment_929_17_561()) jj_scanpos = xsp;
-    if (jj_3R_waveform_element_3360_2_562()) return true;
+    if (jj_3R_waveform_element_3361_2_562()) return true;
     if (jj_scan_token(WHEN_T)) return true;
     if (jj_3R_expression_1371_20_70()) return true;
     xsp = jj_scanpos;
@@ -5669,7 +5669,7 @@ void parseInline();
  {
     if (jj_done) return true;
     if (jj_scan_token(PRIVATE_T)) return true;
-    if (jj_3R_variable_declaration_3311_1_420()) return true;
+    if (jj_3R_variable_declaration_3312_1_420()) return true;
     return false;
   }
 
@@ -5825,7 +5825,7 @@ void parseInline();
  inline bool jj_3_109()
  {
     if (jj_done) return true;
-    if (jj_3R_type_conversion_3232_3_138()) return true;
+    if (jj_3R_type_conversion_3233_3_138()) return true;
     return false;
   }
 
@@ -5930,7 +5930,7 @@ void parseInline();
  inline bool jj_3R_primary_2417_1_572()
  {
     if (jj_done) return true;
-    if (jj_3R_type_conversion_3232_3_138()) return true;
+    if (jj_3R_type_conversion_3233_3_138()) return true;
     return false;
   }
 
@@ -6122,7 +6122,7 @@ void parseInline();
     if (jj_scan_token(50)) jj_scanpos = xsp;
     xsp = jj_scanpos;
     if (jj_3R_concurrent_simple_signal_assignment_851_39_496()) jj_scanpos = xsp;
-    if (jj_3R_waveform_3352_1_382()) return true;
+    if (jj_3R_waveform_3353_1_382()) return true;
     if (jj_scan_token(SEMI_T)) return true;
     return false;
   }
@@ -6558,7 +6558,7 @@ void parseInline();
  inline bool jj_3R_package_declarative_item_2313_3_609()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -6681,7 +6681,7 @@ void parseInline();
  inline bool jj_3R_package_declarative_item_2303_3_601()
  {
     if (jj_done) return true;
-    if (jj_3R_variable_declaration_3311_1_420()) return true;
+    if (jj_3R_variable_declaration_3312_1_420()) return true;
     return false;
   }
 
@@ -6745,7 +6745,7 @@ void parseInline();
  inline bool jj_3R_package_declarative_item_2297_3_597()
  {
     if (jj_done) return true;
-    if (jj_3R_type_declaration_3237_1_415()) return true;
+    if (jj_3R_type_declaration_3238_1_415()) return true;
     return false;
   }
 
@@ -6983,7 +6983,7 @@ void parseInline();
  inline bool jj_3R_package_body_declarative_item_2251_3_779()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -7039,7 +7039,7 @@ void parseInline();
  inline bool jj_3R_package_body_declarative_item_2244_3_774()
  {
     if (jj_done) return true;
-    if (jj_3R_variable_declaration_3311_1_420()) return true;
+    if (jj_3R_variable_declaration_3312_1_420()) return true;
     return false;
   }
 
@@ -7068,7 +7068,7 @@ void parseInline();
  inline bool jj_3R_package_body_declarative_item_2241_3_771()
  {
     if (jj_done) return true;
-    if (jj_3R_type_declaration_3237_1_415()) return true;
+    if (jj_3R_type_declaration_3238_1_415()) return true;
     return false;
   }
 
@@ -7346,7 +7346,7 @@ void parseInline();
  inline bool jj_3R_block_declarative_item_663_3_255()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -7461,7 +7461,7 @@ void parseInline();
  inline bool jj_3R_block_declarative_item_650_3_245()
  {
     if (jj_done) return true;
-    if (jj_3R_variable_declaration_3311_1_420()) return true;
+    if (jj_3R_variable_declaration_3312_1_420()) return true;
     return false;
   }
 
@@ -7519,14 +7519,14 @@ void parseInline();
  inline bool jj_3R_block_configuration_637_11_506()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
  inline bool jj_3R_block_declarative_item_645_3_240()
  {
     if (jj_done) return true;
-    if (jj_3R_type_declaration_3237_1_415()) return true;
+    if (jj_3R_type_declaration_3238_1_415()) return true;
     return false;
   }
 
@@ -8175,7 +8175,7 @@ void parseInline();
     if (jj_scan_token(ATTRIBUTE_T)) return true;
     if (jj_3R_identifier_1646_3_82()) return true;
     if (jj_scan_token(COLON_T)) return true;
-    if (jj_3R_type_mark_3264_3_195()) return true;
+    if (jj_3R_type_mark_3265_3_195()) return true;
     if (jj_scan_token(SEMI_T)) return true;
     return false;
   }
@@ -8356,7 +8356,7 @@ void parseInline();
  inline bool jj_3R_array_type_definition_520_4_857()
  {
     if (jj_done) return true;
-    if (jj_3R_unconstraint_array_definition_3269_1_867()) return true;
+    if (jj_3R_unconstraint_array_definition_3270_1_867()) return true;
     return false;
   }
 
@@ -9017,10 +9017,10 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_wait_statement_3343_97_330()
+ inline bool jj_3R_wait_statement_3344_97_330()
  {
     if (jj_done) return true;
-    if (jj_3R_timeout_clause_3224_1_465()) return true;
+    if (jj_3R_timeout_clause_3225_1_465()) return true;
     return false;
   }
 
@@ -9117,17 +9117,17 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_wait_statement_3344_71_329()
+ {
+    if (jj_done) return true;
+    if (jj_3R_condition_clause_912_3_464()) return true;
+    return false;
+  }
+
  inline bool jj_3R_abstract_literal_340_4_296()
  {
     if (jj_done) return true;
     if (jj_scan_token(BASED_LITERAL)) return true;
-    return false;
-  }
-
- inline bool jj_3R_wait_statement_3343_71_329()
- {
-    if (jj_done) return true;
-    if (jj_3R_condition_clause_912_3_464()) return true;
     return false;
   }
 
@@ -9204,6 +9204,13 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_variable_declaration_3312_90_520()
+ {
+    if (jj_done) return true;
+    if (jj_3R_generic_map_aspect_1609_6_88()) return true;
+    return false;
+  }
+
  inline bool jj_3R_absolute_pathname_329_2_751()
  {
     if (jj_done) return true;
@@ -9222,13 +9229,6 @@ void parseInline();
     jj_scanpos = xsp;
     if (jj_3R_absolute_pathname_331_3_752()) return true;
     }
-    return false;
-  }
-
- inline bool jj_3R_variable_declaration_3311_90_520()
- {
-    if (jj_done) return true;
-    if (jj_3R_generic_map_aspect_1609_6_88()) return true;
     return false;
   }
 
@@ -9267,7 +9267,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_wait_statement_3343_43_328()
+ inline bool jj_3R_wait_statement_3344_43_328()
  {
     if (jj_done) return true;
     if (jj_3R_sensitivity_clause_2817_2_463()) return true;
@@ -9298,7 +9298,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_waveform_element_3360_19_671()
+ inline bool jj_3R_waveform_element_3361_19_671()
  {
     if (jj_done) return true;
     if (jj_scan_token(AFTER_T)) return true;
@@ -9306,18 +9306,18 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_waveform_3353_23_616()
+ {
+    if (jj_done) return true;
+    if (jj_scan_token(COMMA_T)) return true;
+    if (jj_3R_waveform_element_3361_2_562()) return true;
+    return false;
+  }
+
  inline bool jj_3R_interface_package_generic_map_aspect_1836_5_432()
  {
     if (jj_done) return true;
     if (jj_3R_generic_map_aspect_1609_6_88()) return true;
-    return false;
-  }
-
- inline bool jj_3R_waveform_3352_23_616()
- {
-    if (jj_done) return true;
-    if (jj_scan_token(COMMA_T)) return true;
-    if (jj_3R_waveform_element_3360_2_562()) return true;
     return false;
   }
 
@@ -9379,13 +9379,13 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_waveform_element_3360_2_562()
+ inline bool jj_3R_waveform_element_3361_2_562()
  {
     if (jj_done) return true;
     if (jj_3R_expression_1371_20_70()) return true;
     Token * xsp;
     xsp = jj_scanpos;
-    if (jj_3R_waveform_element_3360_19_671()) jj_scanpos = xsp;
+    if (jj_3R_waveform_element_3361_19_671()) jj_scanpos = xsp;
     return false;
   }
 
@@ -9403,33 +9403,33 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_waveform_3354_1_495()
+ inline bool jj_3R_waveform_3355_1_495()
  {
     if (jj_done) return true;
     if (jj_scan_token(UNAFFECTED_T)) return true;
     return false;
   }
 
- inline bool jj_3R_waveform_3352_1_494()
+ inline bool jj_3R_waveform_3353_1_494()
  {
     if (jj_done) return true;
-    if (jj_3R_waveform_element_3360_2_562()) return true;
+    if (jj_3R_waveform_element_3361_2_562()) return true;
     Token * xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_waveform_3352_23_616()) { jj_scanpos = xsp; break; }
+      if (jj_3R_waveform_3353_23_616()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
 
- inline bool jj_3R_waveform_3352_1_382()
+ inline bool jj_3R_waveform_3353_1_382()
  {
     if (jj_done) return true;
     Token * xsp;
     xsp = jj_scanpos;
-    if (jj_3R_waveform_3352_1_494()) {
+    if (jj_3R_waveform_3353_1_494()) {
     jj_scanpos = xsp;
-    if (jj_3R_waveform_3354_1_495()) return true;
+    if (jj_3R_waveform_3355_1_495()) return true;
     }
     return false;
   }
@@ -9465,7 +9465,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_wait_statement_3343_3_327()
+ inline bool jj_3R_wait_statement_3344_3_327()
  {
     if (jj_done) return true;
     if (jj_3R_identifier_1646_3_82()) return true;
@@ -9473,19 +9473,19 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_wait_statement_3343_1_153()
+ inline bool jj_3R_wait_statement_3344_1_153()
  {
     if (jj_done) return true;
     Token * xsp;
     xsp = jj_scanpos;
-    if (jj_3R_wait_statement_3343_3_327()) jj_scanpos = xsp;
+    if (jj_3R_wait_statement_3344_3_327()) jj_scanpos = xsp;
     if (jj_scan_token(WAIT_T)) return true;
     xsp = jj_scanpos;
-    if (jj_3R_wait_statement_3343_43_328()) jj_scanpos = xsp;
+    if (jj_3R_wait_statement_3344_43_328()) jj_scanpos = xsp;
     xsp = jj_scanpos;
-    if (jj_3R_wait_statement_3343_71_329()) jj_scanpos = xsp;
+    if (jj_3R_wait_statement_3344_71_329()) jj_scanpos = xsp;
     xsp = jj_scanpos;
-    if (jj_3R_wait_statement_3343_97_330()) jj_scanpos = xsp;
+    if (jj_3R_wait_statement_3344_97_330()) jj_scanpos = xsp;
     if (jj_scan_token(SEMI_T)) return true;
     return false;
   }
@@ -9549,19 +9549,19 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_unconstraint_array_definition_3270_53_889()
+ {
+    if (jj_done) return true;
+    if (jj_scan_token(COMMA_T)) return true;
+    if (jj_3R_index_subtype_definition_1738_2_863()) return true;
+    return false;
+  }
+
  inline bool jj_3R_interface_declaration_1786_2_441()
  {
     if (jj_done) return true;
     if (jj_3R_object_class_2206_1_545()) return true;
     if (jj_3R_identifier_1646_3_82()) return true;
-    return false;
-  }
-
- inline bool jj_3R_unconstraint_array_definition_3269_53_889()
- {
-    if (jj_done) return true;
-    if (jj_scan_token(COMMA_T)) return true;
-    if (jj_3R_index_subtype_definition_1738_2_863()) return true;
     return false;
   }
 
@@ -9586,18 +9586,18 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3_67()
- {
-    if (jj_done) return true;
-    if (jj_3R_interface_object_declaration_1796_7_116()) return true;
-    return false;
-  }
-
- inline bool jj_3R_variable_declaration_3313_3_521()
+ inline bool jj_3R_variable_declaration_3314_3_521()
  {
     if (jj_done) return true;
     if (jj_scan_token(VARASSIGN_T)) return true;
     if (jj_3R_conditional_expression_955_3_137()) return true;
+    return false;
+  }
+
+ inline bool jj_3_67()
+ {
+    if (jj_done) return true;
+    if (jj_3R_interface_object_declaration_1796_7_116()) return true;
     return false;
   }
 
@@ -9615,14 +9615,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_interface_declaration_1776_1_439()
- {
-    if (jj_done) return true;
-    if (jj_3R_interface_package_declaration_1828_3_118()) return true;
-    return false;
-  }
-
- inline bool jj_3R_variable_declaration_3311_1_420()
+ inline bool jj_3R_variable_declaration_3312_1_420()
  {
     if (jj_done) return true;
     Token * xsp;
@@ -9633,10 +9626,24 @@ void parseInline();
     if (jj_scan_token(COLON_T)) return true;
     if (jj_3R_subtype_indication_3198_3_71()) return true;
     xsp = jj_scanpos;
-    if (jj_3R_variable_declaration_3311_90_520()) jj_scanpos = xsp;
+    if (jj_3R_variable_declaration_3312_90_520()) jj_scanpos = xsp;
     xsp = jj_scanpos;
-    if (jj_3R_variable_declaration_3313_3_521()) jj_scanpos = xsp;
+    if (jj_3R_variable_declaration_3314_3_521()) jj_scanpos = xsp;
     if (jj_scan_token(SEMI_T)) return true;
+    return false;
+  }
+
+ inline bool jj_3R_interface_declaration_1776_1_439()
+ {
+    if (jj_done) return true;
+    if (jj_3R_interface_package_declaration_1828_3_118()) return true;
+    return false;
+  }
+
+ inline bool jj_3R_variable_assignment_statement_3307_2_555()
+ {
+    if (jj_done) return true;
+    if (jj_3R_selected_variable_assignment_2833_3_666()) return true;
     return false;
   }
 
@@ -9644,13 +9651,6 @@ void parseInline();
  {
     if (jj_done) return true;
     if (jj_3R_interface_subprogram_declaration_1851_4_117()) return true;
-    return false;
-  }
-
- inline bool jj_3R_variable_assignment_statement_3306_2_555()
- {
-    if (jj_done) return true;
-    if (jj_3R_selected_variable_assignment_2833_3_666()) return true;
     return false;
   }
 
@@ -9669,7 +9669,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_variable_assignment_statement_3302_1_554()
+ inline bool jj_3R_variable_assignment_statement_3303_1_554()
  {
     if (jj_done) return true;
     Token * xsp;
@@ -9682,11 +9682,23 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_use_clause_3275_28_532()
+ inline bool jj_3R_use_clause_3276_28_532()
  {
     if (jj_done) return true;
     if (jj_scan_token(COMMA_T)) return true;
     if (jj_3R_selected_name_2800_2_508()) return true;
+    return false;
+  }
+
+ inline bool jj_3R_variable_assignment_statement_3303_1_461()
+ {
+    if (jj_done) return true;
+    Token * xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_variable_assignment_statement_3303_1_554()) {
+    jj_scanpos = xsp;
+    if (jj_3R_variable_assignment_statement_3307_2_555()) return true;
+    }
     return false;
   }
 
@@ -9721,18 +9733,6 @@ void parseInline();
  {
     if (jj_done) return true;
     if (jj_3R_interface_variable_declaration_1957_1_115()) return true;
-    return false;
-  }
-
- inline bool jj_3R_variable_assignment_statement_3302_1_461()
- {
-    if (jj_done) return true;
-    Token * xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_variable_assignment_statement_3302_1_554()) {
-    jj_scanpos = xsp;
-    if (jj_3R_variable_assignment_statement_3306_2_555()) return true;
-    }
     return false;
   }
 
@@ -9823,6 +9823,13 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_protected_type_instantiation_definition_3259_20_816()
+ {
+    if (jj_done) return true;
+    if (jj_3R_generic_map_aspect_1609_6_88()) return true;
+    return false;
+  }
+
  inline bool jj_3R_instantiation_unit_1743_1_215()
  {
     if (jj_done) return true;
@@ -9848,10 +9855,17 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_protected_type_instantiation_definition_3258_20_816()
+ inline bool jj_3R_use_clause_3276_2_400()
  {
     if (jj_done) return true;
-    if (jj_3R_generic_map_aspect_1609_6_88()) return true;
+    if (jj_scan_token(USE_T)) return true;
+    if (jj_3R_selected_name_2800_2_508()) return true;
+    Token * xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_use_clause_3276_28_532()) { jj_scanpos = xsp; break; }
+    }
+    if (jj_scan_token(SEMI_T)) return true;
     return false;
   }
 
@@ -9862,30 +9876,16 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_use_clause_3275_2_400()
- {
-    if (jj_done) return true;
-    if (jj_scan_token(USE_T)) return true;
-    if (jj_3R_selected_name_2800_2_508()) return true;
-    Token * xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_use_clause_3275_28_532()) { jj_scanpos = xsp; break; }
-    }
-    if (jj_scan_token(SEMI_T)) return true;
-    return false;
-  }
-
  inline bool jj_3R_index_subtype_definition_1738_2_863()
  {
     if (jj_done) return true;
-    if (jj_3R_type_mark_3264_3_195()) return true;
+    if (jj_3R_type_mark_3265_3_195()) return true;
     if (jj_scan_token(RANGE_T)) return true;
     if (jj_scan_token(BOX_T)) return true;
     return false;
   }
 
- inline bool jj_3R_unconstraint_array_definition_3269_1_867()
+ inline bool jj_3R_unconstraint_array_definition_3270_1_867()
  {
     if (jj_done) return true;
     if (jj_scan_token(ARRAY_T)) return true;
@@ -9894,7 +9894,7 @@ void parseInline();
     Token * xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_unconstraint_array_definition_3269_53_889()) { jj_scanpos = xsp; break; }
+      if (jj_3R_unconstraint_array_definition_3270_53_889()) { jj_scanpos = xsp; break; }
     }
     if (jj_scan_token(RPAREN_T)) return true;
     if (jj_scan_token(OF_T)) return true;
@@ -9909,7 +9909,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_type_mark_3264_3_195()
+ inline bool jj_3R_type_mark_3265_3_195()
  {
     if (jj_done) return true;
     if (jj_3R_name_2126_2_73()) return true;
@@ -9942,6 +9942,17 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_protected_type_instantiation_definition_3259_3_802()
+ {
+    if (jj_done) return true;
+    if (jj_scan_token(NEW_T)) return true;
+    if (jj_3R_name_2126_2_73()) return true;
+    Token * xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_protected_type_instantiation_definition_3259_20_816()) jj_scanpos = xsp;
+    return false;
+  }
+
  inline bool jj_3R_index_constraint_1724_3_75()
  {
     if (jj_done) return true;
@@ -9953,17 +9964,6 @@ void parseInline();
       if (jj_3R_index_constraint_1724_42_190()) { jj_scanpos = xsp; break; }
     }
     if (jj_scan_token(RPAREN_T)) return true;
-    return false;
-  }
-
- inline bool jj_3R_protected_type_instantiation_definition_3258_3_802()
- {
-    if (jj_done) return true;
-    if (jj_scan_token(NEW_T)) return true;
-    if (jj_3R_name_2126_2_73()) return true;
-    Token * xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_protected_type_instantiation_definition_3258_20_816()) jj_scanpos = xsp;
     return false;
   }
 
@@ -9981,17 +9981,17 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_type_definition_3253_3_766()
+ {
+    if (jj_done) return true;
+    if (jj_3R_protected_type_declaration_2603_4_803()) return true;
+    return false;
+  }
+
  inline bool jj_3_158()
  {
     if (jj_done) return true;
     if (jj_3R_generic_map_aspect_1609_6_88()) return true;
-    return false;
-  }
-
- inline bool jj_3R_type_definition_3252_3_766()
- {
-    if (jj_done) return true;
-    if (jj_3R_protected_type_declaration_2603_4_803()) return true;
     return false;
   }
 
@@ -10004,13 +10004,6 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_subprogram_instantiation_declaration_3178_75_353()
- {
-    if (jj_done) return true;
-    if (jj_3R_gen_assoc_list_1533_4_172()) return true;
-    return false;
-  }
-
  inline bool jj_3_167()
  {
     if (jj_done) return true;
@@ -10018,10 +10011,24 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_type_definition_3248_3_765()
+ inline bool jj_3R_subprogram_instantiation_declaration_3178_75_353()
  {
     if (jj_done) return true;
-    if (jj_3R_protected_type_instantiation_definition_3258_3_802()) return true;
+    if (jj_3R_gen_assoc_list_1533_4_172()) return true;
+    return false;
+  }
+
+ inline bool jj_3R_type_definition_3249_3_765()
+ {
+    if (jj_done) return true;
+    if (jj_3R_protected_type_instantiation_definition_3259_3_802()) return true;
+    return false;
+  }
+
+ inline bool jj_3R_type_definition_3248_3_764()
+ {
+    if (jj_done) return true;
+    if (jj_3R_file_type_definition_1454_2_801()) return true;
     return false;
   }
 
@@ -10032,10 +10039,10 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_type_definition_3247_3_764()
+ inline bool jj_3R_type_definition_3247_3_763()
  {
     if (jj_done) return true;
-    if (jj_3R_file_type_definition_1454_2_801()) return true;
+    if (jj_3R_access_type_definition_346_3_800()) return true;
     return false;
   }
 
@@ -10047,45 +10054,38 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_type_definition_3246_3_763()
- {
-    if (jj_done) return true;
-    if (jj_3R_access_type_definition_346_3_800()) return true;
-    return false;
-  }
-
- inline bool jj_3R_type_definition_3245_3_762()
+ inline bool jj_3R_type_definition_3246_3_762()
  {
     if (jj_done) return true;
     if (jj_3R_composite_type_definition_820_2_799()) return true;
     return false;
   }
 
- inline bool jj_3R_type_definition_3244_1_761()
+ inline bool jj_3R_type_definition_3245_1_761()
  {
     if (jj_done) return true;
     if (jj_3R_scalar_type_definition_2773_1_798()) return true;
     return false;
   }
 
- inline bool jj_3R_type_definition_3244_1_691()
+ inline bool jj_3R_type_definition_3245_1_691()
  {
     if (jj_done) return true;
     Token * xsp;
     xsp = jj_scanpos;
-    if (jj_3R_type_definition_3244_1_761()) {
+    if (jj_3R_type_definition_3245_1_761()) {
     jj_scanpos = xsp;
-    if (jj_3R_type_definition_3245_3_762()) {
+    if (jj_3R_type_definition_3246_3_762()) {
     jj_scanpos = xsp;
-    if (jj_3R_type_definition_3246_3_763()) {
+    if (jj_3R_type_definition_3247_3_763()) {
     jj_scanpos = xsp;
-    if (jj_3R_type_definition_3247_3_764()) {
+    if (jj_3R_type_definition_3248_3_764()) {
     jj_scanpos = xsp;
-    if (jj_3R_type_definition_3248_3_765()) {
+    if (jj_3R_type_definition_3249_3_765()) {
     jj_scanpos = xsp;
     if (jj_3_167()) {
     jj_scanpos = xsp;
-    if (jj_3R_type_definition_3252_3_766()) return true;
+    if (jj_3R_type_definition_3253_3_766()) return true;
     }
     }
     }
@@ -10095,7 +10095,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_type_declaration_3239_3_514()
+ inline bool jj_3R_type_declaration_3240_3_514()
  {
     if (jj_done) return true;
     if (jj_3R_incomplete_type_declaration_1716_3_636()) return true;
@@ -10109,13 +10109,6 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_incomplete_type_definition_1698_5_733()
- {
-    if (jj_done) return true;
-    if (jj_3R_access_incomplete_type_definition_352_3_789()) return true;
-    return false;
-  }
-
  inline bool jj_3_166()
  {
     if (jj_done) return true;
@@ -10123,15 +10116,22 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_type_declaration_3237_1_415()
+ inline bool jj_3R_type_declaration_3238_1_415()
  {
     if (jj_done) return true;
     Token * xsp;
     xsp = jj_scanpos;
     if (jj_3_166()) {
     jj_scanpos = xsp;
-    if (jj_3R_type_declaration_3239_3_514()) return true;
+    if (jj_3R_type_declaration_3240_3_514()) return true;
     }
+    return false;
+  }
+
+ inline bool jj_3R_incomplete_type_definition_1698_5_733()
+ {
+    if (jj_done) return true;
+    if (jj_3R_access_incomplete_type_definition_352_3_789()) return true;
     return false;
   }
 
@@ -10149,6 +10149,16 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3R_type_conversion_3233_3_138()
+ {
+    if (jj_done) return true;
+    if (jj_3R_name_2126_2_73()) return true;
+    if (jj_scan_token(LPAREN_T)) return true;
+    if (jj_3R_expression_1371_20_70()) return true;
+    if (jj_scan_token(RPAREN_T)) return true;
+    return false;
+  }
+
  inline bool jj_3R_subprogram_instantiation_declaration_3178_58_352()
  {
     if (jj_done) return true;
@@ -10163,13 +10173,11 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_type_conversion_3232_3_138()
+ inline bool jj_3_165()
  {
     if (jj_done) return true;
-    if (jj_3R_name_2126_2_73()) return true;
-    if (jj_scan_token(LPAREN_T)) return true;
-    if (jj_3R_expression_1371_20_70()) return true;
-    if (jj_scan_token(RPAREN_T)) return true;
+    if (jj_3R_multiplying_operation_2117_1_174()) return true;
+    if (jj_3R_factor_1424_1_175()) return true;
     return false;
   }
 
@@ -10177,14 +10185,6 @@ void parseInline();
  {
     if (jj_done) return true;
     if (jj_3R_physical_incomplete_type_definition_2388_5_786()) return true;
-    return false;
-  }
-
- inline bool jj_3_165()
- {
-    if (jj_done) return true;
-    if (jj_3R_multiplying_operation_2117_1_174()) return true;
-    if (jj_3R_factor_1424_1_175()) return true;
     return false;
   }
 
@@ -10249,7 +10249,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_timeout_clause_3224_1_465()
+ inline bool jj_3R_timeout_clause_3225_1_465()
  {
     if (jj_done) return true;
     if (jj_scan_token(FOR_T)) return true;
@@ -10276,7 +10276,7 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3R_term_3219_2_169()
+ inline bool jj_3R_simpleTerm_3220_2_169()
  {
     if (jj_done) return true;
     if (jj_3R_factor_1424_1_175()) return true;
@@ -10637,7 +10637,7 @@ void parseInline();
     if (jj_scan_token(RETURN_T)) return true;
     xsp = jj_scanpos;
     if (jj_3_161()) jj_scanpos = xsp;
-    if (jj_3R_type_mark_3264_3_195()) return true;
+    if (jj_3R_type_mark_3265_3_195()) return true;
     return false;
   }
 
@@ -10859,7 +10859,7 @@ void parseInline();
  inline bool jj_3R_subprogram_declarative_item_3111_3_839()
  {
     if (jj_done) return true;
-    if (jj_3R_use_clause_3275_2_400()) return true;
+    if (jj_3R_use_clause_3276_2_400()) return true;
     return false;
   }
 
@@ -10908,7 +10908,7 @@ void parseInline();
  inline bool jj_3R_subprogram_declarative_item_3104_3_834()
  {
     if (jj_done) return true;
-    if (jj_3R_variable_declaration_3311_1_420()) return true;
+    if (jj_3R_variable_declaration_3312_1_420()) return true;
     return false;
   }
 
@@ -10943,7 +10943,7 @@ void parseInline();
  inline bool jj_3R_subprogram_declarative_item_3100_2_830()
  {
     if (jj_done) return true;
-    if (jj_3R_type_declaration_3237_1_415()) return true;
+    if (jj_3R_type_declaration_3238_1_415()) return true;
     return false;
   }
 
@@ -11032,6 +11032,14 @@ void parseInline();
     return false;
   }
 
+ inline bool jj_3_154()
+ {
+    if (jj_done) return true;
+    if (jj_3R_adding_operator_393_3_168()) return true;
+    if (jj_3R_simpleTerm_3220_2_169()) return true;
+    return false;
+  }
+
  inline bool jj_3R_signal_declaration_2999_89_519()
  {
     if (jj_done) return true;
@@ -11074,11 +11082,11 @@ void parseInline();
     return false;
   }
 
- inline bool jj_3_154()
+ inline bool jj_3R_simple_expression_3039_41_200()
  {
     if (jj_done) return true;
     if (jj_3R_adding_operator_393_3_168()) return true;
-    if (jj_3R_term_3219_2_169()) return true;
+    if (jj_3R_simpleTerm_3220_2_169()) return true;
     return false;
   }
 
@@ -11089,14 +11097,6 @@ void parseInline();
     if (jj_scan_token(LPAREN_T)) return true;
     if (jj_3R_interface_list_1823_3_377()) return true;
     if (jj_scan_token(RPAREN_T)) return true;
-    return false;
-  }
-
- inline bool jj_3R_simple_expression_3039_35_200()
- {
-    if (jj_done) return true;
-    if (jj_3R_adding_operator_393_3_168()) return true;
-    if (jj_3R_term_3219_2_169()) return true;
     return false;
   }
 

--- a/vhdlparser/vhdlparser.jj
+++ b/vhdlparser/vhdlparser.jj
@@ -3036,7 +3036,7 @@ QCString signature() : {QCString s,s1,s2;}
 
 QCString simple_expression():  {QCString s,s1,s2;}
 {
-[ s=sign() ] s1=term() {s+=s1;} ( LOOKAHEAD(adding_operator() term()) s1=adding_operator() s2=term() {s+=s1;s+=s2;})* { return s;}
+[ s=sign() ] s1=simpleTerm() {s+=s1;} ( LOOKAHEAD(adding_operator() simpleTerm()) s1=adding_operator() s2=simpleTerm() {s+=s1;s+=s2;})* { return s;}
 }
 
 void simple_name() :  {}
@@ -3214,7 +3214,8 @@ QCString target() :  { QCString s; }
 | s=aggregate() { return s;}
 }
 
-QCString term() : { QCString s,s1,s2; }
+// use simpleTerm instead of term to prevent collision with function / macro in doxygen
+QCString simpleTerm() : { QCString s,s1,s2; }
 {
  s=factor() ( LOOKAHEAD(2) s1=multiplying_operation() s2=factor(){s+=s1;s+=s2;} )* { return s;}
 }


### PR DESCRIPTION
A number of warning messages have a double '\n' due to the fact that the message itself contains a '\n' and the warning routine automatically adds a '\n'. Some messages are lacking a `\n` at the end which should be present. In #6924 an automatic correction was attempted but a better solution would be that there is a compile time check that detects the missing / superfluous '\n'. It is hardly possible to find all automatically as one can always trick a bit by means of something like `err("text %s",str) ` where `str` ends with a `\n`.

Some special constructs were necessary to overcome problems with macro substitution
- tagreader.cpp now using `p_warn` for internal / private warn function
- template.h special constructs, disabling `warn` macro with checks (checks done visibly) and directly calling function.
- trace.h, uses spdlog that has an own `warn` function that is temporary disabled.
- vhdlparser.jj has a function `term`, based on the name `term` in the VHDL standard which has nothing to do wit the doxygen `term` function and is renamed.