### PR TITLE
issue #10129 Add \hidetype to hide type aliases' definitions

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2830,7 +2830,7 @@ static void addVariable(const Entry *root,int isFuncPtr=-1)
 
   if (type=="@")
     mtype=MemberType_EnumValue;
-  else if (type.startsWith("typedef ") || type=="typedef")
+  else if (type.startsWith("typedef "))
     mtype=MemberType_Typedef;
   else if (type.startsWith("friend "))
     mtype=MemberType_Friend;

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2363,9 +2363,9 @@ static MemberDef *addVariableToFile(
 
     if (!type.isEmpty())
     {
-      if (root->spec&Entry::Alias) // turn 'typedef B NS::A' into 'using NS::A = B'
+      if (root->spec&Entry::Alias)
       {
-        def="using "+nd->name()+sep+name+" = "+type;
+        def="using "+nd->name()+sep+name;
       }
       else // normal member
       {
@@ -2387,9 +2387,9 @@ static MemberDef *addVariableToFile(
       }
       else
       {
-        if (root->spec&Entry::Alias) // turn 'typedef B A' into 'using A = B'
+        if (root->spec&Entry::Alias)
         {
-          def="using "+root->name+" = "+type.mid(7);
+          def="using "+root->name;
         }
         else // normal member
         {
@@ -2830,7 +2830,7 @@ static void addVariable(const Entry *root,int isFuncPtr=-1)
 
   if (type=="@")
     mtype=MemberType_EnumValue;
-  else if (type.startsWith("typedef "))
+  else if (type.startsWith("typedef ") || type=="typedef")
     mtype=MemberType_Typedef;
   else if (type.startsWith("friend "))
     mtype=MemberType_Friend;

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2446,12 +2446,6 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
       linkifyText(TextGeneratorOLImpl(ol),d,getBodyDef(),this,m_initializer);
     }
   }
-  else if (isTypeAlias()) // using template alias
-  {
-    ol.writeString(" = ");
-    linkifyText(TextGeneratorOLImpl(ol),d,getBodyDef(),this,m_type);
-  }
-
 
   if ((isObjCMethod() || isObjCProperty()) && isImplementation())
   {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1828,6 +1828,7 @@ NONLopt [^\n]*
                                           BEGIN(Using);
                                         }
 <Using>"="                              { // C++11 style template alias?
+                                          yyextra->previous->initializer.str(yytext);
                                           BEGIN(UsingAlias);
                                         }
 <UsingAlias>";"                         {
@@ -1867,13 +1868,13 @@ NONLopt [^\n]*
                                           }
                                         }
 <UsingAlias>">>"                        {
-                                          yyextra->previous->args+="> >"; // see bug769552
+                                          yyextra->previous->initializer << "> >"; // see bug769552
                                         }
 <UsingAlias>.                           {
-                                          yyextra->previous->args+=yytext;
+                                          yyextra->previous->initializer << yytext;
                                         }
 <UsingAlias>\n                          {
-                                          yyextra->previous->args+=yytext;
+                                          yyextra->previous->initializer << yytext;
                                           lineCount(yyscanner);
                                         }
 <UsingAliasEnd>";"                      {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1868,12 +1868,15 @@ NONLopt [^\n]*
                                           }
                                         }
 <UsingAlias>">>"                        {
+                                          yyextra->previous->args+="> >"; // see bug769552
                                           yyextra->previous->initializer << "> >"; // see bug769552
                                         }
 <UsingAlias>.                           {
+                                          yyextra->previous->args+=yytext;
                                           yyextra->previous->initializer << yytext;
                                         }
 <UsingAlias>\n                          {
+                                          yyextra->previous->args+=yytext;
                                           yyextra->previous->initializer << yytext;
                                           lineCount(yyscanner);
                                         }

--- a/testing/059/struct_n_1_1allocator__traits.xml
+++ b/testing/059/struct_n_1_1allocator__traits.xml
@@ -8,9 +8,9 @@
       </param>
     </templateparamlist>
     <sectiondef kind="public-type">
-      <memberdef kind="typedef" id="struct_n_1_1allocator__traits_1a044fe2aaa3b03062c97f6f62ad8b587c" prot="public" static="no">
-        <type>typedef</type>
-        <definition>using N::allocator_traits&lt; _Alloc &gt;::const_pointer = </definition>
+      <memberdef kind="typedef" id="struct_n_1_1allocator__traits_1a764c5cc2bd9edc0cfa83282a3f5a75f8" prot="public" static="no">
+        <type>typename _Ptr&lt; __c_pointer, const value_type &gt;::type</type>
+        <definition>using N::allocator_traits&lt; _Alloc &gt;::const_pointer =  typename _Ptr&lt;__c_pointer, const value_type&gt;::type</definition>
         <argsstring/>
         <name>const_pointer</name>
         <qualifiedname>N::allocator_traits::const_pointer</qualifiedname>
@@ -33,7 +33,7 @@
     </detaileddescription>
     <location file="059_template.cpp" line="8" column="13" bodyfile="059_template.cpp" bodystart="9" bodyend="19"/>
     <listofallmembers>
-      <member refid="struct_n_1_1allocator__traits_1a044fe2aaa3b03062c97f6f62ad8b587c" prot="public" virt="non-virtual">
+      <member refid="struct_n_1_1allocator__traits_1a764c5cc2bd9edc0cfa83282a3f5a75f8" prot="public" virt="non-virtual">
         <scope>N::allocator_traits</scope>
         <name>const_pointer</name>
       </member>

--- a/testing/059/struct_n_1_1allocator__traits.xml
+++ b/testing/059/struct_n_1_1allocator__traits.xml
@@ -8,12 +8,13 @@
       </param>
     </templateparamlist>
     <sectiondef kind="public-type">
-      <memberdef kind="typedef" id="struct_n_1_1allocator__traits_1a764c5cc2bd9edc0cfa83282a3f5a75f8" prot="public" static="no">
-        <type>typename _Ptr&lt; __c_pointer, const value_type &gt;::type</type>
-        <definition>using N::allocator_traits&lt; _Alloc &gt;::const_pointer =  typename _Ptr&lt;__c_pointer, const value_type&gt;::type</definition>
+      <memberdef kind="typedef" id="struct_n_1_1allocator__traits_1a044fe2aaa3b03062c97f6f62ad8b587c" prot="public" static="no">
+        <type>typedef</type>
+        <definition>using N::allocator_traits&lt; _Alloc &gt;::const_pointer = </definition>
         <argsstring/>
         <name>const_pointer</name>
         <qualifiedname>N::allocator_traits::const_pointer</qualifiedname>
+        <initializer>= typename _Ptr&lt;__c_pointer, const value_type&gt;::type</initializer>
         <briefdescription>
           <para>The allocator's const pointer type. </para>
         </briefdescription>
@@ -32,7 +33,7 @@
     </detaileddescription>
     <location file="059_template.cpp" line="8" column="13" bodyfile="059_template.cpp" bodystart="9" bodyend="19"/>
     <listofallmembers>
-      <member refid="struct_n_1_1allocator__traits_1a764c5cc2bd9edc0cfa83282a3f5a75f8" prot="public" virt="non-virtual">
+      <member refid="struct_n_1_1allocator__traits_1a044fe2aaa3b03062c97f6f62ad8b587c" prot="public" virt="non-virtual">
         <scope>N::allocator_traits</scope>
         <name>const_pointer</name>
       </member>

--- a/testing/072/072__using_8cpp.xml
+++ b/testing/072/072__using_8cpp.xml
@@ -9,7 +9,7 @@
             <type>class T</type>
           </param>
         </templateparamlist>
-        <type>typedef</type>
+        <type>std::vector&lt; T &gt;</type>
         <definition>using Vec</definition>
         <argsstring/>
         <name>Vec</name>

--- a/testing/072/072__using_8cpp.xml
+++ b/testing/072/072__using_8cpp.xml
@@ -3,16 +3,17 @@
   <compounddef id="072__using_8cpp" kind="file" language="C++">
     <compoundname>072_using.cpp</compoundname>
     <sectiondef kind="typedef">
-      <memberdef kind="typedef" id="072__using_8cpp_1a1b01c504448c96cd2191a5184dd31acf" prot="public" static="no">
+      <memberdef kind="typedef" id="072__using_8cpp_1a252deba494fd8fd638d78a2e586bfc0a" prot="public" static="no">
         <templateparamlist>
           <param>
             <type>class T</type>
           </param>
         </templateparamlist>
-        <type>std::vector&lt; T &gt;</type>
-        <definition>using Vec =  std::vector&lt;T&gt;</definition>
+        <type>typedef</type>
+        <definition>using Vec</definition>
         <argsstring/>
         <name>Vec</name>
+        <initializer>= std::vector&lt;T&gt;</initializer>
         <briefdescription>
           <para>A vector. </para>
         </briefdescription>


### PR DESCRIPTION
Handling the typedef aliases analogous to normal initializers.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/11790562/example.tar.gz)
