### PR TITLE
Interleave of `stdout` and `stderr`

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -111,6 +111,12 @@ void msg(const char *fmt, ...)
   }
 }
 
+void msg_flush()
+{
+  fflush(stdout);
+}
+
+
 static void format_warn(const QCString &file,int line,const QCString &text)
 {
   QCString fileSubst = file.isEmpty() ? "<unknown>" : file;
@@ -304,6 +310,7 @@ void warn_flush()
 
 extern void finishWarnExit()
 {
+  msg_flush();
   if (g_warnBehavior == WARN_AS_ERROR_t::FAIL_ON_WARNINGS_PRINT && g_warnlogFile != "-")
   {
     Portable::fclose(g_warnFile);

--- a/src/message.h
+++ b/src/message.h
@@ -39,6 +39,7 @@ extern void term(const char *fmt, ...) PRINTFLIKE(1, 2);
 extern QCString warn_line(const QCString &file,int line);
 void initWarningFormat();
 void warn_flush();
+void msg_flush();
 extern void finishWarnExit();
 
 #undef PRINTFLIKE


### PR DESCRIPTION
During testing of #10129 we saw that there were some warnings that should have been at the end of log but appeared in the middle of the (last) lock of `Patching ...`. This is due to the fact that `stdout` and `stderr` are less good synchronized for non terminal modes. We should flush the `stdout` before writing the block of warnings