### PR TITLE
Detection of missing / superfluous `\n` in warnings

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5892,11 +5892,10 @@ static void addMemberFunction(const Entry *root,
 
     warnMsg+="  ";
     warnMsg+=fullFuncDecl;
-    warnMsg+='\n';
 
     if (candidates>0 || noMatchCount>=1)
     {
-      warnMsg+="Possible candidates:\n";
+      warnMsg+="\nPossible candidates:";
 
       NamespaceDef *nd=0;
       if (!namespaceName.isEmpty()) nd=getResolvedNamespace(namespaceName);
@@ -5913,6 +5912,7 @@ static void addMemberFunction(const Entry *root,
         }
         if (cd!=0 && (rightScopeMatch(cd->name(),className) || (cd!=tcd)))
         {
+          warnMsg+='\n';
           const ArgumentList &templAl = md->templateArguments();
           warnMsg+="  '";
           if (templAl.hasParameters())
@@ -5932,11 +5932,10 @@ static void addMemberFunction(const Entry *root,
             warnMsg+=qScope+"::"+md->name();
           warnMsg+=md->argsString();
           warnMsg+="' " + warn_line(md->getDefFileName(),md->getDefLine());
-          warnMsg+='\n';
         }
       }
     }
-    warn_simple(root->fileName,root->startLine,qPrint(warnMsg));
+    warn(root->fileName,root->startLine,"%s",qPrint(warnMsg));
   }
 }
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -220,12 +220,6 @@ void va_warn(const QCString &file,int line,const char *fmt,va_list args)
   do_warn(Config_getBool(WARNINGS), file, line, g_warningStr, fmt, args);
 }
 
-void warn_simple(const QCString &file,int line,const char *text)
-{
-  if (!Config_getBool(WARNINGS)) return; // warning type disabled
-  format_warn(file,line,QCString(g_warningStr) + text);
-}
-
 void warn_undoc_(const QCString &file,int line,const char *fmt, ...)
 {
   va_list args;

--- a/src/message.h
+++ b/src/message.h
@@ -28,7 +28,6 @@
 extern void msg(const char *fmt, ...) PRINTFLIKE(1,2);
 extern void warn_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void va_warn(const QCString &file, int line, const char* fmt, va_list args);
-extern void warn_simple(const QCString &file,int line,const char *text);
 extern void warn_undoc_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void warn_incomplete_doc_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);
 extern void warn_doc_error_(const QCString &file,int line,const char *fmt, ...) PRINTFLIKE(3, 4);


### PR DESCRIPTION
In PR #10135 most of the problems were already solved. There was sill an extra empty line that is now removed as well. (`warn_simple` was only used at 1 place and is now also replaced by the standard `warn` routine).

Found by Fossies for multiple packages)