### PR TITLE
Add 'extern' to xml output

### DIFF
--- a/addon/doxmlparser/README.md
+++ b/addon/doxmlparser/README.md
@@ -6,5 +6,7 @@ This is a python package to make it easier to parse the XML output produced by d
 The API is generated from the index.xsd and compound.xsd XML schema files using
 Dave Kuhlman's generateDS https://www.davekuhlman.org/generateDS.html
 
+The current code is generated with generateDS version 2.37.15.
+
 See the examples directory to get an idea how to use the python module
 

--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -3729,7 +3729,7 @@ class memberdefType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, kind=None, id=None, prot=None, static=None, strong=None, const=None, explicit=None, inline=None, refqual=None, virt=None, volatile=None, mutable=None, noexcept=None, constexpr=None, readable=None, writable=None, initonly=None, settable=None, privatesettable=None, protectedsettable=None, gettable=None, privategettable=None, protectedgettable=None, final=None, sealed=None, new=None, add=None, remove=None, raise_=None, optional=None, required=None, accessor=None, attribute=None, property=None, readonly=None, bound=None, removable=None, constrained=None, transient=None, maybevoid=None, maybedefault=None, maybeambiguous=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, qualifiedname=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, qualifier=None, param=None, enumvalue=None, requiresclause=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None, gds_collector_=None, **kwargs_):
+    def __init__(self, kind=None, id=None, prot=None, static=None, extern=None, strong=None, const=None, explicit=None, inline=None, refqual=None, virt=None, volatile=None, mutable=None, noexcept=None, constexpr=None, readable=None, writable=None, initonly=None, settable=None, privatesettable=None, protectedsettable=None, gettable=None, privategettable=None, protectedgettable=None, final=None, sealed=None, new=None, add=None, remove=None, raise_=None, optional=None, required=None, accessor=None, attribute=None, property=None, readonly=None, bound=None, removable=None, constrained=None, transient=None, maybevoid=None, maybedefault=None, maybeambiguous=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, qualifiedname=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, qualifier=None, param=None, enumvalue=None, requiresclause=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -3743,6 +3743,8 @@ class memberdefType(GeneratedsSuper):
         self.prot_nsprefix_ = None
         self.static = _cast(None, static)
         self.static_nsprefix_ = None
+        self.extern = _cast(None, extern)
+        self.extern_nsprefix_ = None
         self.strong = _cast(None, strong)
         self.strong_nsprefix_ = None
         self.const = _cast(None, const)
@@ -4051,6 +4053,10 @@ class memberdefType(GeneratedsSuper):
         return self.static
     def set_static(self, static):
         self.static = static
+    def get_extern(self):
+        return self.extern
+    def set_extern(self, extern):
+        self.extern = extern
     def get_strong(self):
         return self.strong
     def set_strong(self, strong):
@@ -4346,6 +4352,9 @@ class memberdefType(GeneratedsSuper):
         if self.static is not None and 'static' not in already_processed:
             already_processed.add('static')
             outfile.write(' static=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.static), input_name='static')), ))
+        if self.extern is not None and 'extern' not in already_processed:
+            already_processed.add('extern')
+            outfile.write(' extern=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.extern), input_name='extern')), ))
         if self.strong is not None and 'strong' not in already_processed:
             already_processed.add('strong')
             outfile.write(' strong=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.strong), input_name='strong')), ))
@@ -4573,6 +4582,11 @@ class memberdefType(GeneratedsSuper):
             already_processed.add('static')
             self.static = value
             self.validate_DoxBool(self.static)    # validate type DoxBool
+        value = find_attr_value_('extern', node)
+        if value is not None and 'extern' not in already_processed:
+            already_processed.add('extern')
+            self.extern = value
+            self.validate_DoxBool(self.extern)    # validate type DoxBool
         value = find_attr_value_('strong', node)
         if value is not None and 'strong' not in already_processed:
             already_processed.add('strong')

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3310,6 +3310,7 @@ static void addGlobalFunction(const Entry *root,const QCString &rname,const QCSt
   mmd->setMemberSpecifiers(root->spec);
   mmd->setMemberGroupId(root->mGrpId);
   mmd->setRequiresClause(root->req);
+  mmd->setExplicitExternal(root->explicitExternal,root->fileName,root->startLine,root->startColumn);
 
   NamespaceDefMutable *nd = 0;
   // see if the function is inside a namespace that was not part of

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -646,6 +646,11 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
     t << " constexpr=\"yes\"";
   }
 
+  if (md->isExternal())
+  {
+    t << " extern=\"yes\"";
+  }
+
   if (isFunc)
   {
     const ArgumentList &al = md->argumentList();

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -194,6 +194,7 @@
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="prot" type="DoxProtectionKind" />
     <xsd:attribute name="static" type="DoxBool" />
+    <xsd:attribute name="extern" type="DoxBool" use="optional" />
     <xsd:attribute name="strong" type="DoxBool" use="optional"/>
     <xsd:attribute name="const" type="DoxBool" use="optional"/>
     <xsd:attribute name="explicit" type="DoxBool" use="optional"/>


### PR DESCRIPTION
Attempts to resolve: https://github.com/doxygen/doxygen/issues/10163

Following the strategy taken in the sqlite output (https://github.com/doxygen/doxygen/pull/8533), we add extern if it is set regardless of whether it is a function, variable, etc.

It might be reasonable to only do it for functions and variables though. I don't know what the standard approach for these things is in the code base.

We have to update `addGlobalFunction` so that it passes on the `explicitExternal` information from `Entry` to the `MemberDef` which previously was only done for variables and enums.

Also:

- Update the `xsd` file to indicate that an optional `extern` attribute might be present on the members.