### PR TITLE
Show outline on focused elements with tab press

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -139,6 +139,10 @@ a.navtab {
 	font-weight: bold;
 }
 
+.tablist a:focus {
+	outline: auto;
+}
+
 div.qindex{
 	text-align: center;
 	width: 100%;


### PR DESCRIPTION
## Issue
When navigating pages with `<tab>`* button, navigation elements are not focused/outlined.

## Change
Adjust CSS so that `outline: none;` from another property is not applied on focused element.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Update: *< tab > was not rendered in markdown.