### PR TITLE
Fix for tests failing XHTML validation

### DIFF
--- a/testing/013/class_t1.xml
+++ b/testing/013/class_t1.xml
@@ -8,7 +8,7 @@
     <detaileddescription>
       <para>A class </para>
     </detaileddescription>
-    <location file="013_class.h" line="11" column="1" bodyfile="013_class.h" bodystart="12" bodyend="13"/>
+    <location file="013_class.h" line="10" column="1" bodyfile="013_class.h" bodystart="11" bodyend="12"/>
     <listofallmembers>
     </listofallmembers>
   </compounddef>

--- a/testing/013/class_t2.xml
+++ b/testing/013/class_t2.xml
@@ -8,7 +8,7 @@
     <detaileddescription>
       <para>class <ref refid="class_t2" kindref="compound">T2</ref> </para>
     </detaileddescription>
-    <location file="013_class.h" line="15" column="1" bodyfile="013_class.h" bodystart="16" bodyend="17"/>
+    <location file="013_class.h" line="14" column="1" bodyfile="013_class.h" bodystart="15" bodyend="16"/>
     <listofallmembers>
     </listofallmembers>
   </compounddef>

--- a/testing/013/class_t3.xml
+++ b/testing/013/class_t3.xml
@@ -8,7 +8,7 @@
     <detaileddescription>
       <para>class <ref refid="class_t3" kindref="compound">T3</ref> </para>
     </detaileddescription>
-    <location file="013_class.h" line="19" column="1" bodyfile="013_class.h" bodystart="20" bodyend="21"/>
+    <location file="013_class.h" line="18" column="1" bodyfile="013_class.h" bodystart="19" bodyend="20"/>
     <listofallmembers>
     </listofallmembers>
   </compounddef>

--- a/testing/013/class_t4.xml
+++ b/testing/013/class_t4.xml
@@ -8,7 +8,7 @@
     <detaileddescription>
       <para>class <ref refid="class_t4" kindref="compound">T4</ref> </para>
     </detaileddescription>
-    <location file="013_class.h" line="23" column="1" bodyfile="013_class.h" bodystart="24" bodyend="25"/>
+    <location file="013_class.h" line="22" column="1" bodyfile="013_class.h" bodystart="23" bodyend="24"/>
     <listofallmembers>
     </listofallmembers>
   </compounddef>

--- a/testing/013_class.h
+++ b/testing/013_class.h
@@ -1,5 +1,4 @@
 // objective: test the \class and \headerfile commands
-// config: HTML_CODE_FOLDING=NO
 // check: class_t1.xml
 // check: class_t2.xml
 // check: class_t3.xml

--- a/testing/044/struct_s.xml
+++ b/testing/044/struct_s.xml
@@ -17,7 +17,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="044_section.h" line="11" column="7" bodyfile="044_section.h" bodystart="11" bodyend="-1"/>
+        <location file="044_section.h" line="10" column="7" bodyfile="044_section.h" bodystart="10" bodyend="-1"/>
       </memberdef>
       <memberdef kind="variable" id="struct_s_1a413054db7785010db38c16322c8583cc" prot="public" static="no" mutable="no">
         <type>int</type>
@@ -32,7 +32,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="044_section.h" line="13" column="7" bodyfile="044_section.h" bodystart="13" bodyend="-1"/>
+        <location file="044_section.h" line="12" column="7" bodyfile="044_section.h" bodystart="12" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="protected-attrib">
@@ -49,7 +49,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="044_section.h" line="18" column="7" bodyfile="044_section.h" bodystart="18" bodyend="-1"/>
+        <location file="044_section.h" line="17" column="7" bodyfile="044_section.h" bodystart="17" bodyend="-1"/>
       </memberdef>
       <memberdef kind="variable" id="struct_s_1a0c535a6122f4ae509a336e3a67f927a4" prot="protected" static="no" mutable="no">
         <type>int</type>
@@ -64,7 +64,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="044_section.h" line="20" column="7" bodyfile="044_section.h" bodystart="20" bodyend="-1"/>
+        <location file="044_section.h" line="19" column="7" bodyfile="044_section.h" bodystart="19" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="private-attrib">
@@ -81,7 +81,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="044_section.h" line="25" column="7" bodyfile="044_section.h" bodystart="25" bodyend="-1"/>
+        <location file="044_section.h" line="24" column="7" bodyfile="044_section.h" bodystart="24" bodyend="-1"/>
       </memberdef>
       <memberdef kind="variable" id="struct_s_1a4b26822a09bcd6b946702e99280826ff" prot="private" static="no" mutable="no">
         <type>int</type>
@@ -96,7 +96,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="044_section.h" line="27" column="7" bodyfile="044_section.h" bodystart="27" bodyend="-1"/>
+        <location file="044_section.h" line="26" column="7" bodyfile="044_section.h" bodystart="26" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
@@ -104,7 +104,7 @@
     <detaileddescription>
       <para>A struct </para>
     </detaileddescription>
-    <location file="044_section.h" line="6" column="1" bodyfile="044_section.h" bodystart="7" bodyend="28"/>
+    <location file="044_section.h" line="5" column="1" bodyfile="044_section.h" bodystart="6" bodyend="27"/>
     <listofallmembers>
       <member refid="struct_s_1ab754fee7e3500035f644d0ac528cbfc3" prot="private" virt="non-virtual">
         <scope>S</scope>

--- a/testing/044_section.h
+++ b/testing/044_section.h
@@ -1,5 +1,4 @@
 // objective: test the \(public|protected|private)section commands
-// config: HTML_CODE_FOLDING = NO
 // check: struct_s.xml
 
 /** A struct */

--- a/testing/082/namespace_n.xml
+++ b/testing/082/namespace_n.xml
@@ -17,7 +17,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="082_decl_def.cpp" line="12" column="5" bodyfile="082_decl_def.cpp" bodystart="12" bodyend="-1" declfile="decl_def.h" declline="5" declcolumn="12"/>
+        <location file="082_decl_def.cpp" line="11" column="5" bodyfile="082_decl_def.cpp" bodystart="11" bodyend="-1" declfile="decl_def.h" declline="5" declcolumn="12"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="func">
@@ -39,7 +39,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="082_decl_def.cpp" line="15" column="6" bodyfile="082_decl_def.cpp" bodystart="15" bodyend="17" declfile="decl_def.h" declline="8" declcolumn="6"/>
+        <location file="082_decl_def.cpp" line="14" column="6" bodyfile="082_decl_def.cpp" bodystart="14" bodyend="16" declfile="decl_def.h" declline="8" declcolumn="6"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/082_decl_def.cpp
+++ b/testing/082_decl_def.cpp
@@ -1,7 +1,6 @@
 // objective: test for declaration and definition order independence: decl first
 // check: namespace_n.xml
 // config: INPUT = $INPUTDIR/decl_def.h $INPUTDIR/082_decl_def.cpp
-// config: HTML_CODE_FOLDING = NO
 #include "test.h"
 
 /** Namespace */

--- a/testing/dtd/xhtml1-transitional.dtd
+++ b/testing/dtd/xhtml1-transitional.dtd
@@ -38,6 +38,7 @@
      - added details and summary tag
      - added placeholder to input tag
      - added allowfullscreen to iframe tag
+     - added data-start and data-end to div tag (needed for code folding)
 -->
 
 <!--================ Character mnemonic entities =========================-->
@@ -448,6 +449,8 @@
 <!ATTLIST div
   %attrs;
   %TextAlign;
+  data-start %Text; #IMPLIED
+  data-end   %Text; #IMPLIED
   >
 
 <!ELEMENT details %Flow;>  <!-- generic language/style container -->


### PR DESCRIPTION
The tests were temporarily fixed for the use of `data-start` and `data-end`. These items have now been added to the dtd