### PR TITLE
Non readable error message in tests

### DIFF
--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -56,6 +56,7 @@ def clean_header(errmsg):
                 cnt-=1
             else:
                 rtnmsg+=o
+                rtnmsg+="\n"
     return rtnmsg
  
 class Tester:


### PR DESCRIPTION
Due to the `split('\n')` we lost the return ant thus got a hard to read error message i.e.:
```
No declaration for attribute data-start of element divNo declaration for attribute data-end of element divNo declaration for attribute data-start of element divNo declaration for attribute data-end of element divNo declaration for attribute data-start of element divNo declaration for attribute data-end of element divNo declaration for attribute data-start of element divNo declaration for attribute data-end of element divDocument test_output_013/html/013__class_8h_source.xhtml does not validate
```
instead of
```
No declaration for attribute data-start of element div
No declaration for attribute data-end of element div
No declaration for attribute data-start of element div
No declaration for attribute data-end of element div
No declaration for attribute data-start of element div
No declaration for attribute data-end of element div
No declaration for attribute data-start of element div
No declaration for attribute data-end of element div
Document test_output_013/html/013__class_8h_source.xhtml does not validate
```