### PR TITLE
Fix latex quotes in <pre>

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2364,7 +2364,7 @@ void filterLatexString(TextStream &t,const QCString &str,
                    break;
         case '\\': t << "\\textbackslash{}";
                    break;
-        case '"':  t << "\\\"{}";
+        case '"':  t << "\"{}";
                    break;
         case '`':  t << "\\`{}";
                    break;


### PR DESCRIPTION
Commit 2073b3b (#9978) removed `\char` but left its backslash. `\char` should not be necessary since fontenc is used. If fontenc is not used the curly braces prevent interpretation as an umlaut (although the quote will be curled the wrong way).

## Current output:
![image](https://github.com/doxygen/doxygen/assets/112202543/cf0b4d05-e049-4f7b-ac22-e36e45bff53c)

## With this patch:
![image](https://github.com/doxygen/doxygen/assets/112202543/ff074d5e-c4b5-4721-85d2-97db459b41df)

## Notes

If I understand correctly: before 2073b3b, the output was ``\char`\"``, which worked because `\"` is treated as an argument to `` ` `` instead of a command. Since the ``\char` `` part is now removed, `\"` is treated as the babel command for an umlaut.

I'm still a little confused, since babel is not used when building the Doxygen manual as far as I can tell.

On our internal CI that uses Doxygen + LuaLaTeX + Polyglossia, `\"` generates tofu, but on my local setup it generates an umlaut just like in the doxygen manual.