### PR TITLE
issue #10186 C++: constexpr and / or static trailing return type syntax + void

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4092,7 +4092,7 @@ void MemberDefImpl::warnIfUndocumentedParams() const
   bool isFortranSubroutine = isFortran && returnType.find("subroutine")!=-1;
 
   bool isVoidReturn = (returnType=="void") || (returnType.endsWith(" void"));
-  if (!isVoidReturn && returnType == "auto")
+  if (!isVoidReturn && (returnType == "auto") || (returnType.endsWith(" auto")))
   {
     const ArgumentList &defArgList=isDocsForDefinition() ?  argumentList() : declArgumentList();
     if (!defArgList.trailingReturnType().isEmpty())


### PR DESCRIPTION
not only full returnType should be tested but also the end part (like it is done for void)