### PR TITLE
Spelling correction

### DIFF
--- a/doc/arch.doc
+++ b/doc/arch.doc
@@ -38,7 +38,7 @@ directly by \c doxywizard, so it is put in a separate library.
 Each configuration option has one of 5 possible types: \c String,
 \c List, \c Enum, \c Int, or \c Bool. The values of these options are
 available through the global functions \c Config_getXXX(), where \c XXX is the
-type of the option. The argument of these function is a string naming
+type of the option. The argument of these functions is a string naming
 the option as it appears in the configuration file. For instance:
 \c Config_getBool("GENERATE_TESTLIST") returns a reference to a boolean
 value that is \c TRUE if the test list was enabled in the configuration file.


### PR DESCRIPTION
Words `these` and `function` don't go together