### PR TITLE
issue #10190 References to enumerations within a class named Bool are not properly handled

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -370,7 +370,7 @@ void FileDefImpl::writeTagFile(TextStream &tagFile)
             MemberList * ml = getMemberList(lmd->type);
             if (ml)
             {
-              ml->writeTagFile(tagFile);
+              ml->writeTagFile(tagFile,false,false);
             }
           }
         }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -321,7 +321,7 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual void writeMemberDocSimple(OutputList &ol,const Definition *container) const;
     virtual void writeEnumDeclaration(OutputList &typeDecl,
             const ClassDef *cd,const NamespaceDef *nd,const FileDef *fd,const GroupDef *gd) const;
-    virtual void writeTagFile(TextStream &,bool useQualifiedName) const;
+    virtual void writeTagFile(TextStream &,bool useQualifiedName,bool showNamespaceMembers) const;
     virtual void warnIfUndocumented() const;
     virtual void warnIfUndocumentedParams() const;
     virtual bool visibleInIndex() const;
@@ -4414,9 +4414,10 @@ Specifier MemberDefImpl::virtualness(int count) const
   return v;
 }
 
-void MemberDefImpl::writeTagFile(TextStream &tagFile,bool useQualifiedName) const
+void MemberDefImpl::writeTagFile(TextStream &tagFile,bool useQualifiedName,bool showNamespaceMembers) const
 {
   if (!isLinkableInProject()) return;
+  if (!showNamespaceMembers && getNamespaceDef()) return;
   tagFile << "    <member kind=\"";
   switch (m_mtype)
   {

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -428,7 +428,7 @@ class MemberDefMutable : public DefinitionMutable, public MemberDef
                  bool inGroup,bool showEnumValues=FALSE,bool
                  showInline=FALSE) const = 0;
     virtual void writeMemberDocSimple(OutputList &ol,const Definition *container) const = 0;
-    virtual void writeTagFile(TextStream &,bool useQualifiedName) const = 0;
+    virtual void writeTagFile(TextStream &,bool useQualifiedName,bool showNamespaceMembers) const = 0;
 
     // write helpers
     virtual void setFromAnonymousScope(bool b) = 0;

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -905,7 +905,7 @@ QCString MemberList::listTypeAsString(MemberListType type)
   return "";
 }
 
-void MemberList::writeTagFile(TextStream &tagFile,bool useQualifiedName)
+void MemberList::writeTagFile(TextStream &tagFile,bool useQualifiedName,bool showNamespaceMembers)
 {
   for (const auto &imd : m_members)
   {
@@ -914,7 +914,7 @@ void MemberList::writeTagFile(TextStream &tagFile,bool useQualifiedName)
     {
       if (md->getLanguage()!=SrcLangExt_VHDL)
       {
-        md->writeTagFile(tagFile,useQualifiedName);
+        md->writeTagFile(tagFile,useQualifiedName,showNamespaceMembers);
         if (md->memberType()==MemberType_Enumeration && !md->isStrong())
         {
           for (const auto &ivmd : md->enumFieldList())
@@ -922,7 +922,7 @@ void MemberList::writeTagFile(TextStream &tagFile,bool useQualifiedName)
             MemberDefMutable *vmd = toMemberDefMutable(ivmd);
             if (vmd)
             {
-              vmd->writeTagFile(tagFile,useQualifiedName);
+              vmd->writeTagFile(tagFile,useQualifiedName,showNamespaceMembers);
             }
           }
         }

--- a/src/memberlist.h
+++ b/src/memberlist.h
@@ -134,7 +134,7 @@ class MemberList : public MemberVector
     void writeSimpleDocumentation(OutputList &ol,const Definition *container) const;
     void writeDocumentationPage(OutputList &ol,
                const QCString &scopeName, const DefinitionMutable *container, int hierarchyLevel=0) const;
-    void writeTagFile(TextStream &,bool useQualifiedName=false);
+    void writeTagFile(TextStream &,bool useQualifiedName=false,bool showNamespaceMembers=true);
     bool declVisible() const;
     void addMemberGroup(MemberGroup *mg);
     void addListReferences(Definition *def);


### PR DESCRIPTION
Members that are in a namespace should not be mentioned as members of a file unless with full qualified name. Members were mentioned separately inside the namespace but also as members of the file, remove file mention.