### PR TITLE
Consistency of use of arguments

### DIFF
--- a/src/docparser.h
+++ b/src/docparser.h
@@ -53,11 +53,11 @@ class IDocNodeAST
 using IDocNodeASTPtr = std::unique_ptr<IDocNodeAST>;
 
 /*! Main entry point for the comment block parser.
- *  @param parser    The parser object created via createDocParser()
+ *  @param parserIntf The parser object created via createDocParser()
  *  @param fileName  File in which the documentation block is found (or the
  *                   name of the example file in case isExample is TRUE).
  *  @param startLine Line at which the documentation block is found.
- *  @param context   Class or namespace to which this block belongs.
+ *  @param ctx       Class or namespace to which this block belongs.
  *  @param md        Member definition to which the documentation belongs.
  *                   Can be 0.
  *  @param input     String representation of the documentation block.
@@ -75,8 +75,8 @@ using IDocNodeASTPtr = std::unique_ptr<IDocNodeAST>;
  *  @returns         An object representing the abstract syntax tree. Ownership of the
  *                   pointer is handed over to the caller.
  */
-IDocNodeASTPtr validatingParseDoc(IDocParser &parser,const QCString &fileName,int startLine,
-                            const Definition *context, const MemberDef *md,
+IDocNodeASTPtr validatingParseDoc(IDocParser &parserIntf,const QCString &fileName,int startLine,
+                            const Definition *ctx, const MemberDef *md,
                             const QCString &input,bool indexWords,
                             bool isExample,const QCString &exampleName,
                             bool singleLine,bool linkFromIndex,


### PR DESCRIPTION
When running doxygen with clang assisted parsing this function gave that a few parameters were not documented in the internal documentation, made consistent