### PR TITLE
issue #10212 "refid" attribute on "includes" (incType) XML nodes should be marked optional

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -101,7 +101,7 @@
   <xsd:complexType name="incType">
     <xsd:simpleContent>
       <xsd:extension base="xsd:string">
-        <xsd:attribute name="refid" type="xsd:string" />
+        <xsd:attribute name="refid" type="xsd:string" use="optional" />
         <xsd:attribute name="local" type="DoxBool" />
       </xsd:extension>
     </xsd:simpleContent>


### PR DESCRIPTION
The refid is conditionally added so this should also be reflected in the xsd file