### PR TITLE
Correction in the documentation and internal documentation

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -3928,14 +3928,14 @@ class Receiver
   for Markdown tables.
 
 <hr>
-\section cmdndash \\--
+\section cmdndash \\\--
 
   \addindex \\\--
   This command writes two dashes (\--) to the output. This allows
   writing two consecutive dashes to the output instead of one n-dash character (--).
 
 <hr>
-\section cmdmdash \\---
+\section cmdmdash \\\---
 
   \addindex \\\---
   This command writes three dashes (\---) to the output. This allows

--- a/doc_internal/commands_history.md
+++ b/doc_internal/commands_history.md
@@ -174,8 +174,8 @@ The following table gives an overview of the doxygen special commands and the ve
 <dt>New in 1.8.6</dt><dd>\\diafile</dd>
 <dt></dt>             <dd>\\endparblock</dd>
 <dt></dt>             <dd>\\parblock</dd>
-<dt>New in 1.8.7</dt><dd>\\\\--</dd>
-<dt></dt>             <dd>\\\\---</dd>
+<dt>New in 1.8.7</dt><dd>\\\--</dd>
+<dt></dt>             <dd>\\\---</dd>
 <dt></dt>             <dd>\\latexinclude</dd>
 <dt>New in 1.8.8</dt><dd>\\enduml</dd>
 <dt></dt>             <dd>\\startuml</dd>

--- a/doc_internal/tags_history.md
+++ b/doc_internal/tags_history.md
@@ -444,7 +444,7 @@ The following table gives an overview of the doxygen configuration settings and 
 <!-- PLACEHOLDER -->
 </dl>
 
-## Directives
+# Directives
 
 <dl>
 <dt>New in 1.2.1</dt>

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1499,7 +1499,7 @@ int Markdown::processLink(const char *data,int offset,int size)
   return i;
 }
 
-/** '`' parsing a code span (assuming codespan != 0) */
+/** `` ` `` parsing a code span (assuming codespan != 0) */
 int Markdown::processCodeSpan(const char *data, int /*offset*/, int size)
 {
   AUTO_TRACE("data='{}' size={}",Trace::trunc(data),size);

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -91,8 +91,8 @@ static std::vector<QCString> split(const QCString &str,const QCString &sep,
 
 //----------------------------------------------------------------------------
 
-/** Strips spaces surrounding `=` from string \a in, so
- *  `foo = 10 bar=5 baz= 'hello'` will become `foo=10 bar=5 baz='hello'`
+/** Strips spaces surrounding `=` from string \a s, so
+ *  ``foo = 10 bar=5 baz= 'hello'`` will become ``foo=10 bar=5 baz='hello'``
  */
 static void removeSpacesAroundEquals(QCString &s)
 {

--- a/src/template.h
+++ b/src/template.h
@@ -73,7 +73,7 @@ using TemplateStructIntfWeakPtr = std::weak_ptr<TemplateStructIntf>;
  *
  *  Extension tags:
  *  - `create` which instantiates a template and writes the result to a file.
- *     The syntax is `{% create 'filename' from 'template' %}`.
+ *     The syntax is ``{% create 'filename' from 'template' %}``.
  *  - `recursetree`
  *  - `markers`
  *  - `msg` ... `endmsg`


### PR DESCRIPTION
Based on xmlxsd validity tests, done by hand, on the internal documentation, correction in the documentation and internal documentation of:
- display of original `\--` and `---` commands
- usage of single quotes inside backtics require that 2 backtics are used
- changing level of header