### PR TITLE
Small layout correction in internal documentation

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -18,7 +18,8 @@
  */
 
 /**
- @todo - continuation lines not always recognized
+ @todo
+       - continuation lines not always recognized
        - merging of use-statements with same module name and different only-names
        - rename part of use-statement
        - links to interface functions


### PR DESCRIPTION
Correcting small layout problem in todo list in fortrancode.l for the internal doxygen documentation.