### PR TITLE
issue #10220 \copydoc for file dox does not copy brief

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3260,7 +3260,7 @@ static bool handleCopyDetails(yyscan_t yyscanner,const QCString &, const StringV
 static bool handleCopyDoc(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  if (yyextra->current->brief.isEmpty() && yyextra->current->doc.isEmpty())
+  if (yyextra->current->brief.stripWhiteSpace().isEmpty() && yyextra->current->doc.stripWhiteSpace().isEmpty())
   { // if we don't have a brief or detailed description yet,
     // then the @copybrief should end up in the brief description.
     // otherwise it will be copied inline (see bug691315 & bug700788)


### PR DESCRIPTION
Check that the brief / details documentation section are really empty before deciding about where to place the result of the `\copydoc`