### PR TITLE
Show not up to date message  for translator

### DIFF
--- a/src/language.cpp
+++ b/src/language.cpp
@@ -69,6 +69,8 @@
 
 Translator *theTranslator=0;
 
+void config_warn(const char *fmt, ...);
+
 void setTranslator(OUTPUT_LANGUAGE_t langName)
 {
   switch (langName)
@@ -121,5 +123,5 @@ void setTranslator(OUTPUT_LANGUAGE_t langName)
   }
 
   QCString msg = theTranslator->updateNeededMessage();
-  if (!msg.isEmpty()) ::msg("%s", qPrint(msg));
+  if (!msg.isEmpty()) config_warn("%s", qPrint(msg));
 }


### PR DESCRIPTION
In:
```
Commit: 4c47b238edf4f94894ff70f6b32904e142f159a7 [4c47b23]
Date: Saturday, February 26, 2022 10:44:11 PM
Downgrade stale translator warning to message
```
The text was downgraded to a message and in this way dependent on the setting of `QUIET` whilst other configuration settings are given. Also the text was written to `stdout` instead of `stderr`.