### PR TITLE
Fix a typo

### DIFF
--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -98,7 +98,7 @@ static void splitSearchTokens(QCString &title,IntVector &indices)
     char c = title[si];
     if (isId(c) || c==':') // add "word" character
     {
-      title[di++];
+      title[di++]=c;
       lastIsSpace=false;
     }
     else if (!lastIsSpace) // add one separator as space


### PR DESCRIPTION
With the proposed change the JS search is able to find `Foo (bar/qwe) ` by `bar` and `qwe`