### PR TITLE
Consistency Python_EXECUTABLE in CMake

### DIFF
--- a/cmake/WindowsEncoding.cmake
+++ b/cmake/WindowsEncoding.cmake
@@ -1,7 +1,7 @@
 if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" OR CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   include(FindPythonInterp)
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/cmake/QueryCodePage.py"
+    COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/cmake/QueryCodePage.py"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     RESULT_VARIABLE ReturnCode
     OUTPUT_VARIABLE CodePage

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # run all tests sequentially (keep for backward compatibility)
 add_custom_target(tests
   COMMENT "Running doxygen tests..."
-  COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/testing/runtests.py --doxygen ${PROJECT_BINARY_DIR}/bin/doxygen --inputdir ${PROJECT_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+  COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/testing/runtests.py --doxygen ${PROJECT_BINARY_DIR}/bin/doxygen --inputdir ${PROJECT_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
   DEPENDS doxygen
 )
 
@@ -19,6 +19,6 @@ foreach(TEST_FILE ${TEST_FILES})
   string(REGEX REPLACE "^.*/([0-9][0-9][0-9]*).*$" "\\1" TEST_ID "${TEST_FILE}")
   # add a test target for each test
   add_test(NAME ${TEST_NAME}
-    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/testing/runtests.py --id ${TEST_ID} --doxygen $<TARGET_FILE:doxygen> --inputdir ${PROJECT_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
+    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/testing/runtests.py --id ${TEST_ID} --doxygen $<TARGET_FILE:doxygen> --inputdir ${PROJECT_SOURCE_DIR}/testing --outputdir ${PROJECT_BINARY_DIR}/testing
   )
 endforeach()


### PR DESCRIPTION
Some more PYTHON_EXECUTABLE to Python_EXECUTABLE, apparently didn't influence the normal flow build, but is better for consistency.