### PR TITLE
Enable link on line of edge in a directory graph

### DIFF
--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -392,6 +392,7 @@ void writeDotDirDepGraph(TextStream &t,const DirDef *dd,bool linkRelations)
           QCString fn = relationName;
           addHtmlExtensionIfMissing(fn);
           t << " headhref=\"" << fn << "\"";
+          t << " href=\"" << fn << "\"";
         }
         t << " color=\"steelblue1\" fontcolor=\"steelblue1\"];\n";
       }


### PR DESCRIPTION
See to it that in a directory graph not only the list of files in the other directory can be reached by means of the head / number of the edge but also through the line of the edge.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12388383/example.tar.gz)
