### PR TITLE
More flexible directory graphs regarding show / hide

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -73,6 +73,7 @@ documentation:
 \refitem cmddetails \\details
 \refitem cmddiafile \\diafile
 \refitem cmddir \\dir
+\refitem cmddirectorygraph \\directorygraph
 \refitem cmddocbookinclude \\docbookinclude
 \refitem cmddocbookonly \\docbookonly
 \refitem cmddontinclude \\dontinclude
@@ -118,6 +119,7 @@ documentation:
 \refitem cmdheaderfile \\headerfile
 \refitem cmdhidecallergraph \\hidecallergraph
 \refitem cmdhidecallgraph \\hidecallgraph
+\refitem cmdhidedirectorygraph \\hidedirectorygraph
 \refitem cmdhideincludedbygraph \\hideincludedbygraph
 \refitem cmdhideincludegraph \\hideincludegraph
 \refitem cmdhiderefby \\hiderefby
@@ -486,6 +488,32 @@ Structural indicators
       section \ref cmdincludegraph "\\ncludegraph",
       section \ref cmdhideincludegraph "\\hideincludegraph" and
       option \ref cfg_included_by_graph "INCLUDED_BY_GRAPH"
+
+<hr>
+\section cmddirectorygraph \\directorygraph
+
+  \addindex \\directorygraph
+  When this command is put in a comment block of a directory
+  (see section \ref cmddir "\\dir")
+  then doxygen will generate a directory graph for that directory. The
+  directory graph will be generated regardless of the value of
+  \ref cfg_directory_graph "DIRECTORY_GRAPH".
+
+  \sa section \ref cmdhidedirectorygraph "\\hidedirectorygraph",
+      option \ref cfg_directory_graph "DIRECTORY_GRAPH"
+
+<hr>
+\section cmdhidedirectorygraph \\hidedirectorygraph
+
+  \addindex \\hidedirectorygraph
+  When this command is put in a comment block of a directory
+  (see section \ref cmddir "\\dir")
+  then doxygen will not generate a directory graph for that directory. The
+  directory graph will not be generated regardless of the value of
+  \ref cfg_directory_graph "DIRECTORY_GRAPH".
+
+  \sa section \ref cmddirectorygraph "\\directorygraph",
+      option \ref cfg_directory_graph "DIRECTORY_GRAPH"
 
 <hr>
 \section cmdqualifier \\qualifier <label> | "(text)"

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -128,6 +128,8 @@ static bool handleIncludegraph(yyscan_t yyscanner,const QCString &, const String
 static bool handleIncludedBygraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideIncludegraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideIncludedBygraph(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleHideDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleReferencedByRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideReferencedByRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleReferencesRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
@@ -210,6 +212,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "deprecated",      { &handleDeprecated,       CommandSpacing::XRef      }},
   { "details",         { &handleDetails,          CommandSpacing::Block     }},
   { "dir",             { &handleDir,              CommandSpacing::Invisible }},
+  { "directorygraph",  { &handleDirectoryGraph,   CommandSpacing::Invisible }},
   { "docbookinclude",  { 0,                       CommandSpacing::Inline    }},
   { "docbookonly",     { &handleFormatBlock,      CommandSpacing::Invisible }},
   { "dot",             { &handleFormatBlock,      CommandSpacing::Block     }},
@@ -227,6 +230,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "headerfile",      { &handleHeaderFile,       CommandSpacing::Invisible }},
   { "hidecallergraph", { &handleHideCallergraph,  CommandSpacing::Invisible }},
   { "hidecallgraph",   { &handleHideCallgraph,    CommandSpacing::Invisible }},
+  { "hidedirectorygraph",  { &handleHideDirectoryGraph,  CommandSpacing::Invisible }},
   { "hideincludedbygraph", { &handleHideIncludedBygraph, CommandSpacing::Invisible }},
   { "hideincludegraph",    { &handleHideIncludegraph,    CommandSpacing::Invisible }},
   { "hideinitializer", { &handleHideInitializer,  CommandSpacing::Invisible }},
@@ -3102,6 +3106,20 @@ static bool handleHideIncludedBygraph(yyscan_t yyscanner,const QCString &, const
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->current->includedByGraph = FALSE; // OFF
+  return FALSE;
+}
+
+static bool handleDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->directoryGraph = TRUE; // ON
+  return FALSE;
+}
+
+static bool handleHideDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->directoryGraph = FALSE; // OFF
   return FALSE;
 }
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -3902,6 +3902,11 @@ UML notation for the relationships.
  to \c YES then doxygen will show the dependencies a directory has on other directories
  in a graphical way. The dependency relations are determined by the \c \#include
  relations between the files in the directories.
+ Explicit enabling a directory graph, when \c DIRECTORY_GRAPH is set to \c NO, can be
+ accomplished by means of the command \ref cmddirectorygraph "\\directorygraph".
+ Disabling a directory graph can be accomplished by means of the command
+ \ref cmdhidedirectorygraph "\\hidedirectorygraph".
+
 ]]>
       </docs>
     </option>

--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -146,6 +146,10 @@ class DirDef : public DefinitionMutable, public Definition
     virtual void addUsesDependency(const DirDef *usedDir,const FileDef *srcFd,
                                    const FileDef *dstFd,bool srcDirect, bool dstDirect) = 0;
     virtual void computeDependencies() = 0;
+
+    // directory graph related members
+    virtual bool hasDirectoryGraph() const = 0;
+    virtual void enableDirectoryGraph(bool e) = 0;
 };
 
 // --- Cast functions

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9110,6 +9110,7 @@ static void findDirDocumentation(const Entry *root)
       matchingDir->setBriefDescription(root->brief,root->briefFile,root->briefLine);
       matchingDir->setDocumentation(root->doc,root->docFile,root->docLine);
       matchingDir->setRefItems(root->sli);
+      matchingDir->enableDirectoryGraph(root->directoryGraph);
       addDirToGroups(root,matchingDir);
     }
     else
@@ -12292,12 +12293,9 @@ void parseInput()
   setAnonymousEnumType();
   g_s.end();
 
-  if (Config_getBool(DIRECTORY_GRAPH))
-  {
-    g_s.begin("Computing dependencies between directories...\n");
-    computeDirDependencies();
-    g_s.end();
-  }
+  g_s.begin("Computing dependencies between directories...\n");
+  computeDirDependencies();
+  g_s.end();
 
   g_s.begin("Generating citations page...\n");
   CitationManager::instance().generatePage();

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -67,6 +67,7 @@ Entry::Entry(const Entry &e)
   callerGraph = e.callerGraph;
   includeGraph = e.includeGraph;
   includedByGraph = e.includedByGraph;
+  directoryGraph = e.directoryGraph;
   referencedByRelation = e.referencedByRelation;
   referencesRelation   = e.referencesRelation;
   exported    = e.exported;
@@ -192,6 +193,7 @@ void Entry::reset()
   bool entryReferencesRelation   = Config_getBool(REFERENCES_RELATION);
   bool entryIncludeGraph    = Config_getBool(INCLUDE_GRAPH);
   bool entryIncludedByGraph = Config_getBool(INCLUDED_BY_GRAPH);
+  bool entryDirectoryGraph  = Config_getBool(DIRECTORY_GRAPH);
   //printf("Entry::reset()\n");
   name.resize(0);
   type.resize(0);
@@ -226,6 +228,7 @@ void Entry::reset()
   callerGraph = entryCallerGraph;
   includeGraph = entryIncludeGraph;
   includedByGraph = entryIncludedByGraph;
+  directoryGraph = entryDirectoryGraph;
   referencedByRelation = entryReferencedByRelation;
   referencesRelation   = entryReferencesRelation;
   exported = false;

--- a/src/entry.h
+++ b/src/entry.h
@@ -258,6 +258,7 @@ class Entry
     bool referencesRelation;  //!< do we need to show the references relation?
     bool includeGraph;        //!< do we need to draw the include graph?
     bool includedByGraph;     //!< do we need to draw the included by graph?
+    bool directoryGraph;      //!< do we need to draw the directory graph?
     bool exported;            //!< is the symbol exported from a C++20 module
     Specifier    virt;        //!< virtualness of the entry
     QCString     args;        //!< member argument string


### PR DESCRIPTION
For call / caller / include / included by graphs it is possible to steer the graph creation process on a 1 to 1 base (commands like \callgraph and \hidecallgraph).

Introducing for the directory graphs:
```
    \directorygraph and \hidedirectorygraph
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12388569/example.tar.gz)
