### PR TITLE
issue #10238 Doxygen can't document Global functions

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -481,7 +481,7 @@ static void addAnchor(yyscan_t yyscanner,const QCString &anchor, const QCString 
 static inline void addOutput(yyscan_t yyscanner,const char *s);
 static inline void addOutput(yyscan_t yyscanner,const QCString &s);
 static inline void addOutput(yyscan_t yyscanner,char c);
-static void endBrief(yyscan_t yyscanner,bool addToOutput=TRUE);
+static void endBrief(yyscan_t yyscanner);
 static void handleGuard(yyscan_t yyscanner,const QCString &expr);
 static int yyread(yyscan_t yyscanner,char *buf,int max_size);
 static void addCite(yyscan_t yyscanner);
@@ -1038,7 +1038,7 @@ STopt  [^\n@\\]*
                                           else // yyextra->inContext==OutputBrief
                                           { // only go to the detailed description if we have
                                             // found some brief description and not just whitespace
-                                            endBrief(yyscanner,TRUE);
+                                            endBrief(yyscanner);
                                           }
                                           lineCount(yyscanner);
                                         }
@@ -3829,7 +3829,7 @@ static void addIlineBreak(yyscan_t yyscanner,int lineNr)
   addOutput(yyscanner, cmd);
 }
 
-static void endBrief(yyscan_t yyscanner,bool addToOutput)
+static void endBrief(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (!yyextra->current->brief.stripWhiteSpace().isEmpty())
@@ -3837,8 +3837,16 @@ static void endBrief(yyscan_t yyscanner,bool addToOutput)
     // found some brief description and not just whitespace
     yyextra->briefEndsAtDot=FALSE;
     setOutput(yyscanner,OutputDoc);
-    addIline(yyscanner,yyextra->lineNr);
-    if (addToOutput) addOutput(yyscanner,yytext);
+    if (yyextra->current->doc.stripWhiteSpace().isEmpty())
+    {
+      yyextra->current->docLine = yyextra->lineNr;
+      yyextra->current->doc = "";
+    }
+    else
+    {
+      addIline(yyscanner,yyextra->lineNr);
+    }
+    addOutput(yyscanner,yytext);
   }
   else
   {


### PR DESCRIPTION
When the doc part is empty (or only contains white space) handle the (detailed) block as a new block (and don't forget to remove the possible present white space).