### PR TITLE
Remove Windows compilation warnings

### DIFF
--- a/libxml/xml.l
+++ b/libxml/xml.l
@@ -195,7 +195,7 @@ ENDCDATA        "]]>"
 <Prolog>{
   "encoding"\s*=\s*\"[^\"]*\" {
                      std::string encoding=yytext;
-                     int i=encoding.find('"');
+                     size_t i=encoding.find('"');
                      encoding=encoding.substr(i+1,yyleng-i-2);
                      if (encoding!="UTF-8") // need to transcode to UTF-8
                      {

--- a/src/aliases.cpp
+++ b/src/aliases.cpp
@@ -42,7 +42,7 @@ using AliasInfoMap   = std::unordered_map<std::string,AliasOverloads>;   // key 
 
 static QCString expandAliasRec(StringUnorderedSet &aliasesProcessed,
                                const QCString &s,bool allowRecursion=FALSE);
-static size_t countAliasArguments(const std::string &args, const std::string &sep);
+static int countAliasArguments(const std::string &args, const std::string &sep);
 static QCString extractAliasArgs(const QCString &args,size_t pos);
 static std::string expandAlias(const std::string &aliasName,const std::string &aliasValue);
 
@@ -484,9 +484,9 @@ static QCString expandAliasRec(StringUnorderedSet &aliasesProcessed,const QCStri
 }
 
 
-static size_t countAliasArguments(const std::string &args, const std::string &sep)
+static int countAliasArguments(const std::string &args, const std::string &sep)
 {
-  size_t count=1;
+  int count=1;
   size_t l = args.length();
   size_t i;
   for (i=0;i<l;i++)

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1677,7 +1677,7 @@ void DocParser::readTextFileByName(const QCString &file,QCString &text)
 
 //---------------------------------------------------------------------------
 
-static QCString extractCopyDocId(const char *data, uint32_t &j, uint32_t len)
+static QCString extractCopyDocId(const char *data, uint32_t &j, size_t len)
 {
   uint32_t s=j;
   int round=0;
@@ -1740,7 +1740,7 @@ static QCString extractCopyDocId(const char *data, uint32_t &j, uint32_t len)
    do if ((i+sizeof(str)<len) && qstrncmp(data+i+1,str,sizeof(str)-1)==0) \
    { j=i+sizeof(str); action; } while(0)
 
-static uint32_t isCopyBriefOrDetailsCmd(const char *data, uint32_t i,uint32_t len,bool &brief)
+static uint32_t isCopyBriefOrDetailsCmd(const char *data, uint32_t i,size_t len,bool &brief)
 {
   uint32_t j=0;
   if (i==0 || (data[i-1]!='@' && data[i-1]!='\\')) // not an escaped command
@@ -1751,7 +1751,7 @@ static uint32_t isCopyBriefOrDetailsCmd(const char *data, uint32_t i,uint32_t le
   return j;
 }
 
-static uint32_t isVerbatimSection(const char *data,uint32_t i,uint32_t len,QCString &endMarker)
+static uint32_t isVerbatimSection(const char *data,uint32_t i,size_t len,QCString &endMarker)
 {
   uint32_t j=0;
   if (i==0 || (data[i-1]!='@' && data[i-1]!='\\')) // not an escaped command
@@ -1775,7 +1775,7 @@ static uint32_t isVerbatimSection(const char *data,uint32_t i,uint32_t len,QCStr
   return j;
 }
 
-static uint32_t skipToEndMarker(const char *data,uint32_t i,uint32_t len,const QCString &endMarker)
+static uint32_t skipToEndMarker(const char *data,uint32_t i,size_t len,const QCString &endMarker)
 {
   while (i<len)
   {

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1790,7 +1790,7 @@ static uint32_t skipToEndMarker(const char *data,uint32_t i,size_t len,const QCS
     i++;
   }
   // oops no endmarker found...
-  return i<len ? i+1 : len;
+  return i<len ? i+1 : static_cast<uint32_t>(len);
 }
 
 

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -1450,9 +1450,9 @@ void ModuleManager::writeDocumentation(OutputList &ol)
   }
 }
 
-size_t ModuleManager::numDocumentedModules() const
+int ModuleManager::numDocumentedModules() const
 {
-  size_t count=0;
+  int count=0;
   for (auto &mod : p->moduleFileMap) // foreach module
   {
     if (mod->isPrimaryInterface()) count++;

--- a/src/moduledef.h
+++ b/src/moduledef.h
@@ -130,7 +130,7 @@ class ModuleManager
     void collectExportedSymbols();
     void countMembers();
     void writeDocumentation(OutputList &ol);
-    size_t numDocumentedModules() const;
+    int numDocumentedModules() const;
     const ModuleLinkedMap &modules() const;
     ModuleDef *getPrimaryInterface(const QCString &moduleName) const;
 

--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -65,14 +65,14 @@ QCString SearchTerm::termEncoded() const
   TextStream t;
   for (size_t i=0;i<word.length();i++)
   {
-    if (isIdJS(word[i]))
+    if (isIdJS(word.at(i)))
     {
-      t << word[i];
+      t << word.at(i);
     }
     else // escape non-identifier characters
     {
       static const char *hex = "0123456789ABCDEF";
-      unsigned char uc = static_cast<unsigned char>(word[i]);
+      unsigned char uc = static_cast<unsigned char>(word.at(i));
       t << '_';
       t << hex[uc>>4];
       t << hex[uc&0xF];
@@ -95,19 +95,21 @@ static void splitSearchTokens(QCString &title,IntVector &indices)
   bool lastIsSpace=true;
   for (size_t si=0; si<title.length(); si++)
   {
-    char c = title[si];
+    char c = title.at(si);
     if (isId(c) || c==':') // add "word" character
     {
-      title[di++]=c;
+      title.at(di)=c;
+      di++;
       lastIsSpace=false;
     }
     else if (!lastIsSpace) // add one separator as space
     {
-      title[di++]=' ';
+      title.at(di)=' ';
+      di++;
       lastIsSpace=true;
     }
   }
-  if (di>0 && title[di-1]==' ') di--; // strip trailing whitespace
+  if (di>0 && title.at(di-1)==' ') di--; // strip trailing whitespace
   title.resize(di+1);
 
   // create a list of start positions within title for

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1372,8 +1372,8 @@ bool transcodeCharacterStringToUTF8(std::string &input, const char *inputEncodin
 {
   const char *outputEncoding = "UTF-8";
   if (inputEncoding==0 || qstricmp(inputEncoding,outputEncoding)==0) return true;
-  int inputSize=input.length();
-  int outputSize=inputSize*4+1;
+  size_t inputSize=input.length();
+  size_t outputSize=inputSize*4+1;
   QCString output(outputSize);
   void *cd = portable_iconv_open(outputEncoding,inputEncoding);
   if (cd==reinterpret_cast<void *>(-1))


### PR DESCRIPTION
Removing warnings on Windows of the form:
```
warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
```
(see also the GitHub actions)