### PR TITLE
More flexible collaboration graphs regarding show / hide

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -60,6 +60,7 @@ documentation:
 \refitem cmdcite \\cite
 \refitem cmdclass \\class
 \refitem cmdcode \\code
+\refitem cmdcollaborationgraph \\collaborationgraph
 \refitem cmdconcept \\concept
 \refitem cmdcond \\cond
 \refitem cmdcopybrief \\copybrief
@@ -119,6 +120,7 @@ documentation:
 \refitem cmdheaderfile \\headerfile
 \refitem cmdhidecallergraph \\hidecallergraph
 \refitem cmdhidecallgraph \\hidecallgraph
+\refitem cmdhidecollaborationgraph \\hidecollaborationgraph
 \refitem cmdhidedirectorygraph \\hidedirectorygraph
 \refitem cmdhideincludedbygraph \\hideincludedbygraph
 \refitem cmdhideincludegraph \\hideincludegraph
@@ -514,6 +516,30 @@ Structural indicators
 
   \sa section \ref cmddirectorygraph "\\directorygraph",
       option \ref cfg_directory_graph "DIRECTORY_GRAPH"
+
+<hr>
+\section cmdcollaborationgraph \\collaborationgraph
+
+  \addindex \\collaborationgraph
+  When this command is put in a comment block of a class
+  then doxygen will generate a collaboration graph for that class. The
+  collaboration graph will be generated regardless of the value of
+  \ref cfg_collaboration_graph "COLLABORATION_GRAPH".
+
+  \sa section \ref cmdhidecollaborationgraph "\\hidecollaborationgraph",
+      option \ref cfg_collaboration_graph "COLLABORATION_GRAPH"
+
+<hr>
+\section cmdhidecollaborationgraph \\hidecollaborationgraph
+
+  \addindex \\hidecollaborationgraph
+  When this command is put in a comment block of a class
+  then doxygen will not generate a collaboration graph for that class. The
+  collaboration graph will not be generated regardless of the value of
+  \ref cfg_collaboration_graph "COLLABORATION_GRAPH".
+
+  \sa section \ref cmdcollaborationgraph "\\collaborationgraph",
+      option \ref cfg_collaboration_graph "COLLABORATION_GRAPH"
 
 <hr>
 \section cmdqualifier \\qualifier <label> | "(text)"

--- a/src/classdef.h
+++ b/src/classdef.h
@@ -400,8 +400,6 @@ class ClassDef : public Definition
                  int lt2=-1,bool invert=FALSE,bool showAlways=FALSE) const = 0;
     virtual void addGroupedInheritedMembers(OutputList &ol,MemberListType lt,
                  const ClassDef *inheritedFrom,const QCString &inheritId) const = 0;
-
-
 };
 
 class ClassDefMutable : public DefinitionMutable, public ClassDef
@@ -431,6 +429,10 @@ class ClassDefMutable : public DefinitionMutable, public ClassDef
     virtual void setMetaData(const QCString &md) = 0;
     virtual void setRequiresClause(const QCString &req) = 0;
     virtual void addQualifiers(const StringVector &qualifiers) = 0;
+
+    // collaboration graph related members
+    virtual bool hasCollaborationGraph() const = 0;
+    virtual void enableCollaborationGraph(bool e) = 0;
 
     //-----------------------------------------------------------------------------------
     // --- actions ----

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -130,6 +130,8 @@ static bool handleHideIncludegraph(yyscan_t yyscanner,const QCString &, const St
 static bool handleHideIncludedBygraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleCollaborationgraph(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleHideCollaborationgraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleReferencedByRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideReferencedByRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleReferencesRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
@@ -200,6 +202,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "class",           { &handleClass,            CommandSpacing::Invisible }},
   { "code",            { &handleFormatBlock,      CommandSpacing::Block     }},
   { "icode",           { &handleFormatBlock,      CommandSpacing::Block     }},
+  { "collaborationgraph", { &handleCollaborationgraph, CommandSpacing::Invisible }},
   { "concept",         { &handleConcept,          CommandSpacing::Invisible }},
   { "copybrief",       { &handleCopyBrief,        CommandSpacing::Invisible }},
   { "copydetails",     { &handleCopyDetails,      CommandSpacing::Block     }},
@@ -230,6 +233,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "headerfile",      { &handleHeaderFile,       CommandSpacing::Invisible }},
   { "hidecallergraph", { &handleHideCallergraph,  CommandSpacing::Invisible }},
   { "hidecallgraph",   { &handleHideCallgraph,    CommandSpacing::Invisible }},
+  { "hidecollaborationgraph", { &handleHideCollaborationgraph, CommandSpacing::Invisible }},
   { "hidedirectorygraph",  { &handleHideDirectoryGraph,  CommandSpacing::Invisible }},
   { "hideincludedbygraph", { &handleHideIncludedBygraph, CommandSpacing::Invisible }},
   { "hideincludegraph",    { &handleHideIncludegraph,    CommandSpacing::Invisible }},
@@ -3120,6 +3124,20 @@ static bool handleHideDirectoryGraph(yyscan_t yyscanner,const QCString &, const 
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->current->directoryGraph = FALSE; // OFF
+  return FALSE;
+}
+
+static bool handleCollaborationgraph(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->collaborationGraph = TRUE; // ON
+  return FALSE;
+}
+
+static bool handleHideCollaborationgraph(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->collaborationGraph = FALSE; // OFF
   return FALSE;
 }
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -3761,6 +3761,10 @@ where `loc1` and `loc2` can be relative or absolute paths or URLs.
  will generate a graph for each documented class showing the direct and
  indirect implementation dependencies (inheritance, containment, and
  class references variables) of the class with other documented classes.
+ Explicit enabling a collaboration graph, when \c COLLABORATION_GRAPH is set to \c NO, can be
+ accomplished by means of the command \ref cmdcollaborationgraph "\\collaborationgraph".
+ Disabling a collaboration graph can be accomplished by means of the command
+ \ref cmdhidecollaborationgraph "\\hidecollaborationgraph".
 ]]>
       </docs>
     </option>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1038,6 +1038,7 @@ static void addClassToContext(const Entry *root)
       cd->setClassSpecifier(root->spec);
       cd->addQualifiers(root->qualifiers);
       cd->setTypeConstraints(root->typeConstr);
+      cd->enableCollaborationGraph(root->collaborationGraph);
 
       if (tArgList)
       {

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -68,6 +68,7 @@ Entry::Entry(const Entry &e)
   includeGraph = e.includeGraph;
   includedByGraph = e.includedByGraph;
   directoryGraph = e.directoryGraph;
+  collaborationGraph = e.collaborationGraph;
   referencedByRelation = e.referencedByRelation;
   referencesRelation   = e.referencesRelation;
   exported    = e.exported;
@@ -194,6 +195,7 @@ void Entry::reset()
   bool entryIncludeGraph    = Config_getBool(INCLUDE_GRAPH);
   bool entryIncludedByGraph = Config_getBool(INCLUDED_BY_GRAPH);
   bool entryDirectoryGraph  = Config_getBool(DIRECTORY_GRAPH);
+  bool entryCollaborationGraph = Config_getBool(COLLABORATION_GRAPH);
   //printf("Entry::reset()\n");
   name.resize(0);
   type.resize(0);
@@ -229,6 +231,7 @@ void Entry::reset()
   includeGraph = entryIncludeGraph;
   includedByGraph = entryIncludedByGraph;
   directoryGraph = entryDirectoryGraph;
+  collaborationGraph = entryCollaborationGraph;
   referencedByRelation = entryReferencedByRelation;
   referencesRelation   = entryReferencesRelation;
   exported = false;

--- a/src/entry.h
+++ b/src/entry.h
@@ -259,6 +259,7 @@ class Entry
     bool includeGraph;        //!< do we need to draw the include graph?
     bool includedByGraph;     //!< do we need to draw the included by graph?
     bool directoryGraph;      //!< do we need to draw the directory graph?
+    bool collaborationGraph;  //!< do we need to draw the collaboration graph?
     bool exported;            //!< is the symbol exported from a C++20 module
     Specifier    virt;        //!< virtualness of the entry
     QCString     args;        //!< member argument string

--- a/templates/general/layout_default.xml
+++ b/templates/general/layout_default.xml
@@ -48,7 +48,7 @@
     <briefdescription visible="yes"/>
     <includes visible="$SHOW_HEADERFILE"/>
     <inheritancegraph visible="$CLASS_GRAPH"/>
-    <collaborationgraph visible="$COLLABORATION_GRAPH"/>
+    <collaborationgraph visible="yes"/>
     <memberdecl>
       <nestedclasses visible="yes" title=""/>
       <publictypes title=""/>


### PR DESCRIPTION
For call / caller / include / included by graphs it is possible to steer the graph creation process on a 1 to 1 base (commands like \callgraph and \hidecallgraph).

Introducing for the directory graphs:
```
    \collaborationgraph and \hidecollaborationgraph
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12428365/example.tar.gz)
