### PR TITLE
More flexible inheritance graphs regarding show / hide

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -126,6 +126,7 @@ documentation:
 \refitem cmdhidegroupgraph \\hidegroupgraph
 \refitem cmdhideincludedbygraph \\hideincludedbygraph
 \refitem cmdhideincludegraph \\hideincludegraph
+\refitem cmdhideinheritancegraph \\hideinheritancegraph
 \refitem cmdhiderefby \\hiderefby
 \refitem cmdhiderefs \\hiderefs
 \refitem cmdhideinitializer \\hideinitializer
@@ -142,6 +143,7 @@ documentation:
 \refitem cmdincludegraph \\includegraph
 \refitem cmdincludelineno \\includelineno
 \refitem cmdingroup \\ingroup
+\refitem cmdinheritancegraph \\inheritancegraph
 \refitem cmdinternal \\internal
 \refitem cmdinvariant \\invariant
 \refitem cmdinterface \\interface
@@ -542,6 +544,34 @@ Structural indicators
 
   \sa section \ref cmdcollaborationgraph "\\collaborationgraph",
       option \ref cfg_collaboration_graph "COLLABORATION_GRAPH"
+
+<hr>
+\section cmdinheritancegraph \\inheritancegraph['{option}']
+
+  \addindex \\inheritancegraph
+  When this command is put in a comment block of a class
+  then doxygen will generate an inheritance graph for that class conforming the `option`.
+  The inheritance graph will be generated, conforming the `option`, regardless of the value of
+  \ref cfg_class_graph "CLASS_GRAPH".
+  The possible values of `option` are the smae valuesz as can be used with \ref cfg_class_graph "CLASS_GRAPH".
+  In case no `option` is specified the vaue `YES` is assumed.
+
+  \sa section \ref cmdhideinheritancegraph "\\hideinheritancegraph",
+      option \ref cfg_class_graph "CLASS_GRAPH"
+
+<hr>
+\section cmdhideinheritancegraph \\hideinheritancegraph
+
+  \addindex \\hideinheritancegraph
+  When this command is put in a comment block of a class
+  then doxygen will not generate an inheritance graph for that class. The
+  inheritance graph will not be generated regardless of the value of
+  \ref cfg_class_graph "CLASS_GRAPH".
+
+  \sa section \ref cmdinheritancegraph "\\inheritancegraph",
+      option \ref cfg_class_graph "CLASS_GRAPH"
+
+<hr>
 \section cmdgroupgraph \\groupgraph
 
   \addindex \\groupgraph

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -344,6 +344,9 @@ class ClassDefImpl : public DefinitionMixin<ClassDefMutable>
                  bool showInline=FALSE,const ClassDef *inheritedFrom=0,
                  int lt2=-1,bool invert=FALSE,bool showAlways=FALSE) const override;
     virtual void setRequiresClause(const QCString &req) override;
+        // inheritance graph related members
+    virtual CLASS_GRAPH_t inheritanceGraphType() const override;
+    virtual void setTypeInheritanceGraph(CLASS_GRAPH_t e) override;
 
     // directory graph related members
     virtual bool hasCollaborationGraph() const override;
@@ -786,6 +789,7 @@ class ClassDefImpl::IMPL
     StringVector qualifiers;
 
     bool hasCollaborationGraph = false;
+    CLASS_GRAPH_t typeInheritanceGraph = CLASS_GRAPH_t::NO;
 };
 
 void ClassDefImpl::IMPL::init(const QCString &defFileName, const QCString &name,
@@ -831,6 +835,7 @@ void ClassDefImpl::IMPL::init(const QCString &defFileName, const QCString &name,
     isLocal=FALSE;
   }
   hasCollaborationGraph = Config_getBool(COLLABORATION_GRAPH);
+  typeInheritanceGraph = Config_getEnum(CLASS_GRAPH);
 }
 
 //-------------------------------------------------------------------------------------------
@@ -1668,7 +1673,7 @@ int ClassDefImpl::countInheritanceNodes() const
 void ClassDefImpl::writeInheritanceGraph(OutputList &ol) const
 {
   bool haveDot    = Config_getBool(HAVE_DOT);
-  auto classGraph = Config_getEnum(CLASS_GRAPH);
+  auto classGraph = m_impl->typeInheritanceGraph;
 
   if (classGraph == CLASS_GRAPH_t::NO) return;
   // count direct inheritance relations
@@ -4995,6 +5000,16 @@ QCString ClassDefImpl::collaborationGraphFileName() const
 QCString ClassDefImpl::inheritanceGraphFileName() const
 {
   return m_impl->inheritFileName;
+}
+
+void ClassDefImpl::setTypeInheritanceGraph(CLASS_GRAPH_t e)
+{
+  m_impl->typeInheritanceGraph=e;
+}
+
+CLASS_GRAPH_t ClassDefImpl::inheritanceGraphType() const
+{
+  return m_impl->typeInheritanceGraph;
 }
 
 CodeSymbolType ClassDefImpl::codeSymbolType() const

--- a/src/classdef.h
+++ b/src/classdef.h
@@ -24,6 +24,7 @@
 #include "definition.h"
 #include "arguments.h"
 #include "membergroup.h"
+#include "configvalues.h"
 
 struct Argument;
 class MemberDef;
@@ -429,6 +430,9 @@ class ClassDefMutable : public DefinitionMutable, public ClassDef
     virtual void setMetaData(const QCString &md) = 0;
     virtual void setRequiresClause(const QCString &req) = 0;
     virtual void addQualifiers(const StringVector &qualifiers) = 0;
+        // inheritance graph related members
+    virtual CLASS_GRAPH_t inheritanceGraphType() const = 0;
+    virtual void setTypeInheritanceGraph(CLASS_GRAPH_t e) = 0;
 
     // collaboration graph related members
     virtual bool hasCollaborationGraph() const = 0;

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -132,6 +132,8 @@ static bool handleDirectoryGraph(yyscan_t yyscanner,const QCString &, const Stri
 static bool handleHideDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleCollaborationgraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideCollaborationgraph(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleInheritanceGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleHideInheritanceGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleReferencedByRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideReferencedByRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleReferencesRelation(yyscan_t yyscanner,const QCString &, const StringVector &);
@@ -241,6 +243,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "hidegroupgraph",  { &handleHideGroupgraph,  CommandSpacing::Invisible }},
   { "hideincludedbygraph", { &handleHideIncludedBygraph, CommandSpacing::Invisible }},
   { "hideincludegraph",    { &handleHideIncludegraph,    CommandSpacing::Invisible }},
+  { "hideinheritancegraph",{ &handleHideInheritanceGraph,CommandSpacing::Invisible }},
   { "hideinitializer", { &handleHideInitializer,  CommandSpacing::Invisible }},
   { "hiderefby",       { &handleHideReferencedByRelation, CommandSpacing::Invisible }},
   { "hiderefs",        { &handleHideReferencesRelation,   CommandSpacing::Invisible }},
@@ -257,6 +260,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "includelineno",   { 0,                       CommandSpacing::Block     }},
   { "ingroup",         { &handleIngroup,          CommandSpacing::Invisible }},
   { "inherit",         { &handleInherit,          CommandSpacing::Invisible }},
+  { "inheritancegraph",{ &handleInheritanceGraph, CommandSpacing::Invisible }},
   { "interface",       { &handleInterface,        CommandSpacing::Invisible }},
   { "internal",        { &handleInternal,         CommandSpacing::Block     }},
   { "invariant",       { 0,                       CommandSpacing::Block     }},
@@ -3156,6 +3160,51 @@ static bool handleHideGroupgraph(yyscan_t yyscanner,const QCString &, const Stri
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->current->groupGraph = FALSE; // OFF
+  return FALSE;
+}
+
+static bool handleInheritanceGraph(yyscan_t yyscanner,const QCString &, const StringVector &optList)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->inheritanceGraph = CLASS_GRAPH_t::YES;
+  for (const auto &opt_ : optList)
+  {
+    QCString opt = QCString(opt_).stripWhiteSpace().lower();
+    if (!opt.isEmpty())
+    {
+      if (opt == "yes")
+      {
+        yyextra->current->inheritanceGraph = CLASS_GRAPH_t::YES;
+      }
+      else if (opt == "graph")
+      {
+        yyextra->current->inheritanceGraph = CLASS_GRAPH_t::GRAPH;
+      }
+      else if (opt == "builtin")
+      {
+        yyextra->current->inheritanceGraph = CLASS_GRAPH_t::BUILTIN;
+      }
+      else if (opt == "text")
+      {
+        yyextra->current->inheritanceGraph = CLASS_GRAPH_t::TEXT;
+      }
+      else if (opt == "no")
+      {
+        yyextra->current->inheritanceGraph = CLASS_GRAPH_t::NO;
+      }
+      else
+      {
+        warn(yyextra->fileName,yyextra->lineNr,"Unknown option specified with \\inheritancegraph: '%s'", qPrint(QCString(opt_).stripWhiteSpace()));
+      }
+    }
+  }
+  return FALSE;
+}
+
+static bool handleHideInheritanceGraph(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->inheritanceGraph = CLASS_GRAPH_t::NO; // OFF
   return FALSE;
 }
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -3746,6 +3746,11 @@ where `loc1` and `loc2` can be relative or absolute paths or URLs.
  or if the \c CLASS_GRAPH tag is set to \c BUILTIN, then the built-in generator will be used.
  If the \c CLASS_GRAPH tag is set to \c TEXT the direct and indirect inheritance relations
  will be shown as texts / links.
+ Explicit enabling an inheritance graph or choosing a different representation for an inheritance graph
+ of a specific class, can be accomplished by means of the command
+ \ref cmdinheritancegraph "\\inheritancegraph".
+ Disabling an inheritance graph can be accomplished by means of the command
+ \ref cmdhideinheritancegraph "\\hideinheritancegraph".
 ]]>
       </docs>
       <value name="NO" bool_representation="NO" />

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -1047,6 +1047,7 @@ static void addClassToContext(const Entry *root)
       cd->addQualifiers(root->qualifiers);
       cd->setTypeConstraints(root->typeConstr);
       cd->enableCollaborationGraph(root->collaborationGraph);
+      cd->setTypeInheritanceGraph(root->inheritanceGraph);
 
       if (tArgList)
       {

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -69,6 +69,7 @@ Entry::Entry(const Entry &e)
   includedByGraph = e.includedByGraph;
   directoryGraph = e.directoryGraph;
   collaborationGraph = e.collaborationGraph;
+  inheritanceGraph = e.inheritanceGraph;
   groupGraph  = e.groupGraph;
   referencedByRelation = e.referencedByRelation;
   referencesRelation   = e.referencesRelation;
@@ -197,6 +198,7 @@ void Entry::reset()
   bool entryIncludedByGraph = Config_getBool(INCLUDED_BY_GRAPH);
   bool entryDirectoryGraph  = Config_getBool(DIRECTORY_GRAPH);
   bool entryCollaborationGraph = Config_getBool(COLLABORATION_GRAPH);
+  CLASS_GRAPH_t entryInheritanceGraph  = Config_getBool(CLASS_GRAPH);
   bool entryGroupGraph  = Config_getBool(GROUP_GRAPHS);
   //printf("Entry::reset()\n");
   name.resize(0);
@@ -234,6 +236,7 @@ void Entry::reset()
   includedByGraph = entryIncludedByGraph;
   directoryGraph = entryDirectoryGraph;
   collaborationGraph = entryCollaborationGraph;
+  inheritanceGraph = entryInheritanceGraph;
   groupGraph = entryGroupGraph;
   referencedByRelation = entryReferencedByRelation;
   referencesRelation   = entryReferencesRelation;

--- a/src/entry.h
+++ b/src/entry.h
@@ -26,6 +26,7 @@
 #include "arguments.h"
 #include "reflist.h"
 #include "textstream.h"
+#include "configvalues.h"
 
 class SectionInfo;
 class FileDef;
@@ -260,6 +261,7 @@ class Entry
     bool includedByGraph;     //!< do we need to draw the included by graph?
     bool directoryGraph;      //!< do we need to draw the directory graph?
     bool collaborationGraph;  //!< do we need to draw the collaboration graph?
+    CLASS_GRAPH_t inheritanceGraph; //!< type of inheritance graph?
     bool groupGraph;          //!< do we need to draw the group graph?
     bool exported;            //!< is the symbol exported from a C++20 module
     Specifier    virt;        //!< virtualness of the entry

--- a/templates/general/layout_default.xml
+++ b/templates/general/layout_default.xml
@@ -47,7 +47,7 @@
   <class>
     <briefdescription visible="yes"/>
     <includes visible="$SHOW_HEADERFILE"/>
-    <inheritancegraph visible="$CLASS_GRAPH"/>
+    <inheritancegraph visible="yes"/>
     <collaborationgraph visible="yes"/>
     <memberdecl>
       <nestedclasses visible="yes" title=""/>


### PR DESCRIPTION
For call / caller / include / included by graphs it is possible to steer the graph creation process on a 1 to 1 base (commands like \callgraph and \hidecallgraph).

Introducing for the directory graphs:
```
    \inheritancegraph and \hideinheritacegraph
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12438536/example.tar.gz)
