### PR TITLE
bug_746577 Problem locating unresolvable @ref in case of a MSC image

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -2079,11 +2079,16 @@ IDocNodeASTPtr validatingParseText(IDocParser &parserIntf,const QCString &input)
   return ast;
 }
 
-IDocNodeASTPtr createRef(IDocParser &parserIntf,const QCString &target,const QCString &context)
+IDocNodeASTPtr createRef(IDocParser &parserIntf,const QCString &target,const QCString &context, const QCString &srcFile, int srcLine )
 {
   DocParser *parser = dynamic_cast<DocParser*>(&parserIntf);
   assert(parser!=0);
   if (parser==0) return 0;
+  if (!srcFile.isEmpty())
+  {
+    parser->context.fileName = srcFile;
+    parser->tokenizer.setLineNr(srcLine);
+  }
   return std::make_unique<DocNodeAST>(DocRef(parser,0,target,context));
 }
 

--- a/src/docparser.h
+++ b/src/docparser.h
@@ -87,7 +87,7 @@ IDocNodeASTPtr validatingParseDoc(IDocParser &parserIntf,const QCString &fileNam
  */
 IDocNodeASTPtr validatingParseText(IDocParser &parser,const QCString &input);
 
-IDocNodeASTPtr createRef(IDocParser &parser,const QCString &target,const QCString &context);
+IDocNodeASTPtr createRef(IDocParser &parser,const QCString &target,const QCString &context, const QCString &srcFile = "", int srcLine = -1);
 
 //--------------------------------------------------------------------------------
 


### PR DESCRIPTION
- get better filename and line number (in case of inline image the end of the inline image)
- in case link don't exist don't create it