### PR TITLE
Remove obsolete parts from cmake configuration files

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -118,12 +118,7 @@ if (build_doc_chm)
 )
 endif ()
 
-if (${CMAKE_VERSION} VERSION_EQUAL "3.11.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.11.0")
-    file(GLOB LANG_FILES CONFIGURE_DEPENDS "${TOP}/src//translator_??.h")
-else()
-    file(GLOB LANG_FILES "${TOP}/src//translator_??.h")
-endif()
-
+file(GLOB LANG_FILES CONFIGURE_DEPENDS "${TOP}/src//translator_??.h")
 
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/man
                     ${PROJECT_BINARY_DIR}/src

--- a/doc_internal/CMakeLists.txt
+++ b/doc_internal/CMakeLists.txt
@@ -27,11 +27,7 @@ set(DOC_FILES
         translator.py
 )
 
-if (${CMAKE_VERSION} VERSION_EQUAL "3.11.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.11.0")
-    file(GLOB LANG_FILES CONFIGURE_DEPENDS "${TOP}/src//translator_??.h")
-else()
-    file(GLOB LANG_FILES "${TOP}/src//translator_??.h")
-endif()
+file(GLOB LANG_FILES CONFIGURE_DEPENDS "${TOP}/src//translator_??.h")
 
 foreach (f  ${DOC_FILES})
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/doc_internal/${f}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,11 +23,7 @@ endif()
 
 
 file(MAKE_DIRECTORY ${GENERATED_SRC})
-if (${CMAKE_VERSION} VERSION_EQUAL "3.11.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.11.0")
-    file(GLOB LANGUAGE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/translator_??.h")
-else()
-    file(GLOB LANGUAGE_FILES "${CMAKE_CURRENT_LIST_DIR}/translator_??.h")
-endif()
+file(GLOB LANGUAGE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/translator_??.h")
 
 # instead of increasebuffer.py
 add_definitions(-DYY_BUF_SIZE=${enlarge_lex_buffers} -DYY_READ_BUF_SIZE=${enlarge_lex_buffers})
@@ -84,11 +80,7 @@ add_custom_command(
 set_source_files_properties(${GENERATED_SRC}/ce_parse.h PROPERTIES GENERATED 1)
 
 # all resource files
-if (${CMAKE_VERSION} VERSION_EQUAL "3.11.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.11.0")
-    file(GLOB RESOURCES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/templates/*/*)
-else()
-    file(GLOB RESOURCES ${PROJECT_SOURCE_DIR}/templates/*/*)
-endif()
+file(GLOB RESOURCES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/templates/*/*)
 
 # resources.cpp
 add_custom_command(

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -6,11 +6,7 @@ add_custom_target(tests
 )
 
 # get the files in the testing directory starting with 3 digits and an underscore
-if (${CMAKE_VERSION} VERSION_EQUAL "3.11.0" OR ${CMAKE_VERSION} VERSION_GREATER "3.11.0")
-  file(GLOB TEST_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/[0-9][0-9][0-9]_*.*")
-else()
-  file(GLOB TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/[0-9][0-9][0-9]_*.*")
-endif()
+file(GLOB TEST_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/[0-9][0-9][0-9]_*.*")
 
 foreach(TEST_FILE ${TEST_FILES})
   # extract the test name from the file name


### PR DESCRIPTION
Doxygen requires CMake version 3.14
Removing parts that tested against CMake version 3.11 (the `testing/CMakeLists.txt` was actually introduced in CMake version 3.12, so test was not 100% either)