### PR TITLE
Removing shadowed variables

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4573,16 +4573,16 @@ QCString substituteTemplateArgumentsInString(
       {
         if (formArg.name==n && actualArgs && actIt!=actualArgs->end() && !actArg.type.isEmpty()) // base class is a template argument
         {
-          static constexpr auto hasRecursion = [](const QCString &name,const QCString &subst) -> bool
+          static constexpr auto hasRecursion = [](const QCString &nameArg,const QCString &subst) -> bool
           {
-            int i;
-            int p=0;
-            while ((i=subst.find(name,p))!=-1)
+            int ii;
+            int pp=0;
+            while ((ii=subst.find(nameArg,pp))!=-1)
             {
-              bool beforeNonWord = i==0 || !isId(subst.at(i-1));
-              bool afterNonWord  = subst.length()==i+name.length() || !isId(subst.at(i+name.length()));
-              if (beforeNonWord && afterNonWord) return true; // if name=='A' then subst=='A::Z' or 'S<A>' or 'Z::A' should return true, but 'AA::ZZ' or 'BAH' should not match
-              p=i+name.length();
+              bool beforeNonWord = ii==0 || !isId(subst.at(ii-1));
+              bool afterNonWord  = subst.length()==ii+nameArg.length() || !isId(subst.at(ii+nameArg.length()));
+              if (beforeNonWord && afterNonWord) return true; // if nameArg=='A' then subst=='A::Z' or 'S<A>' or 'Z::A' should return true, but 'AA::ZZ' or 'BAH' should not match
+              pp=ii+nameArg.length();
             }
             return false;
           };


### PR DESCRIPTION
Removing shadowed variables as reported by CGAL and GitHub Actions :
```
/home/runner/work/doxygen/doxygen/src/util.cpp: In lambda function:
/home/runner/work/doxygen/doxygen/src/util.cpp:4576:98: warning: declaration of ‘name’ shadows a previous local [-Wshadow]
 4576 |           static constexpr auto hasRecursion = [](const QCString &name,const QCString &subst) -> bool
      |                                                                                                  ^~~~
/home/runner/work/doxygen/doxygen/src/util.cpp:4528:15: note: shadowed declaration is here
 4528 |   std::string name = nm.str();
      |               ^~~~
/home/runner/work/doxygen/doxygen/src/util.cpp:4578:17: warning: declaration of ‘i’ shadows a previous local [-Wshadow]
 4578 |             int i;
      |                 ^
/home/runner/work/doxygen/doxygen/src/util.cpp:4536:12: note: shadowed declaration is here
 4536 |     size_t i = match.position();
      |            ^
/home/runner/work/doxygen/doxygen/src/util.cpp:4579:17: warning: declaration of ‘p’ shadows a previous local [-Wshadow]
 4579 |             int p=0;
      |                 ^
/home/runner/work/doxygen/doxygen/src/util.cpp:4531:10: note: shadowed declaration is here
 4531 |   size_t p=0;
      |          ^
```