### PR TITLE
bug_746577 Problem locating unresolvable @ref in case of a dot image

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -310,7 +310,7 @@ void writeDotImageMapFromFile(TextStream &t,
   {
     QCString svgName = outDir+"/"+baseName+".svg";
     DotFilePatcher::writeSVGFigureLink(t,relPath,baseName,svgName);
-    DotFilePatcher patcher(svgName);
+    DotFilePatcher patcher(svgName,srcFile,srcLine);
     patcher.addSVGConversion("",TRUE,context,TRUE,graphId);
     patcher.run();
   }
@@ -319,7 +319,7 @@ void writeDotImageMapFromFile(TextStream &t,
     TextStream tt;
     t << "<img src=\"" << relPath << imgName << "\" alt=\""
       << imgName << "\" border=\"0\" usemap=\"#" << mapName << "\"/>\n";
-    DotFilePatcher::convertMapFile(tt, absOutFile, relPath ,TRUE, context);
+    DotFilePatcher::convertMapFile(tt, absOutFile, relPath ,TRUE, context,srcFile,srcLine);
     if (!tt.empty())
     {
       t << "<map name=\"" << mapName << "\" id=\"" << mapName << "\">";

--- a/src/dotfilepatcher.h
+++ b/src/dotfilepatcher.h
@@ -26,7 +26,7 @@ class TextStream;
 class DotFilePatcher
 {
   public:
-    DotFilePatcher(const QCString &patchFile);
+    DotFilePatcher(const QCString &patchFile, const QCString &srcFile="", int srcLine=-1);
     int addMap(const QCString &mapFile,const QCString &relPath,
                bool urlOnly,const QCString &context,const QCString &label);
 
@@ -43,7 +43,7 @@ class DotFilePatcher
 
     static bool convertMapFile(TextStream &t,const QCString &mapName,
                                const QCString &relPath, bool urlOnly=FALSE,
-                               const QCString &context=QCString());
+                               const QCString &context=QCString(), const QCString &srcFile="", int srcLine=-1);
 
     static bool writeSVGFigureLink(TextStream &out,const QCString &relPath,
                                    const QCString &baseName,const QCString &absImgName);
@@ -68,6 +68,8 @@ class DotFilePatcher
     };
     std::vector<Map> m_maps;
     QCString m_patchFile;
+    QCString m_srcFile;
+    int m_srcLine;
 };
 
 


### PR DESCRIPTION
Analogous for the fix with MSC images the fix for `\ref` is also applied to dot images.
(see the pull request #10270)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12503917/example.tar.gz)
