### PR TITLE
Fix linking doxyapp and doxyparse to spdlog

### DIFF
--- a/addon/doxyapp/CMakeLists.txt
+++ b/addon/doxyapp/CMakeLists.txt
@@ -46,7 +46,7 @@ mscgen
 doxygen_version
 doxycfg
 vhdlparser
-spdlog
+spdlog::spdlog
 ${ICONV_LIBRARIES}
 ${CMAKE_THREAD_LIBS_INIT}
 ${SQLITE3_LIBRARIES}

--- a/addon/doxyparse/CMakeLists.txt
+++ b/addon/doxyparse/CMakeLists.txt
@@ -35,7 +35,7 @@ mscgen
 doxygen_version
 doxycfg
 vhdlparser
-spdlog
+spdlog::spdlog
 ${ICONV_LIBRARIES}
 ${CMAKE_THREAD_LIBS_INIT}
 ${SQLITE3_LIBRARIES}


### PR DESCRIPTION
Use spdlog::spdlog instead of spdlog to link to fmt if spdlog were built against an external one.