### PR TITLE
bug_692887 groups display empty Detail Description

### DIFF
--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -778,8 +778,8 @@ void GroupDefImpl::writeTagFile(TextStream &tagFile)
 
 void GroupDefImpl::writeDetailedDescription(OutputList &ol,const QCString &title)
 {
-  if ((!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF))
-      || !documentation().isEmpty() || !inbodyDocumentation().isEmpty()
+  if ((!briefDescription().stripWhiteSpace().isEmpty() && Config_getBool(REPEAT_BRIEF))
+      || !documentation().stripWhiteSpace().isEmpty() || !inbodyDocumentation().stripWhiteSpace().isEmpty()
      )
   {
     ol.pushGeneratorState();


### PR DESCRIPTION
As indicated in the issue the `documentation()` is not empty (it contains just white space), stripping this out fixes the problem. (done also for the other parts, to be on the safe side)