### PR TITLE
add bibtex to testing readme as dependency

### DIFF
--- a/testing/README.txt
+++ b/testing/README.txt
@@ -52,6 +52,8 @@ The runtests.py has the following dependencies on 3rd party tools:
 - python  to run the script
 - xmllint to normalize the XML output
 - diff    to show the differences in case a test fails
+- LaTeX   for test 12 and when testing with --pdf flag (with adequate packages)
+- perl    for test 12
 
 Each test file can have a number of special comment lines that are extracted by
 the runtests.py script and take the form:


### PR DESCRIPTION
building doxygen before graphical environment, so no tex at this point
with 1.9.6 and 1.9.7 test 012 fails, as far as I can tell it is because I don't have bibtex