### PR TITLE
Warning about internal doxygen inconsistency for python packages

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -589,7 +589,7 @@ QCString removeRedundantWhiteSpace(const QCString &s)
     if (csp<6 && c==constScope[csp] && // character matches substring "const"
          (csp>0 ||                     // inside search string
           i==0  ||                     // if it is the first character
-          !isId(pc)                    // the previous may not be a digit
+          !(isId(pc) || pc==':')       // the previous may not be a digit or a colon
          )
        )
       csp++;
@@ -597,9 +597,9 @@ QCString removeRedundantWhiteSpace(const QCString &s)
       csp=0;
 
     if (vosp<6 && c==volatileScope[vosp] && // character matches substring "volatile"
-         (vosp>0 ||                     // inside search string
-          i==0  ||                     // if it is the first character
-          !isId(pc)                    // the previous may not be a digit
+         (vosp>0 ||                         // inside search string
+          i==0  ||                          // if it is the first character
+          !(isId(pc) || pc==':')            // the previous may not be a digit or a colon
          )
        )
       vosp++;
@@ -610,7 +610,7 @@ QCString removeRedundantWhiteSpace(const QCString &s)
     if (vsp<8 && c==virtualScope[vsp] && // character matches substring "virtual"
          (vsp>0 ||                       // inside search string
           i==0  ||                       // if it is the first character
-          !isId(pc)                      // the previous may not be a digit
+          !(isId(pc) || pc==':')         // the previous may not be a digit or a colon
          )
        )
       vsp++;
@@ -621,7 +621,7 @@ QCString removeRedundantWhiteSpace(const QCString &s)
     if (osp<11 && (osp>=8 || c==operatorScope[osp]) && // character matches substring "operator" followed by 3 arbitrary characters
         (osp>0 ||                         // inside search string
          i==0 ||                          // if it is the first character
-         !isId(pc)                        // the previous may not be a digit
+         !(isId(pc) || pc==':')           // the previous may not be a digit or a colon
         )
        )
       osp++;


### PR DESCRIPTION
In the Ansible package (through Fossies) we get warnings like:
```
.../lib/ansible/module_utils/facts/virtual/base.py:27: warning: Internal inconsistency: scope for class ansible::module_utils::facts::virtual ::base::Virtual not found!
```
Due to the naming of python the classes in doxygen it is possible that those names will contain reserved names as the path is used in the identification of the class (here `virtual`). When a `:` is in front of the word it is a class name and no space should be appended.