### PR TITLE
bug_651081 Inconsistency between @page and @subpage parsing

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1670,7 +1670,7 @@ STopt  [^\n@\\]*
 
   /* ----- handle arguments of the subpage command ------- */
 
-<SubpageLabel>{LABELID}                 { // first argument
+<SubpageLabel>{FILE}                    { // first argument
                                           addOutput(yyscanner,yytext);
                                           // we add subpage labels as a kind of "inheritance" relation to prevent
                                           // needing to add another list to the Entry class.


### PR DESCRIPTION
Align usage of the "label" for the `\page` and `\subpage` command