### PR TITLE
Incorrect showing of hidden call graph

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3655,10 +3655,10 @@ static void buildFunctionList(const Entry *root)
 
                   md->addSectionsToDefinition(root->anchors);
 
-                  md->enableCallGraph(md->hasCallGraph(), root->callGraph);
-                  md->enableCallerGraph(md->hasCallerGraph(), root->callerGraph);
-                  md->enableReferencedByRelation(md->hasReferencedByRelation(), root->referencedByRelation);
-                  md->enableReferencesRelation(md->hasReferencesRelation(), root->referencesRelation);
+                  md->mergeEnableCallGraph(root->callGraph);
+                  md->mergeEnableCallerGraph(root->callerGraph);
+                  md->mergeEnableReferencedByRelation(root->referencedByRelation);
+                  md->mergeEnableReferencesRelation(root->referencesRelation);
                   md->addQualifiers(root->qualifiers);
 
                   // merge ingroup specifiers
@@ -3805,16 +3805,16 @@ static void findFriends()
             }
             mmd->setDocsForDefinition(fmd->isDocsForDefinition());
 
-            mmd->enableCallGraph(mmd->hasCallGraph(), fmd->hasCallGraph());
-            mmd->enableCallerGraph(mmd->hasCallerGraph(), fmd->hasCallerGraph());
-            mmd->enableReferencedByRelation(mmd->hasReferencedByRelation(), fmd->hasReferencedByRelation());
-            mmd->enableReferencesRelation(mmd->hasReferencesRelation(), fmd->hasReferencesRelation());
+            mmd->mergeEnableCallGraph(fmd->hasCallGraph());
+            mmd->mergeEnableCallerGraph(fmd->hasCallerGraph());
+            mmd->mergeEnableReferencedByRelation(fmd->hasReferencedByRelation());
+            mmd->mergeEnableReferencesRelation(fmd->hasReferencesRelation());
             mmd->addQualifiers(fmd->getQualifiers());
 
-            fmd->enableCallGraph(mmd->hasCallGraph(), fmd->hasCallGraph());
-            fmd->enableCallerGraph(mmd->hasCallerGraph(), fmd->hasCallerGraph());
-            fmd->enableReferencedByRelation(mmd->hasReferencedByRelation(), fmd->hasReferencedByRelation());
-            fmd->enableReferencesRelation(mmd->hasReferencesRelation(), fmd->hasReferencesRelation());
+            fmd->mergeEnableCallGraph(mmd->hasCallGraph());
+            fmd->mergeEnableCallerGraph(mmd->hasCallerGraph());
+            fmd->mergeEnableReferencedByRelation(mmd->hasReferencedByRelation());
+            fmd->mergeEnableReferencesRelation(mmd->hasReferencesRelation());
             fmd->addQualifiers(mmd->getQualifiers());
           }
         }
@@ -5198,10 +5198,10 @@ static void addMemberDocs(const Entry *root,
     md->setRefItems(root->sli);
   }
 
-  md->enableCallGraph(md->hasCallGraph(), root->callGraph);
-  md->enableCallerGraph(md->hasCallerGraph(), root->callerGraph);
-  md->enableReferencedByRelation(md->hasReferencedByRelation(), root->referencedByRelation);
-  md->enableReferencesRelation(md->hasReferencesRelation(), root->referencesRelation);
+  md->mergeEnableCallGraph(root->callGraph);
+  md->mergeEnableCallerGraph(root->callerGraph);
+  md->mergeEnableReferencedByRelation(root->referencedByRelation);
+  md->mergeEnableReferencesRelation(root->referencesRelation);
   md->addQualifiers(root->qualifiers);
 
   md->mergeMemberSpecifiers(spec);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3655,10 +3655,10 @@ static void buildFunctionList(const Entry *root)
 
                   md->addSectionsToDefinition(root->anchors);
 
-                  md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-                  md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
-                  md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
-                  md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+                  md->enableCallGraph(md->hasCallGraph(), root->callGraph);
+                  md->enableCallerGraph(md->hasCallerGraph(), root->callerGraph);
+                  md->enableReferencedByRelation(md->hasReferencedByRelation(), root->referencedByRelation);
+                  md->enableReferencesRelation(md->hasReferencesRelation(), root->referencesRelation);
                   md->addQualifiers(root->qualifiers);
 
                   // merge ingroup specifiers
@@ -3805,16 +3805,16 @@ static void findFriends()
             }
             mmd->setDocsForDefinition(fmd->isDocsForDefinition());
 
-            mmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
-            mmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
-            mmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
-            mmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
+            mmd->enableCallGraph(mmd->hasCallGraph(), fmd->hasCallGraph());
+            mmd->enableCallerGraph(mmd->hasCallerGraph(), fmd->hasCallerGraph());
+            mmd->enableReferencedByRelation(mmd->hasReferencedByRelation(), fmd->hasReferencedByRelation());
+            mmd->enableReferencesRelation(mmd->hasReferencesRelation(), fmd->hasReferencesRelation());
             mmd->addQualifiers(fmd->getQualifiers());
 
-            fmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
-            fmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
-            fmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
-            fmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
+            fmd->enableCallGraph(mmd->hasCallGraph(), fmd->hasCallGraph());
+            fmd->enableCallerGraph(mmd->hasCallerGraph(), fmd->hasCallerGraph());
+            fmd->enableReferencedByRelation(mmd->hasReferencedByRelation(), fmd->hasReferencedByRelation());
+            fmd->enableReferencesRelation(mmd->hasReferencesRelation(), fmd->hasReferencesRelation());
             fmd->addQualifiers(mmd->getQualifiers());
           }
         }
@@ -5198,10 +5198,10 @@ static void addMemberDocs(const Entry *root,
     md->setRefItems(root->sli);
   }
 
-  md->enableCallGraph(md->hasCallGraph() || root->callGraph);
-  md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
-  md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
-  md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+  md->enableCallGraph(md->hasCallGraph(), root->callGraph);
+  md->enableCallerGraph(md->hasCallerGraph(), root->callerGraph);
+  md->enableReferencedByRelation(md->hasReferencedByRelation(), root->referencedByRelation);
+  md->enableReferencesRelation(md->hasReferencesRelation(), root->referencesRelation);
   md->addQualifiers(root->qualifiers);
 
   md->mergeMemberSpecifiers(spec);

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -293,9 +293,13 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual void setFromAnonymousScope(bool b) override;
     virtual void setFromAnonymousMember(MemberDef *m) override;
     virtual void enableCallGraph(bool e) override;
+    virtual void enableCallGraph(bool e1, bool e2) override;
     virtual void enableCallerGraph(bool e) override;
+    virtual void enableCallerGraph(bool e1, bool e2) override;
     virtual void enableReferencedByRelation(bool e) override;
+    virtual void enableReferencedByRelation(bool e1, bool e2) override;
     virtual void enableReferencesRelation(bool e) override;
+    virtual void enableReferencesRelation(bool e1, bool e2) override;
     virtual void setTemplateMaster(MemberDef *mt) override;
     virtual void addListReference(Definition *d) override;
     virtual void setDocsForDefinition(bool b) override;
@@ -4810,10 +4814,24 @@ void MemberDefImpl::enableCallGraph(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
+void MemberDefImpl::enableCallGraph(bool e1, bool e2)
+{
+  if (e1 == e2) m_hasCallGraph=e1;
+  else m_hasCallGraph=!Config_getBool(CALL_GRAPH);
+  if (m_hasCallGraph) Doxygen::parseSourcesNeeded = TRUE;
+}
+
 void MemberDefImpl::enableCallerGraph(bool e)
 {
   m_hasCallerGraph=e;
   if (e) Doxygen::parseSourcesNeeded = TRUE;
+}
+
+void MemberDefImpl::enableCallerGraph(bool e1, bool e2)
+{
+  if (e1 == e2) m_hasCallerGraph=e1;
+  else m_hasCallerGraph=!Config_getBool(CALLER_GRAPH);
+  if (m_hasCallerGraph) Doxygen::parseSourcesNeeded = TRUE;
 }
 
 void MemberDefImpl::enableReferencedByRelation(bool e)
@@ -4822,10 +4840,24 @@ void MemberDefImpl::enableReferencedByRelation(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
+void MemberDefImpl::enableReferencedByRelation(bool e1, bool e2)
+{
+  if (e1 == e2) m_hasReferencedByRelation=e1;
+  else m_hasReferencedByRelation=!Config_getBool(REFERENCED_BY_RELATION);
+  if (m_hasReferencedByRelation) Doxygen::parseSourcesNeeded = TRUE;
+}
+
 void MemberDefImpl::enableReferencesRelation(bool e)
 {
   m_hasReferencesRelation=e;
   if (e) Doxygen::parseSourcesNeeded = TRUE;
+}
+
+void MemberDefImpl::enableReferencesRelation(bool e1, bool e2)
+{
+  if (e1 == e2) m_hasReferencesRelation=e1;
+  else m_hasReferencesRelation=!Config_getBool(REFERENCES_RELATION);
+  if (m_hasReferencesRelation) Doxygen::parseSourcesNeeded = TRUE;
 }
 
 bool MemberDefImpl::isObjCMethod() const
@@ -6118,15 +6150,15 @@ void combineDeclarationAndDefinition(MemberDefMutable *mdec,MemberDefMutable *md
       mdef->setMemberDeclaration(mdec);
       mdec->setMemberDefinition(mdef);
 
-      mdef->enableCallGraph(mdec->hasCallGraph() || mdef->hasCallGraph());
-      mdef->enableCallerGraph(mdec->hasCallerGraph() || mdef->hasCallerGraph());
-      mdec->enableCallGraph(mdec->hasCallGraph() || mdef->hasCallGraph());
-      mdec->enableCallerGraph(mdec->hasCallerGraph() || mdef->hasCallerGraph());
+      mdef->enableCallGraph(mdec->hasCallGraph(), mdef->hasCallGraph());
+      mdef->enableCallerGraph(mdec->hasCallerGraph(), mdef->hasCallerGraph());
+      mdec->enableCallGraph(mdec->hasCallGraph(), mdef->hasCallGraph());
+      mdec->enableCallerGraph(mdec->hasCallerGraph(), mdef->hasCallerGraph());
 
-      mdef->enableReferencedByRelation(mdec->hasReferencedByRelation() || mdef->hasReferencedByRelation());
-      mdef->enableReferencesRelation(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
-      mdec->enableReferencedByRelation(mdec->hasReferencedByRelation() || mdef->hasReferencedByRelation());
-      mdec->enableReferencesRelation(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
+      mdef->enableReferencedByRelation(mdec->hasReferencedByRelation(), mdef->hasReferencedByRelation());
+      mdef->enableReferencesRelation(mdec->hasReferencesRelation(), mdef->hasReferencesRelation());
+      mdec->enableReferencedByRelation(mdec->hasReferencedByRelation(), mdef->hasReferencedByRelation());
+      mdec->enableReferencesRelation(mdec->hasReferencesRelation(), mdef->hasReferencesRelation());
 
       mdef->addQualifiers(mdec->getQualifiers());
       mdec->addQualifiers(mdef->getQualifiers());

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -293,13 +293,13 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual void setFromAnonymousScope(bool b) override;
     virtual void setFromAnonymousMember(MemberDef *m) override;
     virtual void enableCallGraph(bool e) override;
-    virtual void enableCallGraph(bool e1, bool e2) override;
+    virtual void mergeEnableCallGraph(bool other) override;
     virtual void enableCallerGraph(bool e) override;
-    virtual void enableCallerGraph(bool e1, bool e2) override;
+    virtual void mergeEnableCallerGraph(bool other) override;
     virtual void enableReferencedByRelation(bool e) override;
-    virtual void enableReferencedByRelation(bool e1, bool e2) override;
+    virtual void mergeEnableReferencedByRelation(bool other) override;
     virtual void enableReferencesRelation(bool e) override;
-    virtual void enableReferencesRelation(bool e1, bool e2) override;
+    virtual void mergeEnableReferencesRelation(bool other) override;
     virtual void setTemplateMaster(MemberDef *mt) override;
     virtual void addListReference(Definition *d) override;
     virtual void setDocsForDefinition(bool b) override;
@@ -4814,11 +4814,16 @@ void MemberDefImpl::enableCallGraph(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
-void MemberDefImpl::enableCallGraph(bool e1, bool e2)
+void MemberDefImpl::mergeEnableCallGraph(bool other)
 {
-  if (e1 == e2) m_hasCallGraph=e1;
-  else m_hasCallGraph=!Config_getBool(CALL_GRAPH);
-  if (m_hasCallGraph) Doxygen::parseSourcesNeeded = TRUE;
+  if (Config_getBool(CALL_GRAPH))
+  {
+    enableCallGraph(m_hasCallGraph && other); // enabled if neither deviate from config value
+  }
+  else
+  {
+    enableCallGraph(m_hasCallGraph || other); // enabled if either deviate from config value
+  }
 }
 
 void MemberDefImpl::enableCallerGraph(bool e)
@@ -4827,11 +4832,16 @@ void MemberDefImpl::enableCallerGraph(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
-void MemberDefImpl::enableCallerGraph(bool e1, bool e2)
+void MemberDefImpl::mergeEnableCallerGraph(bool other)
 {
-  if (e1 == e2) m_hasCallerGraph=e1;
-  else m_hasCallerGraph=!Config_getBool(CALLER_GRAPH);
-  if (m_hasCallerGraph) Doxygen::parseSourcesNeeded = TRUE;
+  if (Config_getBool(CALLER_GRAPH))
+  {
+    enableCallerGraph(m_hasCallerGraph && other); // enabled if neither deviate from config value
+  }
+  else
+  {
+    enableCallerGraph(m_hasCallerGraph || other); // enabled if either deviate from config value
+  }
 }
 
 void MemberDefImpl::enableReferencedByRelation(bool e)
@@ -4840,11 +4850,16 @@ void MemberDefImpl::enableReferencedByRelation(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
-void MemberDefImpl::enableReferencedByRelation(bool e1, bool e2)
+void MemberDefImpl::mergeEnableReferencedByRelation(bool other)
 {
-  if (e1 == e2) m_hasReferencedByRelation=e1;
-  else m_hasReferencedByRelation=!Config_getBool(REFERENCED_BY_RELATION);
-  if (m_hasReferencedByRelation) Doxygen::parseSourcesNeeded = TRUE;
+  if (Config_getBool(REFERENCED_BY_RELATION))
+  {
+    enableReferencedByRelation(m_hasReferencedByRelation && other); // enabled if neither deviate from config value
+  }
+  else
+  {
+    enableReferencedByRelation(m_hasReferencedByRelation || other); // enabled if either deviate from config value
+  }
 }
 
 void MemberDefImpl::enableReferencesRelation(bool e)
@@ -4853,11 +4868,16 @@ void MemberDefImpl::enableReferencesRelation(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
-void MemberDefImpl::enableReferencesRelation(bool e1, bool e2)
+void MemberDefImpl::mergeEnableReferencesRelation(bool other)
 {
-  if (e1 == e2) m_hasReferencesRelation=e1;
-  else m_hasReferencesRelation=!Config_getBool(REFERENCES_RELATION);
-  if (m_hasReferencesRelation) Doxygen::parseSourcesNeeded = TRUE;
+  if (Config_getBool(REFERENCES_RELATION))
+  {
+    enableReferencesRelation(m_hasReferencesRelation && other); // enabled if neither deviate from config value
+  }
+  else
+  {
+    enableReferencesRelation(m_hasReferencesRelation || other); // enabled if either deviate from config value
+  }
 }
 
 bool MemberDefImpl::isObjCMethod() const
@@ -6150,15 +6170,15 @@ void combineDeclarationAndDefinition(MemberDefMutable *mdec,MemberDefMutable *md
       mdef->setMemberDeclaration(mdec);
       mdec->setMemberDefinition(mdef);
 
-      mdef->enableCallGraph(mdec->hasCallGraph(), mdef->hasCallGraph());
-      mdef->enableCallerGraph(mdec->hasCallerGraph(), mdef->hasCallerGraph());
-      mdec->enableCallGraph(mdec->hasCallGraph(), mdef->hasCallGraph());
-      mdec->enableCallerGraph(mdec->hasCallerGraph(), mdef->hasCallerGraph());
+      mdef->mergeEnableCallGraph(mdec->hasCallGraph());
+      mdef->mergeEnableCallerGraph(mdec->hasCallerGraph());
+      mdec->mergeEnableCallGraph( mdef->hasCallGraph());
+      mdec->mergeEnableCallerGraph(mdef->hasCallerGraph());
 
-      mdef->enableReferencedByRelation(mdec->hasReferencedByRelation(), mdef->hasReferencedByRelation());
-      mdef->enableReferencesRelation(mdec->hasReferencesRelation(), mdef->hasReferencesRelation());
-      mdec->enableReferencedByRelation(mdec->hasReferencedByRelation(), mdef->hasReferencedByRelation());
-      mdec->enableReferencesRelation(mdec->hasReferencesRelation(), mdef->hasReferencesRelation());
+      mdef->mergeEnableReferencedByRelation(mdec->hasReferencedByRelation());
+      mdef->mergeEnableReferencesRelation(mdec->hasReferencesRelation());
+      mdec->mergeEnableReferencedByRelation(mdef->hasReferencedByRelation());
+      mdec->mergeEnableReferencesRelation(mdef->hasReferencesRelation());
 
       mdef->addQualifiers(mdec->getQualifiers());
       mdec->addQualifiers(mdef->getQualifiers());

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -380,10 +380,14 @@ class MemberDefMutable : public DefinitionMutable, public MemberDef
     virtual void setFromAnonymousMember(MemberDef *m) = 0;
 
     virtual void enableCallGraph(bool e) = 0;
+    virtual void enableCallGraph(bool e1, bool e2) = 0;
     virtual void enableCallerGraph(bool e) = 0;
+    virtual void enableCallerGraph(bool e1, bool e2) = 0;
 
     virtual void enableReferencedByRelation(bool e) = 0;
+    virtual void enableReferencedByRelation(bool e1, bool e2) = 0;
     virtual void enableReferencesRelation(bool e) = 0;
+    virtual void enableReferencesRelation(bool e1, bool e2) = 0;
 
     virtual void setTemplateMaster(MemberDef *mt) = 0;
     virtual void addListReference(Definition *d) = 0;

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -380,14 +380,14 @@ class MemberDefMutable : public DefinitionMutable, public MemberDef
     virtual void setFromAnonymousMember(MemberDef *m) = 0;
 
     virtual void enableCallGraph(bool e) = 0;
-    virtual void enableCallGraph(bool e1, bool e2) = 0;
+    virtual void mergeEnableCallGraph(bool other) = 0;
     virtual void enableCallerGraph(bool e) = 0;
-    virtual void enableCallerGraph(bool e1, bool e2) = 0;
+    virtual void mergeEnableCallerGraph(bool other) = 0;
 
     virtual void enableReferencedByRelation(bool e) = 0;
-    virtual void enableReferencedByRelation(bool e1, bool e2) = 0;
+    virtual void mergeEnableReferencedByRelation(bool other) = 0;
     virtual void enableReferencesRelation(bool e) = 0;
-    virtual void enableReferencesRelation(bool e1, bool e2) = 0;
+    virtual void mergeEnableReferencesRelation(bool other) = 0;
 
     virtual void setTemplateMaster(MemberDef *mt) = 0;
     virtual void addListReference(Definition *d) = 0;


### PR DESCRIPTION
When having:
** aa.cpp **
```
/// \file

void fie() {}

void fie_bare() {fie();}

void fie_hide() {fie();}

void fie_show() {fie();}
```

and ** aa.h **
```
/// the called fie
void fie();

/// the fie
void fie_bare();

/// the hide fie
/// \hidecallgraph
void fie_hide();

/// the show fie
/// \callgraph
void fie_show();
```
with
```
HAVE_DOT = YES
CALL_GRAPH = YES
```
This will lead to the fact that `fie_hide` still shows a call graph although it is explicitly disabled. (analogous for caller graph, referenced by relation and references relation).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12575464/example.tar.gz)
