### PR TITLE
Handling of incorrect HTML end comment

### DIFF
--- a/doc/htmlcmds.doc
+++ b/doc/htmlcmds.doc
@@ -90,7 +90,9 @@ comments can be used:
 \verbatim
 /*! <!-- This is a comment with a comment block --> Visible text */
 \endverbatim
-The part `<!-- ... -->` will not be shown in the main documentation.
+The part `<!-- ... -->` will not be shown in the main documentation.<br>
+Note: It is explicitly forbidden to use 3 dashes before the closing greater than sign.
+Doxygen won't see that as the closing either and give a warning.
 
 
 

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1077,6 +1077,11 @@ STopt  [^\n@\\]*
 
  /* --------------   Rules for handling HTML comments ----------- */
 
+<HtmlComment>"---"[!]?">"{B}*           {
+                                          warn(yyextra->fileName,yyextra->lineNr,
+                                               "incorrect HTML end comment --->"
+                                              );
+                                        }
 <HtmlComment>"--"[!]?">"{B}*            { BEGIN( Comment ); }
 <HtmlComment>{DOCNL}                    {
                                           if (*yytext=='\n')

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -842,6 +842,8 @@ int Markdown::processNmdash(const char *data,int off,int size)
   { AUTO_TRACE_EXIT("result={}",1-count); return 1-count; } // start HTML comment
   if (count==2 && (data[2]=='>'))
   { return 0; } // end HTML comment
+  if (count==3 && (data[3]=='>'))
+  { return 0; } // end HTML comment
   if (count==2 && (off<8 || qstrncmp(data-8,"operator",8)!=0)) // -- => ndash
   {
     m_out.addStr("&ndash;");


### PR DESCRIPTION
Doxygen saw the explicitly forbidden closing comments consisting of 3 dashes followed by a greater than sign differently when having markdown enabled or not
- when markdown was enabled it was translated in a `mdash` and thus was, by accident actually correctly,  not seen as end of comment
- when markdown was not enabled it was incorrectly seen as end of HTML comment

In case of markdown, now the translating to the `mdash` is not done anymore In all cases a waring about incorrect HTML end comment  is given

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12577303/example.tar.gz)
