### PR TITLE
More flexible inline sources regarding show / hide

### DIFF
--- a/doc/commands.doc
+++ b/doc/commands.doc
@@ -127,6 +127,7 @@ documentation:
 \refitem cmdhideincludedbygraph \\hideincludedbygraph
 \refitem cmdhideincludegraph \\hideincludegraph
 \refitem cmdhideinheritancegraph \\hideinheritancegraph
+\refitem cmdhideinlinesource \\hideinlinesource
 \refitem cmdhiderefby \\hiderefby
 \refitem cmdhiderefs \\hiderefs
 \refitem cmdhideinitializer \\hideinitializer
@@ -208,6 +209,7 @@ documentation:
 \refitem cmdshort \\short
 \refitem cmdshowdate \\showdate
 \refitem cmdshowinitializer \\showinitializer
+\refitem cmdshowinlinesource \\showinlinesource
 \refitem cmdshowrefby \\showrefby
 \refitem cmdshowrefs \\showrefs
 \refitem cmdsince \\since
@@ -438,6 +440,32 @@ Structural indicators
       section \ref cmdshowrefby "\\showrefby",
       section \ref cmdhiderefby "\\hiderefby" and
       option \ref cfg_references_relation "REFERENCES_RELATION"
+
+<hr>
+\section cmdshowinlinesource \\showinlinesource
+
+  \addindex \\showinlinesource
+  When this command is put in a comment block of a function, multi-line macro,
+  enum or a list initialized variable
+  then doxygen will generate the inline source for that member. The
+  inline source will be generated regardless of the value of
+  \ref cfg_inline_sources "INLINE_SOURCES".
+
+  \sa section \ref cmdhideinlinesource "\\hideinlinesource",
+      option \ref cfg_inline_sources "INLINE_SOURCES"
+
+<hr>
+\section cmdhideinlinesource \\hideinlinesource
+
+  \addindex \\hideinlinesource
+  When this command is put in a comment block of a function, multi-line macro,
+  enum or a list initialized variable
+  then doxygen will not generate the inline source for that member. The
+  inline source will not be generated regardless of the value of
+  \ref cfg_inline_sources "INLINE_SOURCES".
+
+  \sa section \ref cmdshowinlinesource "\\showinlinesource",
+      option \ref cfg_inline_sources "INLINE_SOURCES"
 
 <hr>
 \section cmdincludegraph \\includegraph

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -126,6 +126,8 @@ static bool handleCallergraph(yyscan_t yyscanner,const QCString &, const StringV
 static bool handleHideCallergraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleIncludegraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleIncludedBygraph(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleShowInlineSource(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleHideInlineSource(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideIncludegraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleHideIncludedBygraph(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleDirectoryGraph(yyscan_t yyscanner,const QCString &, const StringVector &);
@@ -245,6 +247,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "hideincludegraph",    { &handleHideIncludegraph,    CommandSpacing::Invisible }},
   { "hideinheritancegraph",{ &handleHideInheritanceGraph,CommandSpacing::Invisible }},
   { "hideinitializer", { &handleHideInitializer,  CommandSpacing::Invisible }},
+  { "hideinlinesource",    { &handleHideInlineSource,     CommandSpacing::Invisible }},
   { "hiderefby",       { &handleHideReferencedByRelation, CommandSpacing::Invisible }},
   { "hiderefs",        { &handleHideReferencesRelation,   CommandSpacing::Invisible }},
   { "htmlinclude",     { 0,                       CommandSpacing::Inline    }},
@@ -317,6 +320,7 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "see",             { 0,                       CommandSpacing::Block     }},
   { "short",           { &handleBrief,            CommandSpacing::Invisible }},
   { "showinitializer", { &handleShowInitializer,  CommandSpacing::Invisible }},
+  { "showinlinesource",{ &handleShowInlineSource, CommandSpacing::Invisible }},
   { "showrefby",       { &handleReferencedByRelation,     CommandSpacing::Invisible }},
   { "showrefs",        { &handleReferencesRelation,       CommandSpacing::Invisible }},
   { "since",           { 0,                       CommandSpacing::Block     }},
@@ -3095,6 +3099,20 @@ static bool handleHideCallergraph(yyscan_t yyscanner,const QCString &, const Str
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   yyextra->current->callerGraph = FALSE; // OFF
+  return FALSE;
+}
+
+static bool handleShowInlineSource(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->inlineSource = TRUE; // ON
+  return FALSE;
+}
+
+static bool handleHideInlineSource(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->current->inlineSource = FALSE; // OFF
   return FALSE;
 }
 

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1067,18 +1067,18 @@ bool DefinitionImpl::hasSources() const
 /*! Write code of this definition into the documentation */
 void DefinitionImpl::writeInlineCode(OutputList &ol,const QCString &scopeName) const
 {
-  bool inlineSources = Config_getBool(INLINE_SOURCES);
-  ol.pushGeneratorState();
+  const MemberDef *thisMd = 0;
+  if (m_impl->def->definitionType()==Definition::TypeMember)
+  {
+    thisMd = toMemberDef(m_impl->def);
+  }
+  bool inlineSources = thisMd && thisMd->hasInlineSource();
   //printf("Source Fragment %s: %d-%d\n",qPrint(name()),
   //        m_impl->body->startLine,m_impl->body->endLine);
   if (inlineSources && hasSources())
   {
+    ol.pushGeneratorState();
     QCString codeFragment;
-    const MemberDef *thisMd = 0;
-    if (m_impl->def->definitionType()==Definition::TypeMember)
-    {
-      thisMd = toMemberDef(m_impl->def);
-    }
     bool isMacro = thisMd && thisMd->memberType()==MemberType_Define;
     int actualStart=m_impl->body->startLine,actualEnd=m_impl->body->endLine;
     if (readCodeFragment(m_impl->body->fileDef->absFilePath(),isMacro,
@@ -1108,8 +1108,8 @@ void DefinitionImpl::writeInlineCode(OutputList &ol,const QCString &scopeName) c
                      );
       codeOL.endCodeFragment("DoxyCode");
     }
+    ol.popGeneratorState();
   }
-  ol.popGeneratorState();
 }
 
 static inline MemberVector refMapToVector(const std::unordered_map<std::string,MemberDef *> &map)

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2129,6 +2129,7 @@ static void findUsingDeclImports(const Entry *root)
                 newMmd->enableCallerGraph(root->callerGraph);
                 newMmd->enableReferencedByRelation(root->referencedByRelation);
                 newMmd->enableReferencesRelation(root->referencesRelation);
+                newMmd->enableInlineSource(root->inlineSource);
                 newMmd->addQualifiers(root->qualifiers);
                 newMmd->setBitfields(md->bitfieldString());
                 newMmd->addSectionsToDefinition(root->anchors);
@@ -2306,6 +2307,7 @@ static MemberDef *addVariableToClass(
   mmd->enableCallerGraph(root->callerGraph);
   mmd->enableReferencedByRelation(root->referencedByRelation);
   mmd->enableReferencesRelation(root->referencesRelation);
+  mmd->enableInlineSource(root->inlineSource);
   mmd->setHidden(root->hidden);
   mmd->setArtificial(root->artificial);
   mmd->setLanguage(root->lang);
@@ -2530,6 +2532,7 @@ static MemberDef *addVariableToFile(
   mmd->enableCallerGraph(root->callerGraph);
   mmd->enableReferencedByRelation(root->referencedByRelation);
   mmd->enableReferencesRelation(root->referencesRelation);
+  mmd->enableInlineSource(root->inlineSource);
   mmd->setExplicitExternal(root->explicitExternal,fileName,root->startLine,root->startColumn);
   mmd->addQualifiers(root->qualifiers);
   //md->setOuterScope(fd);
@@ -3103,6 +3106,7 @@ static void addInterfaceOrServiceToServiceOrSingleton(
   mmd->enableCallerGraph(root->callerGraph);
   mmd->enableReferencedByRelation(root->referencedByRelation);
   mmd->enableReferencesRelation(root->referencesRelation);
+  mmd->enableInlineSource(root->inlineSource);
   mmd->addQualifiers(root->qualifiers);
 
   AUTO_TRACE("Interface member: fileName='{}' type='{}' name='{}' mtype='{}' prot={} virt={} state={} proto={} def='{}'",
@@ -3300,6 +3304,7 @@ static void addMethodToClass(const Entry *root,ClassDefMutable *cd,
   mmd->enableCallerGraph(root->callerGraph);
   mmd->enableReferencedByRelation(root->referencedByRelation);
   mmd->enableReferencesRelation(root->referencesRelation);
+  mmd->enableInlineSource(root->inlineSource);
   mmd->addQualifiers(root->qualifiers);
 
   AUTO_TRACE("function member: type='{}' scope='{}' name='{}' args='{}' proto={} def='{}'",
@@ -3402,6 +3407,7 @@ static void addGlobalFunction(const Entry *root,const QCString &rname,const QCSt
   mmd->enableCallerGraph(root->callerGraph);
   mmd->enableReferencedByRelation(root->referencedByRelation);
   mmd->enableReferencesRelation(root->referencesRelation);
+  mmd->enableInlineSource(root->inlineSource);
   mmd->addQualifiers(root->qualifiers);
 
   mmd->setRefItems(root->sli);
@@ -3659,6 +3665,7 @@ static void buildFunctionList(const Entry *root)
                   md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
                   md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
                   md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+                  md->enableInlineSource(md->hasInlineSource(), root->inlineSource);
                   md->addQualifiers(root->qualifiers);
 
                   // merge ingroup specifiers
@@ -3809,12 +3816,14 @@ static void findFriends()
             mmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
             mmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
             mmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
+            mmd->enableInlineSource(mmd->hasInlineSource(), fmd->hasInlineSource());
             mmd->addQualifiers(fmd->getQualifiers());
 
             fmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
             fmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
             fmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
             fmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
+            fmd->enableInlineSource(mmd->hasInlineSource(), fmd->hasInlineSource());
             fmd->addQualifiers(mmd->getQualifiers());
           }
         }
@@ -5100,6 +5109,7 @@ static void addMemberDocs(const Entry *root,
   md->enableCallerGraph(root->callerGraph);
   md->enableReferencedByRelation(root->referencedByRelation);
   md->enableReferencesRelation(root->referencesRelation);
+  md->enableInlineSource(root->inlineSource);
   md->addQualifiers(root->qualifiers);
   ClassDefMutable *cd=md->getClassDefMutable();
   const NamespaceDef *nd=md->getNamespaceDef();
@@ -5202,6 +5212,7 @@ static void addMemberDocs(const Entry *root,
   md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
   md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
   md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
+  md->enableInlineSource(md->hasInlineSource(), root->inlineSource);
   md->addQualifiers(root->qualifiers);
 
   md->mergeMemberSpecifiers(spec);
@@ -5662,6 +5673,7 @@ static void addLocalObjCMethod(const Entry *root,
     mmd->enableCallerGraph(root->callerGraph);
     mmd->enableReferencedByRelation(root->referencedByRelation);
     mmd->enableReferencesRelation(root->referencesRelation);
+    mmd->enableInlineSource(root->inlineSource);
     mmd->addQualifiers(root->qualifiers);
     mmd->setDocumentation(root->doc,root->docFile,root->docLine);
     mmd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
@@ -6077,6 +6089,7 @@ static void addMemberSpecialization(const Entry *root,
   mmd->enableCallerGraph(root->callerGraph);
   mmd->enableReferencedByRelation(root->referencedByRelation);
   mmd->enableReferencesRelation(root->referencesRelation);
+  mmd->enableInlineSource(root->inlineSource);
   mmd->addQualifiers(root->qualifiers);
   mmd->setDocumentation(root->doc,root->docFile,root->docLine);
   mmd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
@@ -6145,6 +6158,7 @@ static void addOverloaded(const Entry *root,MemberName *mn,
     mmd->enableCallerGraph(root->callerGraph);
     mmd->enableReferencedByRelation(root->referencedByRelation);
     mmd->enableReferencesRelation(root->referencesRelation);
+    mmd->enableInlineSource(root->inlineSource);
     mmd->addQualifiers(root->qualifiers);
     QCString doc=getOverloadDocs();
     doc+="<p>";
@@ -6721,6 +6735,7 @@ static void findMember(const Entry *root,
           mmd->enableCallerGraph(root->callerGraph);
           mmd->enableReferencedByRelation(root->referencedByRelation);
           mmd->enableReferencesRelation(root->referencesRelation);
+          mmd->enableInlineSource(root->inlineSource);
           mmd->addQualifiers(root->qualifiers);
           mmd->setDocumentation(root->doc,root->docFile,root->docLine);
           mmd->setInbodyDocumentation(root->inbodyDocs,root->inbodyFile,root->inbodyLine);
@@ -7105,6 +7120,7 @@ static void findEnums(const Entry *root)
       mmd->enableCallerGraph(root->callerGraph);
       mmd->enableReferencedByRelation(root->referencedByRelation);
       mmd->enableReferencesRelation(root->referencesRelation);
+      mmd->enableInlineSource(root->inlineSource);
       mmd->addQualifiers(root->qualifiers);
       //printf("%s::setRefItems(%zu)\n",qPrint(md->name()),root->sli.size());
       mmd->setRefItems(root->sli);
@@ -8979,6 +8995,7 @@ static void addDefineDoc(const Entry *root, MemberDefMutable *md)
   }
   md->addSectionsToDefinition(root->anchors);
   md->setMaxInitLines(root->initLines);
+  md->enableInlineSource(root->inlineSource);
   md->setRefItems(root->sli);
   if (root->mGrpId!=-1) md->setMemberGroupId(root->mGrpId);
   addMemberToGroups(root,md);

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3665,7 +3665,7 @@ static void buildFunctionList(const Entry *root)
                   md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
                   md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
                   md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
-                  md->enableInlineSource(md->hasInlineSource(), root->inlineSource);
+                  md->mergeEnableInlineSource(root->inlineSource);
                   md->addQualifiers(root->qualifiers);
 
                   // merge ingroup specifiers
@@ -3816,14 +3816,14 @@ static void findFriends()
             mmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
             mmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
             mmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
-            mmd->enableInlineSource(mmd->hasInlineSource(), fmd->hasInlineSource());
+            mmd->mergeEnableInlineSource(fmd->hasInlineSource());
             mmd->addQualifiers(fmd->getQualifiers());
 
             fmd->enableCallGraph(mmd->hasCallGraph() || fmd->hasCallGraph());
             fmd->enableCallerGraph(mmd->hasCallerGraph() || fmd->hasCallerGraph());
             fmd->enableReferencedByRelation(mmd->hasReferencedByRelation() || fmd->hasReferencedByRelation());
             fmd->enableReferencesRelation(mmd->hasReferencesRelation() || fmd->hasReferencesRelation());
-            fmd->enableInlineSource(mmd->hasInlineSource(), fmd->hasInlineSource());
+            fmd->mergeEnableInlineSource(mmd->hasInlineSource());
             fmd->addQualifiers(mmd->getQualifiers());
           }
         }
@@ -5212,7 +5212,7 @@ static void addMemberDocs(const Entry *root,
   md->enableCallerGraph(md->hasCallerGraph() || root->callerGraph);
   md->enableReferencedByRelation(md->hasReferencedByRelation() || root->referencedByRelation);
   md->enableReferencesRelation(md->hasReferencesRelation() || root->referencesRelation);
-  md->enableInlineSource(md->hasInlineSource(), root->inlineSource);
+  md->mergeEnableInlineSource(root->inlineSource);
   md->addQualifiers(root->qualifiers);
 
   md->mergeMemberSpecifiers(spec);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -74,6 +74,7 @@ Entry::Entry(const Entry &e)
   groupGraph  = e.groupGraph;
   referencedByRelation = e.referencedByRelation;
   referencesRelation   = e.referencesRelation;
+  inlineSource = e.inlineSource;
   exported    = e.exported;
   virt        = e.virt;
   args        = e.args;
@@ -195,6 +196,7 @@ void Entry::reset()
   bool entryCallerGraph = Config_getBool(CALLER_GRAPH);
   bool entryReferencedByRelation = Config_getBool(REFERENCED_BY_RELATION);
   bool entryReferencesRelation   = Config_getBool(REFERENCES_RELATION);
+  bool entryInlineSource    = Config_getBool(INLINE_SOURCES);
   bool entryIncludeGraph    = Config_getBool(INCLUDE_GRAPH);
   bool entryIncludedByGraph = Config_getBool(INCLUDED_BY_GRAPH);
   bool entryDirectoryGraph  = Config_getBool(DIRECTORY_GRAPH);
@@ -241,6 +243,7 @@ void Entry::reset()
   groupGraph = entryGroupGraph;
   referencedByRelation = entryReferencedByRelation;
   referencesRelation   = entryReferencesRelation;
+  inlineSource = entryInlineSource;
   exported = false;
   section = EMPTY_SEC;
   mtype   = MethodTypes::Method;

--- a/src/entry.h
+++ b/src/entry.h
@@ -191,6 +191,7 @@ class Entry
     bool callerGraph;         //!< do we need to draw the caller graph?
     bool referencedByRelation;//!< do we need to show the referenced by relation?
     bool referencesRelation;  //!< do we need to show the references relation?
+    bool inlineSource;        //!< do we need to show the inline source?
     bool includeGraph;        //!< do we need to draw the include graph?
     bool includedByGraph;     //!< do we need to draw the included by graph?
     bool directoryGraph;      //!< do we need to draw the directory graph?

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -219,6 +219,7 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual bool hasCallerGraph() const override;
     virtual bool hasReferencesRelation() const override;
     virtual bool hasReferencedByRelation() const override;
+    virtual bool hasInlineSource() const override;
     virtual const MemberDef *templateMaster() const override;
     virtual QCString getScopeString() const override;
     virtual ClassDef *getClassDefOfAnonymousType() const override;
@@ -296,6 +297,8 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     virtual void enableCallerGraph(bool e) override;
     virtual void enableReferencedByRelation(bool e) override;
     virtual void enableReferencesRelation(bool e) override;
+    virtual void enableInlineSource(bool e) override;
+    virtual void enableInlineSource(bool e1, bool e2) override;
     virtual void setTemplateMaster(MemberDef *mt) override;
     virtual void addListReference(Definition *d) override;
     virtual void setDocsForDefinition(bool b) override;
@@ -486,6 +489,7 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     bool m_hasCallerGraph = false;
     bool m_hasReferencedByRelation = false;
     bool m_hasReferencesRelation = false;
+    bool m_hasInlineSource = false;
     bool m_explExt = false;             // member was explicitly declared external
     bool m_tspec = false;               // member is a template specialization
     bool m_groupHasDocs = false;        // true if the entry that caused the grouping was documented
@@ -845,6 +849,8 @@ class MemberDefAliasImpl : public DefinitionAliasMixin<MemberDef>
     { return getMdAlias()->hasReferencesRelation(); }
     virtual bool hasReferencedByRelation() const
     { return getMdAlias()->hasReferencedByRelation(); }
+    virtual bool hasInlineSource() const
+    { return getMdAlias()->hasInlineSource(); }
     virtual StringVector getQualifiers() const
     { return getMdAlias()->getQualifiers(); }
     virtual const MemberDef *templateMaster() const
@@ -1320,6 +1326,7 @@ void MemberDefImpl::init(Definition *d,
   m_hasCallerGraph = FALSE;
   m_hasReferencedByRelation = FALSE;
   m_hasReferencesRelation = FALSE;
+  m_hasInlineSource = FALSE;
   m_initLines=0;
   m_type=t;
   if (mt==MemberType_Typedef) m_type.stripPrefix("typedef ");
@@ -1496,6 +1503,7 @@ MemberDefImpl::MemberDefImpl(const MemberDefImpl &md) : DefinitionMixin(md)
   m_hasCallerGraph                 = md.m_hasCallerGraph                 ;
   m_hasReferencedByRelation        = md.m_hasReferencedByRelation        ;
   m_hasReferencesRelation          = md.m_hasReferencesRelation          ;
+  m_hasInlineSource                = md.m_hasInlineSource                ;
   m_explExt                        = md.m_explExt                        ;
   m_tspec                          = md.m_tspec                          ;
   m_groupHasDocs                   = md.m_groupHasDocs                   ;
@@ -2646,7 +2654,7 @@ bool MemberDefImpl::hasDetailedDescription() const
     bool hideUndocMembers      = Config_getBool(HIDE_UNDOC_MEMBERS);
     bool extractStatic         = Config_getBool(EXTRACT_STATIC);
     bool extractPrivateVirtual = Config_getBool(EXTRACT_PRIV_VIRTUAL);
-    bool inlineSources         = Config_getBool(INLINE_SOURCES);
+    bool inlineSources         = hasInlineSource();
 
     // the member has detailed documentation because the user added some comments
     bool docFilter =
@@ -2682,7 +2690,7 @@ bool MemberDefImpl::hasDetailedDescription() const
     // _writeExamples                  -> hasExamples()
     // _writeTypeConstraints           -> m_typeConstraints.hasParameters()
     // writeSourceDef                  -> !getSourceFileBase().isEmpty();
-    // writeInlineCode                 -> INLINE_SOURCES && hasSources()
+    // writeInlineCode                 -> hasInlineSource() && hasSources()
     // writeSourceRefs                 -> hasReferencesRelation() && hasSourceRefs()
     // writeSourceReffedBy             -> hasReferencedByRelation() && hasSourceReffedBy()
     // _writeCallGraph                 -> _hasVisibleCallGraph()
@@ -4828,6 +4836,17 @@ void MemberDefImpl::enableReferencesRelation(bool e)
   if (e) Doxygen::parseSourcesNeeded = TRUE;
 }
 
+void MemberDefImpl::enableInlineSource(bool e)
+{
+  m_hasInlineSource=e;
+}
+
+void MemberDefImpl::enableInlineSource(bool e1, bool e2)
+{
+  if (e1 == e2) m_hasInlineSource=e1;
+  else m_hasInlineSource=!Config_getBool(INLINE_SOURCES);
+}
+
 bool MemberDefImpl::isObjCMethod() const
 {
   if (getClassDef() && getClassDef()->isObjectiveC() && isFunction()) return TRUE;
@@ -5565,6 +5584,11 @@ bool MemberDefImpl::hasReferencesRelation() const
   return m_hasReferencesRelation;
 }
 
+bool MemberDefImpl::hasInlineSource() const
+{
+  return m_hasInlineSource;
+}
+
 const MemberDef *MemberDefImpl::templateMaster() const
 {
   return m_templateMaster;
@@ -6127,6 +6151,9 @@ void combineDeclarationAndDefinition(MemberDefMutable *mdec,MemberDefMutable *md
       mdef->enableReferencesRelation(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
       mdec->enableReferencedByRelation(mdec->hasReferencedByRelation() || mdef->hasReferencedByRelation());
       mdec->enableReferencesRelation(mdec->hasReferencesRelation() || mdef->hasReferencesRelation());
+
+      mdef->enableInlineSource(mdec->hasInlineSource(), mdef->hasInlineSource());
+      mdec->enableInlineSource(mdec->hasInlineSource(), mdef->hasInlineSource());
 
       mdef->addQualifiers(mdec->getQualifiers());
       mdec->addQualifiers(mdef->getQualifiers());

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -388,7 +388,7 @@ class MemberDefMutable : public DefinitionMutable, public MemberDef
     virtual void enableReferencesRelation(bool e) = 0;
 
     virtual void enableInlineSource(bool e) = 0;
-    virtual void enableInlineSource(bool e1, bool e2) = 0;
+    virtual void mergeEnableInlineSource(bool other) = 0;
 
     virtual void setTemplateMaster(MemberDef *mt) = 0;
     virtual void addListReference(Definition *d) = 0;

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -244,6 +244,8 @@ class MemberDef : public Definition
     virtual bool hasReferencesRelation() const = 0;
     virtual bool hasReferencedByRelation() const = 0;
 
+    virtual bool hasInlineSource() const = 0;
+
     virtual const MemberDef *templateMaster() const = 0;
     virtual QCString getScopeString() const = 0;
     virtual ClassDef *getClassDefOfAnonymousType() const = 0;
@@ -384,6 +386,9 @@ class MemberDefMutable : public DefinitionMutable, public MemberDef
 
     virtual void enableReferencedByRelation(bool e) = 0;
     virtual void enableReferencesRelation(bool e) = 0;
+
+    virtual void enableInlineSource(bool e) = 0;
+    virtual void enableInlineSource(bool e1, bool e2) = 0;
 
     virtual void setTemplateMaster(MemberDef *mt) = 0;
     virtual void addListReference(Definition *d) = 0;


### PR DESCRIPTION
For different graphs graphs it is possible to steer the creation process on a 1 to 1 base (commands like \callgraph and \hidecallgraph).

Introducing for the inline sources:
```
    \showinlinesource and \hideinlinesource
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12587279/example.tar.gz)
