### PR TITLE
Warning about internal doxygen inconsistency for python packages (2)

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -782,6 +782,22 @@ QCString removeRedundantWhiteSpace(const QCString &s)
         break;
       default:
         *dst++=c;
+        if (c=='t' && csp==5)
+        {
+          if (i<l-2 && src[i+1] == ':' && src[i+2] == ':') csp = 0;
+          else if (i > csp && src[i-csp] == ':' && src[i-csp-1] == ':') csp = 0;
+        }
+        else if (c=='e' && vosp==8)
+        {
+          if (i<l-2 && src[i+1] == ':' && src[i+2] == ':') vosp = 0;
+          else if (i > vosp && src[i-vosp] == ':' && src[i-vosp-1] == ':') vosp = 0;
+        }
+        else if (c=='l' && vsp==7)
+        {
+          if (i<l-2 && src[i+1] == ':' && src[i+2] == ':') vsp = 0;
+          else if (i > vsp && src[i-vsp] == ':' && src[i-vsp-1] == ':') vsp = 0;
+        }
+
         if (c=='t' && csp==5 && i<l-1 && // found 't' in 'const'
              !(isId(nc) || nc==')' || nc==',' || isspace(static_cast<uint8_t>(nc)))
            ) // prevent const ::A from being converted to const::A


### PR DESCRIPTION
In the Ansible package (through Fossies) we get warnings like:
```
.../lib/ansible/module_utils/facts/virtual/base.py:27: warning: Internal inconsistency: scope for class ansible::module_utils::facts::virtual ::base::Virtual not found!
```
Due to the naming of python the classes in doxygen it is possible that those names will contain reserved names as the path is used in the identification of the class (here virtual).

When `::` is directly in front or after of the word it is a class name and no space should be appended.

A first attempt to get was made by means of #10290 though this had problems with the `operator` keyword as noted in #10304 and had to be reverted.

Examples (from #10304): 
- [example3.tar.gz](https://github.com/doxygen/doxygen/files/12641072/example3.tar.gz)
- [example2.tar.gz](https://github.com/doxygen/doxygen/files/12641073/example2.tar.gz)

