### PR TITLE
Add missing C++20 module file extension

### DIFF
--- a/doc/starting.doc
+++ b/doc/starting.doc
@@ -109,23 +109,25 @@ using the following table:
 
 Extension | Language | Extension | Language     | Extension | Language
 ---------:|--------- | ---------:|------------- | ---------:|---------
-.dox      |C / C++   | .hpp      |C / C++       |.py        |Python
-.doc      |C / C++   | .h++      |C / C++       |.pyw       |Python
-.c        |C / C++   | .mm       |C / C++       |.f         |Fortran
-.cc       |C / C++   | .txt      |C / C++       |.for       |Fortran
-.cxx      |C / C++   | .idl      |IDL           |.f90       |Fortran
-.cpp      |C / C++   | .ddl      |IDL           |.f95       |Fortran
-.c++      |C / C++   | .odl      |IDL           |.f03       |Fortran
-.ii       |C / C++   | .java     |Java          |.f08       |Fortran
-.ixx      |C / C++   | .cs       |C#            |.f18       |Fortran
-.ipp      |C / C++   | .d        |D             |.vhd       |VHDL
-.i++      |C / C++   | .php      |PHP           |.vhdl      |VHDL
-.inl      |C / C++   | .php4     |PHP           |.ucf       |VHDL
-.h        |C / C++   | .php5     |PHP           |.qsf       |VHDL
-.H        |C / C++   | .inc      |PHP           |.l         |Lex
-.hh       |C / C++   | .phtml    |PHP           |.md        |Markdown
-.HH       |C / C++   | .m        |Objective-C   |.markdown  |Markdown
-.hxx      |C / C++   | .M        |Objective-C   |.ice       |Slice
+.dox      |C / C++   | .HH       |C / C++       |.py        |Python
+.doc      |C / C++   | .hxx      |C / C++       |.pyw       |Python
+.c        |C / C++   | .hpp      |C / C++       |.f         |Fortran
+.cc       |C / C++   | .h++      |C / C++       |.for       |Fortran
+.cxx      |C / C++   | .mm       |C / C++       |.f90       |Fortran
+.cpp      |C / C++   | .txt      |C / C++       |.f95       |Fortran
+.c++      |C / C++   | .idl      |IDL           |.f03       |Fortran
+.cppm     |C / C++   | .ddl      |IDL           |.f08       |Fortran
+.ccm      |C / C++   | .odl      |IDL           |.f18       |Fortran
+.cxxm     |C / C++   | .java     |Java          |.vhd       |VHDL
+.c++m     |C / C++   | .cs       |C#            |.vhdl      |VHDL
+.ii       |C / C++   | .d        |D             |.ucf       |VHDL
+.ixx      |C / C++   | .php      |PHP           |.qsf       |VHDL
+.ipp      |C / C++   | .php4     |PHP           |.l         |Lex
+.i++      |C / C++   | .php5     |PHP           |.md        |Markdown
+.inl      |C / C++   | .inc      |PHP           |.markdown  |Markdown
+.h        |C / C++   | .phtml    |PHP           |.ice       |Slice
+.H        |C / C++   | .m        |Objective-C   |&nbsp;     |&nbsp;
+.hh       |C / C++   | .M        |Objective-C   |&nbsp;     |&nbsp;
 
 Please note that the above list might contain more items than that by default set
 in the \ref cfg_file_patterns "FILE_PATTERNS".

--- a/src/config.xml
+++ b/src/config.xml
@@ -1543,6 +1543,7 @@ FILE_VERSION_FILTER = "cleartool desc -fmt \%Vn"
       <value name='*.cxxm'/>
       <value name='*.cpp'/>
       <value name='*.cppm'/>
+      <value name='*.ccm'/>
       <value name='*.c++'/>
       <value name='*.c++m'/>
       <value name='*.java'/>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -335,7 +335,7 @@ EntryType guessSection(const QCString &name)
 {
   QCString n=name.lower();
   static const std::unordered_set<std::string> sourceExt = {
-     "c","cc","cxx","cpp","c++","cppm","cxxm","c++m",   // C/C++
+     "c","cc","cxx","cpp","c++","cppm","ccm","cxxm","c++m",   // C/C++
      "java",                       // Java
      "cs",                         // C#
      "m","mm",                     // Objective-C
@@ -5261,6 +5261,7 @@ void initDefaultExtensionMapping()
   updateLanguageMapping(".c++",      "c");
   updateLanguageMapping(".cxxm",     "c"); // C++20 modules
   updateLanguageMapping(".cppm",     "c"); // C++20 modules
+  updateLanguageMapping(".ccm",      "c"); // C++20 modules
   updateLanguageMapping(".c++m",     "c"); // C++20 modules
   updateLanguageMapping(".ii",       "c");
   updateLanguageMapping(".ixx",      "c");


### PR DESCRIPTION
Add missing file extension for Clang importable module units: `.ccm`. See [file name requirement](https://clang.llvm.org/docs/StandardCPlusPlusModules.html#file-name-requirement) in Clang documentation.