### PR TITLE
Prevent reading tag file multiple times

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9797,7 +9797,7 @@ static void readTagFile(const std::shared_ptr<Entry> &root,const QCString &tagLi
     return;
   }
 
-  if (std::find(Doxygen::tagFileSet.begin(), Doxygen::tagFileSet.end(), fi.absFilePath().c_str()) != Doxygen::tagFileSet.end()) return;
+  if (Doxygen::tagFileSet.find(fi.absFilePath().c_str()) != Doxygen::tagFileSet.end()) return;
 
   Doxygen::tagFileSet.emplace(fi.absFilePath());
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -145,7 +145,7 @@ FileNameLinkedMap    *Doxygen::mscFileNameLinkedMap = 0;     // msc files
 FileNameLinkedMap    *Doxygen::diaFileNameLinkedMap = 0;     // dia files
 StringUnorderedMap    Doxygen::namespaceAliasMap;            // all namespace aliases
 StringMap             Doxygen::tagDestinationMap;            // all tag locations
-std::vector<QCString> Doxygen::tagFileVector;                // all tag file names
+StringSet             Doxygen::tagFileSet;                   // all tag file names
 StringUnorderedSet    Doxygen::expandAsDefinedSet;           // all macros that should be expanded
 MemberGroupInfoMap    Doxygen::memberGroupInfoMap;           // dictionary of the member groups heading
 std::unique_ptr<PageDef> Doxygen::mainPage;
@@ -9797,9 +9797,9 @@ static void readTagFile(const std::shared_ptr<Entry> &root,const QCString &tagLi
     return;
   }
 
-  if (std::find(Doxygen::tagFileVector.begin(), Doxygen::tagFileVector.end(), fi.absFilePath().c_str()) != Doxygen::tagFileVector.end()) return;
+  if (std::find(Doxygen::tagFileSet.begin(), Doxygen::tagFileSet.end(), fi.absFilePath().c_str()) != Doxygen::tagFileSet.end()) return;
 
-  Doxygen::tagFileVector.push_back(fi.absFilePath());
+  Doxygen::tagFileSet.emplace(fi.absFilePath());
 
   if (!destName.isEmpty())
   {

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -145,6 +145,7 @@ FileNameLinkedMap    *Doxygen::mscFileNameLinkedMap = 0;     // msc files
 FileNameLinkedMap    *Doxygen::diaFileNameLinkedMap = 0;     // dia files
 StringUnorderedMap    Doxygen::namespaceAliasMap;            // all namespace aliases
 StringMap             Doxygen::tagDestinationMap;            // all tag locations
+std::vector<QCString> Doxygen::tagFileVector;                // all tag file names
 StringUnorderedSet    Doxygen::expandAsDefinedSet;           // all macros that should be expanded
 MemberGroupInfoMap    Doxygen::memberGroupInfoMap;           // dictionary of the member groups heading
 std::unique_ptr<PageDef> Doxygen::mainPage;
@@ -9781,9 +9782,6 @@ static void readTagFile(const std::shared_ptr<Entry> &root,const QCString &tagLi
     fileName = tagLine.left(eqPos).stripWhiteSpace();
     destName = tagLine.right(tagLine.length()-eqPos-1).stripWhiteSpace();
     if (fileName.isEmpty() || destName.isEmpty()) return;
-    FileInfo fi(fileName.str());
-    Doxygen::tagDestinationMap.insert(
-        std::make_pair(fi.absFilePath(), destName.str()));
     //printf("insert tagDestination %s->%s\n",qPrint(fi.fileName()),qPrint(destName));
   }
   else
@@ -9799,8 +9797,16 @@ static void readTagFile(const std::shared_ptr<Entry> &root,const QCString &tagLi
     return;
   }
 
+  if (std::find(Doxygen::tagFileVector.begin(), Doxygen::tagFileVector.end(), fi.absFilePath().c_str()) != Doxygen::tagFileVector.end()) return;
+
+  Doxygen::tagFileVector.push_back(fi.absFilePath());
+
   if (!destName.isEmpty())
+  {
+    Doxygen::tagDestinationMap.insert(
+        std::make_pair(fi.absFilePath(), destName.str()));
     msg("Reading tag file '%s', location '%s'...\n",qPrint(fileName),qPrint(destName));
+  }
   else
     msg("Reading tag file '%s'...\n",qPrint(fileName));
 

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -104,6 +104,7 @@ class Doxygen
     static GroupLinkedMap           *groupLinkedMap;
     static NamespaceLinkedMap       *namespaceLinkedMap;
     static StringMap                 tagDestinationMap;
+    static std::vector<QCString>     tagFileVector;
     static MemberGroupInfoMap        memberGroupInfoMap;
     static StringUnorderedSet        expandAsDefinedSet;
     static std::unique_ptr<NamespaceDef> globalNamespaceDef;

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -104,7 +104,7 @@ class Doxygen
     static GroupLinkedMap           *groupLinkedMap;
     static NamespaceLinkedMap       *namespaceLinkedMap;
     static StringMap                 tagDestinationMap;
-    static std::vector<QCString>     tagFileVector;
+    static StringSet                 tagFileSet;
     static MemberGroupInfoMap        memberGroupInfoMap;
     static StringUnorderedSet        expandAsDefinedSet;
     static std::unique_ptr<NamespaceDef> globalNamespaceDef;


### PR DESCRIPTION
Prevent the reading of a tag file multiple times (as already done for e.g INPUT files) as this might lead to warnings like (example from CGAL):
```
.../doc_tags/BGL.tag:2569: warning: Duplicate anchor fig__regularization_fig found
```