### PR TITLE
issue #10324 [C#] Using expression-bodied functions with generics generates wrong type constraints.

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6037,6 +6037,13 @@ NONLopt [^\n]*
 <CSConstraintType,CSConstraintName>"#"  { // artificially inserted token to signal end of comment block
                                           yyextra->current->typeConstr.back().docs = yyextra->fullArgString;
                                         }
+<CSConstraintType>"=>"                  { // end of type constraint reached
+                                          // parse documentation of the constraints
+                                          handleParametersCommentBlocks(yyscanner,yyextra->current->typeConstr);
+                                          unput('>');
+                                          unput('=');
+                                          BEGIN( yyextra->lastCSConstraint );
+                                        }
 <CSConstraintType>"{"                   { // end of type constraint reached
                                           // parse documentation of the constraints
                                           handleParametersCommentBlocks(yyscanner,yyextra->current->typeConstr);


### PR DESCRIPTION
A C# constraint can also be terminated by means of a `=>`.