### PR TITLE
Publish doxmlparser on PyPI

### DIFF
--- a/.github/workflows/doxmlparser-publish.yml
+++ b/.github/workflows/doxmlparser-publish.yml
@@ -1,0 +1,34 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build package
+      run: python -m build -w addon/doxmlparser/
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: addon/doxmlparser/dist/
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/addon/doxmlparser/setup.py
+++ b/addon/doxmlparser/setup.py
@@ -6,6 +6,9 @@ with open('README.md') as f:
 with open('LICENSE') as f:
     license = f.read()
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setup(
     name='doxmlparser',
     version='0.1',
@@ -15,5 +18,6 @@ setup(
     author_email='doxygen@gmail.com',
     url='https://github.com/doxygen/doxygen/addon/doxmlparser',
     license=license,
-    packages=find_packages(exclude=('tests', 'docs'))
+    packages=find_packages(exclude=('tests', 'docs')),
+    install_requires=requirements
 )

--- a/addon/doxmlparser/setup.py
+++ b/addon/doxmlparser/setup.py
@@ -1,4 +1,12 @@
+import os
+
+from pathlib import Path
 from setuptools import setup, find_packages
+
+topdir = Path(os.getcwd()).parent.parent
+
+with open(topdir / 'VERSION') as f:
+    version = f.read()
 
 with open('README.md') as f:
     readme = f.read()
@@ -11,7 +19,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='doxmlparser',
-    version='0.1',
+    version=version,
     description='Python API to access doxygen generated XML output',
     long_description=readme,
     author='Dimitri van Heesch',


### PR DESCRIPTION
In order to make `doxmlparser` readily available for users, it's important to publish it - being a Python module - to PyPI. This way, it can be included on `requirements.txt` files for Python dependencies.

This PR adds a new github job that, when there's a new relase of doxygen, publishes `doxmlparser` to PyPI. As I'm not a doxygen maintainer, this PR is incomplete, so I'm keeping it as draft now.

What is missing is the `PyPI API token`, that, once created, needs to be added to this repository as a secret.

It would be awesome if a doxygen maintainer could create this token. It should be simple, just a matter of creating an account on [PyPI](https://pypi.org/account/register/), create the API token and adding it as secret named `PYPI_API_TOKEN` to this repository.

Indeed, to test this package, I've created a package for TestPyPI from my fork - one can see it [here](https://test.pypi.org/project/doxmlparser/). I'll remove it once, hopefully, this PR is merged.

I'm ready to help if there's any issues, or look for alternatives to get the PyPI token.
