### PR TITLE
bug_705285 Allow non-globally unique page/section labels when using tagfiles

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2136,7 +2136,18 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     adjustBoolSetting(depOption,"EXTRACT_PACKAGE",      true );
   }
 
-  if (!checkFileName(Config_getString(GENERATE_TAGFILE),"GENERATE_TAGFILE"))
+  QCString tagLine = Config_getString(GENERATE_TAGFILE);
+  QCString fileName;
+  int eqPos = tagLine.find('=');
+  if (eqPos!=-1) // tag command contains a tagname
+  {
+    fileName = tagLine.left(eqPos).stripWhiteSpace();
+  }
+  else
+  {
+    fileName = tagLine;
+  }
+  if (!checkFileName(fileName,"GENERATE_TAGFILE"))
   {
     Config_updateString(GENERATE_TAGFILE,"");
   }

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1138,6 +1138,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          yyextra->token.name=yytext;
                          return TK_WORD;
                        }
+<St_Ref>"{"{REFWORD}"}"{REFWORD} |
 <St_Ref>{REFWORD}      { // label to refer to
                          yyextra->token.name=yytext;
                          return TK_WORD;

--- a/src/section.h
+++ b/src/section.h
@@ -167,6 +167,23 @@ class SectionManager : public LinkedMap<SectionInfo>
         return LinkedMap<SectionInfo>::add(label.data(),fileName,lineNr,title,type,level,ref);
       }
     }
+    void addDeleteSection(const QCString &label)
+    {
+      m_deleteVector.push_back(label);
+    }
+
+    void cleanDeleteSection()
+    {
+      for (const auto &label : m_deleteVector)
+      {
+        SectionInfo *si = LinkedMap<SectionInfo>::find(label);
+        if (si && !si->ref().isEmpty())
+        {
+          LinkedMap<SectionInfo>::del(label);
+        }
+      }
+      m_deleteVector.clear();
+    }
 
     //! returns a reference to the singleton
     static SectionManager &instance()
@@ -179,6 +196,8 @@ class SectionManager : public LinkedMap<SectionInfo>
     SectionManager() {}
     SectionManager(const SectionManager &other) = delete;
     SectionManager &operator=(const SectionManager &other) = delete;
+
+    std::vector<QCString> m_deleteVector;
 };
 
 


### PR DESCRIPTION
The basic idea is that occurrences in the "normal" files are preferred above occurrences in a tag file

To be able to do this there should also be a mechanism to refer (by means of `\ref`) to a page section in the project that is "linked" by means of a tag file.
- define a tag and store this in the tag file (doxygen.cpp extend `GENERATE_TAGFILE` with the possibility to specify a tag), read the tag back when reading the tag file (tagreader.cpp) and adjust the checking of the `GENERATE_TAGFILE` (configimpl.l)
- extend the reading of the `\ref` command to support a tag, this is done by means of having `{<tag>}<ref_word>` (doctokenizer.l)
- adjusting page names (to be used in `\ref`)  when read pages from a tag file, in this way the page could be accessed by means of the original name or the adjusted name with the tag, also the section names should be adjusted (otherwise there could be double section names) (tagreader.cpp).
  - when there is a page in the main part of the documentation (so not linked through a tag file) and the page name is defined here it should not be in present from the tag file (these tagged pages are still accessible through the version with the tag name though), (doxygen.cpp with getPageDoc and checkRemovePageDoc).
  - when a page is present in multiple tag files this is not unique and should be removed  (these tagged pages are still accessible through the version with the tag name though) (doxygen.cpp getPageDocTag, countPageDocTag and checkRemovePageDoc).
- when there are section names that occur in multiple tag files the names of the second and subsequent occurrences are not recorded, so always the first one is used. To prevent this these names are stored and after the tag file reading and reading of the "normal" files these section names are removed (Note 1) that a maximum of 1 occurrence can remain as read from tag files, 2) in case the name also occurs in the "normal" files this occurrence overwrites the possible present version from the tag files, commentscan.l. 3) in case of the an occurrence in multiple tag files a warning could be given, now suppressed, but I think in that case it should be suppressed by means of a Doxyfile setting). (tagreader.cpp and section.h)