### PR TITLE
Missing "Detailed Documentation" header

### DIFF
--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -779,10 +779,9 @@ void GroupDefImpl::writeTagFile(TextStream &tagFile)
 void GroupDefImpl::writeDetailedDescription(OutputList &ol,const QCString &title)
 {
   if ((!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF))
-      || !documentation().isEmpty() || !inbodyDocumentation().isEmpty()
+      || !documentation().stripWhiteSpace().isEmpty() || !inbodyDocumentation().stripWhiteSpace().isEmpty()
      )
   {
-    ol.pushGeneratorState();
     if (m_pages.size()!=numDocMembers()) // not only pages -> classical layout
     {
       ol.pushGeneratorState();
@@ -794,14 +793,10 @@ void GroupDefImpl::writeDetailedDescription(OutputList &ol,const QCString &title
         ol.writeAnchor(QCString(),"details");
       ol.popGeneratorState();
     }
-    else
-    {
-      ol.disableAllBut(OutputType::Man); // always print title for man page
-    }
+
     ol.startGroupHeader();
     ol.parseText(title);
     ol.endGroupHeader();
-    ol.popGeneratorState();
 
     // repeat brief description
     if (!briefDescription().isEmpty() && Config_getBool(REPEAT_BRIEF))


### PR DESCRIPTION
Based on the comment in https://github.com/doxygen/doxygen/issues/10335#issuecomment-1742037088 where it was stated that:
```
/**
 * @defgroup int int
 * @{
 * @brief Der Datentyp "int" repräsentiert eine Ganzzahl.
 * @}
 */
```
resulted in a double:
```
Der Datentyp "int" repräsentiert eine Ganzzahl.
Der Datentyp "int" repräsentiert eine Ganzzahl.
```
and the remark about the missing "Detailed Description" header (in https://github.com/doxygen/doxygen/issues/10335#issuecomment-1742045947).

- the `documentation()` and `inbodyDocumentation()` can contain just white space though this should also be considered as empty.
- the  `ol.disableAllBut(OutputType::Man);` is not necessary anymore as the real problem has been fixed.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12777173/example.tar.gz)
