### PR TITLE
issue #10306 Some intra-page links include the HTML file name

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -280,8 +280,8 @@ static QCString htmlAttribsToString(const HtmlAttribList &attribs, QCString *pAl
 //-------------------------------------------------------------------------
 
 HtmlDocVisitor::HtmlDocVisitor(TextStream &t,OutputCodeList &ci,
-                               const Definition *ctx)
-  : m_t(t), m_ci(ci), m_ctx(ctx)
+                               const Definition *ctx,const QCString &fn)
+  : m_t(t), m_ci(ci), m_ctx(ctx), m_fileName(fn)
 {
   if (ctx) m_langExt=ctx->getDefFileExtension();
 }
@@ -2175,11 +2175,16 @@ void HtmlDocVisitor::startLink(const QCString &ref,const QCString &file,
     m_t << "<a class=\"el\" ";
   }
   m_t << "href=\"";
-  m_t << externalRef(relPath,ref,TRUE);
+  if (!ref.isEmpty()) m_t << externalRef(relPath,ref,TRUE);
   if (!file.isEmpty())
   {
     QCString fn = file;
     addHtmlExtensionIfMissing(fn);
+    if (ref.isEmpty())
+    {
+      if (!anchor.isEmpty() && (m_fileName == Config_getString(HTML_OUTPUT) + "/" + fn)) fn = "";
+      else m_t << externalRef(relPath,ref,TRUE);
+    }
     m_t << fn;
   }
   if (!anchor.isEmpty()) m_t << "#" << anchor;

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -29,7 +29,7 @@ class TextStream;
 class HtmlDocVisitor : public DocVisitor
 {
   public:
-    HtmlDocVisitor(TextStream &t,OutputCodeList &ci,const Definition *ctx);
+    HtmlDocVisitor(TextStream &t,OutputCodeList &ci,const Definition *ctx,const QCString &fn = QCString());
 
     //--------------------------------------
     // visitor functions for leaf nodes
@@ -146,6 +146,7 @@ class HtmlDocVisitor : public DocVisitor
     bool m_hide = false;
     bool m_insideTitle = false;
     const Definition *m_ctx;
+    QCString m_fileName;
     QCString m_langExt;
 };
 

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -890,11 +890,16 @@ void HtmlCodeGenerator::_writeCodeLink(const QCString &className,
     *m_t << "<a class=\"" << className << "\" ";
   }
   *m_t << "href=\"";
-  *m_t << externalRef(m_relPath,ref,TRUE);
+  if (!ref.isEmpty()) *m_t << externalRef(m_relPath,ref,TRUE);
   if (!f.isEmpty())
   {
     QCString fn = f;
     addHtmlExtensionIfMissing(fn);
+    if (ref.isEmpty())
+    {
+      if (!anchor.isEmpty() && (fileName() == fn)) fn = "";
+      else *m_t << externalRef(m_relPath,ref,TRUE);
+    }
     *m_t << fn;
   }
   if (!anchor.isEmpty()) *m_t << "#" << anchor;
@@ -918,7 +923,12 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
   if (!docInfo.url.isEmpty())
   {
     *m_t << "<a href=\"";
-    *m_t << externalRef(m_relPath,docInfo.ref,TRUE);
+    if (!docInfo.ref.isEmpty()) *m_t << externalRef(m_relPath,docInfo.ref,TRUE);
+    else
+    {
+      if (!docInfo.anchor.isEmpty() && (fileName() == url)) url = "";
+      else *m_t << externalRef(m_relPath,docInfo.ref,TRUE);
+    }
     *m_t << url;
     if (!docInfo.anchor.isEmpty())
     {
@@ -932,18 +942,21 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
     *m_t << "</a>";
   }
   *m_t << "</div>";
+
   if (!decl.isEmpty())
   {
     *m_t << "<div class=\"ttdeci\">";
     docify(decl);
     *m_t << "</div>";
   }
+
   if (!desc.isEmpty())
   {
     *m_t << "<div class=\"ttdoc\">";
     docify(desc);
     *m_t << "</div>";
   }
+
   if (!defInfo.file.isEmpty())
   {
     *m_t << "<div class=\"ttdef\"><b>" << theTranslator->trDefinition() << "</b> ";
@@ -952,7 +965,12 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
       url = defInfo.url;
       addHtmlExtensionIfMissing(url);
       *m_t << "<a href=\"";
-      *m_t << externalRef(m_relPath,defInfo.ref,TRUE);
+      if (!defInfo.ref.isEmpty()) *m_t << externalRef(m_relPath,defInfo.ref,TRUE);
+      else
+      {
+        if (!defInfo.anchor.isEmpty() && (fileName() == url)) url = "";
+        else *m_t << externalRef(m_relPath,defInfo.ref,TRUE);
+      }
       *m_t << url;
       if (!defInfo.anchor.isEmpty())
       {
@@ -975,7 +993,12 @@ void HtmlCodeGenerator::writeTooltip(const QCString &id, const DocLinkInfo &docI
       url = declInfo.url;
       addHtmlExtensionIfMissing(url);
       *m_t << "<a href=\"";
-      *m_t << externalRef(m_relPath,declInfo.ref,TRUE);
+      if (!declInfo.ref.isEmpty()) *m_t << externalRef(m_relPath,declInfo.ref,TRUE);
+      else
+      {
+        if (!declInfo.anchor.isEmpty() && (fileName() == url)) url = "";
+        else *m_t << externalRef(m_relPath,declInfo.ref,TRUE);
+      }
       *m_t << url;
       if (!declInfo.anchor.isEmpty())
       {
@@ -1424,6 +1447,7 @@ void HtmlGenerator::startFile(const QCString &name,const QCString &,
   m_lastTitle=title;
 
   startPlainFile(fileName);
+  m_codeGen->setFileName(fileName);
   m_codeGen->setRelativePath(m_relPath);
   {
     std::lock_guard<std::mutex> lock(g_indexLock);
@@ -1723,11 +1747,16 @@ void HtmlGenerator::writeObjectLink(const QCString &ref,const QCString &f,
     m_t << "<a class=\"el\" ";
   }
   m_t << "href=\"";
-  m_t << externalRef(m_relPath,ref,TRUE);
+  if (!ref.isEmpty()) m_t << externalRef(m_relPath,ref,TRUE);
   if (!f.isEmpty())
   {
     QCString fn = f;
     addHtmlExtensionIfMissing(fn);
+    if (ref.isEmpty())
+    {
+      if (!anchor.isEmpty() && (fileName() == Config_getString(HTML_OUTPUT) + "/" + fn)) fn = "";
+      else m_t << externalRef(m_relPath,ref,TRUE);
+    }
     m_t << fn;
   }
   if (!anchor.isEmpty()) m_t << "#" << anchor;
@@ -1743,7 +1772,7 @@ void HtmlGenerator::startTextLink(const QCString &f,const QCString &anchor)
   {
     QCString fn = f;
     addHtmlExtensionIfMissing(fn);
-    m_t << m_relPath << fn;
+    if (anchor.isEmpty() || (fileName() != Config_getString(HTML_OUTPUT) + "/" + fn)) m_t << m_relPath << fn;
   }
   if (!anchor.isEmpty()) m_t << "#" << anchor;
   m_t << "\">";
@@ -2551,7 +2580,7 @@ void HtmlGenerator::writeDoc(const IDocNodeAST *ast,const Definition *ctx,const 
   if (astImpl)
   {
     m_codeList->setId(id);
-    HtmlDocVisitor visitor(m_t,*m_codeList,ctx);
+    HtmlDocVisitor visitor(m_t,*m_codeList,ctx,fileName());
     std::visit(visitor,astImpl->root);
   }
 }

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -28,6 +28,8 @@ class HtmlCodeGenerator
     HtmlCodeGenerator(TextStream *t);
 
     void setTextStream(TextStream *t) { m_t = t; }
+    void setFileName(const QCString fileName) { m_fileName = fileName; }
+    QCString fileName() { return m_fileName; }
 
     OutputType type() const { return OutputType::Html; }
 
@@ -64,6 +66,7 @@ class HtmlCodeGenerator
     TextStream *m_t;
     int m_col = 0;
     QCString m_relPath;
+    QCString m_fileName;
     bool m_lineOpen = false;
 };
 


### PR DESCRIPTION
In case the current filename to write to and the filename in the link (and the link has an anchor) don't write out the filename in the link. One has to be careful with external references to tag files.

(Checked the results against the doxygen internal documentation and against CGAL)