### PR TITLE
Wrong links for stateToString in internal doxygen documentation

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -78,8 +78,6 @@ typedef yyguts_t *yyscan_t;
 #define SCOPEBLOCK 2
 #define INNERBLOCK 3
 
-#define USE_STATE2STRING 0
-
 // context for an Objective-C method call
 struct ObjCCallCtx
 {
@@ -197,9 +195,7 @@ struct codeYY_state
 static bool isCastKeyword(const char *s);
 
 //-------------------------------------------------------------------
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static void saveObjCContext(yyscan_t yyscanner);
 static void restoreObjCContext(yyscan_t yyscanner);
@@ -4202,6 +4198,4 @@ void CCodeParser::parseCode(OutputCodeList &od,const QCString &className,const Q
   yyextra->tooltipManager.writeTooltips(od);
 }
 
-#if USE_STATE2STRING
 #include "code.l.h"
-#endif

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -49,8 +49,6 @@ typedef yyguts_t *yyscan_t;
 #define ADDCHAR(c)    yyextra->outBuf.addChar(c)
 #define ADDARRAY(a,s) yyextra->outBuf.addArray(a,s)
 
-#define USE_STATE2STRING 0
-
 struct commentcnvYY_CondCtx
 {
   commentcnvYY_CondCtx(int line,const QCString &id,bool b)
@@ -105,9 +103,7 @@ struct commentcnvYY_state
   bool       isFixedForm = FALSE; // For Fortran
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 static inline int computeIndent(const char *s);
 
 static void replaceCommentMarker(yyscan_t yyscanner,const char *s,int len);
@@ -1290,6 +1286,4 @@ void convertCppComments(const BufStr &inBuf,BufStr &outBuf,const QCString &fileN
 
 //----------------------------------------------------------------------------
 
-#if USE_STATE2STRING
 #include "commentcnv.l.h"
-#endif

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -64,8 +64,6 @@ typedef yyguts_t *yyscan_t;
 #include "trace.h"
 #include "debug.h"
 
-#define USE_STATE2STRING 0
-
 // forward declarations
 static bool handleBrief(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleFn(yyscan_t yyscanner,const QCString &, const StringVector &);
@@ -166,9 +164,7 @@ static bool handleFileInfo(yyscan_t yyscanner,const QCString &, const StringVect
 static bool handleLineInfo(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleModule(yyscan_t yyscanner,const QCString &, const StringVector &);
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 typedef bool (*DocCmdFunc)(yyscan_t yyscanner,const QCString &name, const StringVector &optList);
 
@@ -831,7 +827,7 @@ STopt  [^\n@\\]*
                                           // the {B}* in the front was added for bug620924
                                           QCString fullMatch = QCString(yytext);
                                           int idx = fullMatch.find('{');
-                                          /* handle `\f{` and `@f{` as special cases */
+                                          /* handle `f{` command as special case */
                                           if ((idx > 1) && (yytext[idx-1] == 'f') && (yytext[idx-2] == '\\' || yytext[idx-2] =='@')) REJECT;
                                           int idxEnd = fullMatch.find("}",idx+1);
                                           QCString cmdName;
@@ -4217,6 +4213,4 @@ void CommentScanner::close(Entry *e,const QCString &fileName,int lineNr,bool fou
   yyextra->docGroup.close(e,fileName,lineNr,foundInline,implicit);
 }
 
-#if USE_STATE2STRING
 #include "commentscan.l.h"
-#endif

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -52,11 +52,7 @@
 // For debugging
 #define SHOW_INCLUDES 0
 
-#define USE_STATE2STRING 0
-
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static const char *warning_str = "warning: ";
 static const char *error_str = "error: ";
@@ -2323,6 +2319,4 @@ void Config::deinit()
   ConfigImpl::instance()->deleteInstance();
 }
 
-#if USE_STATE2STRING
 #include "configimpl.l.h"
-#endif

--- a/src/constexp.l
+++ b/src/constexp.l
@@ -37,11 +37,7 @@
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static int yyread(char *buf,int max_size,yyscan_t yyscanner);
 
@@ -170,6 +166,4 @@ extern "C" {
   int constexpYYwrap(yyscan_t /* yyscanner */) { return 1; }
 }
 
-#if USE_STATE2STRING
 #include "constexp.l.h"
-#endif

--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -48,8 +48,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_UNISTD_H 1
 #define YY_NEVER_INTERACTIVE 1
 
-#define USE_STATE2STRING 0
-
 /* -----------------------------------------------------------------
  *
  *	statics
@@ -74,9 +72,7 @@ struct declinfoYY_state
      bool         insidePHP;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static void addType(yyscan_t yyscanner);
 static void addTypeName(yyscan_t yyscanner);
@@ -419,6 +415,4 @@ int main()
 }
 #endif
 
-#if USE_STATE2STRING
 #include "declinfo.l.h"
-#endif

--- a/src/defargs.l
+++ b/src/defargs.l
@@ -71,8 +71,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-  
 /* -----------------------------------------------------------------
  *	state variables
  */
@@ -104,9 +102,7 @@ struct defargsYY_state
   QCString         delimiter;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static int yyread(yyscan_t yyscanner,char *buf,int max_size);
 static bool nameIsActuallyPartOfType(QCString &name);
@@ -841,6 +837,4 @@ std::unique_ptr<ArgumentList> stringToArgumentList(SrcLangExt lang, const QCStri
   return al;
 }
 
-#if USE_STATE2STRING
 #include "defargs.l.h"
-#endif

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -51,8 +51,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 #define TK_COMMAND_SEL() (yytext[0] == '@' ? TK_COMMAND_AT : TK_COMMAND_BS)
 
 //--------------------------------------------------------------------------
@@ -98,10 +96,7 @@ struct doctokenizerYY_state
 #define lineCount(s,len) do { for(int i=0;i<(int)len;i++) if (s[i]=='\n') yyextra->yyLineNr++; } while(0)
 
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
-
+[[maybe_unused]] static const char *stateToString(int state);
 
 static int yyread(yyscan_t yyscanner,char *buf,int max_size);
 static void handleHtmlTag(yyscan_t yyscanner,const char *text);
@@ -2183,6 +2178,4 @@ int DocTokenizer::getLineNr(void)
   return yyextra->yyLineNr;
 }
 
-#if USE_STATE2STRING
 #include "doctokenizer.l.h"
-#endif

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -74,8 +74,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 /*
  * For fixed formatted code position 6 is of importance (continuation character).
  * The following variables and macros keep track of the column number
@@ -178,9 +176,7 @@ struct fortrancodeYY_state
    int fixedCommentAfter = 72;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static bool getFortranNamespaceDefs(const QCString &mname,
                                NamespaceDef *&cd);
@@ -1600,6 +1596,4 @@ static inline void pop_state(yyscan_t yyscanner)
 }
 //---------------------------------------------------------
 
-#if USE_STATE2STRING
 #include "fortrancode.l.h"
-#endif

--- a/src/lexcode.l
+++ b/src/lexcode.l
@@ -46,8 +46,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 struct lexcodeYY_state
 {
      OutputCodeList *code;
@@ -93,9 +91,7 @@ struct lexcodeYY_state
      const char   *currentFontClass;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor);
 static void startCodeLine(yyscan_t yyscanner);
@@ -1284,6 +1280,4 @@ void LexCodeParser::parseCode(OutputCodeList &codeOutIntf,
 
 //---------------------------------------------------------------------------------
 
-#if USE_STATE2STRING
 #include "lexcode.l.h"
-#endif

--- a/src/lexscanner.l
+++ b/src/lexscanner.l
@@ -52,8 +52,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 #define repeatChar(chr, cnt) std::string(cnt, chr).c_str()
 
 struct lexscannerYY_state
@@ -91,9 +89,7 @@ struct lexscannerYY_state
   SrcLangExt language;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 //-----------------------------------------------------------------------------
 
 // forward declarations for statefull functions
@@ -1033,6 +1029,4 @@ void LexOutlineParser::parseInput(const QCString &fileName,
 
 //----------------------------------------------------------------------------
 
-#if USE_STATE2STRING
 #include "lexscanner.l.h"
-#endif

--- a/src/pre.l
+++ b/src/pre.l
@@ -68,11 +68,7 @@ typedef yyguts_t *yyscan_t;
 
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 struct preYY_CondCtx
 {
@@ -94,6 +90,7 @@ struct FileState
   int oldFileBufPos = 0;
   YY_BUFFER_STATE bufState = 0;
   QCString fileName;
+  bool lexRulesPart = false;
 };
 
 struct PreIncludeInfo
@@ -311,6 +308,9 @@ struct preYY_state
   DefineMap                                localDefines;   // macros defined in this file
   DefineList                               macroDefinitions;
   LinkedMap<PreIncludeInfo>                includeRelations;
+
+  int                                      lastContext = 0;
+  bool                                     lexRulesPart = false;
 };
 
 // stateless functions
@@ -371,6 +371,20 @@ VERBATIM_LINE  [\\@]"noop"{B}+
 LITERAL_BLOCK  {FORMULA_START}|{VERBATIM_START}
 LITERAL_BLOCK_END {FORMULA_END}|{VERBATIM_END}
 
+  // some Lex informations
+nl              (\r\n|\r|\n)
+RulesDelim      "%%"{nl}
+RulesSharp      "<"[^>\n]*">"
+RulesCurly      "{"[^{}\n]*"}"
+StartSquare     "["
+StartDouble     "\""
+StartRound      "("
+StartRoundQuest "(?"
+EscapeRulesCharOpen  "\\["|"\\<"|"\\{"|"\\("|"\\\""|"\\ "|"\\\\"
+EscapeRulesCharClose "\\]"|"\\>"|"\\}"|"\\)"
+EscapeRulesChar      {EscapeRulesCharOpen}|{EscapeRulesCharClose}
+CHARCE    "[:"[^:]*":]"
+
   // C start comment
 CCS   "/\*"
   // C end comment
@@ -425,6 +439,13 @@ WSopt [ \t\r]*
 %x      CondLineCpp
 %x      SkipCond
 %x      IDLquote
+%x      RulesPattern
+%x      RulesDouble
+%x      RulesRoundDouble
+%x      RulesSquare
+%x      RulesRoundSquare
+%x      RulesRound
+%x      RulesRoundQuest
 
 %%
 
@@ -666,6 +687,132 @@ WSopt [ \t\r]*
                                             outputArray(yyscanner,yytext,yyleng);
                                           }
                                         }
+<CopyLine>{RulesDelim}                  {
+                                          if (getLanguageFromFileName(yyextra->fileName)!=SrcLangExt_Lex) REJECT;
+                                          yyextra->lexRulesPart = !yyextra->lexRulesPart;
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+  /* start lex rule handling */
+<CopyLine>{RulesSharp}                  {
+                                          if (!yyextra->lexRulesPart) REJECT;
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(RulesPattern);
+                                        }
+<RulesPattern>{EscapeRulesChar}         {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesPattern>{RulesCurly}              {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesPattern>{StartDouble}             {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          yyextra->lastContext = YY_START;
+                                          BEGIN(RulesDouble);
+                                        }
+<RulesDouble,RulesRoundDouble>"\\\\"    {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesDouble,RulesRoundDouble>"\\\""    {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesDouble>"\""                       {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN( yyextra->lastContext ) ;
+                                        }
+<RulesRoundDouble>"\""                  {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(RulesRound) ;
+                                        }
+<RulesDouble,RulesRoundDouble>.         {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesPattern>{StartSquare}             {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          yyextra->lastContext = YY_START;
+                                          BEGIN(RulesSquare);
+                                        }
+<RulesSquare,RulesRoundSquare>{CHARCE}  {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesSquare,RulesRoundSquare>"\\[" |
+<RulesSquare,RulesRoundSquare>"\\]"     {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesSquare>"]"                        {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(RulesPattern);
+                                        }
+<RulesRoundSquare>"]"                   {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(RulesRound) ;
+                                        }
+<RulesSquare,RulesRoundSquare>"\\\\" {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesSquare,RulesRoundSquare>.         {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesPattern>{StartRoundQuest}         {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          yyextra->lastContext = YY_START;
+                                          BEGIN(RulesRoundQuest);
+                                        }
+<RulesRoundQuest>{nl}                   {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesRoundQuest>[^)]                   {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesRoundQuest>")"                    {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(yyextra->lastContext);
+                                        }
+<RulesPattern>{StartRound}              {
+                                          yyextra->roundCount++;
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          yyextra->lastContext = YY_START;
+                                          BEGIN(RulesRound);
+                                        }
+<RulesRound>{RulesCurly}                {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesRound>{StartSquare}               {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(RulesRoundSquare);
+                                        }
+<RulesRound>{StartDouble}               {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(RulesRoundDouble);
+                                        }
+<RulesRound>{EscapeRulesChar}           {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesRound>"("                         {
+                                          yyextra->roundCount++;
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesRound>")"                         {
+                                          yyextra->roundCount--;
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          if (!yyextra->roundCount) BEGIN( yyextra->lastContext ) ;
+                                        }
+<RulesRound>{nl}                        {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesRound>{B}                         {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesRound>.                           {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<RulesPattern>{B}                       {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          BEGIN(CopyLine);
+                                        }
+<RulesPattern>.                         {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+  /* end lex rule handling */
 <CopyLine,LexCopyLine>{ID}              {
                                           Define *def=0;
                                           if ((yyextra->includeStack.empty() || yyextra->curlyCount>0) &&
@@ -1337,7 +1484,7 @@ WSopt [ \t\r]*
                                           yyextra->javaBlock=1;
                                           BEGIN(JavaDocVerbatimCode);
                                         }
-<SkipCComment,SkipCPPComment>[\\@][\\@]"cond"[ \t]+ { // escaped @cond
+<SkipCComment,SkipCPPComment>[\\@][\\@]"cond"[ \t]+ { // escaped cond command
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <SkipCPPComment>[\\@]"cond"[ \t]+       { // conditional section
@@ -1881,6 +2028,10 @@ WSopt [ \t\r]*
                                         }
 <*>{CPPC}[/!]?                          {
                                           if (YY_START==SkipVerbatim || YY_START == SkipCondVerbatim || YY_START==SkipCond || getLanguageFromFileName(yyextra->fileName)==SrcLangExt_Fortran || YY_START==IDLquote)
+                                          {
+                                            REJECT;
+                                          }
+                                          else if (YY_START==RulesRoundDouble)
                                           {
                                             REJECT;
                                           }
@@ -3329,6 +3480,8 @@ static void readIncludeFile(yyscan_t yyscanner,const QCString &inc)
       fs->fileName = oldFileName;
       fs->curlyCount = state->curlyCount;
       state->curlyCount = 0;
+      fs->lexRulesPart = state->lexRulesPart;
+      state->lexRulesPart = false;
       // push the state on the stack
       FileState *fs_ptr = fs.get();
       state->includeStack.push_back(std::move(fs));
@@ -3739,6 +3892,7 @@ void Preprocessor::processFile(const QCString &fileName,BufStr &input,BufStr &ou
   state->expandOnlyPredef = Config_getBool(EXPAND_ONLY_PREDEF);
   state->skip=FALSE;
   state->curlyCount=0;
+  state->lexRulesPart=false;
   state->nospaces=FALSE;
   state->inputBuf=&input;
   state->inputBufPos=0;
@@ -3852,6 +4006,4 @@ void Preprocessor::processFile(const QCString &fileName,BufStr &input,BufStr &ou
   //yyextra->defineManager.endContext();
 }
 
-#if USE_STATE2STRING
 #include "pre.l.h"
-#endif

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -67,9 +67,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
-
 struct pycodeYY_state
 {
   std::unordered_map< std::string, ScopedTypeVariant > codeClassMap;
@@ -121,9 +118,7 @@ struct pycodeYY_state
 };
 
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static void startCodeLine(yyscan_t yyscanner);
 static int countLines(yyscan_t yyscanner);
@@ -1714,6 +1709,4 @@ static inline void pop_state(yyscan_t yyscanner)
     yy_pop_state(yyscanner);
 }
 
-#if USE_STATE2STRING
 #include "pycode.l.h"
-#endif

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -62,8 +62,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 #define unput_string(yytext,yyleng) do { for (int i=(int)yyleng-1;i>=0;i--) unput(yytext[i]); } while(0)
 
 /* ----------------------------------------------------------------- */
@@ -119,9 +117,7 @@ struct pyscannerYY_state
 };
 
 //-----------------------------------------------------------------------------
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static inline int computeIndent(const char *s);
 
@@ -2210,6 +2206,4 @@ void PythonOutlineParser::parsePrototype(const QCString &text)
 
 //----------------------------------------------------------------------------
 
-#if USE_STATE2STRING
 #include "pyscanner.l.h"
-#endif

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -61,8 +61,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 static AtomicInt  anonCount;
 static AtomicInt  anonNSCount;
 
@@ -216,9 +214,7 @@ struct scannerYY_state
   TextStream       dummyTextStream;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 //-----------------------------------------------------------------------------
 
 // forward declarations for stateless functions
@@ -8110,6 +8106,4 @@ void COutlineParser::parsePrototype(const QCString &text)
 
 //----------------------------------------------------------------------------
 
-#if USE_STATE2STRING
 #include "scanner.l.h"
-#endif

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -49,8 +49,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 struct sqlcodeYY_state
 {
      OutputCodeList * code;
@@ -74,9 +72,7 @@ struct sqlcodeYY_state
      const char   *currentFontClass;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor);
 static void startCodeLine(yyscan_t yyscanner);
@@ -122,7 +118,7 @@ typekeyword     (?i:"ARRAY"|"BIGINT"|"BINARY"|"BLOB"|"BOOLEAN"|"CHAR"|"CHARACTER
 flowkeyword     (?i:"CASE"|"IF"|"ELSE"|"BEGIN"|"END"|"WHILE")
 
 literalkeyword  (?i:"false"|"true"|"NULL"|"UNKNOWN")
-stringliteral   (\"[^"]*\")|('[^']*')
+stringliteral   (\"[^\"]*\")|('[^']*')
 number          [0-9]+
 literals        ({literalkeyword}|{stringliteral}|{number})
 
@@ -492,6 +488,4 @@ void SQLCodeParser::parseCode(OutputCodeList &codeOutIntf,
 
 //---------------------------------------------------------------------------------
 
-#if USE_STATE2STRING
 #include "sqlcode.l.h"
-#endif

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -62,8 +62,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 // Toggle for some debugging info
 //#define DBG_CTX(x) fprintf x
 #define DBG_CTX(x) do { } while(0)
@@ -143,9 +141,7 @@ static void writeFuncProto(yyscan_t yyscanner);
 static void writeProcessProto(yyscan_t yyscanner);
 static int yyread(yyscan_t yyscanner,char *buf,int max_size);
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 //-------------------------------------------------------------------
 
 
@@ -1723,7 +1719,4 @@ void VHDLCodeParser::parseCode(OutputCodeList &od,
   yyextra->tooltipManager.writeTooltips(od);
 }
 
-#if USE_STATE2STRING
 #include "vhdlcode.l.h"
-#endif
-

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -54,8 +54,6 @@ typedef yyguts_t *yyscan_t;
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
-#define USE_STATE2STRING 0
-
 struct xmlcodeYY_state
 {
   OutputCodeList * code;
@@ -89,9 +87,7 @@ struct xmlcodeYY_state
   const char *  currentFontClass = 0;
 };
 
-#if USE_STATE2STRING
-static const char *stateToString(int state);
-#endif
+[[maybe_unused]] static const char *stateToString(int state);
 
 static void codify(yyscan_t yyscanner,const char* text);
 static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor);
@@ -124,7 +120,7 @@ name        {namestart}{namechar}*
 comment     {open}"!--"([^-]|"-"[^-])*"--"{close}
 cdata       {open}"![CDATA["([^\]]|"\]"[^\]])*"]]"{close}
 data        "random string"
-string      \"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
+string      \"([^\"&]|{esc})*\"|\'([^'&]|{esc})*\'
 
 %option noyywrap
 %option nounput
@@ -498,6 +494,4 @@ void XMLCodeParser::parseCode(OutputCodeList &codeOutIntf,
 }
 
 
-#if USE_STATE2STRING
 #include "xmlcode.l.h"
-#endif


### PR DESCRIPTION
When looking at the code of e.g. scanner.l in the doxygen internal documentation and looking at the prototype of the function `stateToString` this function is linked to the same function in the fortranscanner (although this should no happen as the function is `static`). Due to the fact that the `stateToString` functionality is only enabled in the fortranscanner, but in the other lex scanners the prototype and the implementation is hidden inside a `#if` block but the (lex)code scanners still find it as it does not take the `#if` into account.
- enable the functionality of `stateToString` everywhere even when not used
- make the prototypes `[[maybe_unused]]` to satisfy the compilers (warnings)
- adjust `pre.l` so that the counting of the open / close brackets is correct when they are used in the rules (code taken from lexscanner.l)
- some minor fixes to keep the preprocessor happy  (commands in regular comments, escape double quotes in `[...]` part of the rules