### PR TITLE
issue #10344 "param ?callable $callback" misinterpreted as undocumented parameter

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -259,7 +259,7 @@ BLANK     [ \t\r]
 BLANKopt  {BLANK}*
 ID        [$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
-PHPTYPE   [\\:a-z_A-Z0-9\x80-\xFF\-]+
+PHPTYPE   [?]?[\\:a-z_A-Z0-9\x80-\xFF\-]+
 CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
 CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]
 CITEID    {CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*|"\""{CITESCHAR}{CITEECHAR}*("."{CITESCHAR}{CITEECHAR}*)*"\""


### PR DESCRIPTION
Adding `?` as prefix to PHP types (i.e. a nullable type).