### PR TITLE
Reinstate list of brief functions

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2023,15 +2023,6 @@ bool MemberDefImpl::isBriefSectionVisible() const
 
   auto it = Doxygen::memberGroupInfoMap.find(m_grpId);
   bool hasDocs = hasDocumentation();
-  if (it!=Doxygen::memberGroupInfoMap.end())
-  {
-    auto &info = it->second;
-    //printf("name=%s m_grpId=%d info=%p\n",qPrint(name()),m_grpId,info);
-    //QCString *pMemGrp = Doxygen::memberDocDict[grpId];
-    hasDocs = hasDocs &&
-                  // part of a documented member group
-                 (m_grpId!=-1 && !(info->doc.isEmpty() && info->header.isEmpty()));
-  }
 
   // only include static members with file/namespace scope if
   // explicitly enabled in the config file


### PR DESCRIPTION
In PR #9994 the line `    hasDocs = hasDocs ||` was changed into the current line `    hasDocs = hasDocs &&`, though this gives with CGAL problems that there are a few pages where there won't be the part with the brief descriptions generated (e.g he output page BGL/group___pkg_b_g_l_euler_operations.html).

The function `isBriefSectionVisible` is for members and should have nothing to do with groups.
- tested against #9994
- CGAL