### PR TITLE
issue #10356 CopyDoc target is parsed incorrectly

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1694,6 +1694,8 @@ static QCString extractCopyDocId(const char *data, uint32_t &j, size_t len)
         case ')': round--; break;
         case '"': insideDQuote=TRUE; break;
         case '\'': insideSQuote=TRUE; break;
+        case '\\': // fall through, begin of command
+        case '@':  // fall through, begin of command
         case ' ':  // fall through
         case '\t': // fall through
         case '\n':


### PR DESCRIPTION
An id should not only end at a space like character but also at the start of a command.