### PR TITLE
Recognition of `<=` inside template construct

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2044,7 +2044,7 @@ NONLopt [^\n]*
                                             BEGIN(HereDoc);
                                           }
                                         }
-<ClassTemplSpec,EndTemplate>"<<"        {
+<ClassTemplSpec,EndTemplate>("<<"|"<=") {
                                           yyextra->current->name+=yytext;
                                           // *yyextra->currentTemplateSpec+=yytext;
                                         }
@@ -2056,10 +2056,10 @@ NONLopt [^\n]*
                                           }
                                           yyextra->current->name+=yytext;
                                         }
-<ClassTemplSpec,EndTemplate>">>"        {
+<ClassTemplSpec,EndTemplate>(">>"|"=>") {
                                           if (yyextra->insideJava || yyextra->insideCS || yyextra->insideCli || yyextra->roundCount==0)
                                           {
-                                            unput('>');
+                                            unput(*yytext);
                                             unput(' ');
                                             unput('>');
                                           }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2056,12 +2056,12 @@ NONLopt [^\n]*
                                           }
                                           yyextra->current->name+=yytext;
                                         }
-<ClassTemplSpec,EndTemplate>(">>"|"=>") {
+<ClassTemplSpec,EndTemplate>(">>"|">=") {
                                           if (yyextra->insideJava || yyextra->insideCS || yyextra->insideCli || yyextra->roundCount==0)
                                           {
-                                            unput(*yytext);
-                                            unput(' ');
                                             unput('>');
+                                            unput(' ');
+                                            unput(*yytext);
                                           }
                                           else
                                           {


### PR DESCRIPTION
When having a `<=` inside a construct like
```
typename enable_if<
    std::numeric_limits<T>::is_integer && sizeof(T) * 2 <= sizeof(uintmax_t),
    T>::type
```
this is seen as the start as a new level of `<`, this should not be the case. (also `=>` might be problematic, so handled as well)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12909133/example.tar.gz)
(Found in  apache-brpc-1.6.1-src package by Fossies)
