### PR TITLE
Recognition of `>=` inside inintializer construct

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3066,13 +3066,13 @@ NONLopt [^\n]*
                                             BEGIN(CopyGString);
                                           }
                                         }
-<ReadInitializer,ReadInitializerPtr>"->"                        {
+<ReadInitializer,ReadInitializerPtr>"->"        {
                                           yyextra->current->initializer << yytext;
                                         }
-<ReadInitializer,ReadInitializerPtr>"<<"                        {
+<ReadInitializer,ReadInitializerPtr>("<<"|"<=") {
                                           yyextra->current->initializer << yytext;
                                         }
-<ReadInitializer,ReadInitializerPtr>">>"                        {
+<ReadInitializer,ReadInitializerPtr>(">>"|">=") {
                                           yyextra->current->initializer << yytext;
                                         }
 <ReadInitializer,ReadInitializerPtr>[<\[{(]             {


### PR DESCRIPTION
When having a `>=` inside a construct like
```
  static const bool value = sizeof(T) >= (2 * sizeof(Lhs)) &&
                            StaticDstRangeRelationToSrcRange<T, Rhs>::value != NUMERIC_RANGE_CONTAINED;
```
(also `<=` might be problematic, so handled as well)

example: [example.tar.gz](https://github.com/doxygen/doxygen/files/12909290/example.tar.gz)
The problem manifested in the initializer value but also in the warnings log file where an unexpected `@ ` appeared:
```
.../safe_math_impl.h:8: warning: no uniquely matching class member found for
  static const bool butil::internal::IsIntegerArithmeticSafe::Rhs::value
Possible candidates:
  '@ butil::detail::sp_convertible< Y, T >::value' at line 7 of file .../intrusive_ptr.hpp
  'static const bool butil::internal::IsIntegerArithmeticSafe< T, Lhs, Rhs >::value' at line 7 of file .../safe_math_impl.h
```

(Found in apache-brpc-1.6.1-src package by Fossies)