### PR TITLE
Remove double resetting for htmlhelp

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1946,7 +1946,6 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     adjustBoolSetting(  depOption, "GENERATE_TREEVIEW",    false  );
     adjustBoolSetting(  depOption, "SEARCHENGINE",         false  );
     adjustBoolSetting(  depOption, "HTML_DYNAMIC_MENUS",   false  );
-    adjustBoolSetting(  depOption, "HTML_CODE_FOLDING",    false  );
     adjustBoolSetting(  depOption, "HTML_DYNAMIC_SECTIONS",false  );
     adjustBoolSetting(  depOption, "HTML_CODE_FOLDING",    false  );
     adjustBoolSetting(  depOption, "HTML_COPY_CLIPBOARD",  false  );


### PR DESCRIPTION
Remove double resetting of `HTML_CODE_FOLDING` for htmlhelp.