### PR TITLE
Disable `HTML_COPY_CLIPBOARD` for generating doxygen htmlhelp documentation

### DIFF
--- a/doc/Doxyfile_chm
+++ b/doc/Doxyfile_chm
@@ -14,6 +14,7 @@
       GENERATE_LATEX         = NO
       HTML_OUTPUT            = chm
       HTML_CODE_FOLDING      = NO
+      HTML_COPY_CLIPBOARD    = NO
       GENERATE_HTMLHELP      = YES
       GENERATE_TREEVIEW      = NO
       HTML_DYNAMIC_MENUS     = NO


### PR DESCRIPTION
Disable `HTML_COPY_CLIPBOARD` for generating doxygen htmlhelp documentation, otherwise it will give a warning and stop the make process.