### PR TITLE
Recognition of `>=` inside template construct

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2056,12 +2056,15 @@ NONLopt [^\n]*
                                           }
                                           yyextra->current->name+=yytext;
                                         }
-<ClassTemplSpec,EndTemplate>(">>"|">=") {
+<ClassTemplSpec,EndTemplate>">="        {
+                                          yyextra->current->name+=yytext;
+                                        }
+<ClassTemplSpec,EndTemplate>(">>")      {
                                           if (yyextra->insideJava || yyextra->insideCS || yyextra->insideCli || yyextra->roundCount==0)
                                           {
                                             unput('>');
                                             unput(' ');
-                                            unput(*yytext);
+                                            unput('>');
                                           }
                                           else
                                           {


### PR DESCRIPTION
- It is probably better not to split the `>` and `=` but keep it as 1 entity
- unput was also incorrect as in the `*yytext` contains a `>` so in the "split" situation twice a `>` was put back.