### PR TITLE
issue #10353 Doxygen cannot handle `#define` after PlantUML

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -3387,7 +3387,7 @@ static void determineBlockName(yyscan_t yyscanner)
   else
   {
     QCString bn=&yytext[1];
-    if (bn=="startuml")
+    if (bn.stripWhiteSpace()=="startuml")
     {
       yyextra->blockName="uml";
     }


### PR DESCRIPTION
"startuml" was not recognized as it got "startuml " (i.e. with space(s) at the end).