### PR TITLE
Fix dynamic loading of the side panel

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3823,14 +3823,14 @@ static void writePages(const PageDef *pd,FTVHelp *ftv)
       ftv->addContentsItem(
           hasSubPages,pageTitle,
           pd->getReference(),pd->getOutputFileBase(),
-          QCString(),FALSE,TRUE,pd);
+          QCString(),hasSubPages,TRUE,pd);
     }
     if (addToIndex && pd!=Doxygen::mainPage.get())
     {
       Doxygen::indexList->addContentsItem(
           hasSubPages || hasSections,pageTitle,
           pd->getReference(),pd->getOutputFileBase(),
-          QCString(),FALSE,TRUE,pd);
+          QCString(),hasSubPages,TRUE,pd);
     }
   }
   if (hasSubPages && ftv) ftv->incContentsDepth();


### PR DESCRIPTION
cb2c983, which fixed #10234, seems to disable all dynamic loading of the navtree in the side pannel.
This PR reverts that.