### PR TITLE
Properties in python "namespaces"

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1282,8 +1282,15 @@ void FileDefImpl::insertMember(MemberDef *md)
   allMemberList->push_back(md);
   switch (md->memberType())
   {
-    case MemberType_Variable:
     case MemberType_Property:
+      if (md->getLanguage() == SrcLangExt_Python)
+      {
+        addMemberToList(MemberListType_propertyMembers,md);
+        addMemberToList(MemberListType_properties,md);
+        break;
+      }
+      //  fallthrough, explicitly no break here
+    case MemberType_Variable:
       addMemberToList(MemberListType_decVarMembers,md);
       addMemberToList(MemberListType_docVarMembers,md);
       break;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1015,6 +1015,9 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                                                               theTranslator->trConstants() :
                                                                                               theTranslator->trVariables()); })
                                                   } },
+  { "namespace/memberdecl/properties",            { startCb(&LayoutParser::startMemberDeclEntry, MemberListType_properties,
+                                                            []() { return compileOptions(theTranslator->trProperties()); })
+                                                  } },
   { "namespace/memberdef",                        { startCb(&LayoutParser::startMemberDef), endCb(&LayoutParser::endMemberDef) } },
   { "namespace/memberdef/inlineclasses",          { startCb(&LayoutParser::startSectionEntry, LayoutDocEntry::NamespaceInlineClasses,
                                                             []() { return compileOptions(/* default */      theTranslator->trClassDocumentation(),
@@ -1040,6 +1043,9 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                             []() { return compileOptions(Config_getBool(OPTIMIZE_OUTPUT_SLICE) ?
                                                                                               theTranslator->trConstantDocumentation() :
                                                                                               theTranslator->trVariableDocumentation()); })
+                                                  } },
+  { "namespace/memberdef/properties",             { startCb(&LayoutParser::startMemberDefEntry, MemberListType_propertyMembers,
+                                                            []() { return compileOptions(theTranslator->trPropertyDocumentation()); })
                                                   } },
 
   // file layout handlers
@@ -1109,6 +1115,9 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                                                                             theTranslator->trConstants() :
                                                                                                             theTranslator->trVariables()); })
                                                   } },
+  { "file/memberdecl/properties",                 { startCb(&LayoutParser::startMemberDeclEntry, MemberListType_properties,
+                                                            []() { return compileOptions(theTranslator->trProperties()); })
+                                                  } },
   { "file/memberdef",                             { startCb(&LayoutParser::startMemberDef), endCb(&LayoutParser::endMemberDef) } },
 
   { "file/memberdef/inlineclasses",               { startCb(&LayoutParser::startSectionEntry,LayoutDocEntry::FileInlineClasses,
@@ -1138,6 +1147,9 @@ static const std::map< std::string, ElementCallbacks > g_elementHandlers =
                                                             []() { return compileOptions(theTranslator->trVariableDocumentation()); })
                                                   } },
 
+  { "file/memberdef/properties",                  { startCb(&LayoutParser::startMemberDefEntry, MemberListType_propertyMembers,
+                                                            []() { return compileOptions(theTranslator->trPropertyDocumentation()); })
+                                                  } },
   // group layout handlers
   { "group",                                      { startCb(&LayoutParser::startTop,LayoutDocManager::Group,"group/",LayoutNavEntry::None),
                                                     endCb(&LayoutParser::endTop)

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -533,6 +533,14 @@ void NamespaceDefImpl::insertMember(MemberDef *md)
         addMemberToList(MemberListType_decDefineMembers,md);
         addMemberToList(MemberListType_docDefineMembers,md);
         break;
+      case MemberType_Property:
+        if (md->getLanguage() == SrcLangExt_Python)
+        {
+          addMemberToList(MemberListType_propertyMembers,md);
+          addMemberToList(MemberListType_properties,md);
+          break;
+        }
+        //  fallthrough, explicitly no break here
       default:
         err("NamespaceDefImpl::insertMembers(): "
             "member '%s' with unexpected type id %d and class scope '%s' inserted in namespace scope '%s'!\n",

--- a/templates/general/layout_default.xml
+++ b/templates/general/layout_default.xml
@@ -119,6 +119,7 @@
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
+      <properties title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
     <detaileddescription title=""/>
@@ -130,6 +131,7 @@
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
+      <properties title=""/>
     </memberdef>
     <authorsection visible="yes"/>
   </namespace>
@@ -165,6 +167,7 @@
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
+      <properties title=""/>
       <membergroups visible="yes"/>
     </memberdecl>
     <detaileddescription title=""/>
@@ -177,6 +180,7 @@
       <enums title=""/>
       <functions title=""/>
       <variables title=""/>
+      <properties title=""/>
     </memberdef>
     <authorsection/>
   </file>


### PR DESCRIPTION
When having in a python statement like (not in a class or function):
```
cached_property0 = property
```
this will give a warning like:
```
error: NamespaceDefImpl::insertMembers(): member 'cached_property0' with unexpected type id 10 and class scope '' inserted in namespace scope 'resolver'!
```

This is due to the tact that this is in python a property, see rule (in pyscanner.l):
```
^{B}{IDENTIFIER}/{B}"="{B}"property" { // property
```

this has  been corrected specifically for python (also necessary in filedef as otherwise the property is shown as variable).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13060831/example.tar.gz)

(Found by Fossies for pipenv package)
