### PR TITLE
Remove non-namespace items from namespace list

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1837,9 +1837,6 @@ static void writeNamespaceTreeElement(const NamespaceDef *nd,FTVHelp *ftv,
       {
         ftv->incContentsDepth();
         writeNamespaceTree(nd->getNamespaces(),ftv,FALSE,addToIndex);
-        writeClassTree(nd->getClasses(),ftv,addToIndex,FALSE,ClassDef::Class);
-        writeConceptList(nd->getConcepts(),ftv,addToIndex);
-        writeNamespaceMembers(nd,addToIndex);
         ftv->decContentsDepth();
       }
       if (addToIndex && isDir)


### PR DESCRIPTION
Removes classes and other non-namespace members from "Namespace List" page, and from "Namespace List" section of the treeview. I believe this was the behavior a long time ago, but at some point classes started appearing in the "Namespace List" page, making it almost the same exact thing as the "Class List" page, and making it less useful for simply browsing namespaces defined by the documented code.

Someone should review this and make sure it doesn't have any unintended consequences. When used in my project, it does exactly what I intended. The "Namespace List" page and section in the treeview both display namespaces and *only* namespaces.

Fixes #8508