### PR TITLE
More consistent warning messages

### DIFF
--- a/src/codefragment.cpp
+++ b/src/codefragment.cpp
@@ -269,7 +269,7 @@ static QCString readTextFileByName(const QCString &file)
   {
     if (ambig)
     {
-      err("included file name %s is ambiguous. Possible candidates: %s\n",qPrint(file),
+      err("included file name '%s' is ambiguous.\nPossible candidates:\n%s\n",qPrint(file),
            qPrint(showFileDefMatches(Doxygen::exampleNameLinkedMap,file))
           );
     }

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -1080,7 +1080,7 @@ bool DocDotFile::parse()
     ok = true;
     if (ambig)
     {
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dot file name %s is ambiguous.\n"
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dot file name '%s' is ambiguous.\n"
            "Possible candidates:\n%s",qPrint(p->name),
            qPrint(showFileDefMatches(Doxygen::dotFileNameLinkedMap,p->name))
           );
@@ -1088,7 +1088,7 @@ bool DocDotFile::parse()
   }
   else
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dot file %s is not found "
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dot file '%s' is not found "
            "in any of the paths specified via DOTFILE_DIRS!",qPrint(p->name));
   }
   return ok;
@@ -1118,7 +1118,7 @@ bool DocMscFile::parse()
     ok = true;
     if (ambig)
     {
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included msc file name %s is ambiguous.\n"
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included msc file name '%s' is ambiguous.\n"
            "Possible candidates:\n%s",qPrint(p->name),
            qPrint(showFileDefMatches(Doxygen::mscFileNameLinkedMap,p->name))
           );
@@ -1126,7 +1126,7 @@ bool DocMscFile::parse()
   }
   else
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included msc file %s is not found "
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included msc file '%s' is not found "
            "in any of the paths specified via MSCFILE_DIRS!",qPrint(p->name));
   }
   return ok;
@@ -1158,7 +1158,7 @@ bool DocDiaFile::parse()
     ok = true;
     if (ambig)
     {
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dia file name %s is ambiguous.\n"
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dia file name '%s' is ambiguous.\n"
            "Possible candidates:\n%s",qPrint(p->name),
            qPrint(showFileDefMatches(Doxygen::diaFileNameLinkedMap,p->name))
           );
@@ -1166,7 +1166,7 @@ bool DocDiaFile::parse()
   }
   else
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dia file %s is not found "
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"included dia file '%s' is not found "
            "in any of the paths specified via DIAFILE_DIRS!",qPrint(p->name));
   }
   return ok;

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -106,7 +106,7 @@ QCString DocParser::findAndCopyImage(const QCString &fileName, DocImage::Type ty
     if (ambig & doWarn)
     {
       QCString text;
-      text.sprintf("image file name %s is ambiguous.\n",qPrint(fileName));
+      text.sprintf("image file name '%s' is ambiguous.\n",qPrint(fileName));
       text+="Possible candidates:\n";
       text+=showFileDefMatches(Doxygen::imageNameLinkedMap,fileName);
       warn_doc_error(context.fileName,tokenizer.getLineNr(),"%s", qPrint(text));
@@ -1662,7 +1662,7 @@ void DocParser::readTextFileByName(const QCString &file,QCString &text)
     text = fileToString(fd->absFilePath(),Config_getBool(FILTER_SOURCE_FILES));
     if (ambig)
     {
-      warn_doc_error(context.fileName,tokenizer.getLineNr(),"included file name %s is ambiguous"
+      warn_doc_error(context.fileName,tokenizer.getLineNr(),"included file name '%s' is ambiguous"
            "Possible candidates:\n%s",qPrint(file),
            qPrint(showFileDefMatches(Doxygen::exampleNameLinkedMap,file))
           );
@@ -1670,7 +1670,7 @@ void DocParser::readTextFileByName(const QCString &file,QCString &text)
   }
   else
   {
-    warn_doc_error(context.fileName,tokenizer.getLineNr(),"included file %s is not found. "
+    warn_doc_error(context.fileName,tokenizer.getLineNr(),"included file '%s' is not found. "
            "Check your EXAMPLE_PATH",qPrint(file));
   }
 }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -547,6 +547,7 @@ static void buildFileList(const Entry *root)
       {
         text+="matches the following input files:\n";
         text+=showFileDefMatches(Doxygen::inputNameLinkedMap,root->name);
+        text+="\n";
         text+="Please use a more specific name by "
           "including a (larger) part of the path!";
       }
@@ -602,6 +603,7 @@ static void addIncludeFile(DefMutable *cd,FileDef *ifd,const Entry *root)
       {
         text+="matches the following input files:\n";
         text+=showFileDefMatches(Doxygen::inputNameLinkedMap,root->includeFile);
+        text+="\n";
         text+="Please use a more specific name by "
             "including a (larger) part of the path!";
       }

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5450,7 +5450,7 @@ static bool findGlobalMember(const Entry *root,
         warnMsg+="\nPossible candidates:";
         for (const auto &md : *mn)
         {
-          warnMsg+="\n '";
+          warnMsg+="\n  '";
           warnMsg+=substitute(md->declaration(),"%","%%");
           warnMsg+="' " + warn_line(md->getDefFileName(),md->getDefLine());
         }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7081,8 +7081,8 @@ NONLopt [^\n]*
                                         }
 <DocCopyBlock><<EOF>>                   {
                                           warn(yyextra->fileName,yyextra->yyLineNr,
-                                              "reached end of file while inside a '%s' block!\n"
-                                              "The command that should end the block seems to be missing!",
+                                              "reached end of file while inside a '%s' block!"
+                                              " The command that should end the block seems to be missing!",
                                               qPrint(yyextra->docBlockName));
                                           yyterminate();
                                         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3292,11 +3292,14 @@ QCString showFileDefMatches(const FileNameLinkedMap *fnMap,const QCString &n)
   const FileName *fn;
   if ((fn=fnMap->find(name)))
   {
+    bool first = true;
     for (const auto &fd : *fn)
     {
       if (path.isEmpty() || fd->getPath().right(path.length())==path)
       {
-        result+="   "+fd->absFilePath()+"\n";
+        if (!first) result += "\n";
+        else first = false;
+        result+="  "+fd->absFilePath();
       }
     }
   }


### PR DESCRIPTION
In the jabref-5.11 package we see a few, less consistent warning messages like:
```
.../jabref-5.11/src/main/java/org/jabref/gui/fieldeditors/URLUtil.java:140: warning: reached end of file while inside a 'code' block!
The command that should end the block seems to be missing!
```
i.e. warning distributed over multiple lines

and
```
.../jabref-5.11/docs/code-howtos/openoffice/code-reorganization.md:20: warning: image file name layers-v1.svg is ambiguous.
Possible candidates:
   E:/Fossies/jabref-5.11/docs/code-howtos/openoffice/layers-v1.svg
   E:/Fossies/jabref-5.11/docs/images/layers-v1.svg

```
- empty line at the end
- no single quotes around `layers-v1.svg`
- indentation by 3 instead of 2 spaces