### PR TITLE
issue #10377 Wrong syntax for output of non-C++ deprecation lists for enum members

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4447,6 +4447,10 @@ void MemberDefImpl::addListReference(Definition *)
     }
   }
   const RefItemVector &xrefItems = xrefListItems();
+  if (sep!="::")
+  {
+    memName = substitute(memName,"::",sep);
+  }
   addRefItem(xrefItems,
         qualifiedName()+argsString(), // argsString is needed for overloaded functions (see bug 609624)
         memLabel,


### PR DESCRIPTION
The member names should be converted to the syntax in respect to the used language