### PR TITLE
Handling of relative include path in preprocessor

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2851,7 +2851,7 @@ static bool expandExpression(yyscan_t yyscanner,QCString &expr,QCString *rest,in
 
         if (replaced) // expand the macro and rescan the expression
         {
-          //printf(" replacing '%s'->'%s'\n",expr.mid(p,qPrint(len)),qPrint(expMacro));
+          //printf(" replacing '%s'->'%s'\n",qPrint(expr.mid(p,len)),qPrint(expMacro));
           QCString resultExpr=expMacro;
           QCString restExpr=expr.right(expr.length()-len-p);
           processConcatOperators(resultExpr);
@@ -3439,7 +3439,9 @@ static void readIncludeFile(yyscan_t yyscanner,const QCString &inc)
     std::unique_ptr<FileState> fs;
     bool alreadyProcessed = FALSE;
     //printf("calling findFile(%s)\n",qPrint(incFileName));
-    if ((fs=findFile(yyscanner,incFileName,localInclude,alreadyProcessed))) // see if the include file can be found
+    fs=findFile(yyscanner,absIncFileName,localInclude,alreadyProcessed); // see if the absolute include file can be found
+    if (!fs && !alreadyProcessed) fs=findFile(yyscanner,incFileName,localInclude,alreadyProcessed); // see if the include file can be found
+    if (fs)
     {
       {
         std::lock_guard<std::mutex> lock(g_globalDefineMutex);


### PR DESCRIPTION
In the 7z package we get a warning like:
```
error: NamespaceDefImpl::insertMembers(): member 'CCoderReleaser' with unexpected type id 8 and class scope '' inserted in namespace scope 'NCompress::NArj::NDecoder'!
```
this because of the fact that the include files like:
```
#include "../../../C/CpuArch.h"
```
are "not found" in the preprocessor and thus a number of macros are not evaluated (7z heavily relies on macros), so we check now the absolute path and the path as done before so the `INCLUDE_PATH` still can be applied.

(Found by Fossies for the 7z package)