### PR TITLE
Handling comment in macro name

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2448,6 +2448,37 @@ static inline void addTillEndOfString(yyscan_t yyscanner,const QCString &expr,QC
   }
 }
 
+static void skipCommentMacroName(yyscan_t yyscanner, const QCString &expr, QCString *rest,
+                                 int &cc, uint32_t &j, int &len)
+{
+  bool changed = false;
+
+  do
+  {
+    changed = false;
+    while ((cc=getCurrentChar(yyscanner,expr,rest,j))!=EOF && cc!='\n' && isspace(cc))
+    {
+      len++;
+      getNextChar(yyscanner,expr,rest,j);
+    }
+
+    if (cc=='/') // possible start of a comment
+    {
+      int prevChar = '\0';
+      getNextChar(yyscanner,expr,rest,j);
+      if ((cc=getCurrentChar(yyscanner,expr,rest,j))!=EOF && cc == '*') // we have a comment
+      {
+        while ((cc=getNextChar(yyscanner,expr,rest,j))!=EOF && cc!=0)
+        {
+          if (cc == '/' && prevChar == '*') break; // we have an end of comment
+          prevChar = cc;
+        }
+        if (cc != EOF) changed = true;
+      }
+    }
+  } while (changed);
+}
+
 /*! replaces the function macro \a def whose argument list starts at
  * \a pos in expression \a expr.
  * Notice that this routine may scan beyond the \a expr string if needed.
@@ -2463,11 +2494,9 @@ static bool replaceFunctionMacro(yyscan_t yyscanner,const QCString &expr,QCStrin
   len=0;
   result.resize(0);
   int cc;
-  while ((cc=getCurrentChar(yyscanner,expr,rest,j))!=EOF && cc!='\n' && isspace(cc))
-  {
-    len++;
-    getNextChar(yyscanner,expr,rest,j);
-  }
+
+  skipCommentMacroName(yyscanner, expr, rest, cc, j, len);
+
   if (cc!='(')
   {
     unputChar(yyscanner,expr,rest,j,' ');


### PR DESCRIPTION
After fixing the include path problem in the 7z package (see PR #10383) a warning like remained / surfaced:
```
CPP/7zip/Archive/7z/7zExtract.cpp:24: warning: Found ';' while parsing initializer list! (doxygen could be confused by a macro call without semicolon)
```
this is due to code (strongly abbreviated and modified) like:
```
/// \file

#define A(x,y) x ## y(int i)
#define fie1(x) FIE1(x);

A(fie,1 /* test */)

A(fie,1)
```
which gives in the preprocessor:
```
00001 /// \file
00002
00003 #define A(x,y)
00004 #define fie1(x)
00005
00006  fie1 /* test */ (int i)
00007
00008  FIE1( int i );
00009
```
whilst we would expect also on line 6
```
00006  FIE1( int i );
```
This is due to the comment between the name of the (after the first pass) macro and the arguments.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13175974/example.tar.gz)
