### PR TITLE
Handling of `import` in non cpp files

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1086,11 +1086,13 @@ NONLopt [^\n]*
                                           BEGIN( ModuleName );
                                         }
 <FindMembers>{B}*"export"{BN}+"import"{BN}+  { // export an imported module
+                                          if (!yyextra->insideCpp) REJECT;
                                           yyextra->current->exported = true;
                                           lineCount(yyscanner);
                                           BEGIN( ModuleImport );
                                         }
 <FindMembers>{B}*"import"{BN}+          { // start of a module import
+                                          if (!yyextra->insideCpp) REJECT;
                                           lineCount(yyscanner);
                                           BEGIN( ModuleImport );
                                         }


### PR DESCRIPTION
Based on the question: https://stackoverflow.com/questions/77366144/is-there-a-way-to-configure-doxygen-such-that-references-between-packages-also-b?noredirect=1#comment136392319_77366144 In the doxygen version 1.9.7 the `import` statement was working for e.g. the Java language but this is not the case anymore for the version 1.9.8 due to the fact that the handling is geared towards cpp `module`s. In case not in Cpp we now revert back to the old code.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13178463/example.tar.gz)
