### PR TITLE
issue #10388 Can't link to a tagfile page in DoxygenLayout?

### DIFF
--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -73,11 +73,11 @@ static bool convertMapFile(TextStream &t,const QCString &mapName,const QCString 
         auto dfAst  { createRef( *parser.get(), url, context, srcFile, srcLine) };
         auto dfAstImpl = dynamic_cast<const DocNodeAST*>(dfAst.get());
         const DocRef *df = std::get_if<DocRef>(&dfAstImpl->root);
-        t << externalRef(relPath,df->ref(),TRUE);
         if (!df->file().isEmpty() || !df->anchor().isEmpty())
         {
           link = true;
           t << "<area href=\"";
+          t << externalRef(relPath,df->ref(),TRUE);
         }
         if (!df->file().isEmpty())
         {


### PR DESCRIPTION
Adjusting method for the layout file analogous to the methods used in the msc / dot file generators.

During the working on this issue also a small problem was found (external links didn't work) was found for msc graphs.

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13196249/example.tar.gz)
