### PR TITLE
Miscounting in case of markdown links

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1145,7 +1145,6 @@ int Markdown::processLink(const char *data,int offset,int size)
   {
     whiteSpace = true;
     i++;
-    nl++;
     // skip more whitespace
     while (i<size && data[i]==' ') i++;
   }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1148,8 +1148,6 @@ int Markdown::processLink(const char *data,int offset,int size)
     // skip more whitespace
     while (i<size && data[i]==' ') i++;
   }
-  nlTotal += nl;
-  nl = 0;
   if (whiteSpace && i<size && (data[i]=='(' || data[i]=='[')) return 0;
 
   bool explicitTitle=FALSE;


### PR DESCRIPTION
In PR #8111 a number of miscountings were corrected but in case of
```
# Release process

Example PR: [GH-3139]

And now @error_5

[gh-3139]: https://github.com/doxygen/doxygen/pull/3139
```
the reported line was 6 instead of 5
This has been corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13320659/example.tar.gz)

(Found by Fossies for the black package)
