### PR TITLE
Remove double mentioning of 'module'  in compound.xsd

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1008,7 +1008,6 @@ class DoxCompoundKind(str, Enum):
     EXAMPLE='example'
     DIR='dir'
     CONCEPT='concept'
-    MODULE_1='module'
 
 
 class DoxGraphRelation(str, Enum):
@@ -1755,7 +1754,7 @@ class compounddefType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['class', 'struct', 'union', 'interface', 'protocol', 'category', 'exception', 'service', 'singleton', 'module', 'type', 'file', 'namespace', 'group', 'page', 'example', 'dir', 'concept', 'module']
+            enumerations = ['class', 'struct', 'union', 'interface', 'protocol', 'category', 'exception', 'service', 'singleton', 'module', 'type', 'file', 'namespace', 'group', 'page', 'example', 'dir', 'concept']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxCompoundKind' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -949,7 +949,6 @@
       <xsd:enumeration value="example" />
       <xsd:enumeration value="dir" />
       <xsd:enumeration value="concept" />
-      <xsd:enumeration value="module" />
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
Remove double mentioning of 'module'  in compound.xsd