### PR TITLE
Line miscounting in case of structural indicator

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3495,7 +3495,7 @@ static bool makeStructuralIndicator(yyscan_t yyscanner,EntryType t)
     yyextra->current->section = t;
     yyextra->current->fileName = yyextra->fileName;
     yyextra->current->startLine = yyextra->lineNr;
-    yyextra->current->docLine = yyextra->lineNr;
+    if (yyextra->current->docLine == -1) yyextra->current->docLine = yyextra->lineNr;
     return FALSE;
   }
 }


### PR DESCRIPTION
In case the (first) structural indicator is not at the beginning of a comment block, the line counting is not correct and we get warnings like:
```
.../dd.h:4: warning: Found unknown command '@error_2'
.../dd.h:8: warning: Found unknown command '@error_6'
.../PrivacyideaService.php:22: warning: Unsupported xml/html tag <service> found
.../PrivacyideaService.php:29: warning: Found unknown command '@subpackage'
```
whilst the correct line numbers should be here: 2, 6, 13 and 20.

The problem only occurs for the first structural indicator. (It is a bad idea to have the, first, structural indicator in the middle of a comment block.)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13328629/example.tar.gz)

(Found by Fossies for the privacyIDEA package)
