### PR TITLE
Potential buffer overflow (strncat)

### DIFF
--- a/libversion/fullversion.cpp
+++ b/libversion/fullversion.cpp
@@ -9,11 +9,12 @@ const char *getFullVersion(void)
   if (!init)
   {
     strncpy(fullVersionString,getDoxygenVersion(),BUF_SIZE-1);
+    fullVersionString[BUF_SIZE-1]='\0';
     if (strlen(getGitVersion())>0)
     {
-      strncat(fullVersionString," (",BUF_SIZE-1);
-      strncat(fullVersionString,getGitVersion(),BUF_SIZE-1);
-      strncat(fullVersionString,")",BUF_SIZE-1);
+      strncat(fullVersionString," (",BUF_SIZE-strlen(fullVersionString)-1);
+      strncat(fullVersionString,getGitVersion(),BUF_SIZE-strlen(fullVersionString)-1);
+      strncat(fullVersionString,")",BUF_SIZE-strlen(fullVersionString)-1);
     }
     fullVersionString[BUF_SIZE-1]='\0';
     init = true;

--- a/libversion/gitversion.cpp.in
+++ b/libversion/gitversion.cpp.in
@@ -14,7 +14,8 @@ const char *getGitVersion(void)
   if (!init)
   {
     strncpy(gitVersionString,"@GIT_HEAD_SHA1@",BUF_SIZE-1);
-    strncat(gitVersionString,!strcmp("@GIT_IS_DIRTY@","true")?"*":"",BUF_SIZE-1);
+    gitVersionString[BUF_SIZE-1]='\0';
+    strncat(gitVersionString,!strcmp("@GIT_IS_DIRTY@","true")?"*":"",BUF_SIZE-strlen(gitVersionString)-1);
     if (!strcmp("@GIT_HEAD_SHA1@", "GIT-NOTFOUND")) gitVersionString[0] = '\0';
     gitVersionString[BUF_SIZE-1]='\0';
     init = true;


### PR DESCRIPTION
From the draft 2023 C standard:
> char *strncat(char * restrict s1, const char * restrict s2, size_t n);
>
> The strncat function appends not more than n characters (a null character and characters that
> follow it are not appended) from the array pointed to by s2 to the end of the string pointed to by
> s1. The initial character of s2 overwrites the null character at the end of s1. A terminating null
> character is always appended to the result. If copying takes place between objects that overlap,
> the behavior is undefined.

and

> char *strncpy(char * restrict s1, const char * restrict s2, size_t n);

> The strncpy function copies not more than n characters (characters that follow a null character are
> not copied) from the array pointed to by s2 to the array pointed to by s1.377) If copying takes place
> between objects that overlap, the behavior is undefined