### PR TITLE
Remove unused css entry

### DIFF
--- a/doc/doxygen_manual.css
+++ b/doc/doxygen_manual.css
@@ -234,24 +234,6 @@ span.lineno a:hover {
 	user-select: none;
 }
 
-div.ah, span.ah {
-	background-color: black;
-	font-weight: bold;
-	color: #ffffff;
-	margin-bottom: 3px;
-	margin-top: 3px;
-	padding: 0.2em;
-	border: solid thin #333;
-	border-radius: 0.5em;
-	-webkit-border-radius: .5em;
-	-moz-border-radius: .5em;
-	box-shadow: 2px 2px 3px #999;
-	-webkit-box-shadow: 2px 2px 3px #999;
-	-moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
-	background-image: -webkit-gradient(linear, left top, left bottom, from(#eee), to(#000),color-stop(0.3, #444));
-	background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000 110%);
-}
-
 div.classindex ul {
         list-style: none;
         padding-left: 0;


### PR DESCRIPTION
I have not found any indication that the `ah` class is used for `div` or `span` (sonarcloud gave  bug message about "Unexpected nonstandard direction" for `background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000 110%);`)