### PR TITLE
Issue #10414 Report warning with wrong file and wrong line number

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1380,6 +1380,8 @@ STopt  [^\n@\\]*
                                           unput_string(yytext,yyleng);
                                           //if (*yytext=='\n') yyextra->lineNr++;
                                           //addOutput(yyscanner,'\n');
+                                          addOutput(yyscanner," \\ifile \""+ yyextra->fileName);
+                                          addOutput(yyscanner,"\" \\ilinebr \\iline " + QCString().setNum(yyextra->lineNr));
                                           BEGIN( Comment );
                                         }
 <GroupDocArg2>.                         { // title (stored in type)


### PR DESCRIPTION
As the `addtogroup` parts are joined together in one block the second block didn't know anymore wheer it came from originally which resulted in the wrong file name and line number. By adding some internal commands dureng provessing this has been corrected.