### PR TITLE
Fix Discarding of Slice Types during Namespace Doc Generation

### DIFF
--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -399,25 +399,25 @@ void NamespaceDefImpl::addInnerCompound(Definition *d)
 
 void NamespaceDefImpl::insertClass(ClassDef *cd)
 {
-  ClassLinkedRefMap &d = classes;
+  ClassLinkedRefMap *d = &classes;
 
   if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
   {
     if (cd->compoundType()==ClassDef::Interface)
     {
-      d = interfaces;
+      d = &interfaces;
     }
     else if (cd->compoundType()==ClassDef::Struct)
     {
-      d = structs;
+      d = &structs;
     }
     else if (cd->compoundType()==ClassDef::Exception)
     {
-      d = exceptions;
+      d = &exceptions;
     }
   }
 
-  d.add(cd->name(),cd);
+  d->add(cd->name(),cd);
 }
 
 void NamespaceDefImpl::insertConcept(ConceptDef *cd)


### PR DESCRIPTION
The doc generation for Slice files currently throws away the vast majority of Slice definitions.
This is caused by a regression introduced in [ab0bab6c7435c2adc8d7b3fdcc02ce8ee3fab312](https://github.com/doxygen/doxygen/commit/ab0bab6c7435c2adc8d7b3fdcc02ce8ee3fab312#diff-93e837e8c903c46ada3a2b260d053406147eda997bfb2b990b1f7b089727e3b2).

`NamespaceDefImpl` has 4 maps for holding each kind of Slice definition separately.
One of it's functions (`insertClass`) has a branch that is supposed to check what kind of definition is being inserted, then choose the correct map accordingly, defaulting to the `classes` map in case we aren't optimizing for Slice output.

This worked fine previously, when `d` was a pointer, and the branch updated it to point at different maps.
However, that commit switched to using references, which cannot be rebound like pointers.
Now, instead of re-pointing `d` to a different map, this logic actually _overwrites_ the `classes` map with another map.
As a result, the `interfaces`, `structs`, and `enums` maps are always empty, and the `classes` map is constantly being replaced with empty maps; this results in nearly all Slice definitions being discarded, instead of correctly inserted.

----

This PR fixes the issue by using pointers instead of references.
Instead of assigning empty maps to the `classes` field, now we just update which map the pointer `d` points to.

----

I've tested the build both with and without this fix and can confirm it works.
Let me know if you want any test cases or log outputs or etc. to double check this.