### PR TITLE
Issue #10414 Report warning with wrong file and wrong line number

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1433,6 +1433,8 @@ STopt  [^\n@\\]*
                                           unput_string(yytext,yyleng);
                                           //if (*yytext=='\n') yyextra->lineNr++;
                                           //addOutput(yyscanner,'\n');
+                                          addOutput(yyscanner," \\ifile \""+ yyextra->fileName);
+                                          addOutput(yyscanner,"\" \\ilinebr \\iline " + QCString().setNum(yyextra->lineNr));
                                           BEGIN( Comment );
                                         }
 <PageDocArg2>{CMD}[<>]                  {

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1381,7 +1381,7 @@ STopt  [^\n@\\]*
                                           //if (*yytext=='\n') yyextra->lineNr++;
                                           //addOutput(yyscanner,'\n');
                                           addOutput(yyscanner," \\ifile \""+ yyextra->fileName);
-                                          addOutput(yyscanner,"\" \\ilinebr \\iline " + QCString().setNum(yyextra->lineNr));
+                                          addOutput(yyscanner,"\" \\ilinebr \\iline " + QCString().setNum(yyextra->lineNr) + " \\ilinebr ");
                                           BEGIN( Comment );
                                         }
 <GroupDocArg2>.                         { // title (stored in type)
@@ -1434,7 +1434,7 @@ STopt  [^\n@\\]*
                                           //if (*yytext=='\n') yyextra->lineNr++;
                                           //addOutput(yyscanner,'\n');
                                           addOutput(yyscanner," \\ifile \""+ yyextra->fileName);
-                                          addOutput(yyscanner,"\" \\ilinebr \\iline " + QCString().setNum(yyextra->lineNr));
+                                          addOutput(yyscanner,"\" \\ilinebr \\iline " + QCString().setNum(yyextra->lineNr) + " \\ilinebr ");
                                           BEGIN( Comment );
                                         }
 <PageDocArg2>{CMD}[<>]                  {


### PR DESCRIPTION
Analogous to the fix for `aqddtogroup` see @10416: As the `page` parts are joined together in one block the second block didn't know anymore where it came from originally which resulted in the wrong file name and line number. By adding some internal commands during processing this has been corrected.