### PR TITLE
Incorrect warning and output with `\image` followed by HTML command

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -963,6 +963,7 @@ void DocParser::defaultHandleTitleAndSize(const int cmd, DocNodeVariant *parent,
 
   // parse title
   tokenizer.setStateTitle();
+  tokenizer.setStateTitleSize(true);
   int tok;
   while ((tok=tokenizer.lex()))
   {
@@ -1026,6 +1027,7 @@ void DocParser::defaultHandleTitleAndSize(const int cmd, DocNodeVariant *parent,
       tokenizer.unputString(context.token->name);
     }
   }
+  tokenizer.setStateTitleSize(false);
   tokenizer.setStatePara();
 
   handlePendingStyleCommands(parent,children);

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -187,6 +187,8 @@ class DocTokenizer
     void setStateQuotedString();
     void setStateShowDate();
 
+    void setStateTitleSize(const bool);
+
   private:
     struct Private;
     std::unique_ptr<Private> p;

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -80,6 +80,7 @@ struct doctokenizerYY_state
   int sharpCount=0;
   bool markdownSupport=true;
   bool insideHtmlLink=false;
+  bool titleSize=false;
 
   // context for section finding phase
   const Definition  *definition = 0;
@@ -988,7 +989,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                        }
 <St_TitleN>{HTMLTAG}   {
                          yyextra->token.name = yytext;
-                         handleHtmlTag(yyscanner,yytext);
+                         if (!yyextra->titleSize) handleHtmlTag(yyscanner,yytext);
                          return TK_HTMLTAG;
                        }
 <St_TitleN>\n          { /* new line => end of title */
@@ -1834,6 +1835,13 @@ void DocTokenizer::setStateTitleAttrValue()
   yyscan_t yyscanner = p->yyscanner;
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   BEGIN(St_TitleV);
+}
+
+void DocTokenizer::setStateTitleSize(const bool s)
+{
+  yyscan_t yyscanner = p->yyscanner;
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  yyextra->titleSize = s;
 }
 
 void DocTokenizer::setStateCode()


### PR DESCRIPTION
When having:
```
@image html PCore-Block-Diagram.png width=100px <b>bold</b>
```
we get a warning like:
```
dox_main.md:16: warning: found </b> tag without matching <b>
```

and in the output we see as running text: `bbold`

When having instead of a HTML command a doxygen command or a symbol (`&...;`) we don't get a warning. The HTML command should be seen as end of the underlying command and not be handled at this moment (not the code is also used on other places hence the conditional).


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13450905/example.tar.gz)
