### PR TITLE
issue #7688 Include markdown file in mainpage.dox

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -231,6 +231,9 @@ SLASHopt [/]*
                                       if (yyextra->lang!=SrcLangExt_Cpp) REJECT;
                                       copyToOutput(yyscanner,yytext,(int)yyleng);
                                     }
+<*>"\"<!--\""                       {
+                                      copyToOutput(yyscanner,yytext,(int)yyleng);
+                                    }
 <*>"<!--"                           {
                                       copyToOutput(yyscanner,yytext,(int)yyleng);
                                       yyextra->lastContext = YY_START;
@@ -239,7 +242,7 @@ SLASHopt [/]*
 <HtmlComment>"---"[!]?">"{B}*       {
                                       copyToOutput(yyscanner,yytext,(int)yyleng);
                                       warn(yyextra->fileName,yyextra->lineNr,
-                                           "incorrect HTML end comment --->"
+                                           "incorrect HTML end comment '%s'",yytext
                                           );
                                     }
 <HtmlComment>"--"[!]?">"{B}*        {
@@ -1224,7 +1227,6 @@ static inline void copyToOutput(yyscan_t yyscanner,const char *s,int len)
       switch (s[i])
       {
 	case '\n': yyextra->col=0;
-	           //fprintf(stderr,"---> copy %d\n",g_lineNr);
 		   yyextra->lineNr++; break;
 	case '\t': yyextra->col+=tabSize-(yyextra->col%tabSize); break;
 	default:   yyextra->col++; break;

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -101,6 +101,7 @@ struct commentcnvYY_state
   std::stack<int> commentStack;
   QCString blockName;
   int      lastCommentContext = 0;
+  int      lastContext = 0;
   bool     inSpecialComment = FALSE;
   bool     inRoseComment= FALSE;
   int      stringContext = 0;
@@ -166,6 +167,7 @@ MAILADDR   ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a
 %x IncludeDoc
 %x SnippetDoc
 %x IncludeFile
+%x HtmlComment
 
   //- start: NUMBER -------------------------------------------------------------------------
   // Note same defines in code.l: keep in sync
@@ -229,6 +231,32 @@ SLASHopt [/]*
                                       if (yyextra->lang!=SrcLangExt_Cpp) REJECT;
                                       copyToOutput(yyscanner,yytext,(int)yyleng);
                                     }
+<*>"<!--"                           {
+                                      copyToOutput(yyscanner,yytext,(int)yyleng);
+                                      yyextra->lastContext = YY_START;
+                                      BEGIN(HtmlComment);
+                                    }
+<HtmlComment>"---"[!]?">"{B}*       {
+                                      copyToOutput(yyscanner,yytext,(int)yyleng);
+                                      warn(yyextra->fileName,yyextra->lineNr,
+                                           "incorrect HTML end comment --->"
+                                          );
+                                    }
+<HtmlComment>"--"[!]?">"{B}*        {
+                                      copyToOutput(yyscanner,yytext,(int)yyleng);
+                                      BEGIN( yyextra->lastContext );
+                                    }
+<HtmlComment>\n                     {
+                                      copyToOutput(yyscanner,yytext,(int)yyleng);
+                                      yyextra->lineNr++;
+                                    }
+<HtmlComment>[^\\\n\-]+             {
+                                      copyToOutput(yyscanner,yytext,(int)yyleng);
+                                    }
+<HtmlComment>.                      {
+                                      copyToOutput(yyscanner,yytext,(int)yyleng);
+                                    }
+
 <Scan>[^"'!\/\n\\#,\-=; \t]*        { /* eat anything that is not " / , or \n */
                                        copyToOutput(yyscanner,yytext,(int)yyleng);
                                     }

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1078,7 +1078,7 @@ STopt  [^\n@\\]*
 
 <HtmlComment>"---"[!]?">"{B}*           {
                                           warn(yyextra->fileName,yyextra->lineNr,
-                                               "incorrect HTML end comment --->"
+                                               "incorrect HTML end comment '%s'",yytext
                                               );
                                         }
 <HtmlComment>"--"[!]?">"{B}*            { BEGIN( Comment ); }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7848,7 +7848,6 @@ static void parseCompounds(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
       yyextra->yyLineNr = ce->bodyLine;
       yyextra->yyColNr = ce->bodyColumn;
       yyextra->insideObjC = ce->lang==SrcLangExt_ObjC;
-      //printf("---> Inner block starts at line %d objC=%d\n",yyextra->yyLineNr,yyextra->insideObjC);
       yyextra->current = std::make_shared<Entry>();
       yyextra->isStatic = FALSE;
       initEntry(yyscanner);


### PR DESCRIPTION
In the comment https://github.com/doxygen/doxygen/issues/7688#issuecomment-1822840875 a problem was identified regarding HTML type of comments (`<!--... -->`), they are excluded from processing now similar to the code in commentscan.l