### PR TITLE
issue #10460 `\hideinheritancegraph` not working

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -952,6 +952,8 @@ static void addClassToContext(const Entry *root)
 
     cd->setDocumentation(root->doc,root->docFile,root->docLine);
     cd->setBriefDescription(root->brief,root->briefFile,root->briefLine);
+    cd->enableCollaborationGraph(root->collaborationGraph);
+    cd->setTypeInheritanceGraph(root->inheritanceGraph);
 
     if (!root->spec.isForwardDecl() && cd->isForwardDeclared())
     {


### PR DESCRIPTION
get  `\hideinheritancegrap`, `inheritancegraph`, `\hidecollaborationgraph ` and `\collaborationgraph ` working for "out of place" class documentation.