### PR TITLE
Remove help info about non existing option

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10718,7 +10718,6 @@ static void devUsage()
 #if ENABLE_TRACING
   msg("  -t [<file|stdout|stderr>] trace debug info to file, stdout, or stderr (default file stdout)\n");
 #endif
-  msg("  -T          activates output generation via Django like template\n");
   msg("  -d <level>  enable a debug level, such as (multiple invocations of -d are possible):\n");
   Debug::printFlags();
 }


### PR DESCRIPTION
Remove help information about `-T` option as it was removed by means of 0b0ec2e61189c321bb7ead5c0bf2f8cb0b618f65  i.e. "Remove experimental template engine option"