### PR TITLE
Docker: change working directory from / to /doxygen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     graphviz \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /doxygen/build/bin/doxygen /usr/local/bin/
+WORKDIR /doxygen
 ENTRYPOINT ["doxygen"]


### PR DESCRIPTION
Current Dockerfile does not specifiy the working directory for final container. 
(Specified only in builder container.)

It results working directory is set to root(/), and all files are generated to root directory.
Docker prohibits mounting root directory with following error message when running container, making impossible to obtain generated files by Doxygen.
```
$ docker run --rm -v "${PWD}":/ -it ghcr.io/doxygen/doxygen -g
docker: Error response from daemon: invalid volume specification: '/run/desktop/mnt/host/wsl/docker-desktop-bind-mounts/Ubuntu-22.04/013817998ad56b4c5cabca3fdc007b4d2a9d0d3baf0a48e93dee54bf378e1fff:/': invalid mount config for type "bind": invalid specification: destination can't be '/'.
```

This PR makes working directory into `/doxygen`, you can obtain Doxygen generated files like this command.
```
$ docker run --rm -v "${PWD}":/doxygen doxygen -g


Configuration file 'Doxyfile' created.

Now edit the configuration file and enter

  doxygen

to generate the documentation for your project

$ ls
Doxyfile
```

I hope my PR helps people using Doxygen with official docker container.