### PR TITLE
Incorrect warning due to import statement

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1210,17 +1210,18 @@ WSopt [ \t\r]*
                                         }
 <Include>[^\">\n]+[\">]                 {
                                           yyextra->incName+=yytext;
-                                          readIncludeFile(yyscanner,yyextra->incName);
                                           if (yyextra->isImported)
                                           {
                                             BEGIN(EndImport);
                                           }
                                           else
                                           {
+                                            readIncludeFile(yyscanner,yyextra->incName);
                                             BEGIN(Start);
                                           }
                                         }
-<EndImport>{ENDIMPORTopt}/\n                    {
+<EndImport>{ENDIMPORTopt}/\n            {
+                                          readIncludeFile(yyscanner,yyextra->incName);
                                           BEGIN(Start);
                                         }
 <EndImport>\\[\r]?"\n"                  {


### PR DESCRIPTION
With the Objective C example:
**aa.m**
```
#import "bb.h"
```

**bb.h**
```
#ifndef INCLUDED_OOFUNCTIONATTRIBUTES_h
#endif
```
we get the warning:
```
bb.h:2: Error: More #endif's than #if's found.
```
as the first line of the imported file is read as "comment", by delaying the read this is prevented.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13634350/example.tar.gz)
