### PR TITLE
Incorrect jump to anchor inside page when using CTRL-click

### DIFF
--- a/templates/html/navtree.js
+++ b/templates/html/navtree.js
@@ -190,7 +190,7 @@ function initNavTree(toroot,relpath) {
         const aname = '#'+link.split('#')[1];
         const srcPage = stripPath(pathName());
         const targetPage = stripPath(link.split('#')[0]);
-        a.href = srcPage!=targetPage ? url : "javascript:void(0)";
+        a.href = srcPage!=targetPage ? url : aname;
         a.onclick = function() {
           storeLink(link);
           aPPar = $(a).parent().parent();


### PR DESCRIPTION
When having a simple example like:
```
# Hello World

[TOC]

## Introduction
This is the canonical `Hello World` program.

## Reference
This is a second paragraph
```
and clicking in the treeview on "Hello World" followed by a click on "Introduction" a jump to "Introduction is performed but when doing a CTRL_click on "Introduction"  (so opening a new tab) we get as page "javascript:void(0)"  which is empty. In case of a jump "inside" the page we should jump to the anchor.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13638962/example.tar.gz)
