### PR TITLE
issue #10485 Parsing error with C++20 requires clause if at the end of the function declaration

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2329,7 +2329,10 @@ NONLopt [^\n]*
                                             REJECT
                                           }
                                         }
-<RequiresClause>"||"|"&&"             { // "requires A || B" or "requires A && B"
+<RequiresClause>"::"{ID}                {
+                                          yyextra->current->req+=yytext;
+                                        }
+<RequiresClause>"||"|"&&"               { // "requires A || B" or "requires A && B"
                                           yyextra->current->req+=yytext;
                                         }
 <RequiresClause>{BN}+                   {


### PR DESCRIPTION
Handle also things like `::value`