### PR TITLE
Do not lowercase search titles for code and capitalize on page terms

### DIFF
--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -53,6 +53,12 @@ void SearchTerm::makeTitle()
   else if (std::holds_alternative<const SectionInfo *>(info))
   {
     title = std::get<const SectionInfo *>(info)->title();
+
+    // Capitalizing the word as this is not a code entity
+    std::string letter = getUTF8CharAt(word.str(),0);
+    // Uppercase letter could have different size
+    word.remove(0, letter.size());
+    word.prepend(convertUTF8ToUpper(letter));
   }
   else
   {
@@ -425,7 +431,7 @@ void createJavaScriptSearchIndex()
   {
     if (gd->isLinkable())
     {
-      QCString title(convertUTF8ToLower(filterTitle(gd->groupTitle()).str()));
+      QCString title(filterTitle(gd->groupTitle()).str());
       IntVector tokenIndices;
       splitSearchTokens(title,tokenIndices);
       for (int index : tokenIndices)
@@ -441,7 +447,7 @@ void createJavaScriptSearchIndex()
   {
     if (pd->isLinkable())
     {
-      QCString title(convertUTF8ToLower(filterTitle(pd->title()).str()));
+      QCString title(filterTitle(pd->title()).str());
       IntVector tokenIndices;
       splitSearchTokens(title,tokenIndices);
       for (int index : tokenIndices)
@@ -455,7 +461,7 @@ void createJavaScriptSearchIndex()
   // main page
   if (Doxygen::mainPage)
   {
-    QCString title(convertUTF8ToLower(filterTitle(Doxygen::mainPage->title()).str()));
+    QCString title(filterTitle(Doxygen::mainPage->title()).str());
     IntVector tokenIndices;
     splitSearchTokens(title,tokenIndices);
     for (int index : tokenIndices)
@@ -839,7 +845,7 @@ void writeJavaScriptSearchIndex()
 
 void SearchIndexInfo::add(const SearchTerm &term)
 {
-  std::string letter = getUTF8CharAt(term.word.str(),0);
+  std::string letter = convertUTF8ToLower(getUTF8CharAt(term.word.str(),0));
   auto &list = symbolMap[letter]; // creates a new entry if not found
   list.push_back(term);
 }

--- a/src/searchindex_js.h
+++ b/src/searchindex_js.h
@@ -42,8 +42,8 @@ QCString searchName(const Definition *d);
 struct SearchTerm
 {
   using LinkInfo = std::variant<std::monostate,const Definition *,const SectionInfo *>;
-  SearchTerm(const QCString &w,const Definition *d)  : word(convertUTF8ToLower(w.str())), info(d)  { makeTitle(); }
-  SearchTerm(const QCString &w,const SectionInfo *s) : word(convertUTF8ToLower(w.str())), info(s)  { makeTitle(); }
+  SearchTerm(const QCString &w,const Definition *d)  : word(w.str()), info(d)  { makeTitle(); }
+  SearchTerm(const QCString &w,const SectionInfo *s) : word(w.str()), info(s)  { makeTitle(); }
   QCString word;                 //!< lower case word that is indexed (e.g. name of a symbol, or word from a title)
   QCString title;                //!< title to show in the output for this search result
   LinkInfo info;                 //!< definition to link to


### PR DESCRIPTION
This PR addresses the lower-casing of functions in search box so that:

![image](https://github.com/doxygen/doxygen/assets/1700098/92e87523-4621-428c-88c4-823dfa05bd8f)

Becomes the same as in source code:

![image](https://github.com/doxygen/doxygen/assets/1700098/a3d6bf0e-5aeb-4eec-8612-043b585a59c9)

It also capitalizes the words from captions so that:

![image](https://github.com/doxygen/doxygen/assets/1700098/f6e36fd4-b85d-4c33-afc5-63c5f4786343)

becomes:

![image](https://github.com/doxygen/doxygen/assets/1700098/5d932b3e-1fae-4ab4-9176-a8395d3e0c11)
