### PR TITLE
Incorrect line count with `\include{doc}`

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -281,6 +281,13 @@ LOGICOP   "=="|"!="|">"|"<"|">="|"<="|"&&"|"||"|"!"|"<=>"
 BITOP     "&"|"|"|"^"|"<<"|">>"|"~"
 OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 MODULE_ID ({ID}".")*{ID}
+LINENR    {B}*[1-9][0-9]*
+FILEICHAR [a-z_A-Z0-9\\:\\\/\-\+=&#@]
+FILEECHAR [a-z_A-Z0-9\-\+=&#@]
+FILECHARS {FILEICHAR}*{FILEECHAR}+
+HFILEMASK {FILEICHAR}*("."{FILEICHAR}+)+{FILECHARS}*
+VFILEMASK {FILECHARS}("."{FILECHARS})*
+FILEMASK  {VFILEMASK}|{HFILEMASK}
 
   /* no comment start / end signs inside square brackets */
 NCOMM [^/\*]
@@ -6900,6 +6907,31 @@ NONLopt [^\n]*
                                           yyextra->fencedSize=0;
                                           yyextra->nestedComment=0;
                                           BEGIN(DocCopyBlock);
+                                        }
+<DocBlock>{CMD}"ifile"{B}+"\""[^\n\"]+"\"" {
+                                          yyextra->fileName = &yytext[6];
+                                          yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                          yyextra->fileName = yyextra->fileName.mid(1,yyextra->fileName.length()-2);
+                                          yyextra->docBlock << yytext;
+                                        }
+<DocBlock>{CMD}"ifile"{B}+{FILEMASK}    {
+                                          yyextra->fileName = &yytext[6];
+                                          yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                          yyextra->docBlock << yytext;
+                                        }
+<DocBlock>{CMD}"iline"{LINENR}/[\n\.]   |
+<DocBlock>{CMD}"iline"{LINENR}{B}       {
+                                          bool ok = false;
+                                          int nr = QCString(&yytext[6]).toInt(&ok);
+                                          if (!ok)
+                                          {
+                                            warn(yyextra->fileName,yyextra->yyLineNr,"Invalid line number '%s' for iline command",yytext);
+                                          }
+                                          else
+                                          {
+                                            yyextra->yyLineNr = nr;
+                                          }
+                                          yyextra->docBlock << yytext;
                                         }
 <DocBlock>{B}*"<"{PRE}">"               {
                                           yyextra->docBlock << yytext;


### PR DESCRIPTION
In case we have:
**foo.h**
```
/// \file
///
/// The level 1
///
/// provoking an error \error_5_1_h
///
/// \include{doc} kaboom.md

/// \brief the fie 1
/// \details the fie 1
/// \error_11_h
void foo_1() {}
```
**kaboom.md**
```
# Uh-oh 1

Seems Doxygen isn't playing nice with slightly longer paths... \error_3
```
we get the warnings:
```
.../foo.h:5: warning: Found unknown command '\error_5_1_h'
.../kaboom.md:3: warning: Found unknown command '\error_3'
.../foo.h:14: warning: Found unknown command '\error_11_h'
```
though the last one should read
```
.../foo.h:11: warning: Found unknown command '\error_11_h'
```

Problem is due to the fact that `\include{doc}` adds lines but the correction of the number of lines is done based for the current comment block so subsequent comment blocks don't know about it, this has to be handled in the scanner that extracts the comment blocks. (code analogous to the doctokenizer)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13702684/example.tar.gz)
