### PR TITLE
Incorrect handling of `\include{doc}` for Fortran

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -74,6 +74,7 @@ struct commentcnv_FileState
   YY_BUFFER_STATE bufState = 0;
   QCString fileName;
   QCString oldFileName;
+  QCString oldIncPrefix;
   int oldState = 0;
   BufStr fileBuf;
   const BufStr *oldFileBuf = nullptr;
@@ -107,6 +108,7 @@ struct commentcnvYY_state
   int      charContext = 0;
   int      javaBlock = 0;
   bool     specialComment = FALSE;
+  QCString incPrefix;
 
   QCString aliasString;
   int      blockCount = 0;
@@ -269,7 +271,7 @@ SLASHopt [/]*
                                        yyextra->commentStack.push(yyextra->lineNr);
 				     }
                                    }
-<Scan>![><!]/.*\n	   {
+<Scan>{B}*![><!]/.*\n              {
                                      if (yyextra->lang!=SrcLangExt_Fortran)
 				     {
 				       REJECT;
@@ -280,6 +282,7 @@ SLASHopt [/]*
                                        yyextra->nestingCount=0; // Fortran doesn't have an end comment
                                        clearCommentStack(yyscanner); /*  to be on the save side */
 				       BEGIN(CComment);
+                                       yyextra->incPrefix = yytext;
                                        yyextra->commentStack.push(yyextra->lineNr);
 				     }
   				   }
@@ -297,6 +300,7 @@ SLASHopt [/]*
                                          yyextra->nestingCount=0; // Fortran doesn't have an end comment
                                          clearCommentStack(yyscanner); /*  to be on the save side */
 				         BEGIN(CComment);
+                                         yyextra->incPrefix = yytext;
                                          yyextra->commentStack.push(yyextra->lineNr);
 				       }
 				       else
@@ -455,7 +459,7 @@ SLASHopt [/]*
                                        yyextra->commentStack.push(yyextra->lineNr);
 				     }
   				   }
-<Scan>![><!]		           {
+<Scan>{B}*![><!]	           {
                                      if (yyextra->lang!=SrcLangExt_Fortran)
 				     {
 				       REJECT;
@@ -466,6 +470,7 @@ SLASHopt [/]*
                                        yyextra->nestingCount=0;  // Fortran doesn't have an end comment
                                        clearCommentStack(yyscanner); /*  to be on the save side */
 				       BEGIN(CComment);
+                                       yyextra->incPrefix = yytext;
                                        yyextra->commentStack.push(yyextra->lineNr);
 				     }
   				   }
@@ -1110,8 +1115,10 @@ SLASHopt [/]*
                                         yyextra->inBuf      = fs->oldFileBuf;
                                         yyextra->inBufPos   = fs->oldFileBufPos;
                                         yyextra->includeCtx = fs->oldIncludeCtx;
-                                        QCString lineStr=" \\ilinebr\\ifile \""+yyextra->fileName+"\" \\iline "+QCString().setNum(yyextra->lineNr)+" ";
+                                        yyextra->incPrefix  = fs->oldIncPrefix;
+                                        QCString lineStr=yyextra->incPrefix + " \\ilinebr\\ifile \""+yyextra->fileName+"\" \\iline "+QCString().setNum(yyextra->lineNr)+" ";
                                         copyToOutput(yyscanner,lineStr.data(),lineStr.length());
+                                        yyextra->incPrefix  = "";
                                         yyextra->includeStack.pop_back();
                                         //printf("<<EOF>> switch back to %s line %d inbufPos=%d outbufPos=%d\n",
                                         //    qPrint(yyextra->fileName),yyextra->lineNr,yyextra->inBufPos,yyextra->outBuf.curPos());
@@ -1411,6 +1418,7 @@ static bool readIncludeFile(yyscan_t yyscanner,const QCString &inc,const QCStrin
     fs->oldFileBuf    = yyextra->inBuf;
     fs->oldFileBufPos = yyextra->inBufPos;
     fs->oldIncludeCtx = yyextra->includeCtx;
+    fs->oldIncPrefix  = yyextra->incPrefix;
     yy_switch_to_buffer(yy_create_buffer(0, YY_BUF_SIZE, yyscanner),yyscanner);
     yyextra->fileName = absFileName;
     yyextra->lineNr   = lineNr;

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -262,6 +262,7 @@ static inline const char *getLexerFILE() {return __FILE__;}
 
  //-----------------------------------------------------------------------------
  //-----------------------------------------------------------------------------
+CMD       ("\\"|"@")
 IDSYM     [a-z_A-Z0-9]
 NOTIDSYM  [^a-z_A-Z0-9]
 SEPARATE  [:, \t]
@@ -300,6 +301,14 @@ EXTERNAL_STMT (EXTERNAL)
 CONTAINS  CONTAINS
 PREFIX    ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON_)?RECURSIVE|IMPURE|PURE|ELEMENTAL)?
 SCOPENAME ({ID}{BS}"::"{BS})*
+
+LINENR    {B}*[1-9][0-9]*
+FILEICHAR [a-z_A-Z0-9\\:\\\/\-\+=&#@]
+FILEECHAR [a-z_A-Z0-9\-\+=&#@]
+FILECHARS {FILEICHAR}*{FILEECHAR}+
+HFILEMASK {FILEICHAR}*("."{FILEICHAR}+)+{FILECHARS}*
+VFILEMASK {FILECHARS}("."{FILECHARS})*
+FILEMASK  {VFILEMASK}|{HFILEMASK}
 
 %option noyywrap
 %option stack
@@ -1397,12 +1406,43 @@ private                                 {
                                           //cout << "start DocBlock " << endl;
                                         }
 
-<DocBlock>.*                            { // contents of yyextra->current comment line
+<DocBlock>{CMD}"ifile"{B}+"\""[^\n\"]+"\"" {
+                                          yyextra->fileName = &yytext[6];
+                                          yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                          yyextra->fileName = yyextra->fileName.mid(1,yyextra->fileName.length()-2);
+                                          yyextra->docBlock+=yytext;
+                                        }
+<DocBlock>{CMD}"ifile"{B}+{FILEMASK}    {
+                                          yyextra->fileName = &yytext[6];
+                                          yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                          yyextra->docBlock+=yytext;
+                                        }
+<DocBlock>{CMD}"iline"{LINENR}/[\n\.]   |
+<DocBlock>{CMD}"iline"{LINENR}{B}       {
+                                          bool ok = false;
+                                          int nr = QCString(&yytext[6]).toInt(&ok);
+                                          if (!ok)
+                                          {
+                                            warn(yyextra->fileName,yyextra->lineNr,"Invalid line number '%s' for iline command",yytext);
+                                          }
+                                          else
+                                          {
+                                            yyextra->lineNr = nr;
+                                          }
+                                          yyextra->docBlock+=yytext;
+                                        }
+<DocBlock>({CMD}{CMD}){ID}/[^a-z_A-Z0-9] { // escaped command
+                                          yyextra->docBlock+=yytext;
+                                        }
+<DocBlock>[^\\@\n]*                     { // contents of yyextra->current comment line
                                           yyextra->docBlock+=yytext;
                                         }
 <DocBlock>"\n"{BS}"!"(">"|"!"+)         { // comment block (next line is also comment line)
                                           yyextra->docBlock+="\n"; // \n is necessary for lists
                                           newLine(yyscanner);
+                                        }
+<DocBlock>{CMD}                             {
+                                          yyextra->docBlock+=yytext;
                                         }
 <DocBlock>"\n"                          { // comment block ends at the end of this line
                                           //cout <<"3=========> comment block : "<< yyextra->docBlock << endl;


### PR DESCRIPTION
Having:
**foo.f**
```
    !> \file
    !>
    !> The level 1
    !>
    !> provoking an error \error_5_1_ftn
    !>
    !> \include{doc} kaboom_ftn.md

    !> \brief the fie 1
    !> \details the fie 1
    !> \error_11_ftn
    subroutine ftn_1
    end subroutine ftn_1
```

**kaboom_ftn.md**
```
# Uh-oh 1
!>
!> Seems Doxygen isn't playing nice with slightly longer paths... \error_3
```
gives the warning:
```
Error in file .../foo.f line: 17, state: 10(ModuleBody)
```

Due to the fact that the end include line is not a valid Fortran comment line (missing the `!>`) (handling in Fortran scanner analogous to the handling in scanner.l from #10490)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13705545/example.tar.gz)
