### PR TITLE
Problem with `\fC` on man pages

### DIFF
--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -318,6 +318,7 @@ static QCString buildFileName(const QCString &name)
 void ManGenerator::startFile(const QCString &,const QCString &manName,const QCString &,int,int)
 {
   startPlainFile( buildFileName( manName ) );
+  m_t << ".do ftr C R\n";
   m_firstCol=TRUE;
 }
 


### PR DESCRIPTION
In https://github.com/phmarek/fsvs/issues/19 "uses non-portable 'C' font, causing warnings from groff" this problem was menioned and it can be reproduced by means of:
```
/// \file
/// the file description

/// The function description
///
/// some `description`
void fie();
```

and when giving: `man man/ma3/aa.h.3 > /dev/null` we get:
```
troff:<standard input>:24: warning: cannot select font 'C'
```

The chosen way is the least intrusive, an alternative would have been to change all occurences of `\fC` to `\fR` (i.e. to the regular font).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13718341/example.tar.gz)
