### PR TITLE
Problem with `\fC` on man pages

### DIFF
--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -148,7 +148,7 @@ void ManDocVisitor::operator()(const DocStyleChange &s)
       m_firstCol=FALSE;
       break;
     case DocStyleChange::Code:
-      if (s.enable()) m_t << "\\fC";   else m_t << "\\fP";
+      if (s.enable()) m_t << "\\fR";   else m_t << "\\fP";
       m_firstCol=FALSE;
       break;
     case DocStyleChange::Subscript:
@@ -217,7 +217,7 @@ void ManDocVisitor::operator()(const DocVerbatim &s)
       filter(s.text());
       break;
     case DocVerbatim::JavaDocCode:
-      m_t << "\\fC\n";
+      m_t << "\\fR\n";
       filter(s.text());
       m_t << "\\fP\n";
       break;
@@ -741,7 +741,7 @@ void ManDocVisitor::operator()(const DocInternal &i)
 void ManDocVisitor::operator()(const DocHRef &href)
 {
   if (m_hide) return;
-  m_t << "\\fC";
+  m_t << "\\fR";
   visitChildren(href);
   m_t << "\\fP";
 }

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -318,7 +318,6 @@ static QCString buildFileName(const QCString &name)
 void ManGenerator::startFile(const QCString &,const QCString &manName,const QCString &,int,int)
 {
   startPlainFile( buildFileName( manName ) );
-  m_t << ".do ftr C R\n";
   m_firstCol=TRUE;
 }
 
@@ -876,7 +875,7 @@ void ManGenerator::startLabels()
 
 void ManGenerator::writeLabel(const QCString &l,bool isLast)
 {
-  m_t << "\\fC [" << l << "]\\fP";
+  m_t << "\\fR [" << l << "]\\fP";
   if (!isLast) m_t << ", ";
 }
 

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -112,7 +112,7 @@ class ManGenerator : public OutputGenerator
                          const QCString &anchor,const QCString &name);
     void startTextLink(const QCString &,const QCString &) {}
     void endTextLink() {}
-    void startTypewriter() { m_t << "\\fC"; m_firstCol=FALSE; }
+    void startTypewriter() { m_t << "\\fR"; m_firstCol=FALSE; }
     void endTypewriter()   { m_t << "\\fP"; m_firstCol=FALSE; }
     void startGroupHeader(int);
     void endGroupHeader(int);


### PR DESCRIPTION
- Revering original update, see https://github.com/doxygen/doxygen/pull/10497,  due to problems with `mandoc`
- Implementing alternative by changing all `\fC` into `\fR`