### PR TITLE
issue #10511 C# namespace separators are output in C++ style

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1112,6 +1112,11 @@ static bool writeDefArgumentList(OutputList &ol,const Definition *scope,const Me
         {
           n=addTemplateNames(n,scope->name(),cName);
         }
+        QCString sep = getLanguageSpecificSeparator(md->getLanguage(),true);
+        if (sep!="::")
+        {
+          n=substitute(n,"::",sep);
+        }
         linkifyText(TextGeneratorOLImpl(ol),scope,md->getBodyDef(),md,n);
       }
     }


### PR DESCRIPTION
Corrected type in case of non C++