### PR TITLE
issue #10504 A list inside an alias on a markdown page seems broken, it repeats the alias indefinitely

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -5385,11 +5385,7 @@ reparsetoken:
             bool rerun = false;
             while (n)
             {
-              if (std::get_if<DocAutoListItem>(n))
-              {
-                continue;
-              }
-              else if (std::get_if<DocAutoList>(n))
+              if (std::get_if<DocAutoList>(n))
               {
                 const DocAutoList *al = std::get_if<DocAutoList>(n);
                 indent = al->indent();
@@ -5414,7 +5410,7 @@ reparsetoken:
                   break;
                 }
               }
-              else
+              else if (!std::get_if<DocAutoListItem>(n))
               {
                 break;
               }

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -271,7 +271,7 @@ OPTSTARS  ("/""/"{BLANK}*)?"*"*{BLANK}*
 LISTITEM  {BLANK}*[-]("#")?{WS}
 MLISTITEM {BLANK}*[+*]{WS}
 OLISTITEM {BLANK}*[1-9][0-9]*"."{BLANK}
-ENDLIST   {BLANK}*"."{BLANK}*\n
+ENDLIST   {BLANK}*"."{BLANK}*(\n|"\\ilinebr")
 ATTRNAME  [a-z_A-Z\x80-\xFF][:a-z_A-Z0-9\x80-\xFF\-]*
 ATTRIB    {ATTRNAME}{WS}*("="{WS}*(("\""[^\"]*"\"")|("'"[^\']*"'")|[^ \t\r\n'"><]+))?
 URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=\x80-\xFF]


### PR DESCRIPTION
When the HTML tag is an end tag and matches the tag just before the list it is handled as an end list as well.

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13780563/example.tar.gz)
