### PR TITLE
issue #10516 @copybrief command does not take effect with 1.10.0

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3841,26 +3841,23 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
         }
         else
         {
-          static const reg::Ex nonBrief(R"( *[\\@]ifile *\"[^\"]*\" *[\\@]ilinebr *[\\@]iline *(\d+) *[\\@]ilinebr *\n)");
-          static const reg::Ex nonBrief1(R"( *[\\@]ifile *\"[^\"]*\" *[\\@]ilinebr *[\\@]iline *\d+ *[\\@]ilinebr *)");
+          static const reg::Ex nonBrief(R"( *[\\@]ifile *\"[^\"]*\" *[\\@]ilinebr *[\\@]iline *(\d+) *[\\@]ilinebr *([\n]?))");
           std::string str = yyextra->current->brief.str();
           reg::Match match;
-          reg::Match match1;
           if (reg::match(str,match,nonBrief)) // match found
           {
-            yyextra->current->brief = yyextra->current->brief.left(yyextra->current->brief.length()-1);
-            // set warning line correct
-            yyextra->current->brief += "\\iline " + QCString().setNum(1 + static_cast<int>(std::stoul(match[1].str()))) + " \\ilinebr ";
-            foundMatch = true;
-          }
-          else if (reg::match(str,match1,nonBrief1)) // match found
-          {
+            if (QCString(match[2].str()) == "\n")
+            {
+              yyextra->current->brief = yyextra->current->brief.left(yyextra->current->brief.length()-1);
+              // set warning line correct
+              yyextra->current->brief += "\\iline " + QCString().setNum(1 + static_cast<int>(std::stoul(match[1].str()))) + " \\ilinebr ";
+            }
             foundMatch = true;
           }
         }
         if (foundMatch)
         {
-          yyextra->pOutputString = &yyextra->current->brief;
+            yyextra->pOutputString = &yyextra->current->brief;
         }
         else
         {

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -59,6 +59,7 @@ typedef yyguts_t *yyscan_t;
 #include "parserintf.h"
 #include "reflist.h"
 #include "section.h"
+#include "regex.h"
 #include "util.h"
 #include "reflist.h"
 #include "trace.h"
@@ -1065,7 +1066,7 @@ STopt  [^\n@\\]*
                                             yyextra->briefEndsAtDot=FALSE;
                                           }
                                         }
-<Comment>{DOCNL}                             { // newline
+<Comment>{DOCNL}                        { // newline
                                           addOutput(yyscanner,yytext);
                                           if (*yytext == '\n') yyextra->lineNr++;
                                         }
@@ -3821,29 +3822,55 @@ static inline void setOutput(yyscan_t yyscanner,OutputContext ctx)
       yyextra->pOutputString = &yyextra->current->doc;
       break;
     case OutputBrief:
-      if (oldContext!=yyextra->inContext)
       {
-        if (yyextra->current->brief.isEmpty()) yyextra->current->briefLine = yyextra->lineNr;
-        if (yyextra->current->briefFile.isEmpty())
+        if (oldContext!=yyextra->inContext)
         {
-          yyextra->current->briefFile = yyextra->fileName;
-          yyextra->current->briefLine = yyextra->lineNr;
+          if (yyextra->current->brief.isEmpty()) yyextra->current->briefLine = yyextra->lineNr;
+          if (yyextra->current->briefFile.isEmpty())
+          {
+            yyextra->current->briefFile = yyextra->fileName;
+            yyextra->current->briefLine = yyextra->lineNr;
+          }
         }
-      }
-      if (yyextra->current->brief.stripWhiteSpace().isEmpty()) // we only want one brief
-        // description even if multiple
-        // are given...
-      {
-        yyextra->pOutputString = &yyextra->current->brief;
-      }
-      else
-      {
-        if (!yyextra->current->doc.isEmpty()) // when appending parts add a new line
+        bool foundMatch = false;
+        if (yyextra->current->brief.stripWhiteSpace().isEmpty()) // we only want one brief
+          // description even if multiple
+          // are given...
         {
-          yyextra->current->doc += "\n";
+          foundMatch = true;
         }
-        yyextra->pOutputString = &yyextra->current->doc;
-        yyextra->inContext = OutputDoc; // need to switch to detailed docs, see bug 631380
+        else
+        {
+          static const reg::Ex nonBrief(R"( *[\\@]ifile *\"[^\"]*\" *[\\@]ilinebr *[\\@]iline *(\d+) *[\\@]ilinebr *\n)");
+          static const reg::Ex nonBrief1(R"( *[\\@]ifile *\"[^\"]*\" *[\\@]ilinebr *[\\@]iline *\d+ *[\\@]ilinebr *)");
+          std::string str = yyextra->current->brief.str();
+          reg::Match match;
+          reg::Match match1;
+          if (reg::match(str,match,nonBrief)) // match found
+          {
+            yyextra->current->brief = yyextra->current->brief.left(yyextra->current->brief.length()-1);
+            // set warning line correct
+            yyextra->current->brief += "\\iline " + QCString().setNum(1 + static_cast<int>(std::stoul(match[1].str()))) + " \\ilinebr ";
+            foundMatch = true;
+          }
+          else if (reg::match(str,match1,nonBrief1)) // match found
+          {
+            foundMatch = true;
+          }
+        }
+        if (foundMatch)
+        {
+          yyextra->pOutputString = &yyextra->current->brief;
+        }
+        else
+        {
+          if (!yyextra->current->doc.isEmpty()) // when appending parts add a new line
+          {
+            yyextra->current->doc += "\n";
+          }
+          yyextra->pOutputString = &yyextra->current->doc;
+          yyextra->inContext = OutputDoc; // need to switch to detailed docs, see bug 631380
+        }
       }
       break;
     case OutputXRef:


### PR DESCRIPTION
For better error / warning handling a line with file / line information was added to the brief description. When a new brief line arrives it was checked whether or not it could be the brief description by checking against the empty string, the later was not the case anymore and hence such a line should not be taken into consideration for determining the empty-ness of the original brief description.