### PR TITLE
 Adding "engine" files for plantuml

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1123,6 +1123,7 @@ class DoxPlantumlEngine(str, Enum):
     HCL='hcl'
     REGEX='regex'
     EBNF='ebnf'
+    FILES='files'
 
 
 class DoxProtectionKind(str, Enum):
@@ -23998,7 +23999,7 @@ class docPlantumlType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf']
+            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf', 'files']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxPlantumlEngine' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -3418,7 +3418,7 @@ class Receiver
   Not all diagrams can be created with the PlantUML `@startuml` command but need another
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
   the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
-  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex` and `ebnf`.
+  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex`, `ebnf` and `files`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -70,7 +70,7 @@ static const std::set<std::string> g_plantumlEngine {
   "uml", "bpm", "wire", "dot", "ditaa",
   "salt", "math", "latex", "gantt", "mindmap",
   "wbs", "yaml", "creole", "json", "flow",
-  "board", "git", "hcl", "regex", "ebnf"
+  "board", "git", "hcl", "regex", "ebnf", "files"
 };
 
 //---------------------------------------------------------------------------

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -1078,6 +1078,7 @@
       <xsd:enumeration value="hcl"/>
       <xsd:enumeration value="regex"/>
       <xsd:enumeration value="ebnf"/>
+      <xsd:enumeration value="files"/>
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
Add the plantuml "engine" files for displaying directory trees.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13800986/example.tar.gz)
