### PR TITLE
Warning about invalid argument with `\iline` command

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1329,7 +1329,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          unput(*yytext);
                          return 0;
                        }
-<St_ILine>{LINENR}/[\n\.]     |
+<St_ILine>{LINENR}/[\\@\n\.]  |
 <St_ILine>{LINENR}{BLANK}     {
                          bool ok = false;
                          int nr = QCString(yytext).toInt(&ok);


### PR DESCRIPTION
When having a simple file like:
```
/**
 * \if english
 * \brief  Namespace
 * \endif
 *
 * \if german
 * \brief  Namensraum
 *
 * \endif
 */
namespace dBaseRelease
{
}
```
with
```
ENABLED_SECTIONS       = german
```

We get the warning like:
```
.../BoostServer.cc:6: warning: invalid argument for command '\iline'
```

Initial the `iline` command is, when inserted, properly inserted but due to the call of `stripTrailingWhiteSpace` (in commentscan.l) at that moment trailing whitespace and line breaks are removed. The `iline` value can now also be terminated by means of the start of a command.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13809173/example.tar.gz)
