### PR TITLE
issue #10504 issue #10504 A list inside an alias on a markdown page seems broken, it repeats the alias indefinitely

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -5200,7 +5200,7 @@ static bool checkIfHtmlEndTagEndsAutoList(DocParser *parser,const DocNodeVariant
       // insert an artificial 'end of autolist' marker and parse again
       QCString indentStr;
       indentStr.fill(' ',indent);
-      parser->tokenizer.unputString("\\ilinebr.\\ilinebr"+indentStr+"</"+parser->context.token->name+">");
+      parser->tokenizer.unputString("\\ilinebr "+indentStr+".\\ilinebr"+indentStr+"</"+parser->context.token->name+">");
       return true;
     }
   }


### PR DESCRIPTION
Some indentation is needed before the `.`.
An extra space is needed after the `\ilinebr` as one space is eaten by the function `extractPartAfterNewLine`.

(Found by CGAL during overnight tests)