### PR TITLE
Make the menu bar stick to the top of the screen when scrolling

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -871,28 +871,6 @@ void FTVHelp::generateTreeViewScripts()
 
   // generate navtree.js & navtreeindex.js
   generateJSNavTree(p->indentNodes[0]);
-
-  // copy resize.js & navtree.css
-  auto &mgr = ResourceMgr::instance();
-  {
-    std::ofstream f = Portable::openOutputStream(htmlOutput+"/resize.js");
-    if (f.is_open())
-    {
-      TextStream t(&f);
-      t << substitute(
-             substitute(mgr.getAsString("resize.js"),
-                "$TREEVIEW_WIDTH", QCString().setNum(Config_getInt(TREEVIEW_WIDTH))),
-                "$PROJECTID",      getProjectId());
-    }
-  }
-  {
-    std::ofstream f = Portable::openOutputStream(htmlOutput+"/navtree.css");
-    if (f.is_open())
-    {
-      TextStream t(&f);
-      t << HtmlGenerator::getNavTreeCss();
-    }
-  }
 }
 
 // write tree inside page

--- a/templates/html/footer.html
+++ b/templates/html/footer.html
@@ -11,6 +11,7 @@
 <hr class="footer"/><address class="footer"><small>
 $generatedby&#160;<a href="https://www.doxygen.org/index.html"><img class="footer" src="$relpath^doxygen.svg" width="104" height="31" alt="doxygen"/></a> $doxygenversion
 </small></address>
+</div><!-- doc-content -->
 <!--END !GENERATE_TREEVIEW-->
 </body>
 </html>

--- a/templates/html/menu.js
+++ b/templates/html/menu.js
@@ -22,7 +22,7 @@
 
  @licend  The above is the entire license notice for the JavaScript code in this file
  */
-function initMenu(relPath,searchEnabled,serverSide,searchPage,search) {
+function initMenu(relPath,searchEnabled,serverSide,searchPage,search,treeview) {
   function makeTree(data,relPath) {
     let result='';
     if ('children' in data) {
@@ -91,7 +91,7 @@ function initMenu(relPath,searchEnabled,serverSide,searchPage,search) {
   let prevWidth = 0;
   if ($mainMenuState.length) {
     const initResizableIfExists = function() {
-      if (typeof initResizable==='function') initResizable();
+      if (typeof initResizable==='function') initResizable(treeview);
     }
     // animate mobile menu
     $mainMenuState.change(function() {

--- a/templates/html/resize.js
+++ b/templates/html/resize.js
@@ -23,7 +23,7 @@
  @licend  The above is the entire license notice for the JavaScript code in this file
  */
 
-function initResizable() {
+function initResizable(treeview) {
   let sidenav,navtree,content,header,footer,barWidth=6;
   const RESIZE_COOKIE_NAME = '$PROJECTID'+'width';
 
@@ -44,23 +44,31 @@ function initResizable() {
     sidenav.css({width:navWidth + "px"});
   }
 
-  function resizeHeight() {
+  function resizeHeight(treeview) {
     const headerHeight = header.outerHeight();
-    const footerHeight = footer.outerHeight();
     const windowHeight = $(window).height();
-    let contentHeight,navtreeHeight,sideNavHeight;
-    if (typeof page_layout==='undefined' || page_layout==0) { /* DISABLE_INDEX=NO */
-      contentHeight = windowHeight - headerHeight - footerHeight;
-      navtreeHeight = contentHeight;
-      sideNavHeight = contentHeight;
-    } else if (page_layout==1) { /* DISABLE_INDEX=YES */
-      contentHeight = windowHeight - footerHeight;
-      navtreeHeight = windowHeight - headerHeight;
-      sideNavHeight = windowHeight;
+    let contentHeight;
+    if (treeview)
+    {
+      const footerHeight = footer.outerHeight();
+      let navtreeHeight,sideNavHeight;
+      if (typeof page_layout==='undefined' || page_layout==0) { /* DISABLE_INDEX=NO */
+        contentHeight = windowHeight - headerHeight - footerHeight;
+        navtreeHeight = contentHeight;
+        sideNavHeight = contentHeight;
+      } else if (page_layout==1) { /* DISABLE_INDEX=YES */
+        contentHeight = windowHeight - footerHeight;
+        navtreeHeight = windowHeight - headerHeight;
+        sideNavHeight = windowHeight;
+      }
+      navtree.css({height:navtreeHeight + "px"});
+      sidenav.css({height:sideNavHeight + "px"});
+    }
+    else
+    {
+      contentHeight = windowHeight - headerHeight;
     }
     content.css({height:contentHeight + "px"});
-    navtree.css({height:navtreeHeight + "px"});
-    sidenav.css({height:sideNavHeight + "px"});
     if (location.hash.slice(1)) {
       (document.getElementById(location.hash.slice(1))||document.body).scrollIntoView();
     }
@@ -80,30 +88,39 @@ function initResizable() {
   }
 
   header  = $("#top");
-  sidenav = $("#side-nav");
   content = $("#doc-content");
-  navtree = $("#nav-tree");
   footer  = $("#nav-path");
-  $(".side-nav-resizable").resizable({resize: () => resizeWidth() });
-  $(sidenav).resizable({ minWidth: 0 });
-  $(window).resize(() => resizeHeight());
-  const device = navigator.userAgent.toLowerCase();
-  const touch_device = device.match(/(iphone|ipod|ipad|android)/);
-  if (touch_device) { /* wider split bar for touch only devices */
-    $(sidenav).css({ paddingRight:'20px' });
-    $('.ui-resizable-e').css({ width:'20px' });
-    $('#nav-sync').css({ right:'34px' });
-    barWidth=20;
+  sidenav = $("#side-nav");
+  if (treeview)
+  {
+    navtree = $("#nav-tree");
+    $(".side-nav-resizable").resizable({resize: function(e, ui) { resizeWidth(); } });
+    $(sidenav).resizable({ minWidth: 0 });
   }
-  const width = Cookie.readSetting(RESIZE_COOKIE_NAME,$TREEVIEW_WIDTH);
-  if (width) { restoreWidth(width); } else { resizeWidth(); }
-  resizeHeight();
+  $(window).resize(function() { resizeHeight(treeview); });
+  if (treeview)
+  {
+    const device = navigator.userAgent.toLowerCase();
+    const touch_device = device.match(/(iphone|ipod|ipad|android)/);
+    if (touch_device) { /* wider split bar for touch only devices */
+      $(sidenav).css({ paddingRight:'20px' });
+      $('.ui-resizable-e').css({ width:'20px' });
+      $('#nav-sync').css({ right:'34px' });
+      barWidth=20;
+    }
+    const width = Cookie.readSetting(RESIZE_COOKIE_NAME,$TREEVIEW_WIDTH);
+    if (width) { restoreWidth(width); } else { resizeWidth(); }
+  }
+  resizeHeight(treeview);
   const url = location.href;
   const i=url.indexOf("#");
   if (i>=0) window.location.hash=url.substr(i);
-  const _preventDefault = (evt) => evt.preventDefault();
-  $("#splitbar").bind("dragstart", _preventDefault).bind("selectstart", _preventDefault);
-  $(".ui-resizable-handle").dblclick(collapseExpand);
+  const _preventDefault = function(evt) { evt.preventDefault(); };
+  if (treeview)
+  {
+    $("#splitbar").bind("dragstart", _preventDefault).bind("selectstart", _preventDefault);
+    $(".ui-resizable-handle").dblclick(collapseExpand);
+  }
   $(window).on('load',resizeHeight);
 }
 /* @license-end */


### PR DESCRIPTION
In the past an attempt was made (see fcb8cfbcd67d95680ccde950c03fd7e67acdb5b3) to get the top part of the screen fixed in case of `GENERATE_TREEVIEW=NO`. This method was not working and after a small time has been reverted. In the current implementation:
- adds a tag to the HTML file in case of `GENERATE_TREEVIEW=NO` (`div id="doc-content">`) that was also used in case of `GENERATE_TREEVIEW=YES` so `resize.js` can handle the scrollbar
- add end tag to the `footer.html` in case of `GENERATE_TREEVIEW=NO`
- always use `resize.js` and `navtree.css`
- adjust `resize.js` so it can be used for the `GENERATE_TREEVIEW=NO` case (also some javascript arrow functions, `=>` changes had to be reverted for CHM generation).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13840216/example.tar.gz)
