### PR TITLE
Rendering of general `dl.section` styles

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1349,7 +1349,9 @@ dl.deprecated dt a {
     color: var(--deprecated-color-hl) !important;
 }
 
-dl.section dd, dl.bug dd, dl.deprecated dd, dl.todo dd, dl.test dd {
+dl.note dd, dl.warning dd, dl.pre dd, dl.post dd,
+dl.remark dd, dl.attention dd, dl.invariant dd,
+dl.bug dd, dl.deprecated dd, dl.todo dd, dl.test dd {
     margin-inline-start: 0px;
 }
 


### PR DESCRIPTION
In:
```
Commit: e24d8a0589956032d30f53c85f6f9693c55a1a70 [e24d8a0]
Date: Sunday, November 19, 2023 10:48:26 AM
Improved rendering of sections like @note, @warning, @todo etc. for HTML
```
the rendering of a number of sections was improved, but this should only be done for sections that have a specific background and not for the general `dl.section`. The rendering has now been reversed for the general `dl.section` and specific sections are listed to be rendered in the "new" style.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13841355/example.tar.gz)
