### PR TITLE
Add `HTML_CODE_FOLDING` possibility to CHM

### DIFF
--- a/doc/Doxyfile_chm
+++ b/doc/Doxyfile_chm
@@ -13,7 +13,6 @@
 @INCLUDE = Doxyfile
       GENERATE_LATEX         = NO
       HTML_OUTPUT            = chm
-      HTML_CODE_FOLDING      = NO
       HTML_COPY_CLIPBOARD    = NO
       GENERATE_HTMLHELP      = YES
       GENERATE_TREEVIEW      = NO

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1947,7 +1947,6 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     adjustBoolSetting(  depOption, "SEARCHENGINE",         false  );
     adjustBoolSetting(  depOption, "HTML_DYNAMIC_MENUS",   false  );
     adjustBoolSetting(  depOption, "HTML_DYNAMIC_SECTIONS",false  );
-    adjustBoolSetting(  depOption, "HTML_CODE_FOLDING",    false  );
     adjustBoolSetting(  depOption, "HTML_COPY_CLIPBOARD",  false  );
     adjustStringSetting(depOption, "HTML_FILE_EXTENSION", ".html");
     adjustColorStyleSetting(depOption);

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1286,9 +1286,13 @@ void HtmlGenerator::writeTabData()
   mgr.copyResource("nav_g.png",dname);
   Doxygen::indexList->addImageFile("nav_g.png");
   mgr.copyResource("plus.svg",dname);
+  Doxygen::indexList->addImageFile("plus.svg");
   mgr.copyResource("minus.svg",dname);
+  Doxygen::indexList->addImageFile("minus.svg");
   mgr.copyResource("plusd.svg",dname);
+  Doxygen::indexList->addImageFile("plusd.svg");
   mgr.copyResource("minusd.svg",dname);
+  Doxygen::indexList->addImageFile("minusd.svg");
 }
 
 void HtmlGenerator::writeSearchData(const QCString &dname)


### PR DESCRIPTION
Add the possibility of `HTML_CODE_FOLDING` to CHM files, the code was present, just the images and the possibility to set it were not present.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13842516/example.tar.gz)
