### PR TITLE
Display of index on index page.

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2928,7 +2928,7 @@ static void writeDefaultQuickLinks(TextStream &t,
     }
     renderQuickLinksAsTabs(t,relPath,hlEntry,kind,highlightParent,hli==HighlightedItem::Search);
   }
-  else
+  else if (!Config_getBool(GENERATE_TREEVIEW))
   {
     renderQuickLinksAsTree(t,relPath,root);
   }


### PR DESCRIPTION
It doesn't make sense to repeat the information provided in the treeview on the index page as well when `DISABLE_INDEX=YES`.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13854352/example.tar.gz)
