### PR TITLE
Make `HTML_CODE_FOLDING` always possible

### DIFF
--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -251,7 +251,7 @@ class DocbookGenerator : public OutputGenerator
     void writeSplitBar(const QCString &){DB_GEN_EMPTY};
     void writeNavigationPath(const QCString &){DB_GEN_NEW};
     void writeLogo(){DB_GEN_NEW};
-    void writeQuickLinks(HighlightedItem,const QCString &,bool){DB_GEN_EMPTY};
+    void writeQuickLinks(HighlightedItem,const QCString &){DB_GEN_EMPTY};
     void writeSummaryLink(const QCString &,const QCString &,const QCString &,bool){DB_GEN_EMPTY};
     void startContents(){DB_GEN_EMPTY};
     void endContents(){DB_GEN_EMPTY};

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1120,7 +1120,7 @@ void FileDefImpl::writeSourceHeader(OutputList &ol)
     startFile(ol,getSourceFileBase(),QCString(),pageTitle,HighlightedItem::FileVisible,
         !generateTreeView,
         !isDocFile && genSourceFile ? QCString() : getOutputFileBase(),
-        0,true);
+        0);
     if (!generateTreeView)
     {
       getDirDef()->writeNavigationPath(ol);
@@ -1134,7 +1134,7 @@ void FileDefImpl::writeSourceHeader(OutputList &ol)
   {
     startFile(ol,getSourceFileBase(),QCString(),pageTitle,HighlightedItem::FileVisible,false,
         !isDocFile && genSourceFile ? QCString() : getOutputFileBase(),
-        0,true);
+        0);
     startTitle(ol,getSourceFileBase());
     ol.parseText(title);
     endTitle(ol,getSourceFileBase(),QCString());

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1483,6 +1483,14 @@ void HtmlGenerator::startFile(const QCString &name,const QCString &,
     m_t << "/* @license-end */\n";
     m_t << "</script>\n";
   }
+  if (Config_getBool(HTML_CODE_FOLDING))
+  {
+    m_t << "<script type=\"text/javascript\">\n";
+    m_t << "/* @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&amp;dn=expat.txt MIT */\n";
+    m_t << "$(function() { codefold.init(" << (m_relPath.isEmpty() ? "0" : "1") << "); });\n";
+    m_t << "/* @license-end */\n";
+    m_t << "</script>\n";
+  }
   m_sectionCount=0;
 }
 
@@ -2806,8 +2814,7 @@ static void renderQuickLinksAsTabs(TextStream &t,const QCString &relPath,
 static void writeDefaultQuickLinks(TextStream &t,
                                    HighlightedItem hli,
                                    const QCString &file,
-                                   const QCString &relPath,
-                                   bool needsFolding)
+                                   const QCString &relPath)
 {
   bool serverBasedSearch = Config_getBool(SERVER_BASED_SEARCH);
   bool searchEngine = Config_getBool(SEARCHENGINE);
@@ -2932,14 +2939,6 @@ static void writeDefaultQuickLinks(TextStream &t,
   {
     renderQuickLinksAsTree(t,relPath,root);
   }
-  if (needsFolding && Config_getBool(HTML_CODE_FOLDING))
-  {
-    t << "<script type=\"text/javascript\">\n";
-    t << "/* @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&amp;dn=expat.txt MIT */\n";
-    t << "$(function() { codefold.init(" << (relPath.isEmpty() ? "0" : "1") << "); });\n";
-    t << "/* @license-end */\n";
-    t << "</script>\n";
-  }
 }
 
 void HtmlGenerator::endQuickIndices()
@@ -3026,9 +3025,9 @@ void HtmlGenerator::endPageDoc()
   m_t << "</div><!-- PageDoc -->\n";
 }
 
-void HtmlGenerator::writeQuickLinks(HighlightedItem hli,const QCString &file,bool needsFolding)
+void HtmlGenerator::writeQuickLinks(HighlightedItem hli,const QCString &file)
 {
-  writeDefaultQuickLinks(m_t,hli,file,m_relPath,needsFolding);
+  writeDefaultQuickLinks(m_t,hli,file,m_relPath);
 }
 
 // PHP based search script
@@ -3088,7 +3087,7 @@ void HtmlGenerator::writeSearchPage()
     t << "</script>\n";
     if (!Config_getBool(DISABLE_INDEX))
     {
-      writeDefaultQuickLinks(t,HighlightedItem::Search,QCString(),QCString(),false);
+      writeDefaultQuickLinks(t,HighlightedItem::Search,QCString(),QCString());
     }
     else
     {
@@ -3144,7 +3143,7 @@ void HtmlGenerator::writeExternalSearchPage()
     t << "</script>\n";
     if (!Config_getBool(DISABLE_INDEX))
     {
-      writeDefaultQuickLinks(t,HighlightedItem::Search,QCString(),QCString(),false);
+      writeDefaultQuickLinks(t,HighlightedItem::Search,QCString(),QCString());
       if (!Config_getBool(HTML_DYNAMIC_MENUS)) // for dynamic menus, menu.js creates this part
       {
         t << "            <input type=\"text\" id=\"MSearchField\" name=\"query\" value=\"\" placeholder=\"" << theTranslator->trSearch() <<

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -227,7 +227,7 @@ class HtmlGenerator : public OutputGenerator
     void writeSplitBar(const QCString &name);
     void writeNavigationPath(const QCString &s);
     void writeLogo();
-    void writeQuickLinks(HighlightedItem hli,const QCString &file,bool needsFolding);
+    void writeQuickLinks(HighlightedItem hli,const QCString &file);
     void writeSummaryLink(const QCString &file,const QCString &anchor,const QCString &title,bool first);
     void startContents();
     void endContents();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -389,14 +389,14 @@ void endTitle(OutputList &ol,const QCString &fileName,const QCString &name)
 
 void startFile(OutputList &ol,const QCString &name,const QCString &manName,
                const QCString &title,HighlightedItem hli,bool additionalIndices,
-               const QCString &altSidebarName, int hierarchyLevel,bool needsFolding)
+               const QCString &altSidebarName, int hierarchyLevel)
 {
   bool disableIndex = Config_getBool(DISABLE_INDEX);
   ol.startFile(name,manName,title,hierarchyLevel);
   ol.startQuickIndices();
   if (!disableIndex)
   {
-    ol.writeQuickLinks(hli,name,needsFolding);
+    ol.writeQuickLinks(hli,name);
   }
   if (!additionalIndices)
   {
@@ -3130,7 +3130,7 @@ static void writeClassMemberIndexFiltered(OutputList &ol, ClassMemberHighlight::
     ol.startQuickIndices();
     if (!disableIndex)
     {
-      ol.writeQuickLinks(HighlightedItem::Functions,QCString(),false);
+      ol.writeQuickLinks(HighlightedItem::Functions,QCString());
       if (!Config_getBool(HTML_DYNAMIC_MENUS))
       {
         startQuickIndexList(ol);
@@ -3298,7 +3298,7 @@ static void writeFileMemberIndexFiltered(OutputList &ol, FileMemberHighlight::En
     ol.startQuickIndices();
     if (!disableIndex)
     {
-      ol.writeQuickLinks(HighlightedItem::Globals,QCString(),false);
+      ol.writeQuickLinks(HighlightedItem::Globals,QCString());
       if (!Config_getBool(HTML_DYNAMIC_MENUS))
       {
         startQuickIndexList(ol);
@@ -3463,7 +3463,7 @@ static void writeNamespaceMemberIndexFiltered(OutputList &ol,
     ol.startQuickIndices();
     if (!disableIndex)
     {
-      ol.writeQuickLinks(HighlightedItem::NamespaceMembers,QCString(),false);
+      ol.writeQuickLinks(HighlightedItem::NamespaceMembers,QCString());
       if (!Config_getBool(HTML_DYNAMIC_MENUS))
       {
         startQuickIndexList(ol);
@@ -3621,7 +3621,7 @@ static void writeModuleMemberIndexFiltered(OutputList &ol,
     ol.startQuickIndices();
     if (!disableIndex)
     {
-      ol.writeQuickLinks(HighlightedItem::ModuleMembers,QCString(),false);
+      ol.writeQuickLinks(HighlightedItem::ModuleMembers,QCString());
       if (!Config_getBool(HTML_DYNAMIC_MENUS))
       {
         startQuickIndexList(ol);
@@ -4755,7 +4755,7 @@ static void writeIndex(OutputList &ol)
   ol.startQuickIndices();
   if (!Config_getBool(DISABLE_INDEX))
   {
-    ol.writeQuickLinks(HighlightedItem::Main,QCString(),false);
+    ol.writeQuickLinks(HighlightedItem::Main,QCString());
   }
   ol.endQuickIndices();
   ol.writeSplitBar(indexName);
@@ -4804,7 +4804,7 @@ static void writeIndex(OutputList &ol)
   ol.startContents();
   if (Config_getBool(DISABLE_INDEX) && Doxygen::mainPage==0)
   {
-    ol.writeQuickLinks(HighlightedItem::Main,QCString(),false);
+    ol.writeQuickLinks(HighlightedItem::Main,QCString());
   }
 
   if (Doxygen::mainPage)

--- a/src/index.h
+++ b/src/index.h
@@ -225,7 +225,7 @@ void startTitle(OutputList &ol,const QCString &fileName,const DefinitionMutable 
 void endTitle(OutputList &ol,const QCString &fileName,const QCString &name);
 void startFile(OutputList &ol,const QCString &name,const QCString &manName,
                const QCString &title,HighlightedItem hli=HighlightedItem::None,
-               bool additionalIndices=FALSE,const QCString &altSidebarName=QCString(), int hierarchyLevel=0, bool needsFolding=false);
+               bool additionalIndices=FALSE,const QCString &altSidebarName=QCString(), int hierarchyLevel=0);
 void endFile(OutputList &ol,bool skipNavIndex=FALSE,bool skipEndContents=FALSE,
              const QCString &navPath=QCString());
 void endFileWithNavPath(OutputList &ol,const Definition *d);

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -224,7 +224,7 @@ class LatexGenerator : public OutputGenerator
     void writeSplitBar(const QCString &) {}
     void writeNavigationPath(const QCString &) {}
     void writeLogo() {}
-    void writeQuickLinks(HighlightedItem,const QCString &,bool) {}
+    void writeQuickLinks(HighlightedItem,const QCString &) {}
     void writeSummaryLink(const QCString &,const QCString &,const QCString &,bool) {}
     void startContents() {}
     void endContents() {}

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -194,7 +194,7 @@ class ManGenerator : public OutputGenerator
     void writeSplitBar(const QCString &) {}
     void writeNavigationPath(const QCString &) {}
     void writeLogo() {}
-    void writeQuickLinks(HighlightedItem,const QCString &,bool) {}
+    void writeQuickLinks(HighlightedItem,const QCString &) {}
     void writeSummaryLink(const QCString &,const QCString &,const QCString &,bool) {}
     void startContents() {}
     void endContents() {}

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -800,8 +800,8 @@ class OutputList
     { foreach<OutputGenIntf::writeNavigationPath>(s); }
     void writeLogo()
     { foreach<OutputGenIntf::writeLogo>(); }
-    void writeQuickLinks(HighlightedItem hli,const QCString &file,bool needsFolding)
-    { foreach<OutputGenIntf::writeQuickLinks>(hli,file,needsFolding); }
+    void writeQuickLinks(HighlightedItem hli,const QCString &file)
+    { foreach<OutputGenIntf::writeQuickLinks>(hli,file); }
     void writeSummaryLink(const QCString &file,const QCString &anchor,const QCString &title,bool first)
     { foreach<OutputGenIntf::writeSummaryLink>(file,anchor,title,first); }
     void startContents()

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -204,7 +204,7 @@ class RTFGenerator : public OutputGenerator
     void writeSplitBar(const QCString &) {}
     void writeNavigationPath(const QCString &) {}
     void writeLogo() {}
-    void writeQuickLinks(HighlightedItem,const QCString &,bool) {}
+    void writeQuickLinks(HighlightedItem,const QCString &) {}
     void writeSummaryLink(const QCString &,const QCString &,const QCString &,bool) {}
     void startContents() {}
     void endContents() {}


### PR DESCRIPTION
The `HTML_CODE_FOLDING` was only active when `DISABLE_INDEX=NO`, this restriction has been lifted.