### PR TITLE
issue #10544 Doxygen omits closing '>' in method returning `std::function< void(A *) >`

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2592,7 +2592,9 @@ static int findFunctionPtr(const std::string &type,SrcLangExt lang, int *pLength
   size_t be=type.rfind('>');
   bool templFp = false;
   if (be!=std::string::npos) {
-    templFp = type.find("::*")>be || type.find("::&")>be; // hack to find, e.g 'B<X>(A<int>::*)'
+    size_t cc_ast = type.find("::*");
+    size_t cc_amp = type.find("::&");
+    templFp = (cc_ast != std::string::npos && cc_ast>be) || (cc_amp != std::string::npos && cc_amp>be); // hack to find, e.g 'B<X>(A<int>::*)'
   }
 
   if (!type.empty()                            &&  // return type is non-empty


### PR DESCRIPTION
Test was not correct, find returns an unsigned number or `-1` (when not found) and the later was mapped to the largest unsigned possible.