### PR TITLE
issue #10546 crash when clang enable

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -33,7 +33,7 @@ static std::mutex g_clangMutex;
 ClangParser *ClangParser::instance()
 {
   std::lock_guard<std::mutex> lock(g_clangMutex);
-  if (s_instance!=nullptr) s_instance = new ClangParser;
+  if (s_instance==nullptr) s_instance = new ClangParser;
   return s_instance;
 }
 


### PR DESCRIPTION
Regression due to:
```
Commit: 6b70d803fea8771c03e6479d968a8d7c497573a8 [6b70d80]
Date: Tuesday, December 26, 2023 12:50:05 PM
Fixing warnings like: `Use the "nullptr" literal`

Fixing sonar cloud warnings like: `Use the "nullptr" literal`
```