### PR TITLE
add enum type in PERLMOD

### DIFF
--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1496,9 +1496,6 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
       md->memberType()!=MemberType_Enumeration)
     m_output.addFieldQuotedString("type", md->typeString());
 
-if (md->memberType()==MemberType_Enumeration)
-    m_output.addFieldQuotedString("type", md->enumBaseType());
-
   const ArgumentList &al = md->argumentList();
   if (isFunc) //function
   {
@@ -1571,6 +1568,7 @@ if (md->memberType()==MemberType_Enumeration)
   if (md->memberType()==MemberType_Enumeration) // enum
   {
     const MemberVector &enumFields = md->enumFieldList();
+    m_output.addFieldQuotedString("type", md->enumBaseType());
     if (!enumFields.empty())
     {
       m_output.openList("values");

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1496,6 +1496,9 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
       md->memberType()!=MemberType_Enumeration)
     m_output.addFieldQuotedString("type", md->typeString());
 
+if (md->memberType()==MemberType_Enumeration)
+    m_output.addFieldQuotedString("type", md->enumBaseType());
+
   const ArgumentList &al = md->argumentList();
   if (isFunc) //function
   {


### PR DESCRIPTION
- we can see the followin enum in c++.
- but , we could not find enum type in perlmod. so I add enum type

```cpp
enum class Handle : std::uint32_t { Invalid = 0 };
```

- DoxyDocs.pm in OUTPUT/perlmod - add the enum type like ```type => 'std::uint32_t',```