### PR TITLE
Consistency for use of `<code>`

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6997,7 +6997,7 @@ NONLopt [^\n]*
                                           yyextra->nestedComment=0;
                                           BEGIN(DocCopyBlock);
                                         }
-<DocBlock>{B}*"<code>"                  {
+<DocBlock>{B}*"<"{CODE}">"              {
                                           if (yyextra->insideCS)
                                           {
                                             yyextra->docBlock << yytext;


### PR DESCRIPTION
It is more consistent to use here `{CODE}` as this covers upper and lowercase