### PR TITLE
issue #10573 Behavior of quotes in markdown type of links

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1523,7 +1523,7 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
       }
       else
       {
-        processInline(std::string_view(content.str()));
+        processInline(std::string_view(substitute(content,"\"","&quot;").str()));
       }
       out+="\"";
     }


### PR DESCRIPTION
Looks like a regression on:
```
Commit: 351dba64b602b2334f3d7400af1088c1be62aa99 [351dba6]
Date: Sunday, December 17, 2023 7:52:34 PM

issue #10475 doxygen does not correctly render link content in MarkDown file
```

Especially the change in markdown.cpp from:
```
        m_out.addStr(substitute(content,"\"","&quot;"));
```
into
```
        processInline(content.data(),content.length());
```

The double quotes need the "escape" before processing.

(Also checked against #10475)