### PR TITLE
Incorrect linecount in case of `if` command without condition

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1891,11 +1891,10 @@ STopt  [^\n@\\]*
                                           handleGuard(yyscanner,QCString(yytext));
                                         }
 <GuardParam>{DOCNL}                     { // end of argument
-                                          if (*yytext=='\n') yyextra->lineNr++;
                                           //next line is commented out due to bug620924
                                           //addOutput(yyscanner,'\n');
                                           addIlineBreak(yyscanner,yyextra->lineNr);
-                                          unput(*yytext);
+                                          unput_string(yytext,yyleng);
                                           handleGuard(yyscanner,QCString());
                                         }
 <GuardParam>{LC}                        { // line continuation


### PR DESCRIPTION
In case of an `if` command without condition (correctly treated as `false`) the line count is incorrect as the end return is put back. Also correct put back in case of `ilinebr` command as only the first character was put back.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13997666/example.tar.gz)
