### PR TITLE
No extra space after `fileinfo` and `lineinfo` commands

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2958,7 +2958,6 @@ static bool handleFileInfo(yyscan_t yyscanner,const QCString &, const StringVect
       addOutput(yyscanner,yyextra->fileName);
     }
   }
-  addOutput(yyscanner," ");
   return FALSE;
 }
 
@@ -2971,7 +2970,6 @@ static bool handleLineInfo(yyscan_t yyscanner,const QCString &, const StringVect
     yyextra->spaceBeforeCmd.clear();
   }
   addOutput(yyscanner,QCString().setNum(yyextra->lineNr));
-  addOutput(yyscanner," ");
   return FALSE;
 }
 


### PR DESCRIPTION
Don't invent a space after the `fileinfo` and `lineinfo` command as the space prohibits concatenations

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/13997941/example.tar.gz)
