### PR TITLE
Incorrect line number and filename after `\include{doc}` and `\snippet{doc}`

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1140,7 +1140,7 @@ SLASHopt [/]*
                                         yyextra->inBufPos   = fs->oldFileBufPos;
                                         yyextra->includeCtx = fs->oldIncludeCtx;
                                         yyextra->incPrefix  = fs->oldIncPrefix;
-                                        QCString lineStr=yyextra->incPrefix + " \\ilinebr\\ifile \""+yyextra->fileName+"\" \\iline "+QCString().setNum(yyextra->lineNr)+" ";
+                                        QCString lineStr=yyextra->incPrefix + " \\ilinebr \\ifile \""+yyextra->fileName+"\" \\iline "+QCString().setNum(yyextra->lineNr)+" ";
                                         copyToOutput(yyscanner,lineStr.data(),lineStr.length());
                                         yyextra->incPrefix  = "";
                                         yyextra->includeStack.pop_back();
@@ -1429,7 +1429,7 @@ static bool readIncludeFile(yyscan_t yyscanner,const QCString &inc,const QCStrin
     {
       fs->fileBuf.shrink(fs->fileBuf.curPos()-1);
     }
-    QCString lineStr=" \\ilinebr\\ifile \""+absFileName+"\" \\iline " + QCString().setNum(lineNr) + " \\ilinebr ";
+    QCString lineStr=" \\ilinebr \\ifile \""+absFileName+"\" \\iline " + QCString().setNum(lineNr) + " \\ilinebr ";
     copyToOutput(yyscanner,lineStr.data(),lineStr.length());
 
     fs->fileName      = absFileName;

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1377,9 +1377,6 @@ static bool readIncludeFile(yyscan_t yyscanner,const QCString &inc,const QCStrin
 	  qPrint(showFileDefMatches(Doxygen::exampleNameLinkedMap,inc))
 	  );
     }
-    QCString lineStr=" \\ilinebr\\ifile \""+absFileName+"\" \\iline 1 \\ilinebr ";
-    copyToOutput(yyscanner,lineStr.data(),lineStr.length());
-
     bool alreadyProcessed = std::any_of(
       yyextra->includeStack.begin(),
       yyextra->includeStack.end(),
@@ -1432,6 +1429,8 @@ static bool readIncludeFile(yyscan_t yyscanner,const QCString &inc,const QCStrin
     {
       fs->fileBuf.shrink(fs->fileBuf.curPos()-1);
     }
+    QCString lineStr=" \\ilinebr\\ifile \""+absFileName+"\" \\iline " + QCString().setNum(lineNr) + " \\ilinebr ";
+    copyToOutput(yyscanner,lineStr.data(),lineStr.length());
 
     fs->fileName      = absFileName;
     fs->bufState      = YY_CURRENT_BUFFER;

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -386,8 +386,8 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "endmanonly",             { 0,                               CommandSpacing::Invisible, SectionHandling::Escape  }},
   { "endrtfonly",             { 0,                               CommandSpacing::Invisible, SectionHandling::Escape  }},
   { "endxmlonly",             { 0,                               CommandSpacing::Invisible, SectionHandling::Escape  }},
-  { "ifile",                  { &handleIFile,                    CommandSpacing::Invisible, SectionHandling::Escape  }},
-  { "iline",                  { &handleILine,                    CommandSpacing::Invisible, SectionHandling::Escape  }}
+  { "ifile",                  { &handleIFile,                    CommandSpacing::Invisible, SectionHandling::Replace }},
+  { "iline",                  { &handleILine,                    CommandSpacing::Invisible, SectionHandling::Replace }}
 };
 
 #define YY_NO_INPUT 1
@@ -675,7 +675,9 @@ STopt  [^\n@\\]*
 %x      RaiseWarningSection
 %x      Qualifier
 %x      IFile
+%x      IFileSection
 %x      ILine
+%x      ILineSection
 
 %%
 
@@ -1709,19 +1711,43 @@ STopt  [^\n@\\]*
                                             yyextra->lineNr = nr;
                                           }
                                           addOutput(yyscanner,yytext);
-                                          BEGIN(Comment);
+                                          if (YY_START == ILine)
+                                          {
+                                            BEGIN(Comment);
+                                          }
+                                          else
+                                          {
+                                            yyextra->sectionTitle+=yytext;
+                                            BEGIN(SectionTitle);
+                                          }
                                         }
-<ILine>.                                {
+<ILine,ILineSection>.                   {
                                           addOutput(yyscanner,yytext);
-                                          BEGIN(Comment);
+                                          if (YY_START == ILine)
+                                          {
+                                            BEGIN(Comment);
+                                          }
+                                          else
+                                          {
+                                            yyextra->sectionTitle+=yytext;
+                                            BEGIN(SectionTitle);
+                                          }
                                         }
 
-<IFile>{FILE}                           {
+<IFile,IFileSection>{FILE}              {
                                           addOutput(yyscanner,yytext);
                                           QCString text(yytext);
                                           if (yytext[0] == '\"') yyextra->fileName = text.mid(1,text.length()-2);
                                           else yyextra->fileName = yytext;
-                                          BEGIN(Comment);
+                                          if (YY_START == IFile)
+                                          {
+                                            BEGIN(Comment);
+                                          }
+                                          else
+                                          {
+                                            yyextra->sectionTitle+=yytext;
+                                            BEGIN(SectionTitle);
+                                          }
                                         }
 
   /* ----- handle arguments of the relates(also)/addindex commands ----- */
@@ -1913,6 +1939,18 @@ STopt  [^\n@\\]*
                                                     yyextra->sectionTitle+=yytext;
                                                     addOutput(yyscanner,yytext);
                                                     BEGIN(CiteLabelSection);
+                                                  }
+                                                  else if (cmdName == "iline")
+                                                  {
+                                                    yyextra->sectionTitle+=yytext;
+                                                    addOutput(yyscanner,yytext);
+                                                    BEGIN(ILineSection);
+                                                  }
+                                                  else if (cmdName == "ifile")
+                                                  {
+                                                    yyextra->sectionTitle+=yytext;
+                                                    addOutput(yyscanner,yytext);
+                                                    BEGIN(IFileSection);
                                                   }
                                                   else
                                                   {

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -164,6 +164,8 @@ static bool handleRetval(yyscan_t yyscanner,const QCString &, const StringVector
 static bool handleFileInfo(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleLineInfo(yyscan_t yyscanner,const QCString &, const StringVector &);
 static bool handleModule(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleIFile(yyscan_t yyscanner,const QCString &, const StringVector &);
+static bool handleILine(yyscan_t yyscanner,const QCString &, const StringVector &);
 
 [[maybe_unused]] static const char *stateToString(int state);
 
@@ -350,7 +352,9 @@ static const std::map< std::string, DocCmdMap > docCmdMap =
   { "xrefitem",        { &handleXRefItem,         CommandSpacing::XRef      }},
   { "iliteral",        { &handleFormatBlock,      CommandSpacing::Inline    }},
   { "fileinfo",        { &handleFileInfo,         CommandSpacing::Inline    }},
-  { "lineinfo",        { &handleLineInfo,         CommandSpacing::Inline    }}
+  { "lineinfo",        { &handleLineInfo,         CommandSpacing::Inline    }},
+  { "ifile",           { &handleIFile,            CommandSpacing::Invisible }},
+  { "iline",           { &handleILine,            CommandSpacing::Invisible }}
 };
 
 #define YY_NO_INPUT 1
@@ -566,6 +570,7 @@ TMPLSPEC  "<"{BN}*[^>]+{BN}*">"
 MAILADDR  ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a-z_A-Z0-9\x80-\xff\-]+)+[a-z_A-Z0-9\x80-\xff\-]+
 RCSTAG    "$"{ID}":"[^\n$]+"$"
 MODULE_ID ({ID}".")*{ID}
+LINENR    {Bopt}[1-9][0-9]*
 
   // C start comment 
 CCS   "/\*"
@@ -632,6 +637,8 @@ STopt  [^\n@\\]*
 %x      Noop
 %x      RaiseWarning
 %x      Qualifier
+%x      IFile
+%x      ILine
 
 %%
 
@@ -1633,6 +1640,35 @@ STopt  [^\n@\\]*
                                           unput_string(yytext,yyleng);
                                           BEGIN( Comment );
                                         }
+  /* ----- handle arguments of the iline command ----- */
+<ILine>{LINENR}/[\\@\n\.]               |
+<ILine>{LINENR}{B}                      {
+                                          bool ok = false;
+                                          int nr = QCString(yytext).toInt(&ok);
+                                          if (!ok)
+                                          {
+                                            warn(yyextra->fileName,yyextra->lineNr,"Invalid line number '%s' for iline command",yytext);
+                                          }
+                                          else
+                                          {
+                                            yyextra->lineNr = nr;
+                                          }
+                                          addOutput(yyscanner,yytext);
+                                          BEGIN(Comment);
+                                        }
+<ILine>.                                {
+                                          addOutput(yyscanner,yytext);
+                                          BEGIN(Comment);
+                                        }
+
+<IFile>{FILE}                           {
+                                          addOutput(yyscanner,yytext);
+                                          QCString text(yytext);
+                                          if (yytext[0] == '\"') yyextra->fileName = text.mid(1,text.length()-2);
+                                          else yyextra->fileName = yytext;
+                                          BEGIN(Comment);
+                                        }
+
   /* ----- handle arguments of the relates(also)/addindex commands ----- */
 
 <LineParam>{CMD}{CMD}                   { // escaped command
@@ -2972,6 +3008,22 @@ static bool handleLineInfo(yyscan_t yyscanner,const QCString &, const StringVect
   }
   addOutput(yyscanner,QCString().setNum(yyextra->lineNr));
   addOutput(yyscanner," ");
+  return FALSE;
+}
+
+static bool handleILine(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  addOutput(yyscanner,yytext);
+  BEGIN(ILine);
+  return FALSE;
+}
+
+static bool handleIFile(yyscan_t yyscanner,const QCString &, const StringVector &)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  addOutput(yyscanner,yytext);
+  BEGIN(IFile);
   return FALSE;
 }
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1814,7 +1814,7 @@ QCString DocParser::processCopyDoc(const char *data,size_t &len)
             context.copyStack.push_back(def);
             auto addDocs = [&](const QCString &file_,int line_,const QCString &doc_)
             {
-              buf.addStr(" \\ilinebr\\ifile \""+file_+"\" ");
+              buf.addStr(" \\ilinebr \\ifile \""+file_+"\" ");
               buf.addStr("\\iline "+QCString().setNum(line_)+" ");
               size_t len_ = doc_.length();
               buf.addStr(processCopyDoc(doc_.data(),len_));
@@ -1836,7 +1836,7 @@ QCString DocParser::processCopyDoc(const char *data,size_t &len)
               }
             }
             context.copyStack.pop_back();
-            buf.addStr(" \\ilinebr\\ifile \""+context.fileName+"\" ");
+            buf.addStr(" \\ilinebr \\ifile \""+context.fileName+"\" ");
             buf.addStr("\\iline "+QCString().setNum(lineNr)+" ");
           }
           else


### PR DESCRIPTION
After the commands `\include{doc}` and `\snippet{doc}` the information in warnings from the comment scanner points to the includer file and the line numbers keep increasing even when the warning comes from code in the included file. This is due to the fact that the commands are already handled in the comment converter and the, added, `\ifile` and `\iline` commands are not taken into account in the comment scanner. Also the line number from a `\snippet{doc}` command is not correct, it doesn't refer  to the line of the snippet but to the beginning of the file (due to the hard coded `\iline 1`).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14000863/example.tar.gz)
