### PR TITLE
Improve warnings

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -629,7 +629,7 @@ void DocSecRefList::parse()
         case CMD_ENDSECREFLIST:
           return;
         default:
-          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%s%s' as part of a \\secreflist",
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%c%s' as part of a \\secreflist",
               TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
           return;
       }
@@ -955,12 +955,12 @@ QCString DocLink::parse(bool isJavaLink,bool isXmlLink)
             case CMD_ENDLINK:
               if (isJavaLink)
               {
-                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"'{@link...' ended with '%s%s' command",
+                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"'{@link...' ended with '%c%s' command",
                   TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
               }
               goto endlink;
             default:
-              warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%s%s' as part of a \\link",
+              warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%c%s' as part of a \\link",
                   TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
               break;
           }
@@ -2172,7 +2172,7 @@ int DocHtmlDescTitle::parse()
                   tok=parser()->tokenizer.lex();
                   if (tok!=TK_WHITESPACE)
                   {
-                    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+                    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
                         TK_COMMAND_CHAR(tok),qPrint(cmdName));
                   }
                   else
@@ -2181,7 +2181,7 @@ int DocHtmlDescTitle::parse()
                     tok=parser()->tokenizer.lex(); // get the reference id
                     if (tok!=TK_WORD)
                     {
-                      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s' command",
+                      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%c%s' command",
                           DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tok),qPrint(cmdName));
                     }
                     else
@@ -2229,7 +2229,7 @@ int DocHtmlDescTitle::parse()
 
                 break;
               default:
-                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%s%s' found as part of a <dt> tag",
+                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%c%s' found as part of a <dt> tag",
                   TK_COMMAND_CHAR(tok),qPrint(cmdName));
             }
           }
@@ -3178,15 +3178,15 @@ int DocPara::handleParamSection(const QCString &cmdName,
   return (rv!=TK_NEWPARA) ? rv : RetVal_OK;
 }
 
-void DocPara::handleCite(const QCString &cmdName, const int tokIn)
+void DocPara::handleCite(const QCString &cmdName, char cmdChar)
 {
   AUTO_TRACE();
   // get the argument of the cite command.
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
+      cmdChar,qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateCite();
@@ -3194,13 +3194,13 @@ void DocPara::handleCite(const QCString &cmdName, const int tokIn)
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command '%s%s'",TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+        "argument of command '%c%s'",cmdChar,qPrint(cmdName));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
-        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%c%s'",
+        DocTokenizer::tokToString(tok),cmdChar,qPrint(cmdName));
     return;
   }
   parser()->context.token->sectionId = parser()->context.token->name;
@@ -3210,15 +3210,15 @@ void DocPara::handleCite(const QCString &cmdName, const int tokIn)
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleEmoji(const QCString &cmdName, const int tokIn)
+void DocPara::handleEmoji(const QCString &cmdName, char cmdChar)
 {
   AUTO_TRACE();
   // get the argument of the emoji command.
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
+      cmdChar,qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateEmoji();
@@ -3226,14 +3226,14 @@ void DocPara::handleEmoji(const QCString &cmdName, const int tokIn)
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"no emoji name given or unexpected end of comment block while parsing the "
-        "argument of command '%s%s'",TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+        "argument of command '%c%s'",cmdChar,qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
   else if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
-        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%c%s'",
+        DocTokenizer::tokToString(tok),cmdChar,qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3241,14 +3241,14 @@ void DocPara::handleEmoji(const QCString &cmdName, const int tokIn)
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleDoxyConfig(const QCString &cmdName, const int tokIn)
+void DocPara::handleDoxyConfig(const QCString &cmdName, char cmdChar)
 {
   // get the argument of the cite command.
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
+      cmdChar,qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateDoxyConfig();
@@ -3256,13 +3256,13 @@ void DocPara::handleDoxyConfig(const QCString &cmdName, const int tokIn)
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command '%s%s'",TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+        "argument of command '%c%s'",cmdChar,qPrint(cmdName));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
-        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%c%s'",
+        DocTokenizer::tokToString(tok),cmdChar,qPrint(cmdName));
     return;
   }
   ConfigOption * opt = ConfigImpl::instance()->get(parser()->context.token->name);
@@ -3313,13 +3313,13 @@ void DocPara::handleDoxyConfig(const QCString &cmdName, const int tokIn)
         }
         break;
       case ConfigOption::O_Obsolete:
-        warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Obsolete setting for '%s%s': '%s'",
-              TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(parser()->context.token->name));
+        warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Obsolete setting for '%c%s': '%s'",
+              cmdChar,qPrint(cmdName),qPrint(parser()->context.token->name));
         break;
       case ConfigOption::O_Disabled:
         warn(parser()->context.fileName,parser()->tokenizer.getLineNr(),
-              "Disabled setting (i.e. not supported in this doxygen executable) for '%s%s': '%s'",
-              TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(parser()->context.token->name));
+              "Disabled setting (i.e. not supported in this doxygen executable) for '%c%s': '%s'",
+              cmdChar,qPrint(cmdName),qPrint(parser()->context.token->name));
         break;
       case ConfigOption::O_Info:
         // nothing to show here
@@ -3332,8 +3332,8 @@ void DocPara::handleDoxyConfig(const QCString &cmdName, const int tokIn)
   }
   else
   {
-    warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Unknown option for '%s%s': '%s'",
-         TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(parser()->context.token->name));
+    warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Unknown option for '%c%s': '%s'",
+         cmdChar,qPrint(cmdName),qPrint(parser()->context.token->name));
     children().append<DocWord>(parser(),thisVariant(),parser()->context.token->name);
   }
   parser()->tokenizer.setStatePara();
@@ -3360,7 +3360,7 @@ int DocPara::handleXRefItem()
   return retval;
 }
 
-void DocPara::handleShowDate(const QCString &cmdName, const int tokIn)
+void DocPara::handleShowDate(const QCString &cmdName, char cmdChar)
 {
   AUTO_TRACE();
   QCString fmt;
@@ -3368,16 +3368,16 @@ void DocPara::handleShowDate(const QCString &cmdName, const int tokIn)
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
+      cmdChar,qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateQuotedString();
   tok = parser()->tokenizer.lex();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <format> argument for command '%s%s'",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <format> argument for command '%c%s'",
+      cmdChar,qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3391,8 +3391,8 @@ void DocPara::handleShowDate(const QCString &cmdName, const int tokIn)
   bool specDateOnlyWS  = !specDateRaw.isEmpty() && specDate.isEmpty();
   if (!specDate.isEmpty() && tok!=TK_WORD && tok!=0)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '%s%s'",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '%c%s'",
+      cmdChar,qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3402,8 +3402,8 @@ void DocPara::handleShowDate(const QCString &cmdName, const int tokIn)
   QCString err = dateTimeFromString(specDate,dat,specFormat);
   if (!err.isEmpty())
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '%s%s': %s",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(err));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '%c%s': %s",
+      cmdChar,qPrint(cmdName),qPrint(err));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3417,8 +3417,8 @@ void DocPara::handleShowDate(const QCString &cmdName, const int tokIn)
     int bitMask = 1<<i;
     if ((usedFormat&bitMask) && !(specFormat&bitMask)) // a part was used in the format string but its value was not specified.
     {
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"'%s%s' <format> parameter '%s' has %s related markers which are not specified in the <date_time> parameter '%s'. Filling in the current value for %s instead.",
-          TK_COMMAND_CHAR(tokIn),qPrint(cmdName),
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"'%c%s' <format> parameter '%s' has %s related markers which are not specified in the <date_time> parameter '%s'. Filling in the current value for %s instead.",
+          cmdChar,qPrint(cmdName),
           qPrint(fmt),SF_bit2str(i),qPrint(specDate),SF_bit2str(i));
     }
   }
@@ -3431,28 +3431,28 @@ void DocPara::handleShowDate(const QCString &cmdName, const int tokIn)
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleILine(const QCString &cmdName, const int tokIn)
+void DocPara::handleILine(const QCString &cmdName, char cmdChar)
 {
   AUTO_TRACE();
   parser()->tokenizer.setStateILine();
   int tok = parser()->tokenizer.lex();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid argument for command '%s%s'",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid argument for command '%c%s'",
+      cmdChar,qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleIFile(const QCString &cmdName, const int tokIn)
+void DocPara::handleIFile(const QCString &cmdName, char cmdChar)
 {
   AUTO_TRACE();
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
-      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
+      cmdChar,qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateFile();
@@ -3460,8 +3460,8 @@ void DocPara::handleIFile(const QCString &cmdName, const int tokIn)
   parser()->tokenizer.setStatePara();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
-      DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%c%s'",
+      DocTokenizer::tokToString(tok),cmdChar,qPrint(cmdName));
     return;
   }
   parser()->context.fileName = parser()->context.token->name;
@@ -3605,23 +3605,23 @@ void DocPara::handleLink(const QCString &cmdName,bool isJavaLink)
   }
 }
 
-void DocPara::handleRef(const QCString &cmdName,const int tokIn)
+void DocPara::handleRef(const QCString &cmdName,char cmdChar)
 {
   AUTO_TRACE("cmdName={}",cmdName);
   QCString saveCmdName = cmdName;
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
-      TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
+      cmdChar,qPrint(saveCmdName));
     return;
   }
   parser()->tokenizer.setStateRef();
   tok=parser()->tokenizer.lex(); // get the reference id
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
-        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%c%s'",
+        DocTokenizer::tokToString(tok),cmdChar,qPrint(saveCmdName));
     goto endref;
   }
   children().append<DocRef>(parser(),thisVariant(),
@@ -3731,7 +3731,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   children().get_last<DocInclude>()->parse();
 }
 
-void DocPara::handleSection(const QCString &cmdName,const int tokIn)
+void DocPara::handleSection(const QCString &cmdName,char cmdChar)
 {
   AUTO_TRACE("cmdName={}",cmdName);
   QCString saveCmdName = cmdName;
@@ -3739,21 +3739,21 @@ void DocPara::handleSection(const QCString &cmdName,const int tokIn)
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
-        TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%c%s' command",
+        cmdChar,qPrint(saveCmdName));
     return;
   }
   tok=parser()->tokenizer.lex();
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command '%s%s'", TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
+        "argument of command '%c%s'", cmdChar,qPrint(saveCmdName));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
-        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%c%s'",
+        DocTokenizer::tokToString(tok),cmdChar,qPrint(saveCmdName));
     return;
   }
   parser()->context.token->sectionId = parser()->context.token->name;
@@ -3850,7 +3850,7 @@ void DocPara::handleInheritDoc()
 }
 
 
-int DocPara::handleCommand(const QCString &cmdName, const int tok)
+int DocPara::handleCommand(const QCString &cmdName, char cmdChar)
 {
   AUTO_TRACE("cmdName={}",cmdName);
   int retval = RetVal_OK;
@@ -3858,14 +3858,18 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
   switch (cmdId)
   {
     case CMD_UNKNOWN:
-      children().append<DocWord>(parser(),thisVariant(),TK_COMMAND_CHAR(tok) + cmdName);
-      if (isAliasCmd(cmdName))
+      //std::string delimiterString(1, cmdChar)
       {
-        warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Found unexpanded alias '%s%s'. Check if number of arguments passed is correct.",TK_COMMAND_CHAR(tok),qPrint(cmdName));
-      }
-      else
-      {
-        warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Found unknown command '%s%s'",TK_COMMAND_CHAR(tok),qPrint(cmdName));
+        std::string str{cmdChar};
+        children().append<DocWord>(parser(),thisVariant(),str.c_str() + cmdName);
+        if (isAliasCmd(cmdName))
+        {
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Found unexpanded alias '%c%s'. Check if number of arguments passed is correct.",cmdChar,qPrint(cmdName));
+        }
+        else
+        {
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Found unknown command '%c%s'",cmdChar,qPrint(cmdName));
+        }
       }
       break;
     case CMD_EMPHASIS:
@@ -3999,25 +4003,25 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       break;
     case CMD_SECTION:
       {
-        handleSection(cmdName,tok);
+        handleSection(cmdName,cmdChar);
         retval = RetVal_Section;
       }
       break;
     case CMD_SUBSECTION:
       {
-        handleSection(cmdName,tok);
+        handleSection(cmdName,cmdChar);
         retval = RetVal_Subsection;
       }
       break;
     case CMD_SUBSUBSECTION:
       {
-        handleSection(cmdName,tok);
+        handleSection(cmdName,cmdChar);
         retval = RetVal_Subsubsection;
       }
       break;
     case CMD_PARAGRAPH:
       {
-        handleSection(cmdName,tok);
+        handleSection(cmdName,cmdChar);
         retval = RetVal_Paragraph;
       }
       break;
@@ -4450,17 +4454,17 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       handleLink(cmdName,TRUE);
       break;
     case CMD_CITE:
-      handleCite(cmdName,tok);
+      handleCite(cmdName,cmdChar);
       break;
     case CMD_EMOJI:
-      handleEmoji(cmdName,tok);
+      handleEmoji(cmdName,cmdChar);
       break;
     case CMD_DOXYCONFIG:
-      handleDoxyConfig(cmdName,tok);
+      handleDoxyConfig(cmdName,cmdChar);
       break;
     case CMD_REF: // fall through
     case CMD_SUBPAGE:
-      handleRef(cmdName,tok);
+      handleRef(cmdName,cmdChar);
       break;
     case CMD_SECREFLIST:
       {
@@ -4469,10 +4473,10 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       }
       break;
     case CMD_SECREFITEM:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command '%s%s'",TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command '%c%s'",cmdChar,qPrint(parser()->context.token->name));
       break;
     case CMD_ENDSECREFLIST:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command '%s%s'",TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command '%c%s'",cmdChar,qPrint(parser()->context.token->name));
       break;
     case CMD_FORMULA:
       {
@@ -4493,13 +4497,13 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       handleInheritDoc();
       break;
     case CMD_SHOWDATE:
-      handleShowDate(cmdName,tok);
+      handleShowDate(cmdName,cmdChar);
       break;
     case CMD_ILINE:
-      handleILine(cmdName,tok);
+      handleILine(cmdName,cmdChar);
       break;
     case CMD_IFILE:
-      handleIFile(cmdName,tok);
+      handleIFile(cmdName,cmdChar);
       break;
     default:
       // we should not get here!
@@ -5417,7 +5421,7 @@ reparsetoken:
           }
 
           // handle the command
-          retval=handleCommand(parser()->context.token->name,tok);
+          retval=handleCommand(parser()->context.token->name,TK_COMMAND_CHAR(tok));
           AUTO_TRACE_ADD("handleCommand returns {}",DocTokenizer::retvalToString(retval));
 
           // check the return value

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -604,7 +604,6 @@ void DocSecRefList::parse()
   {
     if (tok==TK_COMMAND_AT || tok == TK_COMMAND_BS)
     {
-      const char *cmd_start = (tok==TK_COMMAND_AT ? "@" : "\\");
       switch (Mappers::cmdMapper->map(parser()->context.token->name))
       {
         case CMD_SECREFITEM:
@@ -630,8 +629,8 @@ void DocSecRefList::parse()
         case CMD_ENDSECREFLIST:
           return;
         default:
-          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command %s as part of a \\secreflist",
-              qPrint(cmd_start + parser()->context.token->name));
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%s%s' as part of a \\secreflist",
+              TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
           return;
       }
     }
@@ -946,11 +945,9 @@ QCString DocLink::parse(bool isJavaLink,bool isXmlLink)
   {
     if (!parser()->defaultHandleToken(thisVariant(),tok,children(),FALSE))
     {
-      const char *cmd_start = "\\";
       switch (tok)
       {
         case TK_COMMAND_AT:
-          cmd_start = "@";
         // fall through
         case TK_COMMAND_BS:
           switch (Mappers::cmdMapper->map(parser()->context.token->name))
@@ -958,17 +955,18 @@ QCString DocLink::parse(bool isJavaLink,bool isXmlLink)
             case CMD_ENDLINK:
               if (isJavaLink)
               {
-                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"{@link.. ended with @endlink command");
+                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"'{@link...' ended with '%s%s' command",
+                  TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
               }
               goto endlink;
             default:
-              warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command %s as part of a \\link",
-                  qPrint(cmd_start + parser()->context.token->name));
+              warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%s%s' as part of a \\link",
+                  TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
               break;
           }
           break;
         case TK_SYMBOL:
-          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol %s found as part of a \\link",
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol '%s' found as part of a \\link",
               qPrint(parser()->context.token->name));
           break;
         case TK_HTMLTAG:
@@ -1527,7 +1525,7 @@ int DocIndexEntry::parse()
             case HtmlEntityMapper::Sym_ndash:   m_entry+="--";  break;
             case HtmlEntityMapper::Sym_mdash:   m_entry+="---";  break;
             default:
-              warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected symbol found as argument of \\addindex");
+              warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected symbol '%s' found as argument of \\addindex",qPrint(parser()->context.token->name));
               break;
           }
         }
@@ -2159,11 +2157,9 @@ int DocHtmlDescTitle::parse()
   {
     if (!parser()->defaultHandleToken(thisVariant(),tok,children()))
     {
-      const char *cmd_start = "\\";
       switch (tok)
       {
         case TK_COMMAND_AT:
-          cmd_start = "@";
         // fall through
         case TK_COMMAND_BS:
           {
@@ -2176,8 +2172,8 @@ int DocHtmlDescTitle::parse()
                   tok=parser()->tokenizer.lex();
                   if (tok!=TK_WHITESPACE)
                   {
-                    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\%s command",
-                        qPrint(parser()->context.token->name));
+                    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+                        TK_COMMAND_CHAR(tok),qPrint(cmdName));
                   }
                   else
                   {
@@ -2185,8 +2181,8 @@ int DocHtmlDescTitle::parse()
                     tok=parser()->tokenizer.lex(); // get the reference id
                     if (tok!=TK_WORD)
                     {
-                      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of \\%s command",
-                          DocTokenizer::tokToString(tok),qPrint(cmdName));
+                      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s' command",
+                          DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tok),qPrint(cmdName));
                     }
                     else
                     {
@@ -2233,13 +2229,13 @@ int DocHtmlDescTitle::parse()
 
                 break;
               default:
-                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command %s found as part of a <dt> tag",
-                  qPrint(cmd_start + parser()->context.token->name));
+                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '%s%s' found as part of a <dt> tag",
+                  TK_COMMAND_CHAR(tok),qPrint(cmdName));
             }
           }
           break;
         case TK_SYMBOL:
-          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol \\%s found as part of a <dt> tag",
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol '%s' found as part of a <dt> tag",
               qPrint(parser()->context.token->name));
           break;
         case TK_HTMLTAG:
@@ -3182,15 +3178,15 @@ int DocPara::handleParamSection(const QCString &cmdName,
   return (rv!=TK_NEWPARA) ? rv : RetVal_OK;
 }
 
-void DocPara::handleCite()
+void DocPara::handleCite(const QCString &cmdName, const int tokIn)
 {
   AUTO_TRACE();
   // get the argument of the cite command.
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\%s command",
-        qPrint("cite"));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateCite();
@@ -3198,13 +3194,13 @@ void DocPara::handleCite()
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command %s", qPrint("cite"));
+        "argument of command '%s%s'",TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of %s",
-        DocTokenizer::tokToString(tok),qPrint("cite"));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
+        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->context.token->sectionId = parser()->context.token->name;
@@ -3214,15 +3210,15 @@ void DocPara::handleCite()
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleEmoji()
+void DocPara::handleEmoji(const QCString &cmdName, const int tokIn)
 {
   AUTO_TRACE();
   // get the argument of the emoji command.
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\%s command",
-        qPrint("emoji"));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateEmoji();
@@ -3230,14 +3226,14 @@ void DocPara::handleEmoji()
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"no emoji name given or unexpected end of comment block while parsing the "
-        "argument of command %s", qPrint("emoji"));
+        "argument of command '%s%s'",TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
   else if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of %s",
-        DocTokenizer::tokToString(tok),qPrint("emoji"));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
+        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3245,13 +3241,14 @@ void DocPara::handleEmoji()
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleDoxyConfig()
+void DocPara::handleDoxyConfig(const QCString &cmdName, const int tokIn)
 {
   // get the argument of the cite command.
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\doxyconfig command");
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateDoxyConfig();
@@ -3259,13 +3256,13 @@ void DocPara::handleDoxyConfig()
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command \\doxyconfig");
+        "argument of command '%s%s'",TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of \\doxyconfig",
-        DocTokenizer::tokToString(tok));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
+        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   ConfigOption * opt = ConfigImpl::instance()->get(parser()->context.token->name);
@@ -3316,13 +3313,13 @@ void DocPara::handleDoxyConfig()
         }
         break;
       case ConfigOption::O_Obsolete:
-        warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Obsolete setting for '\\doxyconfig': '%s'",
-              qPrint(parser()->context.token->name));
+        warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Obsolete setting for '%s%s': '%s'",
+              TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(parser()->context.token->name));
         break;
       case ConfigOption::O_Disabled:
         warn(parser()->context.fileName,parser()->tokenizer.getLineNr(),
-              "Disabled setting (i.e. not supported in this doxygen executable) for '\\doxyconfig': '%s'",
-              qPrint(parser()->context.token->name));
+              "Disabled setting (i.e. not supported in this doxygen executable) for '%s%s': '%s'",
+              TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(parser()->context.token->name));
         break;
       case ConfigOption::O_Info:
         // nothing to show here
@@ -3335,8 +3332,8 @@ void DocPara::handleDoxyConfig()
   }
   else
   {
-    warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Unknown option for '\\doxyconfig': '%s'",
-         qPrint(parser()->context.token->name));
+    warn(parser()->context.fileName,parser()->tokenizer.getLineNr(), "Unknown option for '%s%s': '%s'",
+         TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(parser()->context.token->name));
     children().append<DocWord>(parser(),thisVariant(),parser()->context.token->name);
   }
   parser()->tokenizer.setStatePara();
@@ -3363,7 +3360,7 @@ int DocPara::handleXRefItem()
   return retval;
 }
 
-void DocPara::handleShowDate()
+void DocPara::handleShowDate(const QCString &cmdName, const int tokIn)
 {
   AUTO_TRACE();
   QCString fmt;
@@ -3371,15 +3368,16 @@ void DocPara::handleShowDate()
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '\\%s' command",
-        qPrint("showdate"));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateQuotedString();
   tok = parser()->tokenizer.lex();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <format> argument for command '\\showdate'");
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <format> argument for command '%s%s'",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3393,7 +3391,8 @@ void DocPara::handleShowDate()
   bool specDateOnlyWS  = !specDateRaw.isEmpty() && specDate.isEmpty();
   if (!specDate.isEmpty() && tok!=TK_WORD && tok!=0)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '\\showdate'");
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '%s%s'",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3403,7 +3402,8 @@ void DocPara::handleShowDate()
   QCString err = dateTimeFromString(specDate,dat,specFormat);
   if (!err.isEmpty())
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '\\showdate': %s",qPrint(err));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid <date_time> argument for command '%s%s': %s",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName),qPrint(err));
     parser()->tokenizer.setStatePara();
     return;
   }
@@ -3417,7 +3417,8 @@ void DocPara::handleShowDate()
     int bitMask = 1<<i;
     if ((usedFormat&bitMask) && !(specFormat&bitMask)) // a part was used in the format string but its value was not specified.
     {
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"'\\showdate' <format> parameter '%s' has %s related markers which are not specified in the <date_time> parameter '%s'. Filling in the current value for %s instead.",
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"'%s%s' <format> parameter '%s' has %s related markers which are not specified in the <date_time> parameter '%s'. Filling in the current value for %s instead.",
+          TK_COMMAND_CHAR(tokIn),qPrint(cmdName),
           qPrint(fmt),SF_bit2str(i),qPrint(specDate),SF_bit2str(i));
     }
   }
@@ -3430,26 +3431,28 @@ void DocPara::handleShowDate()
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleILine()
+void DocPara::handleILine(const QCString &cmdName, const int tokIn)
 {
   AUTO_TRACE();
   parser()->tokenizer.setStateILine();
   int tok = parser()->tokenizer.lex();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid argument for command '\\iline'");
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"invalid argument for command '%s%s'",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStatePara();
 }
 
-void DocPara::handleIFile()
+void DocPara::handleIFile(const QCString &cmdName, const int tokIn)
 {
   AUTO_TRACE();
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\ifile command");
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+      TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->tokenizer.setStateFile();
@@ -3457,8 +3460,8 @@ void DocPara::handleIFile()
   parser()->tokenizer.setStatePara();
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of \\ifile",
-        DocTokenizer::tokToString(tok));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
+      DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(cmdName));
     return;
   }
   parser()->context.fileName = parser()->context.token->name;
@@ -3602,23 +3605,23 @@ void DocPara::handleLink(const QCString &cmdName,bool isJavaLink)
   }
 }
 
-void DocPara::handleRef(const QCString &cmdName)
+void DocPara::handleRef(const QCString &cmdName,const int tokIn)
 {
   AUTO_TRACE("cmdName={}",cmdName);
   QCString saveCmdName = cmdName;
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\%s command",
-        qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+      TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
     return;
   }
   parser()->tokenizer.setStateRef();
   tok=parser()->tokenizer.lex(); // get the reference id
   if (tok!=TK_WORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of %s",
-        DocTokenizer::tokToString(tok),qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
+        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
     goto endref;
   }
   children().append<DocRef>(parser(),thisVariant(),
@@ -3728,7 +3731,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   children().get_last<DocInclude>()->parse();
 }
 
-void DocPara::handleSection(const QCString &cmdName)
+void DocPara::handleSection(const QCString &cmdName,const int tokIn)
 {
   AUTO_TRACE("cmdName={}",cmdName);
   QCString saveCmdName = cmdName;
@@ -3736,21 +3739,21 @@ void DocPara::handleSection(const QCString &cmdName)
   int tok=parser()->tokenizer.lex();
   if (tok!=TK_WHITESPACE)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\%s command",
-        qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '%s%s' command",
+        TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
     return;
   }
   tok=parser()->tokenizer.lex();
   if (tok==0)
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command %s", qPrint(saveCmdName));
+        "argument of command '%s%s'", TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
     return;
   }
   else if (tok!=TK_WORD && tok!=TK_LNKWORD)
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of %s",
-        DocTokenizer::tokToString(tok),qPrint(saveCmdName));
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token %s as the argument of '%s%s'",
+        DocTokenizer::tokToString(tok),TK_COMMAND_CHAR(tokIn),qPrint(saveCmdName));
     return;
   }
   parser()->context.token->sectionId = parser()->context.token->name;
@@ -3996,25 +3999,25 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       break;
     case CMD_SECTION:
       {
-        handleSection(cmdName);
+        handleSection(cmdName,tok);
         retval = RetVal_Section;
       }
       break;
     case CMD_SUBSECTION:
       {
-        handleSection(cmdName);
+        handleSection(cmdName,tok);
         retval = RetVal_Subsection;
       }
       break;
     case CMD_SUBSUBSECTION:
       {
-        handleSection(cmdName);
+        handleSection(cmdName,tok);
         retval = RetVal_Subsubsection;
       }
       break;
     case CMD_PARAGRAPH:
       {
-        handleSection(cmdName);
+        handleSection(cmdName,tok);
         retval = RetVal_Paragraph;
       }
       break;
@@ -4447,17 +4450,17 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       handleLink(cmdName,TRUE);
       break;
     case CMD_CITE:
-      handleCite();
+      handleCite(cmdName,tok);
       break;
     case CMD_EMOJI:
-      handleEmoji();
+      handleEmoji(cmdName,tok);
       break;
     case CMD_DOXYCONFIG:
-      handleDoxyConfig();
+      handleDoxyConfig(cmdName,tok);
       break;
     case CMD_REF: // fall through
     case CMD_SUBPAGE:
-      handleRef(cmdName);
+      handleRef(cmdName,tok);
       break;
     case CMD_SECREFLIST:
       {
@@ -4466,10 +4469,10 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       }
       break;
     case CMD_SECREFITEM:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command %s",qPrint(parser()->context.token->name));
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command '%s%s'",TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
       break;
     case CMD_ENDSECREFLIST:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command %s",qPrint(parser()->context.token->name));
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected command '%s%s'",TK_COMMAND_CHAR(tok),qPrint(parser()->context.token->name));
       break;
     case CMD_FORMULA:
       {
@@ -4490,13 +4493,13 @@ int DocPara::handleCommand(const QCString &cmdName, const int tok)
       handleInheritDoc();
       break;
     case CMD_SHOWDATE:
-      handleShowDate();
+      handleShowDate(cmdName,tok);
       break;
     case CMD_ILINE:
-      handleILine();
+      handleILine(cmdName,tok);
       break;
     case CMD_IFILE:
-      handleIFile();
+      handleIFile(cmdName,tok);
       break;
     default:
       // we should not get here!
@@ -5480,7 +5483,7 @@ reparsetoken:
           else
           {
             children().append<DocWord>(parser(),thisVariant(),parser()->context.token->name);
-            warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol %s found",
+            warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol '%s' found",
                 qPrint(parser()->context.token->name));
           }
           break;
@@ -5698,7 +5701,7 @@ void DocText::parse()
           }
           else
           {
-            warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol %s found",
+            warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unsupported symbol '%s' found",
                 qPrint(parser()->context.token->name));
           }
         }

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -1044,7 +1044,7 @@ class DocPara : public DocCompoundNode
     bool isFirst() const        { return m_isFirst; }
     bool isLast() const         { return m_isLast; }
 
-    int handleCommand(const QCString &cmdName,const int tok);
+    int handleCommand(const QCString &cmdName,char cmdChar);
     int handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &tagHtmlAttribs);
     int handleHtmlEndTag(const QCString &tagName);
     int handleSimpleSection(DocSimpleSect::Type t,bool xmlContext=FALSE);
@@ -1054,16 +1054,16 @@ class DocPara : public DocCompoundNode
     template<class T> void handleFile(const QCString &cmdName);
     void handleInclude(const QCString &cmdName,DocInclude::Type t);
     void handleLink(const QCString &cmdName,bool isJavaLink);
-    void handleCite(const QCString &cmdName,const int tokIn);
-    void handleDoxyConfig(const QCString &cmdName,const int tokIn);
-    void handleEmoji(const QCString &cmdName,const int tokIn);
-    void handleRef(const QCString &cmdName,const int tokIn);
-    void handleSection(const QCString &cmdName,const int tokIn);
+    void handleCite(const QCString &cmdName,char cmdChar);
+    void handleDoxyConfig(const QCString &cmdName,char cmdChar);
+    void handleEmoji(const QCString &cmdName,char cmdChar);
+    void handleRef(const QCString &cmdName,char cmdChar);
+    void handleSection(const QCString &cmdName,char cmdChar);
     void handleInheritDoc();
     void handleVhdlFlow();
-    void handleILine(const QCString &cmdName,const int tokIn);
-    void handleIFile(const QCString &cmdName,const int tokIn);
-    void handleShowDate(const QCString &cmdName,const int tokIn);
+    void handleILine(const QCString &cmdName,char cmdChar);
+    void handleIFile(const QCString &cmdName,char cmdChar);
+    void handleShowDate(const QCString &cmdName,char cmdChar);
     int handleStartCode();
     int handleHtmlHeader(const HtmlAttribList &tagHtmlAttribs,int level);
 

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -1054,16 +1054,16 @@ class DocPara : public DocCompoundNode
     template<class T> void handleFile(const QCString &cmdName);
     void handleInclude(const QCString &cmdName,DocInclude::Type t);
     void handleLink(const QCString &cmdName,bool isJavaLink);
-    void handleCite();
-    void handleDoxyConfig();
-    void handleEmoji();
-    void handleRef(const QCString &cmdName);
-    void handleSection(const QCString &cmdName);
+    void handleCite(const QCString &cmdName,const int tokIn);
+    void handleDoxyConfig(const QCString &cmdName,const int tokIn);
+    void handleEmoji(const QCString &cmdName,const int tokIn);
+    void handleRef(const QCString &cmdName,const int tokIn);
+    void handleSection(const QCString &cmdName,const int tokIn);
     void handleInheritDoc();
     void handleVhdlFlow();
-    void handleILine();
-    void handleIFile();
-    void handleShowDate();
+    void handleILine(const QCString &cmdName,const int tokIn);
+    void handleIFile(const QCString &cmdName,const int tokIn);
+    void handleShowDate(const QCString &cmdName,const int tokIn);
     int handleStartCode();
     int handleHtmlHeader(const HtmlAttribList &tagHtmlAttribs,int level);
 

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -533,19 +533,20 @@ bool DocParser::findDocsForMemberOrCompound(const QCString &commandName,
 void DocParser::errorHandleDefaultToken(DocNodeVariant *parent,int tok,
                                         DocNodeList &children,const QCString &txt)
 {
-  const char *cmd_start = "\\";
   switch (tok)
   {
     case TK_COMMAND_AT:
-      cmd_start = "@";
       // fall through
     case TK_COMMAND_BS:
-      children.append<DocWord>(this,parent,TK_COMMAND_CHAR(tok) + context.token->name);
-      warn_doc_error(context.fileName,tokenizer.getLineNr(),"Illegal command %s found as part of a %s",
-       qPrint(cmd_start + context.token->name),qPrint(txt));
+      {
+        std::string str{TK_COMMAND_CHAR(tok)};
+        children.append<DocWord>(this,parent,str.c_str() + context.token->name);
+        warn_doc_error(context.fileName,tokenizer.getLineNr(),"Illegal command '%c%s' found as part of a %s",
+         TK_COMMAND_CHAR(tok),qPrint(context.token->name),qPrint(txt));
+      }
       break;
     case TK_SYMBOL:
-      warn_doc_error(context.fileName,tokenizer.getLineNr(),"Unsupported symbol %s found as part of a %s",
+      warn_doc_error(context.fileName,tokenizer.getLineNr(),"Unsupported symbol '%s' found as part of a %s",
            qPrint(context.token->name), qPrint(txt));
       break;
     case TK_HTMLTAG:

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -67,7 +67,7 @@ enum Tokens
   RetVal_EndHtmlDetails = 0x10018
 };
 
-#define TK_COMMAND_CHAR(token) ((token)==TK_COMMAND_AT ? "@" : "\\")
+#define TK_COMMAND_CHAR(token) ((token)==TK_COMMAND_AT ? '@' : '\\')
 
 /** @brief Data associated with a token used by the comment block parser. */
 struct TokenInfo


### PR DESCRIPTION
Improve a number of warnings in respect to the use starting char and placing single quotes around the text part.