### PR TITLE
Single line snippet didn't show

### DIFF
--- a/src/codefragment.cpp
+++ b/src/codefragment.cpp
@@ -92,7 +92,7 @@ void CodeFragmentManager::Private::FragmentInfo::findBlockMarkers()
   for (auto &kv : candidates)
   {
     auto &marker = kv.second;
-    if (marker.lines.size()==2 && marker.lines[0]+1<marker.lines[1]-1)
+    if (marker.lines.size()==2 && marker.lines[0]+1<=marker.lines[1]-1)
     {
       marker.key = kv.first;
       int startLine = marker.lines[0];


### PR DESCRIPTION
A single line snippet (except in case of `\snippet{doc}`) was not shown in the output due to an incorrect test.

(Regression in version 1.10.0, didn't bisect but probably due to:
```
Commit: 19012e55ce84b0b870af950a1e74c9058cd05ea3 [19012e5]
Date: Friday, September 29, 2023 8:52:15 PM

Commit Date: Friday, October 6, 2023 7:20:11 PM
Improve snippet handling
```
)
Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14002277/example.tar.gz)
