### PR TITLE
Show emoji in HTML treeview

### DIFF
--- a/src/textdocvisitor.cpp
+++ b/src/textdocvisitor.cpp
@@ -39,7 +39,7 @@ void TextDocVisitor::operator()(const DocSymbol &s)
 
 void TextDocVisitor::operator()(const DocEmoji &s)
 {
-  // the TextDocVisitor is only invokated for the JS part of the HTML output
+  // the TextDocVisitor is only invoked for the JS part of the HTML output
   const char *res = EmojiEntityMapper::instance().unicode(s.index());
   if (res)
   {

--- a/src/textdocvisitor.cpp
+++ b/src/textdocvisitor.cpp
@@ -39,10 +39,29 @@ void TextDocVisitor::operator()(const DocSymbol &s)
 
 void TextDocVisitor::operator()(const DocEmoji &s)
 {
-  const char *res = EmojiEntityMapper::instance().name(s.index());
+  // the TextDocVisitor is only invokated for the JS part of the HTML output
+  const char *res = EmojiEntityMapper::instance().unicode(s.index());
   if (res)
   {
-    filter(res);
+    const char *p = res;
+    while (*p)
+    {
+      switch(*p)
+      {
+        case '&': case '#':
+          break;
+        case 'x':
+          m_t << "\\u{";
+          break;
+        case ';':
+          m_t << "}";
+          break;
+        default:
+          m_t << *p;
+          break;
+      }
+      p++;
+    }
   }
   else
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4313,7 +4313,9 @@ QCString convertToJSString(const QCString &s)
     switch (c)
     {
       case '"':  growBuf.addStr("\\\""); break;
-      case '\\': growBuf.addStr("\\\\"); break;
+      case '\\': if (*p=='u' && *(p+1)=='{') growBuf.addStr("\\");
+                 else growBuf.addStr("\\\\");
+                 break;
       default:   growBuf.addChar(c);   break;
     }
   }
@@ -5635,7 +5637,8 @@ QCString parseCommentAsText(const Definition *scope,const MemberDef *md,
       if (result.at(i)==',' ||
           result.at(i)=='.' ||
           result.at(i)=='!' ||
-          result.at(i)=='?')
+          result.at(i)=='?' ||
+          result.at(i)=='}')    // good for UTF-16 characters and } otherwise also hood point to stop string
       {
         i++; // we want to be "behind" last inspected character
         break;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5638,7 +5638,7 @@ QCString parseCommentAsText(const Definition *scope,const MemberDef *md,
           result.at(i)=='.' ||
           result.at(i)=='!' ||
           result.at(i)=='?' ||
-          result.at(i)=='}')    // good for UTF-16 characters and } otherwise also hood point to stop string
+          result.at(i)=='}')    // good for UTF-16 characters and } otherwise also a good point to stop the string
       {
         i++; // we want to be "behind" last inspected character
         break;


### PR DESCRIPTION
Show emoji in the HTML treeview as emoji and not as  text

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14013838/example.tar.gz)
