### PR TITLE
issue #10586 Backslash + quote mark causes doxygen not to generate documentation

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2229,7 +2229,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                           BEGIN( SkipComment ) ;
                                         }
-<*>@\"                                  { // C# verbatim string
+<*>[$]?@\"                                  { // C# (interpolated) verbatim string
                                           startFontClass(yyscanner,"stringliteral");
                                           yyextra->code->codify(yytext);
                                           yyextra->lastVerbStringContext=YY_START;

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -157,6 +157,7 @@ MAILADDR   ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a
 
 %x Scan
 %x SkipString
+%x SkipVerbString
 %x SkipChar
 %x SComment
 %x CComment
@@ -232,7 +233,7 @@ SLASHopt [/]*
                                       if (yyextra->lang!=SrcLangExt::Cpp) REJECT;
                                       copyToOutput(yyscanner,yytext,yyleng);
                                     }
-<Scan>[^"'!\/\n\\#,\-=; \t]*        { /* eat anything that is not " / , or \n */
+<Scan>[^"'!\/\n\\#,\-=; \t@$]*      { /* eat anything that is not " / , or \n */
                                        copyToOutput(yyscanner,yytext,yyleng);
                                     }
 <Scan>[,= ;\t]                      { /* eat , so we have a nice separator in long initialization lines */
@@ -342,6 +343,12 @@ SLASHopt [/]*
 				         REJECT;
 				       }
 				     }
+                                   }
+<Scan>[$]?"@\""                    { /* start of an interpolated verbatim C# string */
+                                     if (yyextra->lang!=SrcLangExt::CSharp) REJECT
+                                     copyToOutput(yyscanner,yytext,yyleng);
+				     yyextra->stringContext = YY_START;
+				     BEGIN(SkipVerbString);
                                    }
 <Scan>"\""                         { /* start of a string */
                                      copyToOutput(yyscanner,yytext,yyleng);
@@ -693,6 +700,22 @@ SLASHopt [/]*
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
 <SkipString>\n                     { /* new line inside string (illegal for some compilers) */
+                                     copyToOutput(yyscanner,yytext,yyleng);
+                                   }
+<SkipVerbString>[^"\n]+            {
+                                     copyToOutput(yyscanner,yytext,yyleng);
+                                   }
+<SkipVerbString>\"\"               { // escaped quote
+                                     copyToOutput(yyscanner,yytext,yyleng);
+                                   }
+<SkipVerbString>"\""       	   { /* end of string */
+                                     copyToOutput(yyscanner,yytext,yyleng);
+				     BEGIN(yyextra->stringContext);
+                                   }
+<SkipVerbString>.                  {
+                                     copyToOutput(yyscanner,yytext,yyleng);
+                                   }
+<SkipVerbString>\n                 {
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
 <SkipChar>\\.		           { /* escaped character */

--- a/src/pre.l
+++ b/src/pre.l
@@ -583,7 +583,7 @@ WSopt [ \t\r]*
 <CopyLine,LexCopyLine>"'"."'"           {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
-<CopyLine,LexCopyLine>@\"               {
+<CopyLine,LexCopyLine>[$]?@\"           {
                                           if (getLanguageFromFileName(yyextra->fileName)!=SrcLangExt::CSharp) REJECT;
                                           outputArray(yyscanner,yytext,yyleng);
                                           BEGIN( CopyStringCs );
@@ -608,6 +608,9 @@ WSopt [ \t\r]*
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <CopyStringCs>[^\"\r\n]+                {
+                                          outputArray(yyscanner,yytext,yyleng);
+                                        }
+<CopyStringCs>\"\"                      {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <CopyString>\\.                         {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3160,9 +3160,11 @@ NONLopt [^\n]*
                                           *yyextra->pSkipVerbString << yytext;
                                         }
 <SkipVerbString>"\\\\"                  { // escaped backslash
+                                          if (yyextra->insideCS) REJECT
                                           *yyextra->pSkipVerbString << yytext;
                                         }
 <SkipVerbString>"\\\""                  { // backslash escaped quote
+                                          if (yyextra->insideCS) REJECT
                                           *yyextra->pSkipVerbString << yytext;
                                         }
 <SkipVerbString>"\"\""                  { // quote escape


### PR DESCRIPTION
The handling of (interpolated) verbatim C# strings didn't correctly handle the `\`. Fixed the problem in different places.

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14050654/example.tar.gz)
