### PR TITLE
Endless loop in lists due to #10504 / #10520

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -5224,9 +5224,9 @@ static bool checkIfHtmlEndTagEndsAutoList(DocParser *parser,const DocNodeVariant
       return std::get<DocStyleChange>(*stack.top());
     };
 
-    if (parser->context.styleStack.empty() ||                                                   // no style change
-        topStyleChange(parser->context.styleStack).tagName()!=tagNameLower ||                   // wrong style change
-        topStyleChange(parser->context.styleStack).position()!=parser->context.nodeStack.size() // wrong position
+    if (parser->context.styleStack.empty() ||                                                     // no style change
+        (topStyleChange(parser->context.styleStack).tagName()==tagNameLower &&                    // correct style change
+         topStyleChange(parser->context.styleStack).position()!=parser->context.nodeStack.size()) // wrong position, so normal close
        )
     {
       // insert an artificial 'end of autolist' marker and parse again


### PR DESCRIPTION
Due to the changes for issue #10504 A list inside an alias on a markdown page seems broken, it repeats the alias indefinitely (i.e. PR #10520)  the transform package went into an endless loop du to code like (simplified):
```
- Infer4
<pre>l4
<b>u4 </pre>
```
We should get here a warning about the wrong closing tag.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14053735/example.tar.gz)

(Original problem found by Fossies for: https://github.com/huggingface/transformers/archive/v4.37.1.tar.gz
