### PR TITLE
Problem generating PDF with some commands in section headers

### DIFF
--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -26,6 +26,12 @@ class OutputCodeList;
 class LatexCodeGenerator;
 class TextStream;
 
+enum class TexOrPdf
+{
+   NO,  //!< not called through texorpdf
+   TEX, //!< called through texorpdf as TeX (first) part
+   PDF, //!< called through texorpdf as PDF (second) part
+};
 
 /*! @brief Concrete visitor implementation for LaTeX output. */
 class LatexDocVisitor : public DocVisitor
@@ -169,6 +175,7 @@ class LatexDocVisitor : public DocVisitor
     bool m_hide;
     QCString m_langExt;
     int m_hierarchyLevel;
+    TexOrPdf m_texOrPdf = TexOrPdf::NO;
 
     struct TableState
     {


### PR DESCRIPTION
There were some problems with the handling of a number of commands (`\emoji`, `\ref`, `\subpage`, `link`) in the LaTeX output when used in a section header, the generated PDF would not generate. The PDF can now be generated.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14071927/example.tar.gz)
