### PR TITLE
No mention of citation reference in treeview

### DIFF
--- a/src/textdocvisitor.cpp
+++ b/src/textdocvisitor.cpp
@@ -20,6 +20,7 @@
 #include "message.h"
 #include "util.h"
 #include "htmlentity.h"
+#include "cite.h"
 #include "emoji.h"
 
 //-------------------------------------------------------------------------
@@ -47,6 +48,21 @@ void TextDocVisitor::operator()(const DocEmoji &s)
   else
   {
     filter(s.name());
+  }
+}
+
+void TextDocVisitor::operator()(const DocCite &cite)
+{
+  if (!cite.file().isEmpty())
+  {
+    QCString anchor = cite.anchor();
+    QCString anchorPrefix = CitationManager::instance().anchorPrefix();
+    anchor = anchor.mid(anchorPrefix.length()); // strip prefix
+    m_t << anchor;
+  }
+  else
+  {
+    filter(cite.text());
   }
 }
 

--- a/src/textdocvisitor.h
+++ b/src/textdocvisitor.h
@@ -50,7 +50,7 @@ class TextDocVisitor : public DocVisitor
     void operator()(const DocFormula &)      {}
     void operator()(const DocIndexEntry &)   {}
     void operator()(const DocSimpleSectSep &){}
-    void operator()(const DocCite &)         {}
+    void operator()(const DocCite &);
     void operator()(const DocSeparator &)    { m_t << " "; }
 
     //--------------------------------------


### PR DESCRIPTION
In the treeview there is no reference of the citation reference, this is corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14072002/example.tar.gz)
