### PR TITLE
Keep latex template files with Unix EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,48 @@
+* text=auto eol=lf
+
+### Source code
+*.cpp text
+*.hpp text
+*.cc text
+*.c text
+*.h text
+*.py text
+*.pl text
+
+### LaTeX files
+*.tex text
+*.sty text
+
+*.luma text
+*.lum text
+
+### XML Files
+*.xml text
+*.xsd text
+*.l	text
+
+### Webpage files
+*.html text
+*.xhtml text
+*.css text
+*.js text
+
+### Git files
+*.md text
+LICENSE text
+INSTALL text
+VERSION text
+
+### Cmake
+*.cmake
+*.in text
+
+### Protected
+*.exe binary
+*.pyc binary
+*.pdf binary
+*.ico binary
+*.jpg binary
+*.bmp binary
+*.png binary
+*.lib binary 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,48 +1,9 @@
 * text=auto eol=lf
-
-### Source code
-*.cpp text
-*.hpp text
-*.cc text
-*.c text
-*.h text
-*.py text
-*.pl text
-
-### LaTeX files
-*.tex text
-*.sty text
-
-*.luma text
-*.lum text
-
-### XML Files
-*.xml text
-*.xsd text
-*.l	text
-
-### Webpage files
-*.html text
-*.xhtml text
-*.css text
-*.js text
-
-### Git files
-*.md text
-LICENSE text
-INSTALL text
-VERSION text
-
-### Cmake
-*.cmake text
-*.in text
+* text
 
 ### Protected
-*.exe binary
-*.pyc binary
 *.pdf binary
 *.ico binary
 *.jpg binary
-*.bmp binary
 *.png binary
 *.lib binary 

--- a/.gitattributes
+++ b/.gitattributes
@@ -34,7 +34,7 @@ INSTALL text
 VERSION text
 
 ### Cmake
-*.cmake
+*.cmake text
 *.in text
 
 ### Protected


### PR DESCRIPTION
Windows (CRLF) encoding of `*tex` files causes output to contain multiple empty lines.  
This breaks final output (`refman.tex`) resulting in (for example) attaching latex tags to project id on pdf main page.  
Feel free to see an excerpt of my frustration #10609 