### PR TITLE
Incorrect "More.." with `\file` command

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -548,7 +548,7 @@ void FileDefImpl::writeBriefDescription(OutputList &ol)
       ol.enable(OutputType::RTF);
 
       if (Config_getBool(REPEAT_BRIEF) ||
-          !documentation().isEmpty()
+          !documentation().stripWhiteSpace().isEmpty()
          )
       {
         ol.disableAllBut(OutputType::Html);


### PR DESCRIPTION
Based on comment https://stackoverflow.com/a/77909654/1657886 where it was shown that in case of
```
/*!
 * \file
 * \brief This is a short description.
 */
```
and settings:
```
QUIET = YES
REPEAT_BRIEF = NO
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14125435/example.tar.gz)

