### PR TITLE
Incorrect translation indented fenced code blocks

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2941,7 +2941,7 @@ void Markdown::Private::writeFencedCodeBlock(std::string_view data,std::string_v
     out+="{"+lang+"}";
   }
   out+=" ";
-  addStrEscapeUtf8Nbsp(data.substr(blockStart,blockEnd-blockStart));
+  addStrEscapeUtf8Nbsp(data.substr(blockStart+i,blockEnd-blockStart));
   out+="@endicode ";
 }
 


### PR DESCRIPTION
When having markdown code like:
~~~

  ```
  blk_4
  ```

  ```{py}
  blk_5
  ```
~~~
this is currently translated into:
~~~
  @icode ``
  blk_4
@endicode

  @icode{py} y}
  blk_5
@endicode
~~~
instead of
~~~
  @icode
  blk_4
  @endicode

  @icode{py}
  blk_5
  @endicode
~~~
due to the fact that the check for whitespace moves the start point but this is not taken into consideration in the `substr`.


Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14152294/example.tar.gz)
