### PR TITLE
issue #10618 C++ consteval functions need label

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -3964,7 +3964,7 @@ class memberdefType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, kind=None, id=None, prot=None, static=None, extern=None, strong=None, const=None, explicit=None, inline=None, refqual=None, virt=None, volatile=None, mutable=None, noexcept=None, constexpr=None, readable=None, writable=None, initonly=None, settable=None, privatesettable=None, protectedsettable=None, gettable=None, privategettable=None, protectedgettable=None, final=None, sealed=None, new=None, add=None, remove=None, raise_=None, optional=None, required=None, accessor=None, attribute=None, property=None, readonly=None, bound=None, removable=None, constrained=None, transient=None, maybevoid=None, maybedefault=None, maybeambiguous=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, qualifiedname=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, qualifier=None, param=None, enumvalue=None, requiresclause=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None, gds_collector_=None, **kwargs_):
+    def __init__(self, kind=None, id=None, prot=None, static=None, extern=None, strong=None, const=None, explicit=None, inline=None, refqual=None, virt=None, volatile=None, mutable=None, noexcept=None, constexpr=None, consteval=None, constinit=None, readable=None, writable=None, initonly=None, settable=None, privatesettable=None, protectedsettable=None, gettable=None, privategettable=None, protectedgettable=None, final=None, sealed=None, new=None, add=None, remove=None, raise_=None, optional=None, required=None, accessor=None, attribute=None, property=None, readonly=None, bound=None, removable=None, constrained=None, transient=None, maybevoid=None, maybedefault=None, maybeambiguous=None, templateparamlist=None, type_=None, definition=None, argsstring=None, name=None, qualifiedname=None, read=None, write=None, bitfield=None, reimplements=None, reimplementedby=None, qualifier=None, param=None, enumvalue=None, requiresclause=None, initializer=None, exceptions=None, briefdescription=None, detaileddescription=None, inbodydescription=None, location=None, references=None, referencedby=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -4000,6 +4000,10 @@ class memberdefType(GeneratedsSuper):
         self.noexcept_nsprefix_ = None
         self.constexpr = _cast(None, constexpr)
         self.constexpr_nsprefix_ = None
+        self.consteval = _cast(None, consteval)
+        self.consteval_nsprefix_ = None
+        self.constinit = _cast(None, constinit)
+        self.constinit_nsprefix_ = None
         self.readable = _cast(None, readable)
         self.readable_nsprefix_ = None
         self.writable = _cast(None, writable)
@@ -4332,6 +4336,14 @@ class memberdefType(GeneratedsSuper):
         return self.constexpr
     def set_constexpr(self, constexpr):
         self.constexpr = constexpr
+    def get_consteval(self):
+        return self.consteval
+    def set_consteval(self, consteval):
+        self.consteval = consteval
+    def get_constinit(self):
+        return self.constinit
+    def set_constinit(self, constinit):
+        self.constinit = constinit
     def get_readable(self):
         return self.readable
     def set_readable(self, readable):
@@ -4620,6 +4632,12 @@ class memberdefType(GeneratedsSuper):
         if self.constexpr is not None and 'constexpr' not in already_processed:
             already_processed.add('constexpr')
             outfile.write(' constexpr=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.constexpr), input_name='constexpr')), ))
+        if self.consteval is not None and 'consteval' not in already_processed:
+            already_processed.add('consteval')
+            outfile.write(' consteval=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.consteval), input_name='consteval')), ))
+        if self.constinit is not None and 'constinit' not in already_processed:
+            already_processed.add('constinit')
+            outfile.write(' constinit=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.constinit), input_name='constinit')), ))
         if self.readable is not None and 'readable' not in already_processed:
             already_processed.add('readable')
             outfile.write(' readable=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.readable), input_name='readable')), ))
@@ -4872,6 +4890,16 @@ class memberdefType(GeneratedsSuper):
             already_processed.add('constexpr')
             self.constexpr = value
             self.validate_DoxBool(self.constexpr)    # validate type DoxBool
+        value = find_attr_value_('consteval', node)
+        if value is not None and 'consteval' not in already_processed:
+            already_processed.add('consteval')
+            self.consteval = value
+            self.validate_DoxBool(self.consteval)    # validate type DoxBool
+        value = find_attr_value_('constinit', node)
+        if value is not None and 'constinit' not in already_processed:
+            already_processed.add('constinit')
+            self.constinit = value
+            self.validate_DoxBool(self.constinit)    # validate type DoxBool
         value = find_attr_value_('readable', node)
         if value is not None and 'readable' not in already_processed:
             already_processed.add('readable')

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -179,6 +179,8 @@ class MemberDefImpl : public DefinitionMixin<MemberDefMutable>
     bool livesInsideEnum() const override;
     bool isSliceLocal() const override;
     bool isConstExpr() const override;
+    bool isConstEval() const override;
+    bool isConstInit() const override;
     int  numberOfFlowKeyWords() const override;
     bool isFriendToHide() const override;
     bool isNotFriend() const override;
@@ -775,6 +777,10 @@ class MemberDefAliasImpl : public DefinitionAliasMixin<MemberDef>
     { return getMdAlias()->isSliceLocal(); }
     bool isConstExpr() const override
     { return getMdAlias()->isConstExpr(); }
+    bool isConstEval() const override
+    { return getMdAlias()->isConstEval(); }
+    bool isConstInit() const override
+    { return getMdAlias()->isConstInit(); }
     int  numberOfFlowKeyWords() const override
     { return getMdAlias()->numberOfFlowKeyWords(); }
     bool isFriendToHide() const override
@@ -2798,6 +2804,8 @@ StringVector MemberDefImpl::getLabels(const Definition *container) const
           if    (isPrivateSettable())                   sl.push_back("private set");
         }
         if      (isConstExpr())                         sl.push_back("constexpr");
+        if      (isConstEval())                         sl.push_back("consteval");
+        if      (isConstInit())                         sl.push_back("constinit");
         if      (isAddable())                           sl.push_back("add");
         if      (!isUNOProperty() && isRemovable())     sl.push_back("remove");
         if      (isRaisable())                          sl.push_back("raise");
@@ -5489,6 +5497,16 @@ bool MemberDefImpl::isSliceLocal() const
 bool MemberDefImpl::isConstExpr() const
 {
   return m_memSpec.isConstExpr();
+}
+
+bool MemberDefImpl::isConstEval() const
+{
+  return m_memSpec.isConstEval();
+}
+
+bool MemberDefImpl::isConstInit() const
+{
+  return m_memSpec.isConstInit();
 }
 
 const MemberVector &MemberDefImpl::enumFieldList() const

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -187,6 +187,8 @@ class MemberDef : public Definition
     virtual bool livesInsideEnum() const = 0;
     virtual bool isSliceLocal() const = 0;
     virtual bool isConstExpr() const = 0;
+    virtual bool isConstEval() const = 0;
+    virtual bool isConstInit() const = 0;
     virtual int  numberOfFlowKeyWords() const = 0;
 
     // derived getters

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1238,6 +1238,20 @@ NONLopt [^\n]*
                                           }
                                           REJECT;
                                         }
+<FindMembers>{B}*"consteval"{BN}+       {
+                                          if (yyextra->insideCpp)
+                                          {
+                                            yyextra->current->spec.setConstEval(true);
+                                          }
+                                          REJECT;
+                                        }
+<FindMembers>{B}*"constinit"{BN}+       {
+                                          if (yyextra->insideCpp)
+                                          {
+                                            yyextra->current->spec.setConstInit(true);
+                                          }
+                                          REJECT;
+                                        }
 <FindMembers>{B}*"published"{BN}+       { // UNO IDL published keyword
                                           if (yyextra->insideIDL)
                                           {
@@ -2504,6 +2518,30 @@ NONLopt [^\n]*
                                                 else
                                                 {
                                                   yyextra->current->type+="constexpr ";
+                                                }
+                                                yyextra->current->name=yyextra->current->name.mid(10);
+                                              }
+                                              else if (yyextra->current->name.startsWith("consteval "))
+                                              {
+                                                if (yyextra->current->type.isEmpty())
+                                                {
+                                                  yyextra->current->type="consteval";
+                                                }
+                                                else
+                                                {
+                                                  yyextra->current->type+="consteval ";
+                                                }
+                                                yyextra->current->name=yyextra->current->name.mid(10);
+                                              }
+                                              else if (yyextra->current->name.startsWith("constinit "))
+                                              {
+                                                if (yyextra->current->type.isEmpty())
+                                                {
+                                                  yyextra->current->type="constinit";
+                                                }
+                                                else
+                                                {
+                                                  yyextra->current->type+="constinit ";
                                                 }
                                                 yyextra->current->name=yyextra->current->name.mid(10);
                                               }

--- a/src/types.h
+++ b/src/types.h
@@ -373,7 +373,7 @@ class LocalToc
 /* 45 */ TSPEC(Strong)            TSPEC(Weak)            TSPEC(Unretained)        TSPEC(Alias)        TSPEC(ConstExp)           \
 /* 50 */ TSPEC(Default)           TSPEC(Delete)          TSPEC(NoExcept)          TSPEC(Attribute)    TSPEC(Property)           \
 /* 55 */ TSPEC(Readonly)          TSPEC(Bound)           TSPEC(Constrained)       TSPEC(Transient)    TSPEC(MaybeVoid)          \
-/* 60 */ TSPEC(MaybeDefault)      TSPEC(MaybeAmbiguous)  TSPEC(Published)
+/* 60 */ TSPEC(MaybeDefault)      TSPEC(MaybeAmbiguous)  TSPEC(Published)         TSPEC(ConstEval)    TSPEC(ConstInit)
 
 /** Wrapper class for a number of boolean properties.
  *  The properties are packed together, and initialized to false.

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -647,6 +647,16 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
     t << " constexpr=\"yes\"";
   }
 
+  if (md->isConstEval())
+  {
+    t << " consteval=\"yes\"";
+  }
+
+  if (md->isConstInit())
+  {
+    t << " constinit=\"yes\"";
+  }
+
   if (md->isExternal())
   {
     t << " extern=\"yes\"";

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -221,6 +221,8 @@
     <xsd:attribute name="mutable" type="DoxBool" use="optional"/>
     <xsd:attribute name="noexcept" type="DoxBool" use="optional"/>
     <xsd:attribute name="constexpr" type="DoxBool" use="optional"/>
+    <xsd:attribute name="consteval" type="DoxBool" use="optional"/>
+    <xsd:attribute name="constinit" type="DoxBool" use="optional"/>
     <!-- Qt property -->
     <xsd:attribute name="readable" type="DoxBool" use="optional"/>
     <xsd:attribute name="writable" type="DoxBool" use="optional"/>


### PR DESCRIPTION
Adding analogous to `constexpr`:
- `constinit` (C++20)
- `consteval` (C++20)

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14156368/example.tar.gz)
