### PR TITLE
Prevent compiler warning

### DIFF
--- a/src/aliases.cpp
+++ b/src/aliases.cpp
@@ -212,7 +212,7 @@ struct Marker
  */
 static size_t findEndOfCommand(std::string_view s)
 {
-  char c;
+  char c=' ';
   size_t i=0;
   if (!s.empty())
   {


### PR DESCRIPTION
Prevent the compiler warning:
```
.../src/aliases.cpp: In function ‘size_t findEndOfCommand(std::string_view)’:
.../src/aliases.cpp:220:5: warning: ‘c’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  220 |     if (c=='{') i+=extractAliasArgs(s.substr(i)).length()+2; // +2 for '{' and '}'
      |     ^~
```