### PR TITLE
Enable `this` again as argument of `\snippet{doc}`

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1022,6 +1022,7 @@ SLASHopt [/]*
                                      QCString blockId = "["+fileName.mid(i+1)+"]";
                                      fileName=fileName.left(i).stripWhiteSpace();
                                      //printf("yytext='%s' i=%d fileName='%s' blockId='%s'\n",yytext,i,qPrint(fileName),qPrint(blockId));
+                                     if (fileName == "this") fileName=yyextra->fileName;
                                      if (readIncludeFile(yyscanner,fileName,blockId))
                                      {
                                        BEGIN(IncludeFile);


### PR DESCRIPTION
According to the documentation the placeholder `this` is allowed for the `\snippet` command but due to the restructuring this was not possible anymore for the `\snippet{doc}` (but is is still possible for the other `\snippet` commands). Created possibility to use `this` again with `\snippet{doc}`

Example:
[example.tar.gz](https://github.com/doxygen/doxygen/files/14177626/example.tar.gz)
