### PR TITLE
Issue #10623 Unexpected "code block" formatting for detailed description of enum values using C++ style comments

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6687,6 +6687,11 @@ NONLopt [^\n]*
                                             BEGIN( Comment ) ;
                                           }
                                         }
+<FindMembers,FindFields,MemberSpec,FuncQual,SkipCurly,Operator,ClassVar,SkipInits,Bases,OldStyleArgs>^{B}+({CPPC}{B}*)?{CCS}"*"/{NCOMM} {
+                                          lineCount(yyscanner);
+                                          yyextra->yyColNr=1;
+                                          REJECT;
+                                        }
 <FindMembers,FindFields,MemberSpec,FuncQual,SkipCurly,Operator,ClassVar,SkipInits,Bases,OldStyleArgs>({CPPC}{B}*)?{CCS}"*"/{NCOMM} {
                                           yyextra->lastDocContext = YY_START;
 


### PR DESCRIPTION
Corrected counting of begin spacing.
(Note the adding of the `^{B}+`to the rule.)