### PR TITLE
Fix out of bounds issue in aliases.cpp

### DIFF
--- a/src/aliases.cpp
+++ b/src/aliases.cpp
@@ -452,7 +452,7 @@ static int countAliasArguments(std::string_view args, std::string_view sep)
   for (size_t i=0;i<l;i++)
   {
     char c = args[i];
-    if (c==sep[0] && // start with separator character
+    if (sep.length() && c==sep[0] && // start with separator character
         (i==0 || args[i-1]!='\\') && // is not escaped
         args.substr(i,sep.length())==sep) // whole separator matches
     {


### PR DESCRIPTION
Fix out of bounds issue in aliases.cpp

Problem occurs when generating the CGAL documentation with a Windows debug executable.