### PR TITLE
issue #10631 Spurious .PP on Value headings in Macro Definition Documentation in man page

### DIFF
--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -114,6 +114,7 @@ ManCodeGenerator::ManCodeGenerator(TextStream *t) : m_t(t)
 
 void ManCodeGenerator::startCodeFragment(const QCString &)
 {
+  *m_t << "\n";
   *m_t << ".PP\n";
   *m_t << ".nf\n";
 }
@@ -895,5 +896,22 @@ void ManGenerator::writeInheritedSectionTitle(
   m_t << "\n\n";
   m_t << theTranslator->trInheritedFrom(docifyToString(title), objectLinkToString(name));
   m_firstCol = FALSE;
+}
+
+void ManGenerator::startParameterList(bool openBracket)
+{
+  if (openBracket) m_t << "(";
+}
+
+void ManGenerator::endParameterExtra(bool last,bool /* emptyList */, bool closeBracket)
+{
+  if (last && closeBracket)
+  {
+    m_t << ")";
+  }
+}
+void ManGenerator::endParameterType()
+{
+  m_t << " ";
 }
 

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -115,13 +115,13 @@ ManCodeGenerator::ManCodeGenerator(TextStream *t) : m_t(t)
 void ManCodeGenerator::startCodeFragment(const QCString &)
 {
   *m_t << "\n";
-  *m_t << ".PP\n";
   *m_t << ".nf\n";
 }
 
 void ManCodeGenerator::endCodeFragment(const QCString &)
 {
   if (m_col>0) *m_t << "\n";
+  *m_t << ".PP\n";
   *m_t << ".fi\n";
   m_col=0;
 }

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -230,14 +230,14 @@ class ManGenerator : public OutputGenerator
     void startMemberDocName(bool) {}
     void endMemberDocName() {}
     void startParameterType(bool,const QCString &) {}
-    void endParameterType() {}
+    void endParameterType();
     void startParameterName(bool) {}
     void endParameterName() {}
     void startParameterExtra() {}
-    void endParameterExtra(bool,bool,bool) {}
+    void endParameterExtra(bool,bool,bool);
     void startParameterDefVal(const char *s) { docify(s); startTypewriter(); }
     void endParameterDefVal() { endTypewriter(); }
-    void startParameterList(bool) {}
+    void startParameterList(bool);
     void endParameterList() {}
     void exceptionEntry(const QCString &,bool) {}
 

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -184,6 +184,7 @@ void RTFCodeGenerator::startCodeFragment(const QCString &)
 {
   DBG_RTF(*m_t << "{\\comment (startCodeFragment) }\n")
   *m_t << "{\n";
+  *m_t << "\\par\n";
   *m_t << rtf_Style_Reset << rtf_Code_DepthStyle();
 }
 
@@ -2758,6 +2759,19 @@ void RTFGenerator::writeInheritedSectionTitle(
   m_t << theTranslator->trInheritedFrom(docifyToString(title), objectLinkToString(ref, file, anchor, name));
   m_t << "\\par\n";
   m_t << rtf_Style_Reset << "\n";
+}
+
+void RTFGenerator::startParameterList(bool openBracket)
+{
+  if (openBracket) m_t << "(";
+}
+
+void RTFGenerator::endParameterExtra(bool last,bool /* emptyList */, bool closeBracket)
+{
+  if (last && closeBracket)
+  {
+    m_t << ")";
+  }
 }
 
 //----------------------------------------------------------------------

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -251,10 +251,10 @@ class RTFGenerator : public OutputGenerator
     void startParameterName(bool) {}
     void endParameterName() {}
     void startParameterExtra() {}
-    void endParameterExtra(bool,bool,bool) {}
+    void endParameterExtra(bool,bool,bool);
     void startParameterDefVal(const char *s) { docify(s); startTypewriter(); }
     void endParameterDefVal() { endTypewriter(); }
-    void startParameterList(bool) {}
+    void startParameterList(bool);
     void endParameterList() {}
     void exceptionEntry(const QCString &,bool);
 


### PR DESCRIPTION
Original .PP problem
- have the `.PP` start at a new line
- for RTF the word `Values` was included in the code block due to a missing `\par`

Regarding the problem with the missing round brackets:
- implement some of the original empty functions for RTF and man output


Extended examples: [example.tar.gz](https://github.com/doxygen/doxygen/files/14197269/example.tar.gz)
