### PR TITLE
issue #10643 doxygen --version shows GIT-NOTFOUND

### DIFF
--- a/libversion/gitversion.cpp.in
+++ b/libversion/gitversion.cpp.in
@@ -17,7 +17,7 @@ std::string getGitVersion()
     {
       gitVersion+="*";
     }
-    if (gitVersion=="GIT_NOTFOUND")
+    if (gitVersion=="GIT-NOTFOUND")
     {
       gitVersion="";
     }


### PR DESCRIPTION
Corrected typo "GIT_NOTFOUND" has to be "GIT-NOTFOUND"