### PR TITLE
Add doxyindexer and doxysearch installation instructions

### DIFF
--- a/doc/searching.dox
+++ b/doc/searching.dox
@@ -77,7 +77,9 @@ has its own advantages and disadvantages:
    of choice. To make life easier doxygen ships with an example indexer 
    (doxyindexer) and search engine (doxysearch.cgi) based on 
    the <a href="https://xapian.org/">Xapian</a> open source search engine 
-   library.
+   library. Both binaries are included in the distribution but not installed
+   by default; they can be manually copied from the `bin` folder to i.e.
+   `/usr/local/bin` or `/var/www/cgi-bin` as desired.
 
    To enable this search method set 
    \ref cfg_searchengine "SEARCHENGINE",


### PR DESCRIPTION
I can't find any instructions that say where to find doxyindexer or doxysearch; only by manually hunting around and guessing did I find them in the bin folder and figure out how to "install" them. (The INSTALL file in the Ubuntu ZIP points users to this manual which doesn't say anything about indexer. The README mentions where the binaries are but doesn't say how to install them.)

The install.html vaguely mentions running `make install` which I fortunately guessed was the right way to install the doxygen binary, but it otherwise makes no mention of how to use doxyindexer or doxysearch at all.