### PR TITLE
issue #10642 Group titles not carried over into External Search

### DIFF
--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -468,6 +468,14 @@ void SearchIndexExternal::setCurrentDoc(const Definition *ctx,const QCString &an
     {
       e.args = (toMemberDef(ctx))->argsString();
     }
+    else if (ctx->definitionType()==Definition::TypeGroup)
+    {
+      const GroupDef *gd = toGroupDef(ctx);
+      if (!gd->groupTitle().isEmpty())
+      {
+        e.name = filterTitle(gd->groupTitle());
+      }
+    }
     e.extId = extId;
     e.url  = url;
     it = m_docEntries.insert({key.str(),e}).first;

--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -476,6 +476,14 @@ void SearchIndexExternal::setCurrentDoc(const Definition *ctx,const QCString &an
         e.name = filterTitle(gd->groupTitle());
       }
     }
+    else if (ctx->definitionType()==Definition::TypePage)
+    {
+      const PageDef *pd = toPageDef(ctx);
+      if (pd->hasTitle())
+      {
+        e.name = filterTitle(pd->title());
+      }
+    }
     e.extId = extId;
     e.url  = url;
     it = m_docEntries.insert({key.str(),e}).first;


### PR DESCRIPTION
Set name to the title instead of using the label.