### PR TITLE
issue #10655 Class Member List does not show friend operator parameter list

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -3020,7 +3020,7 @@ void ClassDefImpl::writeMemberList(OutputList &ol) const
                 md->anchor(),name);
 
             if ( md->isFunction() || md->isSignal() || md->isSlot() ||
-                (md->isFriend() && md->argsString().isEmpty()))
+                (md->isFriend() && !md->argsString().isEmpty()))
               ol.docify(md->argsString());
             else if (md->isEnumerate())
               ol.parseText(" "+theTranslator->trEnumName());


### PR DESCRIPTION
Looks like the translation from:
```
                (md->isFriend() && md->argsString()))
```
to
```
                (md->isFriend() && md->argsString().isEmpty()))
```
was done incorrectly (missing `!`).