### PR TITLE
Check validity of Doxyfile.xml against all possible names of the settings

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -34,6 +34,7 @@
 #define Config_getInt(name)    (ConfigValues::instance().name())
 #define Config_getEnum(name)   (ConfigValues::instance().name())
 #define Config_getEnumAsString(name)   (ConfigValues::instance().name##_str())
+#define Config_getStringAsEnum(name,value)   (name##_str2enum(value))
 #define Config_getList(name)   (ConfigValues::instance().name())
 #define Config_updateString(name,value) (ConfigValues::instance().update_##name(value));
 #define Config_updateBool(name,value)   (ConfigValues::instance().update_##name(value));
@@ -70,6 +71,11 @@ namespace Config
    *  to stream \a t.
    */
   void writeXMLDoxyfile(TextStream &t);
+
+  /*! Writes all possible setting ids to an XSD file for validation 
+   *  through the stream \a t.
+   */
+  void writeXSDDoxyfile(TextStream &t);
 
   /*! Parses a configuration file with name \a fn.
    *  \returns TRUE if successful, FALSE if the file could not be

--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -80,6 +80,7 @@ class ConfigOption
     virtual void writeTemplate(TextStream &t,bool sl,bool upd) = 0;
     virtual void compareDoxyfile(TextStream &t,Config::CompareMode compareMode) = 0;
     virtual void writeXMLDoxyfile(TextStream &t) = 0;
+    virtual void writeXSDDoxyfile(TextStream &t) = 0;
     virtual void convertStrToVal(Config::CompareMode) {}
     virtual void emptyValueToDefault() {}
     virtual void substEnvVars() = 0;
@@ -114,6 +115,7 @@ class ConfigInfo : public ConfigOption
     void writeTemplate(TextStream &t, bool sl,bool);
     void compareDoxyfile(TextStream &,Config::CompareMode) {}
     void writeXMLDoxyfile(TextStream &) {}
+    void writeXSDDoxyfile(TextStream &t) {}
     void substEnvVars() {}
 };
 
@@ -139,6 +141,7 @@ class ConfigList : public ConfigOption
     void writeTemplate(TextStream &t,bool sl,bool);
     void compareDoxyfile(TextStream &t,Config::CompareMode compareMode);
     void writeXMLDoxyfile(TextStream &t);
+    void writeXSDDoxyfile(TextStream &t);
     void substEnvVars();
     void init() { m_value = m_defaultValue; }
     bool isDefault();
@@ -169,6 +172,7 @@ class ConfigEnum : public ConfigOption
     void convertStrToVal(Config::CompareMode compareMode);
     void compareDoxyfile(TextStream &t,Config::CompareMode compareMode);
     void writeXMLDoxyfile(TextStream &t);
+    void writeXSDDoxyfile(TextStream &t);
     void init() { m_value = m_defValue; }
     bool isDefault() { return m_value == m_defValue; }
 
@@ -201,6 +205,7 @@ class ConfigString : public ConfigOption
     void writeTemplate(TextStream &t,bool sl,bool);
     void compareDoxyfile(TextStream &t,Config::CompareMode compareMode);
     void writeXMLDoxyfile(TextStream &t);
+    void writeXSDDoxyfile(TextStream &t);
     void substEnvVars();
     void init() { m_value = m_defValue; }
     void emptyValueToDefault() { if (m_value.isEmpty()) m_value=m_defValue; };
@@ -236,6 +241,7 @@ class ConfigInt : public ConfigOption
     void writeTemplate(TextStream &t,bool sl,bool upd);
     void compareDoxyfile(TextStream &t,Config::CompareMode compareMode);
     void writeXMLDoxyfile(TextStream &t);
+    void writeXSDDoxyfile(TextStream &t);
     void init() { m_value = m_defValue; }
     bool isDefault() { return m_value == m_defValue; }
   private:
@@ -267,6 +273,7 @@ class ConfigBool : public ConfigOption
     void writeTemplate(TextStream &t,bool sl,bool upd);
     void compareDoxyfile(TextStream &t,Config::CompareMode compareMode);
     void writeXMLDoxyfile(TextStream &t);
+    void writeXSDDoxyfile(TextStream &t);
     void init() { m_value = m_defValue; }
     bool isDefault() { return m_value == m_defValue; }
   private:
@@ -285,6 +292,7 @@ class ConfigObsolete : public ConfigOption
     void writeTemplate(TextStream &,bool,bool);
     void compareDoxyfile(TextStream &,Config::CompareMode) {}
     void writeXMLDoxyfile(TextStream &) {}
+    void writeXSDDoxyfile(TextStream &) {}
     void substEnvVars() {}
     OptionType orgType() const { return m_orgType; }
     StringVector *valueListRef() { return &m_listvalue; }
@@ -308,6 +316,7 @@ class ConfigDisabled : public ConfigOption
     void writeTemplate(TextStream &,bool,bool);
     void compareDoxyfile(TextStream &,Config::CompareMode) {}
     void writeXMLDoxyfile(TextStream &) {}
+    void writeXSDDoxyfile(TextStream &);
     void substEnvVars() {}
 };
 
@@ -512,6 +521,11 @@ class ConfigImpl
      *  to stream \a t.
      */
     void writeXMLDoxyfile(TextStream &t);
+
+    /*! Writes all possible setting ids to an XSD file for validation 
+     *  through the stream \a t.
+     */
+    void writeXSDDoxyfile(TextStream &t);
 
     void setHeader(const char *header) { m_header = header; }
 

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -448,6 +448,11 @@ void ConfigList::writeXMLDoxyfile(TextStream &t)
   t << "  </option>\n";
 }
 
+void ConfigList::writeXSDDoxyfile(TextStream &t)
+{
+  t << "      <xsd:enumeration value=\"" << m_name << "\"/>\n";
+}
+
 void ConfigEnum::writeTemplate(TextStream &t,bool sl,bool)
 {
   if (!sl)
@@ -480,6 +485,11 @@ void ConfigEnum::writeXMLDoxyfile(TextStream &t)
   writeStringValue(t,m_value,false);
   t << "</value>";
   t << "</option>\n";
+}
+
+void ConfigEnum::writeXSDDoxyfile(TextStream &t)
+{
+  t << "      <xsd:enumeration value=\"" << m_name << "\"/>\n";
 }
 
 void ConfigString::writeTemplate(TextStream &t,bool sl,bool)
@@ -516,6 +526,11 @@ void ConfigString::writeXMLDoxyfile(TextStream &t)
   t << "]]>";
   t << "</value>";
   t << "</option>\n";
+}
+
+void ConfigString::writeXSDDoxyfile(TextStream &t)
+{
+  t << "      <xsd:enumeration value=\"" << m_name << "\"/>\n";
 }
 
 void ConfigInt::writeTemplate(TextStream &t,bool sl,bool upd)
@@ -557,6 +572,11 @@ void ConfigInt::writeXMLDoxyfile(TextStream &t)
   writeIntValue(t,m_value,false);
   t << "</value>";
   t << "</option>\n";
+}
+
+void ConfigInt::writeXSDDoxyfile(TextStream &t)
+{
+  t << "      <xsd:enumeration value=\"" << m_name << "\"/>\n";
 }
 
 void ConfigBool::writeTemplate(TextStream &t,bool sl,bool upd)
@@ -601,8 +621,18 @@ void ConfigBool::writeXMLDoxyfile(TextStream &t)
   t << "</option>\n";
 }
 
+void ConfigBool::writeXSDDoxyfile(TextStream &t)
+{
+  t << "      <xsd:enumeration value=\"" << m_name << "\"/>\n";
+}
+
 void ConfigObsolete::writeTemplate(TextStream &,bool,bool) {}
+
 void ConfigDisabled::writeTemplate(TextStream &,bool,bool) {}
+void ConfigDisabled::writeXSDDoxyfile(TextStream &t)
+{
+  t << "      <xsd:enumeration value=\"" << m_name << "\"/>\n";
+}
 
 /* -----------------------------------------------------------------
  *
@@ -1335,6 +1365,18 @@ void ConfigImpl::writeXMLDoxyfile(TextStream &t)
     option->writeXMLDoxyfile(t);
   }
   t << "</doxyfile>\n";
+}
+
+void ConfigImpl::writeXSDDoxyfile(TextStream &t)
+{
+  for (const auto &option : m_options)
+  {
+    option->writeXSDDoxyfile(t);
+  }
+  for (const auto &option : m_disabled)
+  {
+    option->writeXSDDoxyfile(t);
+  }
 }
 
 void ConfigImpl::convertStrToVal(Config::CompareMode compareMode)
@@ -2280,6 +2322,11 @@ void Config::compareDoxyfile(TextStream &t,Config::CompareMode compareMode)
 void Config::writeXMLDoxyfile(TextStream &t)
 {
   ConfigImpl::instance()->writeXMLDoxyfile(t);
+}
+
+void Config::writeXSDDoxyfile(TextStream &t)
+{
+  ConfigImpl::instance()->writeXSDDoxyfile(t);
 }
 
 bool Config::parse(const QCString &fileName,bool update, Config::CompareMode compareMode)

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -2097,7 +2097,6 @@ void generateXML()
 
   ResourceMgr::instance().copyResource("xml.xsd",outputDirectory);
   ResourceMgr::instance().copyResource("index.xsd",outputDirectory);
-  ResourceMgr::instance().copyResource("doxyfile.xsd",outputDirectory);
 
   QCString fileName=outputDirectory+"/compound.xsd";
   std::ofstream f = Portable::openOutputStream(fileName);
@@ -2124,6 +2123,42 @@ void generateXML()
         if (s.find("<!-- Automatically insert here the HTML entities -->")!=-1)
         {
           HtmlEntityMapper::instance().writeXMLSchema(t);
+        }
+        else
+        {
+          t.write(startLine,len);
+        }
+      }
+      startLine=endLine;
+    }
+  }
+  f.close();
+
+  fileName=outputDirectory+"/doxyfile.xsd";
+  f = Portable::openOutputStream(fileName);
+  if (!f.is_open())
+  {
+    err("Cannot open file %s for writing!\n",qPrint(fileName));
+    return;
+  }
+  {
+    TextStream t(&f);
+
+    // write doxyfile.xsd, but replace special marker with the entities
+    QCString doxyfile_xsd = ResourceMgr::instance().getAsString("doxyfile.xsd");
+    const char *startLine = doxyfile_xsd.data();
+    while (*startLine)
+    {
+      // find end of the line
+      const char *endLine = startLine+1;
+      while (*endLine && *(endLine-1)!='\n') endLine++; // skip to end of the line including \n
+      int len=static_cast<int>(endLine-startLine);
+      if (len>0)
+      {
+        QCString s(startLine,len);
+        if (s.find("<!-- Automatically insert here the configuration settings -->")!=-1)
+        {
+          Config::writeXSDDoxyfile(t);
         }
         else
         {

--- a/templates/xml/doxyfile.xsd
+++ b/templates/xml/doxyfile.xsd
@@ -16,13 +16,19 @@
     <xsd:sequence>
       <xsd:element name="value" type="valueType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
-    <xsd:attribute name="id" type="xsd:string" use="required"/>
+    <xsd:attribute name="id" type="idType" use="required"/>
     <xsd:attribute name="default" type="defaultType" use="required"/>
     <xsd:attribute name="type" type="typeType" use="required"/>
   </xsd:complexType>
 
   <xsd:simpleType name="valueType">
     <xsd:restriction base="xsd:string">
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="idType">
+    <xsd:restriction base="xsd:string">
+      <!-- Automatically insert here the configuration settings -->
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
In the doxyfile.xsd there was just a check on "xsd:string" for the validity of the name (`id`) of the configuration settings, made it explicit so that a full set of names is provided.