### PR TITLE
Fix invalid generated link when using Markdown GitHub style link to a section in another file

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1529,7 +1529,7 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
     }
     else if ((lp=link.find('#'))!=-1 || link.find('/')!=-1 || link.find('.')!=-1)
     { // file/url link
-      if (lp!=-1 && !isURL(link) && Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB)
+      if (lp==0 || (lp>0 && !isURL(link) && Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB))
       {
         out+="@ref \"";
         out+=AnchorGenerator::addPrefixIfNeeded(link.mid(lp+1).str());

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1527,12 +1527,12 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
       }
       out+="\"";
     }
-    else if (link.find('/')!=-1 || link.find('.')!=-1 || link.find('#')!=-1)
+    else if ((lp=link.find('#'))!=-1 || link.find('/')!=-1 || link.find('.')!=-1)
     { // file/url link
-      if (link.at(0) == '#')
+      if (lp!=-1 && !isURL(link))
       {
         out+="@ref \"";
-        out+=AnchorGenerator::addPrefixIfNeeded(link.mid(1).str());
+        out+=AnchorGenerator::addPrefixIfNeeded(link.mid(lp+1).str());
         out+="\" \"";
         out+=substitute(content.simplifyWhiteSpace(),"\"","&quot;");
         out+="\"";

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1529,7 +1529,7 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
     }
     else if ((lp=link.find('#'))!=-1 || link.find('/')!=-1 || link.find('.')!=-1)
     { // file/url link
-      if (lp!=-1 && !isURL(link))
+      if (lp!=-1 && !isURL(link) && Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB)
       {
         out+="@ref \"";
         out+=AnchorGenerator::addPrefixIfNeeded(link.mid(lp+1).str());


### PR DESCRIPTION
Fix for a bug in HTML documentation generated from Markdown files using GitHub style. When I have two Markdown pages and I want to link from the first one to the second one's subsection directly, I would write something like this:

```md
This is the [link](second-page.md#subsection).
```

This works on GitHub and other Markdown previewers such as the one in VS Code, but in Doxygen generated HTML this does not generate a correct link. The link is treated as a regular URL so basically it tries to open `.../out/html/second-page.md#subsection` link on my generated documentation, which does not exist.

I know I can rewrite my Markdown to look like this:

```md
This is the [link](#subsection).
```

And this would work correctly with Doxygen - it opens `.../out/html/md_second-page.html#subsection` which indeed points to the subsection of my second page that I wanted it to point. However this does not work on GitHub nor does it work on other Markdown previewers. For consistency I think that the first way of linking to sections that are in different files should also be supported because I and most likely other people who use the GitHub Markdown style option in Doxygen want the Markdown files to work not just with Doxygen generated documentation but in other Markdown previewers and editors as well.

My change makes the parser recognize `second-page.md#subsection` links as `#subsection` links, so there is no additional logic to verify that the `#subsection` exists on that specific page so technically any page (or text) can be specified in place of `second-page.md` part and the link would still work the same. This is not necessarily that problematic as Doxygen makes the section IDs unique. So for example if we had two sections named "Subsection" and even if they're in their own separate Markdown files, one will get the ID "subsection" and the other will get the ID "subsection-1". So to link to the second one you must use the "#subsection-1" regardless from which page you're trying to link to it, else you're going to make a link to the first "Subsection" section. I didn't want to touch any logic with link resolution myself, but I think that maybe when using GitHub Markdown style the parser should first try to resolve the `#subsection` links to sections named "Subsection" in the current file and only later look elsewhere. Similarly if the link is specified like `second-page.md#subsection` it should attempt to link to that section in that specific page first. This would make the logic more consistent with the GitHub Markdown logic.

In any way, here is the minimal example showcasing the bug which gets fixed by my PR: 
~[markdown_link_bug_minimal_example.zip](https://github.com/doxygen/doxygen/files/14319788/markdown_link_bug_minimal_example.zip)~ (EDIT: wrong file provided by accident, scroll down for correct one)

Also, this PR possibly also fixes the problems in #9021.