### PR TITLE
Fix table overlaping footer

### DIFF
--- a/templates/latex/longtable_doxygen.sty
+++ b/templates/latex/longtable_doxygen.sty
@@ -164,7 +164,7 @@
   \ifdim \dimen@>\z@\vfil\break\fi
       \global\@colroom\@colht
   \ifvoid\LT@foot\else
-    \advance\vsize-\ht\LT@foot
+    \global\advance\vsize-\ht\LT@foot
     \global\advance\@colroom-\ht\LT@foot
     \dimen@\pagegoal\advance\dimen@-\ht\LT@foot\pagegoal\dimen@
     \maxdepth\z@
@@ -193,9 +193,13 @@
     \LT@final@warn
   \fi
   \endgraf\penalty -\LT@end@pen
+  \ifvoid\LT@foot\else
+    \global\advance\vsize\ht\LT@foot
+    \global\advance\@colroom\ht\LT@foot
+    \dimen@\pagegoal\advance\dimen@\ht\LT@foot\pagegoal\dimen@
+  \fi
   \endgroup
   \global\@mparbottom\z@
-  \pagegoal\vsize
   \endgraf\penalty\z@\addvspace\LTpost
   \ifvoid\footins\else\insert\footins{}\fi}
 \def\LT@nofcols#1&{%
@@ -392,18 +396,17 @@
       \setbox\z@\vbox{\unvbox\@cclv}%
       \ifdim \ht\LT@lastfoot>\ht\LT@foot
         \dimen@\pagegoal
+        \advance\dimen@\ht\LT@foot
         \advance\dimen@-\ht\LT@lastfoot
         \ifdim\dimen@<\ht\z@
           \setbox\@cclv\vbox{\unvbox\z@\copy\LT@foot\vss}%
           \@makecol
           \@outputpage
+            \global\vsize\@colroom
           \setbox\z@\vbox{\box\LT@head}%
         \fi
       \fi
-      \global\@colroom\@colht
-      \global\vsize\@colht
-      \vbox
-        {\unvbox\z@\box\ifvoid\LT@lastfoot\LT@foot\else\LT@lastfoot\fi}%
+      \unvbox\z@\ifvoid\LT@lastfoot\copy\LT@foot\else\box\LT@lastfoot\fi
     \fi
   \else
     \setbox\@cclv\vbox{\unvbox\@cclv\copy\LT@foot\vss}%


### PR DESCRIPTION
This bug lies in Latex longtable since ages. doxygen, and  pandoc, suffer this bug since. See #6532.

The issue is that a table may overlap the footer. There are even cases where the bottom of a table is cropped at the end of the page.

The culprit is the longtable latex package. This bug is known for a long time, and a patch has been proposed since 2003. This package is not maintained anymore.

- https://github.com/jgm/pandoc/issues/2889#issuecomment-245879494
- https://www.latex-project.org/cgi-bin/ltxbugs2html?pr=tools/3512

The proposed patch has been applied without any conflict.

The result is that there is not more table overlap. See example in pull request #10667.

Fixes #6532