### PR TITLE
Provide environment for latex tables

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1151,26 +1151,24 @@ static void writeStartTableCommand(TextStream &t,const DocNodeVariant *n,size_t 
 {
   if (tableIsNested(n))
   {
-    t << "{\\begin{tabularx}{\\linewidth}{|*{" << cols << "}{>{\\raggedright\\arraybackslash}X|}}";
+    t << "\\begin{DoxyNestedTable}{" << cols << "}\n";
   }
   else
   {
-    t << "\\tabulinesep=1mm\n\\begin{longtabu}spread 0pt [c]{*{" << cols << "}{|X[-1]}|}\n";
+    t << "\\begin{DoxyTable}{" << cols << "}\n";
   }
-  //return isNested ? "TabularNC" : "TabularC";
 }
 
 static void writeEndTableCommand(TextStream &t,const DocNodeVariant *n)
 {
   if (tableIsNested(n))
   {
-    t << "\\end{tabularx}}\n";
+    t << "\\end{DoxyNestedTable}}\n";
   }
   else
   {
-    t << "\\end{longtabu}\n";
+    t << "\\end{DoxyTable}\n";
   }
-  //return isNested ? "TabularNC" : "TabularC";
 }
 
 void LatexDocVisitor::operator()(const DocHtmlTable &t)

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -510,14 +510,15 @@
 
 % Used by tables
 \newcommand{\PBS}[1]{\let\temp=\\#1\let\\=\temp}%
-\newenvironment{TabularC}[1]%
-{\tabulinesep=1mm
-\begin{longtabu*}spread 0pt [c]{*#1{|X[-1]}|}}%
-{\end{longtabu*}\par}%
 
-\newenvironment{TabularNC}[1]%
-{\begin{tabu}spread 0pt [l]{*#1{|X[-1]}|}}%
-{\end{tabu}\par}%
+\newenvironment{DoxyTable}[1]%
+{\tabulinesep=1mm%
+\begin{longtabu}spread 0pt [c]{*{#1}{|X[-1]}|}}%
+{\end{longtabu}}%
+
+\newenvironment{DoxyNestedTable}[1]%
+{\begin{tabularx}{\linewidth}{|*{#1}{>{\raggedright\arraybackslash}X|}}}%
+{\end{tabularx}}%
 
 % Used for member group headers
 \newenvironment{Indent}{%


### PR DESCRIPTION
Latex tables are literally described in doxygen executable. Doing so, it is not possible for a user to redefine these tables.

By definig an environment for each of them, the user can now redefine them, by using renewenvironment.

NB: old environment TabularC and TabularNC were not used anymore, remove dead code.

This lack of customization has been discussed in #6532 .