### PR TITLE
Handling of empty structural command

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -172,6 +172,7 @@ static bool handleILine(yyscan_t yyscanner,const QCString &, const StringVector 
 [[maybe_unused]] static const char *stateToString(int state);
 
 typedef bool (*DocCmdFunc)(yyscan_t yyscanner,const QCString &name, const StringVector &optList);
+typedef EntryType (*makeEntryType)();
 
 enum class CommandSpacing
 {
@@ -453,6 +454,7 @@ struct commentscanYY_state
   OutlineParserInterface *langParser = nullptr;  // the language parser that is calling us
   QCString         inputString;            // input string
   QCString         currentCmd;             // the command used
+  makeEntryType    currentMakeEntryType;
   int              inputPosition = 0;      // read pointer
   QCString         fileName;               // file name that is read from
   int              lineNr = 0;             // line number in the input
@@ -525,7 +527,8 @@ static SectionType sectionLevelToType(int level);
 static void stripTrailingWhiteSpace(QCString &s);
 
 static void initParser(yyscan_t yyscanner);
-static bool makeStructuralIndicator(yyscan_t yyscanner,EntryType t);
+static bool checkStructuralIndicator(yyscan_t yyscanner);
+[[maybe_unused]] static bool makeStructuralIndicator(yyscan_t yyscanner,EntryType t);
 static void lineCount(yyscan_t yyscanner);
 static void addXRefItem(yyscan_t yyscanner,
                         const QCString &listName,const QCString &itemTitle,
@@ -1251,6 +1254,7 @@ STopt  [^\n@\\]*
   /* ------------ handle argument of enum command --------------- */
 
 <EnumDocArg1>{SCOPEID}                  { // handle argument
+                                          makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
                                           yyextra->current->name = yytext;
                                           BEGIN( Comment );
                                         }
@@ -1260,11 +1264,9 @@ STopt  [^\n@\\]*
                                         }
 <EnumDocArg1>{DOCNL}                    { // missing argument
                                           warn(yyextra->fileName,yyextra->lineNr,
-                                               "missing argument after \\enum."
+                                               "missing argument after '\\enum'."
                                               );
                                           unput_string(yytext,yyleng);
-                                          //addOutput(yyscanner,'\n');
-                                          //if (*yytext=='\n') yyextra->lineNr++;
                                           BEGIN( Comment );
                                         }
 <EnumDocArg1>.                          { // ignore other stuff
@@ -1273,6 +1275,7 @@ STopt  [^\n@\\]*
   /* ------------ handle argument of namespace command --------------- */
 
 <NameSpaceDocArg1>{SCOPENAME}           { // handle argument
+                                          makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
                                           lineCount(yyscanner);
                                           yyextra->current->name = substitute(removeRedundantWhiteSpace(QCString(yytext)),QCString("."),QCString("::"));
                                           BEGIN( Comment );
@@ -1284,11 +1287,9 @@ STopt  [^\n@\\]*
 <NameSpaceDocArg1>{DOCNL}               { // missing argument
                                           warn(yyextra->fileName,yyextra->lineNr,
                                                "missing argument after "
-                                               "\\namespace."
+                                               "'\\namespace'."
                                               );
                                           unput_string(yytext,yyleng);
-                                          //addOutput(yyscanner,'\n');
-                                          //if (*yytext=='\n') yyextra->lineNr++;
                                           BEGIN( Comment );
                                         }
 <NameSpaceDocArg1>.                     { // ignore other stuff
@@ -1320,6 +1321,7 @@ STopt  [^\n@\\]*
   /* ------------ handle argument of concept command --------------- */
 
 <ConceptDocArg1>{SCOPEID}               { // handle argument
+                                          makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
                                           yyextra->current->name = yytext;
                                           BEGIN( Comment );
                                         }
@@ -1330,7 +1332,7 @@ STopt  [^\n@\\]*
 <ConceptDocArg1>{DOCNL}                 { // missing argument
                                           warn(yyextra->fileName,yyextra->lineNr,
                                                "missing argument after "
-                                               "\\concept."
+                                               "'\\concept'."
                                               );
                                           unput_string(yytext,yyleng);
                                           BEGIN( Comment );
@@ -1339,18 +1341,19 @@ STopt  [^\n@\\]*
                                         }
 
   /* ------------ handle argument of module command --------------- */
-<ModuleDocArg1>{MODULE_ID}             { // handle argument
-                                         yyextra->current->name = yytext;
-                                         BEGIN( Comment );
-                                       }
-<ModuleDocArg1>{LC}                    { // line continuation
+<ModuleDocArg1>{MODULE_ID}              { // handle argument
+                                          makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
+                                          yyextra->current->name = yytext;
+                                          BEGIN( Comment );
+                                        }
+<ModuleDocArg1>{LC}                     { // line continuation
                                           yyextra->lineNr++;
                                           addOutput(yyscanner,'\n');
                                         }
-<ModuleDocArg1>{DOCNL}                 { // missing argument
+<ModuleDocArg1>{DOCNL}                  { // missing argument
                                           warn(yyextra->fileName,yyextra->lineNr,
                                                "missing argument after "
-                                               "\\module."
+                                               "'\\module'."
                                               );
                                           unput_string(yytext,yyleng);
                                           BEGIN( Comment );
@@ -1361,11 +1364,13 @@ STopt  [^\n@\\]*
   /* ------ handle argument of class/struct/union command --------------- */
 
 <ClassDocArg1>{SCOPENAME}{TMPLSPEC}     {
+                                          makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
                                           lineCount(yyscanner);
                                           yyextra->current->name = substitute(removeRedundantWhiteSpace(QCString(yytext)),".","::");
                                           BEGIN( ClassDocArg2 );
                                         }
 <ClassDocArg1>{SCOPENAME}               { // first argument
+                                          makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
                                           lineCount(yyscanner);
                                           yyextra->current->name = substitute(QCString(yytext),".","::");
                                           if (yyextra->current->section.isProtocolDoc())
@@ -1376,6 +1381,7 @@ STopt  [^\n@\\]*
                                           BEGIN( ClassDocArg2 );
                                         }
 <CategoryDocArg1>{SCOPENAME}{B}*"("[^\)]+")" {
+                                          makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
                                           lineCount(yyscanner);
                                           yyextra->current->name = substitute(QCString(yytext),".","::");
                                           BEGIN( ClassDocArg2 );
@@ -1389,8 +1395,6 @@ STopt  [^\n@\\]*
                                                "missing argument after "
                                                "'\\%s'.",qPrint(yyextra->currentCmd)
                                               );
-                                          //addOutput(yyscanner,'\n');
-                                          //if (*yytext=='\n') yyextra->lineNr++;
                                           unput_string(yytext,yyleng);
                                           BEGIN( Comment );
                                         }
@@ -1398,8 +1402,6 @@ STopt  [^\n@\\]*
                                         }
 
 <ClassDocArg2>{DOCNL}                   {
-                                          //addOutput(yyscanner,'\n');
-                                          //if (*yytext=='\n') yyextra->lineNr++;
                                           unput_string(yytext,yyleng);
                                           BEGIN( Comment );
                                         }
@@ -2489,10 +2491,19 @@ STopt  [^\n@\\]*
 <FnParam>{DOCNL}                        { // end of argument
                                           if (yyextra->braceCount==0)
                                           {
-                                            //if (*yytext=='\n') yyextra->lineNr++;
-                                            //addOutput(yyscanner,'\n');
+                                            if (yyextra->functionProto.stripWhiteSpace().isEmpty())
+                                            {
+                                              warn(yyextra->fileName,yyextra->lineNr,
+                                                   "missing argument after "
+                                                   "'\\%s'.",qPrint(yyextra->currentCmd)
+                                                  );
+                                            }
+                                            else
+                                            {
+                                              makeStructuralIndicator(yyscanner,yyextra->currentMakeEntryType());
+                                              yyextra->langParser->parsePrototype(yyextra->functionProto);
+                                            }
                                             unput_string(yytext,yyleng);
-                                            yyextra->langParser->parsePrototype(yyextra->functionProto);
                                             BEGIN( Comment );
                                           }
                                         }
@@ -2713,23 +2724,26 @@ static bool handleBrief(yyscan_t yyscanner,const QCString &, const StringVector 
   return FALSE;
 }
 
-static bool handleFn(yyscan_t yyscanner,const QCString &, const StringVector &)
+static bool handleFn(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeMemberDoc());
-  yyextra->functionProto.clear();
   yyextra->braceCount=0;
-  BEGIN(FnParam);
-  return stop;
+  yyextra->functionProto.clear();
+  yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeMemberDoc;
+  BEGIN( FnParam );
+  return checkStructuralIndicator(yyscanner);
 }
 
-static bool handleDef(yyscan_t yyscanner,const QCString &, const StringVector &)
+static bool handleDef(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeDefineDoc());
   yyextra->functionProto.clear();
-  BEGIN(FnParam);
-  return stop;
+  yyextra->braceCount=0;
+  yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeDefineDoc;
+  BEGIN( FnParam );
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleOverload(yyscan_t yyscanner,const QCString &, const StringVector &)
@@ -2743,9 +2757,9 @@ static bool handleOverload(yyscan_t yyscanner,const QCString &, const StringVect
 static bool handleEnum(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeEnumDoc());
-  BEGIN(EnumDocArg1);
-  return stop;
+  yyextra->currentMakeEntryType = EntryType::makeEnumDoc;
+  BEGIN( EnumDocArg1 );
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleDefGroup(yyscan_t yyscanner,const QCString &, const StringVector &)
@@ -2778,9 +2792,9 @@ static bool handleWeakGroup(yyscan_t yyscanner,const QCString &, const StringVec
 static bool handleNamespace(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeNamespaceDoc());
+  yyextra->currentMakeEntryType = EntryType::makeNamespaceDoc;
   BEGIN( NameSpaceDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handlePackage(yyscan_t yyscanner,const QCString &, const StringVector &)
@@ -2794,30 +2808,29 @@ static bool handlePackage(yyscan_t yyscanner,const QCString &, const StringVecto
 static bool handleClass(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeClassDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeClassDoc;
   BEGIN( ClassDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleConcept(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeConceptDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeConceptDoc;
   BEGIN( ConceptDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleModule(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeModuleDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeModuleDoc;
   BEGIN( ModuleDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
-
 
 static bool handleHeaderFile(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
@@ -2829,55 +2842,55 @@ static bool handleHeaderFile(yyscan_t yyscanner,const QCString &, const StringVe
 static bool handleProtocol(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 { // Obj-C protocol
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeProtocolDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeProtocolDoc;
   BEGIN( ClassDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleCategory(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 { // Obj-C category
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeCategoryDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeCategoryDoc;
   BEGIN( CategoryDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleUnion(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeUnionDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeUnionDoc;
   BEGIN( ClassDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleStruct(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeStructDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeStructDoc;
   BEGIN( ClassDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleInterface(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeInterfaceDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeInterfaceDoc;
   BEGIN( ClassDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handleIdlException(yyscan_t yyscanner,const QCString &cmd, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeExceptionDoc());
   yyextra->currentCmd = cmd;
+  yyextra->currentMakeEntryType = EntryType::makeExceptionDoc;
   BEGIN( ClassDocArg1 );
-  return stop;
+  return checkStructuralIndicator(yyscanner);
 }
 
 static bool handlePage(yyscan_t yyscanner,const QCString &, const StringVector &)
@@ -3947,6 +3960,13 @@ static void initParser(yyscan_t yyscanner)
 }
 
 //-----------------------------------------------------------------------------
+
+static bool checkStructuralIndicator(yyscan_t yyscanner)
+{
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  //printf("yyextra->current->section=%x\n",yyextra->current->section);
+  return yyextra->current->section.isDoc();
+}
 
 static bool makeStructuralIndicator(yyscan_t yyscanner,EntryType t)
 {


### PR DESCRIPTION
When having an empty structural command like `\var` or `\namespace` we get different types of warnings and the information following is lost.

Example:
**aa.h**
```
/// \file

/**
 * @var
 *
 * \brief MY_var var1
*/
int var1  = 42;
/**
 * @var var2
 *
 * \brief MY_var var2
 */
int var2  = 42;
```

**bb.h**
```
/// \file

/**
 * @namespace
 *
 * \brief MY_namespace ns1
*/
namespace ns1 {}
/**
 *
 * @namespace ns2
 *
 * \brief MY_namespace ns2
 */
namespace ns2 {}
```
results in the warnings:
```
.../aa.h:8: warning: Empty prototype found!
.../bb.h:6: warning: missing argument after \namespace.
.../aa.h:5: warning: member with no name found.
.../aa.h:9: warning: Member var1 (variable) of file aa.h is not documented.
```
and the information of the "empty" structural comment blocks is lost, whilst expected would be:
```
.../aa.h:5: warning: missing argument after '\var'.
.../bb.h:6: warning: missing argument after '\namespace'.
```
and the information would be assigned to the next  entity.

(we need the `return checkStructuralIndicator(yyscanner);` as otherwise when there are multiple structural commands in a comment block they are no handled properly).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14330040/example.tar.gz)
