### PR TITLE
Correcting links in documentation

### DIFF
--- a/doc/faq.dox
+++ b/doc/faq.dox
@@ -214,7 +214,7 @@ If you don't mind spending some time on it, there are several options:
 - If the grammar of X is somewhat different than you can write an input
   filter that translates X into something similar enough to C/C++ for
   doxygen to understand (this approach is taken for VB, Object Pascal, and
-  JavaScript, see https://www.doxygen.org/download.html#helpers).
+  JavaScript, see https://www.doxygen.org/helpers.html).
 - If the grammar is completely different one could write a parser for X and
   write a backend that produces a similar syntax tree as is done by
   \c src/scanner.l (and also by \c src/tagreader.cpp while reading tag files).

--- a/doc/install.dox
+++ b/doc/install.dox
@@ -51,7 +51,7 @@ tools should be installed.
     version 5.14 or higher (including Qt 6).
     This is needed to build the GUI front-end doxywizard.
 <li>A \LaTeX distribution: for instance
-    <a href="http://www.tug.org/interest.html#free">TeX Live</a>
+    <a href="http://tug.org/interest.html#free">TeX Live</a>
     This is needed for generating \LaTeX, Postscript, and PDF output.
 <li><a href="https://www.graphviz.org/">
     the Graph visualization toolkit version 2.38 or higher</a>

--- a/doc/xmlcmds.dox
+++ b/doc/xmlcmds.dox
@@ -18,7 +18,7 @@
 
 Doxygen supports most of the XML commands that are typically used in C# 
 code comments. The XML tags are defined in Appendix D of the
-<a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-334/">ECMA-334</a> 
+<a href="https://ecma-international.org/publications-and-standards/standards/ecma-334/">ECMA-334</a>
 standard, which defines the C# language. Unfortunately, the specification is
 not very precise and a number of the examples given are of poor quality.
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -755,7 +755,7 @@ Go to the <a href="commands.html">next</a> section or return to the
       <docs>
 <![CDATA[
  Set the \c SIP_SUPPORT tag to \c YES if your project consists
- of <a href="https://www.riverbankcomputing.com/software/sip/intro">sip</a> sources only.
+ of <a href="https://www.riverbankcomputing.com/software">sip</a> sources only.
  Doxygen will parse them like normal C++ but will assume all classes use public
  instead of private inheritance when no explicit protection keyword is present.
 ]]>


### PR DESCRIPTION
Some links in the documentation were permanent redirects or not accessible anymore and have been corrected.