### PR TITLE
Formula doesn't render due to empty lines.

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -462,6 +462,8 @@ struct commentscanYY_state
   OutputContext    inContext;              // are we inside the brief, details or xref part
   bool             briefEndsAtDot = FALSE; // does the brief description stop at a dot?
   QCString         formulaText;            // Running text of a formula
+  QCString         formulaPreText;         // Start command of a formula
+  QCString         formulaPostText;        // End command of a formula
   QCString         formulaEnv;             // environment name
   int              formulaNewLines = 0;    // amount of new lines in the formula
   QCString        *pOutputString = nullptr;      // pointer to string to which the output is appended.
@@ -993,30 +995,38 @@ STopt  [^\n@\\]*
                                         }
 <Comment>{B}*{CMD}"f{"[^}\n]+"}"("{"?)  { // start of a formula with custom environment
                                           setOutput(yyscanner,OutputDoc);
-                                          yyextra->formulaText="\\begin";
+                                          yyextra->formulaText="";
+                                          yyextra->formulaPreText="\\begin";
+                                          yyextra->formulaPostText="";
                                           yyextra->formulaEnv=QCString(yytext).stripWhiteSpace().mid(2);
                                           if (yyextra->formulaEnv.at(yyextra->formulaEnv.length()-1)=='{')
                                           {
                                             // remove trailing open brace
                                             yyextra->formulaEnv=yyextra->formulaEnv.left(yyextra->formulaEnv.length()-1);
                                           }
-                                          yyextra->formulaText+=yyextra->formulaEnv;
+                                          yyextra->formulaPreText+=yyextra->formulaEnv;
                                           yyextra->formulaNewLines=0;
                                           BEGIN(ReadFormulaLong);
                                         }
 <Comment>{B}*{CMD}"f$"                  { // start of a inline formula
-                                          yyextra->formulaText="$";
+                                          yyextra->formulaText="";
+                                          yyextra->formulaPreText="$";
+                                          yyextra->formulaPostText="";
                                           yyextra->formulaNewLines=0;
                                           BEGIN(ReadFormulaShort);
                                         }
 <Comment>{B}*{CMD}"f("                  { // start of a inline formula
                                           yyextra->formulaText="";
+                                          yyextra->formulaPreText="";
+                                          yyextra->formulaPostText="";
                                           yyextra->formulaNewLines=0;
                                           BEGIN(ReadFormulaRound);
                                         }
 <Comment>{B}*{CMD}"f["                  { // start of a block formula
                                           setOutput(yyscanner,OutputDoc);
-                                          yyextra->formulaText="\\[";
+                                          yyextra->formulaText="";
+                                          yyextra->formulaPreText="\\[";
+                                          yyextra->formulaPostText="";
                                           yyextra->formulaNewLines=0;
                                           BEGIN(ReadFormulaLong);
                                         }
@@ -1201,7 +1211,7 @@ STopt  [^\n@\\]*
  /* --------------   Rules for handling formulas ---------------- */
 
 <ReadFormulaShort,ReadFormulaShortSection>{CMD}"f$" { // end of inline formula
-                                          yyextra->formulaText+="$";
+                                          yyextra->formulaPostText+="$";
                                           QCString form = addFormula(yyscanner);
                                           addOutput(yyscanner," "+form);
                                           if (YY_START == ReadFormulaShort)
@@ -1228,13 +1238,13 @@ STopt  [^\n@\\]*
                                           }
                                         }
 <ReadFormulaLong>{CMD}"f]"              { // end of block formula
-                                          yyextra->formulaText+="\\]";
+                                          yyextra->formulaPostText+="\\]";
                                           addOutput(yyscanner," "+addFormula(yyscanner));
                                           BEGIN(Comment);
                                         }
 <ReadFormulaLong>{CMD}"f}"              { // end of custom env formula
-                                          yyextra->formulaText+="\\end";
-                                          yyextra->formulaText+=yyextra->formulaEnv;
+                                          yyextra->formulaPostText+="\\end";
+                                          yyextra->formulaPostText+=yyextra->formulaEnv;
                                           addOutput(yyscanner," "+addFormula(yyscanner));
                                           BEGIN(Comment);
                                         }
@@ -1840,12 +1850,16 @@ STopt  [^\n@\\]*
                                           BEGIN( Comment );
                                         }
 <SectionTitle>{B}*{CMD}"f$"             {
-                                          yyextra->formulaText="$";
+                                          yyextra->formulaText="";
+                                          yyextra->formulaPreText="$";
+                                          yyextra->formulaPostText="";
                                           yyextra->formulaNewLines=0;
                                           BEGIN(ReadFormulaShortSection);
                                         }
 <SectionTitle>{B}*{CMD}"f("             { // start of a inline formula
                                           yyextra->formulaText="";
+                                          yyextra->formulaPreText="";
+                                          yyextra->formulaPostText="";
                                           yyextra->formulaNewLines=0;
                                           BEGIN(ReadFormulaRoundSection);
                                         }
@@ -4102,6 +4116,18 @@ static void addXRefItem(yyscan_t yyscanner,
 }
 
 //-----------------------------------------------------------------------------
+inline bool qqisspace(char c)
+{ return c==' ' || c=='\t'; }
+
+    QCString qStripEndWhiteSpace(QCString rep)
+    {
+      size_t sl = rep.length();
+      if (sl==0 || (!qqisspace(rep[sl-1]))) return rep;
+      size_t start=0,end=sl-1;
+      while (end>start && qqisspace(rep[end])) end--;
+      return QCString(rep.mid(start,1+end-start));
+    }
+
 
 // Adds a formula text to the list/dictionary of formulas if it was
 // not already added. Returns the label of the formula.
@@ -4110,7 +4136,10 @@ static QCString addFormula(yyscan_t yyscanner)
   std::unique_lock<std::mutex> lock(g_formulaMutex);
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   QCString formLabel;
-  int id = FormulaManager::instance().addFormula(yyextra->formulaText.str());
+  int cnt = 0;
+  QCString stripForm = stripLeadingAndTrailingEmptyLines(yyextra->formulaText,cnt);
+  if (yyextra->formulaText.stripWhiteSpace(true).endsWith("\n")) stripForm += "\n";
+  int id = FormulaManager::instance().addFormula((yyextra->formulaPreText + stripForm + yyextra->formulaPostText).str());
   formLabel.sprintf("\\_form#%d",id);
   for (int i=0;i<yyextra->formulaNewLines;i++) formLabel+="@_fakenl"; // add fake newlines to
                                                          // keep the warnings

--- a/src/qcstring.h
+++ b/src/qcstring.h
@@ -81,6 +81,9 @@ inline int qstrncmp( const char *str1, const char *str2, size_t len )
 inline bool qisspace(char c)
 { return c==' ' || c=='\t' || c=='\n' || c=='\r'; }
 
+inline bool qisrealspace(char c)
+{ return c==' ' || c=='\t'; }
+
 int qstricmp( const char *str1, const char *str2 );
 
 int qstrnicmp( const char *str1, const char *str2, size_t len );
@@ -241,14 +244,16 @@ class QCString
     }
 
     /// returns a copy of this string with leading and trailing whitespace removed
-    QCString stripWhiteSpace() const
+    QCString stripWhiteSpace(bool realWhiteSpace = false) const
     {
       size_t sl = m_rep.size();
-      if (sl==0 || (!qisspace(m_rep[0]) && !qisspace(m_rep[sl-1]))) return *this;
+      bool (*whiteSpaceFie)(char c) = qisspace;
+      if (realWhiteSpace) whiteSpaceFie =qisrealspace;
+      if (sl==0 || (!whiteSpaceFie(m_rep[0]) && !whiteSpaceFie(m_rep[sl-1]))) return *this;
       size_t start=0,end=sl-1;
-      while (start<sl && qisspace(m_rep[start])) start++;
+      while (start<sl && whiteSpaceFie(m_rep[start])) start++;
       if (start==sl) return QCString(); // only whitespace
-      while (end>start && qisspace(m_rep[end])) end--;
+      while (end>start && whiteSpaceFie(m_rep[end])) end--;
       return QCString(m_rep.substr(start,1+end-start));
     }
 


### PR DESCRIPTION
When having a formula like:
```
  @f[

      A = \left(\begin{array}{cc}
                                  Ixx & Ixy \\
                                  Ixy & Iyy \\
           \end{array}\right)

  @f]
```
this doesn't render in LaTeX but renders under MathJax. The problem is the starting and ending empty lines inside the formula.

Stripping away the starting and ending empty lines.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14375378/example.tar.gz)

(originally found by Fossies for the rawtherapeepackage)
