### PR TITLE
Missing items in doxygen  internal search

### DIFF
--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -121,24 +121,16 @@ static void splitSearchTokens(QCString &title,IntVector &indices)
   // create a list of start positions within title for
   // each unique word in order of appearance
   int p=0,i;
-  StringSet wordsFound;
   while ((i=title.find(' ',p))!=-1)
   {
     std::string word = title.mid(p,i-p).str();
-    if (wordsFound.find(word)==wordsFound.end())
-    {
-      indices.push_back(p);
-      wordsFound.insert(word);
-    }
+    indices.push_back(p);
     p = i+1;
   }
   if (p<static_cast<int>(title.length()))
   {
     std::string word = title.mid(p).str();
-    if (wordsFound.find(word)==wordsFound.end())
-    {
-      indices.push_back(p);
-    }
+    indices.push_back(p);
   }
 }
 


### PR DESCRIPTION
When having the simple file:
```
\mainpage The main page

\page pg1 The first page

\section sect_1_1 first section first page

\section sect_1_2 second section first page

\page pg2 The second page

\section sect_2_1 first section second page

\section sect_2_2 second section second page
```
and doing a "normal" internal doxygen search for the word `second` we get a.o.
```
first section second page
The second page
second section first page
second section second page
```
but when searching for `second page` we get
```
first section second page
The second page
```
so we are missing the reference to
```
second section second page
```
this is due to the filtering of the words in the string and omitting double words.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14377280/example.tar.gz)
