### PR TITLE
Prevent automatic upper case conversion in doxygen internal search

### DIFF
--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -53,12 +53,6 @@ void SearchTerm::makeTitle()
   else if (std::holds_alternative<const SectionInfo *>(info))
   {
     title = std::get<const SectionInfo *>(info)->title();
-
-    // Capitalizing the word as this is not a code entity
-    std::string letter = getUTF8CharAt(word.str(),0);
-    // Uppercase letter could have different size
-    word.remove(0, letter.size());
-    word.prepend(convertUTF8ToUpper(letter));
   }
   else
   {


### PR DESCRIPTION
When having the simple file:
```
\mainpage The main page

\page pg1 The first page

\section sect_1_1 first section first page

\section sect_1_2 second section first page

\page pg2 The second page

\section sect_2_1 first section second page

\section sect_2_2 second section second page
```
and doing a "normal" internal doxygen search for the word `page` we get:
```
Page
page
```
though all the words `page` are in lowercase in the text, the automatic conversion to uppercase should not take place.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14377423/example.tar.gz)
