### PR TITLE
Empty keywords field for pages with extrenal search

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7701,6 +7701,20 @@ static void addToIndices()
     if (pd->isLinkableInProject())
     {
       Doxygen::indexList->addIndexItem(pd.get(),nullptr,QCString(),filterTitle(pd->title()));
+      if (Doxygen::searchIndex)
+      {
+        Doxygen::searchIndex->setCurrentDoc(pd.get(),pd->anchor(),FALSE);
+        std::string title = pd->title().str();
+        static const reg::Ex re(R"(\a[\w-]*)");
+        reg::Iterator it(title,re);
+        reg::Iterator end;
+        for (; it!=end ; ++it)
+        {
+          const auto &match = *it;
+          std::string matchStr = match.str();
+          Doxygen::searchIndex->addWord(matchStr.c_str(),TRUE);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
When having a project like:
```
\mainpage  The dedicated main page

Some text on the main page

\page pg1  first page first time

Some text on the 1 page 1 time

\page pg2  second page first time

Some text on the 2 page 1 time

\page pg1_2  first page second time

Some text on the 1 page 2 time

\page pg2_2  second page second time

Some text on the 2 page 2 time

\defgroup grp1 first group first occurrence

\defgroup grp2 second group first occurrence

\defgroup grp1_2 first group second occurrence

\defgroup grp2_2 second group second occurrence
```

In the resulting searchdata.xml we see for a group e.g.
```
<field name="keywords">first group first occurrence</field>
```
though for a page the "keywords" field is empty, this has been corrected.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14377566/example.tar.gz)
