### PR TITLE
Incorrect `searchdata.xml` for `mainpage` in case of external search

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7696,6 +7696,25 @@ static void addToIndices()
     }
   }
 
+  if (Doxygen::mainPage)
+  {
+    Doxygen::indexList->addIndexItem(Doxygen::mainPage.get(),nullptr,QCString(),filterTitle(Doxygen::mainPage->title()));
+    if (Doxygen::searchIndex)
+    {
+      Doxygen::searchIndex->setCurrentDoc(Doxygen::mainPage.get(),Doxygen::mainPage->anchor(),FALSE);
+      std::string title = Doxygen::mainPage->title().str();
+      static const reg::Ex re(R"(\a[\w-]*)");
+      reg::Iterator it(title,re);
+      reg::Iterator end;
+      for (; it!=end ; ++it)
+      {
+        const auto &match = *it;
+        std::string matchStr = match.str();
+        Doxygen::searchIndex->addWord(matchStr.c_str(),TRUE);
+      }
+    }
+  }
+
   for (const auto &pd : *Doxygen::pageLinkedMap)
   {
     if (pd->isLinkableInProject())

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4780,8 +4780,8 @@ static void writeIndex(OutputList &ol)
       ol.startHeaderSection();
       ol.startTitleHead(QCString());
       ol.generateDoc(Doxygen::mainPage->docFile(),Doxygen::mainPage->getStartBodyLine(),
-                  Doxygen::mainPage.get(),nullptr,Doxygen::mainPage->title(),TRUE,FALSE,
-                  QCString(),TRUE,FALSE,Config_getBool(MARKDOWN_SUPPORT));
+                  Doxygen::mainPage.get(),nullptr,Doxygen::mainPage->title(),false,false,
+                  QCString(),true,false,Config_getBool(MARKDOWN_SUPPORT));
       headerWritten = TRUE;
     }
   }
@@ -4816,8 +4816,8 @@ static void writeIndex(OutputList &ol)
 
     ol.startTextBlock();
     ol.generateDoc(defFileName,defLine,Doxygen::mainPage.get(),nullptr,
-                Doxygen::mainPage->documentation(),TRUE,FALSE,
-                QCString(),FALSE,FALSE,Config_getBool(MARKDOWN_SUPPORT));
+                Doxygen::mainPage->documentation(),true,false,
+                QCString(),false,false,Config_getBool(MARKDOWN_SUPPORT));
     ol.endTextBlock();
     ol.endPageDoc();
   }
@@ -4861,8 +4861,8 @@ static void writeIndex(OutputList &ol)
   if (!Config_getString(PROJECT_NUMBER).isEmpty())
   {
     ol.startProjectNumber();
-    ol.generateDoc(defFileName,defLine,Doxygen::mainPage.get(),nullptr,Config_getString(PROJECT_NUMBER),FALSE,FALSE,
-                   QCString(),FALSE,FALSE,Config_getBool(MARKDOWN_SUPPORT));
+    ol.generateDoc(defFileName,defLine,Doxygen::mainPage.get(),nullptr,Config_getString(PROJECT_NUMBER),false,false,
+                   QCString(),false,false,Config_getBool(MARKDOWN_SUPPORT));
     ol.endProjectNumber();
   }
   ol.endIndexSection(IndexSection::isTitlePageStart);

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -305,19 +305,36 @@ void PageDefImpl::writePageDocumentation(OutputList &ol) const
     ol.writeString(" - ");
     ol.popGeneratorState();
   }
-  ol.generateDoc(
+  ol.disableAllBut(OutputType::Html);
+    ol.generateDoc(
       docFile(),           // fileName
       docLine(),           // startLine
       this,                // context
-      nullptr,                   // memberdef
+      nullptr,             // memberdef
       docStr,              // docStr
-      TRUE,                // index words
-      FALSE,               // not an example
-      QCString(),                   // exampleName
-      FALSE,               // singleLine
-      FALSE,               // linkFromIndex
+      true,                // index words
+      false,               // not an example
+      QCString(),          // exampleName
+      false,               // singleLine
+      false,               // linkFromIndex
       TRUE                 // markdown support
       );
+  ol.enableAll();
+  ol.disable(OutputType::Html);
+    ol.generateDoc(
+      docFile(),           // fileName
+      docLine(),           // startLine
+      this,                // context
+      nullptr,             // memberdef
+      docStr,              // docStr
+      false,               // index words
+      false,               // not an example
+      QCString(),          // exampleName
+      false,               // singleLine
+      false,               // linkFromIndex
+      TRUE                 // markdown support
+      );
+  ol.enable(OutputType::Html);
   ol.endTextBlock();
 
   if (hasSubPages())


### PR DESCRIPTION
When having a problem like:
```
\mainpage  main_t

main_b
```
and we use an empty `Doxyfile` with just external search settings:
```
QUIET = YES
SERVER_BASED_SEARCH    = YES
EXTERNAL_SEARCH        = YES
SEARCHENGINE_URL       = http://localhost/cgi-bin/doxysearch.cgi
```
we get in the `searchdata.xml`:
```
<?xml version="1.0" encoding="UTF-8"?>
<add>
  <doc>
    <field name="type">page</field>
    <field name="name">main_t</field>
    <field name="url">index.html</field>
    <field name="keywords"></field>
    <field name="text">main_t main_b main_b</field>
  </doc>
</add>
```

We see here:
- missing "keywords"
- content of "text" where only `main_b` is expected.

so like:
```
    <field name="keywords">main_t</field>
    <field name="text">main_b</field>
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14385118/example.tar.gz)
