### PR TITLE
issue #7948 "ilinebr" on every link broke my entire project

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -112,6 +112,7 @@ struct commentcnvYY_state
   bool     specialComment = FALSE;
   QCString incPrefix;
 
+  QCString aliasCmd;
   QCString aliasString;
   int      blockCount = 0;
   bool     lastEscaped = FALSE;
@@ -1093,6 +1094,7 @@ SLASHopt [/]*
                                      yyextra->lastBlockContext=YY_START;
 				     yyextra->blockCount=1;
 				     yyextra->aliasString=yytext;
+				     yyextra->aliasCmd=yytext;
 				     yyextra->lastEscaped=0;
 				     BEGIN( ReadAliasArgs );
   				   }
@@ -1161,6 +1163,12 @@ SLASHopt [/]*
 <<EOF>>                            {
                                       if (yyextra->includeStack.empty())
                                       {
+                                        if (YY_START == ReadAliasArgs)
+                                        {
+                                          warn(yyextra->fileName,yyextra->lineNr,
+                                            "Reached end of file while still searching closing '}' of (probable start: '%s')",
+                                            qPrint(yyextra->aliasCmd));
+                                        }
                                         yyterminate();
                                       }
                                       else // switch back to parent file


### PR DESCRIPTION
The problem of the issue is not the `\ilinebr` but the fact that the closing bracket (`}`) is not found and this is not always reported. Give a waning in case no closing bracket is found when resolving an alias