### PR TITLE
Inconsistency in handling space at end of translated string.

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2956,6 +2956,7 @@ void ClassDefImpl::writeMemberList(OutputList &ol) const
   ol.startContents();
   ol.startParagraph();
   ol.parseText(theTranslator->trThisIsTheListOfAllMembers());
+  ol.docify(" ");
   ol.writeObjectLink(getReference(),getOutputFileBase(),anchor(),displayName());
   ol.parseText(theTranslator->trIncludingInheritedMembers());
   ol.endParagraph();

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2024,6 +2024,7 @@ void HtmlDocVisitor::operator()(const DocVhdlFlow &vf)
     QCString fname=FlowChart::convertNameToFileName();
     m_t << "<p>";
     m_t << theTranslator->trFlowchart();
+    m_t << " ";
     m_t << "<a href=\"";
     m_t << fname;
     m_t << ".svg\">";

--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -106,7 +106,7 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
     /*! this is the first part of a sentence that is followed by a class name */
     /* Isn't used when optimization for C is on. */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Սա դասի անդամների ամբողջական ցուցակն է "; }
+    { return "Սա դասի անդամների ամբողջական ցուցակն է"; }
 
     /*! this is the remainder of the sentence after the class name */
     /* Isn't used when optimization for C is on. */

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -128,7 +128,7 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "هذه فائمة بكل الأعضاء في "; }
+    { return "هذه فائمة بكل الأعضاء في"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -145,7 +145,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Това е пълен списък с членове за "; }
+    { return "Това е пълен списък с членове за"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -279,7 +279,7 @@ class TranslatorBrazilian : public Translator
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Esta é a lista de todos os membros de "; }
+    { return "Esta é a lista de todos os membros de"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2536,7 +2536,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trFlowchart() override
     {
-        return "Fluxograma: ";
+        return "Fluxograma:";
     }
 
     /*! Please translate also updated body of the method

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -141,7 +141,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Aquesta és la llista complerta dels membres de "; }
+    { return "Aquesta és la llista complerta dels membres de"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -148,7 +148,7 @@ class TranslatorChinese : public Translator
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "成员的完整列表，这些成员属于" CN_SPC; }
+    { return "成员的完整列表，这些成员属于"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2313,7 +2313,7 @@ class TranslatorChinese : public Translator
      *  followed by a single name of the VHDL process flowchart.
      */
     QCString trFlowchart() override
-    { return "流程图:" CN_SPC; }
+    { return "流程图:"; }
 
     /*! Please translate also updated body of the method
      *  trMemberFunctionDocumentation(), now better adapted for

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -245,7 +245,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Zde naleznete úplný seznam členů třídy "; }
+    { return "Zde naleznete úplný seznam členů třídy"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2483,7 +2483,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      *  followed by a single name of the VHDL process flowchart.
      */
     QCString trFlowchart() override
-    { return "Vývojový diagram: "; }
+    { return "Vývojový diagram:"; }
 
     /*! Please translate also updated body of the method
      *  trMemberFunctionDocumentation(), now better adapted for

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -230,7 +230,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Vollständige Aufstellung aller Elemente für "; }
+    { return "Vollständige Aufstellung aller Elemente für"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -184,7 +184,7 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Dette er den komplette liste over medlemmer i "; }
+    { return "Dette er den komplette liste over medlemmer i"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -149,7 +149,7 @@ class TranslatorEnglish : public Translator
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "This is the complete list of members for "; }
+    { return "This is the complete list of members for"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2337,7 +2337,7 @@ class TranslatorEnglish : public Translator
      *  followed by a single name of the VHDL process flowchart.
      */
     QCString trFlowchart() override
-    { return "Flowchart: "; }
+    { return "Flowchart:"; }
 
     /*! Please translate also updated body of the method
      *  trMemberFunctionDocumentation(), now better adapted for

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -143,7 +143,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Tiu ĉi estas la kompleta membraro de "; }
+    { return "Tiu ĉi estas la kompleta membraro de"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -227,7 +227,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Lista completa de los miembros de "; }
+    { return "Lista completa de los miembros de"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2483,7 +2483,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      *  followed by a single name of the VHDL process flowchart.
      */
     QCString trFlowchart() override
-    { return "Diagrama de flujo: "; }
+    { return "Diagrama de flujo:"; }
 
     /*! Please translate also updated body of the method
      *  trMemberFunctionDocumentation(), now better adapted for

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -157,7 +157,7 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "اين ليستی کامل از همه اعضای  "; }
+    { return "اين ليستی کامل از همه اعضای"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -185,7 +185,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Tämä on lista kaikista jäsenistä luokassa "; } // "This is the complete list of members for "
+    { return "Tämä on lista kaikista jäsenistä luokassa"; } // "This is the complete list of members for "
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -201,7 +201,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Liste complète des membres de "; }
+    { return "Liste complète des membres de"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -2338,7 +2338,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      *  followed by a single name of the VHDL process flowchart.
      */
     QCString trFlowchart() override
-    { return "Διάγραμμα ροής: "; }
+    { return "Διάγραμμα ροής:"; }
 
     /*! Please translate also updated body of the method
      *  trMemberFunctionDocumentation(), now better adapted for

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -166,7 +166,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "A(z) "; }
+    { return "A(z)"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -124,7 +124,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Berikut ini daftar lengkap anggota untuk "; }
+    { return "Berikut ini daftar lengkap anggota untuk"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -178,7 +178,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Questo è l'elenco completo di tutti i membri di "; }
+    { return "Questo è l'elenco completo di tutti i membri di"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -168,7 +168,7 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "継承メンバを含む "; }
+    { return "継承メンバを含む"; }
     /* trIncludingInheritedMembers に続くように定義すること */
 
     /*! this is the remainder of the sentence after the class name */

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -163,7 +163,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "다음에 대한 모든 멤버의 목록입니다 : "; }
+    { return "다음에 대한 모든 멤버의 목록입니다 :"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -131,7 +131,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Tai galutinis narių sąrašas "; }
+    { return "Tai galutinis narių sąrašas"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -146,7 +146,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Šis ir pilns elementu saraksts klasei "; }
+    { return "Šis ir pilns elementu saraksts klasei"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -127,7 +127,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Ова е целосниот список на членови на "; }
+    { return "Ова е целосниот список на членови на"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -1996,7 +1996,7 @@ class TranslatorDutch : public Translator
      *  followed by a single name of the VHDL process flowchart.
      */
     QCString trFlowchart() override
-    { return "Stroomschema: "; }
+    { return "Stroomschema:"; }
 
     /*! Please translate also updated body of the method
      *  trMemberFunctionDocumentation(), now better adapted for

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -141,7 +141,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Dette er den fullstendige listen over medlemmer for "; }
+    { return "Dette er den fullstendige listen over medlemmer for"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -131,7 +131,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "To jest kompletna lista składowych dla "; }
+    { return "To jest kompletna lista składowych dla"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2282,7 +2282,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      *  followed by a single name of the VHDL process flowchart.
      */
     QCString trFlowchart() override
-    { return "Schemat blokowy: "; }
+    { return "Schemat blokowy:"; }
 
     /*! Please translate also updated body of the method
      *  trMemberFunctionDocumentation(), now better adapted for

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -191,7 +191,7 @@ class TranslatorPortuguese : public Translator
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Lista completa de todos os membros de "; }
+    { return "Lista completa de todos os membros de"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2398,7 +2398,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trFlowchart() override
     {
-        return "Fluxograma: ";
+        return "Fluxograma:";
     }
 
     /*! Please translate also updated body of the method

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -141,7 +141,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Lista completă a membrilor din "; }
+    { return "Lista completă a membrilor din"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -108,7 +108,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
     /*! this is the first part of a sentence that is followed by a class name */
     /* Isn't used when optimization for C is on. */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Полный список членов класса "; }
+    { return "Полный список членов класса"; }
 
     /*! this is the remainder of the sentence after the class name */
     /* Isn't used when optimization for C is on. */

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -144,7 +144,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Ово је списак свих чланова од "; }
+    { return "Ово је списак свих чланова од"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -65,7 +65,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     QCString trMemberList() override
     { return " - seznam metod in atributov."; }
     QCString trThisIsTheListOfAllMembers() override
-    { return "Seznam metod razreda "; }
+    { return "Seznam metod razreda"; }
     QCString trIncludingInheritedMembers() override
     { return ", vključujoč dedovane metode in atribute."; }
     QCString trGeneratedAutomatically(const QCString &s) override

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -114,7 +114,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Tu nájdete úplný zoznam členov triedy "; }
+    { return "Tu nájdete úplný zoznam členov triedy"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -127,7 +127,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Ovo je spisak svih članova "; }
+    { return "Ovo je spisak svih članova"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -262,7 +262,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Det här är en fullständig lista över medlemmar för "; }
+    { return "Det här är en fullständig lista över medlemmar för"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override
@@ -2443,7 +2443,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
 //////////////////////////////////////////////////////////////////////////
 
     QCString trFlowchart() override
-    { return "Flödesdiagram: "; }
+    { return "Flödesdiagram:"; }
 
 //////////////////////////////////////////////////////////////////////////
 // new since 1.9.7

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -139,7 +139,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Şu sınıfın tüm üyelerinin listesidir: "; }
+    { return "Şu sınıfın tüm üyelerinin listesidir:"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -160,7 +160,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Danh sách các thành viên đầy đủ cho "; }
+    { return "Danh sách các thành viên đầy đủ cho"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -125,7 +125,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
 
     /*! this is the first part of a sentence that is followed by a class name */
     QCString trThisIsTheListOfAllMembers() override
-    { return "Hierdie is 'n volledige lys van lede vir "; }
+    { return "Hierdie is 'n volledige lys van lede vir"; }
 
     /*! this is the remainder of the sentence after the class name */
     QCString trIncludingInheritedMembers() override


### PR DESCRIPTION
There were 2 functions that had, sometimes, a space at the end of the translated string.
This space has been removed ad added to the code.