### PR TITLE
Warnings in PDF build of doxygen documentation build

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -1694,7 +1694,7 @@ contains \c TEST, or \c DEV
   for an example.
 
 <hr>
-\section cmdshowdate \\showdate "<format>" [ \<date_time\> ]
+\section cmdshowdate \\showdate \"\<format\>\" [ \<date_time\> ]
 
   \addindex \\showdate
   Shows the date and time based on the given \<format\> and \<date_time\>. Where the \<format\> is a string in which the following tokens have a special meaning:


### PR DESCRIPTION
In the log file of the PDF creation of the doxygen documentation we see a couple of times a warning like:
```
Package hyperref Warning: Token not allowed in a PDF string (Unicode):
(hyperref)                removing `math shift' on input line 1363.
```
this has been corrected.