### PR TITLE
[RFE] ISSUE_TEMPLATE: moving "expected behavior" to after "to reproduce"

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-a-bug-or-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug-or-issue.md
@@ -10,9 +10,6 @@ assignees: ''
 **Describe the bug**
 Describe what you see that (you think) is wrong.
 
-**Expected behavior**
-Describe what you would have expected or think is correct.
-
 **Screenshots**
 If useful, add screenshots to help explain your problem.
 
@@ -20,8 +17,11 @@ If useful, add screenshots to help explain your problem.
 Attach a self contained example that allows us to reproduce the problem.
 Such an example typically exist of some source code (can be dummy code) and a doxygen configuration file used (you can strip it using `doxygen -s -u`). After you verified the example demonstrates the problem, put it in a zip (or tarball) and attach it to the bug report. Try to avoid linking to external sources, since they might disappear in the future.
 
+**Expected behavior**
+Describe what you would have expected or think is correct.
+
 **Version**
-Mention the version of doxygen used (output of `doxygen --version`) and the platform on which you run doxygen (e.g. Windows 10, 64 bit). If you run doxygen under Linux please also mention the name and version of the distribution used (output of `lsb_release -a`) and mention if you compiled doxygen yourself or that you use a binary that comes with the distribution or from the doxygen website.  
+Mention the version of doxygen used (output of `doxygen --version`) and the platform on which you run doxygen (e.g. Windows 10, 64 bit). If you run doxygen under Linux please also mention the name and version of the distribution used (output of `lsb_release -a`) and mention if you compiled doxygen yourself or that you use a binary that comes with the distribution or from the doxygen website.
 
 **Stack trace**
 If you encounter a crash and can build doxygen from sources yourself with debug info (`-DCMAKE_BUILD_TYPE=Debug`), a stack trace can be very helpful (especially if it is not possible to capture the problem in a small example that can be shared).


### PR DESCRIPTION
This is more of a suggestion, so feel free to close right away if you don't think it's useful. I was about to ask about that in some chat, but I only see a mailing list and the suggestion isn't that interesting to create an issue… I figured, "code better than words", making a commit + PR takes just as long as posting to an ML 😊

So anyway, I've created some reports to Doxygen in the past and it always felt weird to me to see how in the issue template the "Expected behavior" goes *before* "Steps to reproduce".

Take [this report](https://github.com/doxygen/doxygen/issues/10696) for example: when I read from top to bottom, I see paragraph "Expected behavior" starting with `In the opened browser window` — and I think to myself "Eh? What? What browser window? So far description said nothing at all about any browser…". This is confusing. That happens because paragraph "Expected" usually describes whatever happens from the "Steps" *(because the "Description" paragraph usually provides some general information: usecase, why, when; it basically creates context for "minimal steps" further below)*.

So, how about moving "Expected behavior" to go after "To Reproduce"?