### PR TITLE
Fix Discarding of Slice Types During File Index Generation

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1335,25 +1335,25 @@ void FileDefImpl::insertClass(ClassDef *cd)
 {
   if (cd->isHidden()) return;
 
-  ClassLinkedRefMap &list = m_classes;
+  ClassLinkedRefMap *list = &m_classes;
 
   if (Config_getBool(OPTIMIZE_OUTPUT_SLICE))
   {
     if (cd->compoundType()==ClassDef::Interface)
     {
-      list = m_interfaces;
+      list = &m_interfaces;
     }
     else if (cd->compoundType()==ClassDef::Struct)
     {
-      list = m_structs;
+      list = &m_structs;
     }
     else if (cd->compoundType()==ClassDef::Exception)
     {
-      list = m_exceptions;
+      list = &m_exceptions;
     }
   }
 
-  list.add(cd->name(),cd);
+  list->add(cd->name(),cd);
 }
 
 void FileDefImpl::insertConcept(ConceptDef *cd)


### PR DESCRIPTION
Back in November, I fixed a bug that impacted documentation for the Slice language: #10429.
That bug affected the generation of the namespace indexes.

Apparently, I should of looked harder because there was an identical bug in the generation of file indexes!
This PR fixes that bug : v)

For an explanation of the bug, please read #10429.