### PR TITLE
issue #10703 Incorrect output for a C++ type containing a function pointer

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2134,7 +2134,7 @@ NONLopt [^\n]*
 <EndTemplate>">"{BNopt}/"("({BN}*{TSCOPE}{BN}*"::")*({BN}*"*"{BN}*)+ { // function pointer returning a template instance
                                           lineCount(yyscanner);
                                           yyextra->current->name+='>';
-                                          if (yyextra->roundCount==0)
+                                          if (yyextra->roundCount==0 && --yyextra->sharpCount<=0)
                                           {
                                             BEGIN(FindMembers);
                                           }


### PR DESCRIPTION
Looks like we were bailing out nested template part a bit early (see also test in rule `<EndTemplate>">"{BNopt}/"::"              {`)