### PR TITLE
Curly brackets in options

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -926,6 +926,7 @@ STopt  [^\n@\\]*
                                           {
                                             cmdName = fullMatch.left(idx).stripWhiteSpace().mid(1); // to remove {CMD}
                                             QCString optStr = fullMatch.mid(idx+1,idxEnd-idx-1).stripWhiteSpace();
+                                            optStr = substitute(substitute(optStr,"\\iopen","{"),"\\iclose","}");
                                             optList = split(optStr.str(),",");
                                           }
                                           auto it = docCmdMap.find(cmdName.str());


### PR DESCRIPTION
When  having a markdown file like:
```


# Some {header}

Ref doxygen style \ref autotoc_md2

# Module {module}

##### mybytestring {bytestring}
```
we get warnings like:
```
warning: Unexpected character '}' while looking for section label or title
```
due to the fact that the `##### mybytestring {bytestring}` heading is translated to
```
\ianchor{mybytestring {bytestring}} autotoc_md2\ilinebr <h5>mybytestring {bytestring}</h5>
```
later on (commentscan) the fist `}` is seen as end of the `\ianchor` option.

By temporary changing the `}` this is prevented.


The problem occurs for the GitHub and doxygen markdown styles.
Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14462412/example.tar.gz)

(Problem found by Fossies for pandoc package)
