### PR TITLE
Prevent warning about possible buffer overflow

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -4426,8 +4426,8 @@ static inline void addOutput(yyscan_t yyscanner,char c)
 
 static void addIline(yyscan_t yyscanner,int lineNr)
 {
-  char cmd[20];
-  qsnprintf(cmd,20," \\iline %d ",lineNr);
+  char cmd[30];
+  qsnprintf(cmd,30," \\iline %d ",lineNr);
   addOutput(yyscanner, cmd);
 }
 


### PR DESCRIPTION
Prevent warning:
```
.../src/commentscan.l:
In function ‘int commentscanYYlex(yyscan_t)’:
.../src/commentscan.l:4431:20:
warning: ‘snprintf’ output may be truncated before the last format
character [-Wformat-truncation=]
    addOutput(yyscanner, cmd);
                     ^~~~~~~~~
.../src/commentscan.l:4431:12:
note: ‘snprintf’ output between 11 and 21 bytes into a destination of
size 20
    addOutput(yyscanner, cmd);
````

(Found by CGAL)