### PR TITLE
latexgen: fix doxy*section references

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -936,6 +936,10 @@ void DocbookGenerator::endDoxyAnchor(const QCString &,const QCString &)
 {
 DB_GEN_C
 }
+void DocbookGenerator::addLabel(const QCString &,const QCString &)
+{
+DB_GEN_C
+}
 void DocbookGenerator::startMemberDocName(bool)
 {
 DB_GEN_C

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -220,6 +220,7 @@ class DocbookGenerator : public OutputGenerator
                          const QCString &anchor,const QCString &name,
                          const QCString &args);
     void endDoxyAnchor(const QCString &fileName,const QCString &anchor);
+    void addLabel(const QCString &,const QCString &);
     void writeLatexSpacing(){DB_GEN_EMPTY}
     void writeStartAnnoItem(const QCString &,const QCString &,
                             const QCString &,const QCString &){DB_GEN_NEW};

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1675,6 +1675,10 @@ void HtmlGenerator::endDoxyAnchor(const QCString &,const QCString &)
 {
 }
 
+void HtmlGenerator::addLabel(const QCString &,const QCString &)
+{
+}
+
 void HtmlGenerator::startParagraph(const QCString &classDef)
 {
   if (!classDef.isEmpty())

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -203,6 +203,7 @@ class HtmlGenerator : public OutputGenerator
                          const QCString &anchor,const QCString &name,
                          const QCString &args);
     void endDoxyAnchor(const QCString &fName,const QCString &anchor);
+    void addLabel(const QCString &,const QCString &);
     void writeLatexSpacing() {}
     void writeStartAnnoItem(const QCString &type,const QCString &file,
                             const QCString &path,const QCString &name);

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1565,15 +1565,19 @@ void LatexGenerator::startDoxyAnchor(const QCString &fName,const QCString &,
     if (!anchor.isEmpty()) m_t << "_" << anchor;
     m_t << "}";
   }
+}
+
+void LatexGenerator::endDoxyAnchor(const QCString &/* fName */,const QCString &/* anchor */)
+{
+}
+
+void LatexGenerator::addLabel(const QCString &fName, const QCString &anchor)
+{
   m_t << "\\label{";
   if (!fName.isEmpty()) m_t << stripPath(fName);
   if (!anchor.isEmpty()) m_t << "_" << anchor;
   if (m_insideTableEnv) m_t << "}";
   m_t << "} \n";
-}
-
-void LatexGenerator::endDoxyAnchor(const QCString &/* fName */,const QCString &/* anchor */)
-{
 }
 
 void LatexGenerator::writeAnchor(const QCString &fName,const QCString &name)

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -191,6 +191,7 @@ class LatexGenerator : public OutputGenerator
     void endMemberDoc(bool);
     void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &);
     void endDoxyAnchor(const QCString &,const QCString &);
+    void addLabel(const QCString &,const QCString &);
     void writeChar(char c);
     void writeLatexSpacing() { m_t << "\\hspace{0.3cm}"; }
     void writeStartAnnoItem(const QCString &type,const QCString &file,

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -542,6 +542,10 @@ void ManGenerator::startDoxyAnchor(const QCString &,const QCString &manName,
     }
 }
 
+void ManGenerator::addLabel(const QCString &,const QCString &)
+{
+}
+
 void ManGenerator::endMemberDoc(bool)
 {
     m_t << "\"\n";

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -162,6 +162,7 @@ class ManGenerator : public OutputGenerator
     void endMemberDoc(bool);
     void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &);
     void endDoxyAnchor(const QCString &,const QCString &) {}
+    void addLabel(const QCString &,const QCString &);
     void writeLatexSpacing() {}
     void writeStartAnnoItem(const QCString &type,const QCString &file,
                             const QCString &path,const QCString &name);

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2252,6 +2252,7 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
       doxyName.prepend(cdname+getLanguageSpecificSeparator(getLanguage()));
     }
     ol.startDoxyAnchor(cfname,cname,anchor(),doxyName,doxyArgs);
+    ol.addLabel(cfname,anchor());
   }
 
   if (!detailsVisible)
@@ -3183,6 +3184,7 @@ void MemberDefImpl::_writeEnumValues(OutputList &ol,const Definition *container,
 
         ol.startDescTableTitle();
         ol.startDoxyAnchor(cfname,cname,fmd->anchor(),fmd->name(),fmd->argsString());
+        ol.addLabel(cfname,anchor());
         first=FALSE;
         ol.docify(fmd->name());
         ol.disableAllBut(OutputType::Man);
@@ -3487,8 +3489,9 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
     {
       if (vmd->isEnumerate() && match.str()==vmd->name())
       {
-        ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs);
+        ol.startDoxyAnchor(cfname, cname, memAnchor, doxyName, doxyArgs);
         ol.startMemberDoc(ciname,name(),memAnchor,name(),memCount,memTotal,showInline);
+        ol.addLabel(cfname, memAnchor);
         std::string prefix = match.prefix().str();
         std::string suffix = match.suffix().str();
         linkifyText(TextGeneratorOLImpl(ol),scopedContainer,getBodyDef(),this,prefix.c_str());
@@ -3504,8 +3507,9 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
       ClassDef *annoClassDef=getClassDefOfAnonymousType();
       QCString typeName;
       if (annoClassDef) typeName=annoClassDef->compoundTypeString();
-      ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs);
+      ol.startDoxyAnchor(cfname, cname, memAnchor, doxyName, doxyArgs);
       ol.startMemberDoc(ciname,name(),memAnchor,"["+typeName+"]",memCount,memTotal,showInline);
+      ol.addLabel(cfname, memAnchor);
       // search for the last anonymous compound name in the definition
 
       ol.startMemberDocName(isObjCMethod());
@@ -3525,8 +3529,9 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
   }
   else // not an enum value or anonymous compound
   {
-    ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs);
+    ol.startDoxyAnchor(cfname, cname, memAnchor, doxyName, doxyArgs);
     ol.startMemberDoc(ciname,name(),memAnchor,title,memCount,memTotal,showInline);
+    ol.addLabel(cfname, memAnchor);
 
     if (!m_metaData.isEmpty() && getLanguage()==SrcLangExt::Slice)
     {
@@ -3885,6 +3890,7 @@ void MemberDefImpl::writeMemberDocSimple(OutputList &ol, const Definition *conta
   {
     ol.startInlineMemberType();
     ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs);
+    ol.addLabel(cfname,anchor());
 
     QCString ts = fieldType();
 

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -394,6 +394,7 @@ void MemberList::writePlainDeclarations(OutputList &ol, bool inGroup,
               if (!detailsLinkable)
               {
                 ol.startDoxyAnchor(md->getOutputFileBase(),QCString(),md->anchor(),md->name(),QCString());
+                ol.addLabel(md->getOutputFileBase(),md->anchor());
               }
               if (md->isSliceLocal())
               {

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -423,6 +423,7 @@ namespace OutputGenIntf
   template<class T> struct endMemberDoc                { static constexpr auto method = &T::endMemberDoc;                };
   template<class T> struct startDoxyAnchor             { static constexpr auto method = &T::startDoxyAnchor;             };
   template<class T> struct endDoxyAnchor               { static constexpr auto method = &T::endDoxyAnchor;               };
+  template<class T> struct addLabel                    { static constexpr auto method = &T::addLabel;                    };
   template<class T> struct writeLatexSpacing           { static constexpr auto method = &T::writeLatexSpacing;           };
   template<class T> struct startDescForItem            { static constexpr auto method = &T::startDescForItem;            };
   template<class T> struct endDescForItem              { static constexpr auto method = &T::endDescForItem;              };
@@ -735,6 +736,8 @@ class OutputList
     { foreach<OutputGenIntf::startDoxyAnchor>(fName,manName,anchor,name,args); }
     void endDoxyAnchor(const QCString &fn,const QCString &anchor)
     { foreach<OutputGenIntf::endDoxyAnchor>(fn,anchor); }
+    void addLabel(const QCString &fName,const QCString &anchor)
+    { foreach<OutputGenIntf::addLabel>(fName,anchor); }
     void writeLatexSpacing()
     { foreach<OutputGenIntf::writeLatexSpacing>(); }
     void startDescForItem()

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1676,6 +1676,12 @@ void RTFGenerator::endDoxyAnchor(const QCString &fName,const QCString &anchor)
   m_t << "}\n";
 }
 
+void RTFGenerator::addLabel(const QCString &,const QCString &)
+{
+  DBG_RTF(m_t << "{\\comment addLabel}\n")
+}
+
+
 void RTFGenerator::addIndexItem(const QCString &s1,const QCString &s2)
 {
   if (!s1.isEmpty())

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -170,6 +170,7 @@ class RTFGenerator : public OutputGenerator
     void endMemberDoc(bool);
     void startDoxyAnchor(const QCString &,const QCString &,const QCString &,const QCString &,const QCString &);
     void endDoxyAnchor(const QCString &,const QCString &);
+    void addLabel(const QCString &,const QCString &);
     void writeChar(char c);
     void writeLatexSpacing() {};//{ m_t << "\\hspace{0.3cm}"; }
     void writeStartAnnoItem(const QCString &type,const QCString &file,

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -1445,6 +1445,7 @@ void VhdlDocGen::writeVHDLDeclaration(const MemberDefMutable* mdef,OutputList &o
     if (!cname.isEmpty()) doxyName.prepend(cname+"::");
     QCString doxyArgs=mdef->argsString();
     ol.startDoxyAnchor(cfname,cname,mdef->anchor(),doxyName,doxyArgs);
+    ol.addLabel(cfname,mdef->anchor());
 
     ol.pushGeneratorState();
     ol.disable(OutputType::Man);


### PR DESCRIPTION
This commit fixes an advanced usage of doxygen, more especially latex doxylink usage.

Standard doxylink is a simple hyperlink:
```latex
\newcommand{\doxylink}[2]{
  \mbox{\hyperlink{#1}{#2}}
}
```

This simple reference is OK for digital pdf. But, in case of printed document, it lacks location information.

We extended doxylink like this, to add section number and title:
```latex
\renewcommand{\doxylink}[2]{
  \hyperlink{#1}{#2}, in \ref{#1} \nameref{#1}
}
```

The latex compiles well. But the generated latex is wrong. In the pdf, we observe that the hyperlink is good, but the `ref` and `nameref` point to the previous section.

Digging into generated .tex files, we found the following construct:
```latex
\Hypertarget{header_8h_ad8a2dfa8cbec508ec4cf97b2c5452797}\label{header_8h_ad8a2dfa8cbec508ec4cf97b2c5452797}
\index{header.h@{header.h}!bar@{bar}}
\index{bar@{bar}!header.h@{header.h}}
\doxysubsubsection{\texorpdfstring{bar()}{bar()}}
```

We can see that the `\label` is placed before `\doxysubsubsection`. doxylink points to `label`. And in this case, `\label` is part of the previous `doxy*section`.

This commit fixes this behavior, by setting the `label` after the `doxy*section`.

The resulted generated .tex is the following:
```latex
\index{header.h@{header.h}!bar@{bar}}
\index{bar@{bar}!header.h@{header.h}}
\doxysubsubsection{\texorpdfstring{bar()}{bar()}}
{\footnotesize\ttfamily
\Hypertarget{header_8h_ad8a2dfa8cbec508ec4cf97b2c5452797}\label{header_8h_ad8a2dfa8cbec508ec4cf97b2c5452797}
```

This behavior can be tested with a simple header file like this:
```c
/** @file header.h */

/** foo function */
void
foo();
/** bar function, see @ref foo */
void
bar();
```

Nota bene:
* We can see that `\Hypertarget` and `\label` are now embedded in `{\footnotesize\ttfamily` environment. That seems OK, and make the diff very simple.
* this commit fixes our specific usecase. It does not seem to break anything in pdf generation, but I may miss something.
* futhermore, this has not been tested with other generations: html, manpage, docbook...