### PR TITLE
Incorrect recognition of a lex rule pattern.

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -698,6 +698,7 @@ WSopt [ \t\r]*
   /* start lex rule handling */
 <CopyLine>{RulesSharp}                  {
                                           if (!yyextra->lexRulesPart) REJECT;
+                                          if (yyextra->curlyCount) REJECT;
                                           outputArray(yyscanner,yytext,yyleng);
                                           BEGIN(RulesPattern);
                                         }


### PR DESCRIPTION
The internal documentation gave the warning :
```
.../src/commentcnv.l:1865: error: include file commentcnv.l.h not found, perhaps you forgot to add its directory to INCLUDE_PATH?
```
due to the line:
```
parseIncludeOptions(yyscanner,std::string_view{yytext,static_cast<size_t>(yyleng)};
```
more precise the part `<size_t>` that was seen as a lex rule pattern though it was inside the "code".