### PR TITLE
Keep utf8 characters together in comments

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -773,6 +773,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                           endFontClass(yyscanner);
                                           pop_state(yyscanner);
                                         }
+<String>[\x80-\xFF]*                    |
 <String>.                               {yyextra->str+=yytext;}
 
 <*>\"|\'                                { /* string starts */


### PR DESCRIPTION
When having in Fortran:
```
ylegend= "Correction (z) [Å²]"
```
this was shown in the source code as:
```
ylegend= Å²"Correction (z) []"
```
due to the incorrect handling of utf8 characters

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14559485/example.tar.gz)
