### PR TITLE
issue #10707 Issue with doxyfigcaption

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -167,7 +167,14 @@ static void visitPreStart(TextStream &t, bool hasCaption, QCString name,  QCStri
     {
       if (!inlineImage)
       {
-        t << "\n\\doxyfigcaption{";
+        if (Config_getBool(PDF_HYPERLINKS))
+        {
+          t << "\n\\doxyfigcaption{";
+        }
+        else
+        {
+          t << "\n\\doxyfigcaptionnolink{";
+        }
       }
       else
       {

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -684,9 +684,15 @@
                                           \doxysubparagraphfont{#1}%
                                           \doxyminisecfont{#1}}%
 % Define caption that is also suitable in a table
+% for usage with hyperlinks
 \makeatletter
 \def\doxyfigcaption{%
 \H@refstepcounter{figure}%
+\@dblarg{\@caption{figure}}}
+
+% for usage without hyperlinks
+\def\doxyfigcaptionnolink{%
+\refstepcounter{figure}%
 \@dblarg{\@caption{figure}}}
 \makeatother
 


### PR DESCRIPTION
The doxygen caption style was, now, written for the version with hyperlinks, without hyperlinks this gave problems. (relevant older commits are: 7b0b7ef746a and 1084519cd41)