### PR TITLE
Incorrect handling of `$` in an objC string

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -3668,9 +3668,28 @@ static void writeObjCMethodCall(yyscan_t yyscanner,ObjCCallCtx *ctx)
   if (!ctx->format.isEmpty())
   {
     const char *p = ctx->format.data();
+    bool skip = false;
+    char skipChar = ' ';
     while ((c=*p++)) // for each character in ctx->format
     {
-      if (c=='$')
+      if (skip)
+      {
+        char s[2];
+        s[0]=c;s[1]=0;
+        codifyLines(yyscanner,s);
+        if (c==skipChar)
+        {
+          skip = false;
+          skipChar = ' ';
+        }
+        else if (c=='\\')
+        {
+          c = *p++;
+          s[0]=c;
+          codifyLines(yyscanner,s);
+        }
+      }
+      else if (c=='$')
       {
         char nc=*p++;
         if (nc=='$') // escaped $
@@ -3877,6 +3896,14 @@ static void writeObjCMethodCall(yyscan_t yyscanner,ObjCCallCtx *ctx)
             ASSERT(0); // "invalid escape sequence"
           }
         }
+      }
+      else if (c=='\'' || c == '"')
+      {
+        char s[2];
+        s[0]=c;s[1]=0;
+        codifyLines(yyscanner,s);
+        skip = true;
+        skipChar = c;
       }
       else // normal non-marker character
       {


### PR DESCRIPTION
From an objC file we got the error:
```
ASSERT: "0" in .../src/code.l (3878)
```
due to the incorrect handling of the `$` in a string in the code like:
```
  _unicode_map['$'] = 36;
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14572436/example.tar.gz)

(Found by Fossies)
