### PR TITLE
Handling escaped commands inside `\if`

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2377,6 +2377,7 @@ STopt  [^\n@\\]*
                                         }
 <SkipGuardedSection>[^ \\@\n]+          { // skip non-special characters
                                         }
+<SkipGuardedSection>{CMD}{CMD}          | 
 <SkipGuardedSection>.                   { // any other character
                                         }
 


### PR DESCRIPTION
The handling of an escaped command was done not properly in by `\if` command disabled sections

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14602277/example.tar.gz)
