### PR TITLE
Incorrect handling command character in comment conversion

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -932,6 +932,7 @@ SLASHopt [/]*
 				     BEGIN(SkipString);
   				   }
    */
+<CComment,CNComment>{CMD}{CMD}     |
 <CComment,CNComment>.	           {
                                      copyToOutput(yyscanner,yytext,yyleng);
   				   }

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -175,6 +175,7 @@ MAILADDR   ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a
 %x SnippetDoc
 %x IncludeFile
 
+CMD ("\\"|"@")
   //- start: NUMBER -------------------------------------------------------------------------
   // Note same defines in code.l: keep in sync
 DECIMAL_INTEGER  [1-9][0-9']*[0-9]?[uU]?[lL]?[lL]?
@@ -953,7 +954,7 @@ SLASHopt [/]*
 				     yyextra->inRoseComment=false;
 				     BEGIN(Scan);
                                    }
-<SComment>\n[ \t]*{CPPC}"/"[^\/\n]/.*\n  {
+<SComment>\n[ \t]*{CPPC}"/"[^\\@\/\n]/.*\n  {
                                      replaceComment(yyscanner,1);
 				     yyextra->readLineCtx=YY_START;
 				     BEGIN(ReadLine);
@@ -1241,6 +1242,7 @@ SLASHopt [/]*
 <ReadLine>`[^`]+`                  {
   				     copyToOutput(yyscanner,yytext,yyleng);
                                    }
+<ReadLine>{CMD}{CMD}               |
 <ReadLine>.			   {
   				     copyToOutput(yyscanner,yytext,yyleng);
   				   }


### PR DESCRIPTION
In case we have a construct like `///@` that should be handled by commentcnv this was not done correctly as the command character was taken a bit early.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14603474/example.tar.gz)
