### PR TITLE
issue #10747 Alias replaces HTML brackets to HTML codes, e.g "<img src=..." to "&lt;img src="

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1554,7 +1554,7 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
         out+=" ";
         out+=externalLinkTarget();
         out+=">";
-        content = substitute(content.simplifyWhiteSpace(),"\"","\\\"");
+        content = content.simplifyWhiteSpace();
         processInline(std::string_view(content.str()));
         out+="</a>";
       }


### PR DESCRIPTION
The fix in #8961 for #8956 (Section links in markdown mainpage not working) also changed the behavior of the `"` in the `<a href...` parts, this should not have been the case.