### PR TITLE
issue #10754 GENERATE_HTMLHELP with \msc & \endmsc is broken because of absolute paths in index.hhp since 1.9.3

### DIFF
--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -198,6 +198,11 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
     }
   }
 
+  int i=std::max(imgName.findRev('/'),imgName.findRev('\\'));
+  if (i!=-1) // strip path
+  {
+    imgName=imgName.right(imgName.length()-i-1);
+  }
   Doxygen::indexList->addImageFile(imgName);
 
 }


### PR DESCRIPTION
Strip path from imgName