### PR TITLE
Correctly parse C++ headers as headers

### DIFF
--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -180,9 +180,9 @@ void ClangTUParser::parse()
     // we use the source file to detected the language. Detection will fail if you
     // pass a bunch of .h files containing ObjC code, and no sources :-(
     SrcLangExt lang = getLanguageFromFileName(fileName);
+    QCString fn = fileName.lower();
     if (lang==SrcLangExt::ObjC || p->detectedLang!=DetectedLang::Cpp)
     {
-      QCString fn = fileName.lower();
       if (p->detectedLang!=DetectedLang::Cpp &&
           (fn.endsWith(".cpp") || fn.endsWith(".cxx") ||
            fn.endsWith(".cc")  || fn.endsWith(".c")))
@@ -200,7 +200,13 @@ void ClangTUParser::parse()
     }
     switch (p->detectedLang)
     {
-      case DetectedLang::Cpp:    argv.push_back(qstrdup("c++"));           break;
+      case DetectedLang::Cpp:
+        if (fn.endsWith(".hpp") || fn.endsWith(".hxx") ||
+            fn.endsWith(".hh")  || fn.endsWith(".h"))
+          argv.push_back(qstrdup("c++-header"));
+        else
+          argv.push_back(qstrdup("c++"));
+        break;
       case DetectedLang::ObjC:   argv.push_back(qstrdup("objective-c"));   break;
       case DetectedLang::ObjCpp: argv.push_back(qstrdup("objective-c++")); break;
     }


### PR DESCRIPTION
Clang differentiates between C++ files and headers, and currently doxygen parses all C++ files as source files. This PR parses the file as header if the file name indicates that it is a header.
Fixes #10744.