### PR TITLE
Flexibility for trDocumentation  in respect to the ProjectName

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4791,7 +4791,7 @@ static void writeIndex(OutputList &ol)
     {
       ol.startHeaderSection();
       ol.startTitleHead(QCString());
-      ol.parseText(projPrefix+theTranslator->trDocumentation());
+      ol.parseText(theTranslator->trDocumentation(projectName));
       headerWritten = TRUE;
     }
   }

--- a/src/translator.h
+++ b/src/translator.h
@@ -200,7 +200,7 @@ class Translator
 
     // index titles (the project name is prepended for these)
 
-    virtual QCString trDocumentation() = 0;
+    virtual QCString trDocumentation(const QCString projName) = 0;
     virtual QCString trModuleIndex() = 0;
     virtual QCString trHierarchicalIndex() = 0;
     virtual QCString trCompoundIndex() = 0;

--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -299,8 +299,8 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return " - Փաստագրություն"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + " - Փաստագրություն"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -332,8 +332,8 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "التوثيق"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "التوثيق"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -361,8 +361,8 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Документация"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Документация"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -486,13 +486,8 @@ class TranslatorBrazilian : public Translator
     { return "Lista de todos os módulos:"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    {
-      // TODO In the future, I think I'll suggest the replacement of this
-      // method to something like trDocumentationOf(projPrefix). This will allow
-      // the latin construction "Documentação de ProjA"
-      return "Documentação";
-    }
+    QCString trDocumentation(const QCString projName) override
+    { return "Documentação" + (!projName.isEmpty()? " de " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -349,8 +349,8 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return ": Documentació"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + ": Documentació"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -345,8 +345,8 @@ class TranslatorChinese : public Translator
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "文档"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "文档"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -469,8 +469,8 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentace"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentace"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -446,8 +446,8 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentation"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -362,8 +362,8 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     { return "Her er en liste over alle moduler:"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentation"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -365,8 +365,8 @@ class TranslatorEnglish : public Translator
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Documentation"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Documentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -351,8 +351,8 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentado"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentado"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -441,11 +441,8 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    {
-      // TODO: Replace with something like trDocumentationOf(projName).
-	  // This will allow the latin construction "Documentación de projName"
-	  return "documentación"; }
+    QCString trDocumentation(const QCString projName) override
+    { return "Documentación" + (!projName.isEmpty()? " de " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -341,8 +341,8 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "مستندات"; }
+    QCString trDocumentation(const QCString projName) override
+    { return "مستندات" + (!projName.isEmpty()?" " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -399,8 +399,8 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentaatio"; } // "Documentation"
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentaatio"; } // "Documentation"
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -414,8 +414,8 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
     { return "Liste de tous les modules :"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Documentation"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Documentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -340,8 +340,8 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Τεκμηρίωση"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Τεκμηρίωση"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_hi.h
+++ b/src/translator_hi.h
@@ -419,8 +419,8 @@ class TranslatorHindi : public TranslatorAdapter_1_9_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "दस्तावेज़ीकरण"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "दस्तावेज़ीकरण"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -226,8 +226,8 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     QCString trModulesDescription() override
     { return "Popis svih modula:"; }
 
-    QCString trDocumentation() override
-    { return "Dokumentacija"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
     QCString trModuleIndex() override
     { return "Kazalo modula"; }
     QCString trHierarchicalIndex() override

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -375,8 +375,8 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentáció"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentáció"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -331,8 +331,8 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentasi"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentasi"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -372,8 +372,8 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Documentazione"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Documentazione"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -385,8 +385,8 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     { return "全モジュールの一覧です。"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "詳解"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "詳解"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -373,8 +373,8 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "문서화"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "문서화"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -339,8 +339,8 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentacija"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -354,8 +354,8 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentācija"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentācija"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -334,8 +334,8 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Документација"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Документација"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -242,8 +242,8 @@ class TranslatorDutch : public Translator
     QCString trModulesDescription() override
     { return "Hieronder volgt de lijst met alle modules:"; }
 
-    QCString trDocumentation() override
-    { return "Documentatie"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Documentatie"; }
     QCString trModuleIndex() override
     { return "Module Index"; }
     QCString trHierarchicalIndex() override

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -349,8 +349,8 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentasjon"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentasjon"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -339,8 +339,8 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentacja"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacja"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -396,8 +396,8 @@ class TranslatorPortuguese : public Translator
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Documentação"; }
+    QCString trDocumentation(const QCString projName) override
+    { return "Documentação" + (!projName.isEmpty()? " de " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -358,8 +358,8 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Documentaţie"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Documentaţie"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -296,8 +296,8 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Документация"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Документация"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -352,8 +352,8 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Документација"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Документација"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -136,8 +136,8 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     { return "Seznam strani z dodatnimi opisi:"; }
     QCString trModulesDescription() override
     { return "Seznam modulov:"; }
-    QCString trDocumentation() override
-    { return "Dokumentacija"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
     QCString trModuleIndex() override
     { return "seznam modulov"; }
     QCString trHierarchicalIndex() override

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -332,8 +332,8 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentácia"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentácia"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -332,8 +332,8 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentacija"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -471,8 +471,8 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentation"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -343,8 +343,8 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokümantasyonu"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokümantasyonu"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_tw.h
+++ b/src/translator_tw.h
@@ -356,8 +356,8 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "說明文件"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "說明文件"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -291,8 +291,8 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Документація"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Документація"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -368,8 +368,8 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Thông tin"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Thông tin"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -331,8 +331,8 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
     { return "'n Lys van alle modules:"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation() override
-    { return "Dokumentasie"; }
+    QCString trDocumentation(const QCString projName) override
+    { return (!projName.isEmpty()?projName + " " : "") + "Dokumentasie"; }
 
     /*! This is used in LaTeX as the title of the chapter with the
      * index of all groups.


### PR DESCRIPTION
In the proposed pull request #439 an initial fix was made for the fact that some languages have a different order of the words when appended. This is not only the case for right to left languages but also for e.g. Spanish, Brazilian  (see comments in their translators).

This implementation gives the flexibility to the respective translators in respect to the wording.