### PR TITLE
Consistency of argument of `trDocumentation`

### DIFF
--- a/src/translator.h
+++ b/src/translator.h
@@ -200,7 +200,7 @@ class Translator
 
     // index titles (the project name is prepended for these)
 
-    virtual QCString trDocumentation(const QCString projName) = 0;
+    virtual QCString trDocumentation(const QCString &projName) = 0;
     virtual QCString trModuleIndex() = 0;
     virtual QCString trHierarchicalIndex() = 0;
     virtual QCString trCompoundIndex() = 0;

--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -299,7 +299,7 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + " - Փաստագրություն"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -332,7 +332,7 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "التوثيق"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -361,7 +361,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Документация"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -486,7 +486,7 @@ class TranslatorBrazilian : public Translator
     { return "Lista de todos os módulos:"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return "Documentação" + (!projName.isEmpty()? " de " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -349,7 +349,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + ": Documentació"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -345,7 +345,7 @@ class TranslatorChinese : public Translator
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "文档"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -469,7 +469,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentace"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -446,7 +446,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -362,7 +362,7 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     { return "Her er en liste over alle moduler:"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -365,7 +365,7 @@ class TranslatorEnglish : public Translator
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Documentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -351,7 +351,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentado"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -441,7 +441,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return "Documentación" + (!projName.isEmpty()? " de " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -341,7 +341,7 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return "مستندات" + (!projName.isEmpty()?" " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -399,7 +399,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentaatio"; } // "Documentation"
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -414,7 +414,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
     { return "Liste de tous les modules :"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Documentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -340,7 +340,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Τεκμηρίωση"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_hi.h
+++ b/src/translator_hi.h
@@ -419,7 +419,7 @@ class TranslatorHindi : public TranslatorAdapter_1_9_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "दस्तावेज़ीकरण"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -226,7 +226,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     QCString trModulesDescription() override
     { return "Popis svih modula:"; }
 
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
     QCString trModuleIndex() override
     { return "Kazalo modula"; }

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -375,7 +375,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentáció"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -331,7 +331,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentasi"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -372,7 +372,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Documentazione"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -385,7 +385,7 @@ class TranslatorJapanese : public TranslatorAdapter_1_8_15
     { return "全モジュールの一覧です。"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "詳解"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -373,7 +373,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "문서화"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -339,7 +339,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -354,7 +354,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentācija"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -334,7 +334,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Документација"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -242,7 +242,7 @@ class TranslatorDutch : public Translator
     QCString trModulesDescription() override
     { return "Hieronder volgt de lijst met alle modules:"; }
 
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Documentatie"; }
     QCString trModuleIndex() override
     { return "Module Index"; }

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -349,7 +349,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentasjon"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -339,7 +339,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacja"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -396,7 +396,7 @@ class TranslatorPortuguese : public Translator
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return "Documentação" + (!projName.isEmpty()? " de " + projName : ""); }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -358,7 +358,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Documentaţie"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -296,7 +296,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Документация"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -352,7 +352,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Документација"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -136,7 +136,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
     { return "Seznam strani z dodatnimi opisi:"; }
     QCString trModulesDescription() override
     { return "Seznam modulov:"; }
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
     QCString trModuleIndex() override
     { return "seznam modulov"; }

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -332,7 +332,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentácia"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -332,7 +332,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentacija"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -471,7 +471,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentation"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -343,7 +343,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokümantasyonu"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_tw.h
+++ b/src/translator_tw.h
@@ -356,7 +356,7 @@ class TranslatorChinesetraditional : public TranslatorAdapter_1_8_15
 
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "說明文件"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -291,7 +291,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Документація"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -368,7 +368,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     // index titles (the project name is prepended for these)
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Thông tin"; }
 
     /*! This is used in LaTeX as the title of the chapter with the

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -331,7 +331,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
     { return "'n Lys van alle modules:"; }
 
     /*! This is used in HTML as the title of index.html. */
-    QCString trDocumentation(const QCString projName) override
+    QCString trDocumentation(const QCString &projName) override
     { return (!projName.isEmpty()?projName + " " : "") + "Dokumentasie"; }
 
     /*! This is used in LaTeX as the title of the chapter with the


### PR DESCRIPTION
Based on the coverity warning and making the `trDocumentation` in respect to the `const QCString` argument more consistent with other translation functions