### PR TITLE
issue #10762 Macro define a class name to a different one causes extra whitespace to appear

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2983,6 +2983,7 @@ static bool expandExpression(yyscan_t yyscanner,QCString &expr,QCString *rest,in
       i=p+l;
     }
   }
+  expr = expr.stripWhiteSpace();
   //printf("<expandExpression(expr='%s',rest='%s',pos=%d,level=%d)\n",qPrint(expr),rest ? qPrint(*rest) : "", pos,level);
   return TRUE;
 }


### PR DESCRIPTION
Problem looks like a side effect of
```
00ee930a1d73e11885197102c54fd4c8141127da is the first bad commit
commit 00ee930a1d73e11885197102c54fd4c8141127da
Date:   Sun Mar 13 10:12:46 2016 +0100

    reimplemented removeRedundantWhiteSpace() to improve performance

 src/util.cpp | 385 +++++++++++++++++++++++++++++++++++------------------------
 1 file changed, 231 insertions(+), 154 deletions(-)
```

the preprocessor should not add extra spaces to the result.