### PR TITLE
issue #10763 CREATE_SUBDIRS and C++20 modules: Doxygen doesn't create directories

### DIFF
--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -137,7 +137,7 @@ class ModuleDefImpl : public DefinitionMixin<ModuleDef>
 
 QCString ModuleDefImpl::getOutputFileBase() const
 {
-  return "module_"+convertNameToFile(name());
+  return convertNameToFile("module_" + name());
 }
 
 QCString ModuleDefImpl::qualifiedName() const


### PR DESCRIPTION
The `module_` should be part of the (file) name not prepended to the directory name.