### PR TITLE
Always set `Compiled file` for HTML help compiler

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -424,6 +424,10 @@ void HtmlHelp::Private::createProjectFile()
     {
       t << "Compiled file=" << Config_getString(CHM_FILE) << "\n";
     }
+    else
+    {
+      t << "Compiled file=index.chm\n";
+    }
     t << "Compatibility=1.1\n"
          "Full-text search=Yes\n";
     if (ctsItemPresent) t << "Contents file=" + hhcFileName + "\n";


### PR DESCRIPTION
For the HTML help compiler `chmcmd` of the Free Pascal Compiler project the setting of `Compiled file` in the `index.hhp` file is mandatory, so when `CHM_FILE` is not specified the default name should be used.