### PR TITLE
Adding sub links to doxygen_crawl file.

### DIFF
--- a/src/sitemap.h
+++ b/src/sitemap.h
@@ -63,7 +63,7 @@ class Crawlmap
     void addContentsItem(bool isDir, const QCString & name, const QCString & ref,
                          const QCString & file, const QCString & anchor,
                          bool separateIndex,bool addToNavIndex,
-                         const Definition *def){}
+                         const Definition *def);
     void addIndexItem(const Definition *context, const MemberDef *md,
                       const QCString &sectionAnchor, const QCString &title){}
     void addIndexFile(const QCString & name);

--- a/src/sitemap.h
+++ b/src/sitemap.h
@@ -65,7 +65,7 @@ class Crawlmap
                          bool separateIndex,bool addToNavIndex,
                          const Definition *def);
     void addIndexItem(const Definition *context, const MemberDef *md,
-                      const QCString &sectionAnchor, const QCString &title){}
+                      const QCString &sectionAnchor, const QCString &title);
     void addIndexFile(const QCString & name);
     void addImageFile(const QCString & name){}
     void addStyleSheetFile(const QCString & name){}


### PR DESCRIPTION
Based on the issue #10765 extended the doxygen_crawl.html so that also, potential,  failing links can be detected by a HTML link checker. Before the change there were no warnings, now we get, correctly:
```
Processing      file:///.../html/doxygen_crawl.html

List of broken links and other issues:
file:///.../html/deltaunit_8h.html
 Lines: 12, 27, 28, 29, 30, 31
  Code: 200 (no message)
 To do: Some of the links to this resource point to broken URI fragments
        (such as index.html#fragment).
The following fragments need to be fixed:
        a522cd9d32a68eabce080861331e10259ad132c6847dca961bd7152d362ea4a96c      Line: 31
        a522cd9d32a68eabce080861331e10259a2c5c630d8c3314ae3df57043ab1b55fa      Line: 29
        a522cd9d32a68eabce080861331e10259a8ba18c9e30fe35e3f041b6ee1453d413      Line: 30
        a522cd9d32a68eabce080861331e10259       Line: 28
```