### PR TITLE
Fix up C++20 module pseudo-keyword masking variables/members

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -953,6 +953,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                         }
 <Body>"module"/{B}*[:;]?                { // 'module X' or 'module : private' or 'module;'
                                           if (yyextra->lang!=SrcLangExt::Cpp) REJECT;
+                                          if (!yyextra->type.isEmpty() || !yyextra->name.isEmpty()) REJECT;
                                           startFontClass(yyscanner,"keyword");
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1084,6 +1084,7 @@ NONLopt [^\n]*
                                         }
 <FindMembers>{B}*"module"{BN}*";"       { // global module section
                                           if (!yyextra->insideCpp) REJECT;
+                                          if (!yyextra->current->type.isEmpty() || !yyextra->current->name.isEmpty()) REJECT;
                                           //printf("Implementation module unit\n");
                                           lineCount(yyscanner);
                                           BEGIN( FindMembers );


### PR DESCRIPTION
Example:

```c
const char *foo;
const char *module;
const char *bar;
```

ends up parsing as:

```c
const char *foo;
const char *const char *bar;
```

after C++20 module support was introduced in 6d80fc7e5d03c259b1a7280972e0b28884217655.

This changes `code.l` and `scanner.l` to `REJECT` in the `module` handlers if `type` or `name` is not empty.