### PR TITLE
issue #10776  Provide the ability to sort implemented/re-implemented list

### DIFF
--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -59,6 +59,11 @@ int genericCompareMembers(const MemberDef *c1,const MemberDef *c2)
   }
   // sort on name
   int cmp = qstricmp(c1->name(),c2->name());
+  // then on qualified name
+  if (cmp==0)
+  {
+    cmp = qstricmp(c1->qualifiedName(),c2->qualifiedName());
+  }
   // then on argument list
   if (cmp==0 && !c1->argsString().isEmpty() && !c2->argsString().isEmpty())
   {


### PR DESCRIPTION
In principle members are already sorted, but this is based on the name, it should also be done on the qualified name.
(sorting is a difficult topic as there are multiple thoughts about what the correct order of the sorting might be).