### PR TITLE
Problem with colon inserted by `\addindex`

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -102,7 +102,7 @@ static QCString convertIndexWordToAnchor(const QCString &word)
       else
       {
         char enc[4];
-        enc[0] = ':';
+        enc[0] = ';';
         enc[1] = hex[(c & 0xf0) >> 4];
         enc[2] = hex[c & 0xf];
         enc[3] = 0;

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -178,8 +178,7 @@ static QCString field2URL(const IndexField *f,bool checkReversed)
   addHtmlExtensionIfMissing(result);
   if (!f->anchor.isEmpty() && (!checkReversed || f->reversed))
   {
-    // HTML Help needs colons in link anchors to be escaped in the .hhk file.
-    result+="#"+substitute(f->anchor,":","%3A");
+    result+="#"+f->anchor;
   }
   return result;
 }


### PR DESCRIPTION
In the `addindex` command the special characters are replaced by a colon followed by a code, this gives a discrepancy in the chm output as here the colon is translated into the escape sequence `%3A` (see bug 765001). The error with the chmcmd of the Free Pascal Compiler is
```
Error: Anchor commands.html#a318_%3A5Caddtogroup undefined; first use Site Map for \addtogroup
```
but in the HTML code still the id like `a318_:5Caddtogroup` is used. The linking is done correctly so the word Error is actually a warning here. Probably the introduction of the colon  (due to bug 746162 as the used percent sign gave there problems with formulas) was not the optimal choice. Now using the semicolon, looks with the `hhc` and `chmcmd` compilers OK.

(Originally seen by the doxygen chm documentation)