### PR TITLE
Warning in pre.l

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2846,9 +2846,9 @@ static void addSeparatorsIfNeeded(yyscan_t yyscanner,const QCString &expr,QCStri
     restExpr=restExpr.stripWhiteSpace();
     if (restExpr.isEmpty()) // peek ahead in the stream for non-whitespace
     {
-      uint32_t j=resultExpr.length();
+      uint32_t j=(uint32_t)resultExpr.length();
       while ((ccNext=getNextChar(yyscanner,resultExpr,nullptr,j))!=EOF && ccNext==' ') { }
-      unputChar(yyscanner,resultExpr,nullptr,j,ccNext);
+      if (ccNext != EOF) unputChar(yyscanner,resultExpr,nullptr,j,(char)ccNext);
     }
     else // take first char from remainder
     {


### PR DESCRIPTION
In `pre.l` we see warnings like:
```
pre.l(2850): warning C4267: 'initializing': conversion from 'size_t' to 'uint32_t', possible loss of data
pre.l(2852): warning C4242: 'argument': conversion from 'int' to 'char', possible loss of data
```
preventing this by means of casts and the fact that EOF should not be unput