### PR TITLE
Guarantee unsigned 32-bit word for  md5 calculation

### DIFF
--- a/deps/libmd5/md5_loc.h
+++ b/deps/libmd5/md5_loc.h
@@ -1,6 +1,7 @@
 #ifndef MD5LOC_H
 #define MD5LOC_H
 
-# define UWORD32 unsigned int
+# include <stdint.h>
+# define UWORD32 uint32_t
 
 #endif


### PR DESCRIPTION
It is not guaranteed that `unsigned int` is 32-bit (according to the standard, though normally it is). We now guarantee that it is 32-bit