### PR TITLE
Delay removing files in case of RTF till end of process

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3331,6 +3331,17 @@ The following block name is set based on whether or not a feature is used in the
 ]]>
       </docs>
     </option>
+    <option type='list' id='RTF_EXTRA_FILES' format='file' depends='GENERATE_RTF'>
+      <docs>
+<![CDATA[
+ The \c RTF_EXTRA_FILES tag can be used to specify one or more extra images
+ or other source files which should be copied to the \ref cfg_rtf_output "RTF_OUTPUT"
+ output directory.
+ Note that the files will be copied as-is; there are no commands or markers
+ available.
+]]>
+      </docs>
+    </option>
   </group>
   <group name='Man' docs='Configuration options related to the man page output'>
     <option type='bool' id='GENERATE_MAN' defval='0'>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -12544,6 +12544,7 @@ void generateOutput()
   {
     copyLogo(Config_getString(RTF_OUTPUT));
     copyIcon(Config_getString(RTF_OUTPUT));
+    copyExtraFiles(Config_getList(RTF_EXTRA_FILES),"RTF_EXTRA_FILES",Config_getString(RTF_OUTPUT));
   }
 
   FormulaManager &fm = FormulaManager::instance();


### PR DESCRIPTION
In case we include a file by means of a `\rtfonly` section like:
```
\rtfonly
\par \pard\plain
{\field\fldedit{\*\fldinst INCLUDETEXT "inc_aa.rtf" \\*MERGEFORMAT}{\fldrslt includedstuff}}
\endrtfonly
```
or
```
\rtfonly
\par \pard\plain
{\field\fldedit{\*\fldinst INCLUDETEXT "../inc_aa1.rtf" \\*MERGEFORMAT}{\fldrslt includedstuff}}
\endrtfonly
```

we get errors when a file is included multiple times or for the relative link on the second invocation as the files are removed directly after been included. This is not desirable.
- remove files just at the end of the merging process
- only remove files in the `RTF_OUTPUT` directory (this will contain only "generated / copied" files)
- create possibility to have "RTF_EXTRA_FILES` analogous to the HTML and LATEX counterparts.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/14948210/example.tar.gz)
