### PR TITLE
issue #10766 C# cref or \ref doesn't work without full namespace, even for classes in same namespace

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -731,7 +731,9 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
     //    qPrint(m_text),qPrint(m_ref),qPrint(m_file),m_refType);
     return;
   }
-  else if (resolveLink(context,target,TRUE,&compound,anchor,parser->context.prefix))
+  else if (resolveLink(context,target,true,&compound,anchor,parser->context.prefix) ||
+           resolveLink(substitute(context,".","::"),target,true,&compound,anchor,parser->context.prefix)
+          )
   {
     bool isFile = compound ?
                  (compound->definitionType()==Definition::TypeFile ||
@@ -911,7 +913,9 @@ DocLink::DocLink(DocParser *parser,DocNodeVariant *parent,const QCString &target
   {
     m_refText = m_refText.right(m_refText.length()-1);
   }
-  if (resolveLink(parser->context.context,stripKnownExtensions(target),parser->context.inSeeBlock,&compound,anchor,parser->context.prefix))
+  if (resolveLink(parser->context.context,stripKnownExtensions(target),parser->context.inSeeBlock,&compound,anchor,parser->context.prefix) ||
+      resolveLink(substitute(parser->context.context,".","::"),stripKnownExtensions(target),parser->context.inSeeBlock,&compound,anchor,parser->context.prefix)
+     )
   {
     m_anchor = anchor;
     if (compound && compound->isLinkable())

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -791,6 +791,7 @@ void DocParser::handleLinkedWord(DocNodeVariant *parent,DocNodeList &children,bo
   //printf("handleLinkedWord(%s) context.context=%s\n",qPrint(context.token->name),qPrint(context.context));
   if (!context.insideHtmlLink &&
       (resolveRef(context.context,context.token->name,context.inSeeBlock,&compound,&member,TRUE,fd,TRUE)
+       || resolveRef(substitute(context.context,".","::"),context.token->name,context.inSeeBlock,&compound,&member,TRUE,fd,TRUE)
        || (!context.context.isEmpty() &&  // also try with global scope
            resolveRef("",context.token->name,context.inSeeBlock,&compound,&member,FALSE,nullptr,TRUE))
       )


### PR DESCRIPTION
Also check against the case that we have a `.` as separator (i.e. C# or Java) in the context name.