### PR TITLE
issue #10240 Multi-line doc not recognized in Python class field

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -716,7 +716,7 @@ ID        [a-z_A-Z%]+{IDSYM}*
                         BEGIN(TripleComment);
                       }
 
-    {STARTDOCSYMS}/[^#]  {  // start of a special comment
+    {STARTDOCSYMS}/[^#\n] {  // start of a special comment
                         initSpecialBlock(yyscanner);
                         BEGIN(SpecialComment);
                       }


### PR DESCRIPTION
Improve handling of start of a special comment block. (Looks like it should not be corrected at other places)