### PR TITLE
Running tests in pdf mode

### DIFF
--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -64,6 +64,17 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
       return "";
     }
 
+    QCString latexCommandName() override
+    {
+      QCString latex_command = Config_getString(LATEX_CMD_NAME);
+      if (latex_command.isEmpty()) latex_command = "latex";
+      if (Config_getBool(USE_PDFLATEX))
+      {
+        if (latex_command == "latex") latex_command = "xelatex";
+      }
+      return latex_command;
+    }
+
     QCString trISOLang() override
     { return "ar-EG"; }
     QCString getLanguageString() override

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -91,6 +91,17 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
       return "";
     }
 
+    QCString latexCommandName() override
+    {
+      QCString latex_command = Config_getString(LATEX_CMD_NAME);
+      if (latex_command.isEmpty()) latex_command = "latex";
+      if (Config_getBool(USE_PDFLATEX))
+      {
+        if (latex_command == "latex") latex_command = "xelatex";
+      }
+      return latex_command;
+    }
+
     QCString trISOLang() override
     {
       return "fa";

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -71,6 +71,17 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
              "\\usepackage[greek]{babel}\n";
     }
 
+    QCString latexCommandName() override
+    {
+      QCString latex_command = Config_getString(LATEX_CMD_NAME);
+      if (latex_command.isEmpty()) latex_command = "latex";
+      if (Config_getBool(USE_PDFLATEX))
+      {
+        if (latex_command == "latex") latex_command = "xelatex";
+      }
+      return latex_command;
+    }
+
     QCString trISOLang() override
     {
       return "el";

--- a/src/translator_hi.h
+++ b/src/translator_hi.h
@@ -183,6 +183,17 @@ class TranslatorHindi : public TranslatorAdapter_1_9_4
     QCString latexLanguageSupportCommand() override
     { return ""; }
 
+    QCString latexCommandName() override
+    {
+      QCString latex_command = Config_getString(LATEX_CMD_NAME);
+      if (latex_command.isEmpty()) latex_command = "latex";
+      if (Config_getBool(USE_PDFLATEX))
+      {
+        if (latex_command == "latex") latex_command = "xelatex";
+      }
+      return latex_command;
+    }
+
     QCString trISOLang() override
     { return "hi-IN"; }
 


### PR DESCRIPTION
For the Greek translator we get when creating a pdf:
```
! Fatal Package fontspec Error: The fontspec package requires either XeTeX or
(fontspec)                      LuaTeX.
```
(form the doxygen tests)

Switching to xetex for Greek.
Also switching for some other languages to xetex (although here there might be some font problems, to be solved by the respective, human, translator).