### PR TITLE
Error generating PDF for test 59 in Spanish

### DIFF
--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -149,7 +149,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString latexLanguageSupportCommand() override
     {
-      return "\\usepackage[spanish]{babel}";
+      return "\\usepackage[spanish, es-noshorthands, shorthands=off]{babel}";
     }
 
     QCString trISOLang() override


### PR DESCRIPTION
When running the tests with `OUTPUT_LANGUAGE=Spanish` we get for the PDF output with test 59 the error like:
```
! Argument of \language@active@arg> has an extra }.
<inserted text>
                \par
l.5 \chapter{Referencia \texorpdfstring{$<$}{<} }
```
Based on https://tex.stackexchange.com/a/715658/44119 the current fix is made.