### PR TITLE
Removing double logic

### DIFF
--- a/doc/translator.py
+++ b/doc/translator.py
@@ -545,6 +545,7 @@ class Transl:
         status = 0
         curlyCnt = 0      # counter for the level of curly braces
 
+        backStatus = 2
         # Loop until the final state 777 is reached. The errors are processed
         # immediately. In this implementation, it always quits the application.
         while status != 777:
@@ -558,6 +559,7 @@ class Transl:
 
             elif status == 1:    # colon after the 'public'
                 if tokenId == 'colon':
+                    backStatus = 2
                     status = 2
                 else:
                     self.__unexpectedToken(status, tokenId, tokenLineNo)
@@ -566,12 +568,16 @@ class Transl:
                 if tokenId == 'virtual':
                     prototype = tokenStr  # but not to unified prototype
                     status = 3
+                elif tokenId == 'id' and tokenStr == 'QCString' and backStatus == 3:
+                    status = 4
                 elif tokenId == 'comment':
                     pass
                 elif tokenId == 'rcurly':
                     status = 11         # expected end of class
                 elif tokenId == 'id' and tokenStr == 'ABSTRACT_BASE_CLASS':
                     status = 18
+                elif tokenId == 'protected':
+                    status = 19
                 else:
                     self.__unexpectedToken(status, tokenId, tokenLineNo)
 
@@ -721,6 +727,13 @@ class Transl:
                     status = 2
                 elif tokenId == 'id':
                     pass
+                else:
+                    self.__unexpectedToken(status, tokenId, tokenLineNo)
+
+            elif status == 19:    # colon after the 'protected'
+                if tokenId == 'colon':
+                    backStatus = 3
+                    status = 3
                 else:
                     self.__unexpectedToken(status, tokenId, tokenLineNo)
 

--- a/doc/translator.py
+++ b/doc/translator.py
@@ -713,6 +713,8 @@ class Transl:
                     prototype += ', '
                     uniPrototype += ', '
                     status = 6
+                elif tokenId == 'assign':
+                    status=20
                 elif tokenId == 'rpar':
                     prototype += tokenStr
                     uniPrototype += tokenStr
@@ -734,6 +736,12 @@ class Transl:
                 if tokenId == 'colon':
                     backStatus = 3
                     status = 3
+                else:
+                    self.__unexpectedToken(status, tokenId, tokenLineNo)
+
+            elif status == 20:
+                if tokenId == 'string':
+                    status = 17
                 else:
                     self.__unexpectedToken(status, tokenId, tokenLineNo)
 

--- a/src/translator.h
+++ b/src/translator.h
@@ -72,13 +72,7 @@ class Translator
      */
     virtual QCString latexCommandName()
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "pdflatex";
-      }
-      return latex_command;
+      return p_latexCommandName("pdflatex");
     }
     virtual QCString trISOLang() = 0;
 
@@ -770,6 +764,30 @@ class Translator
 // new since 1.11.0
 //////////////////////////////////////////////////////////////////////////
     virtual QCString trImportant() = 0;
+
+  protected:
+    QCString p_latexCommandName(const QCString &latexCmd)
+    {
+      QCString latex_command = Config_getString(LATEX_CMD_NAME);
+      if (latex_command.isEmpty()) latex_command = "latex";
+      if (Config_getBool(USE_PDFLATEX))
+      {
+        if (latex_command == "latex") latex_command = latexCmd;
+      }
+      return latex_command;
+    }
+    /*! For easy flexible-noun implementation.
+     *  \internal
+     */
+    QCString createNoun(bool first_capital, bool singular,
+                        const QCString &base,
+                        const QCString &plurSuffix, const QCString &singSuffix = "" )
+    {
+      QCString result(base);
+      if (first_capital) result = result.left(1).upper() + result.mid(1);
+      result += (singular ? singSuffix : plurSuffix);
+      return result;
+    }
 };
 
 #endif

--- a/src/translator.h
+++ b/src/translator.h
@@ -783,8 +783,18 @@ class Translator
                         const QCString &base,
                         const QCString &plurSuffix, const QCString &singSuffix = "" )
     {
-      QCString result(base);
-      if (first_capital) result = result.left(1).upper() + result.mid(1);
+      QCString result;
+      if (first_capital)
+      {
+        std::string res = getUTF8CharAt(base.str(),0);
+        res = convertUTF8ToUpper(res);
+        result = res.c_str();
+        result += base.mid(res.length());
+      }
+      else
+      {
+        result = base;
+      }
       result += (singular ? singSuffix : plurSuffix);
       return result;
     }

--- a/src/translator_ar.h
+++ b/src/translator_ar.h
@@ -66,13 +66,7 @@ class TranslatorArabic : public TranslatorAdapter_1_4_6
 
     QCString latexCommandName() override
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "xelatex";
-      }
-      return latex_command;
+      return p_latexCommandName("xelatex");
     }
 
     QCString trISOLang() override

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -1368,9 +1368,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Classe" : "classe"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "classe", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1379,9 +1377,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Arquivo": "arquivo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "arquivo", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1390,9 +1386,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1401,9 +1395,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupo" : "grupo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "grupo", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1412,9 +1404,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Página" : "página"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "página", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1423,9 +1413,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Membro" : "membro"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "membro", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1434,9 +1422,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globa" : "globa"));
-      result+= singular? "l" : "ais";
-      return result;
+      return createNoun(first_capital, singular, "globa", "ais", "l");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1447,9 +1433,7 @@ class TranslatorBrazilian : public Translator
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (!singular)  result+="es";
-      return result;
+      return createNoun(first_capital, singular, "autor", "es");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1675,9 +1659,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Diretório" : "diretório"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "diretório", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1856,9 +1838,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Módulo" : "módulo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "módulo", "s");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1896,9 +1876,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tipo" : "tipo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "tipo", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1907,9 +1885,7 @@ class TranslatorBrazilian : public Translator
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subrotina" : "subrotina"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "subrotina", "s");
     }
 
     /*! C# Type Contraint list */
@@ -2477,9 +2453,7 @@ class TranslatorBrazilian : public Translator
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-        QCString result((first_capital ? "Conceito" : "conceito"));
-        if (!singular) result+="s";
-        return result;
+      return createNoun(first_capital, singular, "conceito", "s");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -1188,9 +1188,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Classe" : "classe"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "classe", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1199,9 +1197,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Fitxer" : "fitxer"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "fitxer", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1210,9 +1206,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1221,9 +1215,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grup" : "grup"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "grup", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1232,9 +1224,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Pàgin" : "pàgin"));
-      if (!singular)  result+="es"; else result+="a";
-      return result;
+      return createNoun(first_capital, singular, "pàgin", "es", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1243,9 +1233,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Membre" : "membre"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "membre", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1254,9 +1242,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "global", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1267,9 +1253,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "autor", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1491,9 +1475,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Directori" : "directori"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "directori", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1675,9 +1657,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Mòdul" : "mòdul"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "mòdul", "s");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1713,9 +1693,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trType(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "Tipus" : "tipus"));
-      //if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, false, "tipus", "");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1723,10 +1701,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogram" : "subprogram"));
-      if (!singular)  result+="es";
-      else            result+="a";
-      return result;
+      return createNoun(first_capital, singular, "subprogram", "es", "a");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -1340,9 +1340,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tříd" : "tříd"));
-      result += singular ? "a" : "y";
-      return result;
+      return createNoun(first_capital, singular, "tříd", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1351,9 +1349,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Soubor" : "soubor"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "soubor", "y");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1362,11 +1358,8 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Jmenn" : "jmenn"));
-      result += singular ? "ý" : "é";
-      result+=" prostor";
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "jmenn", "é", "ý") + 
+             createNoun(false, singular, " prostor", "y");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1375,9 +1368,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Skupin" : "skupin"));
-      result += singular ? "a" : "y";
-      return result;
+      return createNoun(first_capital, singular, "skupin", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1386,9 +1377,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Stránk" : "stránk"));
-      result += singular ? "a" : "y";
-      return result;
+      return createNoun(first_capital, singular, "stránk", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1409,9 +1398,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "global", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1422,9 +1409,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Auto" : "auto"));
-      result += (singular) ? "r" : "ři";
-      return result;
+      return createNoun(first_capital, singular, "auto", "ři", "r");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1647,9 +1632,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Adresář" : "adresář"));
-      if (!singular) result+="e";
-      return result;
+      return createNoun(first_capital, singular, "adresář", "e");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1828,9 +1811,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "modul", "y");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1864,9 +1845,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Typ" : "typ"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "typ", "y");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1875,9 +1854,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Podprogram" : "podprogram"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "podprogram", "y");
     }
 
     /*! C# Type Constraint list */
@@ -2429,9 +2406,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Koncept" : "koncept"));
-      if (!singular) result+="y";
-      return result;
+      return createNoun(first_capital, singular, "koncept", "y");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -1318,9 +1318,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trClass(bool, bool singular) override
     {
-      QCString result("Klasse");
-      if (!singular)  result+="n";
-      return result;
+      return createNoun(true, singular, "Klasse", "n");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1329,9 +1327,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trFile(bool, bool singular) override
     {
-      QCString result("Datei");
-      if (!singular)  result+="en";
-      return result;
+      return createNoun(true, singular, "Datei", "en");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1340,9 +1336,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trNamespace(bool, bool singular) override
     {
-      QCString result("Namensbereich");
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(true, singular, "Namensbereich", "e");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1351,9 +1345,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trGroup(bool, bool singular) override
     {
-      QCString result("Gruppe");
-      if (!singular)  result+="n";
-      return result;
+      return createNoun(true, singular, "Gruppe", "n");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1362,9 +1354,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trPage(bool, bool singular) override
     {
-      QCString result("Seite");
-      if (!singular)  result+="n";
-      return result;
+      return createNoun(true, singular, "Seite", "n");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1373,20 +1363,16 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trMember(bool, bool singular) override
     {
-      QCString result("Element");
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(true, singular, "Element", "e");
     }
 
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
      *  of the category.
      */
-    QCString trGlobal(bool first_capital, bool singular) override
+    QCString trGlobal(bool, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global")); // FIXME
-      if (!singular)  result+="";
-      return result;
+      return createNoun(true, singular, "Global", ""); // FIXME
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1398,9 +1384,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trAuthor(bool, bool singular) override
     {
-      QCString result("Autor");
-      if (!singular)  result+="en";
-      return result;
+      return createNoun(true, singular, "Autor", "en");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1627,9 +1611,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trDir(bool, bool singular) override
     {
-      QCString result("Verzeichnis");
-      if (!singular) result+="se";
-      return result;
+      return createNoun(true, singular, "Verzeichnis", "se");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1809,9 +1791,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trModule(bool /*first_capital*/, bool singular) override
     {
-      QCString result("Modul");
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(true, singular, "Modul", "e");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1846,9 +1826,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trType(bool /*first_capital*/, bool singular) override
     {
-      QCString result("Typ");
-      if (!singular)  result+="en";
-      return result;
+      return createNoun(true, singular, "Typ", "en");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1857,9 +1835,7 @@ class TranslatorGerman : public TranslatorAdapter_1_8_15
      */
     QCString trSubprogram(bool /*first_capital*/, bool singular) override
     {
-      QCString result("Unterprogramm");
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(true, singular, "Unterprogramm", "e");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -1601,9 +1601,7 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));   // "Module" : "module"));
-      if (!singular)  result+="er";  // "s";
-      return result;
+      return createNoun(first_capital, singular, "modul", "er");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1636,9 +1634,7 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Type" : "type"));   // "Type" : "type"
-      if (!singular)  result+="r";                          // "s"
-      return result;
+      return createNoun(first_capital, singular, "type", "r");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1647,9 +1643,7 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogram" : "subprogram"));   // "Subprogram" : "subprogram"
-      if (!singular)  result+="er";                                     // "s"
-      return result;
+      return createNoun(first_capital, singular, "subprogram", "er");
     }
 
     /*! C# Type Constraint list */
@@ -1783,22 +1777,6 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     QCString trDirDepGraph(const QCString &name) override
     {
       return QCString("Afhængighedsgraf for katalog ")+name+":";
-    }
-
-
-
-/*---------- For internal use: ----------------------------------------*/
-  protected:
-	/*! For easy flexible-noun implementation.
-	 *  \internal
-	 */
-    QCString createNoun(bool first_capital, bool singular,
-			const char* base, const char* plurSuffix)
-    {
-      QCString result(base);
-      if (first_capital) result[0] = static_cast<char>(toupper(result[0]));
-      if (!singular)  result+=plurSuffix;
-      return result;
     }
 };
 

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -1209,9 +1209,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Class" : "class"));
-      if (!singular)  result+="es";
-      return result;
+      return createNoun(first_capital, singular, "class", "es");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1220,9 +1218,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "File" : "file"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "file", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1231,9 +1227,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1242,9 +1236,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Module" : "module"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "module", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1253,9 +1245,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Page" : "page"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "page", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1264,9 +1254,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Member" : "member"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "member", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1275,9 +1263,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "global", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1288,9 +1274,7 @@ class TranslatorEnglish : public Translator
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Author" : "author"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "author", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1512,9 +1496,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Director" : "director"));
-      if (singular) result+="y"; else result+="ies";
-      return result;
+      return createNoun(first_capital, singular, "director", "ies", "y");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1693,9 +1675,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Module" : "module"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "module", "s");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1728,9 +1708,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Type" : "type"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "type", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1739,9 +1717,7 @@ class TranslatorEnglish : public Translator
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogram" : "subprogram"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "subprogram", "s");
     }
 
     /*! C# Type Constraint list */
@@ -2283,9 +2259,7 @@ class TranslatorEnglish : public Translator
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Concept" : "concept"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "concept", "s");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -1192,9 +1192,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klaso" : "klaso"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "klaso", "j");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1203,9 +1201,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Dosiero" : "dosiero"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "dosiero", "j");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1214,9 +1210,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Nomspaco" : "nomspaco"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "nomspaco", "j");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1225,9 +1219,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupo" : "grupo"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "grupo", "j");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1236,9 +1228,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Paĝo" : "paĝo"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "paĝo", "j");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1247,9 +1237,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Membro" : "membro"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "membro", "j");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1258,9 +1246,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Mallokalaĵo" : "mallokalaĵo"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "mallokalaĵo", "j");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1271,9 +1257,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Aŭtoro" : "aŭtoro"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "aŭtoro", "j");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1495,9 +1479,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Dosierujo" : "dosierujo"));
-      if (!singular) result+="j";
-      return result;
+      return createNoun(first_capital, singular, "dosierujo", "j");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1676,9 +1658,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modulo" : "modulo"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "modulo", "j");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1709,9 +1689,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tipo" : "tipo"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "tipo", "j");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1719,9 +1697,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogramo" : "subprogramo"));
-      if (!singular)  result+="j";
-      return result;
+      return createNoun(first_capital, singular, "subprogramo", "j");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -1331,9 +1331,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Clase" : "clase"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "clase", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1342,9 +1340,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Archivo" : "archivo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "archivo", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1353,8 +1349,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Espacio" : "espacio"));
-      if (!singular)  result+="s";
+      QCString result = createNoun(first_capital, singular, "espacio", "s");
       result+=" de nombres";
       return result;
     }
@@ -1365,9 +1360,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Módulo" : "módulo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "módulo", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1376,9 +1369,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Página" : "página"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "página", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1387,9 +1378,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Miembro" : "miembro"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "miembro", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1398,9 +1387,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="es";
-      return result;
+      return createNoun(first_capital, singular, "global", "es");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1411,9 +1398,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (!singular)  result+="es";
-      return result;
+      return createNoun(first_capital, singular, "autor", "es");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1647,9 +1632,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Directorio" : "directorio"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "directorio", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1829,9 +1812,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Módulo" : "módulo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "módulo", "s");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1865,9 +1846,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tipo" : "tipo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "tipo", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1876,9 +1855,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprograma" : "subprograma"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "subprograma", "s");
     }
 
     /*! C# Type Constraint list */
@@ -2426,9 +2403,7 @@ class TranslatorSpanish : public TranslatorAdapter_1_9_6
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Concepto" : "concepto"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "concepto", "s");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -93,13 +93,7 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
 
     QCString latexCommandName() override
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "xelatex";
-      }
-      return latex_command;
+      return p_latexCommandName("xelatex");
     }
 
     QCString trISOLang() override
@@ -1679,9 +1673,7 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Type" : "type"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "type", "s");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names

--- a/src/translator_fi.h
+++ b/src/translator_fi.h
@@ -1296,9 +1296,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Luokka" : "luokka")); // "Class" / "class"
-      if (!singular)  result=(first_capital ? "Luokat" : "luokat"); // "+es" -> "Classes" / "classes"
-      return result;
+      return createNoun(first_capital, singular, "luok", "at", "ka");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1307,9 +1305,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tiedosto" : "tiedosto")); // "File" / "file"
-      if (!singular)  result+="t"; // "+s" -> "Files" / "files"
-      return result;
+      return createNoun(first_capital, singular, "tiedosto", "t");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1318,9 +1314,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Nimiavaruus" : "nimiavaruus")); // "Namespace" / "namespace"
-      if (!singular)  result=(first_capital ? "Nimiavaruudet" : "nimiavaruudet"); // "+s"
-      return result;
+      return createNoun(first_capital, singular, "nimiavaruu", "det", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1329,9 +1323,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Ryhmä" : "ryhmä")); // "Group" / "group"
-      if (!singular)  result+="t"; // "+s"
-      return result;
+      return createNoun(first_capital, singular, "ryhmä", "t");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1340,9 +1332,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Sivu" : "sivu")); // "Page" / "page"
-      if (!singular)  result+="t"; // "+s"
-      return result;
+      return createNoun(first_capital, singular, "sivu", "t");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1351,9 +1341,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Jäsen" : "jäsen")); // "Member" / "member"
-      if (!singular)  result+="et"; // "+s"
-      return result;
+      return createNoun(first_capital, singular, "jäsen", "et");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1362,9 +1350,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globaali" : "globaali")); // "Global" / "global"
-      if (!singular)  result+="t"; // "+s"
-      return result;
+      return createNoun(first_capital, singular, "globaali", "t");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1375,9 +1361,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tekijä" : "tekijä")); // "Author" / "author"
-      if (!singular)  result+="t"; // "+s"
-      return result;
+      return createNoun(first_capital, singular, "tekijä", "t");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1600,9 +1584,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Hakemisto" : "hakemisto")); // "Director" / "director"
-      if (singular) result+=""; else result+="t"; // "+y" / "+ies"
-      return result;
+      return createNoun(first_capital, singular, "hakemisto", "t");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1784,9 +1766,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Moduuli" : "moduuli")); // "Module" / "module"
-      if (!singular)  result+="t"; // "+s"
-      return result;
+      return createNoun(first_capital, singular, "moduuli", "t");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1817,9 +1797,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tyyppi" : "tyyppi")); // "Type" / "type"
-      if (!singular)  result=(first_capital ? "Tyypit" : "tyypit"); // "+s"
-      return result;
+      return createNoun(first_capital, singular, "tyyp", "it", "pi");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1827,9 +1805,7 @@ class TranslatorFinnish : public TranslatorAdapter_1_6_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Aliohjelma" : "aliohjelma")); // "Subprogram" / "subprogram"
-      if (!singular)  result+="t"; // "+s"
-      return result;
+      return createNoun(first_capital, singular, "aliohjelma", "t");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -1262,9 +1262,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Classe" : "classe"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "classe", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1273,9 +1271,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Fichier" : "fichier"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "fichier", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1284,8 +1280,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Espace" : "espace"));
-      if (!singular)  result+="s";
+      QCString result = createNoun(first_capital, singular, "espace", "s");
       result+=" de nommage";
       return result;
     }
@@ -1296,9 +1291,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Groupe" : "groupe"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "groupe", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1307,9 +1300,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Page" : "page"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "page", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1318,9 +1309,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Membre" : "membre"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "membre", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1329,9 +1318,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globa" : "globa"));
-      if (!singular)  result+="ux(ales)"; else result+="l(e)";
-      return result;
+      return createNoun(first_capital, singular, "globa", "ux(ales)", "l(e)");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1342,9 +1329,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Auteur" : "auteur"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "auteur", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1566,9 +1551,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Répertoire" : "répertoire"));
-      if (singular) result+=""; else result+="s";
-      return result;
+      return createNoun(first_capital, singular, "répertoire", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1746,9 +1729,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Module" : "module"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "module", "s");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1781,9 +1762,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Type" : "type"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "type", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1792,9 +1771,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Sous-programme" : "sous-programme"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "sous-programme", "s");
     }
 
     /*! C# Type Constraint list */
@@ -2347,9 +2324,7 @@ class TranslatorFrench : public TranslatorAdapter_1_9_5
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Concept" : "concept"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "concept", "s");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -73,13 +73,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
 
     QCString latexCommandName() override
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "xelatex";
-      }
-      return latex_command;
+      return p_latexCommandName("xelatex");
     }
 
     QCString trISOLang() override

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -1191,9 +1191,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Κλάση" : "κλάση"));
-      if (!singular)  result+="";
-      return result;
+      return createNoun(first_capital, singular, "κλάση", "");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1202,9 +1200,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Αρχεί" : "αρχεί"));
-      if (!singular)  result+="α"; else result+="ο";
-      return result;
+      return createNoun(first_capital, singular, "αρχεί", "α", "ο");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1213,10 +1209,8 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Χ" : "χ"));
-      if (!singular)  result+="ώροι"; else result+="ώρος";
-	  result+=" ονομάτων";
-      return result;
+      return createNoun(first_capital, singular, "χ", "ώροι", "ώρος") + 
+	     " ονομάτων";
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1225,9 +1219,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Ομάδ" : "ομάδ"));
-      if (!singular)  result+="ες"; else result+="α";
-      return result;
+      return createNoun(first_capital, singular, "ομάδ", "ες", "α");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1236,9 +1228,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Σελίδ" : "σελίδ"));
-      if (!singular)  result+="ες"; else result+="α";
-      return result;
+      return createNoun(first_capital, singular, "σελίδ", "ες", "α");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1247,9 +1237,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Μέλ" : "μέλ"));
-      if (!singular)  result+="η"; else result+="ος";
-      return result;
+      return createNoun(first_capital, singular, "μέλ", "η", "ος");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1258,9 +1246,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Καθολικ" : "καθολικ"));
-      if (!singular) result+="ές"; else result+="ή";
-      return result;
+      return createNoun(first_capital, singular, "καθολικ", "ές", "ή");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1271,9 +1257,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Συγραφ" : "συγραφ"));
-      if (!singular)  result+=""; else result+="έας";
-      return result;
+      return createNoun(first_capital,singular,"συγραφ","","έας");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1495,9 +1479,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Κατάλογο" : "κατάλογο"));
-      if (singular) result+="ς"; else result+="ι";
-      return result;
+      return createNoun(first_capital, singular, "κατάλογο", "ι", "ς");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1676,9 +1658,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Υπομονάδ" : "υπομονάδ"));
-      if (!singular)  result+="ες"; else result+="α";
-      return result;
+      return createNoun(first_capital, singular, "υπομονάδ", "ες", "α");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1709,10 +1689,8 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Τύπο" : "τύπο"));
-      if (!singular)  result+="ι"; else result+="ος";
-      result+= first_capital ? " Δεδομένων" : "  δεδομένων";
-      return result;
+      return createNoun(first_capital, singular, "τύπο", "ι", "ος") + " " +
+             createNoun(first_capital, false, "δεδομένων", "");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1720,9 +1698,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Υποπρ" : "υποπρ"));
-      if (!singular)  result+="ογράμματα"; else result+="όγραμμα";
-      return result;
+      return createNoun(first_capital, singular, "υποπρ", "ογράμματα", "όγραμμα");
     }
 
     /*! C# Type Constraint list */
@@ -2267,9 +2243,7 @@ class TranslatorGreek : public TranslatorAdapter_1_11_0
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Έννοι" : "έννοι"));
-      result+=singular ? "α" : "ες";
-      return result;
+      return createNoun(first_capital, singular, "έννοι", "ες", "α");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_hi.h
+++ b/src/translator_hi.h
@@ -185,13 +185,7 @@ class TranslatorHindi : public TranslatorAdapter_1_9_4
 
     QCString latexCommandName() override
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "xelatex";
-      }
-      return latex_command;
+      return p_latexCommandName("xelatex");
     }
 
     QCString trISOLang() override

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -888,9 +888,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klas" : "klas"));
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "klas", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -899,9 +897,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Datotek" : "datotek"));
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "datotek", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -910,12 +906,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-		QCString result;
-		if (singular)
-			result = ((first_capital ? "Imenik" : "imenik"));
-		else
-			result = ((first_capital ? "Imenici" : "imenici"));
-      return result;
+      return createNoun(first_capital, singular, "imeni", "ci", "k");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -924,9 +915,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grup" : "grup"));
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "grup", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -935,9 +924,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Stranic" : "stranic"));
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "stranic", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -946,9 +933,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trMember(bool, bool singular) override
     {
-      QCString result("član");
-      if (!singular)  result+="ovi";
-      return result;
+      return createNoun(false, singular, "član", "ovi");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -957,13 +942,8 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "G" : "g"));
-	  if( singular )
-		  result += "lobalna varijabla";
-	  else
-		  result += "lobalne varijable";
-
-	  return result;
+      return createNoun(first_capital, singular, "globaln", "e", "a") + 
+             createNoun(false, singular, " varijabl", "e", "a");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -974,9 +954,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "autor", "i");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1199,9 +1177,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Direktorij" : "direktorij"));
-      if (!singular) result+="i";
-      return result;
+      return createNoun(first_capital, singular, "direktorij", "i");
     }
 //////////////////////////////////////////////////////////////////////////
 // new since 1.4.1
@@ -1378,9 +1354,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "modul", "i");
     }
     /*! This is put at the bottom of a module documentation page and is
     *  followed by a list of files that were used to generate the page.
@@ -1410,9 +1384,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tip" : "tip"));
-      if (!singular)  result+="ovi";
-      return result;
+      return createNoun(first_capital, singular, "tip", "ovi");
     }
     /*! This is used for translation of the word that will possibly
     *  be followed by a single name or by a list of names
@@ -1420,9 +1392,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogram" : "subprogram"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "subprogram", "i");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -1217,9 +1217,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trClass(bool first_capital, bool /* singular */) override
     {
-      QCString result((first_capital ? "Osztály" : "osztály"));
-      //if (!singular)  result+="ok";
-      return result;
+      return createNoun(first_capital, true, "osztály", "");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1228,9 +1226,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Fájl" : "fájl"));
-      if (!singular)  result+="ok";
-      return result;
+      return createNoun(first_capital, singular, "fájl", "ok");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1239,10 +1235,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result("");
-      if (!singular) result+=first_capital ? "Névterek" : "névterek";
-      else           result+=first_capital ? "Névtér"   : "névtér";
-      return result;
+      return createNoun(first_capital, singular, "névt", "erek", "ér");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1251,9 +1244,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="ok";
-      return result;
+      return createNoun(first_capital, singular, "modul", "ok");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1262,9 +1253,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Oldal" : "oldal"));
-      if (!singular)  result+="ak";
-      return result;
+      return createNoun(first_capital, singular, "oldal", "ak");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1273,9 +1262,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tag" : "tag"));
-      if (!singular)  result+="ok";
-      return result;
+      return createNoun(first_capital, singular, "tag", "ok");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1284,9 +1271,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globális elem" : "globális elem"));
-      if (!singular)  result+="ek";
-      return result;
+      return createNoun(first_capital, singular, "globális elem", "ek");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1297,9 +1282,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Szerző" : "szerző"));
-      if (!singular)  result+="k";
-      return result;
+      return createNoun(first_capital, singular, "szerző", "k");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1521,9 +1504,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trDir(bool first_capital, bool /*singular*/) override
     {
-      QCString result((first_capital ? "Könyvtár" : "könyvtár"));
-      //if (singular) result+="y"; else result+="ies";
-      return result;
+      return createNoun(first_capital, true, "könyvtár", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1701,9 +1682,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "modul", "s");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1737,9 +1716,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Típus" : "típus"));
-      if (!singular)  result+="ok";
-      return result;
+      return createNoun(first_capital, singular, "típus", "ok");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1748,9 +1725,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Alprogram" : "alprogram"));
-      if (!singular)  result+="ok";
-      return result;
+      return createNoun(first_capital, singular, "alprogram", "ok");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -1172,9 +1172,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Kelas" : "kelas"));
-      if (!singular) result+="-kelas";
-      return result;
+      return createNoun(first_capital, singular, "kelas", "-kelas");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1183,9 +1181,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "File" : "file"));
-      if (!singular) result+="-file";
-      return result;
+      return createNoun(first_capital, singular, "file", "-file");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1194,8 +1190,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trNamespace(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      return result;
+      return createNoun(first_capital, false, "namespace", "");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1204,9 +1199,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Kelompok" : "kelompok"));
-      if (!singular) result+="-kelompok";
-      return result;
+      return createNoun(first_capital, singular, "kelompok", "-kelompok");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1215,9 +1208,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Halaman" : "halaman"));
-      if (!singular) result+="-halaman";
-      return result;
+      return createNoun(first_capital, singular, "halaman", "-halaman");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1226,9 +1217,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Anggota" : "anggota"));
-      if (!singular) result+="-anggota";
-      return result;
+      return createNoun(first_capital, singular, "anggota", "-anggota");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1237,10 +1226,8 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Definisi" : "definisi"));
-      if (!singular)  result+="-definisi";
-      result += " global";
-      return result;
+      return createNoun(first_capital, singular, "definisi", "-definisi") + 
+                " global";
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1251,9 +1238,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "Penulis" : "penulis"));
-      //if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, false, "penulis", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1475,9 +1460,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trDir(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "Direktori" : "direktori"));
-      //if (singular) result+="y"; else result+="ies";
-      return result;
+      return createNoun(first_capital, false, "direktori", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1655,9 +1638,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="-modul";
-      return result;
+      return createNoun(first_capital, singular, "modul", "-modul");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1689,9 +1670,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tipe" : "tipe"));
-      if (!singular)  result+="-tipe";
-      return result;
+      return createNoun(first_capital, singular, "tipe", "-tipe");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1699,9 +1678,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogram" : "subprogram"));
-      if (!singular)  result+="-subprogram";
-      return result;
+      return createNoun(first_capital, singular, "subprogram", "-subprogram");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -1172,9 +1172,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Class" : "class"));
-      result+=(singular ? "e" : "i");
-      return result;
+      return createNoun(first_capital, singular, "class", "i", "e");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1183,8 +1181,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trFile(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "File" : "file"));
-      return result;
+      return createNoun(first_capital, false, "file", "");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1193,8 +1190,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trNamespace(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      return result;
+      return createNoun(first_capital, false, "namespace", "");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1203,9 +1199,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupp" : "grupp"));
-      result+=(singular ? "o" : "i");
-      return result;
+      return createNoun(first_capital, singular, "grupp", "i", "o");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1214,9 +1208,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Pagin" : "pagin"));
-      result+=(singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "pagin", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1225,9 +1217,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Membr" : "membr"));
-      result+=(singular ? "o" : "i");
-      return result;
+      return createNoun(first_capital, singular, "membr", "i", "o");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1236,9 +1226,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      result+=(singular ? "e" : "i");
-      return result;
+      return createNoun(first_capital, singular, "global", "i", "e");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1249,9 +1237,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      result+=(singular ? "e" : "i");
-      return result;
+      return createNoun(first_capital, singular, "autor", "i", "e");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1474,8 +1460,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trDir(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "Directory" : "directory"));
-      return result;
+      return createNoun(first_capital, false, "directory", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1654,10 +1639,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (singular) result+="o";
-      else result+="i";
-      return result;
+      return createNoun(first_capital, singular, "modul", "i", "o");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1688,10 +1670,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tip" : "tip"));
-      if (singular) result+="o";
-      else result+="i";
-      return result;
+      return createNoun(first_capital, singular, "tip", "i", "o");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1699,10 +1678,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Sottoprogramm" : "sottoprogramm"));
-      if (singular) result+="a";
-      else result+="i";
-      return result;
+      return createNoun(first_capital, singular, "sottoprogramm", "i", "a");
     }
 
     /*! C# Type Contraint list */

--- a/src/translator_ke.h
+++ b/src/translator_ke.h
@@ -43,13 +43,7 @@ class TranslatorKoreanEn : public TranslatorEnglish
     }
     QCString latexCommandName() override
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "xelatex";
-      }
-      return latex_command;
+      return p_latexCommandName("xelatex");
     }
 
     /*! Used as ansicpg for RTF fcharset

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -86,13 +86,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
     }
     QCString latexCommandName() override
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "xelatex";
-      }
-      return latex_command;
+      return p_latexCommandName("xelatex");
     }
     QCString trISOLang() override
     {

--- a/src/translator_lt.h
+++ b/src/translator_lt.h
@@ -1180,9 +1180,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klasė" : "klasė"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "klasė", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1191,10 +1189,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Faila" : "faila"));
-      if (!singular)  result+="i";
-      else  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "faila", "i", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1203,10 +1198,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Vardų srit" : "vardų srit"));
-      if (!singular)  result+="ys";
-      else  result+="is";
-      return result;
+      return createNoun(first_capital, singular, "vardų srit", "ys", "is");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1215,9 +1207,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupė" : "grupė"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "grupė", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1226,10 +1216,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Puslapi" : "puslapi"));
-      if (!singular)  result+="ai";
-      else  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "puslapi", "ai", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1238,10 +1225,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Nar" : "nar"));
-      if (!singular)  result+="iai";
-      else  result+="ys";
-      return result;
+      return createNoun(first_capital, singular, "nar", "iai", "ys");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1250,10 +1234,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="ūs";
-      else  result+="us";
-      return result;
+      return createNoun(first_capital, singular, "global", "ūs", "us");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1264,10 +1245,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autori" : "autori"));
-      if (!singular)  result+="ai";
-      else  result+="us";
-      return result;
+      return createNoun(first_capital, singular, "autori", "ai", "us");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1488,9 +1466,7 @@ class TranslatorLithuanian : public TranslatorAdapter_1_4_6
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Direktorij" : "direktorij"));
-      if (singular) result+="a"; else result+="os";
-      return result;
+      return createNoun(first_capital, singular, "direktorij", "os", "a");
     }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -1197,9 +1197,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klase" : "klase"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "klase", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1208,9 +1206,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Fail" : "fail"));
-      if (singular) result+="s"; else result+="i";
-      return result;
+      return createNoun(first_capital, singular, "fail", "i", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1219,9 +1215,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Nosaukumvieta" : "nosaukumvieta"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "nosaukumvieta", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1230,9 +1224,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupa" : "grupa"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "grupa", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1241,9 +1233,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Lapa" : "lapa"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "lapa", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1252,9 +1242,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Element" : "element"));
-      if (singular) result+="s"; else result+="i";
-      return result;
+      return createNoun(first_capital, singular, "element", "i", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1263,9 +1251,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globāl" : "globāl"));
-      if (singular) result+="ais"; else result+="ie";
-      return result;
+      return createNoun(first_capital, singular, "globāl", "ie", "ais");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1276,9 +1262,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (singular) result+="s"; else result+="i";
-      return result;
+      return createNoun(first_capital, singular, "autor", "i", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1500,9 +1484,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Direktorija" : "direktorija"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "direktorija", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1681,9 +1663,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modu" : "modu"));
-      if (singular) result+="lis"; else result+="ļi";
-      return result;
+      return createNoun(first_capital, singular, "modu", "ļi", "lis");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1716,9 +1696,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tip" : "tip"));
-      if (singular) result+="s"; else result+="i";
-      return result;
+      return createNoun(first_capital, singular, "tip", "i", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1727,9 +1705,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_8_4
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Apakšprogramma" : "apakšprogramma"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "apakšprogramma", "s");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -968,9 +968,7 @@ class TranslatorDutch : public Translator
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klasse" : "klasse"));
-      if (!singular)  result+="n";
-      return result;
+      return createNoun(first_capital, singular, "klasse", "n");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -979,9 +977,7 @@ class TranslatorDutch : public Translator
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Bestand" : "bestand"));
-      if (!singular)  result+="en";
-      return result;
+      return createNoun(first_capital, singular, "bestand", "en");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -990,9 +986,7 @@ class TranslatorDutch : public Translator
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1001,9 +995,7 @@ class TranslatorDutch : public Translator
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Groep" : "groep"));
-      if (!singular)  result+="en";
-      return result;
+      return createNoun(first_capital, singular, "groep", "en");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1012,9 +1004,7 @@ class TranslatorDutch : public Translator
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Pagina" : "pagina"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "pagina", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1023,9 +1013,7 @@ class TranslatorDutch : public Translator
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Member" : "member"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "member", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1034,9 +1022,7 @@ class TranslatorDutch : public Translator
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globale member" : "globale member"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "globale member", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1047,9 +1033,7 @@ class TranslatorDutch : public Translator
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Auteur" : "auteur"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "auteur", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1265,9 +1249,7 @@ class TranslatorDutch : public Translator
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Folder" : "folder"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "folder", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1426,9 +1408,7 @@ class TranslatorDutch : public Translator
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Module" : "module"));
-      if (!singular)  result+="n";
-      return result;
+      return createNoun(first_capital, singular, "module", "n");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1461,9 +1441,7 @@ class TranslatorDutch : public Translator
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Type" : "type"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "type", "s");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1471,9 +1449,7 @@ class TranslatorDutch : public Translator
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogramma" : "subprogramma"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "subprogramma", "s");
     }
 
     /*! C# Type Contraint list */
@@ -1947,9 +1923,7 @@ class TranslatorDutch : public Translator
 //////////////////////////////////////////////////////////////////////////
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Concept" : "concept"));
-      if (!singular) result+="en";
-      return result;
+      return createNoun(first_capital, singular, "concept", "en");
     }
 
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_no.h
+++ b/src/translator_no.h
@@ -1196,9 +1196,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klasse" : "klasse"));
-      if (!singular)  result+="r";
-      return result;
+      return createNoun(first_capital, singular, "klasse", "r");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1207,9 +1205,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Fil" : "fil"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "fil", "er");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1218,9 +1214,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Navnerom" : "navnerom"));
-      if (!singular)  result+="";
-      return result;
+      return createNoun(first_capital, false, "navnerom", "");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1229,9 +1223,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Gruppe" : "gruppe"));
-      if (!singular)  result+="r";
-      return result;
+      return createNoun(first_capital, singular, "gruppe", "r");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1240,9 +1232,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Side" : "side"));
-      if (!singular)  result+="r";
-      return result;
+      return createNoun(first_capital, singular, "side", "r");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1251,9 +1241,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Medlem" : "medlem"));
-      if (!singular)  result+="mer";
-      return result;
+      return createNoun(first_capital, singular, "medlem", "mer");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1262,9 +1250,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(first_capital, singular, "global", "e");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1275,9 +1261,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Forfatter" : "forfatter"));
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(first_capital, singular, "forfatter", "e");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1499,9 +1483,7 @@ class TranslatorNorwegian : public TranslatorAdapter_1_4_6
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Katalog" : "katalog"));
-      if (!singular) result+="er";
-      return result;
+      return createNoun(first_capital, singular, "katalog", "er");
     }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -1149,9 +1149,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klas" : "klas"));
-      result+=(singular ? "a" : "y");
-      return result;
+      return createNoun(first_capital, singular, "klas", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1160,9 +1158,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Plik" : "plik"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "plik", "i");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1171,10 +1167,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Przestrze" : "przestrze"));
-      result+=(singular ? "ń" : "nie");
-      result+=" nazw";
-      return result;
+      return createNoun(first_capital, singular, "przestrze", "nie", "ń") + " nazw";
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1183,9 +1176,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupa" : "grupa"));
-      result+=(singular ? "a" : "y");
-      return result;
+      return createNoun(first_capital, singular, "grupa", "y");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1194,9 +1185,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Stron" : "stron"));
-      result+=(singular ? "a" : "y");
-      return result;
+      return createNoun(first_capital, singular, "stron", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1205,9 +1194,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Składow" : "składow"));
-      result+=(singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "składow", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1216,9 +1203,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      result+=(singular ? "ny" : "ne");
-      return result;
+      return createNoun(first_capital, singular, "global", "ne", "ny");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1229,9 +1214,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Auto" : "auto"));
-      result += (singular) ? "r" : "rzy";
-      return result;
+      return createNoun(first_capital, singular, "autor", "zy");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1456,9 +1439,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Katalog" : "katalog"));
-      if (! singular) result+="i";
-      return result;
+      return createNoun(first_capital, singular, "katalog", "i");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1636,9 +1617,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Moduł" : "moduł"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "moduł", "y");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1669,9 +1648,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Typ" : "typ"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "typ", "y");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1679,9 +1656,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Podprogram" : "podprogram"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "podprogram", "y");
     }
 
     /*! C# Type Constraint list */
@@ -2229,9 +2204,7 @@ class TranslatorPolish : public TranslatorAdapter_1_11_0
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Koncept" : "koncept"));
-      if (!singular) result+="y";
-      return result;
+      return createNoun(first_capital, singular, "koncept", "y");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -1235,9 +1235,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Classe" : "classe"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "classe", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1246,9 +1244,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Ficheiro" : "ficheiro"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "ficheiro", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1257,9 +1253,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1268,9 +1262,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupo" : "grupo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "grupo", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1279,9 +1271,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Página" : "página"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "página", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1290,9 +1280,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Membro" : "membro"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "membro", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1301,9 +1289,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globa" : "globa"));
-      result+= singular? "l" : "ais";
-      return result;
+      return createNoun(first_capital, singular, "globa", "is", "l");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1314,9 +1300,7 @@ class TranslatorPortuguese : public Translator
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      if (!singular) result+="es";
-      return result;
+      return createNoun(first_capital, singular, "autor", "es");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1542,9 +1526,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Diretório" : "diretório"));
-      if (!singular) result+="s";
-      return result;
+      return createNoun(first_capital, singular, "diretório", "s");
     }
 //////////////////////////////////////////////////////////////////////////
 // new since 1.4.1
@@ -1722,9 +1704,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modulo" : "modulo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "modulo", "s");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1760,9 +1740,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tipo" : "tipo"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "tipo", "s");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1770,9 +1748,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprograma" : "subprograma"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "subprograma", "s");
     }
 
     /*! C# Type Contraint list */
@@ -2344,9 +2320,7 @@ class TranslatorPortuguese : public Translator
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-        QCString result((first_capital ? "Conceito" : "conceito"));
-        if (!singular) result+="s";
-        return result;
+      return createNoun(first_capital, singular, "conceito", "s");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -1201,9 +1201,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Clas" : "clas"));
-	result+= singular ? "a":"ele";
-      return result;
+      return createNoun(first_capital, singular, "clas", "ele", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1212,9 +1210,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Fişier" : "fişier"));
-	result+= singular ? "ul":"ele";
-      return result;
+      return createNoun(first_capital, singular, "fişier", "ele", "ul");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1223,9 +1219,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-	result+= singular ? "-ul":"-urile";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "-urile", "-ul");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1234,9 +1228,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grupu" : "grupu"));
-	result+= singular ? "l":"rile";
-      return result;
+      return createNoun(first_capital, singular, "grupu", "rile", "l");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1245,9 +1237,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Pagin" : "pagin"));
-	result+= singular ? "a":"ile";
-      return result;
+      return createNoun(first_capital, singular, "pagin", "ile", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1256,9 +1246,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Membr" : "membr"));
-	result+= singular ? "ul":"ii";
-      return result;
+      return createNoun(first_capital, singular, "membr", "ii", "ul");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1267,9 +1255,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(first_capital, singular, "global", "e");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1280,9 +1266,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-	result+= singular ? "ul":"ii";
-      return result;
+      return createNoun(first_capital, singular, "autor", "ii", "ul");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1507,9 +1491,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
       */
      QCString trDir(bool first_capital, bool singular) override
      {
-       QCString result((first_capital ? "Directo" : "directo"));
-       if (singular) result+="r"; else result="are";
-       return result;
+      return createNoun(first_capital, singular, "directo", "are", "r");
      }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1687,10 +1669,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (singular)  result+="ul";
-	  else result += "ele";
-      return result;
+      return createNoun(first_capital, singular, "modul", "ele", "ul");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1721,10 +1700,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tip" : "tip"));
-      if (singular)  result+="ul";
-	  else result += "urile";
-      return result;
+      return createNoun(first_capital, singular, "tip", "urile", "ul");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1732,10 +1708,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogram" : "subprogram"));
-      if (singular)  result+="ul";
-	  else result += "ele";
-      return result;
+      return createNoun(first_capital, singular, "subprogram", "ele", "ul");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_si.h
+++ b/src/translator_si.h
@@ -836,9 +836,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Razred" : "razred"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "razred", "i");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -847,10 +845,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Datotek" : "datotek"));
-      if (!singular)  result+="e";
-      else result += "a";
-      return result;
+      return createNoun(first_capital, singular, "datotek", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -859,9 +854,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Imenski prostor" : "imenski prostor"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "imenski prostor", "i");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -870,9 +863,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Skupina" : "skupina"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "skupina", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -881,9 +872,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Stran" : "stran"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "stran", "i");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -892,9 +881,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Element" : "element"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "element", "i");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -903,9 +890,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "global", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -916,9 +901,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Avtor" : "avtor"));
-      if (!singular)  result+="ji";
-      return result;
+      return createNoun(first_capital, singular, "avtor", "ji");
     }
 //////////////////////////////////////////////////////////////////////////
 // new since 1.2.11
@@ -1145,9 +1128,7 @@ class TranslatorSlovene : public TranslatorAdapter_1_4_6
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Imenik" : "imenik"));
-      if (singular) result+="i"; else result+="";
-      return result;
+      return createNoun(first_capital, singular, "imenik", "i");
     }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -1146,9 +1146,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tried" : "tried"));
-      result+=(singular ? "a" : "y");
-      return result;
+      return createNoun(first_capital, singular, "tried", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1157,9 +1155,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Súbor" : "súbor"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "súbor", "y");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1168,10 +1164,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Priestor" : "priestor"));
-      if (!singular)  result+="y";
-      result+=" mien";
-      return result;
+      return createNoun(first_capital, singular, "priestor", "y") + " mien";
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1180,9 +1173,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Skupin" : "skupin"));
-      result+=(singular ? "a" : "y");
-      return result;
+      return createNoun(first_capital, singular, "skupin", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1191,9 +1182,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Stránk" : "stránk"));
-      result+=(singular ? "a" : "y");
-      return result;
+      return createNoun(first_capital, singular, "stránk", "y", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1213,9 +1202,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globáln" : "globáln"));
-      result+=(singular ? "y" : "e");
-      return result;
+      return createNoun(first_capital, singular, "globáln", "e", "y");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1226,9 +1213,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      *	for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Auto" : "auto"));
-      result += (singular) ? "r" : "ri";
-      return result;
+      return createNoun(first_capital, singular, "autor", "i");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1456,10 +1441,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-        QCString result((first_capital ? "Adresár" : "adresár"));
-        if ( ! singular)
-            result += "e";
-        return result;
+      return createNoun(first_capital, singular, "adresár", "e");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1639,9 +1621,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "modul", "y");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1673,9 +1653,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Typ" : "typ"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "typ", "y");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1683,9 +1661,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Podprogram" : "podprogram"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "podprogram", "y");
     }
 
     /*! C# Type Contraint list */

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -1173,9 +1173,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result( (first_capital ? "Klas" : "klas") );
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "klas", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1184,9 +1182,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Datotek" : "datotek"));
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "datotek", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1195,10 +1191,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Prostor" : "prostor"));
-      result += (singular ? "" : "i");
-      result += " imena";
-      return result;
+      return createNoun(first_capital, singular, "prostor", "i") + " imena";
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1207,9 +1200,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grup" : "grup"));
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "grup", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1218,9 +1209,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Stran" : "stran"));
-      result+= (singular ? "a" : "e");
-      return result;
+      return createNoun(first_capital, singular, "stran", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1240,9 +1229,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Globalni " : "globalni "));
-      result+= (singular ? "podatak" : "podaci");
-      return result;
+      return createNoun(first_capital, singular, "globalni poda", "ci", "tak");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1253,9 +1240,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Autor" : "autor"));
-      result+= (singular ? "" : "i");
-      return result;
+      return createNoun(first_capital, singular, "autor", "i");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1477,9 +1462,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Direktorijum" : "direktorijum"));
-      if (!singular) result+="i";
-      return result;
+      return createNoun(first_capital, singular, "direktorijum", "i");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1658,9 +1641,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="i";
-      return result;
+      return createNoun(first_capital, singular, "modul", "i");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1691,9 +1672,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tip" : "tip"));
-      if (!singular)  result+="ovi";
-      return result;
+      return createNoun(first_capital, singular, "tip", "ovi");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1701,9 +1680,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Procedura" : "procedura"));
-      if (!singular)  result = (first_capital ? "Procedure" : "procedure");
-      return result;
+      return createNoun(first_capital, singular, "procedur", "e", "a");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -1309,9 +1309,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klass" : "klass"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "klass", "er");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1320,9 +1318,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Fil" : "fil"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "fil", "er");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1331,9 +1327,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namnrymd" : "namnrymd"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "namnrymd", "er");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1342,9 +1336,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "grupp", "er");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1353,12 +1345,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Sid" : "sid"));
-      if (singular)
-         result+="a";
-      else
-         result+="or";
-      return result;
+      return createNoun(first_capital, singular, "sid", "or", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1367,9 +1354,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Medlem" : "medlem"));
-      if (!singular)  result+="mar";
-      return result;
+      return createNoun(first_capital, singular, "medlem", "mar");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1378,9 +1363,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "global", "er");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1391,8 +1374,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool /*singular*/) override
     {
-      QCString result((first_capital ? "Författare" : "författare"));
-      return result;
+      return createNoun(first_capital, false, "författare", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1614,9 +1596,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Katalog" : "katalog"));
-      if (!singular) result+="er";
-      return result;
+      return createNoun(first_capital, singular, "katalog", "er");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1796,9 +1776,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-     QCString result((first_capital ? "Modul" : "modul"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "modul", "er");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1831,9 +1809,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Typ" : "typ"));
-      if (!singular)  result+="er";
-      return result;
+      return createNoun(first_capital, singular, "typ", "er");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1842,8 +1818,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
      */
     QCString trSubprogram(bool first_capital, bool /*singular*/) override
     {
-      QCString result((first_capital ? "Underprogram" : "underprogram"));
-      return result;
+      return createNoun(first_capital, false, "underprogram", "");
     }
 
     /*! C# Type Constraint list */
@@ -2393,8 +2368,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool /* singular */) override
     {
-      QCString result((first_capital ? "Koncept" : "koncept"));
-      return result;
+      return createNoun(first_capital, false, "koncept", "");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -1185,9 +1185,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Sınıf" : "sınıf"));
-      if (!singular)  result+="lar";
-      return result;
+      return createNoun(first_capital, singular, "sınıf", "lar");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1196,9 +1194,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Dosya" : "dosya"));
-      if (!singular)  result+="lar";
-      return result;
+      return createNoun(first_capital, singular, "dosya", "lar");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1207,9 +1203,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="\'ler";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "\'ler");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1218,9 +1212,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Grup" : "grup"));
-      if (!singular)  result+="lar";
-      return result;
+      return createNoun(first_capital, singular, "grup", "lar");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1229,9 +1221,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Sayfa" : "sayfa"));
-      if (!singular)  result+="lar";
-      return result;
+      return createNoun(first_capital, singular, "sayfa", "lar");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1243,6 +1233,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
       QCString result((first_capital ? "Üye" : "üye"));
       if (!singular)  result+="ler";
       return result;
+
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1251,9 +1242,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global değişken" : "global değişken"));
-      if (!singular)  result+="ler";
-      return result;
+      return createNoun(first_capital, singular, "global değişken", "ler");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1264,9 +1253,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Yazar" : "yazar"));
-      if (!singular)  result+="lar";
-      return result;
+      return createNoun(first_capital, singular, "yazar", "lar");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1488,9 +1475,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Dizin" : "dizin"));
-      if (!singular) result+="ler";
-      return result;
+      return createNoun(first_capital, singular, "dizin", "ler");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1668,9 +1653,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Modül" : "modül"));
-      if (!singular)  result+="ler";
-      return result;
+      return createNoun(first_capital, singular, "modül", "ler");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1702,9 +1685,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tip" : "tip"));
-      if (!singular)  result+="ler";
-      return result;
+      return createNoun(first_capital, singular, "tip", "ler");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1712,9 +1693,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Alt program" : "alt program"));
-      if (!singular)  result+="lar";
-      return result;
+      return createNoun(first_capital, singular, "alt program", "lar");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_vi.h
+++ b/src/translator_vi.h
@@ -87,13 +87,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
     }
     QCString latexCommandName() override
     {
-      QCString latex_command = Config_getString(LATEX_CMD_NAME);
-      if (latex_command.isEmpty()) latex_command = "latex";
-      if (Config_getBool(USE_PDFLATEX))
-      {
-        if (latex_command == "latex") latex_command = "xelatex";
-      }
-      return latex_command;
+      return p_latexCommandName("xelatex");
     }
     QCString trISOLang() override
     {
@@ -1208,9 +1202,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Class" : "class"));
-      if (!singular)  result+="es";
-      return result;
+      return createNoun(first_capital, singular, "class", "es");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1219,9 +1211,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "File" : "file"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "file", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1230,9 +1220,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1241,9 +1229,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Group" : "group"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "group", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1252,9 +1238,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Trang" : "trang"));
-      if (!singular)  result+="";
-      return result;
+      return createNoun(first_capital, singular, "trang", "");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1263,9 +1247,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Member" : "member"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "member", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1274,9 +1256,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "global", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1287,9 +1267,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tác giả" : "tác giả"));
-      if (!singular)  result+="";
-      return result;
+      return createNoun(first_capital, singular, "tác giả", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1511,8 +1489,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trDir(bool first_capital, bool) override
     {
-      QCString result((first_capital ? "Thư mục" : "thư mục"));
-      return result;
+      return createNoun(first_capital, false, "thư mục", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1691,9 +1668,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Module" : "module"));
-      if (!singular)  result+="";
-      return result;
+      return createNoun(first_capital, singular, "module", "");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1724,9 +1699,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Kiểu" : "kiểu"));
-      if (!singular)  result+="";
-      return result;
+      return createNoun(first_capital, false, "kiểu", "");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1734,9 +1707,7 @@ class TranslatorVietnamese : public TranslatorAdapter_1_6_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Chương trình con" : "chương trình con"));
-      if (!singular)  result+="";
-      return result;
+      return createNoun(first_capital, singular, "chương trình con", "");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_za.h
+++ b/src/translator_za.h
@@ -1173,9 +1173,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Klas" : "klas"));
-      if (!singular)  result+="se";
-      return result;
+      return createNoun(first_capital, singular, "klas", "se");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1184,9 +1182,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Leër" : "leër"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "leër", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1195,9 +1191,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Namespace" : "namespace"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "namespace", "s");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1206,9 +1200,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Groep" : "groep"));
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(first_capital, singular, "groep", "e");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1217,9 +1209,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Bladsy" : "bladsy"));
-      if (!singular)  result+="e";
-      return result;
+      return createNoun(first_capital, singular, "bladsy", "e");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1228,9 +1218,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Lid" : "lid"));
-      if (!singular)  result = (first_capital ? "Lede" : "lede");
-      return result;
+      return createNoun(first_capital, singular, "l", "ede", "id");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1239,9 +1227,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Global" : "global"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "global", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1252,9 +1238,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Outeur" : "outeur"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "outeur", "s");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1476,9 +1460,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Director" : "director"));
-      if (singular) result+="y"; else result+="ies";
-      return result;
+      return createNoun(first_capital, singular, "director", "ies", "y");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1657,9 +1639,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Module" : "module"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "module", "s");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1668,7 +1648,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
         bool single) override
     {
       // single is true implies a single file
-      QCString result="The documentation for this ";
+      QCString result="Die dokumentasie vir hierdie ";
       switch(compType)
       {
         case ClassDef::Class:      result+="module"; break;
@@ -1680,7 +1660,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
         case ClassDef::Exception:  result+="eksepsie"; break;
         default: break;
       }
-      result+=" is gegenereer vanaf die foldende leer";
+      result+=" is gegenereer vanaf die volgende leër";
       if (single) result+=":"; else result+="s:";
       return result;
     }
@@ -1690,9 +1670,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Tipe" : "tipe"));
-      if (!singular)  result+="s";
-      return result;
+      return createNoun(first_capital, singular, "tipe", "s");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1700,9 +1678,7 @@ class TranslatorAfrikaans : public TranslatorAdapter_1_6_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Subprogram" : "subprogram"));
-      if (!singular)  result+="me";
-      return result;
+      return createNoun(first_capital, singular, "subprogram", "me");
     }
 
     /*! C# Type Constraint list */


### PR DESCRIPTION
Remove some double logic:
- selection of the LaTeX engine (pdflatex / xelatex)
- plural / singular ; first capital letter  (based on the `createNoun` function in the Danish translator, extended to use in other translators)