### PR TITLE
Writing all debug output  to stderr

### DIFF
--- a/doc/arch.dox
+++ b/doc/arch.dox
@@ -251,6 +251,9 @@ Note that by running doxygen with `-d lex` you get information about which
 To see the information of the flex parser, which is compiled with the flex debug option,
 you have to specify `-d lex:<flex codefile>` when running doxygen.
 
+Note that the information with respect to the lex parsing goes to `stderr` and that the other
+debug output goes by default to `stdout` unless one uses `-d stderr`.
+
 <h3>Testing</h3>
 
 Doxygen has a small set of tests available to test, some, code integrity.

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -47,6 +47,7 @@ static std::map< std::string, Debug::DebugMask > s_labels =
   { "alias",              Debug::Alias              },
   { "entries",            Debug::Entries            },
   { "sections",           Debug::Sections           },
+  { "stderr",             Debug::Stderr             },
   { "lex",                Debug::Lex                },
   { "lex:code",           Debug::Lex_code           },
   { "lex:commentcnv",     Debug::Lex_commentcnv     },
@@ -71,6 +72,7 @@ static std::map< std::string, Debug::DebugMask > s_labels =
 };
 
 //------------------------------------------------------------------------
+static FILE *g_debugFile = stdout;
 
 Debug::DebugMask Debug::curMask = Debug::Quiet;
 int Debug::curPrio = 0;
@@ -81,7 +83,7 @@ void Debug::print(DebugMask mask,int prio,const char *fmt,...)
   {
     va_list args;
     va_start(args,fmt);
-    vfprintf(stdout, fmt, args);
+    vfprintf(g_debugFile, fmt, args);
     va_end(args);
   }
 }
@@ -103,7 +105,14 @@ static uint64_t labelToEnumValue(const QCString &l)
 bool Debug::setFlagStr(const QCString &lab)
 {
   uint64_t retVal = labelToEnumValue(lab);
-  curMask = static_cast<DebugMask>(curMask | retVal);
+  if (retVal == Debug::Stderr)
+  {
+    g_debugFile = stderr;
+  }
+  else
+  {
+    curMask = static_cast<DebugMask>(curMask | retVal);
+  }
   return retVal!=0;
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -45,6 +45,7 @@ class Debug
                      Alias             =             0x01'0000ULL,
                      Entries           =             0x02'0000ULL,
                      Sections          =             0x04'0000ULL,
+                     Stderr            =             0x08'0000ULL,
                      Lex               = 0x0000'FFFF'FF00'0000ULL, // all scanners combined
                      Lex_code          = 0x0000'0000'0100'0000ULL,
                      Lex_commentcnv    = 0x0000'0000'0200'0000ULL,


### PR DESCRIPTION
Creating the possibility to write all debug output to stderr so that all information is properly interleaved.