### PR TITLE
Removing double logic (part 2)

### DIFF
--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -1205,9 +1205,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Клас" : "клас"));
-      if (!singular)  result+="ове";
-      return result;
+      return createNoun(first_capital, singular, "клас", "ове");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1216,9 +1214,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Файл" : "файл"));
-      if (!singular)  result+="ове";
-      return result;
+      return createNoun(first_capital, singular, "файл", "ове");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1227,9 +1223,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Именн" : "именн"));
-	  result+=(singular ? "о пространство" : "и пространства");
-      return result;
+      return createNoun(first_capital, singular, "именн", "и пространства", "о пространство");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1238,9 +1232,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Груп" : "груп"));
-	  result+=(singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "груп", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1249,9 +1241,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Страниц" : "странц"));
-	  result+=(singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "страниц", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1260,9 +1250,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Член" : "член"));
-      if (!singular)  result+="ове";
-      return result;
+      return createNoun(first_capital, singular, "член", "ове");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1271,9 +1259,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Глобалн" : "глобалн"));
-	  result+=(singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "глобалн", "и", "а");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1284,9 +1270,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Автор" : "автор"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "автор", "и");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1508,9 +1492,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Директори" : "директори"));
-      if (singular) result+="я"; else result+="и";
-      return result;
+      return createNoun(first_capital, singular, "директори", "и", "я");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1689,9 +1671,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Модул" : "модул"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "модул", "и");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1724,9 +1704,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Тип" : "тип"));
-      if (!singular)  result+="ове";
-      return result;
+      return createNoun(first_capital, singular, "тип", "ове");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1735,9 +1713,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Подпрограм" : "подпрограм"));
-	  if (singular) result+="а:"; else result+="и:";
-      return result;
+      return createNoun(first_capital, singular, "подпрограм", "и:", "а:");
     }
 
     /*! C# Type Constraint list */
@@ -2279,9 +2255,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
     /** C++20 concept */
     QCString trConcept(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Концепци" : "концепци"));
-	  if (singular)  result+="я"; else result+="и";
-      return result;
+      return createNoun(first_capital, singular, "концепци", "и", "я");
     }
     /*! used as the title of the HTML page of a C++20 concept page */
     QCString trConceptReference(const QCString &conceptName) override

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -1385,9 +1385,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Člen" : "člen"));
-      if (!singular)  result += "y";
-      return result;
+      return createNoun(first_capital, singular, "člen", "y");
     }
 
     /*! ??? Jak to prelozit? Bylo by dobre, kdyby se ozval nekdo, kdo to pouziva.*/

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -1202,9 +1202,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trClass(bool, bool singular) override
     {
-      QCString result("클래스");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "클래스", "들");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1213,9 +1211,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trFile(bool, bool singular) override
     {
-      QCString result("파일");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "파일", "들");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1224,9 +1220,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trNamespace(bool, bool singular) override
     {
-      QCString result("네임스페이스");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "네임스페이스", "들");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1235,9 +1229,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trGroup(bool, bool singular) override
     {
-      QCString result("그룹");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "그룹", "들");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1246,9 +1238,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trPage(bool, bool singular) override
     {
-      QCString result("페이지");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "페이지", "들");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1257,9 +1247,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trMember(bool, bool singular) override
     {
-      QCString result("멤버");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "멤버", "들");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1268,9 +1256,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trGlobal(bool, bool singular) override
     {
-      QCString result("전역");
-      if (!singular)  result+="";
-      return result;
+      return createNoun(false, singular, "전역", "");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1281,9 +1267,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      *  for the author section in man pages. */
     QCString trAuthor(bool, bool singular) override
     {
-      QCString result("작성자");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "작성자", "들");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1505,9 +1489,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trDir(bool, bool singular) override
     {
-      QCString result("디렉토리");
-      if (singular) result+=""; else result+="들";
-      return result;
+      return createNoun(false, singular, "디렉토리", "들");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1686,9 +1668,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trModule(bool, bool singular) override
     {
-      QCString result("모듈");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "모듈", "들");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1721,9 +1701,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trType(bool, bool singular) override
     {
-      QCString result("타입");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "타입", "들");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1731,9 +1709,7 @@ class TranslatorKorean : public TranslatorAdapter_1_8_15
      */
     QCString trSubprogram(bool, bool singular) override
     {
-      QCString result("서브프로그램");
-      if (!singular)  result+="들";
-      return result;
+      return createNoun(false, singular, "서브프로그램", "들");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_mk.h
+++ b/src/translator_mk.h
@@ -1174,9 +1174,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Клас" : "клас"));
-      result += (singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "клас", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1185,9 +1183,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Датотек" : "датотек"));
-      result += (singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "датотек", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1196,9 +1192,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Им" : "им"));
-      result += (singular ? "е на простор" : "иња на простори");
-      return result;
+      return createNoun(first_capital, singular, "им", "иња на простори", "е на простор");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1207,9 +1201,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Груп" : "груп"));
-      result += (singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "груп", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1218,9 +1210,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Стран" : "стран"));
-      result += (singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "стран", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1229,9 +1219,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Член" : "член"));
-      if (!singular)  result+="ови";
-      return result;
+      return createNoun(first_capital, singular, "член", "ови");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1240,9 +1228,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Глобал" : "глобал"));
-      result += (singular ? "ен" : "ни");
-      return result;
+      return createNoun(first_capital, singular, "глобал", "ни", "ен");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1253,9 +1239,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Автор" : "автор"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "автор", "и");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1477,9 +1461,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Имени" : "имени"));
-      if (singular) result+="к"; else result+="ци";
-      return result;
+      return createNoun(first_capital, singular, "имени", "ци", "к");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1656,9 +1638,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Модул" : "модул"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "модул", "и");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1689,9 +1669,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Тип" : "тип"));
-      if (!singular)  result+="ови";
-      return result;
+      return createNoun(first_capital, singular, "тип", "ови");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1699,14 +1677,7 @@ class TranslatorMacedonian : public TranslatorAdapter_1_6_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Потпрограм" : "потпрограм"));
-      if (singular){
-		result+="а";
-      }else{
-      	result+="и";
-      }
-
-      return result;
+      return createNoun(first_capital, singular, "потпрограм", "и", "а");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -1151,9 +1151,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
       }
       else
       {
-        QCString result((first_capital ? "Класс" : "класс"));
-        if(!singular) result+="ы";
-        return result;
+      return createNoun(first_capital, singular, "класс", "ы");
       }
     }
 
@@ -1163,9 +1161,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Файл" : "файл"));
-      if (!singular)  result+="ы";
-      return result;
+      return createNoun(first_capital, singular, "файл", "ы");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1174,9 +1170,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Пространств" : "пространств"));
-      result+=(singular?"о имен":"а имен");
-      return result;
+      return createNoun(first_capital, singular, "пространств", "а имен", "о имен");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1185,9 +1179,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Групп" : "групп"));
-      result+=(singular ? "а" : "ы");
-      return result;
+      return createNoun(first_capital, singular, "групп", "ы", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1196,9 +1188,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Страниц" : "страниц"));
-      result+=(singular ? "а" : "ы");
-      return result;
+      return createNoun(first_capital, singular, "страниц", "ы", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1207,9 +1197,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Член" : "член"));
-      if (!singular)  result+="ы";
-      return result;
+      return createNoun(first_capital, singular, "член", "ы");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1218,9 +1206,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Глобальны" : "глобальны"));
-      result+=(singular ? "й" : "е");
-      return result;
+      return createNoun(first_capital, singular, "глобальны", "е", "й");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1231,9 +1217,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Автор" : "автор"));
-      if (!singular) result+="ы";
-      return result;
+      return createNoun(first_capital, singular, "автор", "ы");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1455,9 +1439,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Директори" : "директори"));
-      if (singular) result+="я"; else result+="и";
-      return result;
+      return createNoun(first_capital, singular, "директори", "и", "я");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1652,9 +1634,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Модул" : "модул"));
-      if (singular)  result+="ь"; else result+="и";
-      return result;
+      return createNoun(first_capital, singular, "модул", "и", "ь");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1685,9 +1665,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Тип" : "тип"));
-      if (!singular)  result+="ы";
-      return result;
+      return createNoun(first_capital, singular, "тип", "ы");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1695,9 +1673,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Подпрограмм" : "подпрограмм"));
-      if (singular)  result+="а"; else result+="ы";
-      return result;
+      return createNoun(first_capital, singular, "подпрограмм", "ы", "а");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_sc.h
+++ b/src/translator_sc.h
@@ -1210,9 +1210,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trClass(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Клас" : "клас"));
-      if (!singular)  result+="e"; else result+="a";
-      return result;
+      return createNoun(first_capital, singular, "клас", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1221,9 +1219,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Датотек" : "датотек"));
-      if (!singular)  result+="e"; else result+="a";
-      return result;
+      return createNoun(first_capital, singular, "датотек", "e", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1232,9 +1228,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Простор" : "простор"));
-      if (!singular)  result+="и имена"; else result+=" имена";
-      return result;
+      return createNoun(first_capital, singular, "простор", "и имена", " имена");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1243,9 +1237,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Груп" : "груп"));
-      if (!singular)  result+="е"; else result+="a";
-      return result;
+      return createNoun(first_capital, singular, "груп", "е", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1254,9 +1246,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Страниц" : "страниц"));
-      if (!singular)  result+="е"; else result += "a";
-      return result;
+      return createNoun(first_capital, singular, "страниц", "е", "a");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1265,9 +1255,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Члан" : "члан"));
-      if (!singular)  result+="ови";
-      return result;
+      return createNoun(first_capital, singular, "члан", "ови");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1276,9 +1264,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Глобалн" : "глобалн"));
-      if (!singular)  result+="а"; else result+="о";
-      return result;
+      return createNoun(first_capital, singular, "глобалн", "а", "о");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1289,9 +1275,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Аутор" : "аутор"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "аутор", "и");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1525,9 +1509,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Директоријум" : "директоријум"));
-      if (singular) result+=""; else result+="и";
-      return result;
+      return createNoun(first_capital, singular, "директоријум", "и");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1705,9 +1687,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Модул" : "модул"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "модул", "и");
     }
     /*! This is put at the bottom of a module documentation page and is
      *  followed by a list of files that were used to generate the page.
@@ -1738,9 +1718,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Тип" : "тип"));
-      if (!singular)  result+="ови";
-      return result;
+      return createNoun(first_capital, singular, "тип", "ови");
     }
     /*! This is used for translation of the word that will possibly
      *  be followed by a single name or by a list of names
@@ -1748,9 +1726,7 @@ class TranslatorSerbianCyrillic : public TranslatorAdapter_1_6_0
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Потпрограм" : "потпрограм"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "потпрограм", "и");
     }
 
     /*! C# Type Constraint list */

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -1190,9 +1190,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Člen" : "člen"));
-      if (!singular)  result+="y";
-      return result;
+      return createNoun(first_capital, singular, "člen", "y");
     }
 
     /*! This is used for translation of the word that will possibly

--- a/src/translator_sr.h
+++ b/src/translator_sr.h
@@ -1217,9 +1217,7 @@ class TranslatorSerbian : public TranslatorAdapter_1_6_0
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Član" : "član"));
-      result+= (singular ? "" : "ovi");
-      return result;
+      return createNoun(first_capital, singular, "član", "ovi");
     }
 
     /*! This is used for translation of the word that will possibly

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -1229,10 +1229,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Üye" : "üye"));
-      if (!singular)  result+="ler";
-      return result;
-
+      return createNoun(first_capital, singular, "üye", "ler");
     }
 
     /*! This is used for translation of the word that will possibly

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -1140,9 +1140,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
       }
       else
       {
-        QCString result((first_capital ? "Клас" : "клас"));
-        if(!singular) result+="и";
-        return result;
+      return createNoun(first_capital, singular, "клас", "и");
       }
     }
 
@@ -1152,9 +1150,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trFile(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Файл" : "файл"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "файл", "и");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1163,9 +1159,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trNamespace(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Прост" : "прост"));
-      result+=(singular?"ір імен":"ори імен");
-      return result;
+      return createNoun(first_capital, singular, "прост", "ори імен", "ір імен");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1174,9 +1168,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trGroup(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Груп" : "груп"));
-      result+=(singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "груп", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1185,9 +1177,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trPage(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Сторінк" : "сторінк"));
-      result+=(singular ? "а" : "и");
-      return result;
+      return createNoun(first_capital, singular, "сторінк", "и", "а");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1196,9 +1186,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trMember(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Елемент" : "елемент"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "елемент", "и");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1207,9 +1195,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trGlobal(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Глобальн" : "глобальн"));
-      result+=(singular ? "ий" : "і");
-      return result;
+      return createNoun(first_capital, singular, "глобальн", "і", "ий");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1220,9 +1206,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      *  for the author section in man pages. */
     QCString trAuthor(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Автор" : "автор"));
-      if (!singular) result+="и";
-      return result;
+      return createNoun(first_capital, singular, "автор", "и");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1447,11 +1431,9 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     /*! This returns the word directory with or without starting capital
      *  (\a first_capital) and in sigular or plural form (\a singular).
      */
-    QCString trDir(bool, bool singular) override
+    QCString trDir(bool first_capital, bool singular) override
     {
-      QCString result("Каталог");
-      if (!singular) result+="и";
-      return result;
+      return createNoun(first_capital, singular, "каталог", "и");
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1646,9 +1628,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trModule(bool first_capital, bool singular) override
     {
-    	    QCString result((first_capital ? "Модул" : "модул"));
-    	    result+=(singular? "ь": "і");
-      return result;
+      return createNoun(first_capital, singular, "модул", "і", "ь");
     }
 
     /*! This is put at the bottom of a module documentation page and is
@@ -1681,9 +1661,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trType(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Тип" : "тип"));
-      if (!singular)  result+="и";
-      return result;
+      return createNoun(first_capital, singular, "тип", "и");
     }
 
     /*! This is used for translation of the word that will possibly
@@ -1692,9 +1670,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
      */
     QCString trSubprogram(bool first_capital, bool singular) override
     {
-      QCString result((first_capital ? "Підпрограм" : "підпрограм"));
-      result+= (singular? "а": "и");
-      return result;
+      return createNoun(first_capital, singular, "підпрограм", "и", "а");
     }
 
     /*! C# Type Constraint list */


### PR DESCRIPTION
Remove some double logic:
- plural / singular ; first capital letter  (based on the `createNoun` function in the Danish translator, extended to use in other translators)