### PR TITLE
issue #10823 Inconsistencies on use of separating space before an [ or { in documentation and examples

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -2056,7 +2056,7 @@ ALIASES  = "english=\if english" \
   \endlatexonly
 
 <hr>
-\section cmdparam \\param [\<dir\>] <parameter-name> { parameter description }
+\section cmdparam \\param[\<dir\>] <parameter-name> { parameter description }
 
   \addindex \\param
   Starts a parameter description for a function parameter with name
@@ -2067,17 +2067,17 @@ ALIASES  = "english=\if english" \
 
   The \c \\param command has an optional attribute, \<dir\>, specifying the direction
   of the parameter. Possible values are "[in]", "[in,out]", and "[out]",
-  note the [square] brackets in this description. Note that the space between the command
-  and the \<dir\> is optional.
+  note the [square] brackets in this description. Note that it is plso ossible to have
+  whitespace between the command and the \<dir\>.
   When a parameter is both input and output, [in,out] is used as attribute.
   Here is an example for the function \c memcpy:
   \code
 /*!
  * Copies bytes from a source memory area to a destination memory area,
  * where both areas may not overlap.
- * @param [out] dest The memory area to copy to.
- * @param [in]  src  The memory area to copy from.
- * @param [in]  n    The number of bytes to copy
+ * @param[out] dest The memory area to copy to.
+ * @param[in]  src  The memory area to copy from.
+ * @param[in]  n    The number of bytes to copy
  */
 void memcpy(void *dest, const void *src, size_t n);
   \endcode

--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -2067,7 +2067,7 @@ ALIASES  = "english=\if english" \
 
   The \c \\param command has an optional attribute, \<dir\>, specifying the direction
   of the parameter. Possible values are "[in]", "[in,out]", and "[out]",
-  note the [square] brackets in this description. Note that it is plso ossible to have
+  note the [square] brackets in this description. Note that it is also possible to put
   whitespace between the command and the \<dir\>.
   When a parameter is both input and output, [in,out] is used as attribute.
   Here is an example for the function \c memcpy:

--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -2056,7 +2056,7 @@ ALIASES  = "english=\if english" \
   \endlatexonly
 
 <hr>
-\section cmdparam \\param '['dir']' <parameter-name> { parameter description }
+\section cmdparam \\param [\<dir\>] <parameter-name> { parameter description }
 
   \addindex \\param
   Starts a parameter description for a function parameter with name
@@ -2065,18 +2065,19 @@ ALIASES  = "english=\if english" \
   the documentation of this (or any other) parameter is missing or not
   present in the function declaration or definition.
 
-  The \c \\param command has an optional attribute, `dir`, specifying the direction
+  The \c \\param command has an optional attribute, \<dir\>, specifying the direction
   of the parameter. Possible values are "[in]", "[in,out]", and "[out]",
-  note the [square] brackets in this description.
+  note the [square] brackets in this description. Note that the space between the command
+  and the \<dir\> is optional.
   When a parameter is both input and output, [in,out] is used as attribute.
   Here is an example for the function \c memcpy:
   \code
 /*!
  * Copies bytes from a source memory area to a destination memory area,
  * where both areas may not overlap.
- * @param[out] dest The memory area to copy to.
- * @param[in]  src  The memory area to copy from.
- * @param[in]  n    The number of bytes to copy
+ * @param [out] dest The memory area to copy to.
+ * @param [in]  src  The memory area to copy from.
+ * @param [in]  n    The number of bytes to copy
  */
 void memcpy(void *dest, const void *src, size_t n);
   \endcode
@@ -2989,7 +2990,7 @@ Commands for displaying examples
   \ref cfg_example_path "EXAMPLE_PATH" tag of doxygen's configuration file.
 
 <hr>
-\section cmdhtmlinclude \\htmlinclude ["[block]"] <file-name>
+\section cmdhtmlinclude \\htmlinclude['[block]'] <file-name>
 
   \addindex \\htmlinclude
   This command includes the contents of the file \<file-name\> as is in the HTML documentation
@@ -3830,7 +3831,7 @@ class Receiver
   \sa section \ref cmdfcurlyopen "\\f{" and section \ref formulas "formulas".
 
 <hr>
-\section cmdhtmlonly \\htmlonly ["[block]"]
+\section cmdhtmlonly \\htmlonly['[block]']
 
   \addindex \\htmlonly
   Starts a block of text that only will be verbatim included in the


### PR DESCRIPTION
Making `\param`, `\htmlonly` and `\htmlinclude`  a bit more consistent