### PR TITLE
Warning for Fortran on `\code` command

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -469,7 +469,7 @@ FILEMASK  {VFILEMASK}|{HFILEMASK}
 
  /*------ ignore simple comment (not documentation yyextra->comments) */
 
-<*>"!"/[^<>\n]                         {  if (YY_START == String)
+<*>"!"/[^<>\n]                         {  if (YY_START == String || YY_START == DocCopyBlock)
                                           { yyextra->colNr -= (int)yyleng;
                                             REJECT;
                                           } // "!" is ignored in strings


### PR DESCRIPTION
When having a simple Fortran file like:
```
!> \file

!>
!!   \code
!!   test
!!   \endcode
!!
  SUBROUTINE h5epush_f()
  END SUBROUTINE h5epush_f
```
we get the warning like:
```
Error in file D:/speeltuin/bug_hdf5_ftn/H5Eff.F90 line: 12, state: 29(DocCopyBlock), starting command: '\code' probable line reference: 5
```
due to the fact that the "DocCopyBlock" is not properly seen as a "literal" line.

Looks like this case was not considered in:
```
Commit: 32157259252124e1efdbc64cde19c69b65eac7f2 [3215725]
Date: Friday, January 12, 2024 4:02:38 PM

issue #10552 thick space in latex formula causes error

The testing around the `docBlock` was missing some rules "formatted" blocks
```

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/15129506/example.tar.gz)

(Originally found for the hdf5 1.14.4-2 project by Fossies)
