### PR TITLE
Warning with ingroup command at end of alias

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2687,7 +2687,7 @@ void Markdown::Private::writeOneLineHeaderOrRuler(std::string_view data)
 
     if (hasLineBreak(data))
     {
-      out+="<br>";
+      out+="\\ilinebr<br>";
     }
     if (tmpSize != data.size()) out+='\n';
   }


### PR DESCRIPTION
When having the simple problem:
```

/** @defgroup dm dep mac */

/** @old{ONIGENC_MBCLEN_CHARFOUND_P} */
int fnmatch_helper()
{
}
```
with
```
QUIET = YES
ALIASES                = "old{1}=@ingroup dm"
INPUT = pp.c

```
we get the warning like:
```
pp.c:6: warning: Found non-existing group 'br' for the command '@ingroup', ignoring command
```

By first ending the command before adding the `<br>`

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/15141933/example.tar.gz)

(Found by Fossies for the ruby 3.2.4. package, warning occurred 14359 times)
