### PR TITLE
issue #10850 Incorrect links generated for cross-references with same name when using tagfiles

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9399,8 +9399,9 @@ void printSectionsTree()
   {
     for (const auto &si : SectionManager::instance())
     {
-      Debug::print(Debug::Sections,0,"Section = %s, file = %s, title = %s\n",
-            qPrint(si->label()),qPrint(si->fileName()),qPrint(si->title()));
+      Debug::print(Debug::Sections,0,"Section = %s, file = %s, title = %s, type = %d, ref = %s\n",
+            qPrint(si->label()),qPrint(si->fileName()),qPrint(si->title()),
+            si->type(),qPrint(si->ref()));
     }
   }
 }

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -1369,7 +1369,11 @@ void TagFileParser::addDocAnchors(const std::shared_ptr<Entry> &e,const std::vec
     }
     else
     {
-      p_warn("Duplicate anchor %s found",qPrint(ta.label));
+      //printf("Replace sectionInfo file=%s anchor=%s\n",
+      //    qPrint(ta->fileName),qPrint(ta->label));
+      SectionInfo *si=SectionManager::instance().replace(
+          ta.label,ta.fileName,-1,ta.title,
+          SectionType::Anchor,0,m_tagName);
     }
   }
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4973,6 +4973,7 @@ PageDef *addRelatedPage(const QCString &name,const QCString &ptitle,
       pd->setNestingLevel(0);
       pd->setPageScope(nullptr);
       pd->setTitle(title);
+      pd->setReference(QCString());
     }
     else // newPage
     {
@@ -4989,7 +4990,6 @@ PageDef *addRelatedPage(const QCString &name,const QCString &ptitle,
       pd->setReference(tagInfo->tagName);
       pd->setFileName(tagInfo->fileName);
     }
-
 
     if (gd) gd->addPage(pd);
 


### PR DESCRIPTION
- properly reset in case of reuse the page definition (util.cpp)
- when having multiple times (multiple tag files) with the same info warnings like `warning: Duplicate anchor md_README found` will occur, better to replace in that case and no warning (tagreader.cpp)
- better debug output (doxygen.cpp)