### PR TITLE
Don't import links from tags into crawl file

### DIFF
--- a/src/sitemap.cpp
+++ b/src/sitemap.cpp
@@ -135,12 +135,14 @@ void Crawlmap::addIndexFile(const QCString & fileName)
   p->crawl << "<a href=\"" << fn << "\"/>\n";
 }
 
-void Crawlmap::addContentsItem(bool, const QCString &, const QCString &,
+void Crawlmap::addContentsItem(bool, const QCString &, const QCString & ref,
                                const QCString & file, const QCString & anchor,
                                bool ,bool ,
                                const Definition *)
 {
-  if (!file.isEmpty())      // made file optional param - KPW
+  if (!file.isEmpty() && ref.isEmpty())      // made file optional param and
+                                             // don't olace links in crawl file imported
+                                             // by tags
   {
     std::string link;
     if (file[0]=='!' || file[0]=='^') // special markers for user defined URLs

--- a/src/sitemap.cpp
+++ b/src/sitemap.cpp
@@ -141,7 +141,7 @@ void Crawlmap::addContentsItem(bool, const QCString &, const QCString & ref,
                                const Definition *)
 {
   if (!file.isEmpty() && ref.isEmpty())      // made file optional param and
-                                             // don't olace links in crawl file imported
+                                             // don't place links in crawl file imported
                                              // by tags
   {
     std::string link;


### PR DESCRIPTION
When importing links through tagfiles these files are shown just with the name of the file in the crawl file and giving on link validation warnings like:
```
Processing      file:///.../html/doxygen_crawl.html

List of broken links and other issues:
file:///.../html/qobject.html
  Line: 27
  Code: 404 File `.../html/qobject.html' does not exist
 To do: The link is broken. Double-check that you have not made any typo,
        or mistake in copy-pasting. If the link points to a resource that
        no longer exists, you may want to remove or fix the link.
```

The crawl file should not go outside its own html directory and sub-directories

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/15261366/example.tar.gz)
