### PR TITLE
QT help problems with tag files

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2143,6 +2143,13 @@ void Config::checkAndCorrect(bool quiet, const bool check)
       err("GENERATE_QHP=YES requires QHP_VIRTUAL_FOLDER to be set. Using 'doc' as default!\n");
       Config_updateString(QHP_VIRTUAL_FOLDER,"doc");
     }
+    const StringVector &tagFileList = Config_getList(TAGFILES);
+    if (tagFileList.size() != 0)
+    {
+      err("When enabling %s the %s option should be empty. I'll adjust it for you.\n","GENERATE_QHP","TAGFILES");
+      const StringVector tagFileListEmpty;
+      Config_updateList(TAGFILES,tagFileListEmpty);
+    }
   }
 
   //------------------------

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -311,6 +311,7 @@ void Qhp::addContentsItem(bool /* isDir */, const QCString & name,
                           bool /* addToNavIndex */,
                           const Definition * /*def*/)
 {
+  static bool blankWritten = false;
   /*
   <toc>
     <section title="My Application Manual" ref="index.html">
@@ -324,6 +325,19 @@ void Qhp::addContentsItem(bool /* isDir */, const QCString & name,
   QCString f = file;
   if (!f.isEmpty() && f.at(0)=='^') return; // absolute URL not supported
 
+  if (f.isEmpty())
+  {
+    f = blankFileName;
+    addHtmlExtensionIfMissing(f);
+    if (!blankWritten)
+    {
+      QCString fileName = Config_getString(HTML_OUTPUT) + "/" + f;
+      std::ofstream blankFile = Portable::openOutputStream(fileName); // we just need an empty file
+      blankFile.close();
+      addFile(f);
+      blankWritten = true;
+    }
+  }
   QCString finalRef = makeRef(f, anchor);
   p->sectionTree.addSection(name,finalRef);
 }

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -27,6 +27,8 @@
 #include "textstream.h"
 #include "util.h"
 #include "portable.h"
+#include "language.h"
+#include "version.h"
 
 static inline void writeIndent(TextStream &t,int indent)
 {
@@ -333,6 +335,26 @@ void Qhp::addContentsItem(bool /* isDir */, const QCString & name,
     {
       QCString fileName = Config_getString(HTML_OUTPUT) + "/" + f;
       std::ofstream blankFile = Portable::openOutputStream(fileName); // we just need an empty file
+      if (!blankFile.is_open())
+      {
+        term("Could not open file %s for writing\n", qPrint(fileName));
+      }
+      TextStream blank;
+      blank.setStream(&blankFile);
+      blank << "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n";
+      blank << "<html xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"" + theTranslator->trISOLang() + "\">\n";
+      blank << "<head>\n";
+      blank << "<title>Validator / crawler helper</title>\n";
+      blank << "<meta http-equiv=\"Content-Type\" content=\"text/xhtml;charset=UTF-8\"/>\n";
+      blank << "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=11\"/>\n";
+    
+      blank << "<meta name=\"generator\" content=\"Doxygen " + getDoxygenVersion() + "\"/>\n";
+      blank << "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/>\n";
+      blank << "</head>\n";
+      blank << "<body>\n";
+      blank << "</body>\n";
+      blank << "</html>\n";
+      blank.flush();
       blankFile.close();
       addFile(f);
       blankWritten = true;

--- a/src/qhp.h
+++ b/src/qhp.h
@@ -46,6 +46,7 @@ class Qhp : public IndexIntf
 
     static inline const QCString qhpFileName = "index.qhp";
     static QCString getQchFileName();
+    static inline const QCString blankFileName = "doxygen_blank";
 
   private:
     void addFile(const QCString &);


### PR DESCRIPTION
The QT assistant has problems with files that are not directly included into its input file (i.e. the qch file).
- This happens when we use tag files, hence `TAGFILES` will be disabled when `GENERATE_QHP` is set
- When there are in the tree items that do not refer to a file (so `ref=""`) this also gives problems. hence replacing these with a placeholder `doxygen_blank` that is just an empty file and will be added when necessary.

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/15263524/example.tar.gz)
