### PR TITLE
bug 783580 hhc.exe fail when a class inherit a class from an external project

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1991,6 +1991,27 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     adjustBoolSetting(  depOption, "HTML_COPY_CLIPBOARD",  false  );
     adjustStringSetting(depOption, "HTML_FILE_EXTENSION", ".html");
     adjustColorStyleSetting(depOption);
+    const StringVector &tagFileList = Config_getList(TAGFILES);
+    StringVector tagFileListNew;
+    for (const auto &s : tagFileList)
+    {
+      bool isRelative = false;
+      int eqPos = s.find('=');
+      if (eqPos!=-1) // tag command contains a destination
+      {
+        QCString dest = s.c_str();
+        QCString destName = dest.right(dest.length()-eqPos-1).stripWhiteSpace();
+        if (!destName.isEmpty())
+        {
+          if (!(destName.left(5).lower() == "http:" || destName.left(6).lower() == "https:")) isRelative = true;
+        }
+      }
+      if (!isRelative) tagFileListNew.push_back(s);
+      else
+        err("When enabling %s the %s option should only contain destination with https / http addresses (not: %s). I'll adjust it for you.\n",
+            "GENERATE_HTMLHELP","TAGFILES",qPrint(s));
+    }
+    Config_updateList(TAGFILES,tagFileListNew);
   }
 
   // check for settings that are inconsistent with having INLINE_GROUPED_CLASSES enabled

--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -546,7 +546,7 @@ void HtmlHelp::decContentsDepth()
  */
 void HtmlHelp::addContentsItem(bool isDir,
                                const QCString &name,
-                               const QCString & /*ref*/,
+                               const QCString &ref,
                                const QCString &file,
                                const QCString &anchor,
                                bool /* separateIndex */,
@@ -573,6 +573,7 @@ void HtmlHelp::addContentsItem(bool isDir,
       addHtmlExtensionIfMissing(currFile);
       QCString currAnc = anchor;
       p->cts << "<param name=\"Local\" value=\"";
+      if (!ref.isEmpty()) p->cts << qPrint(externalRef("",ref,true));
       p->cts << currFile;
       if (p->prevFile == currFile && p->prevAnc.isEmpty() && currAnc.isEmpty())
       {


### PR DESCRIPTION
References to http / https destination addresses work, as indicated in the issue. Other protocols don't work and also relative path don't work / would require that the entire tree, of that project, would be added.

- prepend destination in the hhc file
- Remove non http / https destinations from `TAGFILES`

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/15274409/example.tar.gz)
