### PR TITLE
issue #10958 Markdown: unordered list

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1697,6 +1697,7 @@ static bool readIncludeFile(yyscan_t yyscanner,const QCString &inc,const QCStrin
     QCString oldRaiseLabel = yyextra->raiseLabel;
     yyextra->raiseLevel+=yyextra->raiseIncrement;
     yyextra->raiseLabel+=yyextra->raisePrefix;
+    lineNr--;
     QCString lineStr=" \\ilinebr \\ifile \""+absFileName+"\" \\iline " + std::to_string(lineNr);
     if (yyextra->raiseLevel>0)
     {
@@ -1706,12 +1707,14 @@ static bool readIncludeFile(yyscan_t yyscanner,const QCString &inc,const QCStrin
     {
       lineStr+=" \\iprefix \"" + yyextra->raiseLabel + "\"";
     }
-    lineStr+=" \\ilinebr ";
+    copyToOutput(yyscanner,lineStr.view());
+    insertCommentStart(yyscanner);
+    lineStr="\n";
     copyToOutput(yyscanner,lineStr.view());
 
     fs->fileName      = absFileName;
     fs->bufState      = YY_CURRENT_BUFFER;
-    fs->oldLineNr     = yyextra->lineNr;
+    fs->oldLineNr     = yyextra->lineNr-1;
     fs->oldFileName   = yyextra->fileName;
     fs->oldState      = yyextra->includeCtx;
     fs->oldFileBuf    = yyextra->inBuf;

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -348,7 +348,7 @@ REFWORD4       {REFWORD4_NOCV}{CVSPEC}?
 REFWORD        {FILEMASK}|{LABELID}|{REFWORD2}|{REFWORD3}|{REFWORD4}
 REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revision"|"Source"|"State")":"[^:\n$][^\n$]*"$"
-LINENR {BLANK}*[1-9][0-9]*
+LINENR {BLANK}*([1-9][0-9]*|"0")
 
 SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[0-9]{1,2})?)?
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6180,7 +6180,7 @@ QCString stripIndentation(const QCString &s)
 {
   if (s.isEmpty()) return s; // empty string -> we're done
 
-  //printf("stripIndentation: input=\n%s\n------\n",qPrint(s));
+  //printf("stripIndentation:\n%s\n------\n",qPrint(s));
   // compute minimum indentation over all lines
   const char *p=s.data();
   char c=0;
@@ -6232,24 +6232,11 @@ QCString stripIndentation(const QCString &s)
         indent++;
       }
     }
-    else if (c=='\\' && qstrncmp(p,"ilinebr ",8)==0)
-      // we also need to remove the indentation after a \ilinebr command at the end of a line
-    {
-      result << "\\ilinebr ";
-      p+=8;
-      int skipAmount=0;
-      for (int j=0;j<minIndent;j++) if (*(p+j)==' ') skipAmount++; // test to see if we have the indent
-      if (skipAmount==minIndent)
-      {
-        p+=skipAmount; // remove the indent
-      }
-    }
     else // copy anything until the end of the line
     {
       result << c;
     }
   }
-  //printf("stripIndentation: result=\n%s\n------\n",qPrint(result.str()));
 
   return result.str();
 }


### PR DESCRIPTION
In https://github.com/doxygen/doxygen/issues/10858#issuecomment-2105107315 a problem was mentioned regarding the `\include{doc}` command.

- getting to have proper indentations for further processing after insertion of a file / snippet (and adjusting line number because of extra `\n`).
- needed to support line number 0 as well for the `\iline` command

Extended example: [example.tar.gz](https://github.com/doxygen/doxygen/files/15282639/example.tar.gz)

