### PR TITLE
issue #10859 More restrictive block-id character set in Doxygen >= 1.10

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -137,6 +137,8 @@ struct commentcnvYY_state
   bool       isFixedForm = FALSE; // For Fortran
   std::deque<std::unique_ptr<commentcnv_FileState>> includeStack;
   std::vector<std::string> expandedAliases;
+  QCString snippetFileName;
+  QCString snippetName;
 };
 
 [[maybe_unused]] static const char *stateToString(int state);
@@ -184,6 +186,7 @@ MAILADDR   ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a
 %x ReadAliasArgs
 %x IncludeDoc
 %x SnippetDoc
+%x SnippetDocTag
 %x IncludeFile
 
 CMD ("\\"|"@")
@@ -1107,15 +1110,24 @@ SLASHopt [/]*
                                        BEGIN(yyextra->includeCtx);
                                      }
                                    }
-<SnippetDoc>({FILEMASK}|"\""[^\n\"]+"\""){B}+{ID} {
-                                     QCString fileName=yytext;
-                                     int i=fileName.findRev(' ');
-                                     if (i==-1) i=fileName.findRev('\t');
-                                     QCString blockId = "["+fileName.mid(i+1)+"]";
-                                     fileName=fileName.left(i).stripWhiteSpace();
-                                     //printf("yytext='%s' i=%d fileName='%s' blockId='%s'\n",yytext,i,qPrint(fileName),qPrint(blockId));
-                                     if (fileName == "this") fileName=yyextra->fileName;
-                                     if (readIncludeFile(yyscanner,fileName,blockId))
+<SnippetDoc>({FILEMASK}|"\""[^\n\"]+"\""){B}+ {
+                                     yyextra->snippetFileName=yytext;
+                                     yyextra->snippetFileName=yyextra->snippetFileName.stripWhiteSpace();
+                                     if (yyextra->snippetFileName == "this") yyextra->snippetFileName=yyextra->fileName;
+                                     yyextra->snippetName = "";
+                                     BEGIN(SnippetDocTag);
+                                   }
+<SnippetDocTag>[^\\\n]+            {
+                                     yyextra->snippetName += yytext;
+                                   }
+<SnippetDocTag>"\\"                {
+                                     yyextra->snippetName += yytext;
+                                   }
+<SnippetDocTag>(\n|"\\ilinebr")    {
+                                     for (int i=(int)yyleng-1;i>=0;i--) unput(yytext[i]);
+                                     yyextra->snippetName = yyextra->snippetName.stripWhiteSpace();
+                                     QCString blockId = "["+yyextra->snippetName+"]";
+                                     if (readIncludeFile(yyscanner,yyextra->snippetFileName,blockId))
                                      {
                                        BEGIN(IncludeFile);
                                      }
@@ -1124,6 +1136,7 @@ SLASHopt [/]*
                                        BEGIN(yyextra->includeCtx);
                                      }
                                    }
+
 <IncludeDoc,SnippetDoc>\n          {
 				     copyToOutput(yyscanner,yytext,yyleng);
                                      insertCommentStart(yyscanner);


### PR DESCRIPTION
Corrected block-id usage for `\snippet{doc}` conform "old" usage and usage with other `\snippet` commands (the later see doctokenizer.l).