### PR TITLE
Code sections in Perl documentation not expandable anymore

### DIFF
--- a/templates/html/dynsections.js
+++ b/templates/html/dynsections.js
@@ -23,6 +23,10 @@
  @licend  The above is the entire license notice for the JavaScript code in this file
  */
 
+function toggleVisibility(linkObj) {
+  return dynsection.toggleVisibility(linkObj);
+}
+
 let dynsection = {
 
   // helper function


### PR DESCRIPTION
In the Perl helper function (`doxygen-filter-perl`) for a long time already the function `toggleVisibility` was used to show the dedicated inline, collapsible, code. As of doxygen 1.10.o this doesn't work anymore as the `toggleVisibilty` is now in a `let` construct and should be used as `dynsection.toggleVisibility`. For compatibility adding a function `toggleVisibility` that calls `dynsection.toggleVisibility`.

(Seen when browsing the documentation of munin 2.0.76 on Fossies, see e.g. https://fossies.org/dox/munin-2.0.76/classMunin_1_1Master_1_1Group.html#abf1ed7eef12e91d10e0d0ed5a630d2dc)