### PR TITLE
Fixing compilation warnings

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -768,7 +768,7 @@ int Markdown::Private::processEmphasis1(std::string_view data, char c)
 
   while (i<size)
   {
-    int len = findEmphasisChar(data.substr(i), c, 1);
+    size_t len = findEmphasisChar(data.substr(i), c, 1);
     if (len==0) { return 0; }
     i+=len;
     if (i>=size) { return 0; }
@@ -799,7 +799,7 @@ int Markdown::Private::processEmphasis2(std::string_view data, char c)
 
   while (i<size)
   {
-    int len = findEmphasisChar(data.substr(i), c, 2);
+    size_t len = findEmphasisChar(data.substr(i), c, 2);
     if (len==0)
     {
       return 0;


### PR DESCRIPTION
Found warnings on 64-bit Windows:
```
warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
```