### PR TITLE
issue #10866 Exiting with exit code 1, no warnings, no errors when executed on Github Action

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11563,9 +11563,7 @@ static QCString createOutputDirectory(const QCString &baseDirName,
   Dir formatDir(result.str());
   if (!formatDir.exists() && !formatDir.mkdir(result.str()))
   {
-    err("Could not create output directory %s\n", qPrint(result));
-    cleanUpDoxygen();
-    exit(1);
+    term("Could not create output directory %s\n", qPrint(result));
   }
   return result;
 }
@@ -11816,10 +11814,8 @@ void parseInput()
       dir.setPath(Dir::currentDirPath());
       if (!dir.mkdir(outputDirectory.str()))
       {
-        err("tag OUTPUT_DIRECTORY: Output directory '%s' does not "
-            "exist and cannot be created\n",qPrint(outputDirectory));
-        cleanUpDoxygen();
-        exit(1);
+        term("tag OUTPUT_DIRECTORY: Output directory '%s' does not "
+             "exist and cannot be created\n",qPrint(outputDirectory));
       }
       else
       {

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -145,6 +145,10 @@ static void format_warn(const QCString &file,int line,const QCString &text)
   }
   if (g_warnBehavior == WARN_AS_ERROR_t::YES)
   {
+    if (g_warnFile != stderr && !Config_getBool(QUIET))
+    {
+      msg("See '%s' for the reason of termination.\n",qPrint(g_warnlogFile));
+    }
     Doxygen::terminating=true;
     exit(1);
   }
@@ -159,6 +163,11 @@ static void handle_warn_as_error()
       std::unique_lock<std::mutex> lock(g_mutex);
       QCString msgText = " (warning treated as error, aborting now)\n";
       fwrite(msgText.data(),1,msgText.length(),g_warnFile);
+      if (g_warnFile != stderr && !Config_getBool(QUIET))
+      {
+        // cannot use `msg` due to the mutex
+        fprintf(stdout,"See '%s' for the reason of termination.\n",qPrint(g_warnlogFile));
+      }
     }
     Doxygen::terminating=true;
     exit(1);
@@ -283,6 +292,11 @@ void term_(const char *fmt, ...)
       size_t l = strlen(g_errorStr);
       for (size_t i=0; i<l; i++) fprintf(g_warnFile, " ");
       fprintf(g_warnFile, "%s\n", "Exiting...");
+      if (!Config_getBool(QUIET))
+      {
+        // cannot use `msg` due to the mutex
+        fprintf(stdout,"See '%s' for the reason of termination.\n",qPrint(g_warnlogFile));
+      }
     }
   }
   Doxygen::terminating=true;


### PR DESCRIPTION
Giving a message together with the "Exiting..." text with reference to the warnings log file so the user knows where to look for the reason of termination. Replacing the `err` function at the appropriate places with `term`

Th message was also necessary when using `WARN_AS_ERROR = YES`