### PR TITLE
xmllint error in combination with addindex command

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -93,8 +93,7 @@ static QCString convertIndexWordToAnchor(const QCString &word)
           (c >= 'A' && c <= 'Z') || // ALPHA
           (c >= '0' && c <= '9') || // DIGIT
           c == '-' ||
-          c == '.' ||
-          c == '_'
+          c == '.'
          )
       {
         result += c;
@@ -102,7 +101,7 @@ static QCString convertIndexWordToAnchor(const QCString &word)
       else
       {
         char enc[4];
-        enc[0] = ';';
+        enc[0] = '_';
         enc[1] = hex[(c & 0xf0) >> 4];
         enc[2] = hex[c & 0xf];
         enc[3] = 0;


### PR DESCRIPTION
When running xmllint on the doxygen documentation we get quiet a few warnings like:
```
html/xmlcmds.html:165: element a: validity error : Syntax of value for attribute id of a is not valid
html/xmlcmds.html:165: element a: validity error : Syntax of value for attribute name of a is not valid
```
this is due to the change:
```
Commit: 7caef22ff015928793fb2de6624173467a401bd5 [7caef22]
Date: Friday, April 5, 2024 3:45:50 PM
Problem with colon inserted by `\addindex`
```
Where the `:` was replaced by a `;`, probably the usage of the `;` is an error in xmllint or the dtd  as I could not find a reference that the `;` is not allowed.

(Looks like the anchor is only used for the internal use in chm / qhp formats etc. and not for external referencing)