### PR TITLE
Warning in case of `0.` as start of a list.

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -279,7 +279,7 @@ MAILADDR2 {MAILWS}+{BLANK}+("at"|"AT"|"_at_"|"_AT_"){BLANK}+{MAILWS}+("dot"|"DOT
 OPTSTARS  ("/""/"{BLANK}*)?"*"*{BLANK}*
 LISTITEM  {BLANK}*[-]("#")?{WS}
 MLISTITEM {BLANK}*[+*]{WS}
-OLISTITEM {BLANK}*[1-9][0-9]*"."{BLANK}
+OLISTITEM ({BLANK}*[1-9][0-9]*"."{BLANK}|{BLANK}*"0."{BLANK})
 CLISTITEM {BLANK}*[-]{BLANK}*"\["[ xX]"\]"
 ENDLIST   {BLANK}*"."{BLANK}*(\n|"\\ilinebr")
 ATTRNAME  [a-z_A-Z\x80-\xFF][:a-z_A-Z0-9\x80-\xFF\-]*


### PR DESCRIPTION
When having an example like:
```
\mainpage The mainpage

Steps:

0. First step
  - sub step
1. Second step
```
we get a warnings like:
```
aa.md:7: warning: Invalid list item found
```
this is due to the fact that `0.` is not recognized as start of a list.

There is no objection against having `0.` as start of a list, added it.

When not having the sub element the `0. ...`  is seen just as regular text.

(Note due to the documented way doxygen handles the list numbering, the `0.` is shown as `1.` and the original `1.` as `2.`).

Example: [example.tar.gz](https://github.com/doxygen/doxygen/files/15389946/example.tar.gz)

(Found by Fossies for the Gymnasium package)

