### PR TITLE
Remove temporary file

### DIFF
--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -75,6 +75,10 @@ void writeDiaGraphFromFile(const QCString &inFile,const QCString &outDir,
     {
       err("Problems running epstopdf. Check your TeX installation!\n");
     }
+    else
+    {
+      Dir().remove((outFile + ".eps").data());
+    }
   }
 
 error:

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -29,6 +29,7 @@
 #include "classlist.h"
 #include "textstream.h"
 #include "growbuf.h"
+#include "dir.h"
 
 //-----------------------------------------------------------------------------
 
@@ -1356,6 +1357,10 @@ void ClassDiagram::writeFigure(TextStream &output,const QCString &path,
     {
        err("Problems running epstopdf. Check your TeX installation!\n");
        return;
+    }
+    else
+    {
+      Dir().remove((epsBaseName + ".eps").data());
     }
   }
 }

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -179,6 +179,10 @@ QCString DocParser::findAndCopyImage(const QCString &fileName, DocImage::Type ty
       {
 	err("Problems running epstopdf. Check your TeX installation!\n");
       }
+      else
+      {
+        Dir().remove((outputDir + "/" + baseName + ".eps").data());
+      }
       return baseName;
     }
   }

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -196,6 +196,10 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
       err_full(srcFile,srcLine,"Problems running epstopdf when processing '%s.eps'. Check your TeX installation!",
           qPrint(absOutFile));
     }
+    else
+    {
+      Dir().remove((absOutFile + ".eps").data());
+    }
   }
 
   int i=std::max(imgName.findRev('/'),imgName.findRev('\\'));

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -299,6 +299,10 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
             {
               err_full(nb.srcFile,nb.srcLine,"Problems running epstopdf. Check your TeX installation! Exit code: %d.",exitCode);
             }
+            else
+            {
+              Dir().remove((pumlOutDir + QCString(str) + ".eps").data());
+            }
           }
         }
       }


### PR DESCRIPTION
When using  `HAVE_DOT=NO` the internal doxygen generator for class type diagrams a temporary `eps` file is created in the latex directory to generate the `pdf` file (`epstopdf`) this is now removed when `epstopdf` is successful.