### PR TITLE
Fix buffer overflow in Markdown parser

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -661,6 +661,11 @@ size_t Markdown::Private::findEmphasisChar(std::string_view data, char c, size_t
                      data[i]!='\\' && data[i]!='@' &&
                      !(data[i]=='/' && data[i-1]=='<') && // html end tag also ends emphasis
                      data[i]!='\n') i++;
+    // avoid overflow (unclosed emph token)
+    if (i==size)
+    {
+      return 0;
+    }
     //printf("findEmphasisChar: data=[%s] i=%d c=%c\n",data,i,data[i]);
 
     // not counting escaped chars or characters that are unlikely


### PR DESCRIPTION
This fixes a buffer overflow that happened when parsing a bad Markdown file with an unclosed emphasis nested in other elements, such as

```markdown
> __af_err af_flip(af_array *out, const af_array in, const unsigned dim)__
```

This snippet comes from the ArrayFire repository [1]. The problem was found after the refactoring [2] that introduced std::string_view in the code. The `std::string_view::operator[]` has bounds checking enabled when the macro `_GLIBCXX_ASSERTIONS` is defined, which is the case of Arch Linux build system.

[1] https://github.com/arrayfire/arrayfire/blob/0a25d36238aa1eee3b775d3584937ca65b0a1807/docs/pages/matrix_manipulation.md
[2] https://github.com/doxygen/doxygen/commit/f4e37514325abe4aa6aeecbc96e9e3e027885aef