### PR TITLE
fix: use correct option name with system sqlite3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(
 if (NOT use_sys_spdlog)
     include_directories(${PROJECT_SOURCE_DIR}/deps/spdlog/include)
 endif()
-if (NOT use_sys_sqlite)
+if (NOT use_sys_sqlite3)
     include_directories(${PROJECT_SOURCE_DIR}/deps/sqlite3)
 endif()
 


### PR DESCRIPTION
This PR fixes a typo in `src/CMakeLists.txt` that caused the bundled sqlite3 include directory to be used instead of the system include directory.