### PR TITLE
issue #10902 Improve Markdown Support - blockquotes with special markers parse wrongly

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2782,7 +2782,12 @@ size_t Markdown::Private::writeBlockQuote(std::string_view data)
     }
     if (level==0) break; // end of quote block
     // copy line without quotation marks
-    if (curLevel != 0 || !isGitHubAlert) out+=data.substr(indent,end-indent);
+    if (curLevel != 0 || !isGitHubAlert)
+    {
+      QCString txt = data.substr(indent,end-indent);
+      if (txt.stripWhiteSpace().isEmpty() && !startCmd.isEmpty()) out += "<br><br>\n";
+      else out += txt;
+    }
     else out+= "\n";
     curLevel=level;
     // proceed with next line


### PR DESCRIPTION
In case of a line after the "indentation" only contains white space replace it wit `<br><br>` analogous to what happens with blockquotes and on GitHub.