### PR TITLE
issue #10906 Unable to resolve reference to 'some/path/README.md' for \ref command

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -693,7 +693,7 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
   ASSERT(!target.isEmpty());
   m_relPath = parser->context.relPath;
   const SectionInfo *sec = SectionManager::instance().find(parser->context.prefix+target);
-  if (sec==nullptr && parser->context.lang==SrcLangExt::Markdown) // lookup as markdown file
+  if (sec==nullptr && getLanguageFromFileName(target)==SrcLangExt::Markdown) // lookup as markdown file
   {
     sec = SectionManager::instance().find(markdownFileNameToId(target));
   }


### PR DESCRIPTION
The `target` can also be a filename so this has to be checked independent of the language of the file where the link is (here it is in `Mainpage.hpp` so the Cpp language will be returned!).

(see also analyses with the issue)