### PR TITLE
issue #10907 Cite command creates case sensitivity on name

### DIFF
--- a/src/cite.cpp
+++ b/src/cite.cpp
@@ -79,14 +79,14 @@ void CitationManager::insert(const QCString &label)
 {
   p->entries.insert(
       std::make_pair(
-        label.str(),
-        std::make_unique<CiteInfoImpl>(label)
+        label.lower().str(),
+        std::make_unique<CiteInfoImpl>(label.lower())
       ));
 }
 
 const CiteInfo *CitationManager::find(const QCString &label) const
 {
-  auto it = p->entries.find(label.str());
+  auto it = p->entries.find(label.lower().str());
   if (it!=p->entries.end())
   {
     return it->second.get();
@@ -179,6 +179,7 @@ void CitationManager::insertCrossReferencesForBibFile(const QCString &bibFile)
             k = line.find(',');
           }
         }
+        citeName = citeName.lower();
       }
       //printf("citeName = #%s#\n",qPrint(citeName));
     }
@@ -188,7 +189,7 @@ void CitationManager::insertCrossReferencesForBibFile(const QCString &bibFile)
       int k = line.find('}',i);
       if (j>i && k>j)
       {
-        QCString crossrefName = line.mid(static_cast<size_t>(j+1),static_cast<uint32_t>(k-j-1));
+        QCString crossrefName = line.mid(static_cast<size_t>(j+1),static_cast<uint32_t>(k-j-1)).lower();
         // check if the reference with the cross reference is used
         // insert cross reference when cross reference has not yet been added.
         if ((p->entries.find(citeName.str())!=p->entries.end()) &&

--- a/testing/012/citelist.xml
+++ b/testing/012/citelist.xml
@@ -9,17 +9,17 @@
       <para>
         <variablelist>
           <varlistentry>
-            <term><anchor id="citelist_1CITEREF_Be09"/>[1]</term>
+            <term><anchor id="citelist_1CITEREF_be09"/>[1]</term>
           </varlistentry>
           <listitem>
-            <para>P.<nonbreakablespace/>Belotti. <ulink url="https://link.springer.com/10.1007/978-1-4614-1927-3_5">Disjunctive cuts for non-convex MINLP</ulink>. In <ulink url="#CITEREF_LeLe12">Lee and Leyffer</ulink> <ulink url="#CITEREF_LeLe12">[4]</ulink>, pages 117<ndash/>144.</para>
+            <para>P.<nonbreakablespace/>Belotti. <ulink url="https://link.springer.com/10.1007/978-1-4614-1927-3_5">Disjunctive cuts for non-convex MINLP</ulink>. In <ulink url="#CITEREF_lele12">Lee and Leyffer</ulink> <ulink url="#CITEREF_lele12">[4]</ulink>, pages 117<ndash/>144.</para>
             <para/>
           </listitem>
           <varlistentry>
-            <term><anchor id="citelist_1CITEREF_BertholdHeinzVigerske2009"/>[2]</term>
+            <term><anchor id="citelist_1CITEREF_bertholdheinzvigerske2009"/>[2]</term>
           </varlistentry>
           <listitem>
-            <para>T.<nonbreakablespace/>Berthold, S.<nonbreakablespace/>Heinz, and S.<nonbreakablespace/>Vigerske. <ulink url="https://link.springer.com/10.1007/978-1-4614-1927-3_15">Extending a CIP framework to solve MIQCPs</ulink>. In <ulink url="#CITEREF_LeLe12">Lee and Leyffer</ulink> <ulink url="#CITEREF_LeLe12">[4]</ulink>, pages 427<ndash/>444.</para>
+            <para>T.<nonbreakablespace/>Berthold, S.<nonbreakablespace/>Heinz, and S.<nonbreakablespace/>Vigerske. <ulink url="https://link.springer.com/10.1007/978-1-4614-1927-3_15">Extending a CIP framework to solve MIQCPs</ulink>. In <ulink url="#CITEREF_lele12">Lee and Leyffer</ulink> <ulink url="#CITEREF_lele12">[4]</ulink>, pages 427<ndash/>444.</para>
             <para/>
           </listitem>
           <varlistentry>
@@ -30,7 +30,7 @@
             <para/>
           </listitem>
           <varlistentry>
-            <term><anchor id="citelist_1CITEREF_LeLe12"/>[4]</term>
+            <term><anchor id="citelist_1CITEREF_lele12"/>[4]</term>
           </varlistentry>
           <listitem>
             <para>Jon Lee and Sven Leyffer, editors. <ulink url="https://link.springer.com/10.1007/978-1-4614-1927-3"><emphasis>Mixed Integer Nonlinear Programming</emphasis></ulink>, volume 154 of <emphasis>The IMA Volumes in Mathematics and its Applications</emphasis>. Springer, 2012.</para>

--- a/testing/012/indexpage.xml
+++ b/testing/012/indexpage.xml
@@ -7,7 +7,7 @@
     </briefdescription>
     <detaileddescription>
       <para>See <ref refid="citelist_1CITEREF_knuth79" kindref="member">[3]</ref> for more info.</para>
-      <para>Other references with cross references see <ref refid="citelist_1CITEREF_Be09" kindref="member">[1]</ref> and <ref refid="citelist_1CITEREF_BertholdHeinzVigerske2009" kindref="member">[2]</ref> for more info. </para>
+      <para>Other references with cross references see <ref refid="citelist_1CITEREF_be09" kindref="member">[1]</ref> and <ref refid="citelist_1CITEREF_bertholdheinzvigerske2009" kindref="member">[2]</ref> for more info. </para>
     </detaileddescription>
     <location file="012_cite.dox"/>
   </compounddef>


### PR DESCRIPTION
Relaxing the restriction regarding the case sensitivity of the citation label. The name `CITEREF` is a doxygen name so it can be changed as well (tests).