### PR TITLE
markdown: fix emphasis with extra characters

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -78,11 +78,12 @@ enum class ExplicitPageResult
    (c>='0' && c<='9') || \
    (static_cast<unsigned char>(c)>=0x80)) // unicode characters
 
+// is character allowed right at the beginning of an emphasis section
 #define extraChar(c) \
   (c=='-' || c=='+' || c=='!' || \
    c=='?' || c=='$' || c=='@' || \
    c=='&' || c=='*' || c=='%' || \
-   c=='[')
+   c=='[' || c=='(')
 
 // is character at position i in data allowed before an emphasis section
 #define isOpenEmphChar(c) \

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -81,7 +81,8 @@ enum class ExplicitPageResult
 #define extraChar(c) \
   (c=='-' || c=='+' || c=='!' || \
    c=='?' || c=='$' || c=='@' || \
-   c=='&' || c=='*' || c=='%')
+   c=='&' || c=='*' || c=='%' || \
+   c=='[')
 
 // is character at position i in data allowed before an emphasis section
 #define isOpenEmphChar(c) \
@@ -1058,8 +1059,8 @@ int Markdown::Private::processEmphasis(std::string_view data,size_t offset)
   const size_t size = data.size();
 
   if ((offset>0 && !isOpenEmphChar(data.data()[-1])) || // invalid char before * or _
-      (size>1 && data[0]!=data[1] && !(isIdChar(data[1]) || extraChar(data[1]) || data[1]=='[')) || // invalid char after * or _
-      (size>2 && data[0]==data[1] && !(isIdChar(data[2]) || extraChar(data[2]) || data[2]=='[')))   // invalid char after ** or __
+      (size>1 && data[0]!=data[1] && !(isIdChar(data[1]) || extraChar(data[1]))) || // invalid char after * or _
+      (size>2 && data[0]==data[1] && !(isIdChar(data[2]) || extraChar(data[2]))))   // invalid char after ** or __
   {
     return 0;
   }
@@ -3620,4 +3621,3 @@ void MarkdownOutlineParser::parsePrototype(const QCString &text)
 }
 
 //------------------------------------------------------------------------
-

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -85,7 +85,7 @@ enum class ExplicitPageResult
    c=='&' || c=='*' || c=='%' || \
    c=='[' || c=='(' || c=='.' || \
    c=='>' || c==':' || c==',' || \
-   c==';')
+   c==';' || c=='\'' || c=='"')
 
 // is character at position i in data allowed before an emphasis section
 #define isOpenEmphChar(c) \

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -83,7 +83,9 @@ enum class ExplicitPageResult
   (c=='-' || c=='+' || c=='!' || \
    c=='?' || c=='$' || c=='@' || \
    c=='&' || c=='*' || c=='%' || \
-   c=='[' || c=='(')
+   c=='[' || c=='(' || c=='.' || \
+   c=='>' || c==':' || c==',' || \
+   c==';')
 
 // is character at position i in data allowed before an emphasis section
 #define isOpenEmphChar(c) \


### PR DESCRIPTION
This fixes a number of problems with emphasis in markdown, specifically #10696 #8900 #8902. 

With these changes applied out of [this @RochaStratovan's comment](https://github.com/doxygen/doxygen/issues/8900#issuecomment-974549812) the situation with problematic rendering looks currently like this:

![Screenshot_20240530_221854](https://github.com/doxygen/doxygen/assets/7935057/cade32c0-34be-4695-a1d3-97ec75ebbe22)