### PR TITLE
issue #10606 include command via ALIASES does not work anymore (snippetdoc)

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1187,11 +1187,11 @@ SLASHopt [/]*
 <CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>[\\@][a-z_A-Z][a-z_A-Z0-9-]*  { // expand alias without arguments
 				     replaceAliases(yyscanner,yytext,YY_START==ReadLine && yyextra->readLineCtx==SComment);
   				   }
-<CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>{B}[\\@]"ialias{" { // expand alias with arguments
+<CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>{B}"\\ilinebr"{B}[\\@]"ialias{" { // expand alias with arguments
 				     yyextra->lastBlockContext=YY_START;
 				     yyextra->blockCount=1;
-				     yyextra->aliasString=yytext+1;
-				     yyextra->aliasCmd=yytext+1;
+				     yyextra->aliasString=yytext+10;
+				     yyextra->aliasCmd=yytext+10;
 				     yyextra->lastEscaped=0;
 				     BEGIN( ReadAliasArgs );
 				   }
@@ -1819,7 +1819,7 @@ static void replaceAliases(yyscan_t yyscanner,std::string_view s,bool replaceCom
     }
     expAlias.push_back(cmd);
     // add a ialias command to allow expansion of cmd again
-    result += " \\ialias{";
+    result += " \\ilinebr \\ialias{";
     result += cmd;
     result += "}";
     for (int i=(int)result.length()-1; i>=0; i--)


### PR DESCRIPTION

The warning generated in the example from https://github.com/doxygen/doxygen/issues/10606#issuecomment-2143537892 was like:
```
Modul1.md:12: warning: block marked with [[SNIPPET \ialias{incsnippet1}]] for \snippet{doc} should appear twice in file .../Modul1.pas, found it 0 times, skipping
```

so the end of the "snippet tag" was not properly found, inserting an extra ` \ilinebr` fixes this problem (space is required otherwise the `\linebr` might interfere with arguments with other  commands (e.g. with the `\include{doc}` command).