### PR TITLE
issue #10606 include command via ALIASES does not work anymore (2)

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1187,11 +1187,12 @@ SLASHopt [/]*
 <CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>[\\@][a-z_A-Z][a-z_A-Z0-9-]*  { // expand alias without arguments
 				     replaceAliases(yyscanner,yytext,YY_START==ReadLine && yyextra->readLineCtx==SComment);
   				   }
-<CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>{B}"\\ilinebr"{B}[\\@]"ialias{" { // expand alias with arguments
+<CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>{B}?"\\ilinebr"{B}[\\@]"ialias{" { // expand alias with arguments
 				     yyextra->lastBlockContext=YY_START;
 				     yyextra->blockCount=1;
-				     yyextra->aliasString=yytext+10;
-				     yyextra->aliasCmd=yytext+10;
+                                     int extraSpace = (yytext[0]==' '? 1:0);
+				     yyextra->aliasString=yytext+9+extraSpace;
+				     yyextra->aliasCmd=yytext+9+extraSpace;
 				     yyextra->lastEscaped=0;
 				     BEGIN( ReadAliasArgs );
 				   }


### PR DESCRIPTION
In #10916 the major problem was already fixed but it introduced a small regression took place in CGAL (in a start simplified example):
```
/// \file

///
/// Part0 \cgalCite{X0}.
///
void fie0();
```
and the setting:
```
ALIASES = "cgalCite{1}=\1"
```
to the warning:
```
vcm_estimate_edges.h:5: warning: End of list marker found without any preceding list items
```

The problem is that the rule `<ReadLine,CopyLine>{RLopt}` already could eat the initial space (as `RLopt [^\\@<\n\*\/`]*`).


Example: [example.tar.gz](https://github.com/user-attachments/files/15533729/example.tar.gz)