### PR TITLE
Files stayed in RTF directory

### DIFF
--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2398,7 +2398,6 @@ err:
 bool RTFGenerator::preProcessFileInplace(const QCString &path,const QCString &name)
 {
   static bool rtfDebug = Debug::isFlagSet(Debug::Rtf);
-  QCString rtfOutput = Config_getString(RTF_OUTPUT);
 
   Dir d(path.str());
   // store the original directory
@@ -2450,10 +2449,11 @@ bool RTFGenerator::preProcessFileInplace(const QCString &path,const QCString &na
 
   testRTFOutput(mainRTFName);
 
+  QCString rtfOutputDir = Dir::currentDirPath();
   for (auto &s : removeSet)
   {
     QCString s1(s.c_str());
-    if (s1.startsWith(rtfOutput)) Portable::unlink(s1);
+    if (s1.startsWith(rtfOutputDir)) Portable::unlink(s1);
   }
 
   Dir::setCurrent(oldDir);


### PR DESCRIPTION
In  Delay removing files in case of RTF till end of process (#10794 ) the removal of files of a successful RTF merge was handled though when e.g.:
```
RTF_OUTPUT = ./rtf
```
the files remained as the match didn't succeed, it is better to use the current directory (as here and in its subdirectories all files are located).

Example: [example.tar.gz](https://github.com/user-attachments/files/15584867/example.tar.gz)
