### PR TITLE
issue #10932 message: [generated]:8: warning: invalid argument for command '\iline'

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -348,7 +348,7 @@ REFWORD4       {REFWORD4_NOCV}{CVSPEC}?
 REFWORD        {FILEMASK}|{LABELID}|{REFWORD2}|{REFWORD3}|{REFWORD4}
 REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revision"|"Source"|"State")":"[^:\n$][^\n$]*"$"
-LINENR {BLANK}*([1-9][0-9]*|"0")
+LINENR {BLANK}*([1-9][0-9]*|"0"|"-1")
 
 SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[0-9]{1,2})?)?
 


### PR DESCRIPTION
For generated files also a line number -1 is possible with the iline command.