### PR TITLE
issue #10935 \snippet{doc} tag in Doxygen v1.11 adds incorrect paragraph with a break before snippet text

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -1528,8 +1528,7 @@ private                                 {
                                         }
 <DocBlock>"\\ilinebr "{BS}              {
                                           QCString indent;
-                                          auto extraSpaces = std::max(0,yyleng-9-yyextra->curIndent-1);
-                                          indent.fill(' ',extraSpaces);
+                                          indent.fill(' ',yyleng-9-yyextra->curIndent-1 > 0 ? yyleng-9-yyextra->curIndent-1 : 0);
                                           //printf("extraSpaces=%d\n",extraSpaces);
                                           yyextra->docBlock += "\\ilinebr ";
                                           yyextra->docBlock += indent;

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1579,8 +1579,7 @@ ID        [a-z_A-Z%]+{IDSYM}*
                                   }
     "\\ilinebr "{B}*    {
                           QCString indent;
-                          auto extraSpaces = std::max(0,yyleng-9-yyextra->curIndent-1);
-                          indent.fill(' ',extraSpaces);
+                          indent.fill(' ',yyleng-9-yyextra->curIndent-1 > 0 ? yyleng-9-yyextra->curIndent-1 : 0);
                           //printf("extraSpaces=%d\n",extraSpaces);
                           yyextra->docBlock += "\\ilinebr ";
                           yyextra->docBlock += indent;


### PR DESCRIPTION
Attempt to fix compilation error on MacOS