### PR TITLE
issue #10955 HTML comment affects output

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1162,8 +1162,8 @@ STopt  [^\n@\\]*
 <HtmlComment>{DOCNL}                    {
                                           if (*yytext=='\n')
                                           {
-                                            addOutput(yyscanner,*yytext);
                                             yyextra->lineNr++;
+                                            addOutput(yyscanner," \\iline "+QCString().setNum(yyextra->lineNr)+" "); 
                                           }
                                         }
 <HtmlComment>[^\\\n\-]+                 { // ignore unimportant characters


### PR DESCRIPTION
Adjusted handling of embedded newlines in HTML comment and keep line counting correct (for warnings etc.).