### PR TITLE
issue #10959 Support of special HTML comments

### DIFF
--- a/doc/htmlcmds.dox
+++ b/doc/htmlcmds.dox
@@ -85,12 +85,23 @@ of a HTML tag are passed on to the HTML output only
 <tr><td valign="top">\startendhtmltag{VAR}</td><td valign="top">Starts and ends a piece of text displayed in an italic font.</td></tr>
 </table>
 
-Finally, to put invisible comments inside comment blocks, HTML style
-comments can be used:
-\verbatim
-/*! <!-- This is a comment with a comment block --> Visible text */
-\endverbatim
-The part `<!-- ... -->` will not be shown in the main documentation.<br>
+Finally we have the HTML style comments. 
+- When using the, Doxygen, special HTML style comments, i.e. <code>\<!--! ... --\></code>, it is not seen as comment but as
+  if the `...` part is just in the documentation. This is useful to specify Doxygen commands inside a markdown file like:
+  ```
+  <!--! \page pg1 The page -->
+  ```
+  which will be ignored by regular Markdown processors, but Doxygen will interpret this as if there was written:
+  ```
+        \page pg1 The page 
+  ```
+- To put invisible comments inside comment blocks, the normal HTML style
+  comments can be used:
+  \verbatim
+  /*! <!-- This is a comment with a comment block --> Visible text */
+  \endverbatim
+  The part `<!-- ... -->` will not be shown in the main documentation.
+
 Note: It is explicitly forbidden to use 3 dashes before the closing greater than sign.
 Doxygen won't see that as the closing either and give a warning.
 

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -122,6 +122,7 @@ struct commentcnvYY_state
   int      javaBlock = 0;
   bool     specialComment = FALSE;
   bool     inVerbatim = false;
+  bool     inHtmlDoxygenCommand = false;
   bool     firstIncludeLine = false;
   bool     insertCppCommentMarker = false;
   QCString aliasCmd;
@@ -612,6 +613,21 @@ SLASHopt [/]*
                                      yyextra->inVerbatim=true;
 				     BEGIN(Verbatim);
   			           }
+<CComment,ReadLine,IncludeFile>"<!--!" { /* HTML comment doxygen command*/
+                                     if (yyextra->inVerbatim) REJECT;
+                                     copyToOutput(yyscanner,"     ",5);
+                                     yyextra->inHtmlDoxygenCommand=true;
+                                   }
+<CComment,ReadLine,IncludeFile>"-->" { /* potential end HTML comment doxygen command*/
+                                     if (yyextra->inHtmlDoxygenCommand)
+                                     {
+                                       yyextra->inHtmlDoxygenCommand=false;
+                                     }
+                                     else
+                                     {
+                                       copyToOutput(yyscanner,yytext,yyleng);
+                                     }
+                                   }
 <CComment,ReadLine,IncludeFile>"<!--" { /* HTML comment */
                                      copyToOutput(yyscanner,yytext,yyleng);
 				     yyextra->blockName="-->";


### PR DESCRIPTION
Support the syntax: <code>\<!--! ... --\></code> to have special HTML comments which are ignored by regular Markdown processors but Doxygen will see the part `...` as regular documentation.