### PR TITLE
issue #10953 Java Package Lists does not include nested packages

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -725,7 +725,8 @@ static Definition *buildScopeFromQualifiedName(const QCString &name_,SrcLangExt 
       if (newNd)
       {
         newNd->setLanguage(lang);
-        newNd->setArtificial(TRUE);
+        // looks like an atrificial namespace, but is in fact part of ns1.ns2, issue 10953
+        newNd->setArtificial(false);
         // add namespace to the list
         innerScope = newNd;
       }


### PR DESCRIPTION
In the nested package `n1.n2` the package `n1` was seen as artificial package but this is not really the case.