### PR TITLE
issue #10973 attribute is repeated twice in python

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2252,7 +2252,8 @@ static MemberDef *addVariableToClass(
       MemberDefMutable *md = toMemberDefMutable(imd.get());
       if (md &&
           md->getClassDef()==cd &&
-          removeRedundantWhiteSpace(type)==md->typeString())
+          ((lang==SrcLangExt::Python && type.isEmpty() && !md->typeString().isEmpty()) ||
+          removeRedundantWhiteSpace(type)==md->typeString()))
         // member already in the scope
       {
 


### PR DESCRIPTION
In case of Python the second occurrence had no type whilst the first occurrence has a type hint and this was not considered when adding variables.