### PR TITLE
issue  #10835 Two relates group generates warning: found multiple \relates, \relatesalso or \memberof commands in a comment block, using last definition

### DIFF
--- a/src/docgroup.cpp
+++ b/src/docgroup.cpp
@@ -169,7 +169,11 @@ void DocGroup::close(Entry *e,const QCString &fileName,int line,bool foundInline
     m_memberGroupId=DOX_NOGROUP;
     m_memberGroupRelates.clear();
     m_memberGroupDocs.clear();
-    if (!foundInline) e->mGrpId=DOX_NOGROUP;
+    if (!foundInline)
+    {
+      e->mGrpId=DOX_NOGROUP;
+      e->relates="";
+    }
     //printf("new group id=%d\n",m_memberGroupId);
   }
   else if (!m_autoGroupStack.empty()) // end of auto group


### PR DESCRIPTION
Not only the member group  id field should be reset but also the relates field otherwise a false positive warning is given.