### PR TITLE
issue #10959 Capability to render GitHub flavor Markdown comments

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -826,7 +826,7 @@ SLASHopt [/]*
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
 
-<CComment,CNComment>[^ `~<\\!@*\n{\"'\/]*     { /* anything that is not a '*' or command */
+<CComment,CNComment>[^ `~<\\!@*\n{\"'\/-]*    { /* anything that is not a '*' or command */
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
 <CComment,CNComment>"*"+[^*\/<\\@\n{\"]*      { /* stars without slashes */


### PR DESCRIPTION
When having in the new syntax where the last "comment" character was not separated from the `-->` the `-->` was shown in the output.

Based on: https://github.com/doxygen/doxygen/discussions/10992

Example: [example.tar.gz](https://github.com/user-attachments/files/16157971/example.tar.gz)
