### PR TITLE
issue #10995 Build issue: Build picks up wrong git info

### DIFF
--- a/libversion/CMakeLists.txt
+++ b/libversion/CMakeLists.txt
@@ -8,6 +8,7 @@ set(POST_CONFIGURE_DOXYGEN_VERSION_FILE "${GENERATED_SRC}/doxyversion.cpp")
 set(PRE_CONFIGURE_GIT_VERSION_FILE "${PROJECT_SOURCE_DIR}/libversion/gitversion.cpp.in")
 set(POST_CONFIGURE_GIT_VERSION_FILE "${GENERATED_SRC}/gitversion.cpp")
 set(GIT_STATE_FILE "${GENERATED_SRC}/git_state")
+set(GIT_CONFIG_DIR "${PROJECT_SOURCE_DIR}/.git")
 
 include(${PROJECT_SOURCE_DIR}/cmake/git_watcher.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/doxygen_version.cmake)


### PR DESCRIPTION
Create variable to check whether a doxygen `.git` directory exists, i.e. we have a git version of doxygen or just a distribution with the source files.