### PR TITLE
issue #6473 Plantuml parse error

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -3874,8 +3874,8 @@ class Receiver
   \ref cmdendhtmlonly "\\endhtmlonly" is inserted as-is. When you
   want to insert a HTML fragment that has block scope like a table or list
   which should appear outside \<p\>..\</p\>, this can lead to invalid HTML.
-  You can use `\htmlonly[block]` to make Doxygen
-  end the current paragraph and restart it after \\endhtmlonly.
+  You can use <tt>\\htmlonly[block]</tt> to make Doxygen
+  end the current paragraph and restart it after <tt>\\endhtmlonly</tt>.
 
   \note environment variables (like \$(HOME) ) are resolved inside a
   HTML-only block.

--- a/doc_internal/commands_internal.md
+++ b/doc_internal/commands_internal.md
@@ -7,6 +7,7 @@ and the version in which they were introduced.
 \refitem cmdialias \\ialias
 \refitem cmdendicode \\endicode
 \refitem cmdendiliteral \\endiliteral
+\refitem cmdendiskip \\endiskip
 \refitem cmdendiverbatim \\endiverbatim
 \refitem cmdianchor \\ianchor
 \refitem cmdicode \\icode
@@ -16,6 +17,7 @@ and the version in which they were introduced.
 \refitem cmdiliteral \\iliteral
 \refitem cmdiprefix \\iprefix
 \refitem cmdiraise \\iraise
+\refitem cmdiskip \\iskip
 \refitem cmdiverbatim \\iverbatim
 \endsecreflist
 
@@ -141,6 +143,15 @@ and the version in which they were introduced.
 \since doxygen version 1.11.0
 
 <hr>
+\section cmdiskip \\iskip
+  \addindex \\iskip
+
+  Internal doxygen command to top determing the inital white space as calculated by the detab() function.
+  Inserted when processing commands that contain literal text like `\startuml`, `\verbatim`, `<code>` etc.
+
+\since doxygen version 1.12.0
+
+<hr>
 \section cmdiprefix \\iprefix "<label>"
   \addindex \\iprefix
 
@@ -150,6 +161,14 @@ and the version in which they were introduced.
   Inserted internally when processing `\include{doc}` with the `prefix` option.
 
 \since doxygen version 1.11.0
+
+<hr>
+\section cmdendiskip \\endiskip
+
+  \addindex \\endiskip
+  Ends a block of text that was started with a \ref cmdiskip "\\iskip" command.
+
+\since doxygen version 1.12.0
 
 <hr>
 \section cmdendiverbatim \\endiverbatim

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7077,7 +7077,7 @@ NONLopt [^\n]*
 <DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]* {
                                           QCString pat = substitute(yytext,"*"," ");
                                           if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
-                                          yyextra->docBlock << yytext;
+                                          yyextra->docBlock << pat;
                                           yyextra->docBlockName="```";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
                                           yyextra->nestedComment=0;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7076,8 +7076,8 @@ NONLopt [^\n]*
 <DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]*/"{"[^}]+"}" |
 <DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]* {
                                           QCString pat = substitute(yytext,"*"," ");
-                                          yyextra->docBlock << "\\iskip";
                                           if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
+                                          yyextra->docBlock << yytext;
                                           yyextra->docBlockName="```";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
                                           yyextra->nestedComment=0;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6973,7 +6973,8 @@ NONLopt [^\n]*
 <DocBlock>({CMD}{CMD}){ID}/[^a-z_A-Z0-9] { // escaped command
                                           yyextra->docBlock << yytext;
                                         }
-<DocBlock>{CMD}("f$"|"f["|"f{"|"f(")         {
+<DocBlock>{CMD}("f$"|"f["|"f{"|"f(")    {
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
                                           yyextra->docBlockName=&yytext[1];
                                           if (yyextra->docBlockName.at(1)=='[')
@@ -7017,6 +7018,7 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                         }
 <DocBlock>{B}*"<"{PRE}">"               {
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
                                           yyextra->docBlockName="<pre>";
                                           yyextra->fencedSize=0;
@@ -7024,6 +7026,7 @@ NONLopt [^\n]*
                                           BEGIN(DocCopyBlock);
                                         }
 <DocBlock>{CMD}"startuml"/[^a-z_A-Z0-9\-]     { // verbatim command (which could contain nested comments!)
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
                                           yyextra->docBlockName="uml";
                                           yyextra->fencedSize=0;
@@ -7031,6 +7034,7 @@ NONLopt [^\n]*
                                           BEGIN(DocCopyBlock);
                                         }
 <DocBlock>{CMD}("verbatim"|"iliteral"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"msc"|"code")/[^a-z_A-Z0-9\-]     { // verbatim command (which could contain nested comments!)
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
                                           yyextra->docBlockName=&yytext[1];
                                           yyextra->fencedSize=0;
@@ -7040,6 +7044,7 @@ NONLopt [^\n]*
 <DocBlock>"\\ilinebr "({B}*"*"+)?{B}{0,3}"~~~"[~]* {
                                           QCString pat = substitute(yytext+9,"*"," "); // skip over "\ilinebr " part
                                           yyextra->docBlock << "\\ilinebr ";
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << pat;
                                           yyextra->docBlockName="~~~";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
@@ -7048,6 +7053,7 @@ NONLopt [^\n]*
                                         }
 <DocBlock>^({B}*"*"+)?{B}{0,3}"~~~"[~]* {
                                           QCString pat = substitute(yytext,"*"," ");
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << pat;
                                           yyextra->docBlockName="~~~";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
@@ -7059,6 +7065,7 @@ NONLopt [^\n]*
 <DocBlock>"\\ilinebr "({B}*"*"+)?{B}{0,3}"```"[`]* {
                                           QCString pat = substitute(yytext+9,"*"," "); // skip over "\ilinebr " part
                                           yyextra->docBlock << "\\ilinebr ";
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << pat;
                                           yyextra->docBlockName="```";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
@@ -7069,7 +7076,8 @@ NONLopt [^\n]*
 <DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]*/"{"[^}]+"}" |
 <DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]* {
                                           QCString pat = substitute(yytext,"*"," ");
-                                          yyextra->docBlock << pat;
+                                          yyextra->docBlock << "\\iskip";
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName="```";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
                                           yyextra->nestedComment=0;
@@ -7078,6 +7086,7 @@ NONLopt [^\n]*
 <DocBlock>{B}*"<"{CODE}">"              {
                                           if (yyextra->insideCS)
                                           {
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                             yyextra->docBlock << yytext;
                                             yyextra->docBlockName="<code>";
                                             yyextra->nestedComment=0;
@@ -7102,36 +7111,40 @@ NONLopt [^\n]*
  /* ---- Copy verbatim sections ------ */
 
 <DocCopyBlock>"</"{PRE}">"              { // end of a <pre> block
-                                          yyextra->docBlock << yytext;
                                           if (yyextra->docBlockName=="<pre>")
                                           {
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\endiskip";
                                             yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
+                                          yyextra->docBlock << yytext;
                                         }
 <DocCopyBlock>"</"{CODE}">"             { // end of a <code> block
-                                          yyextra->docBlock << yytext;
                                           if (yyextra->docBlockName=="<code>")
                                           {
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\endiskip";
                                             yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
+                                          yyextra->docBlock << yytext;
                                         }
 <DocCopyBlock>[\\@]("f$"|"f]"|"f}"|"f)")     {
-                                          yyextra->docBlock << yytext;
                                           if (yyextra->docBlockName==&yytext[1])
                                           {
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\endiskip";
                                             yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
+                                          yyextra->docBlock << yytext;
                                         }
 <DocCopyBlock>[\\@]("endverbatim"|"endiliteral"|"endlatexonly"|"endhtmlonly"|"endxmlonly"|"enddocbookonly"|"endmanonly"|"endrtfonly"|"enddot"|"endmsc"|"enduml"|"endcode")/[^a-z_A-Z0-9] { // end of verbatim block
-                                          yyextra->docBlock << yytext;
                                           if (&yytext[4]==yyextra->docBlockName)
                                           {
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\endiskip";
                                             yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
+                                          yyextra->docBlock << yytext;
                                         }
 <DocCopyBlock>^{B}*"*"+/{BN}+           { // start of a comment line
                                           if ((yyextra->docBlockName=="verbatim") || (yyextra->docBlockName=="code") || (yyextra->docBlockName=="iliteral"))
@@ -7191,19 +7204,23 @@ NONLopt [^\n]*
                                         }
 <DocCopyBlock>^({B}*"*"+)?{B}{0,3}"~~~"[~]* {
                                           QCString pat = substitute(yytext,"*"," ");
-                                          yyextra->docBlock << pat;
                                           if (yyextra->docBlockName == "~~~" && yyextra->fencedSize==pat.stripWhiteSpace().length())
                                           {
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\endiskip";
+                                            yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
+                                          yyextra->docBlock << pat;
                                         }
 <DocCopyBlock>^({B}*"*"+)?{B}{0,3}"```"[`]*                 {
                                           QCString pat = substitute(yytext,"*"," ");
-                                          yyextra->docBlock << pat;
                                           if (yyextra->docBlockName == "```" && yyextra->fencedSize==pat.stripWhiteSpace().length())
                                           {
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\endiskip";
+                                            yyextra->docBlockName="";
                                             BEGIN(DocBlock);
                                           }
+                                          yyextra->docBlock << pat;
                                         }
 <DocCopyBlock>[^\<@/\*\]~"\$\\\n]+      { // any character that is not special
                                           yyextra->docBlock << yytext;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -6974,8 +6974,8 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                         }
 <DocBlock>{CMD}("f$"|"f["|"f{"|"f(")    {
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName=&yytext[1];
                                           if (yyextra->docBlockName.at(1)=='[')
                                           {
@@ -7018,24 +7018,24 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                         }
 <DocBlock>{B}*"<"{PRE}">"               {
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName="<pre>";
                                           yyextra->fencedSize=0;
                                           yyextra->nestedComment=0;
                                           BEGIN(DocCopyBlock);
                                         }
 <DocBlock>{CMD}"startuml"/[^a-z_A-Z0-9\-]     { // verbatim command (which could contain nested comments!)
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName="uml";
                                           yyextra->fencedSize=0;
                                           yyextra->nestedComment=0;
                                           BEGIN(DocCopyBlock);
                                         }
 <DocBlock>{CMD}("verbatim"|"iliteral"|"latexonly"|"htmlonly"|"xmlonly"|"manonly"|"rtfonly"|"docbookonly"|"dot"|"msc"|"code")/[^a-z_A-Z0-9\-]     { // verbatim command (which could contain nested comments!)
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << yytext;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName=&yytext[1];
                                           yyextra->fencedSize=0;
                                           yyextra->nestedComment=0;
@@ -7044,8 +7044,8 @@ NONLopt [^\n]*
 <DocBlock>"\\ilinebr "({B}*"*"+)?{B}{0,3}"~~~"[~]* {
                                           QCString pat = substitute(yytext+9,"*"," "); // skip over "\ilinebr " part
                                           yyextra->docBlock << "\\ilinebr ";
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << pat;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName="~~~";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
                                           yyextra->nestedComment=0;
@@ -7053,8 +7053,8 @@ NONLopt [^\n]*
                                         }
 <DocBlock>^({B}*"*"+)?{B}{0,3}"~~~"[~]* {
                                           QCString pat = substitute(yytext,"*"," ");
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << pat;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName="~~~";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
                                           yyextra->nestedComment=0;
@@ -7065,8 +7065,8 @@ NONLopt [^\n]*
 <DocBlock>"\\ilinebr "({B}*"*"+)?{B}{0,3}"```"[`]* {
                                           QCString pat = substitute(yytext+9,"*"," "); // skip over "\ilinebr " part
                                           yyextra->docBlock << "\\ilinebr ";
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << pat;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName="```";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
                                           yyextra->nestedComment=0;
@@ -7076,8 +7076,8 @@ NONLopt [^\n]*
 <DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]*/"{"[^}]+"}" |
 <DocBlock>^({B}*"*"+)?{B}{0,3}"```"[`]* {
                                           QCString pat = substitute(yytext,"*"," ");
-                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlock << pat;
+                                          if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                           yyextra->docBlockName="```";
                                           yyextra->fencedSize=pat.stripWhiteSpace().length();
                                           yyextra->nestedComment=0;
@@ -7086,8 +7086,8 @@ NONLopt [^\n]*
 <DocBlock>{B}*"<"{CODE}">"              {
                                           if (yyextra->insideCS)
                                           {
-                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                             yyextra->docBlock << yytext;
+                                            if (Config_getBool(MARKDOWN_SUPPORT)) yyextra->docBlock << "\\iskip";
                                             yyextra->docBlockName="<code>";
                                             yyextra->nestedComment=0;
                                             BEGIN(DocCopyBlock);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7013,7 +7013,6 @@ QCString detab(const QCString &s,size_t &refIndent)
           i+=5;
           c = data[i];
           skip = true;
-          if (col+1<minIndent) minIndent=col+1;
         }
         else if (i+8 < size && data[i] == 'e' && data[i+1] == 'n' && data[i+2] == 'd' && data[i+3] == 'i' &&
                  data[i+4] == 's' && data[i+5] == 'k' && data[i+6] == 'i' && data[i+7] == 'p') // endiskip command


### PR DESCRIPTION
For "verbatim" type commands the initial indentation counting as done in `detab()` during the markdown phase should be disabled. For the ease of the implementation (not to repeat logics about these, nested, "verbatim" commands the new internal command `\iskip` has bveen andded together with its counterpart `\endiskip`.