### PR TITLE
quest #11007 Is it possible to add usage relations to the collaboration diagrams for properties?

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3888,8 +3888,12 @@ If the \c DOT_UML_DETAILS tag is set to \c NO, Doxygen will
 show attributes and methods without types and arguments in the UML graphs.
 If the \c DOT_UML_DETAILS tag is set to \c YES, Doxygen will
 add type and arguments for attributes and methods in the UML graphs.
-If the \c DOT_UML_DETAILS tag is set to \c NONE, Doxygen will not generate
+If the \c DOT_UML_DETAILS tag is set to \c NONE or \c NONE_FLD, Doxygen will not generate
 fields with class member information in the UML graphs.
+If the \c DOT_UML_DETAILS tag is set to \c NONE_ATTR, Doxygen will not generate
+attributes on the edges between the classes in the UML graphs.
+If the \c DOT_UML_DETAILS tag is set to \c NONE_ATTR_FLD, Doxygen will not generate
+fields with class member information nor attributes on the edges between the classes in the UML graphs.
 The class diagrams will look similar to the default class diagrams but using
 UML notation for the relationships.
 ]]>
@@ -3897,6 +3901,9 @@ UML notation for the relationships.
       <value name="NO" />
       <value name="YES" />
       <value name="NONE" />
+      <value name="NONE_FLD" desc='same as NONE'/>
+      <value name="NONE_ATTR" />
+      <value name="NONE_ATTR_FLD" />
     </option>
     <option type='int' id='DOT_WRAP_THRESHOLD' defval='17' minval='0' maxval='1000' depends='HAVE_DOT'>
       <docs>

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -424,7 +424,9 @@ void DotNode::writeLabel(TextStream &t, GraphType gt) const
     t << "<<TABLE CELLBORDER=\"0\" BORDER=\"1\">";
     t << hr_start << convertLabel(m_label,true) << hr_end;
     auto dotUmlDetails = Config_getEnum(DOT_UML_DETAILS);
-    if (dotUmlDetails!=DOT_UML_DETAILS_t::NONE)
+    if (dotUmlDetails!=DOT_UML_DETAILS_t::NONE &&
+        dotUmlDetails!=DOT_UML_DETAILS_t::NONE_FLD &&
+        dotUmlDetails!=DOT_UML_DETAILS_t::NONE_ATTR_FLD)
     {
       bool lineWritten = false;
       t << sep;
@@ -609,6 +611,11 @@ void DotNode::writeArrow(TextStream &t,
   t << ",tooltip=\" \""; // space in tooltip is required otherwise still something like 'Node0 -> Node1' is used
   if (!ei->label().isEmpty())
   {
+  if (!(Config_getBool(UML_LOOK) &&
+        (Config_getEnum(DOT_UML_DETAILS)==DOT_UML_DETAILS_t::NONE_ATTR ||
+         Config_getEnum(DOT_UML_DETAILS)==DOT_UML_DETAILS_t::NONE_ATTR_FLD) &&
+        (gt==Inheritance || gt==Collaboration))
+     )
     t << ",label=\" " << convertLabel(ei->label()) << "\",fontcolor=\"grey\" ";
   }
   if (Config_getBool(UML_LOOK) &&


### PR DESCRIPTION
Adding to `DOT_UML_DETAILS the possibilities:
- `NONE_FLD` same as `NONE`
- `NONE_ATTR`, Doxygen will not generate attributes on the edges between the classes in the UML graphs.
- `NONE_ATTR_FLD`, Doxygen will not generate fields with class member information nor attributes on the edges between the classes in the UML graphs.

Example: [example.tar.gz](https://github.com/user-attachments/files/16281112/example.tar.gz)
