### PR TITLE
Adding "engine" chen and chronology for plantuml

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -3510,7 +3510,8 @@ class Receiver
   Not all diagrams can be created with the PlantUML `@startuml` command but need another
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
   the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
-  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex`, `ebnf` and `files`.
+  `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex`, `ebnf`,
+  `files`, `chen` and `chronology`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -70,7 +70,8 @@ static const StringUnorderedSet g_plantumlEngine {
   "uml", "bpm", "wire", "dot", "ditaa",
   "salt", "math", "latex", "gantt", "mindmap",
   "wbs", "yaml", "creole", "json", "flow",
-  "board", "git", "hcl", "regex", "ebnf", "files"
+  "board", "git", "hcl", "regex", "ebnf",
+  "files", "chen", "chronology"
 };
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Adding:
> Entity Relationship Diagrams (Chen's notation)
>
> Chen's Entity Relationship notation, which is commonly used in teaching. See also Information Engineering diagrams.
>
> Entity Relationship (ER) diagrams are used to model databases at a conceptual level by describing entities, their attributes, and the relationships between them. In addition to basic relationships, PlantUML also supports subclasses
and union types. This extended notation is sometimes referred to as Enhanced Entity Relationship (EER) or Extended Entity Relationship notation.

and also:
> Chronology Diagram
>
> The Chronology Diagram, adapted from Gantt Chart, is described in natural language, using very simple sentences (subject-verb-complement).

Example: [example.tar.gz](https://github.com/user-attachments/files/16281803/example.tar.gz)
