### PR TITLE
Remove classes and concepts from "Namespace List" page

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1802,7 +1802,8 @@ static void writeNamespaceTreeElement(const NamespaceDef *nd,FTVHelp *ftv,
       (!rootOnly || nd->getOuterScope()==Doxygen::globalScope))
   {
 
-    bool hasChildren = namespaceHasNestedNamespace(nd) ||
+    bool hasNestedNamespace = namespaceHasNestedNamespace(nd);
+    bool hasChildren = hasNestedNamespace ||
       namespaceHasNestedClass(nd,false,ClassDef::Class) ||
       namespaceHasNestedConcept(nd);
     bool isLinkable  = nd->isLinkable();
@@ -1825,7 +1826,7 @@ static void writeNamespaceTreeElement(const NamespaceDef *nd,FTVHelp *ftv,
     bool isDir = hasChildren || visibleMembers>0;
     if (isLinkable || isDir)
     {
-      ftv->addContentsItem(hasChildren,nd->localName(),ref,file,QCString(),FALSE,nd->partOfGroups().empty(),nd);
+      ftv->addContentsItem(hasNestedNamespace,nd->localName(),ref,file,QCString(),FALSE,nd->partOfGroups().empty(),nd);
 
       if (addToIndex)
       {
@@ -1841,8 +1842,8 @@ static void writeNamespaceTreeElement(const NamespaceDef *nd,FTVHelp *ftv,
       {
         ftv->incContentsDepth();
         writeNamespaceTree(nd->getNamespaces(),ftv,FALSE,addToIndex);
-        writeClassTree(nd->getClasses(),ftv,addToIndex,FALSE,ClassDef::Class);
-        writeConceptList(nd->getConcepts(),ftv,addToIndex);
+        writeClassTree(nd->getClasses(),nullptr,addToIndex,FALSE,ClassDef::Class);
+        writeConceptList(nd->getConcepts(),nullptr,addToIndex);
         writeNamespaceMembers(nd,addToIndex);
         ftv->decContentsDepth();
       }


### PR DESCRIPTION
This removes classes and concepts from the "Namespace List" page, so only namespaces are shown, which I believe was the intended behavior. This does not affect the "Namespace List" section of the tree view.

Somebody more familiar with the code base should check the changes if possible to make sure it won't have any unintended side effects. I haven't experienced any.

Fixes #8508
Fixes #9191

More details in the comments below.