### PR TITLE
issue #11015 In Doxygen 1.11.0, Include Graphs are not made for Java

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1941,6 +1941,10 @@ NONLopt [^\n]*
                                           BEGIN(Using);
                                         }
 <JavaImport>({ID}{BN}*"."{BN}*)+{ID}    { // class import => add as a using declaration
+                                          ModuleManager::instance().addImport(yyextra->fileName,
+                                                                              yyextra->yyLineNr,
+                                                                              yytext,
+                                                                              yyextra->current->exported);
                                           lineCount(yyscanner);
                                           QCString scope=yytext;
                                           yyextra->current->name=removeRedundantWhiteSpace(substitute(scope,".","::"));


### PR DESCRIPTION
Adding code so that also include graphs are shown in Java.