### PR TITLE
issue #11016 Faulty xml generated when markdown header is too deep

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -3513,7 +3513,14 @@ void HtmlGenerator::writeLocalToc(const SectionRefs &sectionRefs,const LocalToc 
             {
               incIndent("<ul>");
               cs[0]=static_cast<char>('0'+l+1);
-              incIndent("<li class=\"level" + QCString(cs) + "\">");
+              if (l != nextLevel-1)
+              {
+                incIndent("<li class=\"levelE" + QCString(cs) + "\">");
+              }
+              else
+              {
+                incIndent("<li class=\"level" + QCString(cs) + "\">");
+              }
             }
           }
         }

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1526,20 +1526,33 @@ div.toc ul {
         padding: 0px;
 }
 
-div.toc li.level1 {
+div.toc li.level1, div.toc li.levelE1 {
         margin-left: 0px;
 }
 
-div.toc li.level2 {
+div.toc li.level2, div.toc li.levelE2 {
         margin-left: 15px;
 }
 
-div.toc li.level3 {
+div.toc li.level3, div.toc li.levelE3 {
         margin-left: 15px;
 }
 
-div.toc li.level4 {
+div.toc li.level4, div.toc li.levelE4 {
         margin-left: 15px;
+}
+
+div.toc li.level5, div.toc li.levelE5 {
+        margin-left: 15px;
+}
+
+div.toc li.level6, div.toc li.levelE6 {
+        margin-left: 15px;
+}
+
+div.toc li.levelE1, div.toc li.levelE2, div.toc li.levelE3, div.toc li.levelE4, div.toc li.levelE5, div.toc li.levelE6 {
+        background-image: none;
+        margin-top: 0px;
 }
 
 span.emoji {


### PR DESCRIPTION
- Improving HTML table of contents in respect to skipped section levels.
- adding css entries for level5 and level6