### PR TITLE
Message about style redefinition in RTF

### DIFF
--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -561,7 +561,7 @@ void RTFGenerator::beginRTFDocument()
     uint32_t index = data.index();
     if (array[index] != nullptr)
     {
-      msg("Style '%s' redefines \\s%d.\n", name.c_str(), index);
+      err("Style '%s' redefines \\s%d.\n", name.c_str(), index);
     }
     array[index] = &data;
   }

--- a/src/rtfstyle.cpp
+++ b/src/rtfstyle.cpp
@@ -108,7 +108,7 @@ Rtf_Style_Default rtf_Style_Default[] =
     "\\sbasedon0 \\snext0 heading 5;}{\\*\\cs10 \\additive Default Paragraph Font"
   },
   { "Heading6",
-    "\\s5\\sb90\\sa30\\keepn\\widctlpar\\adjustright \\b\\f1\\fs12\\cgrid ",
+    "\\s6\\sb90\\sa30\\keepn\\widctlpar\\adjustright \\b\\f1\\fs12\\cgrid ",
     "\\sbasedon0 \\snext0 heading 6;}{\\*\\cs10 \\additive Default Paragraph Font"
   },
   { "Title",


### PR DESCRIPTION
With the simple file
```
/// \file
```
and setting
```
GENERATE_RTF=YES
```
we get in the messages a number of times the message:
```
Style 'Heading6' redefines \s5.
```

This has been corrected and made from message to an "error".

Example: [example.tar.gz](https://github.com/user-attachments/files/16378743/example.tar.gz)
