### PR TITLE
issue #11033 Illegal command '\ifile' found as part of a title section

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1398,6 +1398,22 @@ reparsetoken:
         case CMD_IMAGE:
           handleImage(parent,children);
           break;
+        case CMD_ILINE:
+          {
+            int state = tokenizer.getState();
+            tokenizer.setStateILine();
+            (void)tokenizer.lex();
+            tokenizer.setState(state);
+          }
+          break;
+        case CMD_IFILE:
+          {
+            int state = tokenizer.getState();
+            tokenizer.setStateIFile();
+            (void)tokenizer.lex();
+            tokenizer.setState(state);
+          }
+          break;
         default:
           return FALSE;
       }

--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -134,7 +134,9 @@ class DocTokenizer
     static const char *retvalToString(int retval);
 
     void setLineNr(int lineno);
+    void setState(int state);
     int getLineNr(void);
+    int getState(void);
 
     // operations on the scanner
     void findSections(const QCString &input,const Definition *d,
@@ -167,6 +169,7 @@ class DocTokenizer
     void setStateParam();
     void setStateXRefItem();
     void setStateFile();
+    void setStateIFile();
     void setStatePattern();
     void setStateLink();
     void setStateCite();

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -386,6 +386,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 %x St_XRefItem
 %x St_XRefItem2
 %x St_File
+%x St_IFile
 %x St_Pattern
 %x St_Link
 %x St_Cite
@@ -1404,6 +1405,16 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 <St_ILine>.            {
                          return 0;
                        }
+<St_IFile>{BLANK}*{FILEMASK} {
+                         yyextra->fileName = QCString(yytext).stripWhiteSpace();
+                         return TK_WORD;
+                       }
+<St_IFile>{BLANK}*"\""[^\n\"]+"\"" {
+                         QCString text(yytext);
+                         text = text.stripWhiteSpace();
+                         yyextra->fileName = text.mid(1,text.length()-2);
+                         return TK_WORD;
+                       }
 <St_File>{FILEMASK}    {
                          yyextra->token.name = yytext;
                          return TK_WORD;
@@ -2072,6 +2083,13 @@ void DocTokenizer::setStateFile()
   BEGIN(St_File);
 }
 
+void DocTokenizer::setStateIFile()
+{
+  yyscan_t yyscanner = p->yyscanner;
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  BEGIN(St_IFile);
+}
+
 void DocTokenizer::setStatePattern()
 {
   yyscan_t yyscanner = p->yyscanner;
@@ -2257,6 +2275,20 @@ int DocTokenizer::getLineNr(void)
   yyscan_t yyscanner = p->yyscanner;
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   return yyextra->yyLineNr;
+}
+
+void DocTokenizer::setState(int state)
+{
+  yyscan_t yyscanner = p->yyscanner;
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  BEGIN(state);
+}
+
+int DocTokenizer::getState(void)
+{
+  yyscan_t yyscanner = p->yyscanner;
+  struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  return YYSTATE;
 }
 
 #include "doctokenizer.l.h"


### PR DESCRIPTION
Handle the `\ifile` and `\iline` command for the `\par` command. We also needed to properly reset the state properly as otherwise
```
\par EXAMPLE: \copybrief MkStringR

\par EXAMPLE: \copydetails MkStringR
```
would give a warning regarding the second `\par` command.