### PR TITLE
Improve readability of codebase

### DIFF
--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -46,7 +46,7 @@ constexpr auto prefix = "autotoc_md";
 std::string AnchorGenerator::addPrefixIfNeeded(const std::string &anchor)
 {
   if (Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB &&
-      (anchor.empty() || anchor.at(0)=='-' || (anchor.at(0)>='0' && anchor.at(0)<='9')))
+      (anchor.empty() || anchor.front() == '-' || std::isdigit(anchor.front())))
   {
     return prefix+anchor;
   }
@@ -70,7 +70,7 @@ std::string AnchorGenerator::generate(const std::string &label)
 
   auto createGitHubStyleAnchor = [&]()
   {
-    result="";
+    result.clear();
     size_t pos=0;
     while (pos<label.length())
     {

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -43,7 +43,7 @@ struct Argument
   QCString typeConstraint;  /*!< Used for Java generics: \<T extends C\> */
 };
 
-enum RefQualifierType
+enum class RefQualifierType
 {
   None,
   LValue,

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -45,9 +45,9 @@ struct Argument
 
 enum RefQualifierType
 {
-  RefQualifierNone,
-  RefQualifierLValue,
-  RefQualifierRValue
+  None,
+  LValue,
+  RValue
 };
 
 /*! \brief This class represents an function or template argument list.
@@ -78,7 +78,7 @@ class ArgumentList
       m_pureSpecifier = FALSE;
       m_trailingReturnType.clear();
       m_isDeleted = FALSE;
-      m_refQualifier = RefQualifierNone;
+      m_refQualifier = RefQualifierType::None;
       m_noParameters = FALSE;
     }
 
@@ -130,7 +130,7 @@ class ArgumentList
     /*! method with =delete */
     bool m_isDeleted = FALSE;
     /*! C++11 ref qualifier */
-    RefQualifierType m_refQualifier = RefQualifierNone;
+    RefQualifierType m_refQualifier = RefQualifierType::None;
     /*! is it an explicit empty list */
     bool m_noParameters = FALSE;
 };

--- a/src/defargs.l
+++ b/src/defargs.l
@@ -557,10 +557,10 @@ CPPC  "/\/"
 <FuncQual>"override"                    {
                                         }
 <FuncQual>"&"		    	        {
-                                          yyextra->argList->setRefQualifier(RefQualifierLValue);
+                                          yyextra->argList->setRefQualifier(RefQualifierType::LValue);
 					}
 <FuncQual>"&&"		    	        {
-                                          yyextra->argList->setRefQualifier(RefQualifierRValue);
+                                          yyextra->argList->setRefQualifier(RefQualifierType::RValue);
 					}
 <FuncQual,TrailingReturn>"="{B}*"0"  	{
 					  yyextra->argList->setPureSpecifier(TRUE);

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -1225,11 +1225,11 @@ static bool writeDefArgumentList(OutputList &ol,const Definition *scope,const Me
   {
     ol.docify(" volatile");
   }
-  if (defArgList.refQualifier()==RefQualifierLValue)
+  if (defArgList.refQualifier()==RefQualifierType::LValue)
   {
     ol.docify(" &");
   }
-  else if (defArgList.refQualifier()==RefQualifierRValue)
+  else if (defArgList.refQualifier()==RefQualifierType::RValue)
   {
     ol.docify(" &&");
   }

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5131,11 +5131,11 @@ NONLopt [^\n]*
                                         }
 <FuncQual>{BN}*"&"                      {
                                           yyextra->current->args += " &";
-                                          yyextra->current->argList.setRefQualifier(RefQualifierLValue);
+                                          yyextra->current->argList.setRefQualifier(RefQualifierType::LValue);
                                         }
 <FuncQual>{BN}*"&&"                     {
                                           yyextra->current->args += " &&";
-                                          yyextra->current->argList.setRefQualifier(RefQualifierRValue);
+                                          yyextra->current->argList.setRefQualifier(RefQualifierType::RValue);
                                         }
 
 <FuncQual,TrailingReturn>{BN}*"="{BN}*"0"{BN}*          { // pure virtual member function

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1208,8 +1208,8 @@ QCString argListToString(const ArgumentList &al,bool useCanonicalType,bool showD
   result+=")";
   if (al.constSpecifier()) result+=" const";
   if (al.volatileSpecifier()) result+=" volatile";
-  if (al.refQualifier()==RefQualifierLValue) result+=" &";
-  else if (al.refQualifier()==RefQualifierRValue) result+=" &&";
+  if (al.refQualifier()==RefQualifierType::LValue) result+=" &";
+  else if (al.refQualifier()==RefQualifierType::RValue) result+=" &&";
   if (!al.trailingReturnType().isEmpty()) result+=al.trailingReturnType();
   if (al.pureSpecifier()) result+=" =0";
   return removeRedundantWhiteSpace(result);

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -698,10 +698,10 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
     if (md->isInline()) t << "yes"; else t << "no";
     t << "\"";
 
-    if (al.refQualifier()!=RefQualifierNone)
+    if (al.refQualifier()!=RefQualifierType::None)
     {
       t << " refqual=\"";
-      if (al.refQualifier()==RefQualifierLValue) t << "lvalue"; else t << "rvalue";
+      if (al.refQualifier()==RefQualifierType::LValue) t << "lvalue"; else t << "rvalue";
       t << "\"";
     }
 


### PR DESCRIPTION
### Summary

This pull request focuses on improving the readability of the C++ source code under the `src/` folder. The following changes have been made:

- Modernized the usage of `enum class` for better type safety.
- Simplified conditions (std::isdigit, front() etc.)

### Files Modified

- `src/anchor.cpp`
- `src/arguments.h`
- `src/defargs.l`
- `src/memberdef.cpp`
- `src/scanner.l`
- `src/util.cpp`
- `src/xmlgen.cpp`

### Testing

- Ensured that all unit tests pass successfully.
- Verified that the changes do not affect the existing functionality.

### Notes

These changes aim to make the code more readable, maintainable, and efficient while adhering to modern C++ practices.
