### PR TITLE
Consistency enum class Tokens

### DIFF
--- a/src/doctokenizer.h
+++ b/src/doctokenizer.h
@@ -26,49 +26,56 @@
 #include "qcstring.h"
 #include "construct.h"
 
+#define TOKEN_SPECIFICATIONS \
+  TKSPEC(TK_EOF,          -1)                                   \
+  TKSPEC(TK_NONE,          0)                                   \
+  TKSPEC(TK_WORD,          1)                                   \
+  TKSPEC(TK_LNKWORD,       2)                                   \
+  TKSPEC(TK_WHITESPACE,    3)                                   \
+  TKSPEC(TK_LISTITEM,      4)                                   \
+  TKSPEC(TK_ENDLIST,       5)                                   \
+  TKSPEC(TK_COMMAND_AT,    6) /*! Command starting with `@`) */ \
+  TKSPEC(TK_HTMLTAG,       7)                                   \
+  TKSPEC(TK_SYMBOL,        8)                                   \
+  TKSPEC(TK_NEWPARA,       9)                                   \
+  TKSPEC(TK_RCSTAG,       10)                                   \
+  TKSPEC(TK_URL,          11)                                   \
+  TKSPEC(TK_COMMAND_BS,   12) /*! Command starting with `\`) */ 
+
+#define RETVAL_SPECIFICATIONS \
+  TKSPEC(RetVal_OK,              0x10000)  \
+  TKSPEC(RetVal_SimpleSec,       0x10001)  \
+  TKSPEC(RetVal_ListItem,        0x10002)  \
+  TKSPEC(RetVal_Section,         0x10003)  \
+  TKSPEC(RetVal_Subsection,      0x10004)  \
+  TKSPEC(RetVal_Subsubsection,   0x10005)  \
+  TKSPEC(RetVal_Paragraph,       0x10006)  \
+  TKSPEC(RetVal_SubParagraph,    0x10007)  \
+  TKSPEC(RetVal_EndList,         0x10008)  \
+  TKSPEC(RetVal_EndPre,          0x10009)  \
+  TKSPEC(RetVal_DescData,        0x1000A)  \
+  TKSPEC(RetVal_DescTitle,       0x1000B)  \
+  TKSPEC(RetVal_EndDesc,         0x1000C)  \
+  TKSPEC(RetVal_TableRow,        0x1000D)  \
+  TKSPEC(RetVal_TableCell,       0x1000E)  \
+  TKSPEC(RetVal_TableHCell,      0x1000F)  \
+  TKSPEC(RetVal_EndTable,        0x10010)  \
+  TKSPEC(RetVal_Internal,        0x10011)  \
+  TKSPEC(RetVal_SwitchLang,      0x10012)  \
+  TKSPEC(RetVal_CloseXml,        0x10013)  \
+  TKSPEC(RetVal_EndBlockQuote,   0x10014)  \
+  TKSPEC(RetVal_CopyDoc,         0x10015)  \
+  TKSPEC(RetVal_EndInternal,     0x10016)  \
+  TKSPEC(RetVal_EndParBlock,     0x10017)  \
+  TKSPEC(RetVal_EndHtmlDetails,  0x10018)  \
+  TKSPEC(RetVal_SubSubParagraph, 0x10019)
+
 enum class Tokens
 {
-  TK_EOF           = -1,
-  TK_NONE          = 0,
-  TK_WORD          = 1,
-  TK_LNKWORD       = 2,
-  TK_WHITESPACE    = 3,
-  TK_LISTITEM      = 4,
-  TK_ENDLIST       = 5,
-  TK_COMMAND_AT    = 6, //! Command starting with `@`
-  TK_HTMLTAG       = 7,
-  TK_SYMBOL        = 8,
-  TK_NEWPARA       = 9,
-  TK_RCSTAG        = 10,
-  TK_URL           = 11,
-  TK_COMMAND_BS    = 12, //! Command starting with `\`
-
-  RetVal_OK             = 0x10000,
-  RetVal_SimpleSec      = 0x10001,
-  RetVal_ListItem       = 0x10002,
-  RetVal_Section        = 0x10003,
-  RetVal_Subsection     = 0x10004,
-  RetVal_Subsubsection  = 0x10005,
-  RetVal_Paragraph      = 0x10006,
-  RetVal_SubParagraph   = 0x10007,
-  RetVal_EndList        = 0x10008,
-  RetVal_EndPre         = 0x10009,
-  RetVal_DescData       = 0x1000A,
-  RetVal_DescTitle      = 0x1000B,
-  RetVal_EndDesc        = 0x1000C,
-  RetVal_TableRow       = 0x1000D,
-  RetVal_TableCell      = 0x1000E,
-  RetVal_TableHCell     = 0x1000F,
-  RetVal_EndTable       = 0x10010,
-  RetVal_Internal       = 0x10011,
-  RetVal_SwitchLang     = 0x10012,
-  RetVal_CloseXml       = 0x10013,
-  RetVal_EndBlockQuote  = 0x10014,
-  RetVal_CopyDoc        = 0x10015,
-  RetVal_EndInternal    = 0x10016,
-  RetVal_EndParBlock    = 0x10017,
-  RetVal_EndHtmlDetails = 0x10018,
-  RetVal_SubSubParagraph= 0x10019,
+#define TKSPEC(x,y) x = y,
+      TOKEN_SPECIFICATIONS
+      RETVAL_SPECIFICATIONS
+#undef TKSPEC
 };
 
 #define TK_COMMAND_CHAR(token) ((token)==Tokens::TK_COMMAND_AT ? '@' : '\\')

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -126,53 +126,24 @@ const char *DocTokenizer::tokToString(Tokens token)
 {
   switch (token)
   {
-    case Tokens::TK_EOF:         return "Tokens::TK_EOF";
-    case Tokens::TK_NONE:        return "Tokens::TK_NONE";
-    case Tokens::TK_WORD:        return "Tokens::TK_WORD";
-    case Tokens::TK_LNKWORD:     return "Tokens::TK_LNKWORD";
-    case Tokens::TK_WHITESPACE:  return "Tokens::TK_WHITESPACE";
-    case Tokens::TK_LISTITEM:    return "Tokens::TK_LISTITEM";
-    case Tokens::TK_ENDLIST:     return "Tokens::TK_ENDLIST";
-    case Tokens::TK_COMMAND_AT:  return "Tokens::TK_COMMAND_AT";
-    case Tokens::TK_HTMLTAG:     return "Tokens::TK_HTMLTAG";
-    case Tokens::TK_SYMBOL:      return "Tokens::TK_SYMBOL";
-    case Tokens::TK_NEWPARA:     return "Tokens::TK_NEWPARA";
-    case Tokens::TK_RCSTAG:      return "Tokens::TK_RCSTAG";
-    case Tokens::TK_URL:         return "Tokens::TK_URL";
-    case Tokens::TK_COMMAND_BS:  return "Tokens::TK_COMMAND_BS";
+#define TKSPEC(x,y) case Tokens::x:              return #x;
+    TOKEN_SPECIFICATIONS
+#undef TKSPEC
     default:
       return "ERROR";
   }
-  return "ERROR";
 }
 
 const char *DocTokenizer::retvalToString(Tokens retval)
 {
   switch (retval)
   {
-    case Tokens::RetVal_OK:              return "Tokens::RetVal_OK";
-    case Tokens::RetVal_SimpleSec:       return "Tokens::RetVal_SimpleSec";
-    case Tokens::RetVal_ListItem:        return "Tokens::RetVal_ListItem";
-    case Tokens::RetVal_Section:         return "Tokens::RetVal_Section";
-    case Tokens::RetVal_Subsection:      return "Tokens::RetVal_Subsection";
-    case Tokens::RetVal_Subsubsection:   return "Tokens::RetVal_Subsubsection";
-    case Tokens::RetVal_Paragraph:       return "Tokens::RetVal_Paragraph";
-    case Tokens::RetVal_SubParagraph:    return "Tokens::RetVal_SubParagraph";
-    case Tokens::RetVal_SubSubParagraph: return "Tokens::RetVal_SubSubParagraph";
-    case Tokens::RetVal_EndList:         return "Tokens::RetVal_EndList";
-    case Tokens::RetVal_EndPre:          return "Tokens::RetVal_EndPre";
-    case Tokens::RetVal_DescData:        return "Tokens::RetVal_DescData";
-    case Tokens::RetVal_DescTitle:       return "Tokens::RetVal_DescTitle";
-    case Tokens::RetVal_EndDesc:         return "Tokens::RetVal_EndDesc";
-    case Tokens::RetVal_TableRow:        return "Tokens::RetVal_TableRow";
-    case Tokens::RetVal_TableCell:       return "Tokens::RetVal_TableCell";
-    case Tokens::RetVal_TableHCell:      return "Tokens::RetVal_TableHCell";
-    case Tokens::RetVal_EndTable:        return "Tokens::RetVal_EndTable";
-    case Tokens::RetVal_Internal:        return "Tokens::RetVal_Internal";
+#define TKSPEC(x,y) case Tokens::x:              return #x;
+    RETVAL_SPECIFICATIONS
+#undef TKSPEC
     default:
       return "ERROR";
   }
-  return "ERROR";
 }
 
 static int computeIndent(const char *str,size_t length)


### PR DESCRIPTION
- Keeping lists consistent (the enum and the toString function)
- removing coverity warning
- more inline definition with other enum class specifications