### PR TITLE
Detect escaped `\cond` command at end of line

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1527,7 +1527,7 @@ WSopt [ \t\r]*
                                           yyextra->javaBlock=1;
                                           BEGIN(JavaDocVerbatimCode);
                                         }
-<SkipCComment,SkipCPPComment>[\\@][\\@]"cond"[ \t]+ { // escaped cond command
+<SkipCComment,SkipCPPComment>[\\@][\\@]"cond"[ \t\n]+ { // escaped cond command
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <SkipCPPComment>[\\@]"cond"[ \t]+       { // conditional section


### PR DESCRIPTION
Properly detect an escaped `\cond` command i.e. `\\cond` at the end of a line in the preprocessor

(Found by Fossies for the doxygen documentation when `ENABLE_PREPROCCESSING` was enabled)

Example: [example.tar.gz](https://github.com/user-attachments/files/16541992/example.tar.gz)
