### PR TITLE
Fix build with clang >= 19.0

### DIFF
--- a/deps/TinyDeflate/gunzip.hh
+++ b/deps/TinyDeflate/gunzip.hh
@@ -1141,21 +1141,21 @@ namespace gunzip_ns
             //fprintf(stderr, "both track flag\n");
             SizeTracker<DeflateTrackBothSize> tracker;
             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
-                (tracker.template ForwardInput(i), tracker.template ForwardOutput(o), tracker.template ForwardWindow(c), std::forward<B>(b)));
+                (tracker.template ForwardInput<I>(i), tracker.template ForwardOutput<O>(o), tracker.template ForwardWindow<C>(c), std::forward<B>(b)));
         }
         else if constexpr(code & Flag_TrackIn)
         {
             //fprintf(stderr, "in track flag\n");
             SizeTracker<DeflateTrackInSize> tracker;
             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
-                (tracker.template ForwardInput(i),std::forward<O>(o),std::forward<C>(c),std::forward<B>(b)));
+                (tracker.template ForwardInput<I>(i),std::forward<O>(o),std::forward<C>(c),std::forward<B>(b)));
         }
         else if constexpr(code & Flag_TrackOut)
         {
             //fprintf(stderr, "out track flag\n");
             SizeTracker<DeflateTrackOutSize> tracker;
             return tracker(Gunzip<code & Flag_NoTrackFlagMask>
-                (std::forward<I>(i), tracker.template ForwardOutput(o), tracker.template ForwardWindow(c), std::forward<B>(b)));
+                (std::forward<I>(i), tracker.template ForwardOutput<O>(o), tracker.template ForwardWindow<C>(c), std::forward<B>(b)));
         }
         else
         {


### PR DESCRIPTION
Clang >= 19.0 requires a template argument list after the template keyword for CWG96 compliance, see
https://github.com/llvm/llvm-project/pull/80801

This patch has also been submitted to upstream TinyDeflate as https://github.com/bisqwit/TinyDeflate/pull/9