### PR TITLE
Incorrect handling of spaces before `@page` command

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3633,7 +3633,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
     case ExplicitPageResult::explicitPage:
       {
         // look for `@page label My Title\n` and capture `label` (match[1]) and ` My Title` (match[2])
-        static const reg::Ex re(R"([\\@]page\s+(\a[\w-]*)(\s*[^\n]*)\n)");
+        static const reg::Ex re(R"([ ]*[\\@]page\s+(\a[\w-]*)(\s*[^\n]*)\n)");
         reg::Match match;
         std::string s = docs.str();
         if (reg::search(s,match,re))


### PR DESCRIPTION
When having some initial space before the `@page` command this is not considered properly, so when having:
```
      @page test_page A Test Page123456
```
this results in something like:
```
A Test Page123456

23456
```
Note the line with `23456`

Example: [example.tar.gz](https://github.com/user-attachments/files/16611687/example.tar.gz)
