### PR TITLE
issue #11071  Extra spaces added by GFM special comment parsing cause verbatim blocks

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -615,7 +615,7 @@ SLASHopt [/]*
   			           }
 <CComment,ReadLine,IncludeFile>"<!--!" { /* HTML comment doxygen command*/
                                      if (yyextra->inVerbatim) REJECT;
-                                     copyToOutput(yyscanner,"     ",5);
+                                     //copyToOutput(yyscanner,"     ",5);
                                      yyextra->inHtmlDoxygenCommand=true;
                                    }
 <CComment,ReadLine,IncludeFile>"-->" { /* potential end HTML comment doxygen command*/


### PR DESCRIPTION
The `<!--!` should be completely removed