### PR TITLE
issue #11082 C include format error

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1277,7 +1277,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           yyextra->delimiter=yyextra->delimiter.left(yyextra->delimiter.length()-1);
                                           BEGIN( RawString );
                                         }
-<FuncCall,Body,MemberCall,MemberCall2,SkipInits,InlineInit,ClassVar>\"   {
+<FuncCall,Body,MemberCall,MemberCall2,SkipInits,InlineInit,ClassVar,OldStyleArgs>\"   {
                                           startFontClass(yyscanner,"stringliteral");
                                           yyextra->code->codify(yytext);
                                           yyextra->lastStringContext=YY_START;
@@ -1370,7 +1370,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                           yyextra->code->codify(yytext);
                                         }
-<Body,MemberCall,MemberCall2,FuncCall>"'"((\\0[Xx0-9]+)|(\\.)|(.))"'"   {
+<Body,MemberCall,MemberCall2,FuncCall,OldStyleArgs>"'"((\\0[Xx0-9]+)|(\\.)|(.))"'"   {
                                           startFontClass(yyscanner,"charliteral");
                                           yyextra->code->codify(yytext);
                                           endFontClass(yyscanner);


### PR DESCRIPTION
The `"` (and `'`) handling were for the sol called "OldStyleArgs" mode not handled and hence the given wrong coloring.

Example (also with `'` test): [example.tar.gz](https://github.com/user-attachments/files/16692208/example.tar.gz)
