### PR TITLE
Greek and Russian translators are up to date

### DIFF
--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -50,7 +50,7 @@
 #ifndef TRANSLATOR_GR_H
 #define TRANSLATOR_GR_H
 
-class TranslatorGreek : public TranslatorAdapter_1_11_0
+class TranslatorGreek : public Translator
 {
   public:
 

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -26,7 +26,7 @@
 #ifndef TRANSLATOR_RU_H
 #define TRANSLATOR_RU_H
 
-class TranslatorRussian : public TranslatorAdapter_1_8_15
+class TranslatorRussian : public Translator
 {
   public:
     /*! Used for identification of the language. */
@@ -1002,8 +1002,7 @@ class TranslatorRussian : public TranslatorAdapter_1_8_15
         "    Used *m_usedClass;\n"
         "};\n"
         "\\endcode\n"
-        "Если \\c MAX_DOT_GRAPH_HEIGHT в конфигурационном файле "
-        "установлен в 240, получится следующий граф:"
+        "Получится следующий граф:"
         "<p><center><img src=\"graph_legend."+getDotImageExtension()+"\"></center>\n"
         "<p>\n"
         "Прямоугольники в этом графе имеют следующее значение:\n"


### PR DESCRIPTION
The Greek and Russian translators are up to date and should be derived from `Translator` and not from an adapter class.

The Russian translator also had a text regarding MAX_DOT_GRAPH that gave problems (and is obsolete and wasn't present in the newer descriptions of other translators).