### PR TITLE
Incorrect handling of spaces before `@page` command (2)

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3633,7 +3633,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
     case ExplicitPageResult::explicitPage:
       {
         // look for `@page label My Title\n` and capture `label` (match[1]) and ` My Title` (match[2])
-        static const reg::Ex re(R"([\\@]page\s+(\a[\w-]*)(\s*[^\n]*)\n)");
+        static const reg::Ex re(R"([ ]*[\\@]page\s+(\a[\w-]*)(\s*[^\n]*)\n)");
         reg::Match match;
         std::string s = docs.str();
         if (reg::search(s,match,re))
@@ -3646,7 +3646,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
                  newLabel+                                     // new label
                  match[2].str()+                               // part between orgLabel and \n
                  "\\ilinebr @ianchor{" + orgTitle + "} "+orgLabel+"\n"+           // add original anchor plus \n of above
-                 docs.right(docs.length()-s.length());         // add remainder of docs
+                 docs.right(docs.length()-match.length());     // add remainder of docs
         }
       }
       break;


### PR DESCRIPTION
The adjustment:
```
Commit: d09922abb551d089dfb9659cfb67bc3d77af5676 [d09922a]
Date: Saturday, August 17, 2024 1:24:44 PM

Implemented slightly simpler solution
```
caused that e.g. the verbatim parts of the pages didn't show up in the internal documentation (`s` is the full docs and not the part that has been handled). Revering the "Implemented slightly simpler solution".

Example: [example.tar.gz](https://github.com/user-attachments/files/16708127/example.tar.gz)
