### PR TITLE
Plantuml cache file name

### DIFF
--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -114,7 +114,7 @@ QCString PlantumlManager::writePlantUMLSource(const QCString &outDirArg,const QC
 
   //printf("content\n====\n%s\n=====\n->\n-----\n%s\n------\n",qPrint(content),qPrint(text));
 
-  QCString qcOutDir(outDir);
+  QCString qcOutDir(substitute(outDir,"\\","/"));
   uint32_t pos = qcOutDir.findRev("/");
   QCString generateType(qcOutDir.right(qcOutDir.length() - (pos + 1)) );
   Debug::print(Debug::Plantuml,0,"*** %s generateType: %s\n","writePlantUMLSource",qPrint(generateType));


### PR DESCRIPTION
When having the setting:
```
HTML_OUTPUT = html\v1
```
and the simple plantuml command:
```
@startuml
Bob -> Alice : hello
@enduml
```

We get the warning:
```
aa.md:6: error: Could not open file .../html\v1/inline_umlgraph_pnghtml\v1.pu for writing
```
as the backslash was not considered properly