### PR TITLE
issue #11114 Doxygen 1.12.0 mishandles Markdown section header following `<pre>` HTML markup.

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2976,7 +2976,7 @@ size_t Markdown::Private::findEndOfLine(std::string_view data,size_t offset)
           tolower(data[end+2])=='e' && (data[end+3]=='>' || data[end+3]==' ')) // <pre> tag
       {
         // skip part until including </pre>
-        end  = end + processHtmlTagWrite(data.substr(end-1),end-1,false) + 2;
+        end  = end + processHtmlTagWrite(data.substr(end-1),end-1,false);
         break;
       }
       else


### PR DESCRIPTION
Looks like a regression on:
```
commit bf1e768aa86ac5cbca5de4510469dd98334973df (HEAD)

Date:   Sat Jan 19 18:45:26 2019 +0100

    issue #6781 Unable to use math in markdown table headers

    Due to the change of the place where the markdown processing is done the end of the line must be calculated a little bit differently.

    Note: translator.py gave an error due to a strange indentation (did surface now), so had to be corrected as well.

 doc/translator.py |  6 +++---
 src/markdown.cpp  | 36 ++++++++++++------------------------
 2 files changed, 15 insertions(+), 27 deletions(-)
```

The return value of `processHtmlTagWrite` already includes the end `>`, so processing should take place from that point onwards.