### PR TITLE
issue #11116 Graphical glitch with lists and text spilling over on a new line.

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1811,6 +1811,10 @@ tt, code, kbd, samp
 {
   display: inline-block;
 }
+tt, code, kbd, samp code
+{
+  vertical-align: top;
+}
 /* @end */
 
 u {


### PR DESCRIPTION
It looks like an interaction between the `<li>` tag, the `<code>` tag and the css setting `display: inline-block;`.
Setting the  attribute `vertical-alignment: top;`  or the `<code>` parts solves the issue.