### PR TITLE
bug 733239 Wrong documentation generated after #include in functions

### DIFF
--- a/src/commentscan.h
+++ b/src/commentscan.h
@@ -88,6 +88,7 @@ class CommentScanner
      *         needs to be started.
      *  @param[in] markdownEnabled Indicates if markdown specific processing should be done.
      *  @param[inout] guards Tracks nested conditional sections (if,ifnot,..)
+     *  @param[in] inInclude signal whether of not we are inside an included file (i.e. verbatim included)
      *  @returns TRUE if the comment requires further processing. The
      *         parameter \a newEntryNeeded will typically be true in this case and
      *         \a position will indicate the offset inside the \a comment string
@@ -106,7 +107,8 @@ class CommentScanner
                            int &position,
                            bool &newEntryNeeded,
                            bool markdownEnabled,
-                           GuardedSectionStack *guards
+                           GuardedSectionStack *guards,
+                           bool inInclude = false
                           );
     void initGroupInfo(Entry *entry);
     void enterFile(const QCString &fileName,int lineNr);

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -476,6 +476,7 @@ struct commentscanYY_state
   GuardType        guardType = Guard_If;     // kind of guards for conditional section
   QCString         functionProto;            // function prototype
   GuardedSectionStack *guards = nullptr;     // tracks nested conditional sections (if,ifnot,..)
+  bool             inInclude = false;        // signal whether of not we are inside an included file (i.e. verbatim included).
   Entry           *current = nullptr;        // working entry
 
   bool             needNewEntry = FALSE;
@@ -3022,13 +3023,22 @@ static bool handleMainpage(yyscan_t yyscanner,const QCString &, const StringVect
 static bool handleFile(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  bool stop=makeStructuralIndicator(yyscanner,EntryType::makeFileDoc);
-  if (!stop)
+  if (yyextra->inInclude)
   {
-    yyextra->current->name = yyextra->fileName;
+    yyextra->current->inbodyDocs.clear(); // in case the file command is not the first command of the block
+    BEGIN( SkipInternal );
+    return false;
   }
-  BEGIN( FileDocArg1 );
-  return stop;
+  else
+  {
+    bool stop=makeStructuralIndicator(yyscanner,EntryType::makeFileDoc);
+    if (!stop)
+    {
+      yyextra->current->name = yyextra->fileName;
+    }
+    BEGIN( FileDocArg1 );
+    return stop;
+  }
 }
 
 static bool handleParam(yyscan_t yyscanner,const QCString &, const StringVector &)
@@ -4676,7 +4686,8 @@ bool CommentScanner::parseCommentBlock(/* in */     OutlineParserInterface *pars
                        /* in,out */ int &position,
                        /* out */    bool &newEntryNeeded,
                        /* in */     bool markdownSupport,
-                       /* inout */  GuardedSectionStack *guards
+                       /* inout */  GuardedSectionStack *guards,
+                       /* in */     bool inInclude
                       )
 {
   AUTO_TRACE("comment='{}' fileName={} lineNr={} isBrief={} isAutoBriefOn={} inInbody={}"
@@ -4687,6 +4698,7 @@ bool CommentScanner::parseCommentBlock(/* in */     OutlineParserInterface *pars
 
   initParser(yyscanner);
   yyextra->guards = guards;
+  yyextra->inInclude = inInclude;
   yyextra->langParser     = parser;
   yyextra->current        = curEntry;
   yyextra->current->docLine = (lineNr > 1 ? lineNr : 1);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -114,6 +114,7 @@ struct scannerYY_state
   int              yyBegLineNr  = 1 ;
   int              yyColNr      = 1 ;
   int              yyBegColNr   = 1 ;
+  int              inInclude    = 0 ;
   QCString         fileName;
   MethodTypes      mtype = MethodTypes::Method;
   bool             isStatic = false;
@@ -2730,6 +2731,18 @@ NONLopt [^\n]*
                                         }
 <PreLineCtrl>"\""[^\n\"]*"\""           {
                                           yyextra->fileName = stripQuotes(yytext);
+                                          if (yyextra->lastPreLineCtrlContext==ReadBody ||
+                                              yyextra->lastPreLineCtrlContext==ReadNSBody ||
+                                              yyextra->lastPreLineCtrlContext==ReadBodyIntf)
+                                          {
+                                            yyextra->current->program << yytext;
+                                          }
+                                        }
+<PreLineCtrl>{Bopt}[0-9]+               {
+                                          if (QCString(yytext).toInt() == 1)
+                                            yyextra->inInclude++;
+                                          else
+                                            yyextra->inInclude--;
                                           if (yyextra->lastPreLineCtrlContext==ReadBody ||
                                               yyextra->lastPreLineCtrlContext==ReadNSBody ||
                                               yyextra->lastPreLineCtrlContext==ReadBodyIntf)
@@ -7932,7 +7945,8 @@ static void handleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool brief
         position,
         needsEntry,
         Config_getBool(MARKDOWN_SUPPORT),
-        &guards
+        &guards,
+        yyextra->inInclude > 0
         )
      )
   {
@@ -7998,7 +8012,8 @@ static void handleParametersCommentBlocks(yyscan_t yyscanner,ArgumentList &al)
              position,
              needsEntry,
              Config_getBool(MARKDOWN_SUPPORT),
-             &guards
+             &guards,
+             yyextra->inInclude > 0
             )
           )
       {


### PR DESCRIPTION
The problem is that we get a `file` command inside a function etc. based on an included file. The `file` command from an included file inside a function etc. is ignored now.