### PR TITLE
bug 729344 Ignoring an items when / or \ is placed after \addindex

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3379,7 +3379,7 @@ static bool handleFormatBlock(yyscan_t yyscanner,const QCString &s, const String
 static bool handleAddIndex(yyscan_t yyscanner,const QCString &, const StringVector &)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  addOutput(yyscanner,"@addindex ");
+  addOutput(yyscanner,yytext);
   BEGIN(LineParam);
   return FALSE;
 }


### PR DESCRIPTION
The handling of the `addindex` command  is here just a copying action and therefore no extra characters should be added so instead of the `cmdName` the original text (`yytext`) should be outputted.

Example: [example.tar.gz](https://github.com/user-attachments/files/16918986/example.tar.gz)
