### PR TITLE
Repeated variable names is code browser

### DIFF
--- a/src/pycode.l
+++ b/src/pycode.l
@@ -1542,17 +1542,16 @@ static void findMemberLink(yyscan_t yyscanner,
   //    yyextra->currentDefinition?qPrint(yyextra->currentDefinition->name()):"<none>",
   //    yyextra->currentMemberDef?qPrint(yyextra->currentMemberDef->name()):"<none>"
   //    );
-  bool found = false;
   if (yyextra->currentDefinition)
   {
     const auto &v = Doxygen::symbolMap->find(symName);
     for (const auto &p : v)
     {
-      if (findMemberLink(yyscanner,ol,p,symName)) found = true;
+      if (findMemberLink(yyscanner,ol,p,symName)) return;
     }
   }
   //printf("sym %s not found\n",&yytext[5]);
-  if (!found) codify(yyscanner,symName);
+  codify(yyscanner,symName);
 }
 
 static void incrementFlowKeyWordCount(yyscan_t yyscanner)


### PR DESCRIPTION
When having the python program:
```
## class
class A:

    def __INIT__(self):
        self.custom_height = None
        pass

    def do_int(self):
        self.custom_height = 42
        print(self.custom_height)
    def do_dble(self):
        self.custom_height = 3.1415
        print(self.custom_height)

    def do_bool(self):
        self.custom_height = True
        print(self.custom_height)

a = A()
a.do_int()
a.do_bool()
a.do_dble()
```

the source code gives lines like:
```
        self.custom_heightcustom_heightcustom_height = True
        print(self.custom_heightcustom_heightcustom_height)
```
so repeated variable name `custom_height`.
Selecting just the first one.

Example; [example.tar.gz](https://github.com/user-attachments/files/16931596/example.tar.gz)
