### PR TITLE
issue #11130 three-way comparison operator is showing up as "operator" instead of "operator<=>" in related symbols

### DIFF
--- a/src/declinfo.l
+++ b/src/declinfo.l
@@ -368,7 +368,8 @@ void parseFuncDecl(const QCString &decl,const SrcLangExt lang,QCString &cl,QCStr
   cl=yyextra->scope;
   n=removeRedundantWhiteSpace(yyextra->name);
   int il=n.find('<'), ir=n.findRev('>');
-  if (il!=-1 && ir!=-1)
+  if (il!=-1 && ir!=-1 && n.at(il+1)!='=')
+    // prevent <=>
     // TODO: handle cases like where n="operator<< <T>" 
   {
     ftl=removeRedundantWhiteSpace(n.right(n.length()-il));


### PR DESCRIPTION
Prevent that declinfo sees `<=>` as a template specifier