### PR TITLE
Fix out-of-bounds `std::string_view` access in Markdown n-/m-dash processing

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -915,9 +915,9 @@ int Markdown::Private::processNmdash(std::string_view data,size_t offset)
   }
   if (count>=2 && offset>=2 && qstrncmp(data.data()-2,"<!",2)==0)
   { AUTO_TRACE_EXIT("result={}",1-count); return 1-count; } // start HTML comment
-  if (count==2 && (data[2]=='>'))
+  if (count==2 && size > 2 && data[2]=='>')
   { return 0; } // end HTML comment
-  if (count==3 && (data[3]=='>'))
+  if (count==3 && size > 3 && data[3]=='>')
   { return 0; } // end HTML comment
   if (count==2 && (offset<8 || qstrncmp(data.data()-8,"operator",8)!=0)) // -- => ndash
   {

--- a/testing/055/md_055__markdown.xml
+++ b/testing/055/md_055__markdown.xml
@@ -24,6 +24,7 @@
             <ulink url="http://example.com/last-line">Upper-cased reference link on last line</ulink>
           </para>
           <para>Dash - NDash <ndash/> MDash <mdash/> EDash - ENDash -- EMDash --- E3Dash ---</para>
+          <para>Dashes in links shouldn't cause out-of-bounds assertions: <ulink url="https://doxygen.nl"><ndash/></ulink> <ulink url="https://doxygen.nl"><mdash/></ulink></para>
         </sect2>
         <sect2 id="md_055__markdown_1autotoc_md3">
           <title>Markdown in HTML</title>

--- a/testing/055_markdown.md
+++ b/testing/055_markdown.md
@@ -23,6 +23,9 @@ More text
 
 Dash - NDash -- MDash --- EDash \- ENDash \-- EMDash \--- E3Dash \-\-\-
 
+Dashes in links shouldn't cause out-of-bounds assertions:
+[--](https://doxygen.nl) [---](https://doxygen.nl)
+
 ## Markdown in HTML
 
 <h3>**Header3** blah _blah_ `blah`</h3>


### PR DESCRIPTION
When Doxygen is built with libstdc++ assertions enabled (passing `-Wp,-D_GLIBCXX_ASSERTIONS` to the compiler, which is for example how the ArchLinux doxygen package is built), the markdown processing code can hit an OOB condition when processing en- and em-dashes. Which then manifests as a quite nasty abort:

```
/usr/include/c++/14.2.1/string_view:256: constexpr const std::basic_string_view<_CharT, _Traits>::value_type& std::basic_string_view<_CharT, _Traits>::operator[](size_type) const [with _CharT = char; _Traits = std::char_traits<char>; const_reference = const char&; size_type = long unsigned int]: Assertion '__pos < this->_M_len' failed.
```

I suppose same could happen on MSVC debug builds, but I don't have a Windows environment to verify. A minimal repro case is doing this for example, I expanded the markdown test with it to have a regression case:

```cpp
/**
@page wonderful-crashes Boom

[--](https://doxygen.nl)
[---](https://doxygen.nl)
*/
```

The fix just adds a check against the string view size before accessing its contents. I didn't attempt to track down when this happened, all I know that 1.8.16 and older didn't have this problem I think (or maybe `_GLIBCXX_ASSERTIONS` wasn't enabled when those packages got built) and 1.12 does. This is also the only problematic case I found, didn't get any other assertion with `_GLIBCXX_ASSERTIONS` enabled with either [Corrade](https://github.com/mosra/corrade) or the [Magnum](https://github.com/mosra/magnum) projects.

I think it might be also useful to enable `_GLIBCXX_ASSERTIONS` for Debug GCC builds in your GitHub Actions. Can do that as part of this PR if you want.

(The original discovery of this bug was due to [this particular GitHub profile link in my credits page](https://github.com/mosra/corrade/blob/12e5dbadf61807e656d1c06e12dfbcc10b76d8c9/doc/corrade-credits.dox#L145-L146). Hello, @LB--! :laughing:)

Thank you!