### PR TITLE
issue #11134 gswin64c.exe not recognized if path added to EXTERNAL_TOOL_PATH

### DIFF
--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -338,7 +338,14 @@ void Portable::unsetenv(const QCString &variable)
 QCString Portable::getenv(const QCString &variable)
 {
 #if defined(_WIN32) && !defined(__CYGWIN__)
-    return ::getenv(variable.data());
+    #define ENV_BUFSIZE 32768
+    LPTSTR pszVal = (LPTSTR) malloc(ENV_BUFSIZE*sizeof(TCHAR));
+    if (GetEnvironmentVariable(variable.data(),pszVal,ENV_BUFSIZE) == 0) return "";
+    QCString out;
+    out = pszVal;
+    free(pszVal);
+    return out;
+    #undef ENV_BUFSIZE
 #else
     if(!environmentLoaded) // if the environment variables are not loaded already...
     {                      // ...call loadEnvironment to store them in class


### PR DESCRIPTION
On Windows don't use `::getenv` but `GetEnvironmentVariable` as `::getenv` doesn't always work properly with `GetEnvironmentVariable`