### PR TITLE
Properly consider namespace / class scopes when merging typedefs together

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3209,71 +3209,57 @@ static void buildTypedefList(const Entry *root)
       scope=root->parent()->name; //stripAnonymousNamespaceScope(root->parent->name);
     }
     ClassDefMutable *cd=getClassMutable(scope);
-    if (cd && scope+"::"==rname.left(scope.length()+2)) // found A::f inside A
+    MemberName *mn = Doxygen::functionNameLinkedMap->find(rname);
+    bool found=false;
+    if (mn) // symbol with the same name already found
     {
-      // strip scope from name
-      rname=rname.right(rname.length()-root->parent()->name.length()-2);
-    }
-    QCString rtype = root->type;
-    rtype.stripPrefix("typedef ");
-    if (!root->parent()->name.isEmpty() && root->parent()->section.isCompound() && cd)
-    {
-      AUTO_TRACE_ADD("typedef '{}' in class '{}'", rname,cd->name());
-      addVariableToClass(root,cd,MemberType::Typedef,rtype,rname,root->args,false,nullptr,
-                         root->protection,Relationship::Member);
-    }
-    else
-    {
-      MemberName *mn = Doxygen::functionNameLinkedMap->find(rname);
-      bool found=false;
-      if (mn) // symbol with the same name already found
+      for (auto &imd : *mn)
       {
-        for (auto &imd : *mn)
+        QCString rtype = root->type;
+        rtype.stripPrefix("typedef ");
+        bool notBothGrouped = root->groups.empty() || imd->getGroupDef()==nullptr; // see example #100
+        //printf("imd->isTypedef()=%d imd->typeString()=%s root->type=%s\n",imd->isTypedef(),
+        //    qPrint(imd->typeString()),qPrint(root->type));
+        if (imd->isTypedef() && notBothGrouped && imd->typeString()==rtype)
         {
-          bool notBothGrouped = root->groups.empty() || imd->getGroupDef()==nullptr; // see example #100
-                                                                                     //printf("imd->isTypedef()=%d imd->typeString()=%s root->type=%s\n",imd->isTypedef(),
-                                                                                     //    qPrint(imd->typeString()),qPrint(root->type));
-          if (imd->isTypedef() && notBothGrouped && imd->typeString()==rtype)
+          MemberDefMutable *md = toMemberDefMutable(imd.get());
+          if (md)
           {
-            MemberDefMutable *md = toMemberDefMutable(imd.get());
-            if (md)
-            {
-              md->setDocumentation(root->doc,root->docFile,root->docLine);
-              md->setInbodyDocumentation(root->inbodyDocs,root->inbodyFile,root->inbodyLine);
-              md->setDocsForDefinition(!root->proto);
-              md->setBriefDescription(root->brief,root->briefFile,root->briefLine);
-              md->addSectionsToDefinition(root->anchors);
-              md->setRefItems(root->sli);
-              md->addQualifiers(root->qualifiers);
+            md->setDocumentation(root->doc,root->docFile,root->docLine);
+            md->setInbodyDocumentation(root->inbodyDocs,root->inbodyFile,root->inbodyLine);
+            md->setDocsForDefinition(!root->proto);
+            md->setBriefDescription(root->brief,root->briefFile,root->briefLine);
+            md->addSectionsToDefinition(root->anchors);
+            md->setRefItems(root->sli);
+            md->addQualifiers(root->qualifiers);
 
-              // merge ingroup specifiers
-              if (md->getGroupDef()==nullptr && !root->groups.empty())
-              {
-                addMemberToGroups(root,md);
-              }
-              else if (md->getGroupDef()!=nullptr && root->groups.empty())
-              {
-                //printf("existing member is grouped, new member not\n");
-              }
-              else if (md->getGroupDef()!=nullptr && !root->groups.empty())
-              {
-                //printf("both members are grouped\n");
-              }
-              found=true;
-              break;
+            // merge ingroup specifiers
+            if (md->getGroupDef()==nullptr && !root->groups.empty())
+            {
+              addMemberToGroups(root,md);
             }
+            else if (md->getGroupDef()!=nullptr && root->groups.empty())
+            {
+              //printf("existing member is grouped, new member not\n");
+            }
+            else if (md->getGroupDef()!=nullptr && !root->groups.empty())
+            {
+              //printf("both members are grouped\n");
+            }
+            found=true;
+            break;
           }
         }
       }
-      if (found)
-      {
-        AUTO_TRACE_ADD("typedef '{}' already found",rname);
-      }
-      else
-      {
-        AUTO_TRACE_ADD("new typedef '{}'",rname);
-        addVariable(root);
-      }
+    }
+    if (found)
+    {
+      AUTO_TRACE_ADD("typedef '{}' already found",rname);
+    }
+    else
+    {
+      AUTO_TRACE_ADD("new typedef '{}'",rname);
+      addVariable(root);
     }
 
   }

--- a/testing/104/namespace_root.xml
+++ b/testing/104/namespace_root.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="namespace_root" kind="namespace" language="C++">
+    <compoundname>Root</compoundname>
+    <innerclass refid="struct_root_1_1_another_struct" prot="public">Root::AnotherStruct</innerclass>
+    <innernamespace refid="namespace_root_1_1_sub">Root::Sub</innernamespace>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="104__typedef__merging_8cpp_1a54d1abe7d6cdb9df34b7dac79e43d063" prot="public" static="no">
+        <type>int</type>
+        <definition>typedef int Root::Int</definition>
+        <argsstring/>
+        <name>Int</name>
+        <qualifiedname>Root::Int</qualifiedname>
+        <briefdescription>
+          <para>A typedef. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="104_typedef_merging.cpp" line="9" column="13" bodyfile="104_typedef_merging.cpp" bodystart="9" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="typedef" id="104__typedef__merging_8cpp_1a9b339731649b3b1ac36647215f184fba" prot="public" static="no">
+        <type>float</type>
+        <definition>using Root::Float =  float</definition>
+        <argsstring/>
+        <name>Float</name>
+        <qualifiedname>Root::Float</qualifiedname>
+        <briefdescription>
+          <para>A using declaration. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="104_typedef_merging.cpp" line="12" column="1" bodyfile="104_typedef_merging.cpp" bodystart="12" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="typedef" id="104__typedef__merging_8cpp_1a41364ddb2cc61dba25d96e9d2a87ad00" prot="public" static="no">
+        <type>bool</type>
+        <definition>typedef bool Root::BoolShouldNotBecomeFunction</definition>
+        <argsstring/>
+        <name>BoolShouldNotBecomeFunction</name>
+        <qualifiedname>Root::BoolShouldNotBecomeFunction</qualifiedname>
+        <briefdescription>
+          <para>A typedef that shouldn't become a function. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="104_typedef_merging.cpp" line="42" column="14" bodyfile="104_typedef_merging.cpp" bodystart="42" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="104_typedef_merging.cpp" line="6" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/104/namespace_root_1_1_sub.xml
+++ b/testing/104/namespace_root_1_1_sub.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="namespace_root_1_1_sub" kind="namespace" language="C++">
+    <compoundname>Root::Sub</compoundname>
+    <innerclass refid="struct_root_1_1_sub_1_1_struct" prot="public">Root::Sub::Struct</innerclass>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="104__typedef__merging_8cpp_1a244ea95b1131245341a73ee5615ce973" prot="public" static="no">
+        <type>double</type>
+        <definition>typedef double Root::Sub::Double</definition>
+        <argsstring/>
+        <name>Double</name>
+        <qualifiedname>Root::Sub::Double</qualifiedname>
+        <briefdescription>
+          <para>Another typedef in Sub, not related to <ref refid="struct_root_1_1_sub_1_1_struct" kindref="compound">Struct</ref>. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="104_typedef_merging.cpp" line="16" column="18" bodyfile="104_typedef_merging.cpp" bodystart="16" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="104_typedef_merging.cpp" line="14" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/104/struct_root_1_1_sub_1_1_struct.xml
+++ b/testing/104/struct_root_1_1_sub_1_1_struct.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="struct_root_1_1_sub_1_1_struct" kind="struct" language="C++" prot="public">
+    <compoundname>Root::Sub::Struct</compoundname>
+    <sectiondef kind="public-type">
+      <memberdef kind="typedef" id="struct_root_1_1_sub_1_1_struct_1adb4b7d803ad6e7cdd15b16fb51968d58" prot="public" static="no">
+        <type>double</type>
+        <definition>typedef double Root::Sub::Struct::Double</definition>
+        <argsstring/>
+        <name>Double</name>
+        <qualifiedname>Root::Sub::Struct::Double</qualifiedname>
+        <briefdescription>
+          <para>A typedef that doesn't get merged with the one in Sub. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="104_typedef_merging.cpp" line="21" column="20" bodyfile="104_typedef_merging.cpp" bodystart="21" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="related">
+      <memberdef kind="typedef" id="struct_root_1_1_sub_1_1_struct_1a7cc214a236ad3bb6ad435bdcf5262a3f" prot="public" static="no">
+        <type>int</type>
+        <definition>typedef int Int</definition>
+        <argsstring/>
+        <name>Int</name>
+        <qualifiedname>Root::Sub::Struct::Int</qualifiedname>
+        <briefdescription>
+          <para>A typedef in Sub that doesn't get merged with the one in Root. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="104_typedef_merging.cpp" line="27" column="15" bodyfile="104_typedef_merging.cpp" bodystart="27" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="typedef" id="struct_root_1_1_sub_1_1_struct_1a3ffd74e95952eacd75f04a2b85d61845" prot="public" static="no">
+        <type>float</type>
+        <definition>using Float =  float</definition>
+        <argsstring/>
+        <name>Float</name>
+        <qualifiedname>Root::Sub::Struct::Float</qualifiedname>
+        <briefdescription>
+          <para>A using declaration in Sub doesn't get merged with the one in Root. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="104_typedef_merging.cpp" line="32" column="3" bodyfile="104_typedef_merging.cpp" bodystart="32" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>A struct. </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="104_typedef_merging.cpp" line="19" column="3" bodyfile="104_typedef_merging.cpp" bodystart="19" bodyend="22"/>
+    <listofallmembers>
+      <member refid="struct_root_1_1_sub_1_1_struct_1adb4b7d803ad6e7cdd15b16fb51968d58" prot="public" virt="non-virtual">
+        <scope>Root::Sub::Struct</scope>
+        <name>Double</name>
+      </member>
+      <member refid="struct_root_1_1_sub_1_1_struct_1a3ffd74e95952eacd75f04a2b85d61845" prot="public" virt="non-virtual">
+        <scope>Root::Sub::Struct</scope>
+        <name>Float</name>
+      </member>
+      <member refid="struct_root_1_1_sub_1_1_struct_1a7cc214a236ad3bb6ad435bdcf5262a3f" prot="public" virt="non-virtual">
+        <scope>Root::Sub::Struct</scope>
+        <name>Int</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/104_typedef_merging.cpp
+++ b/testing/104_typedef_merging.cpp
@@ -1,0 +1,52 @@
+// objective: test typedef deduplication that properly considers scopes
+// check: namespace_root.xml
+// check: namespace_root_1_1_sub.xml
+// check: struct_root_1_1_sub_1_1_struct.xml
+
+namespace Root {
+
+/** @brief A typedef */
+typedef int Int;
+
+/* Documentation comes later */
+using Float = float;
+
+namespace Sub {
+  /* Documentation comes later */
+  typedef double Double;
+
+  /** @brief A struct */
+  struct Struct {
+    /** @brief A typedef that doesn't get merged with the one in Sub */
+    typedef double Double;
+  };
+
+  /** @relatedalso Struct
+   * @brief A typedef in Sub that doesn't get merged with the one in Root
+   */
+  typedef int Int;
+
+  /** @relatedalso Struct
+   * @brief A using declaration in Sub doesn't get merged with the one in Root
+   */
+  using Float = float;
+
+  /** @brief Another typedef in Sub, not related to @ref Struct */
+  typedef double Double;
+}
+
+/** @brief A using declaration */
+using Float = float;
+
+/* Documentation comes later */
+typedef bool BoolShouldNotBecomeFunction;
+
+/** @brief Another struct */
+struct AnotherStruct {};
+
+/** @relatedalso AnotherStruct
+ * @brief A typedef that shouldn't become a function
+ */
+typedef bool BoolShouldNotBecomeFunction;
+
+}


### PR DESCRIPTION
With Doxygen 1.12, the typedefs in the following snippet get combined together even though they are in different namespaces. Which, depending on the context, results in various issues, like being unable to link to either of them, or they not even appearing in generated documentation, etc.

```cpp
namespace Root {

/** @brief A typedef */
typedef int Int;

/** @brief A using declaration */
using Float = float;

namespace Sub {

/** @brief A struct */
struct Struct {};

/** @relatedalso Struct
 * @brief A typedef in Sub that doesn't get merged with Root::Int
 */
typedef int Int;

/** @relatedalso Struct
 * @brief A using declaration in Sub doesn't get merged with Root::Float
 */
using Float = float;

}}
```

And, as a side effect, because of the `@relatedalso`, the XML then contains them marked as *functions*, causing interesting breakages in downstream tools.

```html
<?xml version='1.0' encoding='UTF-8' standalone='no'?>
<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.12.0" xml:lang="en-US">
  <compounddef id="classRoot_1_1Sub_1_1Class" kind="class" language="C++" prot="public">
    ...
    <sectiondef kind="related">
      ...
      <memberdef kind="function" id="classRoot_1_1Sub_1_1Class_1a7cc214a236ad3bb6ad435bdcf5262a3f" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
      <!--             ^^^^^^^^---- note this here -->
        <type>typedef int</type>
        <definition>typedef int Int</definition>
        <argsstring></argsstring>
        <name>Int</name>
        <qualifiedname>Root::Sub::Class::Int</qualifiedname>
        <briefdescription>
<para>A typedef in Sub namespace. </para>
```

I tracked this down to a7179f016c974c38b3d1725dcfcb77924da8b182 (which was fixing #11010), which got subsequently patched in 70aff92f9ecdfced4ea745c94eb98d22a90543bd. The former commit had an issue where it didn't consider actual scopes at all, the latter then partially patched this to restore the original functionality for typedefs defined in classes, but typedefs defined outside of classes got still merged even if they had a different namespace.

In this PR I partially reverted the second commit, and replaced it with a check that both candidates appear in the same scope (the same class, the same namespace, or neither, i.e. a global symbol). That made the above snippet work again. (I hope I did that correctly, let me know if not.)

That wasn't enough however, as the snippet below still produces a typedef marked as a function. The `@relatedalso` is again important here.

```cpp
using Float = float;

/** @brief A struct */
struct Struct {};

/** @relatedalso Struct
 * @brief A using declaration
 */
using Float = float;
```

The reason, in my understanding, is that if the duplicated typedefs get merged, the original second duplicate is left in the entry tree, and due to `@relatedalso` ends up in `filterMemberDocumentation()` later, which implicitly treats it as a function. To fix that, I marked it as processed, which is what `addVariable()` itself did before the two above-referenced commits, restoring the original behavior. In other words, I didn't see a reason to pass it further to another filter, given that the merge happened once already.

I added an extra test to verify both the deduplication behavior and that deduplication takes the scope correctly into account. I recommend viewing the diff with whitespace ignored, or going comit-by-commit. Let me know if you have any questions -- thanks!