### PR TITLE
Incorrect marking of enum values in source browser

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -2732,7 +2732,14 @@ static MemberDef *addVariableToFile(
   //md->setOuterScope(fd);
   if (!root->explicitExternal)
   {
-    mmd->setBodySegment(root->startLine,root->bodyLine,root->endBodyLine);
+    if (mmd->isEnumValue())
+    {
+      mmd->setBodySegment(root->bodyLine,root->bodyLine,root->endBodyLine);
+    }
+    else
+    {
+      mmd->setBodySegment(root->startLine,root->bodyLine,root->endBodyLine);
+    }
     mmd->setBodyDef(fd);
   }
   addMemberToGroups(root,md.get());
@@ -7610,7 +7617,14 @@ static void addEnumValuesToEnums(const Entry *root)
                   fmmd->setOuterScope(md->getOuterScope());
                   fmmd->setTagInfo(e->tagInfo());
                   fmmd->setLanguage(e->lang);
-                  fmmd->setBodySegment(e->startLine,e->bodyLine,e->endBodyLine);
+                  if (fmmd->isEnumValue())
+                  {
+                    fmmd->setBodySegment(e->bodyLine,e->bodyLine,e->endBodyLine);
+                  }
+                  else
+                  {
+                    fmmd->setBodySegment(e->startLine,e->bodyLine,e->endBodyLine);
+                  }
                   fmmd->setBodyDef(e->fileDef());
                   fmmd->setId(e->id);
                   fmmd->setDocumentation(e->doc,e->docFile,e->docLine);


### PR DESCRIPTION
When having a simple example like:
```
/// \file

enum class Enum_cls
{
    All_cls
    = 0,
    Functions_cls,
    New_cls
};

enum Enum
{
    All
    = 0,
    Functions,
    New
};
```
we see in the source listing (when `EXTRACT_ALL=YES`) that the lines 3, 6, 7, 9, 11, 14, 15 and 17 are (grey) marked instead of the lines 3, 6, 7, 8, 11, 13, 15 and 16. This has been corrected.

Example: [example.tar.gz](https://github.com/user-attachments/files/17012498/example.tar.gz)
