### PR TITLE
More flexibility showing undocumented namespaces

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -997,6 +997,17 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+    <option type='bool' id='HIDE_UNDOC_NAMESPACES' defval='1'>
+      <docs>
+<![CDATA[
+ If the \c HIDE_UNDOC_NAMESPACES tag is set to \c YES, Doxygen will hide all
+ undocumented namespaces that are normally visible in the namespace hierarchy.
+ If set to \c NO, these namespaces will be included in the
+ various overviews.
+ This option has no effect if \ref cfg_extract_all "EXTRACT_ALL" is enabled.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='HIDE_FRIEND_COMPOUNDS' defval='0'>
       <docs>
 <![CDATA[

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -1531,6 +1531,7 @@ bool NamespaceDefImpl::isLinkableInProject() const
   int i = name().findRev("::");
   if (i==-1) i=0; else i+=2;
   bool extractAnonNs = Config_getBool(EXTRACT_ANON_NSPACES);
+  bool hideUndoc     = Config_getBool(HIDE_UNDOC_NAMESPACES);
   if (extractAnonNs &&                             // extract anonymous ns
       name().mid(i,20)=="anonymous_namespace{"     // correct prefix
      )                                             // not disabled by config
@@ -1538,7 +1539,7 @@ bool NamespaceDefImpl::isLinkableInProject() const
     return TRUE;
   }
   return !name().isEmpty() && name().at(i)!='@' && // not anonymous
-    (hasDocumentation() || getLanguage()==SrcLangExt::CSharp) &&  // documented
+    (hasDocumentation() || !hideUndoc || getLanguage()==SrcLangExt::CSharp) &&  // documented
     !isReference() &&      // not an external reference
     !isHidden() &&         // not hidden
     !isArtificial();       // or artificial


### PR DESCRIPTION
Contrary to classes (`HIDE_UNDOC_CLASSES`) there is for namespaces no possibility to flexible show / hide them (only by means of documenting the namespace or set `EXTRACT_ALL=YES`). With `HIDE_UNDOC_NAMESPACES` this possibility is created and the default behavior remains as it was (i.e. `HIDE_UNDOC_NAMESPACES=YES`).

Example: [example.tar.gz](https://github.com/user-attachments/files/17013424/example.tar.gz)
