### PR TITLE
Incorrect marking of enum values in source browser

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4060,8 +4060,16 @@ NONLopt [^\n]*
                                           if (!yyextra->current->name.isEmpty())
                                           {
                                             yyextra->current->fileName   = yyextra->fileName;
-                                            yyextra->current->startLine  = yyextra->yyLineNr;
-                                            yyextra->current->startColumn = yyextra->yyColNr;
+                                            if (yyextra->current_root->section.isEnum() || yyextra->current_root->spec.isEnum())
+                                            {
+                                              yyextra->current->startLine  = yyextra->current->bodyLine;
+                                              yyextra->current->startColumn = yyextra->current->bodyColumn;
+                                            }
+                                            else
+                                            {
+                                              yyextra->current->startLine  = yyextra->yyLineNr;
+                                              yyextra->current->startColumn = yyextra->yyColNr;
+                                            }
                                             if (!yyextra->current_root->spec.isEnum())
                                             {
                                               yyextra->current->type       = "@"; // enum marker


### PR DESCRIPTION
When having a simple example like:
```
/// \file

enum class Enum_cls
{
    All_cls
    = 0,
    Functions_cls,
    New_cls
};

enum Enum
{
    All
    = 0,
    Functions,
    New
};
```
we see in the source listing (when `EXTRACT_ALL=YES`) that the lines 3, 6, 7, 9, 11, 14, 15 and 17 are (grey) marked instead of the lines 3, 6, 7, 8, 11, 13, 15 and 16. This has been corrected