### PR TITLE
More flexibility showing undocumented namespaces (2)

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -5139,6 +5139,26 @@ static void findUsedTemplateInstances()
   }
 }
 
+static void warnUndocumentedNamespaces()
+{
+  AUTO_TRACE();
+  for (const auto &nd : *Doxygen::namespaceLinkedMap)
+  {
+    if (!nd->hasDocumentation())
+    {
+      if ((guessSection(nd->getDefFileName()).isHeader() ||
+           nd->getLanguage() == SrcLangExt::Fortran) &&     // Fortran doesn't have header files.
+          !Config_getBool(HIDE_UNDOC_NAMESPACES)            // undocumented namespaces are visible
+         )
+      {
+        warn_undoc(nd->getDefFileName(),nd->getDefLine(), "%s %s is not documented.",
+                   nd->getLanguage() == SrcLangExt::Fortran ? "Module" : "Namespace",
+                   qPrint(nd->name()));
+      }
+    }
+  }
+}
+
 static void computeClassRelations()
 {
   AUTO_TRACE();
@@ -12610,6 +12630,10 @@ void parseInput()
 
   g_s.begin("Flushing cached template relations that have become invalid...\n");
   flushCachedTemplateRelations();
+  g_s.end();
+
+  g_s.begin("Warn for undocumented namespaces...\n");
+  warnUndocumentedNamespaces();
   g_s.end();
 
   g_s.begin("Computing class relations...\n");


### PR DESCRIPTION
As extension to #11143 (More flexibility showing undocumented namespaces) also add a warning analogous to the warning for undocumented classes.