### PR TITLE
issue #11147 Functions are incorrectly flagged as undocumented if not generating HTML or LaTeX

### DIFF
--- a/src/outputlist.cpp
+++ b/src/outputlist.cpp
@@ -176,7 +176,7 @@ void OutputList::generateDoc(const QCString &fileName,int startLine,
 
   auto count=std::count_if(m_outputGenList.begin(),m_outputGenList.end(),
                            [](const auto &e) { return e.enabled; });
-  if (count>0)
+  if (count>0 || Config_getBool(GENERATE_XML))
   {
     // we want to validate irrespective of the number of output formats
     // specified as:
@@ -204,7 +204,7 @@ void OutputList::parseText(const QCString &textStr)
   auto count=std::count_if(m_outputGenList.begin(),m_outputGenList.end(),
                            [](const auto &e) { return e.enabled; });
 
-  if (count>0)
+  if (count>0 || Config_getBool(GENERATE_XML))
   {
     // we want to validate irrespective of the number of output formats
     // specified as:


### PR DESCRIPTION
Regression on:
```
commit 2c76059d714ea6f2a179578966021df9e365a2a6 (HEAD)

Date:   Wed Apr 20 19:52:43 2022 +0200

    Minor optimisation
```

The fact that XML output is a bit an odd one out was not considered (although mentioned in the comment:  "when only XML format there should be warnings as well (XML has its own write routines)").