### PR TITLE
Incorrect label for enum values

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3229,7 +3229,7 @@ void MemberDefImpl::_writeEnumValues(OutputList &ol,const Definition *container,
 
         ol.startDescTableTitle();
         ol.startDoxyAnchor(cfname,cname,fmd->anchor(),fmd->name(),fmd->argsString());
-        ol.addLabel(cfname,anchor());
+        ol.addLabel(cfname,fmd->anchor());
         ol.docify(fmd->name());
         ol.disableAllBut(OutputType::Man);
         ol.writeString(" ");
@@ -3955,7 +3955,7 @@ void MemberDefImpl::writeMemberDocSimple(OutputList &ol, const Definition *conta
   {
     ol.startInlineMemberType();
     ol.startDoxyAnchor(cfname,cname,memAnchor,doxyName,doxyArgs);
-    ol.addLabel(cfname,anchor());
+    ol.addLabel(cfname,memAnchor);
 
     QCString ts = fieldType();
 


### PR DESCRIPTION
The label for the enum value should not point to the enum (`anchor()`) but to the value (`fmd->anchor()`). Under LaTeX this gave some warnings like:
```
LaTeX Warning: Label `index_8h_a8150b7776c2a1749101acf22e868d091' multiply defined
```

Example: [example.tar.gz](https://github.com/user-attachments/files/17089231/example.tar.gz)
