### PR TITLE
Stripping code comments together with `@dontinclude` and `@snippet`

### DIFF
--- a/addon/doxyapp/doxyapp.cpp
+++ b/addon/doxyapp/doxyapp.cpp
@@ -133,6 +133,7 @@ static void findXRefSymbols(FileDef *fd)
                 QCString(),
                 fileToString(fd->absFilePath()),
                 lang,
+                Config_getBool(STRIP_CODE_COMMENTS),
                 FALSE,
                 QCString(),
                 fd);

--- a/addon/doxyparse/doxyparse.cpp
+++ b/addon/doxyparse/doxyparse.cpp
@@ -105,7 +105,8 @@ static void findXRefSymbols(FileDef *fd)
   parseList.add(std::move(parse));
 
   // parse the source code
-  intf->parseCode(parseList, QCString(), fileToString(fd->absFilePath()), lang, FALSE, QCString(), fd);
+  intf->parseCode(parseList, QCString(), fileToString(fd->absFilePath()), lang,
+                  Config_getBool(STRIP_CODE_COMMENTS), FALSE, QCString(), fd);
 }
 
 static bool ignoreStaticExternalCall(const MemberDef *context, const MemberDef *md) {

--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -2730,7 +2730,11 @@ Commands for displaying examples
   \ref cfg_example_path "EXAMPLE_PATH"
   tag of Doxygen's configuration file.
 
-  You can add option `lineno` to enable line numbers for the included code if desired.
+  You can add the option `lineno` to enable line numbers for the included code if desired.
+  You can add the option `stripcodecomments` that will always hide any special comments
+  from the included code irrespective of the setting of
+  \ref cfg_strip_code_comments "STRIP_CODE_COMMENTS" or you can add the option
+  `nostripcodecomments` that will always show the special comments.
 
   The class and member declarations and definitions inside the code fragment
   are 'remembered' during the parsing of the comment block that contained
@@ -2799,6 +2803,11 @@ Commands for displaying examples
   - The `option` `doc` can be used to treat the file as documentation rather than code.
   - The `option` `local` can be used make Doxygen interpret the code as if it was in the
                class or namespace in which the include command appears, rather than the global namespace.
+  - The `option` `stripcodecomments` can be used so that any special comment will always be hidden
+  from the included code irrespective of the setting of
+  \ref cfg_strip_code_comments "STRIP_CODE_COMMENTS" or you can use the `option`
+  `nostripcodecomments` that will always show the special comments. These options have no effect in
+  combination with the `option` `doc`.
 
   When using option `doc`, there is also the option `raise` that can be specified to raise
   all sections found in the referenced file by a certain amount. For example
@@ -2947,6 +2956,11 @@ Commands for displaying examples
  - The `option` `doc` can be used to treat the file as documentation rather than code.
  - The `option` `local` can be used make Doxygen interpret the code as if it was in the
                class or namespace in which the include command appears, rather than the global namespace.
+  - The `option` `stripcodecomments` can be used so that any special comment will always be hidden
+  from the included code irrespective of the setting of
+  \ref cfg_strip_code_comments "STRIP_CODE_COMMENTS" or you can use the `option`
+  `nostripcodecomments` that will always show the special comments. These options have no effect in
+  combination with the `option` `doc`.
 
  When using option `doc`, there is also the option `raise` that can be specified to raise
  all sections found in the referenced file by a certain amount. For example

--- a/src/code.h
+++ b/src/code.h
@@ -36,6 +36,7 @@ class CCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt lang,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/code.l
+++ b/src/code.l
@@ -113,6 +113,7 @@ struct codeYY_state
   bool          insideCodeLine = FALSE;
   bool          skipCodify = FALSE;  //!< for CSharp files scoped namespace {
 
+  bool          stripCodeComments = TRUE;
   bool          exampleBlock = FALSE;
   QCString      exampleName;
   QCString      exampleFile;
@@ -2050,7 +2051,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                         }
 <*>\n({B}*{CPPC}[!/][^\n]*\n)+            { // remove special one-line comment
                                           if (YY_START==SkipCPP) REJECT;
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             skipHiddenComment(yyscanner,yytext);
                                             nextCodeLine(yyscanner);
@@ -2073,7 +2074,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           unput('\n');
                                         }
 <*>\n{B}*{CPPC}"@"[{}].*\n                  { // remove one-line group marker
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             skipHiddenComment(yyscanner,yytext);
                                             nextCodeLine(yyscanner);
@@ -2091,7 +2092,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                         }
 <*>\n{B}*{CCS}"@"[{}]                      { // remove one-line group marker
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             if (YY_START != RemoveSpecialCComment) yyextra->lastSpecialCContext = YY_START;
                                             yyextra->yyLineNr++;
@@ -2110,7 +2111,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                         }
 <*>^{B}*{CPPC}"@"[{}].*\n                   { // remove one-line group marker
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             skipHiddenComment(yyscanner,yytext);
                                             nextCodeLine(yyscanner);
@@ -2123,7 +2124,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                         }
 <*>^{B}*{CCS}"@"[{}]                       { // remove multi-line group marker
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             if (YY_START != RemoveSpecialCComment) yyextra->lastSpecialCContext = YY_START;
                                             BEGIN(RemoveSpecialCComment);
@@ -2141,7 +2142,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                         }
 <*>^{B}*{CPPC}[!/][^\n]*                  { // remove special one-line comment
-                                          if (!Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (!yyextra->stripCodeComments)
                                           {
                                             startFontClass(yyscanner,"comment");
                                             codifyLines(yyscanner,yytext);
@@ -2150,7 +2151,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                         }
 <*>{CPPC}[!/][^\n]*                       { // strip special one-line comment
                                           if (YY_START==SkipComment || YY_START==SkipString) REJECT;
-                                          if (!Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (!yyextra->stripCodeComments)
                                           {
                                             startFontClass(yyscanner,"comment");
                                             codifyLines(yyscanner,yytext);
@@ -2158,7 +2159,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                         }
 <*>\n{B}*{CCS}[!*]/{NCOMM}               {
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             skipHiddenComment(yyscanner,yytext);
                                             if (YY_START != RemoveSpecialCComment) yyextra->lastSpecialCContext = YY_START;
@@ -2177,7 +2178,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                         }
 <*>^{B}*{CCS}"*"[*]+/[^/]                  { // special C "banner" comment block at a new line
-                                          if (Config_getBool(JAVADOC_BANNER) && Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (Config_getBool(JAVADOC_BANNER) && yyextra->stripCodeComments)
                                           {
                                             if (YY_START != RemoveSpecialCComment) yyextra->lastSpecialCContext = YY_START;
                                             BEGIN(RemoveSpecialCComment);
@@ -2195,7 +2196,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           }
                                         }
 <*>^{B}*{CCS}[!*]/{NCOMM}               { // special C comment block at a new line
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             if (YY_START != RemoveSpecialCComment) yyextra->lastSpecialCContext = YY_START;
                                             BEGIN(RemoveSpecialCComment);
@@ -2214,7 +2215,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                         }
 <*>{CCS}[!*]/{NCOMM}                    { // special C comment block half way a line
                                           if (YY_START==SkipString) REJECT;
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             if (YY_START != RemoveSpecialCComment) yyextra->lastSpecialCContext = YY_START;
                                             BEGIN(RemoveSpecialCComment);
@@ -2233,7 +2234,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                         }
 <*>{CCS}("!"?){CCE}                     {
                                           if (YY_START==SkipString) REJECT;
-                                          if (!Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (!yyextra->stripCodeComments)
                                           {
                                             startFontClass(yyscanner,"comment");
                                             yyextra->code->codify(yytext);
@@ -4211,7 +4212,7 @@ bool CCodeParser::insideCodeLine() const
 }
 
 void CCodeParser::parseCode(OutputCodeList &od,const QCString &scopeName,const QCString &s,
-                SrcLangExt lang,bool exBlock, const QCString &exName,const FileDef *fd,
+                SrcLangExt lang,bool stripCodeComments,bool exBlock,const QCString &exName,const FileDef *fd,
                 int startLine,int endLine,bool inlineFragment,
                 const MemberDef *memberDef,bool showLineNumbers,const Definition *searchCtx,
                 bool collectXRefs)
@@ -4257,6 +4258,7 @@ void CCodeParser::parseCode(OutputCodeList &od,const QCString &scopeName,const Q
   while (!yyextra->scopeStack.empty()) yyextra->scopeStack.pop();
   yyextra->scopeName     = scopeName;
   DBG_CTX((stderr,"parseCCode %s\n",qPrint(scopeName)));
+  yyextra->stripCodeComments  = stripCodeComments;
   yyextra->exampleBlock  = exBlock;
   yyextra->exampleName   = exName;
   yyextra->sourceFileDef = fd;

--- a/src/codefragment.h
+++ b/src/codefragment.h
@@ -35,7 +35,8 @@ class CodeFragmentManager
                    const QCString &blockId,
                    const QCString &scopeName,
                    bool showLineNumbers,
-                   bool trimLeft
+                   bool trimLeft,
+                   bool stripCodeComments
                    );
   private:
     CodeFragmentManager();

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -433,7 +433,7 @@ void ConceptDefImpl::writeDefinition(OutputList &ol,const QCString &title) const
     if (getOuterScope()!=Doxygen::globalScope) scopeName=getOuterScope()->name();
     TextStream conceptDef;
     conceptDef << m_initializer;
-    intf->parseCode(codeOL,scopeName,conceptDef.str(),SrcLangExt::Cpp,false,QCString(),
+    intf->parseCode(codeOL,scopeName,conceptDef.str(),SrcLangExt::Cpp,Config_getBool(STRIP_CODE_COMMENTS),false,QCString(),
                     m_fileDef, -1,-1,true,nullptr,false,this);
     codeOL.endCodeFragment("DoxyCode");
 }

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1062,6 +1062,7 @@ void DefinitionImpl::writeInlineCode(OutputList &ol,const QCString &scopeName) c
                       scopeName,        // scope
                       codeFragment,     // input
                       m_impl->lang,     // lang
+                      Config_getBool(STRIP_CODE_COMMENTS),
                       FALSE,            // isExample
                       QCString(),       // exampleName
                       m_impl->body->fileDef,  // fileDef

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -343,6 +343,7 @@ DB_VIS_C
       getCodeParser(m_langExt).parseCode(m_ci,s.context(),
                                          s.text(),
                                          langExt,
+                                         Config_getBool(STRIP_CODE_COMMENTS),
                                          s.isExample(),
                                          s.exampleFile());
       m_t << "</computeroutput></literallayout>";
@@ -463,6 +464,7 @@ DB_VIS_C
         getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                                   inc.text(),
                                                   langExt,
+                                                  inc.stripCodeComments(),
                                                   inc.isExample(),
                                                   inc.exampleFile(), fd.get());
         m_t << "</computeroutput></literallayout>";
@@ -473,6 +475,7 @@ DB_VIS_C
       getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                                 inc.text(),
                                                 langExt,
+                                                inc.stripCodeComments(),
                                                 inc.isExample(),
                                                 inc.exampleFile());
       m_t << "</computeroutput></literallayout>";
@@ -502,7 +505,8 @@ DB_VIS_C
                                           inc.blockId(),
                                           inc.context(),
                                           inc.type()==DocInclude::SnippetWithLines,
-                                          inc.type()==DocInclude::SnippetTrimLeft
+                                          inc.type()==DocInclude::SnippetTrimLeft,
+                                          inc.stripCodeComments()
                                          );
       m_t << "</computeroutput></literallayout>";
       break;
@@ -537,7 +541,9 @@ DB_VIS_C
       }
 
       getCodeParser(locLangExt).parseCode(m_ci,op.context(),
-                                        op.text(),langExt,op.isExample(),
+                                        op.text(),langExt,
+                                        op.stripCodeComments(),
+                                        op.isExample(),
                                         op.exampleFile(),
                                         fd.get(),     // fileDef
                                         op.line(),    // startLine

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -282,6 +282,7 @@ void DocInclude::parse()
       parser()->context.includeFileLength = m_text.length();
       parser()->context.includeFileLine   = 0;
       parser()->context.includeFileShowLineNo = (m_type == DontIncWithLines || m_type == IncWithLines);
+      parser()->context.stripCodeComments = m_stripCodeComments;
       //printf("parser->context.includeFile=<<%s>>\n",qPrint(parser->context.includeFileText));
       break;
     case VerbInclude:
@@ -359,6 +360,7 @@ void DocIncOperator::parse()
       }
       parser()->context.includeFileOffset = std::min(l,o+1); // set pointer to start of new line
       m_showLineNo = parser()->context.includeFileShowLineNo;
+      m_stripCodeComments = parser()->context.stripCodeComments;
       break;
     case SkipLine:
       while (o<l)
@@ -391,6 +393,7 @@ void DocIncOperator::parse()
       }
       parser()->context.includeFileOffset = std::min(l,o+1); // set pointer to start of new line
       m_showLineNo = parser()->context.includeFileShowLineNo;
+      m_stripCodeComments = parser()->context.stripCodeComments;
       break;
     case Skip:
       while (o<l)
@@ -420,6 +423,7 @@ void DocIncOperator::parse()
       }
       parser()->context.includeFileOffset = so; // set pointer to start of new line
       m_showLineNo = parser()->context.includeFileShowLineNo;
+      m_stripCodeComments = parser()->context.stripCodeComments;
       break;
     case Until:
       bo=o;
@@ -453,6 +457,7 @@ void DocIncOperator::parse()
       }
       parser()->context.includeFileOffset = std::min(l,o+1); // set pointer to start of new line
       m_showLineNo = parser()->context.includeFileShowLineNo;
+      m_stripCodeComments = parser()->context.stripCodeComments;
       break;
   }
   if (!found)
@@ -3597,11 +3602,15 @@ void DocPara::handleIncludeOperator(const QCString &cmdName,DocIncOperator::Type
   auto it2 = children().size()>=2 ? std::prev(it1)              : children().end();
   DocNodeVariant *n1 = it1!=children().end() ? &(*it1) : nullptr;
   DocNodeVariant *n2 = it2!=children().end() ? &(*it2) : nullptr;
+  //TODO get from context the stripCodeComments() 
+  bool stripCodeComments = Config_getBool(STRIP_CODE_COMMENTS);
   children().append<DocIncOperator>(parser(),thisVariant(),t,
                                     parser()->context.token->name,
                                     parser()->context.context,
+                                    stripCodeComments,
                                     parser()->context.isExample,
-                                    parser()->context.exampleName);
+                                    parser()->context.exampleName
+                                    );
   DocIncOperator *op = children().get_last<DocIncOperator>();
   DocIncOperator *n1_docIncOp = std::get_if<DocIncOperator>(n1);
   DocWhiteSpace  *n1_docWs    = std::get_if<DocWhiteSpace >(n1);
@@ -3737,6 +3746,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   Token tok=parser()->tokenizer.lex();
   bool isBlock = false;
   bool localScope = false;
+  bool stripCodeComments = Config_getBool(STRIP_CODE_COMMENTS);
   if (tok.is(TokenRetval::TK_WORD) && parser()->context.token->name=="{")
   {
     parser()->tokenizer.setStateOptions();
@@ -3748,6 +3758,9 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
       return std::find(optList.begin(),optList.end(),kw)!=optList.end();
     };
     localScope = contains("local");
+    if (contains("nostripcodecomments")) stripCodeComments = false;
+    else if (contains("stripcodecomments")) stripCodeComments = true;
+
     if (t==DocInclude::Include && contains("lineno"))
     {
       t = DocInclude::IncWithLines;
@@ -3823,6 +3836,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
                                 fileName,
                                 localScope ? parser()->context.context : "",
                                 t,
+                                stripCodeComments,
                                 parser()->context.isExample,
                                 parser()->context.exampleName,
                                 blockId,isBlock);

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -419,10 +419,11 @@ class DocInclude : public DocNode
 	      DontIncWithLines, RtfInclude, ManInclude, DocbookInclude, XmlInclude,
               SnippetTrimLeft};
     DocInclude(DocParser *parser,DocNodeVariant *parent,const QCString &file,
-               const QCString &context, Type t,
+               const QCString &context, Type t, bool stripCodeComments,
                bool isExample,const QCString &exampleFile,
                const QCString &blockId, bool isBlock)
     : DocNode(parser,parent), m_file(file), m_context(context), m_type(t),
+      m_stripCodeComments(stripCodeComments),
       m_isExample(isExample), m_isBlock(isBlock),
       m_exampleFile(exampleFile), m_blockId(blockId) {}
     QCString file() const        { return m_file; }
@@ -431,6 +432,7 @@ class DocInclude : public DocNode
     QCString text() const        { return m_text; }
     QCString context() const     { return m_context; }
     QCString blockId() const     { return m_blockId; }
+    bool stripCodeComments() const { return m_stripCodeComments; }
     bool isExample() const       { return m_isExample; }
     QCString exampleFile() const { return m_exampleFile; }
     bool isBlock() const         { return m_isBlock; }
@@ -441,6 +443,7 @@ class DocInclude : public DocNode
     QCString  m_context;
     QCString  m_text;
     Type      m_type;
+    bool      m_stripCodeComments;
     bool      m_isExample;
     bool      m_isBlock;
     QCString  m_exampleFile;
@@ -453,9 +456,9 @@ class DocIncOperator : public DocNode
   public:
     enum Type { Line, SkipLine, Skip, Until };
     DocIncOperator(DocParser *parser,DocNodeVariant *parent,Type t,const QCString &pat,
-                   const QCString &context,bool isExample,const QCString &exampleFile)
+                   const QCString &context,bool stripCodeComments,bool isExample,const QCString &exampleFile)
     : DocNode(parser,parent), m_type(t), m_pattern(pat), m_context(context),
-      m_isFirst(FALSE), m_isLast(FALSE),
+      m_isFirst(FALSE), m_isLast(FALSE), m_stripCodeComments(stripCodeComments),
       m_isExample(isExample), m_exampleFile(exampleFile) {}
     Type type() const           { return m_type; }
     const char *typeAsString() const
@@ -478,6 +481,7 @@ class DocIncOperator : public DocNode
     bool isLast() const          { return m_isLast; }
     void markFirst(bool v=TRUE)  { m_isFirst = v; }
     void markLast(bool v=TRUE)   { m_isLast = v; }
+    bool stripCodeComments() const { return m_stripCodeComments; }
     bool isExample() const       { return m_isExample; }
     QCString exampleFile() const { return m_exampleFile; }
     QCString includeFileName() const { return m_includeFileName; }
@@ -493,6 +497,7 @@ class DocIncOperator : public DocNode
     bool     m_isFirst = false;
     bool     m_isLast = false;
     bool     m_isExample = false;
+    bool     m_stripCodeComments = true;
     QCString  m_exampleFile;
     QCString m_includeFileName;
 };

--- a/src/docparser_p.h
+++ b/src/docparser_p.h
@@ -87,6 +87,7 @@ struct DocParserContext
   size_t       includeFileLength = 0;
   int          includeFileLine;
   bool         includeFileShowLineNo = false;
+  bool         stripCodeComments = true;
 
   TokenInfo *token = nullptr;
   int      lineNo = 0;

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1191,12 +1191,14 @@ void FileDefImpl::writeSourceBody(OutputList &ol,[[maybe_unused]] ClangTUParser 
       intf->parseCode(devNullList,QCString(),
                        fileToString(absFilePath(),TRUE,TRUE),
                        getLanguage(),
+                       Config_getBool(STRIP_CODE_COMMENTS),
                        FALSE,QCString(),this
                       );
     }
     intf->parseCode(codeOL,QCString(),
         fileToString(absFilePath(),filterSourceFiles,TRUE),
         getLanguage(),      // lang
+        Config_getBool(STRIP_CODE_COMMENTS),
         FALSE,              // isExampleBlock
         QCString(),         // exampleName
         this,               // fileDef
@@ -1240,6 +1242,7 @@ void FileDefImpl::parseSource([[maybe_unused]] ClangTUParser *clangParser)
             devNullList,QCString(),
             fileToString(absFilePath(),filterSourceFiles,TRUE),
             getLanguage(),
+            Config_getBool(STRIP_CODE_COMMENTS),
             FALSE,QCString(),this
            );
   }

--- a/src/fileparser.cpp
+++ b/src/fileparser.cpp
@@ -21,6 +21,7 @@ void FileCodeParser::parseCode(OutputCodeList &codeOutIntf,
                const QCString &,    // scopeName
                const QCString &     input,
                SrcLangExt,          // lang
+               bool,                // stripCodeComments
                bool,                // isExampleBlock
                const QCString &,    // exampleName
                const FileDef *      fileDef,

--- a/src/fileparser.h
+++ b/src/fileparser.h
@@ -26,6 +26,7 @@ class FileCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt lang,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/fortrancode.h
+++ b/src/fortrancode.h
@@ -37,6 +37,7 @@ class FortranCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt lang,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -151,6 +151,7 @@ struct fortrancodeYY_state
   bool          insideBody = false;      //!< inside subprog/program body? => create links
   const char *  currentFontClass = nullptr;
 
+  bool          stripCodeComments = true;
   bool          exampleBlock = false;
   QCString      exampleName;
   QCString      exampleFile;
@@ -691,7 +692,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
 <DocBlock>"\n"                          { // comment block ends at the end of this line
                                           // remove special comment (default config)
                                           yyextra->contLineNr++;
-                                          if (Config_getBool(STRIP_CODE_COMMENTS))
+                                          if (yyextra->stripCodeComments)
                                           {
                                             yyextra->yyLineNr+=yyextra->docBlock.contains('\n');
                                             yyextra->yyLineNr+=1;
@@ -834,7 +835,7 @@ LANGUAGE_BIND_SPEC BIND{BS}"("{BS}C{BS}(,{BS}NAME{BS}"="{BS}"\""(.*)"\""{BS})?")
                                         }
 <*><<EOF>>                              {
                                           if (YY_START == DocBlock) {
-                                            if (!Config_getBool(STRIP_CODE_COMMENTS))
+                                            if (!yyextra->stripCodeComments)
                                             {
                                               startFontClass(yyscanner,"comment");
                                               codifyLines(yyscanner,yyextra->docBlock);
@@ -1488,6 +1489,7 @@ void FortranCodeParser::parseCode(OutputCodeList & codeOutIntf,
                    const QCString & /* scopeName */,
                    const QCString & input,
                    SrcLangExt /*lang*/,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString & exampleName,
                    const FileDef * fileDef,
@@ -1538,6 +1540,7 @@ void FortranCodeParser::parseCode(OutputCodeList & codeOutIntf,
   else
     yyextra->inputLines  = yyextra->yyLineNr + countLines(yyscanner) - 1;
 
+  yyextra->stripCodeComments = stripCodeComments;
   yyextra->exampleBlock  = isExampleBlock;
   yyextra->exampleName   = exampleName;
   yyextra->sourceFileDef = fileDef;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -584,6 +584,7 @@ void HtmlDocVisitor::operator()(const DocVerbatim &s)
                                         s.context(),
                                         s.text(),
                                         langExt,
+                                        Config_getBool(STRIP_CODE_COMMENTS),
                                         s.isExample(),
                                         s.exampleFile(),
                                         nullptr,     // fileDef
@@ -736,6 +737,7 @@ void HtmlDocVisitor::operator()(const DocInclude &inc)
                                         inc.context(),
                                         inc.text(),
                                         langExt,
+                                        inc.stripCodeComments(),
                                         inc.isExample(),
                                         inc.exampleFile(),
                                         nullptr,     // fileDef
@@ -759,6 +761,7 @@ void HtmlDocVisitor::operator()(const DocInclude &inc)
                                            inc.context(),
                                            inc.text(),
                                            langExt,
+                                           inc.stripCodeComments(),
                                            inc.isExample(),
                                            inc.exampleFile(),
                                            fd.get(),   // fileDef,
@@ -805,7 +808,8 @@ void HtmlDocVisitor::operator()(const DocInclude &inc)
                                        inc.blockId(),
                                        inc.context(),
                                        inc.type()==DocInclude::SnippetWithLines,
-                                       inc.type()==DocInclude::SnippetTrimLeft
+                                       inc.type()==DocInclude::SnippetTrimLeft,
+                                       inc.stripCodeComments()
                                       );
       m_ci.endCodeFragment("DoxyCode");
       forceStartParagraph(inc);
@@ -843,6 +847,7 @@ void HtmlDocVisitor::operator()(const DocIncOperator &op)
                                 op.context(),
                                 op.text(),
                                 langExt,
+                                op.stripCodeComments(),
                                 op.isExample(),
                                 op.exampleFile(),
                                 fd.get(),     // fileDef

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -459,6 +459,7 @@ void LatexDocVisitor::operator()(const DocVerbatim &s)
       {
         m_ci.startCodeFragment("DoxyCode");
         getCodeParser(lang).parseCode(m_ci,s.context(),s.text(),langExt,
+                                      Config_getBool(STRIP_CODE_COMMENTS),
                                       s.isExample(),s.exampleFile());
         m_ci.endCodeFragment("DoxyCode");
       }
@@ -582,6 +583,7 @@ void LatexDocVisitor::operator()(const DocInclude &inc)
         getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                                   inc.text(),
                                                   langExt,
+                                                  inc.stripCodeComments(),
                                                   inc.isExample(),
                                                   inc.exampleFile(),
                                                   fd.get(),    // fileDef,
@@ -598,7 +600,9 @@ void LatexDocVisitor::operator()(const DocInclude &inc)
       {
         m_ci.startCodeFragment("DoxyCodeInclude");
         getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
-                                                  inc.text(),langExt,inc.isExample(),
+                                                  inc.text(),langExt,
+                                                  inc.stripCodeComments(),
+                                                  inc.isExample(),
                                                   inc.exampleFile(),
                                                   nullptr,     // fileDef
                                                   -1,    // startLine
@@ -636,7 +640,8 @@ void LatexDocVisitor::operator()(const DocInclude &inc)
                                          inc.blockId(),
                                          inc.context(),
                                          inc.type()==DocInclude::SnippetWithLines,
-                                         inc.type()==DocInclude::SnippetTrimLeft
+                                         inc.type()==DocInclude::SnippetTrimLeft,
+                                         inc.stripCodeComments()
                                         );
         m_ci.endCodeFragment("DoxyCodeInclude");
       }
@@ -670,6 +675,7 @@ void LatexDocVisitor::operator()(const DocIncOperator &op)
       }
 
       getCodeParser(locLangExt).parseCode(m_ci,op.context(),op.text(),langExt,
+                                          op.stripCodeComments(),
                                           op.isExample(),op.exampleFile(),
                                           fd.get(),     // fileDef
                                           op.line(),    // startLine

--- a/src/lexcode.h
+++ b/src/lexcode.h
@@ -37,6 +37,7 @@ class LexCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/lexcode.l
+++ b/src/lexcode.l
@@ -79,6 +79,7 @@ struct lexcodeYY_state
      size_t        fencedSize = 0;
      bool          nestedComment = false;
 
+     bool          stripCodeComments;
      bool          exampleBlock;
      QCString      exampleName;
      QCString      classScope;
@@ -1146,6 +1147,7 @@ static void handleCCode(yyscan_t yyscanner)
                yyextra->classScope,
                yyextra->CCodeBuffer,
                SrcLangExt::Cpp,
+               yyextra->stripCodeComments,
                yyextra->exampleBlock,
                yyextra->exampleName,
                yyextra->sourceFileDef,
@@ -1196,6 +1198,7 @@ void LexCodeParser::parseCode(OutputCodeList &codeOutIntf,
                const QCString &scopeName,
                const QCString &input,
                SrcLangExt,
+               bool stripCodeComments,
                bool isExampleBlock,
                const QCString &exampleName,
                const FileDef *fileDef,
@@ -1238,6 +1241,7 @@ void LexCodeParser::parseCode(OutputCodeList &codeOutIntf,
     yyextra->inputLines  = yyextra->yyLineNr + countLines(yyscanner) - 1;
 
   yyextra->startCCodeLine = yyextra->yyLineNr;
+  yyextra->stripCodeComments = stripCodeComments;
   yyextra->exampleBlock  = isExampleBlock;
   yyextra->exampleName   = exampleName;
   yyextra->sourceFileDef = fileDef;

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -207,6 +207,7 @@ void ManDocVisitor::operator()(const DocVerbatim &s)
       m_t << ".nf\n";
       getCodeParser(lang).parseCode(m_ci,s.context(),s.text(),
                                         langExt,
+                                        Config_getBool(STRIP_CODE_COMMENTS),
                                         s.isExample(),s.exampleFile());
       if (!m_firstCol) m_t << "\n";
       m_t << ".fi\n";
@@ -268,6 +269,7 @@ void ManDocVisitor::operator()(const DocInclude &inc)
          getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                            inc.text(),
                                            langExt,
+                                           inc.stripCodeComments(),
                                            inc.isExample(),
                                            inc.exampleFile(),
                                            fd.get(), // fileDef,
@@ -290,6 +292,7 @@ void ManDocVisitor::operator()(const DocInclude &inc)
       getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                         inc.text(),
                                         langExt,
+                                        inc.stripCodeComments(),
                                         inc.isExample(),
                                         inc.exampleFile(),
                                         nullptr,     // fileDef
@@ -336,7 +339,8 @@ void ManDocVisitor::operator()(const DocInclude &inc)
                                           inc.blockId(),
                                           inc.context(),
                                           inc.type()==DocInclude::SnippetWithLines,
-                                          inc.type()==DocInclude::SnippetTrimLeft
+                                          inc.type()==DocInclude::SnippetTrimLeft,
+                                          inc.stripCodeComments()
                                          );
       if (!m_firstCol) m_t << "\n";
       m_t << ".fi\n";
@@ -377,6 +381,7 @@ void ManDocVisitor::operator()(const DocIncOperator &op)
       }
 
       getCodeParser(locLangExt).parseCode(m_ci,op.context(),op.text(),langExt,
+                                        op.stripCodeComments(),
                                         op.isExample(),op.exampleFile(),
                                         fd.get(),     // fileDef
                                         op.line(),    // startLine

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3422,7 +3422,7 @@ void MemberDefImpl::_writeMultiLineInitializer(OutputList &ol,const QCString &sc
     intf->resetCodeParserState();
     auto &codeOL = ol.codeGenerators();
     codeOL.startCodeFragment("DoxyCode");
-    intf->parseCode(codeOL,scopeName,m_initializer,srcLangExt,FALSE,QCString(),getFileDef(),
+    intf->parseCode(codeOL,scopeName,m_initializer,srcLangExt,Config_getBool(STRIP_CODE_COMMENTS),FALSE,QCString(),getFileDef(),
                      -1,-1,TRUE,this,FALSE,this);
     codeOL.endCodeFragment("DoxyCode");
 }

--- a/src/parserintf.h
+++ b/src/parserintf.h
@@ -90,6 +90,7 @@ class CodeParserInterface
      *  @param[in] scopeName Name of scope to which the code belongs.
      *  @param[in] input Actual code in the form of a string
      *  @param[in] lang The programming language of the code fragment.
+     *  @param[in] stripCodeComments signals whether or not for the code block the doxygen comments should be stripped.
      *  @param[in] isExampleBlock TRUE iff the code is part of an example.
      *  @param[in] exampleName Name of the example.
      *  @param[in] fileDef File definition to which the code
@@ -110,6 +111,7 @@ class CodeParserInterface
                            const QCString &scopeName,
                            const QCString &input,
                            SrcLangExt lang,
+                           bool stripCodeComments,
                            bool isExampleBlock,
                            const QCString &exampleName=QCString(),
                            const FileDef *fileDef=nullptr,

--- a/src/pycode.h
+++ b/src/pycode.h
@@ -41,6 +41,7 @@ class PythonCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt lang,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -95,6 +95,7 @@ struct pycodeYY_state
   int           paramParens = 0;
 
   bool          insideBody = false;
+  bool          stripCodeComments = true;
   bool          exampleBlock = FALSE;
   QCString      exampleName;
 
@@ -747,7 +748,7 @@ TARGET            ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBU
                                     }
 <DocBlock>{NEWLINE}                 { // comment block ends at the end of this line
                                       // remove special comment (default config)
-                                      if (Config_getBool(STRIP_CODE_COMMENTS))
+                                      if (yyextra->stripCodeComments)
                                       {
                                         yyextra->yyLineNr+=((QCString)yyextra->docBlock).contains('\n');
                                         yyextra->endComment=TRUE;
@@ -811,7 +812,7 @@ TARGET            ({IDENTIFIER}|"("{TARGET_LIST}")"|"["{TARGET_LIST}"]"|{ATTRIBU
                                   }
 
 <*><<EOF>>                        {
-                                    if (YY_START==DocBlock && !Config_getBool(STRIP_CODE_COMMENTS))
+                                    if (YY_START==DocBlock && !yyextra->stripCodeComments)
                                     {
                                       startFontClass(yyscanner,"comment");
                                       codifyLines(yyscanner,yyextra->docBlock);
@@ -1607,6 +1608,7 @@ void PythonCodeParser::parseCode(OutputCodeList &codeOutIntf,
     const QCString &/* scopeName */,
     const QCString &input,
     SrcLangExt /*lang*/,
+    bool stripCodeComments,
     bool isExampleBlock,
     const QCString &exampleName,
     const FileDef *fileDef,
@@ -1644,6 +1646,7 @@ void PythonCodeParser::parseCode(OutputCodeList &codeOutIntf,
     yyextra->inputLines  = yyextra->yyLineNr + countLines(yyscanner) - 1;
 
 
+  yyextra->stripCodeComments = stripCodeComments;
   yyextra->exampleBlock  = isExampleBlock;
   yyextra->exampleName   = exampleName;
   yyextra->sourceFileDef = fileDef;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -330,6 +330,7 @@ void RTFDocVisitor::operator()(const DocVerbatim &s)
       m_t << "\\par\n";
       m_t << rtf_Style_Reset << getStyle("CodeExample");
       getCodeParser(lang).parseCode(m_ci,s.context(),s.text(),langExt,
+                                    Config_getBool(STRIP_CODE_COMMENTS),
                                     s.isExample(),s.exampleFile());
       //m_t << "\\par\n";
       m_t << "}\n";
@@ -474,6 +475,7 @@ void RTFDocVisitor::operator()(const DocInclude &inc)
          getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                            inc.text(),
                                            langExt,
+                                           inc.stripCodeComments(),
                                            inc.isExample(),
                                            inc.exampleFile(),
                                            fd.get(),   // fileDef,
@@ -492,7 +494,9 @@ void RTFDocVisitor::operator()(const DocInclude &inc)
       m_t << "\\par\n";
       m_t << rtf_Style_Reset << getStyle("CodeExample");
       getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
-                                        inc.text(),langExt,inc.isExample(),
+                                        inc.text(),langExt,
+                                        inc.stripCodeComments(),
+                                        inc.isExample(),
                                         inc.exampleFile(),
                                         nullptr,     // fileDef
                                         -1,    // startLine
@@ -534,7 +538,8 @@ void RTFDocVisitor::operator()(const DocInclude &inc)
                                          inc.blockId(),
                                          inc.context(),
                                          inc.type()==DocInclude::SnippetWithLines,
-                                         inc.type()==DocInclude::SnippetTrimLeft
+                                         inc.type()==DocInclude::SnippetTrimLeft,
+                                         inc.stripCodeComments()
                                         );
       m_t << "}";
       break;
@@ -574,6 +579,7 @@ void RTFDocVisitor::operator()(const DocIncOperator &op)
       }
 
       getCodeParser(locLangExt).parseCode(m_ci,op.context(),op.text(),langExt,
+                                        op.stripCodeComments(),
                                         op.isExample(),op.exampleFile(),
                                         fd.get(),     // fileDef
                                         op.line(),    // startLine

--- a/src/sqlcode.h
+++ b/src/sqlcode.h
@@ -37,6 +37,7 @@ class SQLCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -60,6 +60,7 @@ struct sqlcodeYY_state
      bool          insideCodeLine = false;
      const Definition   *searchCtx = nullptr;
 
+     bool          stripCodeComments = true;
      bool          exampleBlock = false;
      QCString      exampleName;
      QCString      classScope;
@@ -410,6 +411,7 @@ void SQLCodeParser::parseCode(OutputCodeList &codeOutIntf,
                const QCString &/* scopeName */,
                const QCString &input,
                SrcLangExt,
+               bool stripCodeComments,
                bool isExampleBlock,
                const QCString &exampleName,
                const FileDef *fileDef,
@@ -447,6 +449,7 @@ void SQLCodeParser::parseCode(OutputCodeList &codeOutIntf,
   else
     yyextra->inputLines  = yyextra->yyLineNr + countLines(yyscanner) - 1;
 
+  yyextra->stripCodeComments = stripCodeComments;
   yyextra->exampleBlock  = isExampleBlock;
   yyextra->exampleName   = exampleName;
   yyextra->sourceFileDef = fileDef;

--- a/src/vhdlcode.h
+++ b/src/vhdlcode.h
@@ -33,6 +33,7 @@ class VHDLCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt lang,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -96,6 +96,7 @@ struct vhdlcodeYY_state
   bool          insideCodeLine = false;
   const Definition *searchCtx = nullptr;
 
+  bool          stripCodeComments = true;
   bool          exampleBlock = false;
   QCString      exampleName;
   QCString      exampleFile;
@@ -887,7 +888,7 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
                                       int i=text.find("--");
                                       if (text.mid(i,3)=="--!") // && // hide special comment
                                       {
-                                        if (!Config_getBool(STRIP_CODE_COMMENTS))
+                                        if (!yyextra->stripCodeComments)
                                         {
                                           codifyLines(yyscanner,text,QCString(),false,true);
                                         }
@@ -904,7 +905,7 @@ XILINX      "INST"|"NET"|"PIN"|"BLKNM"|"BUFG"|"COLLAPSE"|"CPLD"|"COMPGRP"|"CONFI
                                       if (text.mid(i,3)=="--!")
                                       {
                                         // hide special comment
-                                        if (!Config_getBool(STRIP_CODE_COMMENTS))
+                                        if (!yyextra->stripCodeComments)
                                         {
                                           codifyLines(yyscanner,text,QCString(),false,true);
                                         }
@@ -1623,6 +1624,7 @@ void VHDLCodeParser::parseCode(OutputCodeList &od,
                                const QCString &/* className */,
                                const QCString &s,
                                SrcLangExt,
+                               bool stripCodeComments,
                                bool exBlock,
                                const QCString &exName,
                                const FileDef *fd,
@@ -1666,6 +1668,7 @@ void VHDLCodeParser::parseCode(OutputCodeList &od,
 
 
   // yyextra->theCallContext.clear();
+  yyextra->stripCodeComments = stripCodeComments;
   yyextra->exampleBlock  = exBlock;
   yyextra->exampleName   = exName;
   yyextra->sourceFileDef = fd;

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -1867,6 +1867,7 @@ void VhdlDocGen::writeSource(const MemberDef* mdef,OutputList& ol,const QCString
                        QCString(),       // scope
                        codeFragment,     // input
                        SrcLangExt::VHDL,  // lang
+                       Config_getBool(STRIP_CODE_COMMENTS),
                        FALSE,            // isExample
                        QCString(),       // exampleName
                        mdef->getFileDef(), // fileDef

--- a/src/xmlcode.h
+++ b/src/xmlcode.h
@@ -38,6 +38,7 @@ class XMLCodeParser : public CodeParserInterface
                    const QCString &scopeName,
                    const QCString &input,
                    SrcLangExt,
+                   bool stripCodeComments,
                    bool isExampleBlock,
                    const QCString &exampleName=QCString(),
                    const FileDef *fileDef=nullptr,

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -68,6 +68,7 @@ struct xmlcodeYY_state
   bool          insideCodeLine = false;
   const Definition   *searchCtx = nullptr;
 
+  bool          stripCodeComments = true;
   bool          exampleBlock = false;
   QCString      exampleName;
   QCString      exampleFile;
@@ -417,6 +418,7 @@ void XMLCodeParser::parseCode(OutputCodeList &codeOutIntf,
                const QCString &/* scopeName */,
                const QCString &input,
                SrcLangExt,
+               bool stripCodeComments,
                bool isExampleBlock,
                const QCString &exampleName,
                const FileDef *fileDef,
@@ -454,6 +456,7 @@ void XMLCodeParser::parseCode(OutputCodeList &codeOutIntf,
   else
     yyextra->inputLines  = yyextra->yyLineNr + countLines(yyscanner) - 1;
 
+  yyextra->stripCodeComments = stripCodeComments;
   yyextra->exampleBlock  = isExampleBlock;
   yyextra->exampleName   = exampleName;
   yyextra->sourceFileDef = fileDef;

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -318,6 +318,7 @@ void XmlDocVisitor::operator()(const DocVerbatim &s)
       else
           m_t << ">";
       getCodeParser(lang).parseCode(m_ci,s.context(),s.text(),langExt,
+                                    Config_getBool(STRIP_CODE_COMMENTS),
                                     s.isExample(),s.exampleFile());
       m_t << "</programlisting>";
       break;
@@ -409,6 +410,7 @@ void XmlDocVisitor::operator()(const DocInclude &inc)
          getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                            inc.text(),
                                            langExt,
+                                           inc.stripCodeComments(),
                                            inc.isExample(),
                                            inc.exampleFile(),
                                            fd.get(), // fileDef,
@@ -426,6 +428,7 @@ void XmlDocVisitor::operator()(const DocInclude &inc)
       getCodeParser(inc.extension()).parseCode(m_ci,inc.context(),
                                         inc.text(),
                                         langExt,
+                                        inc.stripCodeComments(),
                                         inc.isExample(),
                                         inc.exampleFile(),
                                         nullptr,     // fileDef
@@ -489,7 +492,8 @@ void XmlDocVisitor::operator()(const DocInclude &inc)
                                        inc.blockId(),
                                        inc.context(),
                                        inc.type()==DocInclude::SnippetWithLines,
-                                       inc.type()==DocInclude::SnippetTrimLeft
+                                       inc.type()==DocInclude::SnippetTrimLeft,
+                                       inc.stripCodeComments()
                                       );
       m_t << "</programlisting>";
       break;
@@ -525,7 +529,9 @@ void XmlDocVisitor::operator()(const DocIncOperator &op)
       }
 
       getCodeParser(locLangExt).parseCode(m_ci,op.context(),
-                                          op.text(),langExt,op.isExample(),
+                                          op.text(),langExt,
+                                          op.stripCodeComments(),
+                                          op.isExample(),
                                           op.exampleFile(),
                                           fd.get(),     // fileDef
                                           op.line(),    // startLine

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -408,6 +408,7 @@ void writeXMLCodeBlock(TextStream &t,FileDef *fd)
                 QCString(),   // scopeName
                 fileToString(fd->absFilePath(),Config_getBool(FILTER_SOURCE_FILES)),
                 langExt,     // lang
+                Config_getBool(STRIP_CODE_COMMENTS),
                 FALSE,       // isExampleBlock
                 QCString(),  // exampleName
                 fd,          // fileDef


### PR DESCRIPTION
More flexibility in showing the doxygen type code comments in code snippets and included documents.

Example: [example.tar.gz](https://github.com/user-attachments/files/17190326/example.tar.gz)


