### PR TITLE
Snippet with options `lineno` and `trimleft`

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -494,7 +494,6 @@ DB_VIS_C
       m_t << "</literallayout>";
       break;
     case DocInclude::Snippet:
-    case DocInclude::SnippetTrimLeft:
     case DocInclude::SnippetWithLines:
       m_t << "<literallayout><computeroutput>";
       CodeFragmentManager::instance().parseCodeFragment(m_ci,
@@ -502,7 +501,7 @@ DB_VIS_C
                                           inc.blockId(),
                                           inc.context(),
                                           inc.type()==DocInclude::SnippetWithLines,
-                                          inc.type()==DocInclude::SnippetTrimLeft
+                                          inc.trimLeft()
                                          );
       m_t << "</computeroutput></literallayout>";
       break;

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -295,7 +295,6 @@ void DocInclude::parse()
       parser()->readTextFileByName(m_file,m_text);
       break;
     case Snippet:
-    case SnippetTrimLeft:
     case SnippetWithLines:
       parser()->readTextFileByName(m_file,m_text);
       // check here for the existence of the blockId inside the file, so we
@@ -3736,6 +3735,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   QCString saveCmdName = cmdName;
   Token tok=parser()->tokenizer.lex();
   bool isBlock = false;
+  bool trimLeft = false;
   bool localScope = false;
   if (tok.is(TokenRetval::TK_WORD) && parser()->context.token->name=="{")
   {
@@ -3748,6 +3748,11 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
       return std::find(optList.begin(),optList.end(),kw)!=optList.end();
     };
     localScope = contains("local");
+    if (t==DocInclude::Snippet && contains("trimleft"))
+    {
+      trimLeft = true;
+    }
+
     if (t==DocInclude::Include && contains("lineno"))
     {
       t = DocInclude::IncWithLines;
@@ -3759,10 +3764,6 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
     else if (t==DocInclude::DontInclude && contains("lineno"))
     {
       t = DocInclude::DontIncWithLines;
-    }
-    else if (t==DocInclude::Snippet && contains("trimleft"))
-    {
-      t = DocInclude::SnippetTrimLeft;
     }
     tok=parser()->tokenizer.lex();
     if (!tok.is(TokenRetval::TK_WHITESPACE))
@@ -3803,7 +3804,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
   }
   QCString fileName = parser()->context.token->name;
   QCString blockId;
-  if (t==DocInclude::Snippet || t==DocInclude::SnippetWithLines || t == DocInclude::SnippetTrimLeft)
+  if (t==DocInclude::Snippet || t==DocInclude::SnippetWithLines)
   {
     if (fileName == "this") fileName=parser()->context.fileName;
     parser()->tokenizer.setStateSnippet();
@@ -3825,7 +3826,7 @@ void DocPara::handleInclude(const QCString &cmdName,DocInclude::Type t)
                                 t,
                                 parser()->context.isExample,
                                 parser()->context.exampleName,
-                                blockId,isBlock);
+                                blockId,isBlock,trimLeft);
   children().get_last<DocInclude>()->parse();
 }
 

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -416,14 +416,14 @@ class DocInclude : public DocNode
   public:
   enum Type { Include, DontInclude, VerbInclude, HtmlInclude, LatexInclude,
 	      IncWithLines, Snippet , SnippetWithLines,
-	      DontIncWithLines, RtfInclude, ManInclude, DocbookInclude, XmlInclude,
-              SnippetTrimLeft};
+	      DontIncWithLines, RtfInclude, ManInclude, DocbookInclude, XmlInclude
+            };
     DocInclude(DocParser *parser,DocNodeVariant *parent,const QCString &file,
                const QCString &context, Type t,
                bool isExample,const QCString &exampleFile,
-               const QCString &blockId, bool isBlock)
+               const QCString &blockId, bool isBlock, bool trimLeft)
     : DocNode(parser,parent), m_file(file), m_context(context), m_type(t),
-      m_isExample(isExample), m_isBlock(isBlock),
+      m_isExample(isExample), m_isBlock(isBlock), m_trimLeft(trimLeft),
       m_exampleFile(exampleFile), m_blockId(blockId) {}
     QCString file() const        { return m_file; }
     QCString extension() const   { int i=m_file.findRev('.'); return i!=-1 ? m_file.mid(i) : QCString(); }
@@ -434,6 +434,7 @@ class DocInclude : public DocNode
     bool isExample() const       { return m_isExample; }
     QCString exampleFile() const { return m_exampleFile; }
     bool isBlock() const         { return m_isBlock; }
+    bool trimLeft() const        { return m_trimLeft; }
     void parse();
 
   private:
@@ -443,6 +444,7 @@ class DocInclude : public DocNode
     Type      m_type;
     bool      m_isExample;
     bool      m_isBlock;
+    bool      m_trimLeft;
     QCString  m_exampleFile;
     QCString  m_blockId;
 };

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -796,7 +796,6 @@ void HtmlDocVisitor::operator()(const DocInclude &inc)
       forceStartParagraph(inc);
       break;
     case DocInclude::Snippet:
-    case DocInclude::SnippetTrimLeft:
     case DocInclude::SnippetWithLines:
       forceEndParagraph(inc);
       m_ci.startCodeFragment("DoxyCode");
@@ -805,7 +804,7 @@ void HtmlDocVisitor::operator()(const DocInclude &inc)
                                        inc.blockId(),
                                        inc.context(),
                                        inc.type()==DocInclude::SnippetWithLines,
-                                       inc.type()==DocInclude::SnippetTrimLeft
+                                       inc.trimLeft()
                                       );
       m_ci.endCodeFragment("DoxyCode");
       forceStartParagraph(inc);

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -627,7 +627,6 @@ void LatexDocVisitor::operator()(const DocInclude &inc)
       m_t << "\\end{DoxyVerbInclude}\n";
       break;
     case DocInclude::Snippet:
-    case DocInclude::SnippetTrimLeft:
     case DocInclude::SnippetWithLines:
       {
         m_ci.startCodeFragment("DoxyCodeInclude");
@@ -636,7 +635,7 @@ void LatexDocVisitor::operator()(const DocInclude &inc)
                                          inc.blockId(),
                                          inc.context(),
                                          inc.type()==DocInclude::SnippetWithLines,
-                                         inc.type()==DocInclude::SnippetTrimLeft
+                                         inc.trimLeft()
                                         );
         m_ci.endCodeFragment("DoxyCodeInclude");
       }

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -326,7 +326,6 @@ void ManDocVisitor::operator()(const DocInclude &inc)
       m_firstCol=TRUE;
       break;
     case DocInclude::Snippet:
-    case DocInclude::SnippetTrimLeft:
     case DocInclude::SnippetWithLines:
       if (!m_firstCol) m_t << "\n";
       m_t << ".PP\n";
@@ -336,7 +335,7 @@ void ManDocVisitor::operator()(const DocInclude &inc)
                                           inc.blockId(),
                                           inc.context(),
                                           inc.type()==DocInclude::SnippetWithLines,
-                                          inc.type()==DocInclude::SnippetTrimLeft
+                                          inc.trimLeft()
                                          );
       if (!m_firstCol) m_t << "\n";
       m_t << ".fi\n";

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -683,7 +683,6 @@ void PerlModDocVisitor::operator()(const DocInclude &inc)
     case DocInclude::DocbookInclude: type = "docbookonly"; break;
     case DocInclude::VerbInclude:	type = "preformatted"; break;
     case DocInclude::Snippet: return;
-    case DocInclude::SnippetTrimLeft: return;
     case DocInclude::SnippetWithLines: return;
   }
   openItem(type);

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -212,7 +212,6 @@ class PrintDocVisitor
         case DocInclude::XmlInclude: printf("xmlinclude"); break;
         case DocInclude::VerbInclude: printf("verbinclude"); break;
         case DocInclude::Snippet: printf("snippet"); break;
-        case DocInclude::SnippetTrimLeft: printf("snippettrimleft"); break;
         case DocInclude::SnippetWithLines: printf("snipwithlines"); break;
       }
       printf("\"/>");

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -524,7 +524,6 @@ void RTFDocVisitor::operator()(const DocInclude &inc)
       m_t << "}\n";
       break;
     case DocInclude::Snippet:
-    case DocInclude::SnippetTrimLeft:
     case DocInclude::SnippetWithLines:
       m_t << "{\n";
       if (!m_lastIsPara) m_t << "\\par\n";
@@ -534,7 +533,7 @@ void RTFDocVisitor::operator()(const DocInclude &inc)
                                          inc.blockId(),
                                          inc.context(),
                                          inc.type()==DocInclude::SnippetWithLines,
-                                         inc.type()==DocInclude::SnippetTrimLeft
+                                         inc.trimLeft()
                                         );
       m_t << "}";
       break;

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -481,7 +481,6 @@ void XmlDocVisitor::operator()(const DocInclude &inc)
       m_t << "</verbatim>";
       break;
     case DocInclude::Snippet:
-    case DocInclude::SnippetTrimLeft:
     case DocInclude::SnippetWithLines:
       m_t << "<programlisting filename=\"" << inc.file() << "\">";
       CodeFragmentManager::instance().parseCodeFragment(m_ci,
@@ -489,7 +488,7 @@ void XmlDocVisitor::operator()(const DocInclude &inc)
                                        inc.blockId(),
                                        inc.context(),
                                        inc.type()==DocInclude::SnippetWithLines,
-                                       inc.type()==DocInclude::SnippetTrimLeft
+                                       inc.trimLeft()
                                       );
       m_t << "</programlisting>";
       break;


### PR DESCRIPTION
Enabling the possibility to use the options `lineno` and `trimleft` together with the `\snippet` command. (When using both the old behavior was that the `trimleft` was not seen).

Example: [example.tar.gz](https://github.com/user-attachments/files/17191663/example.tar.gz)
