### PR TITLE
issue #10569 First sentence after defgroup no longer used as brief decriptions

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1547,8 +1547,11 @@ STopt  [^\n@\\]*
                                           }
                                           //if (*yytext=='\n') yyextra->lineNr++;
                                           //addOutput(yyscanner,'\n');
-                                          addOutput(yyscanner," \\ifile \""+ yyextra->fileName);
-                                          addOutput(yyscanner,"\" \\iline " + QCString().setNum(yyextra->lineNr + extraLineNr) + " \\ilinebr ");
+                                          if ( yyextra->current->groupDocType!=Entry::GROUPDOC_NORMAL)
+                                          {
+                                            addOutput(yyscanner," \\ifile \""+ yyextra->fileName);
+                                            addOutput(yyscanner,"\" \\iline " + QCString().setNum(yyextra->lineNr + extraLineNr) + " \\ilinebr ");
+                                          }
                                           BEGIN( Comment );
                                         }
 <GroupDocArg2>.                         { // title (stored in type)


### PR DESCRIPTION
Regression caused by the fixes for #10414
In case of a `\defgroup` we have a new group so we don't need the `\ifile` / \iline`