### PR TITLE
Spelling corrections

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -655,7 +655,7 @@ void MainWindow::runComplete()
   }
   else
   {
-    m_outputLog->append(APPQT(tr("*** Cancelled by user\n")));
+    m_outputLog->append(APPQT(tr("*** Canceled by user\n")));
   }
   m_outputLog->ensureCursorVisible();
   m_run->setText(tr("Run doxygen"));

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -252,7 +252,7 @@ href="https://github.com/doxygen/doxygen/commit/a2ae848c6f63e25cd18c5717116997b2
 <li>QT help problems with tag files [<a href="https://github.com/doxygen/doxygen/commit/c42b99e85ec1950604da772a91ac379cb5a42674">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/c9ce08db0bd84426a6f150348777badcac525da3">view</a>]</li>
 <li>Single line snippet didn&#39;t show [<a href="https://github.com/doxygen/doxygen/commit/c80d345defd9b8e53a377dec3f1b7112491731ba">view</a>]</li>
 <li>Support unicode characters in referenced file names [<a href="https://github.com/doxygen/doxygen/commit/9acb711f9ee9f5c45400d44e9bb0530c11cb28f5">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/c6fa06f86ac72a557f56e1083b7bc8e844107d93">view</a>]</li>
-<li>Waring with ingroup command at end of alias [<a href="https://github.com/doxygen/doxygen/commit/04f17aff126f55ef864139b7d26ac07012544df4">view</a>]</li>
+<li>Warning with ingroup command at end of alias [<a href="https://github.com/doxygen/doxygen/commit/04f17aff126f55ef864139b7d26ac07012544df4">view</a>]</li>
 <li>Warning for Fortran on <tt>\code</tt> command [<a href="https://github.com/doxygen/doxygen/commit/3857210386c8ca2c5939d09a45a94611ce2fc959">view</a>]</li>
 <li>Warnings due to multiple &quot;sectioning&quot; commands inside an <tt>\if</tt> type construct [<a href="https://github.com/doxygen/doxygen/commit/36f35b5202e196855e2969db1ef2901f51856bdb">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/effa6d95f726232a709a13fb4e4e075bc0a7a629">view</a>], [<a href="https://github.com/doxygen/doxygen/commit/bd373c91cf7a05ce496f92e405ee37da8c1378e7">view</a>]</li>
 <li>When having markdown code like: ~~~ [<a href="https://github.com/doxygen/doxygen/commit/a870cd4695aa98788022ccb8d0c0c8e507421572">view</a>]</li>
@@ -2637,7 +2637,7 @@ and
 <li>Small spelling correction in portable.cpp [<a href="https://github.com/doxygen/doxygen/commit/ba4e098a09da73738bd0f849492719bc37d36f1b">view</a>]</li>
 <li>Specifying filename in preprocessor debug output [<a href="https://github.com/doxygen/doxygen/commit/8616d8e1ee61d3fc1a929a04f1594b0f417da7c2">view</a>]</li>
 <li>Unknown configuration enum values [<a href="https://github.com/doxygen/doxygen/commit/9c9e30b295ca8b0a2130aa00c26bb5aa40a0e608">view</a>]</li>
-<li>Updated test 024 to better test spacing behaviour. [<a href="https://github.com/doxygen/doxygen/commit/b47de248b2c4d54bd83a4c679fa6a58dbaf3fe11">view</a>]</li>
+<li>Updated test 024 to better test spacing behavior. [<a href="https://github.com/doxygen/doxygen/commit/b47de248b2c4d54bd83a4c679fa6a58dbaf3fe11">view</a>]</li>
 <li>Warnings in case of a VHDL error [<a href="https://github.com/doxygen/doxygen/commit/5bda6a19dcb48720ee57fc099f7ad14e4ad15b0a">view</a>]</li>
 <li>commentscan.l: replace QStack by std::stack [<a href="https://github.com/doxygen/doxygen/commit/5e815d8f3dd1cad071a6152b458c08f197bb00d2">view</a>]</li>
 <li>fixed some parser bugs,make parser ready for javacc 7.0.5 [<a href="https://github.com/doxygen/doxygen/commit/543a30dfcf050c772a5ef5420c821acbfe3cac9f">view</a>]</li>
@@ -3211,7 +3211,7 @@ href="https://github.com/doxygen/doxygen/commit/9d83d43f0d8b7058e2f89371a6ab276c
 <li>remove PLANTUML_RUN_FAST because FAST is default. [<a href="https://github.com/doxygen/doxygen/commit/51bba9d513b22bd92d90127657b76f51d4555fa8">view</a>]</li>
 <li>secref command output shows in 1 column (HTML) [<a href="https://github.com/doxygen/doxygen/commit/6c731ddf5f77247ef07f9772a9d80d7eedba9d19">view</a>]</li>
 <li>source arrangement [<a href="https://github.com/doxygen/doxygen/commit/ccdf5ee278d7029c055954a733f0db90e47e075d">view</a>]</li>
-<li>spelling error: suported -&gt; supported [<a href="https://github.com/doxygen/doxygen/commit/e182d98227fe78ff58fe541b25683f0a034e3aab">view</a>]</li>
+<li>spelling error: supported -&gt; supported [<a href="https://github.com/doxygen/doxygen/commit/e182d98227fe78ff58fe541b25683f0a034e3aab">view</a>]</li>
 <li>sqlcode.l: generate a reentrant scanner [<a href="https://github.com/doxygen/doxygen/commit/52e32ead5d8152d75a18f3cc7f4b7e5c7bb38b29">view</a>]</li>
 <li>take doc group out of commentscan.l [<a href="https://github.com/doxygen/doxygen/commit/b30e834cd04881ddeaadf8c78a9e716b4dd6a689">view</a>]</li>
 <li>testing: add a test for TOC levels in the XML output. [<a href="https://github.com/doxygen/doxygen/commit/c3768085f8ab68cd61bae4d132b74d9edd813ce0">view</a>]</li>
@@ -4012,7 +4012,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5808">5808</a> - Doxygen don&#39;t support longer key in bibtex [<a href="https://github.com/doxygen/doxygen/commit/b0fc11e4a891e51bb4d982730efecddac2ef807e">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5809">5809</a> - \cite still rejects valid BibTeX keys [<a href="https://github.com/doxygen/doxygen/commit/b1601548308c8a6ec586a406155d24f80d75aafd">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5821">5821</a> - using plantuml cause a popup &quot;openwith&quot; windows when calling java.exe [<a href="https://github.com/doxygen/doxygen/commit/51ee1b0633fbfa935da08c8a13f70da6fc1c074d">view</a>]</li>
-<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5826">5826</a> - PATCH: Honour SOURCE_DATE_EPOCH environment variable for reproducible output [<a href="https://github.com/doxygen/doxygen/commit/b31266c1076c6284116f17241d9e8aa048f88e60">view</a>]</li>
+<li>Bug <a href="https://github.com/doxygen/doxygen/issues/5826">5826</a> - PATCH: Honor SOURCE_DATE_EPOCH environment variable for reproducible output [<a href="https://github.com/doxygen/doxygen/commit/b31266c1076c6284116f17241d9e8aa048f88e60">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5830">5830</a> - XML not documenting a class in python [<a href="https://github.com/doxygen/doxygen/commit/288afe7d4fe0953f5717b0ac85f805f78d96afa4">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5831">5831</a> - XML empty &lt;argsstring/&gt; in python [<a href="https://github.com/doxygen/doxygen/commit/a1b3f7b1157b8e7b392bfcd6c6452c664bf5a7c2">view</a>]</li>
 <li>Bug <a href="https://github.com/doxygen/doxygen/issues/5832">5832</a> - last entry missing in a @name group of typedefs [<a href="https://github.com/doxygen/doxygen/commit/21d14b3c7697f8807065070f5850259b1b6550e4">view</a>]</li>
@@ -4931,7 +4931,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
 <li> doc/language.doc generated from the updated sources (bgcolored)</li>
 <li> doc/language.tpl -- UTF-8 reflected in the langhowto template</li>
 <li> doc/language.tpl -- trailing spaces removed</li>
-<li> doc/translator.py -- coloured status in HTML</li>
+<li> doc/translator.py -- colored status in HTML</li>
 <li> doxygen /** style creates spurious code blocks with markdown enabled</li>
 <li> doxygen version 1.8.5 throws many "Internal Inconsistency" errors when parsing .idl files</li>
 <li> doxygen.sty.h was not ignored and not included/generated properly</li>
@@ -5347,7 +5347,7 @@ href="https://github.com/doxygen/doxygen/commit/a697caadf1912d0d74faa208f4cff887
        when using C++11 style enums.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4920">4920</a>: Even though HIDE_UNDOC_MEMBERS was enabled, the navigation
        still showed undocumented members.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/4921">4921</a>: Fixed back button behaviour when using the navigation tree.</li>
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/4921">4921</a>: Fixed back button behavior when using the navigation tree.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4927">4927</a>: Added anchors to refs in the index.qhp TOC.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/"></a>: Added XML declaration to index.qhp TOC.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/4932">4932</a>: When a class and its base class has the same nested class,
@@ -6714,7 +6714,7 @@ make sure you add the following:
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3627">3627</a>, <a href="https://github.com/doxygen/doxygen/issues/3648">3648</a>: The title of pages whose label had an underscore
                   was not shown</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3631">3631</a>: Include guard not starting with #ifndef SOME_GUARD_H were not
-                  recognised as such.</li>
+                  recognized as such.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3632">3632</a>: Setting SEARCHENGINE to YES and GENERATE_HTML to NO caused
                   error that search results directory could not be created.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3635">3635</a>, <a href="https://github.com/doxygen/doxygen/issues/3655">3655</a>: typedef'ed enums or struct with the same as the
@@ -6821,7 +6821,7 @@ make sure you add the following:
                   was enabled.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3549">3549</a>: Scope was not hidden for members in the todo list even
                   though HIDE_SCOPE_NAMES was set to YES.</li>
-<li>   id <a href="https://github.com/doxygen/doxygen/issues/3562">3562</a>: Struct variable with explicit struct keyword got labelled
+<li>   id <a href="https://github.com/doxygen/doxygen/issues/3562">3562</a>: Struct variable with explicit struct keyword got labeled
                   with [read] attribute.</li>
 <li>   id <a href="https://github.com/doxygen/doxygen/issues/3545">3545</a>: PHP was not parsed properly when it appeared in a
                   &lt;script language="php"&gt; section.</li>
@@ -11817,7 +11817,7 @@ make sure you add the following:
        option: <code>INCLUDE_FILE_PATTERNS</code>. This tag can be used to
        set the file patterns for the include files (if left empty the
        <code>FILE_PATTERNS</code> will be used, which was also the old
-       behaviour). </li>
+       behavior). </li>
 <li>   Added a couple of commands for kdoc compatibility: <code>@p</code>,
        <code>@li</code>, <code>@em</code>.
        Also made @ref a bit less strict.</li>

--- a/doc/translator.py
+++ b/doc/translator.py
@@ -62,7 +62,7 @@
                was prefixed by backslash (was LaTeX related error).
   2013/02/19 - Better diagnostics when translator_xx.h is too crippled.
   2013/06/25 - TranslatorDecoder checks removed after removing the class.
-  2013/09/04 - Coloured status in langhowto. *ALMOST up-to-date* category
+  2013/09/04 - Colored status in langhowto. *ALMOST up-to-date* category
                of translators introduced.
   2014/06/16 - unified for Python 2.6+ and 3.0+
   """

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2207,7 +2207,7 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   }
 
 #if 0 // TODO: this breaks test 25; SOURCEBROWSER = NO and SOURCE_TOOLTIPS = YES.
-      // So this and other regressions should be analysed and fixed before this can be enabled
+      // So this and other regressions should be analyzed and fixed before this can be enabled
   // disable any boolean options that depend on disabled options
   for (const auto &option : m_options)
   {

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -182,7 +182,7 @@ static StringSet        g_usingDeclarations; // used classes
 static bool             g_successfulRun = FALSE;
 static bool             g_dumpSymbolMap = FALSE;
 
-// keywords recognised as compounds
+// keywords recognized as compounds
 static const StringUnorderedSet g_compoundKeywords =
 { "template class", "template struct", "class", "struct", "union", "interface", "exception" };
 
@@ -10637,7 +10637,7 @@ static void parseFilesMultiThreading(const std::shared_ptr<Entry> &root)
         results.emplace_back(threadPool.queue(processFile));
       }
     }
-    // synchronise with the Entry result lists produced and add them to the root
+    // synchronize with the Entry result lists produced and add them to the root
     for (auto &f : results)
     {
       auto l = f.get();
@@ -10675,7 +10675,7 @@ static void parseFilesMultiThreading(const std::shared_ptr<Entry> &root)
         results.emplace_back(threadPool.queue(processFile));
       }
     }
-    // synchronise with the Entry result lists produced and add them to the root
+    // synchronize with the Entry result lists produced and add them to the root
     for (auto &f : results)
     {
       auto l = f.get();
@@ -10706,7 +10706,7 @@ static void parseFilesMultiThreading(const std::shared_ptr<Entry> &root)
       // dispatch the work and collect the future results
       results.emplace_back(threadPool.queue(processFile));
     }
-    // synchronise with the Entry results produced and add them to the root
+    // synchronize with the Entry results produced and add them to the root
     for (auto &f : results)
     {
       root->moveToSubEntryAndKeep(f.get());
@@ -11275,7 +11275,7 @@ void initDoxygen()
   //Doxygen::tagDestinationDict.setAutoDelete(TRUE);
   Doxygen::indexList = new IndexList;
 
-  // initialisation of these globals depends on
+  // initialization of these globals depends on
   // configuration switches so we need to postpone these
   Doxygen::globalScope     = nullptr;
   Doxygen::inputNameLinkedMap   = nullptr;

--- a/src/growbuf.h
+++ b/src/growbuf.h
@@ -23,7 +23,7 @@
 
 #define GROW_AMOUNT 1024*4
 
-/** Class representing a string buffer optimised for growing. */
+/** Class representing a string buffer optimized for growing. */
 class GrowBuf
 {
   public:

--- a/src/growvector.h
+++ b/src/growvector.h
@@ -22,7 +22,7 @@
 
 #include "construct.h"
 
-/** @brief std::vector like container optimised for pushing elements to the back.
+/** @brief std::vector like container optimized for pushing elements to the back.
  *
  *  It differs from std::vector in that it can grow without invalidating
  *  pointers to its members just like std::deque and std::list.

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -269,7 +269,7 @@ static QCString htmlAttribsToString(const HtmlAttribList &attribs, QCString *pAl
     {
         // The open attribute is a boolean attribute.
         // Specifies that the details should be visible (open) to the user
-        // As it is a boolean attribute the initialisation value is of no interest
+        // As it is a boolean attribute the initialization value is of no interest
         result+=" ";
         result+=att.name;
         result+="=\"true\"";

--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -332,7 +332,7 @@ void createJavaScriptSearchIndex()
           g_searchIndexInfo[SEARCH_INDEX_CLASSES].add(SearchTerm(n,cd.get()));
         }
       }
-      else // non slice optimisation: group all types under classes
+      else // non slice optimization: group all types under classes
       {
         g_searchIndexInfo[SEARCH_INDEX_CLASSES].add(SearchTerm(n,cd.get()));
       }

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -1058,10 +1058,10 @@ class TranslatorEnglish : public Translator
         "<li>%A dark green arrow is used for protected inheritance.</li>\n"
         "<li>%A dark red arrow is used for private inheritance.</li>\n"
         "<li>%A purple dashed arrow is used if a class is contained or used "
-        "by another class. The arrow is labelled with the variable(s) "
+        "by another class. The arrow is labeled with the variable(s) "
         "through which the pointed class or struct is accessible.</li>\n"
         "<li>%A yellow dashed arrow denotes a relation between a template instance and "
-        "the template class it was instantiated from. The arrow is labelled with "
+        "the template class it was instantiated from. The arrow is labeled with "
         "the template parameters of the instance.</li>\n"
         "</ul>\n";
     }
@@ -1894,7 +1894,7 @@ class TranslatorEnglish : public Translator
     QCString trPanelSynchronisationTooltip(bool enable) override
     {
       QCString opt = enable ? "enable" : "disable";
-      return "click to "+opt+" panel synchronisation";
+      return "click to "+opt+" panel synchronization";
     }
 
     /*! Used in a method of an Objective-C class that is declared in a

--- a/testing/037/class_receiver.xml
+++ b/testing/037/class_receiver.xml
@@ -26,7 +26,7 @@
     <briefdescription>
     </briefdescription>
     <detaileddescription>
-      <para><ref refid="class_receiver" kindref="compound">Receiver</ref> class. Can be used to receive and execute commands. After execution of a command, the receiver will send an acknowledgement <msc>
+      <para><ref refid="class_receiver" kindref="compound">Receiver</ref> class. Can be used to receive and execute commands. After execution of a command, the receiver will send an acknowledgment <msc>
   Receiver,Sender;
   Receiver&lt;-Sender [label="Command()", URL="\ref Command()"];
   Receiver-&gt;Sender [label="Ack()", URL="\ref Sender::Ack()", ID="1"];

--- a/testing/037/class_sender.xml
+++ b/testing/037/class_sender.xml
@@ -16,7 +16,7 @@
         <briefdescription>
         </briefdescription>
         <detaileddescription>
-          <para>Acknowledgement from server </para>
+          <para>Acknowledgment from server </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>

--- a/testing/037_msc.cpp
+++ b/testing/037_msc.cpp
@@ -31,12 +31,12 @@
 class Sender
 {
   public:
-    /** Acknowledgement from server */
+    /** Acknowledgment from server */
     void Ack(bool ok);
 };
 
 /** Receiver class. Can be used to receive and execute commands.
- *  After execution of a command, the receiver will send an acknowledgement
+ *  After execution of a command, the receiver will send an acknowledgment
  *  \msc
  *    Receiver,Sender;
  *    Receiver<-Sender [label="Command()", URL="\ref Command()"];

--- a/testing/092/namespacestrings.xml
+++ b/testing/092/namespacestrings.xml
@@ -524,7 +524,7 @@ Appends <emphasis>item</emphasis> to <emphasis>vector</emphasis> if <emphasis>it
           <defname>vector</defname>
         </param>
         <briefdescription>
-          <para>Pack function specialised for TYPE(String) as a replacement for the intrinsic. </para>
+          <para>Pack function specialized for TYPE(String) as a replacement for the intrinsic. </para>
         </briefdescription>
         <detaileddescription>
           <para><parameterlist kind="param"><parameteritem><parameternamelist><parametername direction="in">array</parametername></parameternamelist><parameterdescription><para>The array of things to pack.</para></parameterdescription></parameteritem><parameteritem><parameternamelist><parametername direction="in">mask</parametername></parameternamelist><parameterdescription><para>Shall be the same size as <emphasis>array</emphasis>. The intrinsic form simply requires conformability, but that's a trivial case to implement in client code.</para></parameterdescription></parameteritem><parameteritem><parameternamelist><parametername direction="in">vector</parametername></parameternamelist><parameterdescription><para>Optional. Shall have at least as many elements as there are .TRUE. elements in <emphasis>mask</emphasis>.</para></parameterdescription></parameteritem></parameterlist><simplesect kind="return"><para>If <emphasis>vector</emphasis> is present, the result size is that of <emphasis>vector</emphasis>, otherwise the result size is the number <emphasis>t</emphasis> of true elements in <emphasis>mask</emphasis>.</para></simplesect>

--- a/testing/092_more_interfaces.f90
+++ b/testing/092_more_interfaces.f90
@@ -660,7 +660,7 @@ CONTAINS
   
   !*****************************************************************************
   !!
-  !> Pack function specialised for TYPE(String) as a replacement for 
+  !> Pack function specialized for TYPE(String) as a replacement for 
   !! the intrinsic.
   !!
   !! @param[in]     array             The array of things to pack.

--- a/vhdlparser/vhdlstring.h
+++ b/vhdlparser/vhdlstring.h
@@ -26,7 +26,7 @@ namespace vhdl {
 }
 
 
-/** @brief Minimal string class with std::string like behaviour that fulfills the JavaCC
+/** @brief Minimal string class with std::string like behavior that fulfills the JavaCC
  *  string requirements.
  */
 


### PR DESCRIPTION
Spelling corrections, mainly differences between `en-GB` and `en-US`