### PR TITLE
Output when brief description ends with multiple spaces

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -4771,6 +4771,7 @@ bool CommentScanner::parseCommentBlock(/* in */     OutlineParserInterface *pars
   }
 
   yyextra->current->doc=stripLeadingAndTrailingEmptyLines(yyextra->current->doc,yyextra->current->docLine);
+  yyextra->current->brief=stripLeadingAndTrailingEmptyLines(yyextra->current->brief,yyextra->current->docLine);
 
   if (yyextra->current->section.isFileDoc() && yyextra->current->doc.isEmpty())
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5389,6 +5389,7 @@ QCString stripLeadingAndTrailingEmptyLines(const QCString &s,int &docLine)
     c=*p;
     if (c==' ' || c=='\t' || c=='\r') b--,p--;
     else if (c=='r' && b>=7 && qstrncmp(p-7,"\\ilinebr",8)==0) bi=b-7,b-=8,p-=8;
+    else if (c=='>' && b>=11 && qstrncmp(p-11,"\\ilinebr<br>",12)==0) bi=b-11,b-=12,p-=12;
     else if (c=='\n') bi=b,b--,p--;
     else break;
   }


### PR DESCRIPTION
When we have multiple spaces at the end of a brief description like in:
```
#define BRLAPI_PACKET_RESUMEDRIVER0    'R'   /**< Resume driver               */
```
and settings:
```
JAVADOC_AUTOBRIEF = YES
MARKDOWN_SUPPORT = YES
GENERATE_MAN           = YES
```
This leads in e.g. the HTML output to some extra white space for the brief description and in the MAN output to:
```
       #define BRLAPI_PACKET_RESUMEDRIVER0   'R'
           Resume driver
            "
```

The problem is the empty spaces at the end of the brief description that are converted by the `MARKDOWN_SUPPORT` to `\ilinbr<br>`, the brief description is now stripped of leading and trailing whitesapce and also the later is now stripped.


Example: [example.tar.gz](https://github.com/user-attachments/files/17381805/example.tar.gz)
