### PR TITLE
Remove warnings regarding bison package

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -188,7 +188,7 @@ jobs:
     - name: Install bison/flex (Windows)
       run: |
         #Choco-Install -PackageName winflexbison
-        choco install winflexbison
+        choco install winflexbison3
       if: matrix.config.os == 'windows-latest'
 
     - name: Install Graphviz (Linux)

--- a/src/constexp.y
+++ b/src/constexp.y
@@ -33,7 +33,7 @@ int constexpYYerror(yyscan_t yyscanner, const char *s)
 
 %}
 
-%name-prefix "constexpYY"
+%define api.prefix {constexpYY}
 %define api.pure full
 %lex-param {yyscan_t yyscanner}
 %parse-param {yyscan_t yyscanner}

--- a/src/constexp_p.h
+++ b/src/constexp_p.h
@@ -22,6 +22,9 @@
 //! @brief Private interface between Parser (constexp.y) and Lexer (constexp.l)
 
 #include "cppvalue.h"
+#ifdef YYSTYPE
+#undef YYSTYPE
+#endif
 #define YYSTYPE CPPValue
 #define YY_TYPEDEF_YY_SCANNER_T
 


### PR DESCRIPTION
When running bison we get warnings like:
```
/home/cgal-testsuite/cgal_doc_build/CGAL-6.0.1-Ic-349/doc/scripts/doxygen_master/src/constexp.y:36.1-25:
warning: deprecated directive: ‘%name-prefix "constexpYY"’, use ‘%define
api.prefix {constexpYY}’ [-Wdeprecated]
    36 | %name-prefix "constexpYY"
       | ^~~~~~~~~~~~~~~~~~~~~~~~~
       | %define api.prefix {constexpYY}
/home/cgal-testsuite/cgal_doc_build/CGAL-6.0.1-Ic-349/doc/scripts/doxygen_master/src/constexp.y:36.1-25:
warning: deprecated directive: ‘%name-prefix "constexpYY"’, use ‘%define
api.prefix {constexpYY}’ [-Wdeprecated]
    36 | %name-prefix "constexpYY"
       | ^~~~~~~~~~~~~~~~~~~~~~~~~
       | %define api.prefix {constexpYY}
/home/cgal-testsuite/cgal_doc_build/CGAL-6.0.1-Ic-349/doc/scripts/doxygen_master/src/constexp.y:
```

The problem was called because of the usage of an old bison version (2.7) in GitHub Actions for windows so the `%name-prefix "constexpYY"` was necessary. There is a newer version of bison available on chocolaty and also on sourceforge so no reason for using the old version.