### PR TITLE
Removing compiler warnings

### DIFF
--- a/src/mangen.h
+++ b/src/mangen.h
@@ -57,7 +57,7 @@ class ManCodeGenerator : public OutputCodeIntf
     void endFold() override {}
 
   private:
-    int  m_col = 0;
+    size_t m_col = 0;
     TextStream *m_t;
     bool m_stripCodeComments = false;
     bool m_hide = false;

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -64,7 +64,7 @@ class RTFCodeGenerator : public OutputCodeIntf
     void setSourceFileName(const QCString &name);
     void setIndentLevel(int level) { m_indentLevel=level; }
     QCString rtf_Code_DepthStyle();
-    int  m_col = 0;
+    size_t  m_col = 0;
     TextStream *m_t;
     bool m_doxyCodeLineOpen = false;
     QCString m_sourceFileName;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7203,7 +7203,7 @@ void mergeMemberOverrideOptions(MemberDefMutable *md1,MemberDefMutable *md2)
   if (Config_getBool(INLINE_SOURCES)!=md2->hasInlineSource()) md1->overrideInlineSource(md2->hasInlineSource());
 }
 
-int updateColumnCount(const char *s,int col)
+size_t updateColumnCount(const char *s,size_t col)
 {
   if (s)
   {

--- a/src/util.h
+++ b/src/util.h
@@ -470,6 +470,6 @@ QCString projectLogoFile();
 
 void mergeMemberOverrideOptions(MemberDefMutable *md1,MemberDefMutable *md2);
 
-int updateColumnCount(const char *s,int col);
+size_t updateColumnCount(const char *s,size_t col);
 
 #endif


### PR DESCRIPTION
Removing some compiler warnings of type:
```
conversion from 'size_t' to 'int', possible loss of data
```