### PR TITLE
Handling of `#pragma once`

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -306,6 +306,7 @@ struct preYY_state
   DefineMap                                localDefines;   // macros defined in this file
   DefineList                               macroDefinitions;
   LinkedMap<PreIncludeInfo>                includeRelations;
+  StringVector                             pragmaList;
 
   int                lastContext = 0;
   bool               lexRulesPart = false;
@@ -448,6 +449,7 @@ WSopt [ \t\r]*
 %x      RulesRoundSquare
 %x      RulesRound
 %x      RulesRoundQuest
+%x      PragmaOnce
 
 %%
 
@@ -1063,6 +1065,21 @@ WSopt [ \t\r]*
                                         }
 <Command>"pragma"{B}+"once"             {
                                           yyextra->expectGuard = FALSE;
+                                          if (std::find(yyextra->pragmaList.begin(), yyextra->pragmaList.end(), yyextra->fileName.data()) != yyextra->pragmaList.end())
+                                          {
+                                            outputChar(yyscanner,'\n');
+                                            BEGIN(PragmaOnce);
+                                          }
+                                          else
+                                          {
+                                            yyextra->pragmaList.push_back(yyextra->fileName.data());
+                                          }
+                                        }
+<PragmaOnce>.                           {}
+<PragmaOnce>\n                          {}
+<PragmaOnce><<EOF>>                     {
+                                          yyextra->expectGuard = FALSE;
+                                          BEGIN(Start);
                                         }
 <Command>{ID}                           { // unknown directive
                                           BEGIN(IgnoreLine);
@@ -2048,7 +2065,7 @@ WSopt [ \t\r]*
                                         }
 <*>{CCS}/{CCE}                          |
 <*>{CCS}[*!]?                           {
-                                          if (YY_START==SkipVerbatim || YY_START == SkipCondVerbatim || YY_START==SkipCond || YY_START==IDLquote)
+                                          if (YY_START==SkipVerbatim || YY_START == SkipCondVerbatim || YY_START==SkipCond || YY_START==IDLquote || YY_START == PragmaOnce)
                                           {
                                             REJECT;
                                           }
@@ -2070,7 +2087,7 @@ WSopt [ \t\r]*
                                           }
                                         }
 <*>{CPPC}[/!]?                          {
-                                          if (YY_START==SkipVerbatim || YY_START == SkipCondVerbatim || YY_START==SkipCond || getLanguageFromFileName(yyextra->fileName)==SrcLangExt::Fortran || YY_START==IDLquote)
+                                          if (YY_START==SkipVerbatim || YY_START == SkipCondVerbatim || YY_START==SkipCond || getLanguageFromFileName(yyextra->fileName)==SrcLangExt::Fortran || YY_START==IDLquote || YY_START == PragmaOnce)
                                           {
                                             REJECT;
                                           }
@@ -4015,6 +4032,7 @@ void Preprocessor::processFile(const QCString &fileName,const std::string &input
   state->includeStack.clear();
   state->expandedDict.clear();
   state->contextDefines.clear();
+  state->pragmaList.clear();
   while (!state->condStack.empty()) state->condStack.pop();
 
   setFileName(yyscanner,fileName);

--- a/src/pre.l
+++ b/src/pre.l
@@ -306,7 +306,7 @@ struct preYY_state
   DefineMap                                localDefines;   // macros defined in this file
   DefineList                               macroDefinitions;
   LinkedMap<PreIncludeInfo>                includeRelations;
-  StringVector                             pragmaList;
+  StringUnorderedSet                       pragmaSet;
 
   int                lastContext = 0;
   bool               lexRulesPart = false;
@@ -1065,14 +1065,14 @@ WSopt [ \t\r]*
                                         }
 <Command>"pragma"{B}+"once"             {
                                           yyextra->expectGuard = FALSE;
-                                          if (std::find(yyextra->pragmaList.begin(), yyextra->pragmaList.end(), yyextra->fileName.data()) != yyextra->pragmaList.end())
+                                          if (yyextra->pragmaSet.find(yyextra->fileName.str())!=yyextra->pragmaSet.end())
                                           {
                                             outputChar(yyscanner,'\n');
                                             BEGIN(PragmaOnce);
                                           }
                                           else
                                           {
-                                            yyextra->pragmaList.push_back(yyextra->fileName.data());
+                                            yyextra->pragmaSet.insert(yyextra->fileName.data());
                                           }
                                         }
 <PragmaOnce>.                           {}
@@ -4032,7 +4032,7 @@ void Preprocessor::processFile(const QCString &fileName,const std::string &input
   state->includeStack.clear();
   state->expandedDict.clear();
   state->contextDefines.clear();
-  state->pragmaList.clear();
+  state->pragmaSet.clear();
   while (!state->condStack.empty()) state->condStack.pop();
 
   setFileName(yyscanner,fileName);


### PR DESCRIPTION
The handling of the `#pragma once` was different from the handling of a file with the `#ifndef` guard construction, making, especially when nested include files were in e.g. a namespace, very slow.

Found by Fossies for the mysql-workbench-community 8.0.40 package.

Example: [example.tar.gz](https://github.com/user-attachments/files/17438388/example.tar.gz)
