### PR TITLE
XSD warnings

### DIFF
--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -174,8 +174,10 @@
     <xsd:sequence>
       <xsd:element name="header" type="xsd:string" minOccurs="0" />
       <xsd:element name="description" type="descriptionType" minOccurs="0" />
-      <xsd:element name="memberdef" type="memberdefType" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="member" type="MemberType" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:choice maxOccurs="unbounded">
+        <xsd:element name="memberdef" type="memberdefType" minOccurs="0" maxOccurs="unbounded" />
+        <xsd:element name="member" type="MemberType" minOccurs="0" maxOccurs="unbounded" />
+      </xsd:choice>
     </xsd:sequence>
     <xsd:attribute name="kind" type="DoxSectionKind" />
   </xsd:complexType>


### PR DESCRIPTION
In CGAL we got a number of times a warning like:
```
element memberdef: Schemas validity error : Element 'memberdef': This element is not expected. Expected is ( member )
```
when running a xsd check.

The resulting XML output gave that in a `sectiondef` part there were a number of `member`s and `memberdef`s in a unsorted order and this was not supported in the `compound.xsd`.

Problem found in the CGAL package.