### PR TITLE
Compilation warning in `pre.l`

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -4089,8 +4089,8 @@ void Preprocessor::processFile(const QCString &fileName,const std::string &input
       {
         if (startOfLine)
         {
-          char lineNrStr[10];
-          snprintf(lineNrStr,10,"%05d ",line++);
+          char lineNrStr[15];
+          snprintf(lineNrStr,15,"%05d ",line++);
           contents+=lineNrStr;
         }
         contents   += output[pos];


### PR DESCRIPTION
In `pre.l` we got warnings like:
```
.../src/pre.l:4094:33: warning: ‘ ’ directive output may be truncated writing 1 byte into a region of size between 0 and 5 [-Wformat-truncation=]
 4094 |           contents+=lineNrStr;
      |                                 ^
.../src/pre.l:4094:19: note: ‘snprintf’ output between 7 and 12 bytes into a destination of size 10
 4094 |           contents+=lineNrStr;
      |           ~~~~~~~~^~~~~~~~~~~~
```

Increasing the buffer slightly resolves this problem.