### PR TITLE
issue #11209 `<kbd>` tag gets rewritten as `<code>`

### DIFF
--- a/src/cmdmapper.cpp
+++ b/src/cmdmapper.cpp
@@ -183,7 +183,7 @@ static const CommandMap<HtmlTagType>  g_htmlTagMap =
   { "ul",         HtmlTagType::HTML_UL },
   { "li",         HtmlTagType::HTML_LI },
   { "tt",         HtmlTagType::XML_C /*HtmlTagType::HTML_CODE*/ },
-  { "kbd",        HtmlTagType::XML_C /*HtmlTagType::HTML_CODE*/ },
+  { "kbd",        HtmlTagType::HTML_KBD },
   { "em",         HtmlTagType::HTML_EMPHASIS },
   { "hr",         HtmlTagType::HTML_HR },
   { "dl",         HtmlTagType::HTML_DL },

--- a/src/cmdmapper.h
+++ b/src/cmdmapper.h
@@ -211,6 +211,7 @@ enum class HtmlTagType
   HTML_THEAD     = 41,
   HTML_TBODY     = 42,
   HTML_TFOOT     = 43,
+  HTML_KBD       = 44,
 
   XML_CmdMask    = 0x100,
 

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -287,6 +287,7 @@ DB_VIS_C
     case DocStyleChange::Italic:
       if (s.enable()) m_t << "<emphasis>";     else m_t << "</emphasis>";
       break;
+    case DocStyleChange::Kbd:
     case DocStyleChange::Code:
       if (s.enable()) m_t << "<computeroutput>";   else m_t << "</computeroutput>";
       break;

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -142,6 +142,7 @@ const char *DocStyleChange::styleString() const
     case DocStyleChange::Del:          return "del";
     case DocStyleChange::Underline:    return "u";
     case DocStyleChange::Ins:          return "ins";
+    case DocStyleChange::Kbd:          return "kbd";
   }
   return "<invalid>";
 }
@@ -4782,6 +4783,9 @@ Token DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &
         parser()->handleStyleEnter(thisVariant(),children(),DocStyleChange::Code,tagName,&parser()->context.token->attribs);
       }
       break;
+    case HtmlTagType::HTML_KBD:
+        parser()->handleStyleEnter(thisVariant(),children(),DocStyleChange::Kbd,tagName,&parser()->context.token->attribs);
+      break;
     case HtmlTagType::HTML_EMPHASIS:
       if (!parser()->context.token->emptyTag) parser()->handleStyleEnter(thisVariant(),children(),DocStyleChange::Italic,tagName,&parser()->context.token->attribs);
       break;
@@ -5251,6 +5255,9 @@ Token DocPara::handleHtmlEndTag(const QCString &tagName)
       break;
     case HtmlTagType::HTML_CODE:
       parser()->handleStyleLeave(thisVariant(),children(),DocStyleChange::Code,tagName);
+      break;
+    case HtmlTagType::HTML_KBD:
+      parser()->handleStyleLeave(thisVariant(),children(),DocStyleChange::Kbd,tagName);
       break;
     case HtmlTagType::HTML_EMPHASIS:
       parser()->handleStyleLeave(thisVariant(),children(),DocStyleChange::Italic,tagName);

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -278,7 +278,8 @@ class DocStyleChange : public DocNode
                  Del           = (1<<12),
                  Ins           = (1<<13),
                  S             = (1<<14),
-                 Cite          = (1<<15)
+                 Cite          = (1<<15),
+                 Kbd           = (1<<16)
                };
 
     DocStyleChange(DocParser *parser,DocNodeVariant *parent,size_t position,Style s,

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1513,6 +1513,16 @@ reparsetoken:
               handleStyleLeave(parent,children,DocStyleChange::Code,tokenName);
             }
             break;
+          case HtmlTagType::HTML_KBD:
+            if (!context.token->endTag)
+            {
+              handleStyleEnter(parent,children,DocStyleChange::Kbd,tokenName,&context.token->attribs);
+            }
+            else
+            {
+              handleStyleLeave(parent,children,DocStyleChange::Kbd,tokenName);
+            }
+            break;
           case HtmlTagType::HTML_EMPHASIS:
             if (!context.token->endTag)
             {

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -505,6 +505,9 @@ void HtmlDocVisitor::operator()(const DocStyleChange &s)
     case DocStyleChange::Italic:
       if (s.enable()) m_t << "<em" << htmlAttribsToString(s.attribs()) << ">";     else m_t << "</em>";
       break;
+    case DocStyleChange::Kbd:
+      if (s.enable()) m_t << "<kbd" << htmlAttribsToString(s.attribs()) << ">";   else m_t << "</kbd>";
+      break;
     case DocStyleChange::Code:
       if (s.enable()) m_t << "<code" << htmlAttribsToString(s.attribs()) << ">";   else m_t << "</code>";
       break;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -409,6 +409,7 @@ void LatexDocVisitor::operator()(const DocStyleChange &s)
     case DocStyleChange::Italic:
       if (s.enable()) m_t << "{\\itshape ";     else m_t << "}";
       break;
+    case DocStyleChange::Kbd:
     case DocStyleChange::Code:
       if (s.enable()) m_t << "{\\ttfamily ";   else m_t << "}";
       break;

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -147,6 +147,7 @@ void ManDocVisitor::operator()(const DocStyleChange &s)
       if (s.enable()) m_t << "\\fI";     else m_t << "\\fP";
       m_firstCol=FALSE;
       break;
+    case DocStyleChange::Kbd:
     case DocStyleChange::Code:
       if (s.enable()) m_t << "\\fR";   else m_t << "\\fP";
       m_firstCol=FALSE;

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -613,6 +613,7 @@ void PerlModDocVisitor::operator()(const DocStyleChange &s)
     case DocStyleChange::Preformatted:  style = "preformatted"; break;
     case DocStyleChange::Div:           style = "div"; break;
     case DocStyleChange::Span:          style = "span"; break;
+    case DocStyleChange::Kbd:           style = "kbd"; break;
   }
   openItem("style");
   m_output.addFieldQuotedString("style", style)

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -120,6 +120,9 @@ class PrintDocVisitor
         case DocStyleChange::Italic:
           if (s.enable()) printf("<italic>"); else printf("</italic>");
           break;
+        case DocStyleChange::Kbd:
+          if (s.enable()) printf("<kbd>"); else printf("</kbd>");
+          break;
         case DocStyleChange::Code:
           if (s.enable()) printf("<code>"); else printf("</code>");
           break;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -274,6 +274,7 @@ void RTFDocVisitor::operator()(const DocStyleChange &s)
     case DocStyleChange::Italic:
       if (s.enable()) m_t << "{\\i ";     else m_t << "} ";
       break;
+    case DocStyleChange::Kbd:
     case DocStyleChange::Code:
       if (s.enable()) m_t << "{\\f2 ";   else m_t << "} ";
       break;

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -265,6 +265,7 @@ void XmlDocVisitor::operator()(const DocStyleChange &s)
     case DocStyleChange::Italic:
       if (s.enable()) m_t << "<emphasis>";     else m_t << "</emphasis>";
       break;
+    case DocStyleChange::Kbd:
     case DocStyleChange::Code:
       if (s.enable()) m_t << "<computeroutput>";   else m_t << "</computeroutput>";
       break;

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1807,11 +1807,11 @@ th.markdownTableHeadCenter, td.markdownTableBodyCenter {
 	text-align: center
 }
 
-tt, code, kbd, samp
+tt, code, kbd
 {
   display: inline-block;
 }
-tt, code, kbd, samp code
+tt, code, kbd
 {
   vertical-align: top;
 }


### PR DESCRIPTION
Create the possibility so that the `<kbd>` tag is distinct from the `<code>` tag and user has the possibility to render the `<kbd>` tag in a way the user likes. and that it is n