### PR TITLE
issue #11210 Support for Numeric code fence directives - GitHub flavor

### DIFF
--- a/doc/markdown.dox
+++ b/doc/markdown.dox
@@ -451,7 +451,8 @@ which will produce:
 int func(int a,int b) { return a*b; }
 ~~~~~~~~~~~~~~~
 
-The curly braces and dot are optional by the way.
+The dot is optional, the curly braces are optional when the that language name begins with a
+alphabetical character and further characters are alphanumerical characters.
 
 Another way to denote fenced code blocks is to use 3 or more backticks (```):
 


### PR DESCRIPTION
- support for numerical character in language name
- adjusted documentation to make it more clear
- stripped initial `.` in language name, as otherwise fenced code blocks with e.g. `.dot` or `.plantuml` don't work.