### PR TITLE
Use style `plainnat` with `natbib` package

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3297,7 +3297,7 @@ The following block name is set based on whether or not a feature is used in the
 ]]>
       </docs>
     </option>
-    <option type='string' id='LATEX_BIB_STYLE' format='string' defval='plain' depends='GENERATE_LATEX'>
+    <option type='string' id='LATEX_BIB_STYLE' format='string' defval='plainnat' depends='GENERATE_LATEX'>
       <docs>
 <![CDATA[
  The \c LATEX_BIB_STYLE tag can be used to specify the style to use for the

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -798,7 +798,7 @@ static QCString substituteLatexKeywords(const QCString &str,
   QCString style = Config_getString(LATEX_BIB_STYLE);
   if (style.isEmpty())
   {
-    style="plain";
+    style="plainnat";
   }
 
   TextStream tg;

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -168,7 +168,7 @@
 
   % ToC, LoF, LoT, bibliography, and index
   % Indices & bibliography
-  \usepackage{natbib}
+  \usepackage[numbers]{natbib}
   \usepackage[titles]{tocloft}
   \setcounter{tocdepth}{3}
   \setcounter{secnumdepth}{5}


### PR DESCRIPTION
In the documentation (answer and comments of https://tex.stackexchange.com/questions/729789/how-can-i-arrange-my-bibliography-in-alphabetical-order) it is advised to use `plainnat` together with the `natbib` package and not the `plain` style. For compatibility with the old style (and e.g. HTML) the option `numbers` should be used with the `natbib` package.

(also tested against one of the subpackages of CGAL including LaTeX even though CGAL doesn't generate LaTeX)