### PR TITLE
Define defined in multiple, nested, files

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1926,6 +1926,7 @@ WSopt [ \t\r]*
                                             }
                                             else
                                             {
+                                              if (def->fileName != yyextra->fileName) addDefine(yyscanner);
                                               //printf("error: define %s is defined more than once!\n",qPrint(yyextra->defName));
                                             }
                                           }


### PR DESCRIPTION
When having a define that is defined in multiple, nested, files the second occurrence is not recorded and thus not resolved, this leads e.g. for a line like:
```
static const uint32_t k[] ALIGNED(64) = { 0 };

static const uint8_t r[] ALIGNED(64) = { 7};
```
to a warning like:
```
md5.c:5: warning: documented symbol 'static const uint8_t r' was not declared or defined.
```

Example: [example.tar.gz](https://github.com/user-attachments/files/17645110/example.tar.gz)

(Found by Fossies for the dd_rescue 1.99.17package)
