### PR TITLE
bug 432893 handling `*` in ODL properties

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3908,7 +3908,7 @@ NONLopt [^\n]*
                                         }
 <IDLAttribute>.                         {
                                         }
-<IDLPropName>{BN}*{ID}{BN}*             {
+<IDLPropName>{BN}*{ID}({BN}*[*]*{BN}*)? {
                                           // return type (probably HRESULT) - skip it
 
                                           if (yyextra->odlProp)


### PR DESCRIPTION
The `*` was not handled in the type of ODL properties

Example: [example.tar.gz](https://github.com/user-attachments/files/17663125/example.tar.gz)
