### PR TITLE
Handling multiple `<br>` tags

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -623,17 +623,32 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 
   /********* patterns for linkable words ******************/
 
+<St_Para>{ID}/("<br>"|"<BR>")+ {
+                         yyextra->token.name = yytext;
+                         return Token::make_TK_LNKWORD();
+                        }
 <St_Para>{ID}/"<"{HTMLKEYW}">" { /* this rule is to prevent opening html
                                   * tag to be recognized as a templated classes
                                   */
                          yyextra->token.name = yytext;
                          return Token::make_TK_LNKWORD();
                         }
-<St_Para>{LNKWORD1}/"<tt>" { // prevent <tt> html tag to be parsed as template arguments
+<St_Para>{LNKWORD1}/"<TT>"   { // prevent <TT> html tag to be parsed as template arguments
                          yyextra->token.name = yytext;
                          return Token::make_TK_LNKWORD();
                        }
-<St_Para>{LNKWORD1}/"<br>"           | // prevent <br> html tag to be parsed as template arguments
+<St_Para>{LNKWORD1}/"<tt>"   { // prevent <tt> html tag to be parsed as template arguments
+                         yyextra->token.name = yytext;
+                         return Token::make_TK_LNKWORD();
+                       }
+<St_Para>{LNKWORD1}/"<BR>"   { // prevent <BR> html tag to be parsed as template arguments
+                         yyextra->token.name = yytext;
+                         return Token::make_TK_LNKWORD();
+                       }
+<St_Para>{LNKWORD1}/"<br>"   { // prevent <br> html tag to be parsed as template arguments
+                         yyextra->token.name = yytext;
+                         return Token::make_TK_LNKWORD();
+                       }
 <St_Para>{LNKWORD1}                  |
 <St_Para>{LNKWORD1}{FUNCARG}         |
 <St_Para>{LNKWORD2}                  |


### PR DESCRIPTION
When having an example like:
```
/** \file
  * line 1 text1<br>
  * line 2 text2<br><br>
  * line 3 text3
  */
```
this is shown as:
```
line 1 text1
line 2 text2<br>
line 3 text3
```

Not the `<br>` that actually should be a new line.

Example: [example.tar.gz](https://github.com/user-attachments/files/17679098/example.tar.gz)
