### PR TITLE
issue #11225 Improve support for code blocks in included markdown files

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -828,8 +828,17 @@ SLASHopt [/]*
 <CComment,CNComment>[^ `~<\\!@*\n{\"'\/-]*    { /* anything that is not a '*' or command */
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
-<CComment,CNComment>"*"+[^*\/<\\@\n{\"]*      { /* stars without slashes */
+<CComment,CNComment>^{B}*"*"+[^*\/<\\@\n{\"]*      { /* stars without slashes */
                                      if (yyextra->lang==SrcLangExt::Markdown) REJECT;
+                                     int i = 0;
+                                     yyextra->col = 0;
+                                     int tabSize=Config_getInt(TAB_SIZE);
+                                     while (yytext[i] == ' ' || yytext[i] == '\t')
+                                     {
+	                               if (yytext[i] == '\t') yyextra->col+=tabSize-(yyextra->col%tabSize);
+	                               else yyextra->col++;
+                                       i++;
+                                     }
                                      if (yyextra->col>yyextra->blockHeadCol)
                                      {
                                        //printf("new blockHeadCol=%d\n",yyextra->blockHeadCol);
@@ -878,6 +887,7 @@ SLASHopt [/]*
                                      yyextra->commentStack.push(yyextra->lineNr);
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
+<CComment,CNComment>^{B}*"*"+"/"   |
 <CComment,CNComment>"*"+"/"                  { /* end of C comment */
                                      if (yyextra->lang==SrcLangExt::Python ||
                                          yyextra->lang==SrcLangExt::Markdown)

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -829,6 +829,7 @@ SLASHopt [/]*
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
 <CComment,CNComment>"*"+[^*\/<\\@\n{\"]*      { /* stars without slashes */
+                                     if (yyextra->lang==SrcLangExt::Markdown) REJECT;
                                      if (yyextra->col>yyextra->blockHeadCol)
                                      {
                                        //printf("new blockHeadCol=%d\n",yyextra->blockHeadCol);


### PR DESCRIPTION
Looks like the `**` in the line:
```
This is sample **content** and code for Primary file
```
are mistakenly seen as continuation comment signs of a Cpp  line also due to the initial setting of the lex state to `CComment`