### PR TITLE
issue #11227 Generated documentation for the IDL interface has wrong quotes

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -73,7 +73,7 @@ QCString includeStatement(SrcLangExt lang,IncludeKind kind)
 QCString includeOpen(SrcLangExt lang,IncludeKind kind)
 {
   if (lang==SrcLangExt::Java || kind==IncludeKind::ImportModule) return "";
-  if (kind & IncludeKind_LocalMask)
+  if ((kind & IncludeKind_LocalMask) || (lang==SrcLangExt::IDL))
   {
     return "\"";
   }
@@ -85,7 +85,9 @@ QCString includeOpen(SrcLangExt lang,IncludeKind kind)
 
 QCString includeClose(SrcLangExt lang,IncludeKind kind)
 {
-  if (lang==SrcLangExt::Java || lang==SrcLangExt::IDL) return ";";
+  if (lang==SrcLangExt::IDL) return "\";";
+  else if (lang==SrcLangExt::Java) return ";";
+
   switch (kind)
   {
     case IncludeKind::ImportLocal:       return "\";";


### PR DESCRIPTION
Fixing quotes for IDL import statements.
(based on the fix in the repository of @kazssym)

Example: [example.tar.gz](https://github.com/user-attachments/files/17700449/example.tar.gz)
