### PR TITLE
Better warning in case of an internal error of a layout element

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2872,8 +2872,8 @@ void ClassDefImpl::writeDocumentationContents(OutputList &ol,const QCString & /*
       case LayoutDocEntry::DirSubDirs:
       case LayoutDocEntry::DirFiles:
       case LayoutDocEntry::DirGraph:
-        err("Internal inconsistency: member %d should not be part of "
-            "LayoutDocManager::Class entry list\n",lde->kind());
+        err("Internal inconsistency: member '%s' should not be part of "
+            "LayoutDocManager::Class entry list\n",qPrint(lde->entryToString()));
         break;
     }
   }

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -609,8 +609,8 @@ void ConceptDefImpl::writeDocumentation(OutputList &ol)
       case LayoutDocEntry::DirSubDirs:
       case LayoutDocEntry::DirFiles:
       case LayoutDocEntry::DirGraph:
-        err("Internal inconsistency: member %d should not be part of "
-            "LayoutDocManager::Concept entry list\n",lde->kind());
+        err("Internal inconsistency: member '%s' should not be part of "
+            "LayoutDocManager::Concept entry list\n",qPrint(lde->entryToString()));
         break;
     }
   }

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -643,8 +643,8 @@ void DirDefImpl::writeDocumentation(OutputList &ol)
       case LayoutDocEntry::MemberDef:
       case LayoutDocEntry::MemberDefStart:
       case LayoutDocEntry::MemberDefEnd:
-        err("Internal inconsistency: member %d should not be part of "
-            "LayoutDocManager::Directory entry list\n",lde->kind());
+        err("Internal inconsistency: member '%s' should not be part of "
+            "LayoutDocManager::Directory entry list\n",qPrint(lde->entryToString()));
         break;
     }
   }

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -1027,8 +1027,8 @@ void FileDefImpl::writeDocumentation(OutputList &ol)
       case LayoutDocEntry::DirSubDirs:
       case LayoutDocEntry::DirFiles:
       case LayoutDocEntry::DirGraph:
-        err("Internal inconsistency: member %d should not be part of "
-            "LayoutDocManager::File entry list\n",lde->kind());
+        err("Internal inconsistency: member '%s' should not be part of "
+            "LayoutDocManager::File entry list\n",qPrint(lde->entryToString()));
         break;
     }
   }

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1317,8 +1317,8 @@ void GroupDefImpl::writeDocumentation(OutputList &ol)
       case LayoutDocEntry::DirSubDirs:
       case LayoutDocEntry::DirFiles:
       case LayoutDocEntry::DirGraph:
-        err("Internal inconsistency: member %d should not be part of "
-            "LayoutDocManager::Group entry list\n",lde->kind());
+        err("Internal inconsistency: member '%s' should not be part of "
+            "LayoutDocManager::Group entry list\n",qPrint(lde->entryToString()));
         break;
     }
   }

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -463,8 +463,8 @@ void ModuleDefImpl::writeDocumentation(OutputList &ol)
       case LayoutDocEntry::DirSubDirs:
       case LayoutDocEntry::DirFiles:
       case LayoutDocEntry::DirGraph:
-        err("Internal inconsistency: member %d should not be part of "
-            "LayoutDocManager::Module entry list\n",lde->kind());
+        err("Internal inconsistency: member '%s' should not be part of "
+            "LayoutDocManager::Module entry list\n",qPrint(lde->entryToString()));
         break;
     }
   }

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -1116,8 +1116,8 @@ void NamespaceDefImpl::writeDocumentation(OutputList &ol)
       case LayoutDocEntry::DirSubDirs:
       case LayoutDocEntry::DirFiles:
       case LayoutDocEntry::DirGraph:
-        err("Internal inconsistency: member %d should not be part of "
-            "LayoutDocManager::Namespace entry list\n",lde->kind());
+        err("Internal inconsistency: member '%s' should not be part of "
+            "LayoutDocManager::Namespace entry list\n",qPrint(lde->entryToString()));
         break;
     }
   }


### PR DESCRIPTION
Better warning in case of an internal error. At the moment we could get warnings like:
```
error: Internal inconsistency: member 10 should not be part of LayoutDocManager::Namespace entry list
```
though it would be better to have a mnemonic instead of a number.