### PR TITLE
issue #11271 man pages incorrectly convert \" to \'

### DIFF
--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -996,7 +996,6 @@ void ManDocVisitor::filter(const QCString &str)
       {
         case '.':  m_t << "\\&."; break; // see  bug652277
         case '\\': m_t << "\\\\"; break;
-        case '"':  c = '\''; // fall through
         default: m_t << c; break;
       }
     }


### PR DESCRIPTION
6c5b9295509e introduced `ManDocVisitor::filter()` which corrects \\ but converts \" to \' which is wrong for `case DocVerbatim::Verbatim` and the `case` of normal text at least.

If there are any cases where it is correct to convert \" to \', `filter()` would need a bool argument;
until then simply delete the offending line.

Fixes: 6c5b9295509e: Issue with spacing around \<programlisting\>