### PR TITLE
Size of project name when part of "treeview"

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1420,6 +1420,11 @@ dl.invariant dt, dl.pre dt, dl.post dt {
 	padding: 2px 0px;
 }
 
+#side-nav #projectname
+{
+	font-size: 130%;
+}
+
 #projectbrief
 {
 	font-size: 90%;


### PR DESCRIPTION
When having:
```
    GENERATE_TREEVIEW = YES
    DISABLE_INDEX = YES
    FULL_SIDEBAR = YES
```
the project name is a bit large, better would be to have it, by default a bit smaller.

this is independent  of the request to revert the defaults for the above mentioned settings as indicated in https://github.com/doxygen/doxygen/commit/2a62c197550990a6346d826cf0644a52d5e03e9b#commitcomment-150534822