### PR TITLE
Don't convert CMake environment variables when using `-x_noenv` option

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1396,13 +1396,14 @@ void ConfigImpl::emptyValueToDefault()
 
 static const reg::Ex reEnvVar(R"(\$\((\a[\w.-]*)\))");                 // e.g. $(HOME)
 static const reg::Ex reEnvVarExt(R"(\$\((\a[\w.-]*\(\a[\w.-]*\))\))"); // e.g. $(PROGRAMFILES(X86))
-static const reg::Ex reEnvVarCMake(R"(@\a\w*@)");                      // CMake type replacement
+static const reg::Ex reEnvVarCMake(R"(@\a\w*@)");                      // CMake type replacement (@...@)
+static const reg::Ex reEnvVar1CMake(R"(\${\a\w*})");                   // CMake type replacement (${...})
 
 static bool containsEnvVar(QCString &str)
 {
   reg::Match m;
   std::string s = str.str();
-  return reg::search(s,m,reEnvVar) || reg::search(s,m,reEnvVarExt) || reg::search(s,m,reEnvVarCMake);
+  return reg::search(s,m,reEnvVar) || reg::search(s,m,reEnvVarExt) || reg::search(s,m,reEnvVarCMake) || reg::search(s,m,reEnvVar1CMake);
 }
 
 static void substEnvVarsInString(QCString &str)


### PR DESCRIPTION
When having environment CMake variables in the form of `${....}` and using `doxygen -x_noenv`  we still can get warnings like:
```
warning: argument '${EIGEN_DOXY_INTERNAL}' for option INTERNAL_DOCS is not a valid boolean value
Using the default: NO!
```
whilst in this case these environment variables should not give a warning and remain in the resulting Doxyfile. These variables are normally resolved by CMake, but when creating one's own Doxyfile based on a CMake Doxyfile.in without running CMake they should not be touched and not be converted to the default value.

(Found when doing some tests with the Eigen package).