### PR TITLE
Encoding `doxycommentview` output

### DIFF
--- a/addon/doxycommentview/doxycommentview.py
+++ b/addon/doxycommentview/doxycommentview.py
@@ -44,7 +44,7 @@ def main():
 
                 # Run doxygen in single comment mode, reading from stdin and writing to stdout
                 result = subprocess.run([DOXYGEN, '-c', '-', DOXYFILE], \
-                                        input=input_text, capture_output=True, text=True)
+                                        input=input_text, capture_output=True, text=True, encoding="utf-8")
 
                 # Insert CSS link tag into the HTML output
                 self.send_response(200)


### PR DESCRIPTION
When having a simile input for the doxycommentview like:
```
In the examples, the `→` character is used to represent tabs.
```

the server throws an exception like:
```
Exception occurred during processing of request from ('127.0.0.1', 64755)
Traceback (most recent call last):
  File "D:\Programs\Python\Python312\Lib\socketserver.py", line 318, in _handle_request_noblock
    self.process_request(request, client_address)
  File "D:\Programs\Python\Python312\Lib\socketserver.py", line 349, in process_request
    self.finish_request(request, client_address)
  File "D:\Programs\Python\Python312\Lib\socketserver.py", line 362, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "D:\Programs\Python\Python312\Lib\http\server.py", line 672, in __init__
    super().__init__(*args, **kwargs)
  File "D:\Programs\Python\Python312\Lib\socketserver.py", line 761, in __init__
    self.handle()
  File "D:\Programs\Python\Python312\Lib\http\server.py", line 436, in handle
    self.handle_one_request()
  File "D:\Programs\Python\Python312\Lib\http\server.py", line 424, in handle_one_request
    method()
  File "D:\speeltuin\tst_commentview\ex_2\doxycommentview.py", line 46, in do_POST
    result = subprocess.run([DOXYGEN, '-c', '-', DOXYFILE], \
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Programs\Python\Python312\Lib\subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Programs\Python\Python312\Lib\subprocess.py", line 1209, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Programs\Python\Python312\Lib\subprocess.py", line 1622, in _communicate
    self._stdin_write(input)
  File "D:\Programs\Python\Python312\Lib\subprocess.py", line 1143, in _stdin_write
    self.stdin.write(input)
  File "D:\Programs\Python\Python312\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 22: character maps to <undefined>
```

The line File "D:\Programs\Python\Python312\Lib\encodings\cp1252.py" gives the clue that the output, on Windows, uses a default code page / encoding. Setting the output encoding explicitly solves the issue.