### PR TITLE
issue #11273 Using a tilde in the URL of a Markdown image tag breaks the tag if the image is in the IMAGE_PATH

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -600,8 +600,8 @@ ATTR      ({B}+[^>\n]*)?
 DOCNL     "\n"|"\\ilinebr"
 LC        "\\"{B}*"\n"
 NW        [^a-z_A-Z0-9]
-FILESCHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=@&#]
-FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=@&#]
+FILESCHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=@&#~]
+FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=@&#~]
 FILE      ({FILESCHAR}*{FILEECHAR}+("."{FILESCHAR}*{FILEECHAR}+)*)|("\""[^\n\"]*"\"")
 ID        [$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
@@ -1464,6 +1464,8 @@ STopt  [^\n@\\]*
                                           BEGIN( Comment );
                                         }
 <ClassDocArg2>{FILE}|"<>"               { // second argument; include file
+                                          if (yytext[0] == '~') REJECT;
+                                          if (yytext[0] == '"' && yytext[1] == '~') REJECT;
                                           yyextra->current->includeFile = yytext;
                                           BEGIN( ClassDocArg3 );
                                         }
@@ -1475,6 +1477,8 @@ STopt  [^\n@\\]*
                                         }
 
 <ClassDocArg3>[<"]?{FILE}?[">]?         { // third argument; include file name
+                                          if (yytext[0] == '~') REJECT;
+                                          if ((yytext[0] == '<' || yytext[0] == '"') && yytext[1] == '~') REJECT;
                                           yyextra->current->includeName = yytext;
                                           BEGIN( Comment );
                                         }
@@ -1569,6 +1573,9 @@ STopt  [^\n@\\]*
                                           QCString text = yytext;
                                           int start = text.find('{');
                                           int end   = text.find('}',start+1);
+                                          QCString tmp = text.mid(end+2);
+                                          tmp = stripQuotes(tmp.data());
+                                          if (tmp[0] == '~') REJECT;
                                           yyextra->current->name = text.mid(end+2);
                                           int istart = yyextra->current->name.find("\\ilinebr");
                                           if (istart != -1)
@@ -1582,7 +1589,9 @@ STopt  [^\n@\\]*
                                           BEGIN( PageDocArg2 );
                                         }
 <PageDocArg1>{FILE}                     { // first argument; page name
-                                          yyextra->current->name = stripQuotes(yytext);
+                                          QCString tmp = stripQuotes(yytext);
+                                          if (tmp[0] == '~') REJECT;
+                                          yyextra->current->name = tmp;
                                           yyextra->current->args = "";
                                           BEGIN( PageDocArg2 );
                                         }
@@ -1648,7 +1657,9 @@ STopt  [^\n@\\]*
                                           BEGIN( Comment );
                                         }
 <FileDocArg1>{FILE}                     { // first argument; name
-                                          yyextra->current->name = stripQuotes(yytext);
+                                          QCString tmp = stripQuotes(yytext);
+                                          if (tmp[0] == '~') REJECT;
+                                          yyextra->current->name = tmp;
                                           BEGIN( Comment );
                                         }
 <FileDocArg1>{LC}                       { yyextra->lineNr++;
@@ -1846,10 +1857,10 @@ STopt  [^\n@\\]*
   /* ----- handle arguments of the ifile command ----- */
 
 <IFile,IFileSection>{FILE}              {
+                                          QCString tmp = stripQuotes(yytext);
+                                          if (tmp[0] == '~') REJECT;
                                           addOutput(yyscanner,yytext);
-                                          QCString text(yytext);
-                                          if (yytext[0] == '\"') yyextra->fileName = text.mid(1,text.length()-2);
-                                          else yyextra->fileName = yytext;
+                                          yyextra->fileName = tmp;
                                           if (YY_START == IFile)
                                           {
                                             BEGIN(Comment);
@@ -2143,6 +2154,8 @@ STopt  [^\n@\\]*
   /* ----- handle arguments of the subpage command ------- */
 
 <SubpageLabel>{FILE}                    { // first argument
+                                          QCString tmp = stripQuotes(yytext);
+                                          if (tmp[0] == '~') REJECT;
                                           addOutput(yyscanner,yytext);
                                           // we add subpage labels as a kind of "inheritance" relation to prevent
                                           // needing to add another list to the Entry class.

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -198,8 +198,8 @@ ATTRIB    {ATTRNAME}{WS}*("="{WS}*(("\""[^\"]*"\"")|("'"[^\']*"'")|[^ \t\r\n'"><
 URLCHAR   [a-z_A-Z0-9\!\~\,\:\;\'\$\?\@\&\%\#\.\-\+\/\=\x80-\xFF]
 URLMASK   ({URLCHAR}+([({]{URLCHAR}*[)}])?)+
 URLPROTOCOL ("http:"|"https:"|"ftp:"|"ftps:"|"sftp:"|"file:"|"news:"|"irc:"|"ircs:")
-FILEICHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@]
-FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=&#@]
+FILEICHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@~]
+FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=&#@~]
 FILECHARS {FILEICHAR}*{FILEECHAR}+
 HFILEMASK {FILEICHAR}*("."{FILEICHAR}+)+{FILECHARS}*
 VFILEMASK {FILECHARS}("."{FILECHARS})*
@@ -260,8 +260,8 @@ REFWORD2_NOCV  {REFWORD2_PRE}("("{FUNCPART}")")?
 REFWORD3       ({ID}":")*{ID}":"?
 REFWORD4_NOCV  (({SCOPEPRE}*"operator"{OPMASKOP2})|(("::"|"#"){SCOPEPRE}*"operator"{OPMASKOP2}))
 REFWORD4       {REFWORD4_NOCV}{CVSPEC}?
-REFWORD        {FILEMASK}|{LABELID}|{REFWORD2}|{REFWORD3}|{REFWORD4}
-REFWORD_NOCV   {FILEMASK}|{LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
+REFWORD        {LABELID}|{REFWORD2}|{REFWORD3}|{REFWORD4}
+REFWORD_NOCV   {LABELID}|{REFWORD2_NOCV}|{REFWORD3}|{REFWORD4_NOCV}
 RCSID "$"("Author"|"Date"|"Header"|"Id"|"Locker"|"Log"|"Name"|"RCSfile"|"Revision"|"Source"|"State")":"[^:\n$][^\n$]*"$"
 LINENR {BLANK}*([1-9][0-9]*|"0"|"-1")
 
@@ -897,19 +897,31 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          return Token::make_RetVal_OK();
                        }
 <St_PlantUMLOpt>{BLANK}*{FILEMASK}{BLANK}+/{ID}"=" { // case 2: plain file name specified followed by an attribute
-                         yyextra->token.sectionId = QCString(yytext).stripWhiteSpace();
+                         QCString tmp = yytext;
+                         tmp = tmp.stripWhiteSpace();
+                         if (tmp[0] == '~') REJECT;
+                         yyextra->token.sectionId = tmp;
                          return Token::make_RetVal_OK();
                        }
 <St_PlantUMLOpt>{BLANK}*{FILEMASK}{BLANK}+/"\"" { // case 3: plain file name specified followed by a quoted title
-                         yyextra->token.sectionId = QCString(yytext).stripWhiteSpace();
+                         QCString tmp = yytext;
+                         tmp = tmp.stripWhiteSpace();
+                         if (tmp[0] == '~') REJECT;
+                         yyextra->token.sectionId = tmp;
                          return Token::make_RetVal_OK();
                        }
 <St_PlantUMLOpt>{BLANK}*{FILEMASK}{BLANKopt}/\n { // case 4: plain file name specified without title or attributes
-                         yyextra->token.sectionId = QCString(yytext).stripWhiteSpace();
+                         QCString tmp = yytext;
+                         tmp = tmp.stripWhiteSpace();
+                         if (tmp[0] == '~') REJECT;
+                         yyextra->token.sectionId = tmp;
                          return Token::make_RetVal_OK();
                        }
 <St_PlantUMLOpt>{BLANK}*{FILEMASK}{BLANKopt}/"\\ilinebr" { // case 5: plain file name specified without title or attributes
-                         yyextra->token.sectionId = QCString(yytext).stripWhiteSpace();
+                         QCString tmp = yytext;
+                         tmp = tmp.stripWhiteSpace();
+                         if (tmp[0] == '~') REJECT;
+                         yyextra->token.sectionId = tmp;
                          return Token::make_RetVal_OK();
                        }
 <St_PlantUMLOpt>"\\ilinebr" |
@@ -1090,11 +1102,26 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          unput(*yytext);
                          return Token::make_TK_NONE();
                        }
+<St_Ref>{FILEMASK}/{BLANK}("const")[a-z_A-Z0-9] { // see bug776988
+                         if (yytext[0] == '~') REJECT;
+                         yyextra->token.name=yytext;
+                         return Token::make_TK_WORD();
+                       }
 <St_Ref>{REFWORD_NOCV}/{BLANK}("const")[a-z_A-Z0-9] { // see bug776988
                          yyextra->token.name=yytext;
                          return Token::make_TK_WORD();
                        }
+<St_Ref>{FILEMASK}/{BLANK}("volatile")[a-z_A-Z0-9] { // see bug776988
+                         if (yytext[0] == '~') REJECT;
+                         yyextra->token.name=yytext;
+                         return Token::make_TK_WORD();
+                       }
 <St_Ref>{REFWORD_NOCV}/{BLANK}("volatile")[a-z_A-Z0-9] { // see bug776988
+                         yyextra->token.name=yytext;
+                         return Token::make_TK_WORD();
+                       }
+<St_Ref>{FILEMASK}     { // label to refer to
+                         if (yytext[0] == '~') REJECT;
                          yyextra->token.name=yytext;
                          return Token::make_TK_WORD();
                        }
@@ -1129,7 +1156,14 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
 <St_IntRef>{BLANK}+"\"" {
                          BEGIN(St_Ref2);
                        }
-<St_SetScope>({SCOPEMASK}|{ANONNS}){BLANK}|{FILEMASK} {
+<St_SetScope>{FILEMASK} {
+                         QCString tmp = yytext;
+                         tmp = tmp.stripWhiteSpace();
+                         if (tmp[0] == '~') REJECT;
+                         yyextra->token.name = tmp;
+                         return Token::make_TK_WORD();
+                       }
+<St_SetScope>({SCOPEMASK}|{ANONNS}){BLANK} {
                          yyextra->token.name = yytext;
                          yyextra->token.name = yyextra->token.name.stripWhiteSpace();
                          return Token::make_TK_WORD();
@@ -1319,7 +1353,10 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          return Token::make_TK_NONE();
                        }
 <St_IFile>{BLANK}*{FILEMASK} {
-                         yyextra->fileName = QCString(yytext).stripWhiteSpace();
+                         QCString tmp = yytext;
+                         tmp = tmp.stripWhiteSpace();
+                         if (tmp[0] == '~') REJECT;
+                         yyextra->fileName = tmp;
                          return Token::make_TK_WORD();
                        }
 <St_IFile>{BLANK}*"\""[^\n\"]+"\"" {
@@ -1329,7 +1366,10 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          return Token::make_TK_WORD();
                        }
 <St_File>{FILEMASK}    {
-                         yyextra->token.name = yytext;
+                         QCString tmp = yytext;
+                         tmp = tmp.stripWhiteSpace();
+                         if (tmp[0] == '~') REJECT;
+                         yyextra->token.name = tmp;
                          return Token::make_TK_WORD();
                        }
 <St_File>"\""[^\n\"]+"\"" {
@@ -1351,6 +1391,11 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                        }
 <St_Pattern>.          {
                          yyextra->token.name += yytext;
+                       }
+<St_Link>{FILEMASK}    {
+                         if (yytext[0] == '~') REJECT;
+                         yyextra->token.name = yytext;
+                         return Token::make_TK_WORD();
                        }
 <St_Link>{LINKMASK}|{REFWORD}    {
                          yyextra->token.name = yytext;

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -311,8 +311,8 @@ PREFIX    ((NON_)?RECURSIVE{BS_}|IMPURE{BS_}|PURE{BS_}|ELEMENTAL{BS_}){0,4}((NON
 SCOPENAME ({ID}{BS}"::"{BS})*
 
 LINENR    {B}*[1-9][0-9]*
-FILEICHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@]
-FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=&#@]
+FILEICHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@~]
+FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=&#@~]
 FILECHARS {FILEICHAR}*{FILEECHAR}+
 HFILEMASK {FILEICHAR}*("."{FILEICHAR}+)+{FILECHARS}*
 VFILEMASK {FILECHARS}("."{FILECHARS})*
@@ -1452,8 +1452,10 @@ private                                 {
                                           yyextra->docBlock += yytext;
                                         }
 <DocBlock>{CMD}"ifile"{B}+{FILEMASK}    {
-                                          yyextra->fileName = &yytext[6];
-                                          yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                          QCString tmp = &yytext[6];
+                                          tmp = tmp.stripWhiteSpace();
+                                          if (tmp[0] == '~') REJECT;
+                                          yyextra->fileName = tmp;
                                           yyextra->docBlock += yytext;
                                         }
 <DocBlock>{CMD}"iline"{LINENR}/[\n\.]   |

--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -204,8 +204,8 @@ SCRIPTCOMMENT      "#!".*
 STARTDOCSYMS      "##"
 
 LINENR            {B}*[1-9][0-9]*
-FILEICHAR         [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@]
-FILEECHAR         [a-z_A-Z0-9\x80-\xFF\-\+=&#@]
+FILEICHAR         [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@~]
+FILEECHAR         [a-z_A-Z0-9\x80-\xFF\-\+=&#@~]
 FILECHARS         {FILEICHAR}*{FILEECHAR}+
 HFILEMASK         {FILEICHAR}*("."{FILEICHAR}+)+{FILECHARS}*
 VFILEMASK         {FILECHARS}("."{FILECHARS})*
@@ -1499,8 +1499,10 @@ ID        [a-z_A-Z%]+{IDSYM}*
                                     yyextra->docBlock+=yytext;
                                   }
     {CMD}"ifile"{B}+{FILEMASK}    {
-                                    yyextra->fileName = &yytext[6];
-                                    yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                    QCString tmp = &yytext[6];
+                                    tmp = tmp.stripWhiteSpace();
+                                    if (tmp[0] == '~') REJECT;
+                                    yyextra->fileName = tmp;
                                     yyextra->docBlock+=yytext;
                                   }
     {CMD}"iline"{LINENR}/[\n\.]   |
@@ -1543,8 +1545,10 @@ ID        [a-z_A-Z%]+{IDSYM}*
                                     yyextra->docBlock+=yytext;
                                   }
     {CMD}"ifile"{B}+{FILEMASK}    {
-                                    yyextra->fileName = &yytext[6];
-                                    yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                    QCString tmp = &yytext[6];
+                                    tmp = tmp.stripWhiteSpace();
+                                    if (tmp[0] == '~') REJECT;
+                                    yyextra->fileName = tmp;
                                     yyextra->docBlock+=yytext;
                                   }
     {CMD}"iline"{LINENR}/[\n\.]   |

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -290,8 +290,8 @@ OPERATOR  "operator"{B}*({ARITHOP}|{ASSIGNOP}|{LOGICOP}|{BITOP})
 FUNCOP    "operator"("()"|"[]"|{B}+[^;\n]+)
 MODULE_ID ({ID}".")*{ID}
 LINENR    {B}*[1-9][0-9]*
-FILEICHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@]
-FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=&#@]
+FILEICHAR [a-z_A-Z0-9\x80-\xFF\\:\\\/\-\+=&#@~]
+FILEECHAR [a-z_A-Z0-9\x80-\xFF\-\+=&#@~]
 FILECHARS {FILEICHAR}*{FILEECHAR}+
 HFILEMASK {FILEICHAR}*("."{FILEICHAR}+)+{FILECHARS}*
 VFILEMASK {FILECHARS}("."{FILECHARS})*
@@ -7092,8 +7092,10 @@ NONLopt [^\n]*
                                           yyextra->docBlock << yytext;
                                         }
 <DocBlock>{CMD}"ifile"{B}+{FILEMASK}    {
-                                          yyextra->fileName = &yytext[6];
-                                          yyextra->fileName = yyextra->fileName.stripWhiteSpace();
+                                          QCString tmp = &yytext[6];
+                                          tmp = tmp.stripWhiteSpace();
+                                          if (tmp[0] == '~') REJECT;
+                                          yyextra->fileName = tmp;
                                           yyextra->docBlock << yytext;
                                         }
 <DocBlock>{CMD}"iline"{LINENR}{B}       {


### PR DESCRIPTION
Adding possibility to use a `~` in the file / directory name except on the first position of a file / directory name