### PR TITLE
issue #11210 Support for Plus sign code fence directives - GitHub flavor

### DIFF
--- a/doc/markdown.dox
+++ b/doc/markdown.dox
@@ -453,8 +453,8 @@ which will produce:
 int func(int a,int b) { return a*b; }
 ~~~~~~~~~~~~~~~
 
-The dot is optional, the curly braces are optional when the that language name begins with a
-alphabetical character and further characters are alphanumerical characters.
+The dot is optional, the curly braces are optional when the that language name begins with an
+alphabetical character and further characters are alphanumerical characters or a plus sign.
 
 Another way to denote fenced code blocks is to use 3 or more backticks (```):
 

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -180,6 +180,7 @@ BLANK     [ \t\r]
 BLANKopt  {BLANK}*
 ID        [$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
+CODEID    [a-zA-Z][a-zA-Z0-9+]*
 PHPTYPE   [?]?[\\:a-z_A-Z0-9\x80-\xFF\-]+
 CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
 CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]
@@ -736,13 +737,13 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                            return Token::make_TK_NEWPARA();
                          }
                        }
-<St_CodeOpt>{BLANK}*"{"(".")?{LABELID}"}" {
+<St_CodeOpt>{BLANK}*"{"(".")?{CODEID}"}" {
                          yyextra->token.name = yytext;
                          int i=yyextra->token.name.find('{'); /* } to keep vi happy */
                          yyextra->token.name = yyextra->token.name.mid(i+1,yyextra->token.name.length()-i-2);
                          BEGIN(St_Code);
                        }
-<St_iCodeOpt>{BLANK}*"{"(".")?{LABELID}"}" {
+<St_iCodeOpt>{BLANK}*"{"(".")?{CODEID}"}" {
                          yyextra->token.name = yytext;
                          int i=yyextra->token.name.find('{'); /* } to keep vi happy */
                          yyextra->token.name = yyextra->token.name.mid(i+1,yyextra->token.name.length()-i-2);

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -284,7 +284,7 @@ static QCString escapeSpecialChars(const QCString &s)
 }
 
 /** helper function to convert presence of left and/or right alignment markers
- *  to a alignment value
+ *  to an alignment value
  */
 static Alignment markersToAlignment(bool leftMarker,bool rightMarker)
 {
@@ -2231,7 +2231,7 @@ static bool isFencedCodeBlock(std::string_view data,size_t refIndent,
   AUTO_TRACE("data='{}' refIndent={}",Trace::trunc(data),refIndent);
   const char dot = '.';
   auto isAlphaChar  = [ ](char c) { return (c>='A' && c<='Z') || (c>='a' && c<='z'); };
-  auto isAlphaNChar = [ ](char c) { return (c>='A' && c<='Z') || (c>='a' && c<='z') || (c>='0' && c<='9'); };
+  auto isAlphaNChar = [ ](char c) { return (c>='A' && c<='Z') || (c>='a' && c<='z') || (c>='0' && c<='9') || (c=='+'); };
   auto isLangChar   = [&](char c) { return c==dot || isAlphaChar(c); };
   // rules: at least 3 ~~~, end of the block same amount of ~~~'s, otherwise
   // return FALSE


### PR DESCRIPTION
- Support plus sign (for e.g. `C++`) in file extension of fenced code block
- small spelling correction