### PR TITLE
Interaction between markdown blockquotes and sections

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2854,6 +2854,9 @@ size_t Markdown::Private::writeBlockQuote(std::string_view data)
       }
       else
       {
+        curLevel=level;
+        i = indent;
+        if (txt[0] == '#') break; // begin of markdown section command
         out += txt;
       }
       isGitHubFirst = false;
@@ -2875,6 +2878,7 @@ size_t Markdown::Private::writeBlockQuote(std::string_view data)
   {
     out+="</blockquote>";
   }
+  out+="\\ilinebr ";
   AUTO_TRACE_EXIT("i={}",i);
   return i;
 }


### PR DESCRIPTION
In an example (Fossies) I found the code like:
```
@page pg1 page

> text
## section
```
and this results in the warning like:
```
warning: found </blockquote> tag without matching <blockquote>
```
so it is better to terminate the block quote when a potential section command appears.

Example: [example.tar.gz](https://github.com/user-attachments/files/18306639/example.tar.gz)
