### PR TITLE
Correction default output of `\doxyconfig` and adding options

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -889,8 +889,8 @@ Structural indicators
 
   \addindex \\fileinfo
   Shows (part) of the file name in which this command is placed.
-  The `option` can be `name`, `extension`, `filename`, `directory` or, `full`,
-  with
+  The `option` can be `name`, `extension`, `filename`, `directory` or `full`
+  with:
   - `name` the name of the file without extension
   - `extension` the extension of the file
   - `filename` the filename i.e. `name` plus `extension`
@@ -3682,11 +3682,17 @@ class Receiver
   \ref cmdimage "\\image" command.
 
 <hr>
-\section cmddoxyconfig \\doxyconfig \<config_option\>
+\section cmddoxyconfig \\doxyconfig['{'option'}'] [\<config_option\>]
 
   \addindex \\doxyconfig
   Displays the value of the configuration option `<config_option>` as used in Doxygen's
   configuration file that is in use when this command is processed.
+
+  The `option` can be one of `full`, `help` or `all` with:
+  - `full` the name of the `config_option` (together with ` = `) is displayed along with the value
+  - `help` the help information of the `config_option` is displayed
+  - `all` the name and value (analogous to the format with `full`) s displayed for all possible
+    configuration options (so no the `config_option` should be given);
 
   \par Example:
   When creating this manual the following:

--- a/src/configimpl.h
+++ b/src/configimpl.h
@@ -74,6 +74,7 @@ class ConfigOption
     void addDependency(const char *dep) { m_dependency = dep; }
     void setEncoding(const QCString &e) { m_encoding = e; }
     void setUserComment(const QCString &u) { m_userComment += u; }
+    QCString getDocumentation() const { return m_doc; }
 
   protected:
     virtual void writeTemplate(TextStream &t,bool sl,bool upd) = 0;
@@ -229,6 +230,7 @@ class ConfigInt : public ConfigOption
       m_maxVal = maxVal;
     }
     QCString *valueStringRef() { return &m_valueString; }
+    QCString getDefaultStr() { return QCString().setNum(m_value); }
     int *valueRef() { return &m_value; }
     int minVal() const { return m_minVal; }
     int maxVal() const { return m_maxVal; }
@@ -262,6 +264,7 @@ class ConfigBool : public ConfigOption
       m_defValue = defVal;
     }
     QCString *valueStringRef() { return &m_valueString; }
+    QCString getDefaultStr() { return m_value ? "YES" : "NO"; }
     bool *valueRef() { return &m_value; }
     void convertStrToVal(Config::CompareMode compareMode) override;
     void substEnvVars() override;
@@ -609,6 +612,8 @@ class ConfigImpl
     static void config_err(const char *fmt, ...);
     static void config_term(const char *fmt, ...);
     static void config_warn(const char *fmt, ...);
+
+    ConfigOptionList *getOptions() {return &m_options;}
 
   private:
     ConfigOptionList m_options;


### PR DESCRIPTION
- showing the used value of a configuration option when not given (otherwise e.g. `\doxyconfig GENERATE_TREEVIEW` would show up as an empty value instead of `YES`).
- adding options `full`, `help` and `all`.

Example: [example.tar.gz](https://github.com/user-attachments/files/18310449/example.tar.gz)
