### PR TITLE
Flexibility of number of labels along edges in UNL_LOOK diagram

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -3924,6 +3924,18 @@ where `loc1` and `loc2` can be relative or absolute paths or URLs.
 ]]>
       </docs>
     </option>
+    <option type='int' id='UML_LIMIT_EDGE_FIELDS' defval='10' minval='0' maxval='100' depends='UML_LOOK'>
+      <docs>
+<![CDATA[
+ If the \ref cfg_uml_look "UML_LOOK" tag is enabled, fields are shown along
+ the edge between 2 clas nodes.
+ If there are many fields and many nodes the
+ graph may become too big to be useful. The \c UML_LIMIT_EDGE_FIELDS
+ threshold limits the number of items to make the size more
+ manageable. Set this to 0 for no limit.
+]]>
+      </docs>
+    </option>
     <option type='enum' id='DOT_UML_DETAILS' defval='NO' depends='UML_LOOK'>
       <docs>
 <![CDATA[

--- a/src/dotclassgraph.cpp
+++ b/src/dotclassgraph.cpp
@@ -231,17 +231,17 @@ static QCString joinLabels(const StringSet &ss)
 {
   QCString label;
   int count=1;
-  int maxLabels=10;
+  int maxLabels = Config_getInt(UML_LIMIT_EDGE_FIELDS);
   auto it = std::begin(ss), e = std::end(ss);
   if (it!=e) // set not empty
   {
     label += (*it++).c_str();
-    for (; it!=e && count < maxLabels ; ++it,++count)
+    for (; it!=e && (maxLabels == 0 || count < maxLabels) ; ++it,++count)
     {
       label += '\n';
       label += (*it).c_str();
     }
-    if (count==maxLabels) label+="\n...";
+    if (maxLabels != 0 && count==maxLabels) label+="\n...";
   }
   return label;
 }


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/79338813/how-to-make-doxygen-generate-full-list-of-fields-in-class-diagram making the fixed number of 10 labels along the edge of a UNL_LOOK diagram more flexible.