### PR TITLE
Remove redundant 'visible' attrs in layout

### DIFF
--- a/templates/general/layout_default.xml
+++ b/templates/general/layout_default.xml
@@ -120,7 +120,7 @@
       <functions visible="yes" title=""/>
       <variables visible="yes" title=""/>
       <properties visible="yes" title=""/>
-      <membergroups visible="yes" visible="yes"/>
+      <membergroups visible="yes"/>
     </memberdecl>
     <detaileddescription visible="yes" title=""/>
     <memberdef>
@@ -168,7 +168,7 @@
       <functions visible="yes" title=""/>
       <variables visible="yes" title=""/>
       <properties visible="yes" title=""/>
-      <membergroups visible="yes" visible="yes"/>
+      <membergroups visible="yes"/>
     </memberdecl>
     <detaileddescription visible="yes" title=""/>
     <memberdef>


### PR DESCRIPTION
These appear to have been accidentally introduced in 00191119ddd06de4737e145cc305ed7ea4fb6e35 and cause the output of `doxygen -l` to be invalid XML.
