### PR TITLE
Layout labels on edges

### DIFF
--- a/src/dotnode.h
+++ b/src/dotnode.h
@@ -69,7 +69,7 @@ class DotNode
   public:
     static constexpr auto placeholderUrl = "-";
     static void deleteNodes(DotNode* node);
-    static QCString convertLabel(const QCString& , bool htmlLike=false);
+    static QCString convertLabel(const QCString& , bool htmlLike=false, bool tableLike=false);
     DotNode(DotGraph *graph,const QCString &lab,const QCString &tip,const QCString &url,
         bool rootNode=FALSE,const ClassDef *cd=nullptr);
 


### PR DESCRIPTION
Labels alongside edges were centered in respect to each other, this has been changed so it looks a bit cleaner.

Example: [example.tar.gz](https://github.com/user-attachments/files/18380867/example.tar.gz)

**Old**
![image](https://github.com/user-attachments/assets/d9c828b6-4331-405c-b718-b703f710d4c0)


**New**
![image](https://github.com/user-attachments/assets/42867dc2-53f7-4187-b56f-8750df21e8dd)

