### PR TITLE
Doxycommentview html corrections

### DIFF
--- a/addon/doxycommentview/index.html
+++ b/addon/doxycommentview/index.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Doxygen comment viewer</title>
     <link rel="stylesheet" type="text/css" href="/doxygen.css"/>
     <style>
@@ -77,6 +77,7 @@
         </div>
     </div>
     <script>
+        //<![CDATA[
         function updateLineNumbers() {
             const textarea = document.getElementById('input');
             const lineNumbers = document.getElementById('line-numbers');
@@ -127,6 +128,7 @@
             // Initial line numbers update
             updateLineNumbers();
         };
+        //]]>
     </script>
 </body>
 </html>


### PR DESCRIPTION
correcting  the index.html of doxycommentview
- make `meta` tag correct
- the `<` inside the script is not HTML complient unless in a `CDATA section
- making startup tags consistent with "normal" doxygen output and xhtml