### PR TITLE
issue #11246 Markdown links to headings are not handled by doxygen like by GitHub or azure

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2016,7 +2016,7 @@ QCString Markdown::Private::extractTitleId(QCString &title, int level, bool *pIs
     AUTO_TRACE_EXIT("id={}",id);
     return id;
   }
-  if ((level>0) && (level<=Config_getInt(TOC_INCLUDE_HEADINGS)))
+  if (((level>0) && (level<=Config_getInt(TOC_INCLUDE_HEADINGS))) || (Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB))
   {
     QCString id = AnchorGenerator::instance().generate(ti);
     if (pIsIdGenerated) *pIsIdGenerated=true;


### PR DESCRIPTION
section type anchors also have a reference function when `MARKDOWN_ID_STYLE = GITHUB`