### PR TITLE
Consistent translation of `//!` comments

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -401,7 +401,14 @@ SLASHopt [/]*
 					 while (i<(int)yyleng && yytext[i]=='/') i++;
 				       }
 				       yyextra->blockHeadCol=yyextra->col+1;
-				       copyToOutput(yyscanner,"/**");
+                                       if (yytext[2] == '!')
+                                       {
+				         copyToOutput(yyscanner,"/*!");
+                                       }
+                                       else
+                                       {
+				         copyToOutput(yyscanner,"/**");
+                                       }
 				       if (i<yyleng) replaceAliases(yyscanner,yytext+i);
 				       yyextra->inSpecialComment=TRUE;
 				       //BEGIN(SComment);


### PR DESCRIPTION
More consistent translation of `//!` comments
Am input like:
```
int dvar2; //!< dvar 2
           //!<
```
was translated into:
```
int dvar2; /**< dvar 2
             *  */
```
instead of
```
int dvar2; /*!< dvar 2
             *  */
```
this has been adjusted.