### PR TITLE
Remove macro defines from C++ scoped enum values

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7751,6 +7751,7 @@ static void addEnumValuesToEnums(const Entry *root)
               bool isJavaLike = sle==SrcLangExt::CSharp || sle==SrcLangExt::Java || sle==SrcLangExt::XML;
               if ( isJavaLike || root->spec.isStrong())
               {
+                if (sle == SrcLangExt::Cpp && e->section.isDefine()) continue;
                 // Unlike classic C/C++ enums, for C++11, C# & Java enum
                 // values are only visible inside the enum scope, so we must create
                 // them here and only add them to the enum

--- a/testing/107/107__define__in__enums_8cpp.xml
+++ b/testing/107/107__define__in__enums_8cpp.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="107__define__in__enums_8cpp" kind="file" language="C++">
+    <compoundname>107_define_in_enums.cpp</compoundname>
+    <sectiondef kind="define">
+      <memberdef kind="define" id="107__define__in__enums_8cpp_1aee80934e9528cc7801303ace34d76873" prot="public" static="no">
+        <name>ID</name>
+        <param>
+          <defname>X</defname>
+        </param>
+        <initializer>X,</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="107_define_in_enums.cpp" line="7" column="9" bodyfile="107_define_in_enums.cpp" bodystart="7" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="define" id="107__define__in__enums_8cpp_1aee80934e9528cc7801303ace34d76873" prot="public" static="no">
+        <name>ID</name>
+        <param>
+          <defname>X</defname>
+        </param>
+        <initializer>X,</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="107_define_in_enums.cpp" line="13" column="9" bodyfile="107_define_in_enums.cpp" bodystart="7" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="107__define__in__enums_8cpp_1a3b98e2dffc6cb06a89dcb0d5c60a0206" prot="public" static="no" strong="no">
+        <type/>
+        <name>A</name>
+        <enumvalue id="107__define__in__enums_8cpp_1a3b98e2dffc6cb06a89dcb0d5c60a0206a6ff26890857c886c86453f0c8078bf95" prot="public">
+          <name>A1</name>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="107__define__in__enums_8cpp_1a3b98e2dffc6cb06a89dcb0d5c60a0206a47329f455692c2a8284d7594405f16d4" prot="public">
+          <name>A2</name>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="107_define_in_enums.cpp" line="6" column="1" bodyfile="107_define_in_enums.cpp" bodystart="6" bodyend="10"/>
+      </memberdef>
+      <memberdef kind="enum" id="107__define__in__enums_8cpp_1a9d3d9048db16a7eee539e93e3618cbe7" prot="public" static="no" strong="yes">
+        <type/>
+        <name>B</name>
+        <enumvalue id="107__define__in__enums_8cpp_1a9d3d9048db16a7eee539e93e3618cbe7ac9512565ef6194ca664dc41ec0de7a53" prot="public">
+          <name>B1</name>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue id="107__define__in__enums_8cpp_1a9d3d9048db16a7eee539e93e3618cbe7abbd97b00c539801e32317ab550867ec4" prot="public">
+          <name>B2</name>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="107_define_in_enums.cpp" line="12" column="1" bodyfile="107_define_in_enums.cpp" bodystart="12" bodyend="16"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="107_define_in_enums.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/107/107__define__in__enums_8cpp.xml
+++ b/testing/107/107__define__in__enums_8cpp.xml
@@ -3,8 +3,8 @@
   <compounddef id="107__define__in__enums_8cpp" kind="file" language="C++">
     <compoundname>107_define_in_enums.cpp</compoundname>
     <sectiondef kind="define">
-      <memberdef kind="define" id="107__define__in__enums_8cpp_1aee80934e9528cc7801303ace34d76873" prot="public" static="no">
-        <name>ID</name>
+      <memberdef kind="define" id="107__define__in__enums_8cpp_1af5306e4b64f0a20303086d3936c64e0c" prot="public" static="no">
+        <name>ID_A</name>
         <param>
           <defname>X</defname>
         </param>
@@ -17,8 +17,8 @@
         </inbodydescription>
         <location file="107_define_in_enums.cpp" line="7" column="9" bodyfile="107_define_in_enums.cpp" bodystart="7" bodyend="-1"/>
       </memberdef>
-      <memberdef kind="define" id="107__define__in__enums_8cpp_1aee80934e9528cc7801303ace34d76873" prot="public" static="no">
-        <name>ID</name>
+      <memberdef kind="define" id="107__define__in__enums_8cpp_1a244e85f8f6926f9cb8e576ad9c797f47" prot="public" static="no">
+        <name>ID_B</name>
         <param>
           <defname>X</defname>
         </param>
@@ -29,7 +29,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="107_define_in_enums.cpp" line="13" column="9" bodyfile="107_define_in_enums.cpp" bodystart="7" bodyend="-1"/>
+        <location file="107_define_in_enums.cpp" line="13" column="9" bodyfile="107_define_in_enums.cpp" bodystart="13" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="enum">

--- a/testing/107_define_in_enums.cpp
+++ b/testing/107_define_in_enums.cpp
@@ -1,0 +1,16 @@
+// objective: test use of define inside enums
+// config: EXTRACT_ALL=YES
+// config: MACRO_EXPANSION=YES
+// check: 107__define__in__enums_8cpp.xml
+
+enum A {
+#define ID(X) X,
+  ID(A1)
+  ID(A2)
+};
+
+enum class B {
+#define ID(X) X,
+  ID(B1)
+  ID(B2)
+};

--- a/testing/107_define_in_enums.cpp
+++ b/testing/107_define_in_enums.cpp
@@ -4,13 +4,13 @@
 // check: 107__define__in__enums_8cpp.xml
 
 enum A {
-#define ID(X) X,
-  ID(A1)
-  ID(A2)
+#define ID_A(X) X,
+  ID_A(A1)
+  ID_A(A2)
 };
 
 enum class B {
-#define ID(X) X,
-  ID(B1)
-  ID(B2)
+#define ID_B(X) X,
+  ID_B(B1)
+  ID_B(B2)
 };


### PR DESCRIPTION
Currently ``#define``s are listed as values of C++ scoped enums. For example:

```cpp
// config: EXTRACT_ALL=YES
// config: MACRO_EXPANSION=YES

enum A {
#define ID(X) X,
  ID(A1)
  ID(A2)
};

enum class B {
#define ID(X) X,
  ID(B1)
  ID(B2)
};
```

Produces the following output with v1.13.2:

<img width="222" alt="Define_in_Scoped_Enum_Values" src="https://github.com/user-attachments/assets/6985d040-138d-4ae6-965b-e94d0f5767b5" />

This is a somewhat common pattern, usually with an ``#include`` that uses some user-defined macro:

```cpp
enum class B {
#define ID(X) X,
#include "values.inc"
#undef ID
};
```

This PR is to exclude ``#define``s from the "strong" enum values in C++ only. These members would remain as members of the surrounding scope, as seen in the test case.

Note: the ``#define``s are not listed in unscoped/weak enums because they use a ``MemberNameLinkedMap`` lookup which does not include the ``#define`` names.