### PR TITLE
Page anchor of directory description

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3681,6 +3681,10 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
       }
       else if (isSubdirDocs)
       {
+        if (!generatedId.isEmpty() && !title.isEmpty())
+        {
+          docs.prepend("@ianchor{" + title + "} " + generatedId + "\\ilinebr ");
+        }
         docs.prepend("@dir\\ilinebr ");
       }
       else


### PR DESCRIPTION
When having a simple file `README.md` and a directory `cmd/boulder-observer`:
```
# boulder-observer

A modular configuration driven approach to black box monitoring with
Prometheus.

* [boulder-observer](#boulder-observer)
```
and the settings:
```
QUIET = YES
RECURSIVE = YES
MARKDOWN_ID_STYLE = GITHUB
```

We get the warning like:
```
cmd/boulder-observer/README.md:6: warning: unable to resolve reference to 'boulder-observer' for \ref command
```

Due to the type of file and the settings the file was seen as a directory description (`@dir`) but in the mean time the "anchor" of the original page was forgotten.

Example: [example.tar.gz](https://github.com/user-attachments/files/18509589/example.tar.gz)

(Found by Fossies for the boulder package)
