### PR TITLE
Section information lost in case of `IMPLICIT_DIR_DOCS=YES` and `Readme.md`

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3683,7 +3683,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
       {
         if (!generatedId.isEmpty() && !title.isEmpty())
         {
-          docs.prepend("@ianchor{" + title + "} " + generatedId + "\\ilinebr ");
+          docs.prepend("@section " + generatedId + " " + title + "\\ilinebr ");
         }
         docs.prepend("@dir\\ilinebr ");
       }


### PR DESCRIPTION
In #11363 a problem was solved in respect to anchors with `IMPLICIT_DIR_DOCS=YES` and `Readme.md`, but the text as specified with the "anchor line" was lost. Not a `@ianchor` should be added but a `@section`