### PR TITLE
bug_771452 Warnings show wrong filename when same addtogroup name used in multiple files

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -405,7 +405,11 @@ void DefinitionImpl::_setDocumentation(const QCString &d,const QCString &docFile
       p->details = std::make_optional<DocInfo>();
     }
     DocInfo &details = p->details.value();
-    QCString docPre = " \\ifile \"" + docFile + "\" \\iline " + std::to_string(docLine) + " \\ilinebr ";
+    QCString docPre;
+    if (!docFile.isEmpty())
+    {
+      docPre = " \\ifile \"" + docFile + "\" \\iline " + std::to_string(docLine) + " \\ilinebr ";
+    }
     if (details.doc.isEmpty()) // fresh detailed description
     {
       details.doc = docPre + doc;


### PR DESCRIPTION
Positional commands added at to of command block as otherwise when adding extra blocks the wrong line might be used