### PR TITLE
issue #11377 [in,out] param dir ignored for inline documentation

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6647,8 +6647,8 @@ QCString extractDirection(QCString &docs)
                               ),dir.end());
       unsigned char ioMask=0;
       size_t inIndex  = dir.find( "in");
-      size_t outIndex = dir.find("out");
       if ( inIndex!=std::string::npos) dir.erase( inIndex,2),ioMask|=(1<<0);
+      size_t outIndex = dir.find("out");
       if (outIndex!=std::string::npos) dir.erase(outIndex,3),ioMask|=(1<<1);
       if (dir.empty() && ioMask!=0) // only in and/or out attributes found
       {


### PR DESCRIPTION
The position of the `out` direction should be calculated after that the `in` direction has been removed (otherwise the start position might not be correct).

Regression on:
```
Commit: 1af459c0c910ab0e6b729e11db0c3be6a35c686f [1af459c]

Date: Sunday, April 21, 2024 12:34:37 PM

Refactoring: make sure all variables are initialized

Found using clang tidy's cppcoreguidelines-init-variables check
```