### PR TITLE
Missing warnings for `\ingroup` with pages

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2580,7 +2580,7 @@ STopt  [^\n@\\]*
 
 <InGroupParam>{LABELID}                 { // group id
                                           yyextra->current->groups.emplace_back(
-                                             QCString(yytext), Grouping::GROUPING_INGROUP
+                                             QCString(yytext), Grouping::GROUPING_INGROUP,yyextra->lineNr
                                           );
                                           yyextra->inGroupParamFound=TRUE;
                                         }

--- a/src/docgroup.cpp
+++ b/src/docgroup.cpp
@@ -112,7 +112,7 @@ void DocGroup::open(Entry *e,const QCString &,int, bool implicit)
   //  	qPrint(e->name),e->section,m_autoGroupStack.size());
   if (e->section.isGroupDoc()) // auto group
   {
-    m_autoGroupStack.emplace_back(e->name,e->groupingPri());
+    m_autoGroupStack.emplace_back(e->name,e->groupingPri(),-1);
   }
   else // start of a member group
   {

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -327,12 +327,37 @@ static void addPageToContext(PageDef *pd,Entry *root)
 
 static void addRelatedPage(Entry *root)
 {
-  GroupDef *gd=nullptr;
+  Grouping::GroupPri_t pri = Grouping::GROUPING_LOWEST;
+  GroupDef *fgd=nullptr;
   for (const Grouping &g : root->groups)
   {
-    if (!g.groupname.isEmpty() && (gd=Doxygen::groupLinkedMap->find(g.groupname))) break;
+    GroupDef *gd=nullptr;
+    if (!g.groupname.isEmpty()) gd=Doxygen::groupLinkedMap->find(g.groupname);
+    if (gd && g.pri >= pri)
+    {
+      if (fgd && gd!=fgd && g.pri==pri)
+      {
+        warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
+            "Page {} ({}) found in multiple {} groups! "
+            "The page will be put in group {}, and not in group {}",
+            root->name, root->args.stripWhiteSpace(), Grouping::getGroupPriName( pri ),
+            gd->name(), fgd->name()
+            );
+      }
+
+      fgd = gd;
+      pri = g.pri;
+    }
+    else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
+    {
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
+          "Found non-existing group '{}' for the command '{}', ignoring command",
+          g.groupname, Grouping::getGroupPriName( g.pri )
+          );
+    }
   }
-  //printf("---> addRelatedPage() %s gd=%p\n",qPrint(root->name),gd);
+
+  //printf("---> addRelatedPage() %s gd=%p\n",qPrint(root->name),fgd);
   QCString doc=root->doc+root->inbodyDocs;
 
   PageDef *pd = addRelatedPage(root->name,root->args,doc,
@@ -340,7 +365,7 @@ static void addRelatedPage(Entry *root)
       root->docLine,
       root->startLine,
       root->sli,
-      gd,root->tagInfo(),
+      fgd,root->tagInfo(),
       FALSE,
       root->lang
      );
@@ -546,7 +571,7 @@ static void buildFileList(const Entry *root)
         }
         else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
         {
-          warn(root->fileName, root->startLine,
+          warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
                "Found non-existing group '{}' for the command '{}', ignoring command",
                g.groupname, Grouping::getGroupPriName( g.pri )
               );
@@ -7958,7 +7983,7 @@ static bool tryAddEnumDocsToGroupMember(const Entry *root,const QCString &name)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1426,7 +1426,7 @@ void addClassToGroups(const Entry *root,ClassDef *cd)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );
@@ -1450,7 +1450,7 @@ void addConceptToGroups(const Entry *root,ConceptDef *cd)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );
@@ -1470,7 +1470,7 @@ void addModuleToGroups(const Entry *root,ModuleDef *mod)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );
@@ -1498,7 +1498,7 @@ void addNamespaceToGroups(const Entry *root,NamespaceDef *nd)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );
@@ -1521,7 +1521,7 @@ void addDirToGroups(const Entry *root,DirDef *dd)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );
@@ -1555,7 +1555,7 @@ void addGroupToGroups(const Entry *root,GroupDef *subGroup)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );
@@ -1580,7 +1580,7 @@ void addMemberToGroups(const Entry *root,MemberDef *md)
     {
       if (fgd && gd!=fgd && g.pri==pri)
       {
-        warn(root->fileName, root->startLine,
+        warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
             "Member {} found in multiple {} groups! "
             "The member will be put in group {}, and not in group {}",
             md->name(), Grouping::getGroupPriName( pri ),
@@ -1593,7 +1593,7 @@ void addMemberToGroups(const Entry *root,MemberDef *md)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );
@@ -1702,7 +1702,7 @@ void addExampleToGroups(const Entry *root,PageDef *eg)
     }
     else if (!gd && g.pri == Grouping::GROUPING_INGROUP)
     {
-      warn(root->fileName, root->startLine,
+      warn(root->fileName, (g.lineNr == -1?  root->startLine : g.lineNr),
           "Found non-existing group '{}' for the command '{}', ignoring command",
           g.groupname, Grouping::getGroupPriName( g.pri )
           );

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -1407,7 +1407,7 @@ void TagFileParser::buildMemberList(const std::shared_ptr<Entry> &ce,const std::
     me->startLine  = tmi.lineNr;
     if (ce->section.isGroupDoc())
     {
-      me->groups.emplace_back(ce->name,Grouping::GROUPING_INGROUP);
+      me->groups.emplace_back(ce->name,Grouping::GROUPING_INGROUP,-1);
     }
     addDocAnchors(me,tmi.docAnchors);
     me->tagInfoData.tagName    = m_tagName;
@@ -1719,7 +1719,7 @@ void TagFileParser::buildLists(const std::shared_ptr<Entry> &root)
             [&](const std::shared_ptr<Entry> &e) { return e->name == sg.c_str(); });
         if (i!=children.end())
         {
-          (*i)->groups.emplace_back(tgi->name,Grouping::GROUPING_INGROUP);
+          (*i)->groups.emplace_back(tgi->name,Grouping::GROUPING_INGROUP,-1);
         }
       }
     }

--- a/src/types.h
+++ b/src/types.h
@@ -91,9 +91,10 @@ struct Grouping
     return "???";
   }
 
-  Grouping( const QCString &gn, GroupPri_t p ) : groupname(gn), pri(p) {}
+  Grouping( const QCString &gn, GroupPri_t p, int nr ) : groupname(gn), pri(p), lineNr(nr) {}
   QCString groupname;   //!< name of the group
   GroupPri_t pri;       //!< priority of this definition
+  int lineNr;           //!< lineNr of the group
 
 };
 


### PR DESCRIPTION
- warning in case of incorrect name with `\ingroup` on pages
- warning when multiple names with `\ingroup` on pages (analogous to function ``)
- correcting linenumbers in warnings

Example: [example.tar.gz](https://github.com/user-attachments/files/18618661/example.tar.gz)
