### PR TITLE
Handling return in `\cite` command

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -2750,24 +2750,7 @@ STopt  [^\n@\\]*
                                             BEGIN(SectionTitle);
                                           }
                                         }
-<CiteLabel,CiteLabelSection>{DOCNL}     { // missing argument
-                                          warn(yyextra->fileName,yyextra->lineNr,
-                                              "\\cite command has no label"
-                                              );
-                                          //if (*yytext=='\n') yyextra->lineNr++;
-                                          //addOutput(yyscanner,'\n');
-                                          if (YY_START == CiteLabel)
-                                          {
-                                            unput_string(yytext,yyleng);
-                                            BEGIN(Comment);
-                                          }
-                                          else
-                                          {
-                                            yyextra->sectionTitle+=yytext;
-                                            unput_string(yytext,yyleng);
-                                            BEGIN(SectionTitle);
-                                          }
-                                        }
+<CiteLabel,CiteLabelSection>{DOCNL}     { if (*yytext=='\n') yyextra->lineNr++;}
 <CiteLabel,CiteLabelSection>.           { // invalid character for cite label
                                            warn(yyextra->fileName,yyextra->lineNr,
                                               "Invalid or missing cite label"


### PR DESCRIPTION
When having something like:
```
/**
 * First al \cite
 * mattes2001
 */
```
we get a warning about an empty / missing label and the link is generated depending on the fact whether on another place there is something like:
```
 * \cite  mattes2001
```

The split of the `\cite` and  the label is in the commentscan not allowed but allowed in the doctokenizer. Fixed by allowing the split also in the commentscan.

Found by the ITK project.

Example: [example.tar.gz](https://github.com/user-attachments/files/18628970/example.tar.gz)
