### PR TITLE
issue #11310 "^^" in aliases not proper evaluated

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -561,7 +561,7 @@ SLASHopt [/]*
                                      yyextra->inVerbatim=true;
                                      BEGIN(VerbatimCode);
   				   }
-<CComment,ReadLine,IncludeFile>"\\ilinebr"[ \t]+("```"[`]*|"~~~"[~]*) { /* start of markdown code block */
+<CComment,ReadLine,IncludeFile>{CMD}"ilinebr"[ \t]+("```"[`]*|"~~~"[~]*) { /* start of markdown code block */
                                      if (!Config_getBool(MARKDOWN_SUPPORT))
                                      {
                                        REJECT;
@@ -1070,7 +1070,7 @@ SLASHopt [/]*
 <ReadLine,CopyLine>{RL}            {
 				     copyToOutput(yyscanner,yytext,yyleng);
 				   }
-<ReadLine,CopyLine>{RL}/{B}"\\ilinebr"{B} {
+<ReadLine,CopyLine>{RL}/{B}{CMD}"ilinebr"{B} {
                                      copyToOutput(yyscanner,yytext,yyleng);
                                    }
 <ReadLine,CopyLine>{RLopt}/\n      {
@@ -1132,13 +1132,13 @@ SLASHopt [/]*
                                      yyextra->snippetName = "";
                                      BEGIN(SnippetDocTag);
                                    }
-<SnippetDocTag>[^\\\n]+            {
+<SnippetDocTag>[^\\@\n]+            {
                                      yyextra->snippetName += yytext;
                                    }
-<SnippetDocTag>"\\"                {
+<SnippetDocTag>{CMD}               {
                                      yyextra->snippetName += yytext;
                                    }
-<SnippetDocTag>(\n|"\\ilinebr")    {
+<SnippetDocTag>(\n|{CMD}"ilinebr") {
                                      for (int i=(int)yyleng-1;i>=0;i--) unput(yytext[i]);
                                      yyextra->snippetName = yyextra->snippetName.stripWhiteSpace();
                                      QCString blockId = "["+yyextra->snippetName+"]";
@@ -1204,7 +1204,7 @@ SLASHopt [/]*
 <CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>[\\@][a-z_A-Z][a-z_A-Z0-9-]*  { // expand alias without arguments
 				     replaceAliases(yyscanner,yytext,YY_START==ReadLine && yyextra->readLineCtx==SComment);
   				   }
-<CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>{B}?"\\ilinebr"{B}[\\@]"ialias{" { // expand alias with arguments
+<CComment,ReadLine,IncludeFile,Verbatim,VerbatimCode>{B}?{CMD}"ilinebr"{B}[\\@]"ialias{" { // expand alias with arguments
 				     yyextra->lastBlockContext=YY_START;
 				     yyextra->blockCount=1;
                                      int extraSpace = (yytext[0]==' '? 1:0);

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3640,7 +3640,7 @@ void MarkdownOutlineParser::parseInput(const QCString &fileName,
   current->fileName = fileName;
   current->docFile  = fileName;
   current->docLine  = 1;
-  QCString docs = fileBuf;
+  QCString docs = stripIndentation(fileBuf);
   Debug::print(Debug::Markdown,0,"======== Markdown =========\n---- input ------- \n{}\n",fileBuf);
   QCString id;
   Markdown markdown(fileName,1,0);


### PR DESCRIPTION
There are 2 problems (introduced by #11172):
- handling of `@ilinebr` in commentcnv, so farther handling after alias substitution works when a `@ilinebr` is found
- handling of `@ilinebr` in the markdown parser, in the *scanner.l this was already done by `stripIndentation` added this for markdown as well.