### PR TITLE
issue #11393 With `EXPAND_ONLY_PREDEF`, Doxygen won't expand `PREDEFINED` macro that's defined in an included header file.

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1927,7 +1927,7 @@ WSopt [ \t\r]*
                                             }
                                             else
                                             {
-                                              if (def->fileName != yyextra->fileName) addDefine(yyscanner);
+                                              if (def->fileName != yyextra->fileName && !yyextra->expandOnlyPredef) addDefine(yyscanner);
                                               //printf("error: define %s is defined more than once!\n",qPrint(yyextra->defName));
                                             }
                                           }


### PR DESCRIPTION
Also the setting `EXPAND_ONLY_PREDEF` should be taken into consideration