### PR TITLE
Incorrect field when ampersand in URL

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -401,7 +401,8 @@ void HtmlDocVisitor::operator()(const DocURL &u)
   else // web address
   {
     m_t << "<a href=\"";
-    m_t << u.url() << "\">";
+    filter(u.url());
+    m_t << "\">";
     filter(u.url());
     m_t << "</a>";
   }


### PR DESCRIPTION
When having an ampersand in an URL like:
```
https://en.wikipedia.org/w/index.php?title=Unsharp_masking&oldid=750486803#Photographic_unsharp_masking
```
this can lead to a warning in the xmllint checker like:
```
html\md_aa.html:108: parser error : EntityRef: expecting ';'
ck"><p><a href="https://en.wikipedia.org/w/index.php?title=Unsharp_masking&oldid
                                                                               ^
```

Note in e.g. the xml and docbook format there were already twice the filter call.


Example: [example.tar.gz](https://github.com/user-attachments/files/18707233/example.tar.gz)

(Found in the ITK package)
