### PR TITLE
Update htmlgen.cpp 2025-02-16

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -1784,7 +1784,7 @@ void HtmlGenerator::writeObjectLink(const QCString &ref,const QCString &f,
   }
   else
   {
-    m_t << "<a class=\"el\" ";
+    m_t << "<a class=\"RENAMED_el\" ";   // paule32: 16-02-2023 TODO !!!
   }
   m_t << "href=\"";
   QCString fn = f;


### PR DESCRIPTION
Line: 1787 - change **el** to **RENAMED_el** as workaround for a CHM Link produce Problem. When RENAMED_ is not available, doxygen tends to produce double quotes for a Link