### PR TITLE
Dangerous trailing context in commentcnv.l

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -190,7 +190,7 @@ MAILADDR   ("mailto:")?[a-z_A-Z0-9\x80-\xff.+-]+"@"[a-z_A-Z0-9\x80-\xff-]+("."[a
 %x SnippetDocTag
 %x IncludeFile
 
-CMD ("\\"|"@")
+CMD [\\@]
   //- start: NUMBER -------------------------------------------------------------------------
   // Note same defines in code.l: keep in sync
 DECIMAL_INTEGER  [1-9][0-9']*[0-9]?[uU]?[lL]?[lL]?


### PR DESCRIPTION
After the change for #11310 / 11385 got the message:
```
.../generated_src/commentcnv.l:1074: warning, dangerous trailing context
```
with this equivalent statement this message is gone