### PR TITLE
issue #11420 Add documentation about triple underscore emphasis

### DIFF
--- a/doc/markdown.dox
+++ b/doc/markdown.dox
@@ -162,6 +162,7 @@ seen as a level 2 header (see \ref md_headers).
 
 To emphasize a text fragment you start and end the fragment with an underscore or star.
 Using two stars or underscores will produce strong emphasis.
+Three stars or underscores will combine the emphasis from the previous two options.
 
 Examples:
 
@@ -172,6 +173,10 @@ Examples:
 *    **double asterisks**
 *
 *    __double underscores__
+*
+*    ***triple asterisks***
+*
+*    ___triple underscores___
 
 See section \ref mddox_emph_spans for more info how Doxygen handles
 emphasis / strikethrough spans slightly different than standard / Markdown GitHub Flavored Markdown.


### PR DESCRIPTION
The pull request #11437 introduced the triple underscores as emphasis in Markdown as requested in issue #11420.
Triple asterisks as emphasis were supported before already.

This PR adds the feature to the documentation in the page "Markdown Support -> Emphasis".
![image](https://github.com/user-attachments/assets/1812c257-42f0-4a17-83a3-d969fa2df71e)
