### PR TITLE
Incorrect substitute pattern in header / footer

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -62,6 +62,8 @@
 #define DBG_HTML(x)
 
 static QCString g_header;
+static QCString g_header_file;
+static QCString g_footer_file;
 static QCString g_footer;
 static QCString g_mathjax_code;
 static QCString g_latex_macro;
@@ -317,7 +319,8 @@ static QCString getSearchBox(bool serverSide, QCString relPath, bool highlightSe
   return t.str();
 }
 
-static QCString substituteHtmlKeywords(const QCString &str,
+static QCString substituteHtmlKeywords(const QCString &file,
+                                       const QCString &str,
                                        const QCString &title,
                                        const QCString &relPath,
                                        const QCString &navPath=QCString())
@@ -580,13 +583,13 @@ static QCString substituteHtmlKeywords(const QCString &str,
   }
 
   // first substitute generic keywords
-  QCString result = substituteKeywords(str,title,
+  QCString result = substituteKeywords(file,str,title,
         convertToHtml(Config_getString(PROJECT_NAME)),
         convertToHtml(Config_getString(PROJECT_NUMBER)),
         convertToHtml(Config_getString(PROJECT_BRIEF)));
 
   // then do the HTML specific keywords
-  result = substituteKeywords(result,
+  result = substituteKeywords(file,result,
   {
     // keyword           value getter
     { "$navpath",        [&]() { return navPath;        } },
@@ -1144,29 +1147,33 @@ void HtmlGenerator::init()
   //writeLogo(dname);
   if (!Config_getString(HTML_HEADER).isEmpty())
   {
-    g_header=fileToString(Config_getString(HTML_HEADER));
+    g_header_file=Config_getString(HTML_HEADER);
+    g_header=fileToString(g_header_file);
     //printf("g_header='%s'\n",qPrint(g_header));
-    QCString result = substituteHtmlKeywords(g_header,QCString(),QCString());
+    QCString result = substituteHtmlKeywords(g_header_file,g_header,QCString(),QCString());
     checkBlocks(result,Config_getString(HTML_HEADER),htmlMarkerInfo);
   }
   else
   {
-    g_header = ResourceMgr::instance().getAsString("header.html");
-    QCString result = substituteHtmlKeywords(g_header,QCString(),QCString());
+    g_header_file="header.html";
+    g_header = ResourceMgr::instance().getAsString(g_header_file);
+    QCString result = substituteHtmlKeywords(g_header_file,g_header,QCString(),QCString());
     checkBlocks(result,"<default header.html>",htmlMarkerInfo);
   }
 
   if (!Config_getString(HTML_FOOTER).isEmpty())
   {
-    g_footer=fileToString(Config_getString(HTML_FOOTER));
+    g_footer_file=Config_getString(HTML_FOOTER);
+    g_footer=fileToString(g_footer_file);
     //printf("g_footer='%s'\n",qPrint(g_footer));
-    QCString result = substituteHtmlKeywords(g_footer,QCString(),QCString());
+    QCString result = substituteHtmlKeywords(g_footer_file,g_footer,QCString(),QCString());
     checkBlocks(result,Config_getString(HTML_FOOTER),htmlMarkerInfo);
   }
   else
   {
-    g_footer = ResourceMgr::instance().getAsString("footer.html");
-    QCString result = substituteHtmlKeywords(g_footer,QCString(),QCString());
+    g_footer_file = "footer.html";
+    g_footer = ResourceMgr::instance().getAsString(g_footer_file);
+    QCString result = substituteHtmlKeywords(g_footer_file,g_footer,QCString(),QCString());
     checkBlocks(result,"<default footer.html>",htmlMarkerInfo);
   }
 
@@ -1481,7 +1488,7 @@ void HtmlGenerator::startFile(const QCString &name,const QCString &,
   }
 
   m_lastFile = fileName;
-  m_t << substituteHtmlKeywords(g_header,convertToHtml(filterTitle(title)),m_relPath);
+  m_t << substituteHtmlKeywords(g_header_file,g_header,convertToHtml(filterTitle(title)),m_relPath);
 
   m_t << "<!-- " << theTranslator->trGeneratedBy() << " Doxygen "
       << getDoxygenVersion() << " -->\n";
@@ -1581,7 +1588,7 @@ void HtmlGenerator::writeLogo()
 void HtmlGenerator::writePageFooter(TextStream &t,const QCString &lastTitle,
                               const QCString &relPath,const QCString &navPath)
 {
-  t << substituteHtmlKeywords(g_footer,convertToHtml(lastTitle),relPath,navPath);
+  t << substituteHtmlKeywords(g_footer_file,g_footer,convertToHtml(lastTitle),relPath,navPath);
 }
 
 void HtmlGenerator::writeFooter(const QCString &navPath)
@@ -3137,7 +3144,7 @@ void HtmlGenerator::writeSearchPage()
   if (f.is_open())
   {
     TextStream t(&f);
-    t << substituteHtmlKeywords(g_header,"Search","");
+    t << substituteHtmlKeywords(g_header_file,g_header,"Search","");
 
     t << "<!-- " << theTranslator->trGeneratedBy() << " Doxygen "
       << getDoxygenVersion() << " -->\n";
@@ -3203,7 +3210,7 @@ void HtmlGenerator::writeExternalSearchPage()
   if (f.is_open())
   {
     TextStream t(&f);
-    t << substituteHtmlKeywords(g_header,"Search","");
+    t << substituteHtmlKeywords(g_header_file,g_header,"Search","");
 
     t << "<!-- " << theTranslator->trGeneratedBy() << " Doxygen "
       << getDoxygenVersion() << " -->\n";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3561,9 +3561,10 @@ QCString showFileDefMatches(const FileNameLinkedMap *fnMap,const QCString &n)
 
 //----------------------------------------------------------------------
 
-QCString substituteKeywords(const QCString &s,const KeywordSubstitutionList &keywords)
+QCString substituteKeywords(const QCString &file, const QCString &s,const KeywordSubstitutionList &keywords)
 {
   std::string substRes;
+  int line = 1;
   const char *p = s.data();
   if (p)
   {
@@ -3600,6 +3601,7 @@ QCString substituteKeywords(const QCString &s,const KeywordSubstitutionList &key
               else
               {
                 //printf("missing argument\n");
+                warn(file,line,"Missing argument for '{}'",kw.keyword);
                 p+=keyLen;
               }
             }
@@ -3610,6 +3612,12 @@ QCString substituteKeywords(const QCString &s,const KeywordSubstitutionList &key
               //printf("found '%s'->'%s'\n",kw.keyword,qPrint(getValue()));
               p+=keyLen;
             }
+            else
+            {
+              //printf("%s %d Expected arguments, none specified '%s'\n",qPrint(file), line, qPrint(kw.keyword));
+              warn(file,line,"Expected arguments for '{}' but none were specified",kw.keyword);
+              p+=keyLen;
+            }
             found = true;
             break;
           }
@@ -3617,6 +3625,7 @@ QCString substituteKeywords(const QCString &s,const KeywordSubstitutionList &key
       }
       if (!found) // copy
       {
+        if (c=='\n') line++;
         substRes+=c;
         p++;
       }
@@ -3704,10 +3713,10 @@ static QCString projectLogoSize()
   return sizeVal;
 }
 
-QCString substituteKeywords(const QCString &s,const QCString &title,
+QCString substituteKeywords(const QCString &file,const QCString &s,const QCString &title,
          const QCString &projName,const QCString &projNum,const QCString &projBrief)
 {
-  return substituteKeywords(s,
+  return substituteKeywords(file,s,
   {
     // keyword          value getter
     { "$title",           [&]() { return !title.isEmpty() ? title : projName;       } },

--- a/src/util.h
+++ b/src/util.h
@@ -247,9 +247,9 @@ struct KeywordSubstitution
 
 using KeywordSubstitutionList = std::vector<KeywordSubstitution>;
 
-QCString substituteKeywords(const QCString &s,const KeywordSubstitutionList &keywords);
+QCString substituteKeywords(const QCString &file,const QCString &s,const KeywordSubstitutionList &keywords);
 
-QCString substituteKeywords(const QCString &s,const QCString &title,
+QCString substituteKeywords(const QCString &file,const QCString &s,const QCString &title,
          const QCString &projName,const QCString &projNum,const QCString &projBrief);
 
 int getPrefixIndex(const QCString &name);


### PR DESCRIPTION
When having in the html or latex header or footer the substitute pattern `$showdata` without the mandatory format so something like `$showdate(%Y %H %M %S)` doxygen will go into an endless loop as the input pointer is not changed.
- handling incorrect, e.g.  `$showdata`
- giving an appropriate warning (substitute [pattern is not shown and might get unnoticed

Example: [example.tar.gz](https://github.com/user-attachments/files/18906478/example.tar.gz)
(added in the footer an extra "blue line" just for testing)
