### PR TITLE
issue #11415 doxywizard replaces < and > in aliases with &lt; / &gt;

### DIFF
--- a/addon/doxywizard/config.h
+++ b/addon/doxywizard/config.h
@@ -26,7 +26,7 @@ bool parseConfig(
       const QHash<QString,Input *> &options
     );
 
-void writeStringValue(QTextStream &t,TextCodecAdapter *codec,const QString &s);
+void writeStringValue(QTextStream &t,TextCodecAdapter *codec,const QString &s,bool convert);
 
 // directly copied from ../../src/config.h to be consistent
 enum

--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -785,7 +785,7 @@ bool parseConfig(
   return true;
 }
 
-void writeStringValue(QTextStream &t,TextCodecAdapter *codec,const QString &s)
+void writeStringValue(QTextStream &t,TextCodecAdapter *codec,const QString &s,bool convert)
 {
   QChar c;
   bool needsEscaping=false;
@@ -823,10 +823,17 @@ void writeStringValue(QTextStream &t,TextCodecAdapter *codec,const QString &s)
         if (*p   ==QChar::fromLatin1(' ') &&
            *(p+1)==QChar::fromLatin1('\0')) break; // skip inserted space at the end
         if (*p   ==QChar::fromLatin1('"')) t << "\\"; // escape quotes
-        if (*p   ==QChar::fromLatin1('<')) t << "&lt;";
-        else if (*p   ==QChar::fromLatin1('>')) t << "&gt;";
-        else if (*p   ==QChar::fromLatin1('&')) t << "&amp;";
-        else t << *p;
+        if (convert)
+        {
+          if (*p   ==QChar::fromLatin1('<')) t << "&lt;";
+          else if (*p   ==QChar::fromLatin1('>')) t << "&gt;";
+          else if (*p   ==QChar::fromLatin1('&')) t << "&amp;";
+          else t << *p;
+        }
+        else
+        {
+          t << *p;
+        }
         p++;
       }
     }
@@ -835,10 +842,17 @@ void writeStringValue(QTextStream &t,TextCodecAdapter *codec,const QString &s)
       p=s.data();
       while (!p->isNull())
       {
-        if (*p   ==QChar::fromLatin1('<')) t << "&lt;";
-        else if (*p   ==QChar::fromLatin1('>')) t << "&gt;";
-        else if (*p   ==QChar::fromLatin1('&')) t << "&amp;";
-        else t << *p;
+        if (convert)
+        {
+          if (*p   ==QChar::fromLatin1('<')) t << "&lt;";
+          else if (*p   ==QChar::fromLatin1('>')) t << "&gt;";
+          else if (*p   ==QChar::fromLatin1('&')) t << "&amp;";
+          else t << *p;
+        }
+        else
+        {
+          t << *p;
+        }
         p++;
       }
     }

--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -341,7 +341,7 @@ void MainWindow::saveConfig(const QString &fileName)
   }
   QTextStream t(&f);
   t.device()->setTextModeEnabled(false);
-  m_expert->writeConfig(t,false,false);
+  m_expert->writeConfig(t,false,false,false);
   updateConfigFileName(fileName);
   m_modified = false;
   updateTitle();
@@ -586,7 +586,7 @@ void MainWindow::runDoxygen()
       return;
     }
     QTextStream t(m_runProcess);
-    m_expert->writeConfig(t,false,false);
+    m_expert->writeConfig(t,false,false,false);
     t.flush();
     m_runProcess->closeWriteChannel();
 
@@ -718,11 +718,11 @@ void MainWindow::showSettings()
   QTextStream t(&text);
   if (m_showCondensedSettings->isChecked())
   {
-    m_expert->writeConfig(t,true,true);
+    m_expert->writeConfig(t,true,true,true);
   }
   else
   {
-    m_expert->writeConfig(t,true,false);
+    m_expert->writeConfig(t,true,false,true);
   }
   m_outputLog->clear();
   m_outputLog->append(APPQT(text));

--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -791,7 +791,7 @@ void Expert::loadConfig(const QString &fileName)
 }
 
 void Expert::saveTopic(QTextStream &t,QDomElement &elem,TextCodecAdapter *codec,
-                       bool brief,bool condensed)
+                       bool brief,bool condensed,bool convert)
 {
   if (!brief)
   {
@@ -832,7 +832,7 @@ void Expert::saveTopic(QTextStream &t,QDomElement &elem,TextCodecAdapter *codec,
             if (option && !option->isEmpty())
             {
               t << " ";
-              option->writeValue(t,codec);
+              option->writeValue(t,codec,convert);
             }
             t << "\n";
           }
@@ -843,7 +843,7 @@ void Expert::saveTopic(QTextStream &t,QDomElement &elem,TextCodecAdapter *codec,
   }
 }
 
-bool Expert::writeConfig(QTextStream &t,bool brief, bool condensed)
+bool Expert::writeConfig(QTextStream &t,bool brief, bool condensed, bool convert)
 {
   // write global header
   t << "# Doxyfile " << getDoxygenVersion().c_str() << "\n\n";
@@ -859,7 +859,7 @@ bool Expert::writeConfig(QTextStream &t,bool brief, bool condensed)
   {
     if (childElem.tagName()==SA("group"))
     {
-      saveTopic(t,childElem,&codec,brief,condensed);
+      saveTopic(t,childElem,&codec,brief,condensed,convert);
     }
     childElem = childElem.nextSiblingElement();
   }

--- a/addon/doxywizard/expert.h
+++ b/addon/doxywizard/expert.h
@@ -38,7 +38,7 @@ class Expert : public QSplitter, public DocIntf
     void loadSettings(QSettings *);
     void saveSettings(QSettings *);
     void loadConfig(const QString &fileName);
-    bool writeConfig(QTextStream &t,bool brief,bool condensed);
+    bool writeConfig(QTextStream &t,bool brief,bool condensed, bool convert);
     QByteArray saveInnerState () const;
     bool restoreInnerState ( const QByteArray & state );
     const QHash<QString,Input*> &modelData() const { return m_options; }
@@ -67,7 +67,7 @@ class Expert : public QSplitter, public DocIntf
 
   private:
     void createTopics(const QDomElement &);
-    void saveTopic(QTextStream &t,QDomElement &elem,TextCodecAdapter *codec,bool brief,bool dondensed);
+    void saveTopic(QTextStream &t,QDomElement &elem,TextCodecAdapter *codec,bool brief,bool dondensed,bool convert);
 
     QSplitter               *m_splitter;
     QTextBrowser            *m_helper;

--- a/addon/doxywizard/input.h
+++ b/addon/doxywizard/input.h
@@ -42,7 +42,7 @@ class Input
     virtual void updateDependencies() = 0;
     virtual void reset() = 0;
     virtual bool isDefault() = 0;
-    virtual void writeValue(QTextStream &t,TextCodecAdapter *codec) = 0;
+    virtual void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert) = 0;
     virtual void setTemplateDocs(const QString &docs) = 0;
     virtual bool isEmpty() { return false; };
 };

--- a/addon/doxywizard/inputbool.cpp
+++ b/addon/doxywizard/inputbool.cpp
@@ -134,7 +134,7 @@ void InputBool::reset()
   setValue(m_default);
 }
 
-void InputBool::writeValue(QTextStream &t,TextCodecAdapter *codec)
+void InputBool::writeValue(QTextStream &t,TextCodecAdapter *codec,bool)
 {
   if (m_state)
     t << codec->encode(QString::fromLatin1("YES"));

--- a/addon/doxywizard/inputbool.h
+++ b/addon/doxywizard/inputbool.h
@@ -39,7 +39,7 @@ class InputBool : public QObject, public Input
     void setEnabled(bool);
     void updateDependencies();
     bool isDefault();
-    void writeValue(QTextStream &t,TextCodecAdapter *codec);
+    void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     static bool convertToBool(const QVariant &v,bool &isValid);
 

--- a/addon/doxywizard/inputint.cpp
+++ b/addon/doxywizard/inputint.cpp
@@ -123,7 +123,7 @@ void InputInt::reset()
   setValue(m_default);
 }
 
-void InputInt::writeValue(QTextStream &t,TextCodecAdapter *)
+void InputInt::writeValue(QTextStream &t,TextCodecAdapter *,bool)
 {
   t << m_val;
 }

--- a/addon/doxywizard/inputint.h
+++ b/addon/doxywizard/inputint.h
@@ -42,7 +42,7 @@ class InputInt : public QObject, public Input
     void setEnabled(bool);
     void updateDependencies() {}
     bool isDefault();
-    void writeValue(QTextStream &t,TextCodecAdapter *codec);
+    void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
 
   public slots:

--- a/addon/doxywizard/inputobsolete.h
+++ b/addon/doxywizard/inputobsolete.h
@@ -30,7 +30,7 @@ class InputObsolete : public Input
     void updateDependencies()    {}
     void reset()                 {}
     bool isDefault()             { return false; }
-    void writeValue(QTextStream &,TextCodecAdapter *) {}
+    void writeValue(QTextStream &,TextCodecAdapter *,bool) {}
     void setTemplateDocs(const QString &) {}
     bool isEmpty()               { return false; };
     Kind orgKind() const         { return m_orgKind; }

--- a/addon/doxywizard/inputstring.cpp
+++ b/addon/doxywizard/inputstring.cpp
@@ -253,9 +253,9 @@ void InputString::reset()
   setDefault();
 }
 
-void InputString::writeValue(QTextStream &t,TextCodecAdapter *codec)
+void InputString::writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert)
 {
-  writeStringValue(t,codec,m_str);
+  writeStringValue(t,codec,m_str,convert);
 }
 
 bool InputString::isDefault()

--- a/addon/doxywizard/inputstring.h
+++ b/addon/doxywizard/inputstring.h
@@ -60,7 +60,7 @@ class InputString : public QObject, public Input
     void setEnabled(bool);
     void updateDependencies() {}
     bool isDefault();
-    void writeValue(QTextStream &t,TextCodecAdapter *codec);
+    void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     bool isEmpty() { return m_str.isEmpty(); }
     QString checkEnumVal(const QString &value);

--- a/addon/doxywizard/inputstrlist.cpp
+++ b/addon/doxywizard/inputstrlist.cpp
@@ -242,7 +242,7 @@ void InputStrList::reset()
   setValue(m_default);
 }
 
-void InputStrList::writeValue(QTextStream &t,TextCodecAdapter *codec)
+void InputStrList::writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert)
 {
   bool first=true;
   foreach (QString s, m_strList)
@@ -253,7 +253,7 @@ void InputStrList::writeValue(QTextStream &t,TextCodecAdapter *codec)
       t << "                         ";
     }
     first=false;
-    writeStringValue(t,codec,s);
+    writeStringValue(t,codec,s,convert);
   }
 }
 

--- a/addon/doxywizard/inputstrlist.h
+++ b/addon/doxywizard/inputstrlist.h
@@ -51,7 +51,7 @@ class InputStrList : public QObject, public Input
     void setEnabled(bool);
     void updateDependencies() {}
     bool isDefault();
-    void writeValue(QTextStream &t,TextCodecAdapter *codec);
+    void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     bool isEmpty();
 


### PR DESCRIPTION
We have to distinguish for writing of the settings between
- writing to the, HTML, doxywizard "console"
- writing to file / pipe to run doxygen

In the first case characters like `<` have to be escaped, in the second case this should not happen.

This is actually a regression on:
```
Commit: d3d0a1d0a5ce23e7b1d1995dc2b69ee4b493baaa [d3d0a1d]
Date: Thursday, January 2, 2025 4:00:17 PM
String representation at "show configuration" in doxywizard

In case a string in the settings contains a `<` / `>` / `&` this can give strange results as they are literally interpreted but should be escaped.
(issue is a side note to issue #11310)
```