### PR TITLE
issue #11421 `SHOW_GROUPED_MEMB_INC` does not respect `STRIP_FROM_INC_PATH`

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3367,8 +3367,12 @@ void MemberDefImpl::_writeGroupInclude(OutputList &ol,bool inGroup) const
   bool showGroupedMembInc = Config_getBool(SHOW_GROUPED_MEMB_INC);
   const FileDef *fd = getFileDef();
   QCString nm;
-  if (fd) nm = getFileDef()->docName();
-  if (inGroup && fd && showGroupedMembInc && !nm.isEmpty())
+  if (inGroup && fd && showGroupedMembInc)
+  {
+    nm = fd->absFilePath();
+    nm = stripFromIncludePath(nm);
+  }
+  if (!nm.isEmpty())
   {
     ol.startParagraph();
     ol.startTypewriter();


### PR DESCRIPTION
When `SHOW_GROUPED_MEMB_INC` is set the filename respects `STRIP_FROM_PATH` and not `STRIP_FROM_INC_PATH` although the documentation already say it will add a `#include` statement.