### PR TITLE
Fix wrong links created in search box for external documentations with absolute paths

### DIFF
--- a/templates/html/search.js
+++ b/templates/html/search.js
@@ -623,7 +623,11 @@ function createResults(resultsPath) {
     srLink.innerHTML = elem[1][0];
     srEntry.appendChild(srLink);
     if (elem[1].length==2) { // single result
-      srLink.setAttribute('href',resultsPath+elem[1][1][0]);
+      if (elem[1][1][0].startsWith('http://') || elem[1][1][0].startsWith('https://')) { // absolute path
+        srLink.setAttribute('href',elem[1][1][0]);
+      } else { // relative path
+        srLink.setAttribute('href',resultsPath+elem[1][1][0]);
+      }
       srLink.setAttribute('onclick','searchBox.CloseResultsWindow()');
       if (elem[1][1][1]) {
        srLink.setAttribute('target','_parent');
@@ -643,7 +647,11 @@ function createResults(resultsPath) {
         srChild.setAttribute('id','Item'+index+'_c'+c);
         setKeyActions(srChild,'return searchResults.NavChild(event,'+index+','+c+')');
         setClassAttr(srChild,'SRScope');
-        srChild.setAttribute('href',resultsPath+elem[1][c+1][0]);
+        if (elem[1][c+1][0].startsWith('http://') || elem[1][c+1][0].startsWith('https://')) { // absolute path
+          srLink.setAttribute('href',elem[1][c+1][0]);
+        } else { // relative path
+          srLink.setAttribute('href',resultsPath+elem[1][c+1][0]);
+        }
         srChild.setAttribute('onclick','searchBox.CloseResultsWindow()');
         if (elem[1][c+1][1]) {
          srChild.setAttribute('target','_parent');


### PR DESCRIPTION
Hello,
I have some doxygen projects which I want to link to external documentations on different servers which therefore need absolute paths. An example configuration would be: `TAGFILES = gcc-8.3.0-libstdc++.tag=https://gcc.gnu.org/onlinedocs/gcc-8.3.0/libstdc++/api`
This worked perfectly until doxygen version 1.9.4, however after this version I noticed that the links created in the search box were invalid like for example `search/https://somepath` because in commit 50871a4 the file `search.js` was rewritten to prepend the `resultsPath` to all paths of search results which obviously only works for relative but not absolute paths.
This PR intends to fix this problem.
Best regards,
Triple-S