### PR TITLE
issue #11436 External SVG images not loaded with image-command

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1695,7 +1695,7 @@ void HtmlDocVisitor::operator()(const DocImage &img)
     {
       src = correctURL(url,img.relPath());
     }
-    if (typeSVG && !inlineImage)
+    if (typeSVG && !inlineImage && !src.startsWith("http://") && !src.startsWith("https://"))
     {
       m_t << "<object type=\"image/svg+xml\" data=\"" << convertToHtml(src)
         << "\"" << sizeAttribs << attrs;


### PR DESCRIPTION
Made an exception for images starting with `http:://` and `https://"