### PR TITLE
issue #11400 python documentation fails with "::bool" and "::str" warnings

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1771,6 +1771,7 @@ static void initEntry(yyscan_t yyscanner)
   yyextra->current->lang       = SrcLangExt::Python;
   yyextra->current->type.clear();
   yyextra->current->name.clear();
+  yyextra->current->initializer.clear();
   yyextra->commentScanner.initGroupInfo(yyextra->current.get());
   yyextra->isStatic = FALSE;
 }
@@ -1778,6 +1779,11 @@ static void initEntry(yyscan_t yyscanner)
 static void newEntry(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
+  if (yyextra->current->name.isEmpty())
+  {
+    initEntry(yyscanner);
+    return;
+  }
   bool found = false;
   if (yyextra->checkDupEntry)
   {


### PR DESCRIPTION
In case no name is specified the current entry is not valid and should be "emptied" Also the initializer line should be removed (might be a left over from some other parts as found some other tests).

Note this also tackles #11451