### PR TITLE
issue #11419 static keyword appearing as function prefix but not inline

### DIFF
--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -3533,6 +3533,7 @@ void MemberDefImpl::writeDocumentation(const MemberList *ml,
   ldef.stripPrefix("constexpr ");
   ldef.stripPrefix("consteval ");
   ldef.stripPrefix("constinit ");
+  ldef.stripPrefix("static ");
 
   //----------------------------------------
 


### PR DESCRIPTION
It is a bit inconsistent / strange that for variables the word "static" was already stripped in the variables but not for functions. Stripping the word "static" now as well.