### PR TITLE
Warning when more `#if` than `#endif` statements

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -4069,6 +4069,11 @@ void Preprocessor::processFile(const QCString &fileName,const std::string &input
   // make sure we don't extend a \cond with missing \endcond over multiple files (see bug 624829)
   forceEndCondSection(yyscanner);
 
+  if (!state->levelGuard.empty())
+  {
+    warn(state->fileName,state->yyLineNr,"More #if's than #endif's found (might be in an included file).");
+  }
+
   if (Debug::isFlagSet(Debug::Preprocessor))
   {
     std::lock_guard<std::mutex> lock(g_debugMutex);


### PR DESCRIPTION
When more `#endif`s  present than `#if`s we got a warning, but not wen it is the other way around.

Example: [example.tar.gz](https://github.com/user-attachments/files/19074802/example.tar.gz)

(Found in the ITK Package)
