### PR TITLE
Update docker base os from focal to jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:focal AS builder
+FROM ubuntu:jammy AS builder
 
 RUN apt-get update && apt-get install -y \
     g++ \
-    python \
+    python3 \
     cmake \
     flex \
     bison \
@@ -18,7 +18,7 @@ RUN mkdir build \
     && make install
 
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 RUN apt-get update && apt-get install --no-install-recommends -y \
     graphviz \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Since general support ends soon and to match version used in the gitlab pipeline  

build the image locally successfully 