### PR TITLE
issue #9437,#11179 Add docs about markdown page exceptions

### DIFF
--- a/doc/markdown.dox
+++ b/doc/markdown.dox
@@ -545,7 +545,12 @@ be `.md` or `.markdown` (see
 \ref cfg_extension_mapping "EXTENSION_MAPPING" if your Markdown files have
 a different extension, and use `md` as the name of the parser).
 Each file is converted to a page (see the \ref cmdpage "page" command for
-details).
+details). Doxygen will not create a dedicated page if the Markdown file
+starts with a dedicated command (a.o. `\defgroup`, `\dir`) to avoid creating
+an empty page when the file only contains directory or group documentation.
+A `README.md` file in a subdirectory will be treated as directory
+documentation, unless it is explicitly overruled by a dedicated command
+(a.o. `@page`, `@mainpage`) to create a new page.
 
 By default the name and title of the page are derived from the file name.
 If the file starts with a level 1 header however, it is used as the title


### PR DESCRIPTION
The pull request #11478 and commit https://github.com/doxygen/doxygen/commit/fd23262193b9e528d44b0067bda0341bb3d0d11c added new features/exceptions for the generation of pages when using Markdown files.

This PR aims to add documentation about the new behavior.
![image](https://github.com/user-attachments/assets/320c072f-6760-4b54-9dd7-5bfab77dbdf7)

I am unsure about the inconsistency of the command format: `\dir` in the first sentence and `@page` in the other sentence.
There is probably a guideline which one to use preferably, but I did not find it.