### PR TITLE
Consistency of use of `HIDE_COMPOUND_REFERENCE`

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2887,31 +2887,73 @@ QCString ClassDefImpl::title() const
 
   if (lang==SrcLangExt::Fortran)
   {
-    pageTitle = theTranslator->trCompoundReferenceFortran(displayName(),
-              m_compType,
-              !m_tempArgs.empty());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trCompoundReferenceFortran(displayName(),
+                m_compType,
+                !m_tempArgs.empty());
+    }
   }
   else if (lang==SrcLangExt::Slice)
   {
-    pageTitle = theTranslator->trCompoundReferenceSlice(displayName(),
-              m_compType,
-              isSliceLocal());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trCompoundReferenceSlice(displayName(),
+                m_compType,
+                isSliceLocal());
+    }
   }
   else if (lang==SrcLangExt::VHDL)
   {
-    pageTitle = theTranslator->trCustomReference(VhdlDocGen::getClassTitle(this));
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = VhdlDocGen::getClassName(this);
+    }
+    else
+    {
+      pageTitle = theTranslator->trCustomReference(VhdlDocGen::getClassTitle(this));
+    }
   }
   else if (isJavaEnum())
   {
-    pageTitle = theTranslator->trEnumReference(displayName());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trEnumReference(displayName());
+    }
   }
   else if (m_compType==Service)
   {
-    pageTitle = theTranslator->trServiceReference(displayName());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trServiceReference(displayName());
+    }
   }
   else if (m_compType==Singleton)
   {
-    pageTitle = theTranslator->trSingletonReference(displayName());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trSingletonReference(displayName());
+    }
   }
   else
   {

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -285,7 +285,14 @@ const ModuleDef *ConceptDefImpl::getModuleDef() const
 
 QCString ConceptDefImpl::title() const
 {
-  return theTranslator->trConceptReference(displayName());
+  if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+  {
+    return displayName();
+  }
+  else
+  {
+    return theTranslator->trConceptReference(displayName());
+  }
 }
 
 int ConceptDefImpl::groupId() const
@@ -513,7 +520,15 @@ void ConceptDefImpl::addConceptAttributes(OutputList &ol) const
 void ConceptDefImpl::writeDocumentation(OutputList &ol)
 {
   bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
-  QCString pageTitle = theTranslator->trConceptReference(displayName());
+  QCString pageTitle;
+  if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+  {
+    pageTitle = displayName();
+  }
+  else
+  {
+    pageTitle = theTranslator->trConceptReference(displayName());
+  }
   startFile(ol,getOutputFileBase(),name(),pageTitle,HighlightedItem::ConceptVisible,!generateTreeView);
 
   // ---- navigation part

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -486,7 +486,14 @@ void DirDefImpl::endMemberDeclarations(OutputList &ol)
 
 QCString DirDefImpl::shortTitle() const
 {
-  return theTranslator->trDirReference(m_shortName);
+  if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+  {
+    return m_shortName;
+  }
+  else
+  {
+    return theTranslator->trDirReference(m_shortName);
+  }
 }
 
 bool DirDefImpl::hasDetailedDescription() const
@@ -539,7 +546,15 @@ void DirDefImpl::writeDocumentation(OutputList &ol)
   bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   ol.pushGeneratorState();
 
-  QCString title=theTranslator->trDirReference(m_dispName);
+  QCString title;
+  if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+  {
+    title=m_dispName;
+  }
+  else
+  {
+    title=theTranslator->trDirReference(m_dispName);
+  }
   AUTO_TRACE("title={}",title);
   startFile(ol,getOutputFileBase(),name(),title,HighlightedItem::Files,!generateTreeView);
 

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -867,7 +867,15 @@ void FileDefImpl::writeDocumentation(OutputList &ol)
     versionTitle=("("+m_fileVersion+")");
   }
   QCString title = m_docname+versionTitle;
-  QCString pageTitle=theTranslator->trFileReference(m_docname);
+  QCString pageTitle;
+  if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+  {
+    pageTitle=m_docname;
+  }
+  else
+  {
+    pageTitle=theTranslator->trFileReference(m_docname);
+  }
 
   if (getDirDef())
   {
@@ -880,12 +888,28 @@ void FileDefImpl::writeDocumentation(OutputList &ol)
     startTitle(ol,getOutputFileBase(),this);
     ol.pushGeneratorState();
       ol.disableAllBut(OutputType::Html);
-      ol.parseText(theTranslator->trFileReference(displayName())); // Html only
+      if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+      {
+        ol.parseText(displayName()); // Html only
+      }
+      else
+      {
+        ol.parseText(theTranslator->trFileReference(displayName())); // Html only
+      }
       ol.enableAll();
       ol.disable(OutputType::Html);
-      ol.parseText(Config_getBool(FULL_PATH_NAMES) ?  // other output formats
-                   pageTitle :
-                   theTranslator->trFileReference(name()));
+      if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+      {
+        ol.parseText(Config_getBool(FULL_PATH_NAMES) ?  // other output formats
+                     pageTitle :
+                     name());
+      }
+      else
+      {
+        ol.parseText(Config_getBool(FULL_PATH_NAMES) ?  // other output formats
+                     pageTitle :
+                     theTranslator->trFileReference(name()));
+      }
     ol.popGeneratorState();
     addGroupListToTitle(ol,this);
     endTitle(ol,getOutputFileBase(),title);
@@ -1819,7 +1843,14 @@ void FileDefImpl::getAllIncludeFilesRecursively(StringVector &incFiles) const
 
 QCString FileDefImpl::title() const
 {
-  return theTranslator->trFileReference(name());
+  if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+  {
+    return name();
+  }
+  else
+  {
+    return theTranslator->trFileReference(name());
+  }
 }
 
 QCString FileDefImpl::fileVersion() const

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -342,7 +342,15 @@ void ModuleDefImpl::writeDocumentation(OutputList &ol)
   ol.pushGeneratorState();
   AUTO_TRACE("%s file=%s",name(),getDefFileName());
   SrcLangExt lang = getLanguage();
-  QCString pageTitle = theTranslator->trModuleReference(displayName());
+  QCString pageTitle;
+  if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+  {
+    pageTitle = displayName();
+  }
+  else
+  {
+    pageTitle = theTranslator->trModuleReference(displayName());
+  }
   startFile(ol,getOutputFileBase(),name(),pageTitle,HighlightedItem::ModuleVisible,false,QCString(),0);
 
   // ---- title part

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -1566,17 +1566,38 @@ QCString NamespaceDefImpl::title() const
   }
   else if (lang==SrcLangExt::Fortran || lang==SrcLangExt::Slice)
   {
-    pageTitle = theTranslator->trModuleReference(displayName());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trModuleReference(displayName());
+    }
   }
   else if (lang==SrcLangExt::IDL)
   {
-    pageTitle = isConstantGroup()
-        ? theTranslator->trConstantGroupReference(displayName())
-        : theTranslator->trModuleReference(displayName());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = isConstantGroup()
+          ? theTranslator->trConstantGroupReference(displayName())
+          : theTranslator->trModuleReference(displayName());
+    }
   }
   else
   {
-    pageTitle = theTranslator->trNamespaceReference(displayName());
+    if (Config_getBool(HIDE_COMPOUND_REFERENCE))
+    {
+      pageTitle = displayName();
+    }
+    else
+    {
+      pageTitle = theTranslator->trNamespaceReference(displayName());
+    }
   }
   return pageTitle;
 }


### PR DESCRIPTION
In the question https://stackoverflow.com/questions/79483301/doxygen-hide-compound-reference-for-namespace it was noted that the `HIDE_COMPOUND_REFERENCE` does not work for e.g. namespaces. Currently it only works for classes (and also for Struct,  Union, Interface, Protocol, Category and Exception, as they all use the routine `trCompoundReference`) Besides the problem for namespaces ithe issue is present for other parts as well that call the routines:
- `trFileReference`
- `trNamespaceReference`
- `trDirReference`
- `trCompoundReferenceFortran`
- `trModuleReference`
- `trEnumReference`
- `trConstantGroupReference`
- `trServiceReference`
- `trSingletonReference`
- `trCustomReference`
- `trCompoundReferenceSlice`
- `trConceptReference`

The usage of `HIDE_COMPOUND_REFERENCE` has ben implemented for these calls as well