### PR TITLE
Flexibility of `\cite` command

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -2477,7 +2477,7 @@ Commands to create links
   \sa section \ref cmdref "\\ref".
 
 <hr>
-\section cmdcite \\cite \<label\>
+\section cmdcite \\cite['{'[option]'}'] \<label\>
 
   \addindex \\cite
   Adds a bibliographic reference in the text and in the list of bibliographic
@@ -2487,6 +2487,18 @@ Commands to create links
   configured with \ref cfg_latex_bib_style "LATEX_BIB_STYLE". For other
   output formats a fixed representation is used. Note that using this
   command requires the \c bibtex tool to be present in the search path.
+
+  There are a number of options possible:
+  - `number`, `shortauthor`, `year`, these options are mutually exclusive,
+    in case none of these is specified `number` is assumed.
+    - `number` create a numerical reference
+    - `shortauthor` just the surname of the first author is given, and in case
+      multiple authors are present the text "et al." is added
+    - `year`, the year of publication is mentioned (when specified in the bibtex
+      file.
+  - `nopar`, no (square) brackets are added
+  - `nocite`, no link to a citation in the bibliography is made (and the
+    reference is not added to the bibliography based on this item)
 
 <hr>
 \section cmdendlink \\endlink

--- a/src/cite.h
+++ b/src/cite.h
@@ -29,6 +29,18 @@ struct CiteInfo
 
   virtual QCString label() const = 0;
   virtual QCString text() const = 0;
+  virtual QCString shortAuthor() const = 0;
+  virtual QCString year() const = 0;
+
+  enum CiteOptionType {
+    UNKNOWN     = 0x00,
+    NUMBER      = 0x01,
+    SHORTAUTHOR = 0x02,
+    YEAR        = 0x04,
+
+    NOPAR_BIT   = 0x001000, //< Don't use square brackets
+    NOCITE_BIT  = 0x100000, //< Don't create a link
+  };
 };
 
 /**

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -3368,7 +3368,7 @@ static bool handleImage(yyscan_t yyscanner,const QCString &s, const StringVector
   return FALSE;
 }
 
-static bool handleCite(yyscan_t yyscanner,const QCString &s, const StringVector &)
+static bool handleCite(yyscan_t yyscanner,const QCString &s, const StringVector &optList)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   if (!yyextra->spaceBeforeCmd.isEmpty())
@@ -3376,7 +3376,14 @@ static bool handleCite(yyscan_t yyscanner,const QCString &s, const StringVector 
     addOutput(yyscanner,yyextra->spaceBeforeCmd);
     yyextra->spaceBeforeCmd.clear();
   }
-  addOutput(yyscanner,"@"+s+" ");
+  if (optList.empty())
+  {
+    addOutput(yyscanner,"@"+s+" ");
+  }
+  else
+  {
+    addOutput(yyscanner,"@"+s+"{"+QCString(join(optList,","))+"} ");
+  }
   BEGIN(CiteLabel);
   return FALSE;
 }

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -35,6 +35,7 @@
 #include "fileinfo.h"
 #include "portable.h"
 #include "codefragment.h"
+#include "cite.h"
 
 #if 0
 #define DB_VIS_C DB_VIS_C1(m_t)
@@ -601,9 +602,23 @@ void DocbookDocVisitor::operator()(const DocCite &cite)
 {
 DB_VIS_C
   if (m_hide) return;
-  if (!cite.file().isEmpty()) startLink(cite.file(),filterId(cite.anchor()));
-  filter(cite.text());
-  if (!cite.file().isEmpty()) endLink();
+  int opt = cite.option();
+  if (!cite.file().isEmpty())
+  {
+    if (!(opt & CiteInfo::NOCITE_BIT)) startLink(cite.file(),filterId(cite.anchor()));
+
+    filter(cite.getText());
+
+    if (!(opt & CiteInfo::NOCITE_BIT)) endLink();
+  }
+  else
+  {
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("[");
+    filter(cite.target());
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("]");
+
+  }
+
 }
 
 //--------------------------------------

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -891,7 +891,7 @@ void DocRef::parse()
 
 //---------------------------------------------------------------------------
 
-DocCite::DocCite(DocParser *parser,DocNodeVariant *parent,const QCString &target,const QCString &) : DocNode(parser,parent)
+DocCite::DocCite(DocParser *parser,DocNodeVariant *parent,const QCString &target,const QCString &,int opt) : DocNode(parser,parent)
 {
   size_t numBibFiles = Config_getList(CITE_BIB_FILES).size();
   //printf("DocCite::DocCite(target=%s)\n",qPrint(target));
@@ -900,9 +900,10 @@ DocCite::DocCite(DocParser *parser,DocNodeVariant *parent,const QCString &target
   const CitationManager &ct = CitationManager::instance();
   const CiteInfo *cite = ct.find(target);
   //printf("cite=%p text='%s' numBibFiles=%d\n",cite,cite?qPrint(cite->text):"<null>",numBibFiles);
+  m_option = opt;
+  m_target = target;
   if (numBibFiles>0 && cite && !cite->text().isEmpty()) // ref to citation
   {
-    m_text         = cite->text();
     m_ref          = "";
     m_anchor       = ct.anchorPrefix()+cite->label();
     m_file         = convertNameToFile(ct.fileName(),FALSE,TRUE);
@@ -910,7 +911,6 @@ DocCite::DocCite(DocParser *parser,DocNodeVariant *parent,const QCString &target
     //    qPrint(m_text),qPrint(m_ref),qPrint(m_file),qPrint(m_anchor));
     return;
   }
-  m_text = target;
   if (numBibFiles==0)
   {
     warn_doc_error(parser->context.fileName,parser->tokenizer.getLineNr(),"\\cite command found but no bib files specified via CITE_BIB_FILES!");
@@ -926,6 +926,27 @@ DocCite::DocCite(DocParser *parser,DocNodeVariant *parent,const QCString &target
              target);
   }
 }
+
+QCString DocCite::getText() const
+{
+  QCString txt;
+  int opt = m_option;
+  const CitationManager &ct = CitationManager::instance();
+  const CiteInfo *citeInfo = ct.find(m_target);
+
+  if (!(opt & CiteInfo::NOPAR_BIT))  txt += "[";
+
+  if (citeInfo)
+  {
+    if (opt & CiteInfo::NUMBER)  txt += citeInfo->text();
+    else if (opt & CiteInfo::SHORTAUTHOR)  txt += citeInfo->shortAuthor();
+    else if (opt & CiteInfo::YEAR)  txt += citeInfo->year();
+  }
+
+  if (!(opt & CiteInfo::NOPAR_BIT)) txt += "]";
+  return txt;
+}
+
 
 //---------------------------------------------------------------------------
 
@@ -3295,31 +3316,102 @@ Token DocPara::handleParamSection(const QCString &cmdName,
 void DocPara::handleCite(char cmdChar,const QCString &cmdName)
 {
   AUTO_TRACE();
+  QCString saveCmdName = cmdName;
   // get the argument of the cite command.
   Token tok=parser()->tokenizer.lex();
-  if (!tok.is(TokenRetval::TK_WHITESPACE))
+
+  int option = CiteInfo::UNKNOWN;
+  bool nopar_bit = false;
+  bool nocite_bit = false;
+  if (tok.is(TokenRetval::TK_WORD) && parser()->context.token->name=="{")
+  {
+    parser()->tokenizer.setStateOptions();
+    parser()->tokenizer.lex();
+    StringVector optList=split(parser()->context.token->name.str(),",");
+    for (auto const &opt : optList)
+    {
+      if (opt == "number")
+      {
+        if (option != CiteInfo::UNKNOWN)
+        {
+          warn(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Multiple options specified with \\{}, discarding '{}'", saveCmdName, opt);
+        }
+        else
+        {
+          option = CiteInfo::NUMBER;
+        }
+      }
+      else if (opt == "year")
+      {
+        if (option != CiteInfo::UNKNOWN)
+        {
+          warn(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Multiple options specified with \\{}, discarding '{}'", saveCmdName, opt);
+        }
+        else
+        {
+          option = CiteInfo::YEAR;
+        }
+      }
+      else if (opt == "shortauthor")
+      {
+        if (option != CiteInfo::UNKNOWN)
+        {
+          warn(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Multiple options specified with \\{}, discarding '{}'", saveCmdName, opt);
+        }
+        else
+        {
+          option = CiteInfo::SHORTAUTHOR;
+        }
+      }
+      else if (opt == "nopar")  nopar_bit = true;
+      else if (opt == "nocite") nocite_bit = true;
+      else
+      {
+        warn(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unkown option specified with \\{}, discarding '{}'", saveCmdName, opt);
+      }
+    }
+
+    if (option == CiteInfo::UNKNOWN) option = CiteInfo::NUMBER;
+    if (nopar_bit) option |= CiteInfo::NOPAR_BIT;
+    if (nocite_bit) option |= CiteInfo::NOCITE_BIT;
+
+    parser()->tokenizer.setStatePara();
+    tok=parser()->tokenizer.lex();
+    if (!tok.is(TokenRetval::TK_WHITESPACE))
+    {
+      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\{} command",
+          saveCmdName);
+      return;
+    }
+  }
+  else if (!tok.is(TokenRetval::TK_WHITESPACE))
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '{:c}{}' command",
-      cmdChar,cmdName);
+      cmdChar,saveCmdName);
     return;
   }
+  else
+  {
+    option = CiteInfo::NUMBER;
+  }
+
   parser()->tokenizer.setStateCite();
   tok=parser()->tokenizer.lex();
   if (tok.is_any_of(TokenRetval::TK_NONE,TokenRetval::TK_EOF))
   {
-    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected end of comment block while parsing the "
-        "argument of command '{:c}{}'",cmdChar,cmdName);
+    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"THE ONE unexpected end of comment block while parsing the "
+        "argument of command '{:c}{}'",cmdChar,saveCmdName);
     return;
   }
   else if (!tok.is_any_of(TokenRetval::TK_WORD,TokenRetval::TK_LNKWORD))
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token {} as the argument of '{:c}{}'",
-        tok.to_string(),cmdChar,cmdName);
+        tok.to_string(),cmdChar,saveCmdName);
     return;
   }
   parser()->context.token->sectionId = parser()->context.token->name;
   children().append<DocCite>(
-        parser(),thisVariant(),parser()->context.token->name,parser()->context.context);
+        parser(),thisVariant(),parser()->context.token->name,parser()->context.context,option);
 
   parser()->tokenizer.setStatePara();
 }

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -243,19 +243,22 @@ class DocAnchor : public DocNode
 class DocCite : public DocNode
 {
   public:
-    DocCite(DocParser *parser,DocNodeVariant *parent,const QCString &target,const QCString &context);
+    DocCite(DocParser *parser,DocNodeVariant *parent,const QCString &target,const QCString &context, int opt);
     QCString file() const        { return m_file; }
     QCString relPath() const     { return m_relPath; }
     QCString ref() const         { return m_ref; }
     QCString anchor() const      { return m_anchor; }
-    QCString text() const        { return m_text; }
+    QCString target() const      { return m_target; }
+    int option() const           { return m_option; }
+    QCString getText() const;
 
   private:
     QCString   m_file;
     QCString   m_relPath;
     QCString   m_ref;
     QCString   m_anchor;
-    QCString   m_text;
+    QCString   m_target;
+    int        m_option;
 };
 
 

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -39,6 +39,7 @@
 #include "growbuf.h"
 #include "portable.h"
 #include "codefragment.h"
+#include "cite.h"
 
 static const int NUM_HTML_LIST_TYPES = 4;
 static const char g_types[][NUM_HTML_LIST_TYPES] = {"1", "a", "i", "A"};
@@ -981,22 +982,20 @@ void HtmlDocVisitor::operator()(const DocSimpleSectSep &)
 void HtmlDocVisitor::operator()(const DocCite &cite)
 {
   if (m_hide) return;
+  int opt = cite.option();
   if (!cite.file().isEmpty())
   {
-    startLink(cite.ref(),cite.file(),cite.relPath(),cite.anchor());
+    if (!(opt & CiteInfo::NOCITE_BIT)) startLink(cite.ref(),cite.file(),cite.relPath(),cite.anchor());
+    filter(cite.getText());
+    if (!(opt & CiteInfo::NOCITE_BIT)) endLink();
   }
   else
   {
-    m_t << "<b>[";
-  }
-  filter(cite.text());
-  if (!cite.file().isEmpty())
-  {
-    endLink();
-  }
-  else
-  {
-    m_t << "]</b>";
+    m_t << "<b>";
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("[");
+    filter(cite.target());
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("]");
+    m_t << "</b>";
   }
 }
 

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -28,6 +28,7 @@
 #include "emoji.h"
 #include "fileinfo.h"
 #include "codefragment.h"
+#include "cite.h"
 
 ManDocVisitor::ManDocVisitor(TextStream &t,OutputCodeList &ci,
                              const QCString &langExt)
@@ -426,9 +427,19 @@ void ManDocVisitor::operator()(const DocCite &cite)
 {
   if (m_hide) return;
   m_t << "\\fB";
-  if (cite.file().isEmpty()) m_t << "[";
-  filter(cite.text());
-  if (cite.file().isEmpty()) m_t << "]";
+  int opt = cite.option();
+  QCString txt;
+  if (!cite.file().isEmpty())
+  {
+    txt = cite.getText();
+  }
+  else
+  {
+    if (!(opt & CiteInfo::NOPAR_BIT)) txt += "[";
+    txt += cite.target();
+    if (!(opt & CiteInfo::NOPAR_BIT)) txt += "]";
+  }
+  filter(txt);
   m_t << "\\fP";
 }
 

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -41,6 +41,7 @@
 #include "portable.h"
 #include "moduledef.h"
 #include "construct.h"
+#include "cite.h"
 
 #define PERLOUTPUT_MAX_INDENTATION 40
 
@@ -743,7 +744,19 @@ void PerlModDocVisitor::operator()(const DocSimpleSectSep &)
 void PerlModDocVisitor::operator()(const DocCite &cite)
 {
   openItem("cite");
-  m_output.addFieldQuotedString("text", cite.text());
+  int opt = cite.option();
+  QCString txt;
+  if (!cite.file().isEmpty())
+  {
+    txt = cite.getText();
+  }
+  else
+  {
+    if (!(opt & CiteInfo::NOPAR_BIT)) txt += "[";
+    txt += cite.target();
+    if (!(opt & CiteInfo::NOPAR_BIT)) txt += "]";
+  }
+  m_output.addFieldQuotedString("text", txt);
   closeItem();
 }
 

--- a/src/printdocvisitor.h
+++ b/src/printdocvisitor.h
@@ -22,6 +22,7 @@
 #include "htmlentity.h"
 #include "emoji.h"
 #include "message.h"
+#include "cite.h"
 
 /*! Visitor implementation for pretty printing */
 class PrintDocVisitor
@@ -250,11 +251,23 @@ class PrintDocVisitor
     void operator()(const DocCite &cite)
     {
       indent_leaf();
+      int opt = cite.option();
+      QCString txt;
+      if (!cite.file().isEmpty())
+      {
+        txt = cite.getText();
+      }
+      else
+      {
+        if (!(opt & CiteInfo::NOPAR_BIT)) txt += "[";
+        txt += cite.target();
+        if (!(opt & CiteInfo::NOPAR_BIT)) txt += "]";
+      }
       printf("<cite ref=\"%s\" file=\"%s\" "
              "anchor=\"%s\" text=\"%s\""
              "/>\n",
              qPrint(cite.ref()),qPrint(cite.file()),qPrint(cite.anchor()),
-             qPrint(cite.text()));
+             qPrint(txt));
     }
     void operator()(const DocSeparator &)
     {

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -37,6 +37,7 @@
 #include "fileinfo.h"
 #include "portable.h"
 #include "codefragment.h"
+#include "cite.h"
 
 //#define DBG_RTF(x) m_t << x
 #define DBG_RTF(x) do {} while(0)
@@ -646,21 +647,21 @@ void RTFDocVisitor::operator()(const DocCite &cite)
 {
   if (m_hide) return;
   DBG_RTF("{\\comment RTFDocVisitor::operator()(const DocCite &)}\n");
+  int opt = cite.option();
   if (!cite.file().isEmpty())
   {
-    startLink(cite.ref(),cite.file(),cite.anchor());
+    if (!(opt & CiteInfo::NOCITE_BIT)) startLink(cite.ref(),cite.file(),cite.anchor());
+
+    filter(cite.getText());
+
+    if (!(opt & CiteInfo::NOCITE_BIT)) endLink(cite.ref());
   }
   else
   {
-    m_t << "{\\b ";
-  }
-  filter(cite.text());
-  if (!cite.file().isEmpty())
-  {
-    endLink(cite.ref());
-  }
-  else
-  {
+    m_t << "{\\b";
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("[");
+    filter(cite.target());
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("]");
     m_t << "}";
   }
 }

--- a/src/textdocvisitor.cpp
+++ b/src/textdocvisitor.cpp
@@ -81,7 +81,7 @@ void TextDocVisitor::operator()(const DocCite &cite)
   }
   else
   {
-    filter(cite.text());
+    filter(cite.target());
   }
 }
 

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -30,6 +30,7 @@
 #include "filedef.h"
 #include "fileinfo.h"
 #include "codefragment.h"
+#include "cite.h"
 
 static void startSimpleSect(TextStream &t,const DocSimpleSect &s)
 {
@@ -588,9 +589,23 @@ void XmlDocVisitor::operator()(const DocSimpleSectSep &sep)
 void XmlDocVisitor::operator()(const DocCite &cite)
 {
   if (m_hide) return;
-  if (!cite.file().isEmpty()) startLink(cite.ref(),cite.file(),cite.anchor());
-  filter(cite.text());
-  if (!cite.file().isEmpty()) endLink();
+  int opt = cite.option();
+  if (!cite.file().isEmpty())
+  {
+    if (!(opt & CiteInfo::NOCITE_BIT)) startLink(cite.ref(),cite.file(),cite.anchor());
+
+    filter(cite.getText());
+
+    if (!(opt & CiteInfo::NOCITE_BIT)) endLink();
+  }
+  else
+  {
+    m_t << "<b>";
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("[");
+    filter(cite.target());
+    if (!(opt & CiteInfo::NOPAR_BIT)) filter("]");
+    m_t << "</b>";
+  }
 }
 
 //--------------------------------------

--- a/templates/html/bib2xhtml.pl
+++ b/templates/html/bib2xhtml.pl
@@ -204,8 +204,9 @@ while (<BBLFILE>) {
     }
     $nentry++;
     ($bcite, $blabel) = m:<dt><a\s+name=\"([^\"]*)\">\[([^\]]*)\]</a></dt><dd>:;
-    $blabel = "$nentry";
+    $blabel = "$nentry,$2$3";
     $bibcite{$bcite} = $blabel;
+    $bibnum{$bcite}  = $nentry;
 }
 close(BBLFILE);
 $label_style = $LABEL_DEFAULT if (! defined $label_style);
@@ -228,7 +229,7 @@ while (<BBLFILE>) {
     }
     s/\%\n//g;
     s/(\.(<\/cite>|<\/a>|\')+)\./$1/g;
-    s:(<dt><a\s+name=\"[^\"]*\">\[)[^\]]*(\]</a></dt><dd>):$1$nentry$2:;
+    s:(<dt><a\s+name=\"[^\"]*\">)\[([^\]]*)\](</a></dt><dd>):$1\[$nentry\]<!--\[$nentry,$2\]-->$3:;
     while (m/(\\(cite(label)?)(\001\d+)\{([^\001]+)\4\})/) {
 	$old = $1;
 	$cmd = $2;
@@ -237,7 +238,7 @@ while (<BBLFILE>) {
 	if (! defined $bibcite{$bcite}) {
 	    $blabel = " [" . $bcite . "]";
 	} elsif ($doxref) {
-	    $blabel = " <a href=\"#$bcite\">[" . $bibcite{$bcite} . "]<\/a>";
+	    $blabel = " <a href=\"#$bcite\">[" . $bibnum{$bcite} . "]<\/a>";
 	} else {
 	    $blabel = " [" . $bibcite{$bcite} . "]";
 	}
@@ -296,6 +297,7 @@ while (<BBLFILE>) {
     s/(\\\((([^\\]|\\[^\(\)])+)\\\))/&domath($2)/ge;
     s/\\mbox(\001\d+)\{(.*)\1\}/$2/gs;
     while (s/(\<a href\=\"[^"]*?)\~/$1\005/g) { ; }
+    s/et~al/et al/g;
     s/([^\\])~/$1&nbsp;/g;
     s/\\\,/&thinsp;/g;
     s/\\ldots\b/&hellip;/g;

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -542,6 +542,37 @@
   \mbox{\hyperlink{#1}{#2}}%
 }
 
+% Used for the cite command
+\newcommand{\DoxyCite}[3]{%
+  \ifthenelse{#3=1}% 1 with square parenthesis
+  {
+    \ifthenelse{\equal{#2}{number}}%
+    { \cite{#1} }%
+    {%
+      \ifthenelse{\equal{#2}{shortauthor}}%
+      { \citetext{\citeauthor{#1}} }%
+      {%
+        \ifthenelse{\equal{#2}{year}}%
+        { \citeyearpar{#1} }%
+        {}%
+      }%
+    }%
+  }%
+  {%
+    \ifthenelse{\equal{#2}{number}}%
+    { \citealp{#1} }%
+    {%
+      \ifthenelse{\equal{#2}{shortauthor}}%
+      { \citeauthor{#1} }%
+      {%
+        \ifthenelse{\equal{#2}{year}}%
+        { \citeyear{#1} }%
+        {}%
+      }%
+    }%
+  }%
+}
+
 % Used when hyperlinks are turned on
 % Third argument is the SectionType, see the doxygen internal
 % documentation for the values (relevant: Page ... Subsubsection).


### PR DESCRIPTION
Adding some options to the `\cite` command to make it more flexible so that not only a reference number can be shown.

Example: [example.tar.gz](https://github.com/user-attachments/files/19249528/example.tar.gz)
