### PR TITLE
issue #11492 `@plantumlfile` command not recognized

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -431,13 +431,16 @@ DB_VIS_C
     case DocVerbatim::PlantUML:
       {
         QCString docbookOutput = Config_getString(DOCBOOK_OUTPUT);
-        QCString baseName = PlantumlManager::instance().writePlantUMLSource(docbookOutput,
+        std::vector<QCString> baseNameVector = PlantumlManager::instance().writePlantUMLSource(docbookOutput,
             s.exampleFile(),s.text(),PlantumlManager::PUML_BITMAP,
             s.engine(),s.srcFile(),s.srcLine(),true);
-        QCString shortName = makeShortName(baseName);
-        m_t << "<para>\n";
-        writePlantUMLFile(baseName,s);
-        m_t << "</para>\n";
+        for(const auto &baseName: baseNameVector)
+        {
+          QCString shortName = makeShortName(baseName);
+          m_t << "<para>\n";
+          writePlantUMLFile(baseName,s);
+          m_t << "</para>\n";
+        }
       }
       break;
   }
@@ -1561,12 +1564,18 @@ DB_VIS_C
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   std::string inBuf;
   readInputFile(fileName,inBuf);
-  QCString baseName = PlantumlManager::instance().writePlantUMLSource(outDir,
+  std::vector<QCString> baseNameVector = PlantumlManager::instance().writePlantUMLSource(outDir,
             QCString(),inBuf.c_str(),PlantumlManager::PUML_BITMAP,QCString(),srcFile,srcLine,false);
-  baseName=makeBaseName(baseName);
-  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
-  m_t << "<para>\n";
-  visitPreStart(m_t, children, hasCaption, relPath + baseName + ".png",  width,  height);
+  bool first = true;
+  for(auto &baseName: baseNameVector)
+  {
+    baseName=makeBaseName(baseName);
+    PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
+    if (!first) endPlantUmlFile(hasCaption);
+    first = false;
+    m_t << "<para>\n";
+    visitPreStart(m_t, children, hasCaption, relPath + baseName + ".png",  width,  height);
+  }
 }
 
 void DocbookDocVisitor::endPlantUmlFile(bool hasCaption)

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -675,13 +675,16 @@ void HtmlDocVisitor::operator()(const DocVerbatim &s)
         {
           format = PlantumlManager::PUML_SVG;
         }
-        QCString baseName = PlantumlManager::instance().writePlantUMLSource(
+        std::vector<QCString> baseNameVector = PlantumlManager::instance().writePlantUMLSource(
                                     htmlOutput,s.exampleFile(),
                                     s.text(),format,s.engine(),s.srcFile(),s.srcLine(),true);
-        m_t << "<div class=\"plantumlgraph\">\n";
-        writePlantUMLFile(baseName,s.relPath(),s.context(),s.srcFile(),s.srcLine());
-        visitCaption(m_t, s);
-        m_t << "</div>\n";
+        for(const auto &baseName: baseNameVector)
+        {
+          m_t << "<div class=\"plantumlgraph\">\n";
+          writePlantUMLFile(baseName,s.relPath(),s.context(),s.srcFile(),s.srcLine());
+          visitCaption(m_t, s);
+          m_t << "</div>\n";
+        }
         forceStartParagraph(s);
       }
       break;
@@ -1836,22 +1839,25 @@ void HtmlDocVisitor::operator()(const DocPlantUmlFile &df)
   }
   std::string inBuf;
   readInputFile(df.file(),inBuf);
-  QCString baseName = PlantumlManager::instance().writePlantUMLSource(
+  std::vector<QCString> baseNameVector = PlantumlManager::instance().writePlantUMLSource(
                                     htmlOutput,QCString(),
                                     inBuf.c_str(),format,QCString(),df.srcFile(),df.srcLine(),false);
-  baseName=makeBaseName(baseName);
-  m_t << "<div class=\"plantumlgraph\">\n";
-  writePlantUMLFile(baseName,df.relPath(),QCString(),df.srcFile(),df.srcLine());
-  if (df.hasCaption())
+  for(auto &baseName: baseNameVector)
   {
-    m_t << "<div class=\"caption\">\n";
-  }
-  visitChildren(df);
-  if (df.hasCaption())
-  {
+    baseName=makeBaseName(baseName);
+    m_t << "<div class=\"plantumlgraph\">\n";
+    writePlantUMLFile(baseName,df.relPath(),QCString(),df.srcFile(),df.srcLine());
+    if (df.hasCaption())
+    {
+      m_t << "<div class=\"caption\">\n";
+    }
+    visitChildren(df);
+    if (df.hasCaption())
+    {
+      m_t << "</div>\n";
+    }
     m_t << "</div>\n";
   }
-  m_t << "</div>\n";
   forceStartParagraph(df);
 }
 

--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "containers.h"
 #include "qcstring.h"
@@ -58,9 +59,9 @@ class PlantumlManager
      *  @param[in] srcLine     the line number resulting in the write command.
      *  @param[in] inlineCode  the code is coming from the `\statuml ... \enduml` (`true`) command or
      *   from the `\planumlfile` command (`false`)
-     *  @returns The name of the generated file.
+     *  @returns The names of the generated files.
      */
-    QCString writePlantUMLSource(const QCString &outDirArg,const QCString &fileName,
+    std::vector<QCString> writePlantUMLSource(const QCString &outDirArg,const QCString &fileName,
                                  const QCString &content, OutputFormat format,
                                  const QCString &engine,const QCString &srcFile,
                                  int srcLine,bool inlineCode);
@@ -83,6 +84,8 @@ class PlantumlManager
                 const QCString &puContent,
                 const QCString &srcFile,
                 int srcLine);
+    void generatePlantUmlFileNames(const QCString &fileName,OutputFormat format,const QCString &outDir,
+                                                    QCString &baseName,QCString &puName,QCString &imgName);
 
     FilesMap   m_pngPlantumlFiles;
     FilesMap   m_svgPlantumlFiles;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -424,13 +424,16 @@ void RTFDocVisitor::operator()(const DocVerbatim &s)
     case DocVerbatim::PlantUML:
       {
         QCString rtfOutput = Config_getString(RTF_OUTPUT);
-        QCString baseName = PlantumlManager::instance().writePlantUMLSource(
+        std::vector<QCString> baseNameVector = PlantumlManager::instance().writePlantUMLSource(
                        rtfOutput,s.exampleFile(),s.text(),PlantumlManager::PUML_BITMAP,
                        s.engine(),s.srcFile(),s.srcLine(),true);
 
-        writePlantUMLFile(baseName, s.hasCaption());
-        visitChildren(s);
-        includePicturePostRTF(true, s.hasCaption());
+        for(const auto &baseName: baseNameVector)
+        {
+          writePlantUMLFile(baseName, s.hasCaption());
+          visitChildren(s);
+          includePicturePostRTF(true, s.hasCaption());
+        }
       }
       break;
   }
@@ -1318,12 +1321,15 @@ void RTFDocVisitor::operator()(const DocPlantUmlFile &df)
   QCString rtfOutput = Config_getString(RTF_OUTPUT);
   std::string inBuf;
   readInputFile(df.file(),inBuf);
-  QCString baseName = PlantumlManager::instance().writePlantUMLSource(
+  std::vector<QCString> baseNameVector = PlantumlManager::instance().writePlantUMLSource(
                        rtfOutput,QCString(),inBuf.c_str(),PlantumlManager::PUML_BITMAP,
                        QCString(),df.srcFile(),df.srcLine(),false);
-  writePlantUMLFile(baseName, df.hasCaption());
-  visitChildren(df);
-  includePicturePostRTF(true, df.hasCaption());
+  for(auto &baseName: baseNameVector)
+  {
+    writePlantUMLFile(baseName, df.hasCaption());
+    visitChildren(df);
+    includePicturePostRTF(true, df.hasCaption());
+  }
 }
 
 void RTFDocVisitor::operator()(const DocLink &lnk)

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3007,8 +3007,11 @@ void  FlowChart::printUmlTree()
   QCString htmlOutDir = Config_getString(HTML_OUTPUT);
 
   QCString n=convertNameToFileName();
-  n=PlantumlManager::instance().writePlantUMLSource(htmlOutDir,n,qcs,PlantumlManager::PUML_SVG,"uml",n,1,true);
-  PlantumlManager::instance().generatePlantUMLOutput(n,htmlOutDir,PlantumlManager::PUML_SVG);
+  std::vector<QCString> baseNameVector=PlantumlManager::instance().writePlantUMLSource(htmlOutDir,n,qcs,PlantumlManager::PUML_SVG,"uml",n,1,true);
+  for(const auto &baseName: baseNameVector)
+  {
+    PlantumlManager::instance().generatePlantUMLOutput(baseName,htmlOutDir,PlantumlManager::PUML_SVG);
+  }
 }
 
 QCString FlowChart::convertNameToFileName()


### PR DESCRIPTION
- The original problem is about the fact that fact that the `@startuml` command had a filename and this was not expected / anticipated, the result was a concatenation of the name with and "inline" name (i.e. an generated dummy name) and the given name
- Potential problem with handing out the same number for an "inline" file name (multithreading, now protected by means of a mutex.
- With a `\plantumlfile` it is possible to have multiple diagrams in one file, only one was shown, now all are shown.