### PR TITLE
Fixing some incorrect tags in HTML output

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -489,7 +489,7 @@ void FTVHelp::Private::generateTree(TextStream &t, const FTVNodes &nl,int level,
       }
       else
       {
-        t << "<span class=\"icondoc\"><dic class=\"doc-icon\"></div></span>";
+        t << "<span class=\"icondoc\"><div class=\"doc-icon\"></div></span>";
       }
       if (srcRef)
       {

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -88,7 +88,7 @@ static void writeClientSearchBox(TextStream &t,const QCString &relPath)
   t << "               onkeyup=\"searchBox.OnSearchFieldChange(event)\"/>\n";
   t << "          </span><span class=\"right\">\n";
   t << "            <a id=\"MSearchClose\" href=\"javascript:searchBox.CloseResultsWindow()\">"
-    << "<div id=\"MSearchCloseImg\" class=\"close-icon\"/></div></a>\n";
+    << "<div id=\"MSearchCloseImg\" class=\"close-icon\"/></a>\n";
   t << "          </span>\n";
   t << "        </div>\n";
 }

--- a/testing/dtd/xhtml1-transitional.dtd
+++ b/testing/dtd/xhtml1-transitional.dtd
@@ -43,6 +43,9 @@
 
      December 28, 2024
      - added entity &quest; as used in doxygen
+
+     March 23, 2025
+     - added div with special elements
 -->
 
 <!--================ Character mnemonic entities =========================-->
@@ -219,7 +222,7 @@
 <!--=================== Text Elements ====================================-->
 
 <!ENTITY % special.extra
-   "object | applet | img | map | iframe | picture | details | summary">
+   "object | applet | img | div | map | iframe | picture | details | summary">
 	
 <!ENTITY % special.basic
 	"br | span | bdo">


### PR DESCRIPTION
Fixing regressions due to:
```
Commit: 0bcc24b0045dd95ed958b321585f6bb00903f2c2 [0bcc24b]

Commit Date: Sunday, March 23, 2025 3:19:59 PM

Cleanup unused HTML/CSS elements
```