### PR TITLE
Adding "loading" attribute to dtd

### DIFF
--- a/testing/dtd/xhtml1-transitional.dtd
+++ b/testing/dtd/xhtml1-transitional.dtd
@@ -46,6 +46,9 @@
 
      March 23, 2025
      - added div with special elements
+
+     March 28, 2025
+     - added loading attribute with special iframe amd img
 -->
 
 <!--================ Character mnemonic entities =========================-->
@@ -428,6 +431,7 @@
   height      %Length;       #IMPLIED
   width       %Length;       #IMPLIED
   allowfullscreen (true|false)   "true"
+  loading     (eager|lazy)   #IMPLIED
   >
 
 <!-- alternate content container for non frame-based rendering -->
@@ -889,6 +893,7 @@
   border      %Length;       #IMPLIED
   hspace      %Pixels;       #IMPLIED
   vspace      %Pixels;       #IMPLIED
+  loading     (eager|lazy)   #IMPLIED
   >
 
 <!ELEMENT source EMPTY>


### PR DESCRIPTION
Adding the "loading attribute to the dtd as necessary due to:
```
Commit: eafe670f3207a8e22cd366b8cf11a25c56031dd9 [eafe670]

Date: Monday, March 24, 2025 8:26:06 PM

Set lazy loading attribute for images

To speed up loading, especially for the graphical class hierarchy page
```