### PR TITLE
CMakeLists.txt: use 64-bit file API on 32-bit linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,12 @@ endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSQLITE_OMIT_LOAD_EXTENSION=1")
 
+# Use 64-bit off_t on 32-bit Linux
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+  # ensure 64bit offsets are used for filesystem accesses for 32bit compilation
+  add_compile_definitions(_FILE_OFFSET_BITS=64)
+endif()
+
 if (WIN32)
     if (MSVC)
         if (NOT ICONV_DIR)


### PR DESCRIPTION
Without the change `doxygen` fails to run when built against `i686-linux` target and installed on thew filesystem with 64-bit inodes (`btrfs` with many files in my case):

    $ doxygen -g && doxygen && echo ok
    Configuration file 'Doxyfile' created.
    ...
    error: Doxyfile not found and no input file specified!

This happens because the inode number is outside 32-bit values:

    $ stat Doxyfile
    ...
    Device: 0,31    Inode: 11833552292  Links: 1

After the change the doc generation succeeds as expected:

    $ doxygen -g && doxygen && echo ok
    ...
    ok

The change enables the respective macros to enable 64-bit API.