### PR TITLE
Handling of case sensitive file / directory names

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6115,12 +6115,6 @@ bool genericPatternMatch(const FileInfo &fi,
   bool caseSenseNames = getCaseSenseNames();
   bool found = FALSE;
 
-  // For platforms where the file system is non case sensitive overrule the setting
-  if (!Portable::fileSystemIsCaseSensitive())
-  {
-    caseSenseNames = FALSE;
-  }
-
   if (!patList.empty())
   {
     std::string fn = fi.fileName();


### PR DESCRIPTION
In case `CASE_SENSE_NAMES=YES` the directory name `TestKernel` was matched with `EXCLUDE_PATTERNS=*/test*` on Windows. When introducing the settings `SYSTEM` / `YES` / `NO` for `CASE_SENSE_NAMES` in:
```
Commit: f41a679b3e68f13eff9f4eceaf04aacc51555fc5 [f41a679]

Date: Thursday, August 18, 2022 3:23:54 PM

issue #9236 doxygen x_noenv should always diff system-dependent settings

Making the `CASE_SENSE_NAMES` settings an enum with values `SYSTEM`, `YES` and `NO`.
In case `SYSTEM` is chosen the value is, system dependently changed at runtime.
```
no automatic overruling should take place anymore.


Example: [example.tar.gz](https://github.com/user-attachments/files/19535375/example.tar.gz)

(Found for the ITK project)
