### PR TITLE
Value mentioned twice with configuration setting `FILE_PATTERNS`

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1620,7 +1620,6 @@ PATH=/Library/TeX/texbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
       <value name='*.hxx'/>
       <value name='*.hpp'/>
       <value name='*.h++'/>
-      <value name='*.ixx'/>
       <value name='*.l'/>
       <value name='*.cs'/>
       <value name='*.d'/>


### PR DESCRIPTION
The value `.ixx` was mentioned twice with configuration setting `FILE_PATTERNS`