### PR TITLE
issue #11001 \copydoc does not respect section hierarchy in table of contents

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -711,6 +711,11 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
   m_relPath = parser->context.relPath;
   auto lang = parser->context.lang;
   const SectionInfo *sec = SectionManager::instance().find(parser->context.prefix+target);
+  if (sec==nullptr && !parser->context.prefix.isEmpty())
+  {
+    sec = SectionManager::instance().find(target);
+  }
+
   if (sec==nullptr && getLanguageFromFileName(target)==SrcLangExt::Markdown) // lookup as markdown file
   {
     sec = SectionManager::instance().find(markdownFileNameToId(target));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3298,6 +3298,13 @@ bool resolveLink(/* in */ const QCString &scName,
     AUTO_TRACE_EXIT("section");
     return TRUE;
   }
+  else if ((si=SectionManager::instance().find(linkRef)))
+  {
+    *resContext=si->definition();
+    resAnchor = si->label();
+    AUTO_TRACE_EXIT("section");
+    return TRUE;
+  }
   else if ((pd=Doxygen::exampleLinkedMap->find(linkRef))) // link to an example
   {
     *resContext=pd;


### PR DESCRIPTION
When linking to pages / sections prefer the version with the "prefix" (i.e. local version) but when no match is found also try the one without "prefix" (i.e. global version).