### PR TITLE
issue #11528 `\example{lineno}` does not generate the example

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -784,7 +784,7 @@ enum class VhdlSpecifier
  ETYPE(ObjcImpl,           None)            \
  ETYPE(ExportedInterface,  None)            \
  ETYPE(IncludedService,    None)            \
- ETYPE(ExampleLineno,      None)            \
+ ETYPE(ExampleLineno,      Doc)             \
 
 /** Wrapper class for the Entry type. Can be set only during construction.
  *  Packs the type together with category flags.


### PR DESCRIPTION
The category in respect to `ExampleLineno` was incorrect