### PR TITLE
Warning ` mismatch `#if` / `#endif` from preprocessor

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2259,6 +2259,7 @@ static std::unique_ptr<FileState> checkAndOpenFile(yyscan_t yyscanner,const QCSt
     }
     else
     {
+      addTerminalCharIfMissing(fs->fileBuf,'\n');
       fs->oldFileBuf    = state->inputBuf;
       fs->oldFileBufPos = state->inputBufPos;
     }


### PR DESCRIPTION
When an included file is not terminated by means of a `\n` it is possible that we get a warning like:
```
warning: More #if's than #endif's found (might be in an included file).
```
adding the `\n`, as already done with files that are "normally" preprocessed , solves the problem

Example: [example.tar.gz](https://github.com/user-attachments/files/19622658/example.tar.gz)

(Found as a side effect of #11528)
