### PR TITLE
Update doxygen.css for CSS validation

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -1597,7 +1597,7 @@ dl.invariant dt, dl.pre dt, dl.post dt {
 #projectnumber
 {
 	font-size: 50%;
-	font-family: 50% var(--font-family-title);
+	font-family: var(--font-family-title);
 	margin: 0px;
 	padding: 0px;
 }


### PR DESCRIPTION
Fixed validation issue:
https://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Fdocs.opencv.org%2F4.10.0%2Fd4%2Fd17%2Fnamespacecv_1_1aruco.html&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=en