### PR TITLE
Update doxygen.css to fix validation issue (II)

### DIFF
--- a/doc/doxygen_manual_chm.css
+++ b/doc/doxygen_manual_chm.css
@@ -155,10 +155,11 @@ dl.el {
 
 div.line {
 	font-family: 'JetBrains Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace, fixed;
-        font-size: 13px;
+    font-size: 13px;
 	min-height: 13px;
 	line-height: 1.2;
-	text-wrap: unrestricted;
+	text-wrap: wrap; 
+	word-break: break-all;
 	white-space: -moz-pre-wrap; /* Moz */
 	white-space: -pre-wrap;     /* Opera 4-6 */
 	white-space: -o-pre-wrap;   /* Opera 7 */

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -370,7 +370,8 @@ div.line {
 	font-size: 13px;
 	min-height: 13px;
 	line-height: 1.2;
-	text-wrap: unrestricted;
+	text-wrap: wrap; 
+	word-break: break-all;
 	white-space: -moz-pre-wrap; /* Moz */
 	white-space: -pre-wrap;     /* Opera 4-6 */
 	white-space: -o-pre-wrap;   /* Opera 7 */


### PR DESCRIPTION
It is unclear what `text-wrap: unrestricted` is supposed to do, as it is not standard and I cannot find any documentation but this page: http://www.css-infos.neolao.com/property/text-wrap

I replaced it with inherit to hopefully neuter it out.

https://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Fdocs.opencv.org%2F4.10.0%2Fd4%2Fd17%2Fnamespacecv_1_1aruco.html&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=en