### PR TITLE
issue #11549 Leftover variable in CSS (validation and possible logic issue)

### DIFF
--- a/src/resourcemgr.cpp
+++ b/src/resourcemgr.cpp
@@ -99,62 +99,6 @@ bool ResourceMgr::copyResourceAs(const QCString &name,const QCString &targetDir,
           }
         }
         break;
-      case Resource::Luminance:
-        {
-          QCString n = name;
-          n = n.left(n.length()-4)+".png"; // replace .lum by .png
-          const uint8_t *data = res->data;
-          uint16_t width   = (data[0]<<8)+data[1];
-          uint16_t height  = (data[2]<<8)+data[3];
-          ColoredImgDataItem images[2];
-          images[0].name    = n.data();
-          images[0].width   = width;
-          images[0].height  = height;
-          images[0].content = &data[4];
-          images[0].alpha   = nullptr;
-          images[1].name    = nullptr; // terminator
-          writeColoredImgData(targetDir,images);
-          return TRUE;
-        }
-        break;
-      case Resource::LumAlpha:
-        {
-          QCString n = name;
-          n = n.left(n.length()-5)+".png"; // replace .luma by .png
-          const uint8_t *data = res->data;
-          uint16_t width   = (data[0]<<8)+data[1];
-          uint16_t height  = (data[2]<<8)+data[3];
-          ColoredImgDataItem images[2];
-          images[0].name    = n.data();
-          images[0].width   = width;
-          images[0].height  = height;
-          images[0].content = &data[4];
-          images[0].alpha   = &data[4+width*height];
-          images[1].name    = nullptr; // terminator
-          writeColoredImgData(targetDir,images);
-          return TRUE;
-        }
-        break;
-      case Resource::CSS:
-        {
-          std::ofstream t = Portable::openOutputStream(pathName,append);
-          if (t.is_open())
-          {
-            QCString buf(res->size, QCString::ExplicitSize);
-            memcpy(buf.rawData(),res->data,res->size);
-            buf = replaceColorMarkers(buf);
-            if (name=="navtree.css")
-            {
-              t << substitute(buf,"$width",QCString().setNum(Config_getInt(TREEVIEW_WIDTH))+"px");
-            }
-            else
-            {
-              t << substitute(buf,"$doxygenversion",getDoxygenVersion());
-            }
-            return TRUE;
-          }
-        }
-        break;
       case Resource::SVG:
         {
           std::ofstream t = Portable::openOutputStream(pathName,append);

--- a/src/resourcemgr.h
+++ b/src/resourcemgr.h
@@ -24,7 +24,7 @@
 /** @brief Compiled resource */
 struct Resource
 {
-  enum Type { Verbatim, Luminance, LumAlpha, CSS, SVG };
+  enum Type { Verbatim, CSS, SVG };
   const char *category;
   const char *name;
   const unsigned char *data;

--- a/templates/html/navtree.css
+++ b/templates/html/navtree.css
@@ -86,7 +86,6 @@
   display:block;
   position: absolute;
   left: 0px;
-  width: $width;
   overflow : hidden;
 }
 


### PR DESCRIPTION
- `width: $width` is handled in navtree.js
- css files are not handled by means of `copyResource...` anymore
- handling of the contents of Luminance files is done solely in css files now, so no separate Luminance template files anymore