### PR TITLE
CSS resource files don't need special treatment

### DIFF
--- a/src/res2cc_cmd.py
+++ b/src/res2cc_cmd.py
@@ -55,12 +55,6 @@ class File(object):
     @staticmethod
     def factory(directory,subdir,fname):
         ext = splitext(fname)[1]
-        if ext=='.lum':  # TODO: remove this format
-            return LumFile(directory,subdir,fname)
-        if ext=='.luma': # TODO: remove this format
-            return LumaFile(directory,subdir,fname)
-        if ext=='.css':
-            return CSSFile(directory,subdir,fname)
         if ext=='.svg':
             return SVGFile(directory,subdir,fname)
         return VerbatimFile(directory,subdir,fname)
@@ -73,14 +67,6 @@ class VerbatimFile(File):
     def writeDirEntry(self,outputFile):
         print("  { \"%s\", \"%s\", %s_data, %s_len, Resource::Verbatim }," % (self.subdir,self.fileName,self.bareName,self.bareName), file=outputFile)
 
-class CSSFile(File):
-    def __init__(self,directory,subdir,fileName):
-        File.__init__(self,directory,subdir,fileName,"r")
-    def writeContents(self,outputFile):
-        self.writeBytes(self.inputFile.read(),outputFile)
-    def writeDirEntry(self,outputFile):
-        print("  { \"%s\", \"%s\", %s_data, %s_len, Resource::CSS }," % (self.subdir,self.fileName,self.bareName,self.bareName), file=outputFile)
-
 class SVGFile(File):
     def __init__(self,directory,subdir,fileName):
         File.__init__(self,directory,subdir,fileName,"r")
@@ -88,22 +74,6 @@ class SVGFile(File):
         self.writeBytes(self.inputFile.read(),outputFile)
     def writeDirEntry(self,outputFile):
         print("  { \"%s\", \"%s\", %s_data, %s_len, Resource::SVG }," % (self.subdir,self.fileName,self.bareName,self.bareName), file=outputFile)
-
-class LumFile(File):
-    def __init__(self,directory,subdir,fileName):
-        File.__init__(self,directory,subdir,fileName,"r")
-    def writeContents(self,outputFile):
-        self.convertToBytes(outputFile)
-    def writeDirEntry(self,outputFile):
-        print("  { \"%s\", \"%s\", %s_data, %s_len, Resource::Luminance }," % (self.subdir,self.fileName,self.bareName,self.bareName), file=outputFile)
-
-class LumaFile(File):
-    def __init__(self,directory,subdir,fileName):
-        File.__init__(self,directory,subdir,fileName,"r")
-    def writeContents(self,outputFile):
-        self.convertToBytes(outputFile)
-    def writeDirEntry(self,outputFile):
-        print("  { \"%s\", \"%s\", %s_data, %s_len, Resource::LumAlpha }," % (self.subdir,self.fileName,self.bareName,self.bareName), file=outputFile)
 
 def main():
     if len(sys.argv)<3:

--- a/src/resourcemgr.cpp
+++ b/src/resourcemgr.cpp
@@ -99,19 +99,6 @@ bool ResourceMgr::copyResourceAs(const QCString &name,const QCString &targetDir,
           }
         }
         break;
-      case Resource::CSS:
-        {
-          std::ofstream t = Portable::openOutputStream(pathName,append);
-          if (t.is_open())
-          {
-            QCString buf(res->size, QCString::ExplicitSize);
-            memcpy(buf.rawData(),res->data,res->size);
-            buf = replaceColorMarkers(buf);
-            t << substitute(buf,"$doxygenversion",getDoxygenVersion());
-            return TRUE;
-          }
-        }
-        break;
       case Resource::SVG:
         {
           std::ofstream t = Portable::openOutputStream(pathName,append);

--- a/src/resourcemgr.h
+++ b/src/resourcemgr.h
@@ -24,7 +24,7 @@
 /** @brief Compiled resource */
 struct Resource
 {
-  enum Type { Verbatim, CSS, SVG };
+  enum Type { Verbatim, SVG };
   const char *category;
   const char *name;
   const unsigned char *data;


### PR DESCRIPTION
As indicated in https://github.com/doxygen/doxygen/pull/11550#discussion_r2059771971 the css files don't need any special treatment anymore, so making them "Verbatim" and removing obsolete code. Removing in python script reverences to Luminance files as not used either.