### PR TITLE
Fix links not being generated

### DIFF
--- a/src/symbolresolver.h
+++ b/src/symbolresolver.h
@@ -68,12 +68,14 @@ class SymbolResolver
      *  @param args    Argument list associated with the symbol (for functions)
      *  @param checkCV Check const/volatile qualifiers (for methods)
      *  @param insideCode Is the symbol found in a code fragment
+     *  @param onlyLinkable Only search linkable definitions
      */
     const Definition *resolveSymbol(const Definition *scope,
                                     const QCString &name,
                                     const QCString &args=QCString(),
                                     bool checkCV=false,
-                                    bool insideCode=false
+                                    bool insideCode=false,
+                                    bool onlyLinkable=false
                                    );
 
     /** Checks if symbol \a item is accessible from within \a scope.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2289,7 +2289,7 @@ GetDefResult getDefsNew(const GetDefInput &input)
   }
   //printf("@@  -> found scope scope=%s member=%s out=%s\n",qPrint(input.scopeName),qPrint(input.memberName),qPrint(scope?scope->name():""));
   //
-  const Definition *symbol = resolver.resolveSymbol(scope,input.memberName,input.args,input.checkCV,input.insideCode);
+  const Definition *symbol = resolver.resolveSymbol(scope,input.memberName,input.args,input.checkCV,input.insideCode,true);
   //printf("@@  -> found symbol in=%s out=%s\n",qPrint(input.memberName),qPrint(symbol?symbol->qualifiedName():QCString()));
   if (symbol && symbol->definitionType()==Definition::TypeMember)
   {


### PR DESCRIPTION
Ignore non-linkable definitions when resolving links. This avoids links not being generated if a definition in a non-linkable file has higher priority than the one in the linkable file.

Add a flag `onlyLinkable` to `getResolvedSymbolRec` which makes it skip over unlinkable definitions. This flag is only set in `getDefsNew`. The result of this function is ultimately used in

- DocParser::handleLinkedWord via resolveRef
- DocRef::DocRef via resolveLink
- DocLink::DocLink via resolveLink
- linkifyText via getDefs

All these users ignore unlinkable definitions.

Fixes #11560.