### PR TITLE
Tables without any rows result in error in LaTeX

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -4975,6 +4975,7 @@ Token DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &
       {
         children().append<DocHtmlTable>(parser(),thisVariant(),tagHtmlAttribs);
         retval=children().get_last<DocHtmlTable>()->parse();
+        if (children().get_last<DocHtmlTable>()->children().empty()) children().pop_back();
       }
       break;
     case HtmlTagType::HTML_TR:
@@ -5270,6 +5271,7 @@ Token DocPara::handleHtmlStartTag(const QCString &tagName,const HtmlAttribList &
         {
           children().append<DocHtmlTable>(parser(),thisVariant(),emptyList);
           retval=children().get_last<DocHtmlTable>()->parseXml();
+          if (children().get_last<DocHtmlTable>()->children().empty()) children().pop_back();
         }
         else
         {


### PR DESCRIPTION
Based on the analyses in comment https://github.com/doxygen/doxygen/issues/8049#issuecomment-2888917859 where a lone `<table>` tag was identified which resulted in an empty table in the LaTeX output. which resulted in the error:
```
! Missing # inserted in alignment preamble.
<to be read again>
                   \cr
l.24 \end{longtabu}

?
```
when building the pdf file.

Source code:
```
/**
 * Defines the style from attributes and properties of an AbiWord <table>.
 */
void fetchAttributesFromAbiTable(const PP_AttrProp* pAP) {
}
```

Empty tables (i.e. tables without any rows are discarded).

Example: [example.tar.gz](https://github.com/user-attachments/files/20280015/example.tar.gz)
