### PR TITLE
issue #11583 The search functionality does not find items any more since SHA-1 2604e3f in large projects

### DIFF
--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -767,6 +767,7 @@ static void writeJavasScriptSearchDataPage(const QCString &baseName,const QCStri
       else if (si)
       {
         name = parseCommentAsHtml(si->definition(),nullptr,si->title(),si->fileName(),si->lineNr());
+        name = convertToXML(name);
         found = true;
       }
       if (!found) // fallback


### PR DESCRIPTION
The result for section titles was not properly converted to XML format (also required for `js` code).