### PR TITLE
Incorrect links in HTML with `IMPLICIT_DIR_DOCS`

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -12976,6 +12976,24 @@ void parseInput()
   findSectionsInDocumentation();
   g_s.end();
 
+  g_s.begin("Finding leftover anchors and sections...\n");
+  if (Config_getBool(IMPLICIT_DIR_DOCS))
+  {
+    for (const auto &si : SectionManager::instance())
+    {
+      QCString m_file   = si->fileName();
+      if (m_file.lower().endsWith("/readme.md"))
+      {
+        m_file = m_file.left(m_file.length()-9);
+        for (const auto &dd : *Doxygen::dirLinkedMap)
+        {
+          if (dd->name() == m_file) {si->setFileName(dd->getOutputFileBase()); break;}
+        }
+      }
+    }
+  }
+  g_s.end();
+
   g_s.begin("Transferring function references...\n");
   transferFunctionReferences();
   g_s.end();


### PR DESCRIPTION
As a side effect of issue #11583 (comment https://github.com/doxygen/doxygen/issues/11583#issuecomment-2905161805, https://github.com/doxygen/doxygen/issues/11583#issuecomment-2910145947 for example and https://github.com/doxygen/doxygen/issues/11583#issuecomment-2915986476) it was found that in the searchindex and also regarding links theer were some incorrect references. This was all due the possibility of `IMPLICIT_DIR_DOCS` was not taken into account for anchors / sections.

Regarding HTML this has been solved.