### PR TITLE
Handling of TIMESTAMP in html footer and header

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -871,6 +871,10 @@ static QCString substituteLatexKeywords(const QCString &file,
   result = substituteKeywords(file,result,
   {
     // keyword                     value getter
+    { "$datetime",                 [&]() { return dateToString(DateTimeType::DateTime);         } },
+    { "$date",                     [&]() { return dateToString(DateTimeType::Date);             } },
+    { "$time",                     [&]() { return dateToString(DateTimeType::Time);             } },
+    { "$year",                     [&]() { return yearToString();                               } },
     { "$latexdocumentpre",         [&]() { return theTranslator->latexDocumentPre();            } },
     { "$latexdocumentpost",        [&]() { return theTranslator->latexDocumentPost();           } },
     { "$generatedby",              [&]() { return generatedBy;                                  } },

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3728,10 +3728,6 @@ QCString substituteKeywords(const QCString &file,const QCString &s,const QCStrin
   {
     // keyword          value getter
     { "$title",           [&]() { return !title.isEmpty() ? title : projName;       } },
-    { "$datetime",        [&]() { return dateToString(DateTimeType::DateTime);      } },
-    { "$date",            [&]() { return dateToString(DateTimeType::Date);          } },
-    { "$time",            [&]() { return dateToString(DateTimeType::Time);          } },
-    { "$year",            [&]() { return yearToString();                            } },
     { "$doxygenversion",  [&]() { return getDoxygenVersion();                       } },
     { "$projectname",     [&]() { return projName;                                  } },
     { "$projectnumber",   [&]() { return projNum;                                   } },


### PR DESCRIPTION
In the commit 9509724 , based on the pull request #11448 the `$generatedby` was handled but not the (documented) `$datetime`, `$date`, `$time` and `$year`. The later is done with this patch