### PR TITLE
Fix XML generation for trailing return types with `delete` and `default`

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -749,6 +749,14 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
       {
         argsStr += "=0";
       }
+      if (stripKeyword(typeStr, "=default", false))
+      {
+        argsStr += "=default";
+      }
+      if (stripKeyword(typeStr, "=delete", false))
+      {
+        argsStr += "=delete";
+      }
       i=defStr.find("auto ");
       if (i!=-1)
       {

--- a/testing/108/class_c.xml
+++ b/testing/108/class_c.xml
@@ -63,13 +63,49 @@
         </inbodydescription>
         <location file="108_trailing_return_types.cpp" line="14" column="18"/>
       </memberdef>
+      <memberdef kind="function" id="class_c_1ac89d613451bc4c7c2eb12c5121bbc35b" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type><ref refid="class_c" kindref="compound">C</ref> &amp;</type>
+        <definition>C &amp; C::operator=</definition>
+        <argsstring>(C const &amp;)=delete</argsstring>
+        <name>operator=</name>
+        <qualifiedname>C::operator=</qualifiedname>
+        <param>
+          <type><ref refid="class_c" kindref="compound">C</ref> const &amp;</type>
+        </param>
+        <briefdescription>
+          <para>Deleted copy operator. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="108_trailing_return_types.cpp" line="17" column="9"/>
+      </memberdef>
+      <memberdef kind="function" id="class_c_1a878c06a8ad8ce12df17af2ea4a838850" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type><ref refid="class_c" kindref="compound">C</ref> &amp;</type>
+        <definition>C &amp; C::operator=</definition>
+        <argsstring>(C &amp;&amp;)=default</argsstring>
+        <name>operator=</name>
+        <qualifiedname>C::operator=</qualifiedname>
+        <param>
+          <type><ref refid="class_c" kindref="compound">C</ref> &amp;&amp;</type>
+        </param>
+        <briefdescription>
+          <para>Defaulted move operator. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="108_trailing_return_types.cpp" line="19" column="9"/>
+      </memberdef>
     </sectiondef>
     <briefdescription>
       <para>A structure. </para>
     </briefdescription>
     <detaileddescription>
     </detaileddescription>
-    <location file="108_trailing_return_types.cpp" line="5" column="1" bodyfile="108_trailing_return_types.cpp" bodystart="5" bodyend="15"/>
+    <location file="108_trailing_return_types.cpp" line="5" column="1" bodyfile="108_trailing_return_types.cpp" bodystart="5" bodyend="20"/>
     <listofallmembers>
       <member refid="class_c_1a04dd9ca5948792c146024e91dc007446" prot="public" virt="virtual">
         <scope>C</scope>
@@ -86,6 +122,14 @@
       <member refid="class_c_1a0b664e9b999fca39643fe34a77579794" prot="public" virt="pure-virtual">
         <scope>C</scope>
         <name>f_pure</name>
+      </member>
+      <member refid="class_c_1ac89d613451bc4c7c2eb12c5121bbc35b" prot="public" virt="non-virtual">
+        <scope>C</scope>
+        <name>operator=</name>
+      </member>
+      <member refid="class_c_1a878c06a8ad8ce12df17af2ea4a838850" prot="public" virt="non-virtual">
+        <scope>C</scope>
+        <name>operator=</name>
       </member>
     </listofallmembers>
   </compounddef>

--- a/testing/108_trailing_return_types.cpp
+++ b/testing/108_trailing_return_types.cpp
@@ -12,4 +12,9 @@ public:
     virtual auto f_final() -> int final;
     /** @brief Final and override. */
     virtual auto f_override_final() -> int override final;
+
+    /** @brief Deleted copy operator. */
+    auto operator=(C const&) -> C& = delete;
+    /** @brief Defaulted move operator. */
+    auto operator=(C&&) -> C& = default;
 };


### PR DESCRIPTION
When an operator is declared with a trailing return type and is explicitly defaulted or deleted, the `=default` and `=delete` text is incorrectly placed in the XML `definition` tag. This change puts these in the `argsstring` tag instead, as is the case for non-trailing return types.

This is a similar problem to that addressed by https://github.com/doxygen/doxygen/pull/11572.