### PR TITLE
issue #11619 Wrong Python module separator

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -763,6 +763,7 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
                  (compound->definitionType()==Definition::TypeFile ||
                   compound->definitionType()==Definition::TypePage ? TRUE : FALSE) :
                  FALSE;
+    if (compound && lang==SrcLangExt::Markdown) lang = compound->getLanguage();
     m_text = linkToText(lang,target,isFile);
     m_anchor = anchor;
     if (compound && compound->isLinkable()) // ref to compound


### PR DESCRIPTION
In case the reference is in a Python file, the right separator is used, but when in a markdown file the doxygen generic `::` separator is used and not replaced by the language specific separator of the reference i.e. in case of Python a `.`.