### PR TITLE
Input buffer overflow

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -1279,10 +1279,10 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           yyextra->inForEachExpression = FALSE;
                                           BEGIN( SkipStringS );
                                         }
-<SkipString>[^\"\\\r\n]*                {
+<SkipString>[^\"\\\r\n]{1,100}          {
                                           yyextra->code->codify(yytext);
                                         }
-<SkipStringS>[^\'\\\r\n]*               {
+<SkipStringS>[^\'\\\r\n]{1,100}         {
                                           yyextra->code->codify(yytext);
                                         }
 <SkipString,SkipStringS>{CPPC}|{CCS}       {

--- a/src/pre.l
+++ b/src/pre.l
@@ -607,10 +607,10 @@ WSopt [ \t\r]*
                                           outputChar(yyscanner,*yytext);
                                           BEGIN( CopyStringFtn );
                                         }
-<CopyString>[^\"\\\r\n]+                {
+<CopyString>[^\"\\\r\n]{1,1000}         {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
-<CopyStringCs>[^\"\r\n]+                {
+<CopyStringCs>[^\"\r\n]{1,1000}         {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <CopyStringCs>\"\"                      {
@@ -623,7 +623,7 @@ WSopt [ \t\r]*
                                           outputChar(yyscanner,*yytext);
                                           BEGIN( CopyLine );
                                         }
-<CopyStringFtnDouble>[^\"\\\r\n]+       {
+<CopyStringFtnDouble>[^\"\\\r\n]{1,1000} {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <CopyStringFtnDouble>\\.                {
@@ -633,7 +633,7 @@ WSopt [ \t\r]*
                                           outputChar(yyscanner,*yytext);
                                           BEGIN( CopyLine );
                                         }
-<CopyStringFtn>[^\'\\\r\n]+             {
+<CopyStringFtn>[^\'\\\r\n]{1,1000}      {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <CopyStringFtn>\\.                      {
@@ -652,7 +652,7 @@ WSopt [ \t\r]*
                                             BEGIN( CopyLine );
                                           }
                                         }
-<CopyRawString>[^)]+                    {
+<CopyRawString>[^)]{1,1000}             {
                                           outputArray(yyscanner,yytext,yyleng);
                                         }
 <CopyRawString>.                        {

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5141,7 +5141,7 @@ NONLopt [^\n]*
                                           if (yyextra->insidePHP)
                                           {
                                             yyextra->lastCopyArgStringContext=YY_START;
-                                            BEGIN(CopyArgPHPString);
+                                            BEGIN(SkipPHPString);
                                           }
                                         }
 <ReadFuncArgType,ReadTempArgs,CopyArgString,CopyArgPHPString,CopyArgRound,CopyArgSquare,CopyArgSharp>"<="|">="|"<=>" {


### PR DESCRIPTION
When having a, very,  long string as an argument in e.g. PHP or C++ we get am error like:
```
input buffer overflow, can't enlarge buffer because scanner uses REJECT
```
which can be overcome by enlarging the lex buffers (CMake option `enlarge_lex_buffers`) but is also possible to limit the search pattern from a `+` pattern to a number of elements `{1,n}` pattern.

For PHP the string argument should, analogous to C++ not be a copy rule but a skip rule (`scanner.l`)

Originally found by Fossies for the groupoffice project.

Example: [example.tar.gz](https://github.com/user-attachments/files/20852260/example.tar.gz)
