### PR TITLE
issue #11631 Doxygen generates incorrect links for nested README.md files in subfolders

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -757,6 +757,20 @@ DocRef::DocRef(DocParser *parser,DocNodeVariant *parent,const QCString &target,c
     AUTO_TRACE_EXIT("section");
     return;
   }
+  else if (Config_getBool(IMPLICIT_DIR_DOCS) && target.lower().endsWith("/readme.md"))
+  {
+    QCString dirTarget = target.left(target.length() - 9);
+    for (const auto &dd : *Doxygen::dirLinkedMap)
+    {
+      if (dd->name() == dirTarget)
+      {
+        m_text = target;
+        m_file = dd->getOutputFileBase();
+        AUTO_TRACE_EXIT("directory");
+        return;
+      }
+    }
+  }
   else if (resolveLink(context,target,true,&compound,anchor,lang,parser->context.prefix))
   {
     bool isFile = compound ?


### PR DESCRIPTION
In case of a readme file and implicit directories documentation set create a link to the correct file (describing the directory)