### PR TITLE
Handling of backticks in bibliography

### DIFF
--- a/templates/html/bib2xhtml.pl
+++ b/templates/html/bib2xhtml.pl
@@ -119,6 +119,10 @@ sub html_ent {
 	s/\\rceil\b/&rceil;/g;
 	s/\\lfloor\b/&lfloor;/g;
 	s/\\rfloor\b/&rfloor;/g;
+	s/``/&ldquo;/g;
+	s/''/&rdquo;/g;
+	s/`/&lsquo;/g;
+	s/'/&rsquo;/g;
 }
 $bdebug = 0;
 foreach (@ARGV) {


### PR DESCRIPTION
When looking at the bibliography we see that there is a difference in the handling of backticks and single quotes between LaTeX and the other formats. In LaTeX they are translated in a similar way as nowadays is done in Markdown but in the other formats they are shown literally. The bibliography items are,correctly, not run through the markdown processor as the entries are in LaTeX style. By replacing the backticks and single quotes by the required HTML entities in the rapper script the problem is solved.

Example: [example.tar.gz](https://github.com/user-attachments/files/21004967/example.tar.gz)
