### PR TITLE
Imp/dot n plantuml improvements

### DIFF
--- a/doc_internal/Doxyfile.in
+++ b/doc_internal/Doxyfile.in
@@ -350,6 +350,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 DOT_IMAGE_FORMAT       = svg
 INTERACTIVE_SVG        = YES
 DOT_PATH               =
+DOT_DRY_RUN            = NO
 DOTFILE_DIRS           =
 DIA_PATH               =
 DIAFILE_DIRS           =

--- a/src/config.xml
+++ b/src/config.xml
@@ -4228,6 +4228,21 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    <option type='bool' id='DOT_DRY_RUN' defval='0' depends='HAVE_DOT'>
+      <docs>
+<![CDATA[
+ If the \c DOT_DRY_RUN tag is set to \c YES Doxygen will omit running Graphiz' dot.
+ As a result only the dot files are generated and not the graph images. Running
+ dot from Doxygen can be slow, especially for large projects. You might want to
+ generate the graph images yourself by running dot with the -O option as shown
+ in the example below:
+ find . -type f -name "*.dot" -print0 | xargs -0 dot -Tsvg -O
+
+ Please note: The options DOT_CLEANUP, INTERACTIVE_SVG, DOT_MULTI_TARGETS and
+ DOT_PATH are ignored.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='GENERATE_LEGEND' defval='1' depends='HAVE_DOT'>
       <docs>
 <![CDATA[

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -306,7 +306,7 @@ void writeDotImageMapFromFile(TextStream &t,
     return;
   }
 
-  if (imgExt=="svg") // vector graphics
+  if (imgExt.endsWith("svg")) // vector graphics
   {
     QCString svgName = outDir+"/"+baseName+".svg";
     DotFilePatcher::writeSVGFigureLink(t,relPath,baseName,svgName);

--- a/src/dotcallgraph.cpp
+++ b/src/dotcallgraph.cpp
@@ -120,7 +120,7 @@ void DotCallGraph::determineTruncatedNodes(DotNodeDeque &queue)
 DotCallGraph::DotCallGraph(const MemberDef *md,bool inverse)
 {
   m_inverse = inverse;
-  m_diskName = md->getOutputFileBase()+"_"+md->anchor();
+  m_diskName = md->anchor();
   m_scope    = md->getOuterScope();
   QCString uniqueId = getUniqueId(md);
   QCString name;

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -138,10 +138,14 @@ static TextStream &common_attributes(TextStream &t, const DirDef *const dir, con
 {
   QCString url = dir->getOutputFileBase();
   addHtmlExtensionIfMissing(url);
-  return t <<
+  t <<
     "style=\""   << getDirectoryBorderStyle(prop) << "\", "
     "URL=\""     << url << "\","
     "tooltip=\"" << escapeTooltip(dir->briefDescriptionAsTooltip()) << "\"";
+  if (Config_getBool(DOT_DRY_RUN)) {
+    t << ", target=\"_parent\"";
+  }
+  return t;
 }
 
 /**

--- a/src/dotfilepatcher.cpp
+++ b/src/dotfilepatcher.cpp
@@ -582,6 +582,13 @@ static void writeSVGNotSupported(TextStream &out)
 bool DotFilePatcher::writeSVGFigureLink(TextStream &out,const QCString &relPath,
                         const QCString &baseName,const QCString &absImgName)
 {
+  if (Config_getBool(DOT_DRY_RUN)) {
+    // Using CSS-stylesheet to scale graphic in HTML. Links within SVG will use target="_parent" to open destination in current tab.
+    out << "<embed src=\""
+        << relPath << baseName << "." << getDotImageExtension() << "\" style=\"max-width: 100%; object-fit: contain\" />";
+    return TRUE;
+  }
+
   int width=600,height=600;
   if (!readSVGSize(absImgName,&width,&height))
   {
@@ -621,6 +628,18 @@ bool DotFilePatcher::writeSVGFigureLink(TextStream &out,const QCString &relPath,
 bool DotFilePatcher::writeVecGfxFigure(TextStream &out,const QCString &baseName,
                                  const QCString &figureName)
 {
+  if (Config_getBool(DOT_DRY_RUN)) {
+    out << "\\nopagebreak\n"
+          "\\begin{figure}[H]\n"
+          "\\begin{center}\n"
+          "\\leavevmode\n"
+          "\\includegraphics[]"
+          "{" << baseName << "}\n"
+          "\\end{center}\n"
+          "\\end{figure}\n";
+    return TRUE;
+  }
+
   int width=400,height=550;
   if (Config_getBool(USE_PDFLATEX))
   {

--- a/src/dotlegendgraph.cpp
+++ b/src/dotlegendgraph.cpp
@@ -29,7 +29,7 @@ void DotLegendGraph::writeGraph(const QCString &path)
   TextStream ts;
   DotGraph::writeGraph(ts, GraphOutputFormat::BITMAP, EmbeddedOutputFormat::Html, path, "", "", FALSE, 0);
 
-  if (getDotImageExtension()=="svg")
+  if (getDotImageExtension().endsWith("svg"))
   {
     DotManager::instance()->
       createFilePatcher(absBaseName()+Config_getString(HTML_FILE_EXTENSION))->
@@ -72,4 +72,3 @@ QCString DotLegendGraph::getMapLabel() const
 {
   return "";
 }
-

--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -290,6 +290,11 @@ QCString getBaseNameOfOutput(const QCString &output)
 
 bool DotRunner::run()
 {
+  if (Config_getBool(DOT_DRY_RUN)) {
+    // this is unexpected in dry run case; maybe we should report an error instead of silently skipping
+    return TRUE;
+  }
+
   int exitCode=0;
 
   QCString dotArgs;
@@ -370,5 +375,3 @@ error:
     exitCode,m_dotExe,dotArgs);
   return FALSE;
 }
-
-

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -686,7 +686,7 @@ void HtmlDocVisitor::operator()(const DocVerbatim &s)
         QCString htmlOutput = Config_getString(HTML_OUTPUT);
         QCString imgExt = getDotImageExtension();
         PlantumlManager::OutputFormat format = PlantumlManager::PUML_BITMAP;	// default : PUML_BITMAP
-        if (imgExt=="svg")
+        if (imgExt.endsWith("svg"))
         {
           format = PlantumlManager::PUML_SVG;
         }
@@ -1846,7 +1846,7 @@ void HtmlDocVisitor::operator()(const DocPlantUmlFile &df)
   QCString htmlOutput = Config_getString(HTML_OUTPUT);
   QCString imgExt = getDotImageExtension();
   PlantumlManager::OutputFormat format = PlantumlManager::PUML_BITMAP;	// default : PUML_BITMAP
-  if (imgExt=="svg")
+  if (imgExt.endsWith("svg"))
   {
     format = PlantumlManager::PUML_SVG;
   }
@@ -2262,7 +2262,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   QCString baseName=makeBaseName(fileName);
   QCString outDir = Config_getString(HTML_OUTPUT);
   QCString imgExt = getDotImageExtension();
-  if (imgExt=="svg")
+  if (imgExt.endsWith("svg"))
   {
     PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />\n";
@@ -2423,4 +2423,3 @@ void HtmlDocVisitor::forceStartParagraph(const Node &n)
     if (needsTag) m_t << "<p>";
   }
 }
-

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4085,7 +4085,7 @@ void writeGraphInfo(OutputList &ol)
   int s = legendDocs.find("<center>");
   int e = legendDocs.find("</center>");
   QCString imgExt = getDotImageExtension();
-  if (imgExt=="svg" && s!=-1 && e!=-1)
+  if (imgExt.endsWith("svg") && s!=-1 && e!=-1)
   {
     legendDocs = legendDocs.left(s+8) + "[!-- " + "SVG 0 --]" + legendDocs.mid(e);
     //printf("legendDocs=%s\n",qPrint(legendDocs));

--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -21,6 +21,7 @@
 
 #include "containers.h"
 #include "qcstring.h"
+#include <vector>
 
 #define DIVIDE_COUNT            4
 #define MIN_PLANTUML_COUNT      8
@@ -29,11 +30,11 @@ class QCString;
 struct PlantumlContent
 {
   PlantumlContent(const QCString &content_, const QCString &outDir_, const QCString &srcFile_, int srcLine_)
-     : content(content_), outDir(outDir_), srcFile(srcFile_), srcLine(srcLine_) {}
-  QCString content;
-  QCString outDir;
-  QCString srcFile;
-  int srcLine;
+     : outDir(outDir_), srcFile(srcFile_), srcLine(srcLine_) {content_vec.push_back(content_);}
+    QCString outDir;
+    QCString srcFile;
+    int srcLine;
+    ::std::vector<QCString> content_vec;
 };
 
 /** Singleton that manages plantuml relation actions */
@@ -83,8 +84,14 @@ class PlantumlManager
                 const QCString &puContent,
                 const QCString &srcFile,
                 int srcLine);
-    void generatePlantUmlFileNames(const QCString &fileName,OutputFormat format,const QCString &outDir,
-                                                    QCString &baseName,QCString &puName,QCString &imgName);
+    
+    /**
+     * Generate unique PlantUML file names.
+     * @return true if new file names were generated, false if existing names were reused.
+     */
+    bool generatePlantUmlFileNames(const QCString &fileName,OutputFormat format,const QCString &outDir,
+                                   QCString &baseName,QCString &puName,QCString &imgName,
+                                   const QCString &content);
 
     FilesMap   m_pngPlantumlFiles;
     FilesMap   m_svgPlantumlFiles;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6804,6 +6804,10 @@ bool mainPageHasTitle()
 QCString getDotImageExtension()
 {
   QCString imgExt = Config_getEnumAsString(DOT_IMAGE_FORMAT);
+  if (Config_getBool(DOT_DRY_RUN)) {
+    // use ".dot.png", "dot.jpg", ... ending as this is the default if dot is executed with -O option.
+    imgExt = "dot." + imgExt;
+  }
   int i= imgExt.find(':'); // strip renderer part when using e.g. 'png:cairo:gd' as format
   return i==-1 ? imgExt : imgExt.left(i);
 }


### PR DESCRIPTION
There are some improvements regarding speed especially for systems with expensive file i/o or calls to executables:
- option DOT_DRY_RUN does not call dot from doxygen. Generation of files can be done afterwards e.g. using xargs dot.exe.
- there's a look-up table that checks if the dot-graph has been already written to a file. This avoids file i/o checking if the file already exists.
- the dot-files do not start with getOutputFileBase(). This reduces the number of files with identical content and also the time to render the graphs.
- there's a look-up table that checks if the uml-graph has been already processed. If yes, it is skipped. 
- PlantUML file inline_umlgraph_* is now split up into multiple files. PlantUML supports only multi-threading for separated files. Thus, writing all graphs to one file uses only one thread in plantuml. 
- The inline_umlgraph files contain now a reference to the origin. This helps to fix syntax issues in the graphs. 
- Plantuml syntax errors are now reported as warnings.

This is my first pull request, so consider it as a draft proposal far away from been perfect and fully tested.
