### PR TITLE
Fix findFileDef incorrectly flagging ambiguities

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3474,7 +3474,9 @@ FileDef *findFileDef(const FileNameLinkedMap *fnMap,const QCString &n,bool &ambi
       {
         FileDef *fd = fd_p.get();
         QCString fdStripPath = stripFromIncludePath(fd->getPath());
-        if (path.isEmpty() || fdStripPath.right(pathStripped.length())==pathStripped)
+        if (path.isEmpty() ||
+            (!pathStripped.isEmpty() && fdStripPath.endsWith(pathStripped)) ||
+            (pathStripped.isEmpty() && fdStripPath.isEmpty()))
         {
           count++;
           lastMatch=fd;


### PR DESCRIPTION
Fix issues when comparing stripped paths due to improper handling of empty stripped paths.

Fixes: doxygen/doxygen#6178
Fixes: doxygen/doxygen#11261