### PR TITLE
Improved handling of nested tables

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1256,7 +1256,7 @@ void LatexDocVisitor::writeStartTableCommand(const DocNodeVariant *n,size_t cols
 {
   if (isTableNested(n))
   {
-    m_t << "\n\\begin{DoxyTableNested}{" << cols << "}";
+    m_t << "\\begin{DoxyTableNested}{" << cols << "}";
   }
   else
   {


### PR DESCRIPTION
In case of a nested table an extra empty line was shown in the latex output, this has been removed.
(When the user wants an extra line he bac always use e.g. a `\n`)