### PR TITLE
issue #11708 [BUG] Variadic macro expansion doesn't work when the arguments contain comments starting with //

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -897,6 +897,9 @@ WSopt [ \t\r]*
 <FindDefineArgs>{CPPC}[/!].*\n          { // replace C++ single line style comment by C style comment
                                           yyextra->defArgsStr+=QCString("/**")+&yytext[3]+" */";
                                         }
+<FindDefineArgs>{CPPC}.*\n              { // replace C++ single line style comment by C style comment
+                                          yyextra->defArgsStr+=QCString("/*")+&yytext[2]+" */";
+                                        }
 <FindDefineArgs>\"                      {
                                           yyextra->defArgsStr+=*yytext;
                                           BEGIN(ReadString);


### PR DESCRIPTION
When having:
```
/**
 * @brief My struct A.
 */
typedef PACK(struct {
    int struct_a_1; ///< Description of struct_a_1
    int struct_a_2; // This comment causes the problem
}) my_structA_t;
```
and
```
PREDEFINED             = PACK(...)=__VA_ARGS__
```
this will translate during the preprocessing into:
```
/**
 * @brief My struct A.
 */
typedef
// This comment causes the problem
 struct {     int struct_a_1; /**< Description of struct_a_1
 */    int struct_a_2;  } my_structA_t;
```
Note the strange place of the `//` comment

The problem is that the `//` comment lands in the "catch all" rule:
```
<*>{CPPC}[/!]?
```
instead of having an own rule with the `FindDefineArgs` which retains the comment at the regular place.