### PR TITLE
Disabling Mathjax 4 packages

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -482,7 +482,16 @@ static QCString substituteHtmlKeywords(const QCString &file,
       for (const auto &s : mathJaxExtensions)
       {
         if (!first) mathJaxJs+= ",";
-        mathJaxJs+= "\n        '[+]': ['"+s+"']";
+        if (s.at(0) =='-')
+        {
+          mathJaxJs+= "\n        '[-]': ['";
+          mathJaxJs+=s.data()+1;
+          mathJaxJs+="']";
+        }
+        else
+        {
+          mathJaxJs+= "\n        '[+]': ['"+s+"']";
+        }
         first = false;
       }
       mathJaxJs += "\n    }\n";
@@ -510,9 +519,12 @@ static QCString substituteHtmlKeywords(const QCString &file,
                       "    load: [";
           for (const auto &s : mathJaxExtensions)
           {
-            if (!first) mathJaxJs+= ",";
-            mathJaxJs+= "'[tex]/"+s+"'";
-            first = false;
+            if (s.at(0) !='-')
+            {
+              if (!first) mathJaxJs+= ",";
+              mathJaxJs+= "'[tex]/"+s+"'"; // packages preceded by a minus sign should not be loaded
+              first = false;
+            }
           }
           mathJaxJs+= "]\n"
                       "  },\n";


### PR DESCRIPTION
With Mathjax version 4 quite a few packages are automatically loaded, though this can lead to inconsistencies with, the default use of, older versions  Mathjax versions. An example of this is the use of the `_` inside `\text` (the default Mathjax 4 behavior is the same as with regular LaTeX, see also https://github.com/doxygen/doxygen/pull/11705#discussion_r2265208555), by disabling the `textmacros` the old behavior can be obtained again (see also https://docs.mathjax.org/en/latest/upgrading/whats-new-4.0/input.html#textmacros-enabled-by-default) which is also valid for the underscore handling inside the `\text`.

By prepending a `-` (minus sign) to the package name in the `MATHJAX_EXTENSIONS` the package will be disabled.