### PR TITLE
Spurious asterisk after preprocessing when using macros

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -928,9 +928,8 @@ WSopt [ \t\r]*
                                           BEGIN(FindDefineArgs);
                                         }
 <ArgCopyCComment>\n                     {
-                                          yyextra->defArgsStr+=' ';
+                                          yyextra->defArgsStr+=yytext;
                                           yyextra->yyLineNr++;
-                                          outputChar(yyscanner,'\n');
                                         }
 <ArgCopyCComment>.                      {
                                           yyextra->defArgsStr+=yytext;


### PR DESCRIPTION
When having something like:
```
typedef PACK(enum {
    ENUMA, /**< @brief The asterisk character at the beginning of the next line is not removed, but
            * becomes part of the documentation. */
}) my_enum_t;
```
and a `PREDEFINED `PACK` this leads to an `*` in the output before the word "becomes. This is due to the, incorrect, joining of lines in case of a multi line block of comment.

This is based on the comment: https://github.com/doxygen/doxygen/issues/11708#issuecomment-3183502931

Example: [example.tar.gz](https://github.com/user-attachments/files/21758855/example.tar.gz)
