### PR TITLE
Incorrect warning regarding type and start of backtick type of block

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -764,12 +764,10 @@ SLASHopt [/]*
 				     }
   				   }
 <VerbatimCode>("```"[`]*|"~~~"[~]*) { /* end of markdown code block */
-                                     if (yytext[0]=='`' && (yyextra->blockName=="`" || yyextra->blockName=="``")) // ``` inside single quote block
+                                     if (yytext[0]=='`' && (yyextra->blockName=="`" || yyextra->blockName=="``")) // ``` type block inside single or double backtick "block"
                                      {
                                        // copy the end block marker
                                        copyToOutput(yyscanner,yytext,yyleng);
-                                       yyextra->inVerbatim=false;
-                                       BEGIN(yyextra->lastCommentContext);
                                      }
                                      else
                                      {


### PR DESCRIPTION
When having:
```
# Installing the AWS CLI v2 from source

* to `pyproject.toml

The
```
https://awscli.amazonaws.com/awscli.tar.gz
```
```
we get the warning:
```
source-install.md:9: warning: Reached end of file while still searching closing '```' of a verbatim block starting at line 8
```
this looks like a regression on:
```
Commit: 9defcc3ff78869455687bd8c39ccfe7b75b8aebe [9defcc3]
Date: Sunday, June 22, 2025 3:03:57 PM
issue #11621 Markdown code handling `` ` `` gets confused by unterminated `` ` `` within (introduced by 1.11)
```

Example:  [example.tar.gz](https://github.com/user-attachments/files/21812271/example.tar.gz)

(seen by quite a few projects on Fossies)
