### PR TITLE
Remove redundant test on `DOT_NUM_THREADS`

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2029,17 +2029,12 @@ void Config::checkAndCorrect(bool quiet, const bool check)
   }
 
   //------------------------
-  // clip number of threads
   int dotNumThreads = Config_getInt(DOT_NUM_THREADS);
-  if (dotNumThreads>512)
-  {
-    dotNumThreads=512;
-  }
-  else if (dotNumThreads<=0)
+  if (dotNumThreads<=0)
   {
     dotNumThreads=std::max(2u,std::thread::hardware_concurrency()+1);
+    Config_updateInt(DOT_NUM_THREADS,dotNumThreads);
   }
-  Config_updateInt(DOT_NUM_THREADS,dotNumThreads);
 
   //------------------------
   // check plantuml path


### PR DESCRIPTION
Remove redundant test on `DOT_NUM_THREADS`, the test on the maximum is already done when reading the value from the configuration file.