### PR TITLE
Don't load Mathjax in source browser files

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2995,7 +2995,7 @@ void ClassDefImpl::writeDocumentation(OutputList &ol) const
   {
     memListFile = getMemberListFileName();
   }
-  startFile(ol,getOutputFileBase(),name(),pageTitle,hli,!generateTreeView,QCString(),0,memListFile);
+  startFile(ol,getOutputFileBase(),false,name(),pageTitle,hli,!generateTreeView,QCString(),0,memListFile);
   if (!generateTreeView)
   {
     if (getOuterScope()!=Doxygen::globalScope)
@@ -3143,7 +3143,7 @@ void ClassDefImpl::writeMemberList(OutputList &ol) const
   }
 
   QCString memListFile = getMemberListFileName();
-  startFile(ol,memListFile,memListFile,theTranslator->trMemberList(),hli,!generateTreeView,getOutputFileBase());
+  startFile(ol,memListFile,false,memListFile,theTranslator->trMemberList(),hli,!generateTreeView,getOutputFileBase());
   if (!generateTreeView)
   {
     if (getOuterScope()!=Doxygen::globalScope)

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -529,7 +529,7 @@ void ConceptDefImpl::writeDocumentation(OutputList &ol)
   {
     pageTitle = theTranslator->trConceptReference(displayName());
   }
-  startFile(ol,getOutputFileBase(),name(),pageTitle,HighlightedItem::ConceptVisible,!generateTreeView);
+  startFile(ol,getOutputFileBase(),false,name(),pageTitle,HighlightedItem::ConceptVisible,!generateTreeView);
 
   // ---- navigation part
   if (!generateTreeView)

--- a/src/dirdef.cpp
+++ b/src/dirdef.cpp
@@ -565,7 +565,7 @@ void DirDefImpl::writeDocumentation(OutputList &ol)
     title=theTranslator->trDirReference(m_dispName);
   }
   AUTO_TRACE("title={}",title);
-  startFile(ol,getOutputFileBase(),name(),title,HighlightedItem::Files,!generateTreeView);
+  startFile(ol,getOutputFileBase(),false,name(),title,HighlightedItem::Files,!generateTreeView);
 
   if (!generateTreeView)
   {
@@ -957,7 +957,7 @@ void DirRelation::writeDocumentation(OutputList &ol)
   QCString title=theTranslator->trDirRelation(
                  (m_src->displayName()+" -> "+m_dst->dir()->shortName()));
   AUTO_TRACE("title={}",title);
-  startFile(ol,getOutputFileBase(),getOutputFileBase(),
+  startFile(ol,getOutputFileBase(),false,getOutputFileBase(),
             title,HighlightedItem::None,!generateTreeView,m_src->getOutputFileBase());
 
   if (!generateTreeView)

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -392,7 +392,7 @@ void DocbookGenerator::cleanup()
 }
 
 
-void DocbookGenerator::startFile(const QCString &name,const QCString &,const QCString &,int,int)
+void DocbookGenerator::startFile(const QCString &name,bool,const QCString &,const QCString &,int,int)
 {
 DB_GEN_C
   QCString fileName=name;

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -122,7 +122,7 @@ class DocbookGenerator : public OutputGenerator, public OutputGenIntf
     void addCodeGen(OutputCodeList &list) override;
     void cleanup() override;
     void writeDoc(const IDocNodeAST *node,const Definition *ctx,const MemberDef *md,int id) override;
-    void startFile(const QCString &name,const QCString &manName,const QCString &title,int id,int hierarchyLevel) override;
+    void startFile(const QCString &name,bool isSource,const QCString &manName,const QCString &title,int id,int hierarchyLevel) override;
     void endFile() override;
 
     void writeSearchInfo() override {DB_GEN_EMPTY}

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -9966,7 +9966,7 @@ static void generateExampleDocs()
       intf->resetCodeParserState();
     }
     QCString n=pd->getOutputFileBase();
-    startFile(*g_outputList,n,n,pd->name());
+    startFile(*g_outputList,n,false,n,pd->name());
     startTitle(*g_outputList,n);
     g_outputList->docify(pd->name());
     endTitle(*g_outputList,n,QCString());

--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -885,7 +885,7 @@ void FileDefImpl::writeDocumentation(OutputList &ol)
 
   if (getDirDef())
   {
-    startFile(ol,getOutputFileBase(),name(),pageTitle,HighlightedItem::FileVisible,!generateTreeView);
+    startFile(ol,getOutputFileBase(),false,name(),pageTitle,HighlightedItem::FileVisible,!generateTreeView);
     if (!generateTreeView)
     {
       getDirDef()->writeNavigationPath(ol);
@@ -922,7 +922,7 @@ void FileDefImpl::writeDocumentation(OutputList &ol)
   }
   else
   {
-    startFile(ol,getOutputFileBase(),name(),pageTitle,HighlightedItem::FileVisible,!generateTreeView);
+    startFile(ol,getOutputFileBase(),false,name(),pageTitle,HighlightedItem::FileVisible,!generateTreeView);
     if (!generateTreeView)
     {
       ol.endQuickIndices();
@@ -1152,7 +1152,7 @@ void FileDefImpl::writeSourceHeader(OutputList &ol)
   bool genSourceFile = !isDocFile && generateSourceFile();
   if (getDirDef())
   {
-    startFile(ol,getSourceFileBase(),QCString(),pageTitle,HighlightedItem::FileVisible,
+    startFile(ol,getSourceFileBase(),true,QCString(),pageTitle,HighlightedItem::FileVisible,
         !generateTreeView,
         !isDocFile && genSourceFile ? QCString() : getOutputFileBase(),
         0);
@@ -1167,7 +1167,7 @@ void FileDefImpl::writeSourceHeader(OutputList &ol)
   }
   else
   {
-    startFile(ol,getSourceFileBase(),QCString(),pageTitle,HighlightedItem::FileVisible,false,
+    startFile(ol,getSourceFileBase(),true,QCString(),pageTitle,HighlightedItem::FileVisible,false,
         !isDocFile && genSourceFile ? QCString() : getOutputFileBase(),
         0);
     startTitle(ol,getSourceFileBase());

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1188,7 +1188,7 @@ void GroupDefImpl::writeDocumentation(OutputList &ol)
     ++hierarchyLevel;
   }
 
-  startFile(ol,getOutputFileBase(),name(),m_title,HighlightedItem::Topics,
+  startFile(ol,getOutputFileBase(),false,name(),m_title,HighlightedItem::Topics,
             FALSE /* additionalIndices*/, QCString() /*altSidebarName*/, hierarchyLevel);
 
   ol.startHeaderSection();

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -325,7 +325,8 @@ static QCString substituteHtmlKeywords(const QCString &file,
                                        const QCString &str,
                                        const QCString &title,
                                        const QCString &relPath,
-                                       const QCString &navPath=QCString())
+                                       const QCString &navPath=QCString(),
+                                       bool isSource = false)
 {
   // Build CSS/JavaScript tags depending on treeview, search engine settings
   QCString cssFile;
@@ -452,7 +453,7 @@ static QCString substituteHtmlKeywords(const QCString &file,
     searchBox = getSearchBox(serverBasedSearch, relPath, FALSE);
   }
 
-  if (mathJax)
+  if (mathJax && !isSource)
   {
     auto mathJaxVersion = Config_getEnum(MATHJAX_VERSION);
     QCString path = Config_getString(MATHJAX_RELPATH);
@@ -1537,7 +1538,7 @@ void HtmlGenerator::writeFooterFile(TextStream &t)
 
 static std::mutex g_indexLock;
 
-void HtmlGenerator::startFile(const QCString &name,const QCString &,
+void HtmlGenerator::startFile(const QCString &name,bool isSource,const QCString &,
                               const QCString &title,int /*id*/, int /*hierarchyLevel*/)
 {
   //printf("HtmlGenerator::startFile(%s)\n",qPrint(name));
@@ -1555,7 +1556,7 @@ void HtmlGenerator::startFile(const QCString &name,const QCString &,
   }
 
   m_lastFile = fileName;
-  m_t << substituteHtmlKeywords(g_header_file,g_header,convertToHtml(filterTitle(title)),m_relPath);
+  m_t << substituteHtmlKeywords(g_header_file,g_header,convertToHtml(filterTitle(title)),m_relPath,QCString(),isSource);
 
   m_t << "<!-- " << theTranslator->trGeneratedBy() << " Doxygen "
       << getDoxygenVersion() << " -->\n";

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -124,7 +124,7 @@ class HtmlGenerator : public OutputGenerator, public OutputGenIntf
     void addCodeGen(OutputCodeList &list) override;
     void cleanup() override;
     void writeDoc(const IDocNodeAST *node,const Definition *,const MemberDef *,int id) override;
-    void startFile(const QCString &name,const QCString &manName,const QCString &title,int id, int hierarchyLevel) override;
+    void startFile(const QCString &name,bool isSource,const QCString &manName,const QCString &title,int id, int hierarchyLevel) override;
     void endFile() override;
 
     void writeFooter(const QCString &navPath) override;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -398,7 +398,7 @@ void endTitle(OutputList &ol,const QCString &fileName,const QCString &name)
   ol.endHeaderSection();
 }
 
-void startFile(OutputList &ol,const QCString &name,const QCString &manName,
+void startFile(OutputList &ol,const QCString &name,bool isSource,const QCString &manName,
                const QCString &title,HighlightedItem hli,bool additionalIndices,
                const QCString &altSidebarName, int hierarchyLevel, const QCString &allMembersFile)
 {
@@ -406,7 +406,7 @@ void startFile(OutputList &ol,const QCString &name,const QCString &manName,
   bool generateTreeView = Config_getBool(GENERATE_TREEVIEW);
   bool fullSidebar      = Config_getBool(FULL_SIDEBAR);
   bool quickLinksAfterSplitbar = !disableIndex && generateTreeView && fullSidebar;
-  ol.startFile(name,manName,title,hierarchyLevel);
+  ol.startFile(name,isSource,manName,title,hierarchyLevel);
   ol.startQuickIndices();
   if (!disableIndex && !quickLinksAfterSplitbar)
   {
@@ -1133,7 +1133,7 @@ static void writeHierarchicalIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trClassHierarchy();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"hierarchy",QCString(), title, HighlightedItem::ClassHierarchy);
+  startFile(ol,"hierarchy",false,QCString(), title, HighlightedItem::ClassHierarchy);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -1208,7 +1208,7 @@ static void writeGraphicalClassHierarchy(OutputList &ol)
   ol.disableAllBut(OutputType::Html);
   LayoutNavEntry *lne = LayoutDocManager::instance().rootNavEntry()->find(LayoutNavEntry::ClassHierarchy);
   QCString title = lne ? lne->title() : theTranslator->trClassHierarchy();
-  startFile(ol,"inherits",QCString(),title,HighlightedItem::ClassHierarchy,FALSE,"hierarchy");
+  startFile(ol,"inherits",false,QCString(),title,HighlightedItem::ClassHierarchy,FALSE,"hierarchy");
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -1239,7 +1239,7 @@ static void writeHierarchicalInterfaceIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trInterfaceHierarchy();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"interfacehierarchy",QCString(), title, HighlightedItem::InterfaceHierarchy);
+  startFile(ol,"interfacehierarchy",false,QCString(), title, HighlightedItem::InterfaceHierarchy);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -1313,7 +1313,7 @@ static void writeGraphicalInterfaceHierarchy(OutputList &ol)
   ol.disableAllBut(OutputType::Html);
   LayoutNavEntry *lne = LayoutDocManager::instance().rootNavEntry()->find(LayoutNavEntry::InterfaceHierarchy);
   QCString title = lne ? lne->title() : theTranslator->trInterfaceHierarchy();
-  startFile(ol,"interfaceinherits",QCString(),title,HighlightedItem::InterfaceHierarchy,FALSE,"interfacehierarchy");
+  startFile(ol,"interfaceinherits",false,QCString(),title,HighlightedItem::InterfaceHierarchy,FALSE,"interfacehierarchy");
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -1344,7 +1344,7 @@ static void writeHierarchicalExceptionIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trExceptionHierarchy();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"exceptionhierarchy",QCString(), title, HighlightedItem::ExceptionHierarchy);
+  startFile(ol,"exceptionhierarchy",false,QCString(), title, HighlightedItem::ExceptionHierarchy);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -1418,7 +1418,7 @@ static void writeGraphicalExceptionHierarchy(OutputList &ol)
   ol.disableAllBut(OutputType::Html);
   LayoutNavEntry *lne = LayoutDocManager::instance().rootNavEntry()->find(LayoutNavEntry::ExceptionHierarchy);
   QCString title = lne ? lne->title() : theTranslator->trExceptionHierarchy();
-  startFile(ol,"exceptioninherits",QCString(),title,HighlightedItem::ExceptionHierarchy,FALSE,"exceptionhierarchy");
+  startFile(ol,"exceptioninherits",false,QCString(),title,HighlightedItem::ExceptionHierarchy,FALSE,"exceptionhierarchy");
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -1545,7 +1545,7 @@ static void writeDirIndex(OutputList &ol)
   ol.disable(OutputType::Html);
 
   QCString title = theTranslator->trDirectories();
-  startFile(ol,"dirs",QCString(),title,HighlightedItem::Files);
+  startFile(ol,"dirs",false,QCString(),title,HighlightedItem::Files);
   startTitle(ol,title);
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -1580,7 +1580,7 @@ static void writeFileIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trFileList();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"files",QCString(),title,HighlightedItem::Files);
+  startFile(ol,"files",false,QCString(),title,HighlightedItem::Files);
   startTitle(ol,QCString());
   //if (!Config_getString(PROJECT_NAME).isEmpty())
   //{
@@ -2030,7 +2030,7 @@ static void writeNamespaceIndex(OutputList &ol)
   if (lne==nullptr) lne = LayoutDocManager::instance().rootNavEntry()->find(LayoutNavEntry::Namespaces); // fall back
   QCString title = lne ? lne->title() : theTranslator->trNamespaceList();
   bool addToIndex = lne==nullptr || lne->visible();
-  startFile(ol,"namespaces",QCString(),title,HighlightedItem::Namespaces);
+  startFile(ol,"namespaces",false,QCString(),title,HighlightedItem::Namespaces);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -2442,7 +2442,7 @@ static void writeAlphabeticalIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trCompoundIndex();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"classes",QCString(),title,HighlightedItem::Classes);
+  startFile(ol,"classes",false,QCString(),title,HighlightedItem::Classes);
 
   startTitle(ol,QCString());
   ol.parseText(title);
@@ -2471,7 +2471,7 @@ static void writeAlphabeticalInterfaceIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trInterfaceIndex();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"interfaces",QCString(),title,HighlightedItem::Interfaces);
+  startFile(ol,"interfaces",false,QCString(),title,HighlightedItem::Interfaces);
 
   startTitle(ol,QCString());
   ol.parseText(title);
@@ -2500,7 +2500,7 @@ static void writeAlphabeticalStructIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trStructIndex();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"structs",QCString(),title,HighlightedItem::Structs);
+  startFile(ol,"structs",false,QCString(),title,HighlightedItem::Structs);
 
   startTitle(ol,QCString());
   ol.parseText(title);
@@ -2529,7 +2529,7 @@ static void writeAlphabeticalExceptionIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trExceptionIndex();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"exceptions",QCString(),title,HighlightedItem::Exceptions);
+  startFile(ol,"exceptions",false,QCString(),title,HighlightedItem::Exceptions);
 
   startTitle(ol,QCString());
   ol.parseText(title);
@@ -2592,7 +2592,7 @@ static void writeAnnotatedIndexGeneric(OutputList &ol,const AnnotatedIndexContex
   QCString title = lne ? lne->title() : ctx.listDefaultTitleText;
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,ctx.fileBaseName,QCString(),title,ctx.hiItem);
+  startFile(ol,ctx.fileBaseName,false,QCString(),title,ctx.hiItem);
 
   startTitle(ol,QCString());
   ol.parseText(title);
@@ -3220,7 +3220,7 @@ static void writeClassMemberIndexFiltered(OutputList &ol, ClassMemberHighlight::
       }
     };
 
-    ol.startFile(fileName+extension,QCString(),title);
+    ol.startFile(fileName+extension,false,QCString(),title);
     ol.startQuickIndices();
     if (!disableIndex && !quickLinksAfterSplitbar)
     {
@@ -3406,7 +3406,7 @@ static void writeFileMemberIndexFiltered(OutputList &ol, FileMemberHighlight::En
       }
     };
 
-    ol.startFile(fileName+extension,QCString(),title);
+    ol.startFile(fileName+extension,false,QCString(),title);
     ol.startQuickIndices();
     if (!disableIndex && !quickLinksAfterSplitbar)
     {
@@ -3590,7 +3590,7 @@ static void writeNamespaceMemberIndexFiltered(OutputList &ol,
       }
     };
 
-    ol.startFile(fileName+extension,QCString(),title);
+    ol.startFile(fileName+extension,false,QCString(),title);
     ol.startQuickIndices();
     if (!disableIndex && !quickLinksAfterSplitbar)
     {
@@ -3767,7 +3767,7 @@ static void writeModuleMemberIndexFiltered(OutputList &ol,
       }
     };
 
-    ol.startFile(fileName+extension,QCString(),title);
+    ol.startFile(fileName+extension,false,QCString(),title);
     ol.startQuickIndices();
     if (!disableIndex && !quickLinksAfterSplitbar)
     {
@@ -3841,7 +3841,7 @@ static void writeExampleIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trExamples();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"examples",QCString(),title,HighlightedItem::Examples);
+  startFile(ol,"examples",false,QCString(),title,HighlightedItem::Examples);
 
   startTitle(ol,QCString());
   ol.parseText(title);
@@ -3993,7 +3993,7 @@ static void writePageIndex(OutputList &ol)
   ol.disableAllBut(OutputType::Html);
   LayoutNavEntry *lne = LayoutDocManager::instance().rootNavEntry()->find(LayoutNavEntry::Pages);
   QCString title = lne ? lne->title() : theTranslator->trRelatedPages();
-  startFile(ol,"pages",QCString(),title,HighlightedItem::Pages);
+  startFile(ol,"pages",false,QCString(),title,HighlightedItem::Pages);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -4076,7 +4076,7 @@ void writeGraphInfo(OutputList &ol)
   // temporarily disable create subdirs for linking to our example
   Config_updateBool(CREATE_SUBDIRS,FALSE);
 
-  startFile(ol,"graph_legend",QCString(),theTranslator->trLegendTitle());
+  startFile(ol,"graph_legend",false,QCString(),theTranslator->trLegendTitle());
   startTitle(ol,QCString());
   ol.parseText(theTranslator->trLegendTitle());
   endTitle(ol,QCString(),QCString());
@@ -4387,7 +4387,7 @@ static void writeTopicIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trTopics();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"topics",QCString(),title,HighlightedItem::Topics);
+  startFile(ol,"topics",false,QCString(),title,HighlightedItem::Topics);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -4529,7 +4529,7 @@ static void writeModuleIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trModules();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"modules",QCString(),title,HighlightedItem::Modules);
+  startFile(ol,"modules",false,QCString(),title,HighlightedItem::Modules);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -4701,7 +4701,7 @@ static void writeConceptIndex(OutputList &ol)
   QCString title = lne ? lne->title() : theTranslator->trConceptList();
   bool addToIndex = lne==nullptr || lne->visible();
 
-  startFile(ol,"concepts",QCString(),title,HighlightedItem::Concepts);
+  startFile(ol,"concepts",false,QCString(),title,HighlightedItem::Concepts);
   startTitle(ol,QCString());
   ol.parseText(title);
   endTitle(ol,QCString(),QCString());
@@ -4801,7 +4801,7 @@ static void writeUserGroupStubPage(OutputList &ol,LayoutNavEntry *lne)
   {
     ol.pushGeneratorState();
     ol.disableAllBut(OutputType::Html);
-    startFile(ol,lne->baseFile(),QCString(),lne->title(),HighlightedItem::UserGroup);
+    startFile(ol,lne->baseFile(),false,QCString(),lne->title(),HighlightedItem::UserGroup);
     startTitle(ol,QCString());
     ol.parseText(lne->title());
     endTitle(ol,QCString(),QCString());
@@ -4874,7 +4874,7 @@ static void writeIndex(OutputList &ol)
   }
 
   QCString indexName="index";
-  ol.startFile(indexName,QCString(),title);
+  ol.startFile(indexName,false,QCString(),title);
 
   if (Doxygen::mainPage)
   {
@@ -5012,7 +5012,7 @@ static void writeIndex(OutputList &ol)
     Doxygen::mainPage->writeDocumentation(ol);
   }
 
-  ol.startFile("refman",QCString(),QCString());
+  ol.startFile("refman",false,QCString(),QCString());
   ol.startIndexSection(IndexSection::isTitlePageStart);
   ol.disable(OutputType::Latex);
   ol.disable(OutputType::Docbook);

--- a/src/index.h
+++ b/src/index.h
@@ -225,7 +225,7 @@ void writeGraphInfo(OutputList &ol);
 void writeIndexHierarchy(OutputList &ol);
 void startTitle(OutputList &ol,const QCString &fileName,const DefinitionMutable *def=nullptr);
 void endTitle(OutputList &ol,const QCString &fileName,const QCString &name);
-void startFile(OutputList &ol,const QCString &name,const QCString &manName,
+void startFile(OutputList &ol,const QCString &name,bool isSource,const QCString &manName,
                const QCString &title,HighlightedItem hli=HighlightedItem::None,
                bool additionalIndices=false,const QCString &altSidebarName=QCString(), int hierarchyLevel=0,
                const QCString &allMembersFile=QCString());

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -706,7 +706,7 @@ void LatexGenerator::writeStyleSheetFile(TextStream &t)
   writeDefaultStyleSheet(t);
 }
 
-void LatexGenerator::startFile(const QCString &name,const QCString &,const QCString &,int,int hierarchyLevel)
+void LatexGenerator::startFile(const QCString &name,bool,const QCString &,const QCString &,int,int hierarchyLevel)
 {
 #if 0
   setEncoding(Config_getString(LATEX_OUTPUT_ENCODING));

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -116,7 +116,7 @@ class LatexGenerator : public OutputGenerator, public OutputGenIntf
     void addCodeGen(OutputCodeList &list) override;
     void cleanup() override;
     void writeDoc(const IDocNodeAST *node,const Definition *ctx,const MemberDef *,int id) override;
-    void startFile(const QCString &name,const QCString &manName,const QCString &title,int id,int hierarchyLevel) override;
+    void startFile(const QCString &name,bool isSource,const QCString &manName,const QCString &title,int id,int hierarchyLevel) override;
     void endFile() override;
 
     void writeSearchInfo() override {}

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -334,7 +334,7 @@ static QCString buildFileName(const QCString &name)
   return fileName;
 }
 
-void ManGenerator::startFile(const QCString &,const QCString &manName,const QCString &,int,int)
+void ManGenerator::startFile(const QCString &,bool,const QCString &manName,const QCString &,int,int)
 {
   startPlainFile( buildFileName( manName ) );
   m_firstCol=TRUE;

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -86,7 +86,7 @@ class ManGenerator : public OutputGenerator, public OutputGenIntf
     void addCodeGen(OutputCodeList &list) override;
     void cleanup() override;
     void writeDoc(const IDocNodeAST *ast,const Definition *,const MemberDef *,int) override;
-    void startFile(const QCString &name,const QCString &manName,const QCString &title,int id, int hierarchyLevel) override;
+    void startFile(const QCString &name,bool isSource,const QCString &manName,const QCString &title,int id, int hierarchyLevel) override;
     void endFile() override;
 
     void writeSearchInfo() override {}

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -744,7 +744,7 @@ void MemberList::writeDocumentationPage(OutputList &ol,
       uint32_t &count = it->second.count;
       QCString diskName=md->getOutputFileBase();
       QCString title=md->qualifiedName();
-      startFile(ol,diskName,md->name(),title,HighlightedItem::None,!generateTreeView,diskName, hierarchyLevel);
+      startFile(ol,diskName,false,md->name(),title,HighlightedItem::None,!generateTreeView,diskName, hierarchyLevel);
       if (!generateTreeView)
       {
         container->writeNavigationPath(ol);

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -353,7 +353,7 @@ void ModuleDefImpl::writeDocumentation(OutputList &ol)
   {
     pageTitle = theTranslator->trModuleReference(displayName());
   }
-  startFile(ol,getOutputFileBase(),name(),pageTitle,HighlightedItem::ModuleVisible,false,QCString(),0);
+  startFile(ol,getOutputFileBase(),false,name(),pageTitle,HighlightedItem::ModuleVisible,false,QCString());
 
   // ---- title part
   ol.startHeaderSection();

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -980,7 +980,7 @@ void NamespaceDefImpl::writeDocumentation(OutputList &ol)
   //bool fortranOpt = Config_getBool(OPTIMIZE_FOR_FORTRAN);
 
   QCString pageTitle = title();
-  startFile(ol,getOutputFileBase(),name(),pageTitle,HighlightedItem::NamespaceVisible,!generateTreeView);
+  startFile(ol,getOutputFileBase(),false,name(),pageTitle,HighlightedItem::NamespaceVisible,!generateTreeView);
 
   if (!generateTreeView)
   {

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -140,7 +140,7 @@ class OutputGenIntf
     virtual void writeStyleInfo(int part) = 0;
     virtual void writeSearchInfo() = 0;
     virtual void writeFooter(const QCString &navPath) = 0;
-    virtual void startFile(const QCString &name,const QCString &manName,const QCString &title,int id, int hierarchyLevel) = 0;
+    virtual void startFile(const QCString &name,bool isSource,const QCString &manName,const QCString &title,int id, int hierarchyLevel) = 0;
     virtual void endFile() = 0;
     virtual void startTitleHead(const QCString &fileName) = 0;
     virtual void endTitleHead(const QCString &fileName,const QCString &name) = 0;

--- a/src/outputlist.cpp
+++ b/src/outputlist.cpp
@@ -189,11 +189,11 @@ void OutputList::generateDoc(const QCString &fileName,int startLine,
   if (ast && count>0) writeDoc(ast.get(),ctx,md);
 }
 
-void OutputList::startFile(const QCString &name,const QCString &manName,const QCString &title, int hierarchyLevel)
+void OutputList::startFile(const QCString &name,bool isSource,const QCString &manName,const QCString &title, int hierarchyLevel)
 {
   newId();
   m_codeGenList.setId(m_id);
-  foreach(&OutputGenIntf::startFile,name,manName,title,m_id,hierarchyLevel);
+  foreach(&OutputGenIntf::startFile,name,isSource,manName,title,m_id,hierarchyLevel);
 }
 
 void OutputList::parseText(const QCString &textStr)

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -375,7 +375,7 @@ class OutputList
                      bool markdownSupport=Config_getBool(MARKDOWN_SUPPORT),
                      bool autolinkSupport=Config_getBool(AUTOLINK_SUPPORT));
 
-    void startFile(const QCString &name,const QCString &manName,const QCString &title, int hierarchyLevel=0);
+    void startFile(const QCString &name, bool isSource,const QCString &manName,const QCString &title, int hierarchyLevel=0);
     void parseText(const QCString &textStr);
 
     //////////////////////////////////////////////////

--- a/src/pagedef.cpp
+++ b/src/pagedef.cpp
@@ -259,11 +259,11 @@ void PageDefImpl::writeDocumentation(OutputList &ol)
   ol.pushGeneratorState();
   //2.{
   ol.disableAllBut(OutputType::Man);
-  startFile(ol,getOutputFileBase(),manPageName,title(),HighlightedItem::Pages,!generateTreeView,
+  startFile(ol,getOutputFileBase(),false,manPageName,title(),HighlightedItem::Pages,!generateTreeView,
             QCString() /* altSidebarName */, hierarchyLevel);
   ol.enableAll();
   ol.disable(OutputType::Man);
-  startFile(ol,getOutputFileBase(),pageName,title(),HighlightedItem::Pages,!generateTreeView,
+  startFile(ol,getOutputFileBase(),false,pageName,title(),HighlightedItem::Pages,!generateTreeView,
             QCString() /* altSidebarName */, hierarchyLevel);
   ol.popGeneratorState();
   //2.}

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -701,7 +701,7 @@ void RTFGenerator::beginRTFSection()
   m_t << rtf_Style[QCString().sprintf("Heading%d", level).str()].reference() << "\n";
 }
 
-void RTFGenerator::startFile(const QCString &name,const QCString &,const QCString &,int,int hierarchyLevel)
+void RTFGenerator::startFile(const QCString &name,bool,const QCString &,const QCString &,int,int hierarchyLevel)
 {
   //setEncoding(QCString().sprintf("CP%s",theTranslator->trRTFansicp()));
   QCString fileName=name;

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -103,7 +103,7 @@ class RTFGenerator : public OutputGenerator, public OutputGenIntf
     void addCodeGen(OutputCodeList &list) override;
     void cleanup() override;
     void writeDoc(const IDocNodeAST *ast,const Definition *,const MemberDef *,int) override;
-    void startFile(const QCString &name,const QCString &manName,const QCString &title,int id,int hierarchyLevel) override;
+    void startFile(const QCString &name,bool isSource,const QCString &manName,const QCString &title,int id,int hierarchyLevel) override;
     void endFile() override;
 
     void writeSearchInfo() override {}


### PR DESCRIPTION
For the representation of the source files in the source file browser it is not necessary to to load the Mathjax code.

(It is insufficient to check for `_source` as in case as files without extensions are used as well files like `aa_source` will have names like `aa__source.html` and `aa__source_source.html`)