### PR TITLE
Remove double used text

### DIFF
--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -140,6 +140,5 @@ int AnchorGenerator::reserve(const std::string &anchor)
 bool AnchorGenerator::looksGenerated(const std::string &anchor)
 {
   return Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::DOXYGEN &&
-         QCString(anchor).startsWith("autotoc_md");
+         QCString(anchor).startsWith(prefix);
 }
-


### PR DESCRIPTION
Text should not be present twice (especially when the first occurrence is a constexpr