### PR TITLE
issue #11683 duplicates in searchdata.xml "text" field

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -180,7 +180,7 @@ DocWord::DocWord(DocParser *parser,DocNodeVariant *parent,const QCString &word) 
       DocNode(parser,parent), m_word(word)
 {
   //printf("new word %s url=%s\n",qPrint(word),qPrint(parser->context.searchUrl));
-  if (Doxygen::searchIndex.enabled() && !parser->context.searchUrl.isEmpty())
+  if (Doxygen::searchIndex.enabled() && !Doxygen::searchIndex.inherited() && !parser->context.searchUrl.isEmpty())
   {
     Doxygen::searchIndex.addWord(word,false);
   }

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -2614,11 +2614,13 @@ void MemberDefImpl::writeDeclaration(OutputList &ol,
      )
   {
     auto parser { createDocParser() };
+    Doxygen::searchIndex.setInherited(inheritedFrom!=nullptr);
     auto ast    { validatingParseDoc(*parser.get(),
                                      briefFile(),briefLine(),
                                      getOuterScope()?getOuterScope():d,
                                      this,briefDescription(),TRUE,FALSE,
                                      QCString(),TRUE,FALSE) };
+    Doxygen::searchIndex.setInherited(false);
     if (!ast->isEmpty())
     {
       ol.startMemberDescription(anchor(),inheritId);

--- a/src/searchindex.h
+++ b/src/searchindex.h
@@ -188,8 +188,11 @@ class SearchIndexIntf
       }
     }
     Kind kind() const { return m_kind; }
+    void setInherited(bool inh) {m_inherited = inh;}
+    bool inherited() {return m_inherited;}
   private:
     Kind m_kind;
+    bool m_inherited = false;
     SearchIndexVariant m_variant;
 };
 


### PR DESCRIPTION
In case of an inherited member the, brief, text of the inherited member should not be added to the search text field.