### PR TITLE
issue #11751 Latex documentation with many functions causes pdflatex to hit memory limit

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -13,6 +13,22 @@
 \RequirePackage{longtable}
 \RequirePackage{xltabular}
 \RequirePackage{tabularray}
+\ExplSyntaxOn
+\IfPackageAtLeastTF{tabularray}{2025-03-11}
+{
+  \IfPackageAtLeastTF{tabularray}{2025-03-12}
+  {
+    %newer version, do nothing
+  }
+  {
+     %the required version
+     \bool_gset_false:N \g__tblr_use_intarray_bool
+  }
+}
+{
+  %older version, do nothing
+}
+\ExplSyntaxOff
 \UseTblrLibrary{varwidth}
 \RequirePackage{fancyvrb}
 \RequirePackage{tabularx}


### PR DESCRIPTION
Added correction code for the tabularray version 2025A (see also discussion: https://tex.stackexchange.com/questions/750342/check-for-exact-version-of-loaded-package)