### PR TITLE
Missing hyperlinks after table in table

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -14,6 +14,21 @@
 \RequirePackage{xltabular}
 \RequirePackage{tabularray}
 \UseTblrLibrary{varwidth}
+\ExplSyntaxOn
+\int_new:N \g__doxy_nohyper_int
+\AtBeginDocument
+  {
+    \renewenvironment{tblrNoHyper}
+      {
+        \int_compare:nNnT {\g__doxy_nohyper_int} = {0} {\begin{NoHyper}}
+        \int_gincr:N \g__doxy_nohyper_int
+      }
+      {
+        \int_gdecr:N \g__doxy_nohyper_int
+        \int_compare:nNnT {\g__doxy_nohyper_int} = {0} {\end{NoHyper}}
+      }
+  }
+\ExplSyntaxOff
 \RequirePackage{fancyvrb}
 \RequirePackage{tabularx}
 \RequirePackage{multicol}


### PR DESCRIPTION
Hyperlinks were missing after the usage of a nested table.(see discussion at: https://github.com/lvjr/tabularray/issues/620 and subsequent issue https://github.com/latex3/hyperref/issues/397)

(Issue was found in the doxygen manual)