### PR TITLE
issue #11755 Behavior of \tableofcontents is different in V.1.14.0 and prior version

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1462,8 +1462,9 @@ void DefinitionImpl::writeToc(OutputList &ol, const LocalToc &localToc) const
         const Definition *scope = p->def->definitionType()==Definition::TypeMember ? p->def->getOuterScope() : p->def;
         QCString docTitle = si->title();
         if (docTitle.isEmpty()) docTitle = si->label();
-        ol.generateDoc(docFile(),
+        ol.generateDocTocEntry(docFile(),
                        getStartBodyLine(),
+                       si,
                        scope,
                        md,
                        docTitle,

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -1477,6 +1477,28 @@ void DocbookGenerator::endTocEntry(const SectionInfo *si)
   }
 }
 
+void DocbookGenerator::generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id)
+{
+  SectionType type = si->type();
+  int nextLevel = type.level();
+  if (type.isSection() && nextLevel<=m_tocState.maxLevel)
+  {
+    if (docStr.isEmpty()) return;
+    auto parser { createDocParser() };
+    auto ast    { validatingParseDoc(*parser.get(),
+                                   fileName,
+                                   startLine,
+                                   ctx,
+                                   md,
+                                   docStr,
+                                   options)
+               };
+    if (ast) writeDoc(ast.get(),ctx,md,id);
+  }
+}
+
 //-------------------------------------------------------------------------------------------------
 
 static constexpr auto hex="0123456789ABCDEF";

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -316,6 +316,10 @@ class DocbookGenerator : public OutputGenerator, public OutputGenIntf
     void endLocalToc() override;
     void startTocEntry(const SectionInfo *si) override;
     void endTocEntry(const SectionInfo *si) override;
+    void generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id) override;
+
 
     void startPlainFile(const QCString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -3731,3 +3731,24 @@ void HtmlGenerator::endTocEntry(const SectionInfo *si)
   }
 }
 
+void HtmlGenerator::generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id)
+{
+  SectionType type = si->type();
+  int nextLevel = type.level();
+  if (type.isSection() && nextLevel<=m_tocState.maxLevel)
+  {
+    if (docStr.isEmpty()) return;
+    auto parser { createDocParser() };
+    auto ast    { validatingParseDoc(*parser.get(),
+                                   fileName,
+                                   startLine,
+                                   ctx,
+                                   md,
+                                   docStr,
+                                   options)
+               };
+    if (ast) writeDoc(ast.get(),ctx,md,id);
+  }
+}

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -330,6 +330,9 @@ class HtmlGenerator : public OutputGenerator, public OutputGenIntf
     void endLocalToc() override;
     void startTocEntry(const SectionInfo *si) override;
     void endTocEntry(const SectionInfo *si) override;
+    void generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id) override;
 
     void startPlainFile(const QCString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -315,6 +315,9 @@ class LatexGenerator : public OutputGenerator, public OutputGenIntf
     void endLocalToc() override {}
     void startTocEntry(const SectionInfo *) override {}
     void endTocEntry(const SectionInfo *) override {}
+    void generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id) override {}
 
     void startPlainFile(const QCString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -285,6 +285,9 @@ class ManGenerator : public OutputGenerator, public OutputGenIntf
     void endLocalToc() override {}
     void startTocEntry(const SectionInfo *) override {}
     void endTocEntry(const SectionInfo *) override {}
+    void generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id) override {}
 
     void startPlainFile(const QCString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -320,6 +320,9 @@ class OutputGenIntf
     virtual void endLocalToc() = 0;
     virtual void startTocEntry(const SectionInfo *si) = 0;
     virtual void endTocEntry(const SectionInfo *si) = 0;
+    virtual void generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id) = 0;
     virtual void cleanup() = 0;
     virtual void startPlainFile(const QCString &name) = 0;
     virtual void endPlainFile() = 0;

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -749,6 +749,10 @@ class OutputList
     { foreach(&OutputGenIntf::startTocEntry,si); }
     void endTocEntry(const SectionInfo *si)
     { foreach(&OutputGenIntf::endTocEntry,si); }
+    void generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options)
+    { foreach(&OutputGenIntf::generateDocTocEntry,fileName,startLine,si,ctx,md,docStr,options,m_id); }
     void cleanup()
     { foreach(&OutputGenIntf::cleanup); }
     void startPlainFile(const QCString &name)

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -302,6 +302,9 @@ class RTFGenerator : public OutputGenerator, public OutputGenIntf
     void endLocalToc() override {}
     void startTocEntry(const SectionInfo *) override {}
     void endTocEntry(const SectionInfo *) override {}
+    void generateDocTocEntry(const QCString &fileName,int startLine,const SectionInfo *si,
+                     const Definition *ctx,const MemberDef *md,const QCString &docStr,
+                     const DocOptions &options,int id) override {}
 
     void startPlainFile(const QCString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }


### PR DESCRIPTION
Only write out the TOC items in case requested / needed