### PR TITLE
perf(dir): avoid unnecessary string copy in isEmpty by using const reference

### DIFF
--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -260,7 +260,7 @@ bool Dir::exists() const
   return fi.exists() && fi.isDir();
 }
 
-bool Dir::isEmpty(const std::string subdir) const
+bool Dir::isEmpty(const std::string &subdir) const
 {
   fs::path pth = path();
   pth /= subdir;

--- a/src/dir.h
+++ b/src/dir.h
@@ -86,7 +86,7 @@ class Dir final
 
     DirIterator iterator() const;
 
-    bool isEmpty(const std::string subdir) const;
+    bool isEmpty(const std::string &subdir) const;
     bool exists() const;
     std::string filePath(const std::string &path,bool acceptsAbsPath=true) const;
     bool exists(const std::string &path,bool acceptsAbsPath=true) const;


### PR DESCRIPTION
Changes:
- Avoids copying the string, reducing memory overhead and improving performance slightly.
- Behavior of the method remains unchanged.