### PR TITLE
Improvement/formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+IndentWidth: 2
+IndentAccessModifiers: true
+UseTab: Never
+BreakBeforeBraces: Allman
+PointerAlignment: Right
+AllowShortFunctionsOnASingleLine: Inline
+---
+Language: Cpp
+ColumnLimit: 80


### PR DESCRIPTION
The `.clang-format` file usage is optional; it doesn’t enforce formatting, but it saves time and keeps code style consistent.