### PR TITLE
Feature/link-time-optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,9 @@ option(enable_coverage "Enable coverage reporting for gcc/clang [development]" O
 option(enable_tracing  "Enable tracing option in release builds [development]" OFF)
 option(enable_lex_debug "Enable debugging info for lexical scanners in release builds [development]" OFF)
 
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
 
 include(CheckCXXCompilerFlag)
 


### PR DESCRIPTION
- Turned on link-time optimizations

***Results:***

| Artifact                                                        | Without LTO          | With LTO          |
| ------------------------------------------------------- | :----------------------: | :-----------------: |
| Ubuntu Latest Clang Debug (Arm)        | 45 MB                   | 38.9 MB         |
| Ubuntu Latest Clang Debug (Intel)       | 44.4 MB                | 37.7 MB         |
| Ubuntu Latest Clang Release (Arm)      | 21.1 MB                | 20.9 MB         |
| Ubuntu Latest Clang Release (Intel)      | 21 MB                  | 20.7 MB          |
| Ubuntu Latest GCC Debug (Arm)           | 140 MB                | 127 MB           |
| Ubuntu Latest GCC Debug (Intel)          | 141 MB                | 128 MB           |
| Ubuntu Latest GCC Release (Arm)        | 26.6 MB                | 21 MB             |
| Ubuntu Latest GCC Release (Intel)       | 28.2 MB                | 22.8 MB          |
| Windows Latest MSVC Debug               | 61.2 MB                | 32.3 MB          |
| Windows Latest MSVC Release             | 6.95 MB                | 6.91 MB          |
| macOS Latest Debug (Apple Silicon)    | 12.6 MB               | 12 MB              |
| macOS Latest Release (Apple Silicon) | 7.7 MB                   | 7.67 MB          |
| macOS Latest Debug (Intel)                  | 12.6 MB                | 12 MB             |
| macOS Latest Release (Intel)                | 7.7 MB                  | 7.67 MB          |

**Table 1:** GitHub Actions artifact sizes

| Artifact                                                        | Without LTO          | With LTO          |
| ------------------------------------------------------- | :----------------------: | :-----------------: |
| Ubuntu Latest Clang Debug (Arm)        | 2m 20s                  | 2m 26s          |
| Ubuntu Latest Clang Debug (Intel)       | 3m 5s                    | 4m 28s          |
| Ubuntu Latest Clang Release (Arm)      | 2m 59s                 |  3m 12s          |
| Ubuntu Latest Clang Release (Intel)      | 5m 16s                 | 6m 3s            |
| Ubuntu Latest GCC Debug (Arm)           | 2m 30s                 | 3m 28s           |
| Ubuntu Latest GCC Debug (Intel)          | 3m 28s                 | 4m 42s           |
| Ubuntu Latest GCC Release (Arm)        | 3m 42s                  | 5m 27s           |
| Ubuntu Latest GCC Release (Intel)       | 5m 3s                    | 7m 26s           |
| Windows Latest MSVC Debug               | 7m 48s                  | 7m 26s           |
| Windows Latest MSVC Release             | 10m 33s                | 9m 48s           |
| macOS Latest Debug (Apple Silicon)    | 2m 25s                  | 2m 29s           |
| macOS Latest Release (Apple Silicon) | 2m 24s                   | 2m 39s           |
| macOS Latest Debug (Intel)                  | 2m 24s                   | 2m 44s           |
| macOS Latest Release (Intel)                | 2m 29s                   | 2m 37s           |

**Table 2:** GitHub Actions build times