### PR TITLE
issue #11812 How to linebreak inside long titles in a HTML description list

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -2517,6 +2517,10 @@ Token DocHtmlDescTitle::parse()
                 parser()->handleAHref(thisVariant(),children(),parser()->context.token->attribs);
               }
             }
+            else if (tagId==HtmlTagType::HTML_BR)
+            {
+              children().append<DocLineBreak>(parser(),thisVariant(),parser()->context.token->attribs);
+            }
             else
             {
               warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected html tag <{}{}> found within <dt> context",

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -350,7 +350,14 @@ void LatexDocVisitor::operator()(const DocURL &u)
 void LatexDocVisitor::operator()(const DocLineBreak &)
 {
   if (m_hide) return;
+  if (m_insideItem)
+  {
+  m_t << "\\\\\n";
+  }
+  else
+  {
   m_t << "~\\newline\n";
+  }
 }
 
 void LatexDocVisitor::operator()(const DocHorRuler &)
@@ -1215,11 +1222,11 @@ void LatexDocVisitor::operator()(const DocHtmlDescList &dl)
 void LatexDocVisitor::operator()(const DocHtmlDescTitle &dt)
 {
   if (m_hide) return;
-  m_t << "\n\\item[";
+  m_t << "\n\\item[{\\parbox[t]{\\linewidth}{";
   m_insideItem=TRUE;
   visitChildren(dt);
   m_insideItem=FALSE;
-  m_t << "]";
+  m_t << "}}]";
 }
 
 void LatexDocVisitor::operator()(const DocHtmlDescData &dd)


### PR DESCRIPTION
- Allow `<br>` tag inside a `<dt>` tag
- adjust latex code so it will also be shown properly