### PR TITLE
issue #11812 How to linebreak inside long titles in a HTML description list (2)

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -2475,7 +2475,11 @@ Token DocHtmlDescTitle::parse()
                     }
                   }
                 }
-
+                break;
+              case CommandType::CMD_LINEBREAK:
+                {
+                  children().append<DocLineBreak>(parser(),thisVariant(),parser()->context.token->attribs);
+                }
                 break;
               default:
                 warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '{:c}{}' found as part of a <dt> tag",


### PR DESCRIPTION
- Allow `\n` command inside a `<dt>` tag