### PR TITLE
Disabling LTO under Cygwin (and Mingw)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,11 @@ option(enable_tracing  "Enable tracing option in release builds [development]" O
 option(enable_lex_debug "Enable debugging info for lexical scanners in release builds [development]" OFF)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+  if (CYGWIN OR MINGW)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+  else()
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+  endif()
 endif()
 
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
Due to the changes in:
```
Commit: 3d38ae4b2f0e856af58067907324cfc1a6a20692 [3d38ae4]

Date: Monday, October 20, 2025 4:27:13 PM

Feature/link-time-optimization
```
this gives the warnings:
```
/usr/lib/gcc/x86_64-pc-cygwin/13/../../../../x86_64-pc-cygwin/bin/ar: CMakeFiles/md5.dir/md5.c.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-pc-cygwin/13/../../../../x86_64-pc-cygwin/bin/ranlib: ../../lib/libmd5.a(md5.c.o): plugin needed to handle lto object
```
redefining ranlib / ar / ... didn't work

Disabling lto for the mentioned platforms.