### PR TITLE
Prevent page break in doxygen parameter table after head.

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -478,8 +478,8 @@
           {vline{1-Z}={2-Z}{solid},%    show vertical lines for all rows except the first
            measure=vbox,%               needed to allow nested lists and tables
            colspec=\DoxyTableColSpec}}% set column type for all columns
-  \SetCell[c=#1]{l} \tf{#3} \\[1ex]%
-  \hline%
+  \SetCell[c=#1]{l} \tf{#3} \\\nopagebreak%
+  \hline\nopagebreak%
   #4
   \end{longtblr}%
   \par\addvspace{6pt}%


### PR DESCRIPTION
Prevent page break after the top line plus accompanying horizontal line in a doxygen parameter like type of table.