### PR TITLE
Undefined environment NoHyper

### DIFF
--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -37,6 +37,11 @@
     \IfFormatAtLeastTF{2015/01/01}{\pdfsuppresswarningpagegroup=1}{}
   \fi
 
+
+%%BEGIN !PDF_HYPERLINKS
+  \newenvironment{NoHyper}{}{}
+%%END !PDF_HYPERLINKS
+
   \usepackage{doxygen}
 
   $extralatexstylesheet


### PR DESCRIPTION
When having `PDF_HYPERLINKS = NO` specified (and having some tables defined) doxygen will give the error:
```
! LaTeX Error: Environment NoHyper undefined.
```
when generating the pdf file.

By defining a dummy `NoHyper` environment this problem can be overcome.

Example: [example.tar.gz](https://github.com/user-attachments/files/23163421/example.tar.gz)
