### PR TITLE
Initial space with end of heredoc.

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2269,8 +2269,8 @@ NONLopt [^\n]*
                                           yyextra->delimiter = &yytext[1];
                                           BEGIN(HereDocEnd);
                                         }
-<HereDocEnd>^{ID}                       { // id at start of the line could mark the end of the block
-                                          if (yyextra->delimiter==yytext) // it is the end marker
+<HereDocEnd>^{Bopt}{ID}                 { // id at start of the line could mark the end of the block
+                                          if (yyextra->delimiter==QCString(yytext).stripWhiteSpace()) // it is the end marker
                                           {
                                             BEGIN(yyextra->lastHereDocContext);
                                           }


### PR DESCRIPTION
The closing identifier may be indented by space or tab, in which case the indentation will be stripped from all lines in the doc string. Prior to PHP 7.3.0, the closing identifier must begin in the first column of the line. The possibility to haven initial space is implemented