### PR TITLE
issue #11847 Method string parameter: bug if simple quotes used

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -5143,7 +5143,7 @@ NONLopt [^\n]*
                                           if (yyextra->insidePHP)
                                           {
                                             yyextra->lastCopyArgStringContext=YY_START;
-                                            BEGIN(SkipPHPString);
+                                            BEGIN(CopyArgPHPString);
                                           }
                                         }
 <ReadFuncArgType,ReadTempArgs,CopyArgString,CopyArgPHPString,CopyArgRound,CopyArgSquare,CopyArgSharp>"<="|">="|"<=>" {


### PR DESCRIPTION
Using correct state, analogous to the case for the double quote.