### PR TITLE
issue #11838 It is not possible to add long tables in pdf documentation

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -45,6 +45,19 @@
       }
   }
 \ExplSyntaxOff
+
+\ExplSyntaxOn
+\dim_new:N \doxytablewidth
+\NewDocumentCommand \doxycalculatetablewidth {}
+  {
+    \cs_set_protected:Nn \__tblr_build_whole:
+      {
+        \__tblr_get_table_width:
+        \dim_gset:Nn \doxytablewidth { \tablewidth }
+      }
+  }
+\ExplSyntaxOff
+
 \RequirePackage{fancyvrb}
 \RequirePackage{tabularx}
 \RequirePackage{multicol}
@@ -414,12 +427,15 @@
     \SetTblrOuter[longtblr]{theme=DoxyTableCaptionTheme,caption={#2},label={#3}}% set table caption and label
   \fi%
 \fi%
-\sbox0{% first render the table in a savebox to calculate the width of the table which will be stored in \wd0
+\begingroup
+\doxycalculatetablewidth
+\sbox0{% first render the table in a savebox to calculate the width of the table which will be stored in \doxytablewidth
 \begin{tblr}{hlines,vlines,measure=vbox,colspec={*{#1}{l}}}%
 #5
 \end{tblr}%
 }% end of sbox0
-\ifdim\wd0>\linewidth% use flexible columns
+\endgroup
+\ifdim\doxytablewidth>\linewidth% use flexible columns
 % now render the table for real
 \begin{longtblr}{hlines,vlines,% automatically set horizontal and vertical cell lines
                  measure=vbox,% needed to allow nested lists and tables
@@ -443,15 +459,33 @@
 % parameters:
 % - #1: number of columns
 % - #2: 1=table has a heading row, 0=no heading row
-\NewDocumentEnvironment{DoxyTableNested}{m m}{%
+\NewDocumentEnvironment{DoxyTableNested}{m m +b}{%
+\begingroup
+\doxycalculatetablewidth
+\sbox0{% first render the table in a savebox to calculate the width of the table which will be stored in \doxytablewidth
+\begin{tblr}{hlines,vlines,measure=vbox,colspec={*{#1}{l}}}%
+#3
+\end{tblr}%
+}% end of sbox0
+\endgroup
+\ifdim\doxytablewidth>\linewidth% use flexible columns
 % now render the table for real
 \begin{tblr}{hlines,vlines,% automatically set horizontal and vertical cell lines
-             measure=vbox,% needed to allow nested lists and tables
-	     colspec={*{#1}{X[-1]}},% set column type for all columns
-             rowhead=#2% set which row is the header (0=disable, 1=enable)
-            }
+                 measure=vbox,% needed to allow nested lists and tables
+                 colspec={*{#1}{X[-1]}},% set column type for all columns
+                 rowhead=#2} % set which row is the header (0=disable, 1=enable)
+#3
+\end{tblr}%
+\else% use fixed left aligned columns
+% now render the table for real
+\begin{tblr}{hlines,vlines,% automatically set horizontal and vertical cell lines
+                 measure=vbox,% needed to allow nested lists and tables
+                 colspec={*{#1}{l}},% set column type for all columns
+                 rowhead=#2} % set which row is the header (0=disable, 1=enable)
+#3
+\end{tblr}%
+\fi%
 }{% no end marker needed anymore
-\end{tblr}
 }%
 
 % Defines a parameter table
@@ -462,14 +496,17 @@
 % #4: Body
 \NewDocumentCommand{\DoxyParamTable}{m m +m +m}{%
   \SetTblrOuter[longtblr]{theme=DoxyTableBareTheme,entry=none}% set table caption and label
-  \sbox0{% render table off-screen first to capture its width in \wd0
+  \begingroup
+  \doxycalculatetablewidth
+  \sbox0{% render table off-screen first to capture its width in \doxytablewidth
     \begin{tblr}{measure=vbox,colspec={*{#1}{|l}|}}%
     \SetCell[c=#1]{l} \tf{#3} \\[1ex]%
     \hline%
     #4
     \end{tblr}%
   }%
-  \ifdim\wd0>\linewidth%
+  \endgroup
+  \ifdim\doxytablewidth>\linewidth% use flexible columns
     \edef\DoxyTableColSpec{#2X[-1]}%
   \else%
     \edef\DoxyTableColSpec{#2l}%


### PR DESCRIPTION
Reimplemented the calculation of the table width based on https://github.com/lvjr/tabularray/issues/630#issuecomment-3489060342 Needed also to adjust the nested table possibility otherwise (in the doxygen documentation) an overflow would occur to the right of the page.make docs