### PR TITLE
issue #11828 Inconsistent vertical spacing of ordered list items in generated HTML

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -3017,6 +3017,7 @@ Token DocAutoList::parse()
 
     children().append<DocAutoListItem>(parser(),thisVariant(),m_indent,num++);
     retval = children().get_last<DocAutoListItem>()->parse();
+    m_singleParagraph = m_singleParagraph &&  children().get_last<DocAutoListItem>()->children().size()<=1 ;
     //printf("DocAutoList::parse(): retval=0x%x parser()->context.token->indent=%d m_indent=%d "
     //       "m_isEnumList=%d parser()->context.token->isEnumList=%d parser()->context.token->name=%s\n",
     //       retval,parser()->context.token->indent,m_indent,m_isEnumList,parser()->context.token->isEnumList,
@@ -3031,6 +3032,7 @@ Token DocAutoList::parse()
         );
 
   parser()->tokenizer.endAutoList();
+
   AUTO_TRACE_EXIT("retval={}",retval.to_string());
   return retval;
 }

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -580,6 +580,7 @@ class DocAutoList : public DocCompoundNode
     bool isEnumList() const    { return m_isEnumList; }
     int  indent() const        { return m_indent; }
     bool isCheckedList() const { return m_isCheckedList; }
+    bool isSingleParagraph() const { return m_singleParagraph; }
     int depth() const          { return m_depth; }
     Token parse();
 
@@ -587,6 +588,7 @@ class DocAutoList : public DocCompoundNode
     int      m_indent = 0;
     bool     m_isEnumList = false;
     bool     m_isCheckedList = false;
+    bool     m_singleParagraph = true;
     int      m_depth = 0;
 };
 

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -79,6 +79,11 @@ p.startli, p.startdd {
 	margin-top: 2px;
 }
 
+p.startlisingle {
+	margin-top: 0px;
+	margin-bottom: 0px;
+}
+
 th p.starttd, th p.intertd, th p.endtd {
 	font-size: 100%;
 	font-weight: 700;


### PR DESCRIPTION
The current situation is a bit inconsistent as depending on the number of paragraphs in an item the `<p class="startli">` is added or nor.

In case one of the items consists of multiple paragraphs the `<p class="startli">` is added for all paragraphs in the items in the current item block. When having maximal 1 paragraph for each item the  `<p class="startlisingle">` is added so the user can (through a css file) choose a different layout for both situations.