### PR TITLE
issue #11870 Spaces after `\fileinfo` are deleted

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1350,6 +1350,11 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                        }
 <St_File>{FILEMASK}    {
                          yyextra->token.name = yytext;
+                         if (yyextra->token.name.endsWith("\\ilinebr") ||yyextra->token.name.endsWith("@ilinebr"))
+                         {
+                           unput_string("\\ilinebr",8);
+                           yyextra->token.name = yyextra->token.name.left(yyleng-8);
+                         }
                          return Token::make_TK_WORD();
                        }
 <St_File>"\""[^\n\"]+"\"" {


### PR DESCRIPTION
Handle the `ilinebr` command properly after a file mask (i.e. ending the file mask and pushing the` ilinebr` command back_