### PR TITLE
issue #11691 Faulty interpretation of Generics as Inheriting Classes in Python

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -122,6 +122,7 @@ struct pyscannerYY_state
   int                     decoratorRound = 0;
   bool                    checkDupEntry = false;
   bool                    firstPass = true;
+  int                     bracketDepth = 0;
 };
 
 //-----------------------------------------------------------------------------
@@ -1232,6 +1233,7 @@ ID        [a-z_A-Z%]+{IDSYM}*
                           yyextra->docBlockInBody    = FALSE;
                           yyextra->docBlockJavaStyle = FALSE;
                           yyextra->docBlock.clear();
+                          yyextra->bracketDepth = 0;
 
                           BEGIN(ClassInheritance);
                         }
@@ -1239,7 +1241,13 @@ ID        [a-z_A-Z%]+{IDSYM}*
 <ClassInheritance>{
    ({BB}|[\(,\)])      { // syntactic sugar for the list
                        }
-
+   "["                 {
+                         yyextra->bracketDepth++;
+                       }
+   "]"                 {
+                         if (yyextra->bracketDepth > 0)
+                           yyextra->bracketDepth--;
+                       }
     ":"                { // begin of the class definition
                          yyextra->specialBlock = TRUE; // expecting a docstring
                          yyextra->current->bodyLine  = yyextra->yyLineNr;
@@ -1248,9 +1256,12 @@ ID        [a-z_A-Z%]+{IDSYM}*
                        }
 
     {SCOPE}            {
-                         yyextra->current->extends.emplace_back(
-                                              substitute(yytext,".","::"),Protection::Public,Specifier::Normal
+                         if (yyextra->bracketDepth == 0)
+                         {
+                           yyextra->current->extends.emplace_back(
+                                                substitute(yytext,".","::"),Protection::Public,Specifier::Normal
                                             );
+                         }
                          //Has base class-do stuff
                        }
     "'"                { // start of a single quoted string


### PR DESCRIPTION
- Address [Issue 11691](https://github.com/doxygen/doxygen/issues/11691), which involves the incorrect assumption that Python Generics are part of the inheritance chain
- Fixes this by introducing a counter in *pyscanner.l* for instances of brackets, and only including classes in the inheritance chain if they are outside of brackets