### PR TITLE
Inconsistent handling of command indicator

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -88,7 +88,7 @@ static constexpr bool extraChar(char c)
   return c=='-' || c=='+' || c=='!' || c=='?' || c=='$' || c=='@'  ||
          c=='&' || c=='*' || c=='_' || c=='%' || c=='[' || c=='('  ||
          c=='.' || c=='>' || c==':' || c==',' || c==';' || c=='\'' ||
-         c=='"' || c=='`';
+         c=='"' || c=='`' || c=='\\';
 }
 
 // is character c allowed before an emphasis section
@@ -1823,7 +1823,7 @@ int Markdown::Private::processSpecialCommand(std::string_view data, size_t offse
     out+=data.substr(0,endPos);
     return static_cast<int>(endPos);
   }
-  if (size>1 && data[0]=='\\') // escaped characters
+  if (size>1 && (data[0]=='\\' || data[0]=='@')) // escaped characters
   {
     char c=data[1];
     if (c=='[' || c==']' || c=='*' || c=='(' || c==')' || c=='`' || c=='_')
@@ -1849,16 +1849,6 @@ int Markdown::Private::processSpecialCommand(std::string_view data, size_t offse
       out+=data.substr(1,2);
       AUTO_TRACE_EXIT("3");
       return 3;
-    }
-  }
-  else if (size>1 && data[0]=='@') // escaped characters
-  {
-    char c=data[1];
-    if (c=='\\' || c=='@')
-    {
-      out+=data.substr(0,2);
-      AUTO_TRACE_EXIT("2");
-      return 2;
     }
   }
   return 0;


### PR DESCRIPTION
The handling of `@` command indicator was different from the handling of the `\` command indicator.
- looks like the addition in
  ```
  Commit: 35f2f23ca121d2259e6c1ab5c803a3e1cd0a9eec [35f2f23]

  Date: Monday, August 29, 2022 7:58:20 PM

  Incorrect handling of escaped command start commands in markdown
  ``` 
  was incomplete. 
- Also the `\` character was missing  in the list of extra characters.

Example: [example.tar.gz](https://github.com/user-attachments/files/23748244/example.tar.gz)

(Based on problems seen by Fossies for libavif project)
