### PR TITLE
issue #11881 `@code` block inside a parameter list produces latex "Missing } inserted"

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -182,7 +182,7 @@
     {\lccode`~32 \lowercase{\global\let~}\NiceSpace}\obeyspaces%
   }%
   {%
-    {\lccode`~32 \lowercase{\global\let~}}\obeyspaces%
+    {\lccode`~32 \lowercase{\global\let~}\relax}\obeyspaces%
   }%
   \vspace{2pt}%
 }{%


### PR DESCRIPTION
Changed rule as indicated in issue.