### PR TITLE
issue #11791 Brief descriptions for Enums contain invalid links

### DIFF
--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -413,7 +413,7 @@ void MemberList::writePlainDeclarations(OutputList &ol, bool inGroup,
                 auto ast    { validatingParseDoc(*parser.get(),
                                                  md->briefFile(),
                                                  md->briefLine(),
-                                                 cd,
+                                                 cd ? cd : md->getOuterScope(),
                                                  md,
                                                  md->briefDescription(),
                                                  DocOptions()


### PR DESCRIPTION
In case no class definition available use the outerScope of the member