### PR TITLE
GroupDef::sortSubGroups() should not be gated by SORT_BRIEF_DOCS

### DIFF
--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -1992,13 +1992,10 @@ void GroupDefImpl::removeMemberFromList(MemberListType lt,MemberDef *md)
 
 void GroupDefImpl::sortSubGroups()
 {
-  if (Config_getBool(SORT_BRIEF_DOCS))
-  {
-    std::stable_sort(m_groups.begin(),
-              m_groups.end(),
-              [](const auto &g1,const auto &g2)
-              { return g1->groupTitle() < g2->groupTitle(); });
-  }
+  std::stable_sort(m_groups.begin(),
+            m_groups.end(),
+            [](const auto &g1,const auto &g2)
+            { return g1->groupTitle() < g2->groupTitle(); });
 }
 
 static bool hasNonReferenceNestedGroupRec(const GroupDef *gd,int level)


### PR DESCRIPTION
Fixes a regression introduced with commit 9cb220d whereby subgroup sorting was gated using `SORT_BRIEF_DOCS`. This is incorrect as sortSubGroups() is called in the context of sorting member groups, which is gated by `SORT_GROUP_NAMES` already, and there should not be an additional/different option being introduced.