### PR TITLE
Incorrect stripping of extension of graphics files

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -82,29 +82,6 @@ static bool supportedHtmlAttribute(const QCString &name)
           name=="title");
 }
 
-static QCString makeShortName(const QCString &baseName)
-{
-  QCString result = baseName;
-  int i = result.findRev('/');
-  if (i!=-1)
-  {
-    result=result.mid(i+1);
-  }
-  return result;
-}
-
-static QCString makeBaseName(const QCString &name)
-{
-  QCString result = makeShortName(name);
-  int i = result.find('.');
-  if (i!=-1)
-  {
-    result=result.left(i);
-  }
-  return result;
-}
-
-
 void DocbookDocVisitor::visitCaption(const DocNodeList &children)
 {
   for (const auto &n : children)
@@ -1243,7 +1220,7 @@ DB_VIS_C
   {
     if (m_hide) return;
     m_t << "\n";
-    QCString baseName=makeShortName(img.name());
+    QCString baseName=stripPath(img.name());
     visitPreStart(m_t, img.children(), img.hasCaption(), img.relPath() + baseName, img.width(), img.height(), img.isInlineImage());
     visitChildren(img);
     visitPostEnd(m_t, img.hasCaption(),img.isInlineImage());
@@ -1546,7 +1523,7 @@ DB_VIS_C
 void DocbookDocVisitor::writeMscFile(const QCString &baseName, const DocVerbatim &s)
 {
 DB_VIS_C
-  QCString shortName = makeShortName(baseName);
+  QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeMscGraphFromFile(baseName+".msc",outDir,shortName,MscOutputFormat::BITMAP,s.srcFile(),s.srcLine());
   visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(), s.height());
@@ -1557,7 +1534,7 @@ DB_VIS_C
 void DocbookDocVisitor::writePlantUMLFile(const QCString &baseName, const DocVerbatim &s)
 {
 DB_VIS_C
-  QCString shortName = makeShortName(baseName);
+  QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
   visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(),s.height());
@@ -1583,7 +1560,7 @@ DB_VIS_C
   bool first = true;
   for (const auto &bName: baseNameVector)
   {
-    QCString baseName=makeBaseName(bName);
+    QCString baseName=makeBaseName(bName,".pu");
     PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
     if (!first) endPlantUmlFile(hasCaption);
     first = false;
@@ -1612,7 +1589,7 @@ void DocbookDocVisitor::startMscFile(const QCString &fileName,
     )
 {
 DB_VIS_C
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".msc");
   baseName.prepend("msc_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine);
@@ -1631,7 +1608,7 @@ DB_VIS_C
 void DocbookDocVisitor::writeDiaFile(const QCString &baseName, const DocVerbatim &s)
 {
 DB_VIS_C
-  QCString shortName = makeShortName(baseName);
+  QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DiaOutputFormat::BITMAP,s.srcFile(),s.srcLine());
   visitPreStart(m_t, s.children(), s.hasCaption(), shortName, s.width(),s.height());
@@ -1650,7 +1627,7 @@ void DocbookDocVisitor::startDiaFile(const QCString &fileName,
     )
 {
 DB_VIS_C
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
@@ -1669,7 +1646,7 @@ DB_VIS_C
 void DocbookDocVisitor::writeDotFile(const QCString &baseName, const DocVerbatim &s)
 {
 DB_VIS_C
-  QCString shortName = makeShortName(baseName);
+  QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   writeDotGraphFromFile(baseName+".dot",outDir,shortName,GraphOutputFormat::BITMAP,s.srcFile(),s.srcLine());
   visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + "." + getDotImageExtension(), s.width(),s.height());
@@ -1688,7 +1665,7 @@ void DocbookDocVisitor::startDotFile(const QCString &fileName,
     )
 {
 DB_VIS_C
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".dot");
   baseName.prepend("dot_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   QCString imgExt = getDotImageExtension();

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -226,29 +226,6 @@ static bool isInvisibleNode(const DocNodeVariant &node)
   return false;
 }
 
-static QCString makeShortName(const QCString &name)
-{
-  QCString shortName = name;
-  int i = shortName.findRev('/');
-  if (i!=-1)
-  {
-    shortName=shortName.mid(i+1);
-  }
-  return shortName;
-}
-
-static QCString makeBaseName(const QCString &name)
-{
-  QCString baseName = makeShortName(name);
-  int i=baseName.find('.');
-  if (i!=-1)
-  {
-    baseName=baseName.left(i);
-  }
-  return baseName;
-}
-
-
 //-------------------------------------------------------------------------
 
 HtmlDocVisitor::HtmlDocVisitor(TextStream &t,OutputCodeList &ci,
@@ -1665,7 +1642,7 @@ void HtmlDocVisitor::operator()(const DocImage &img)
       forceEndParagraph(img);
     }
     if (m_hide) return;
-    QCString baseName=makeShortName(img.name());
+    QCString baseName=stripPath(img.name());
     if (!inlineImage) m_t << "<div class=\"image\">\n";
     QCString sizeAttribs;
     if (!img.width().isEmpty())
@@ -1839,7 +1816,7 @@ void HtmlDocVisitor::operator()(const DocPlantUmlFile &df)
                                     inBuf,format,QCString(),df.srcFile(),df.srcLine(),false);
   for (const auto &bName: baseNameVector)
   {
-    QCString baseName=makeBaseName(bName);
+    QCString baseName=makeBaseName(bName,".pu");
     m_t << "<div class=\"plantumlgraph\">\n";
     writePlantUMLFile(baseName,df.relPath(),QCString(),df.srcFile(),df.srcLine());
     if (df.hasCaption())
@@ -2208,7 +2185,7 @@ void HtmlDocVisitor::endLink()
 void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
                                   const QCString &context,const QCString &srcFile,int srcLine)
 {
-  QCString baseName=makeBaseName(fn);
+  QCString baseName=makeBaseName(fn,".dot");
   baseName.prepend("dot_");
   QCString outDir = Config_getString(HTML_OUTPUT);
   writeDotGraphFromFile(fn,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine);
@@ -2218,7 +2195,7 @@ void HtmlDocVisitor::writeDotFile(const QCString &fn,const QCString &relPath,
 void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPath,
                                   const QCString &context,const QCString &srcFile,int srcLine)
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".msc");
   baseName.prepend("msc_");
   QCString outDir = Config_getString(HTML_OUTPUT);
   QCString imgExt = getDotImageExtension();
@@ -2232,7 +2209,7 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPa
 void HtmlDocVisitor::writeDiaFile(const QCString &fileName, const QCString &relPath,
                                   const QCString &,const QCString &srcFile,int srcLine)
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
   QCString outDir = Config_getString(HTML_OUTPUT);
   writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
@@ -2243,7 +2220,7 @@ void HtmlDocVisitor::writeDiaFile(const QCString &fileName, const QCString &relP
 void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString &relPath,
                                        const QCString &,const QCString &/* srcFile */,int /* srcLine */)
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".pu");
   QCString outDir = Config_getString(HTML_OUTPUT);
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -206,29 +206,6 @@ static void visitPostEnd(TextStream &t, bool hasCaption, bool inlineImage = FALS
     }
 }
 
-static QCString makeShortName(const QCString &name)
-{
-  QCString shortName = name;
-  int i = shortName.findRev('/');
-  if (i!=-1)
-  {
-    shortName=shortName.mid(i+1);
-  }
-  return shortName;
-}
-
-static QCString makeBaseName(const QCString &name)
-{
-  QCString baseName = makeShortName(name);
-  int i=baseName.find('.');
-  if (i!=-1)
-  {
-    baseName=baseName.left(i);
-  }
-  return baseName;
-}
-
-
 void LatexDocVisitor::visitCaption(const DocNodeList &children)
 {
   for (const auto &n : children)
@@ -1941,7 +1918,7 @@ void LatexDocVisitor::startDotFile(const QCString &fileName,
                                    int srcLine
                                   )
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".dot");
   baseName.prepend("dot_");
   QCString outDir = Config_getString(LATEX_OUTPUT);
   QCString name = fileName;
@@ -1963,7 +1940,7 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
                                    int srcLine
                                   )
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".msc");
   baseName.prepend("msc_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
@@ -1980,7 +1957,7 @@ void LatexDocVisitor::endMscFile(bool hasCaption)
 
 void LatexDocVisitor::writeMscFile(const QCString &baseName, const DocVerbatim &s)
 {
-  QCString shortName = makeShortName(baseName);
+  QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(LATEX_OUTPUT);
   writeMscGraphFromFile(baseName+".msc",outDir,shortName,MscOutputFormat::EPS,s.srcFile(),s.srcLine());
   visitPreStart(m_t, s.hasCaption(), shortName, s.width(),s.height());
@@ -1997,7 +1974,7 @@ void LatexDocVisitor::startDiaFile(const QCString &fileName,
                                    int srcLine
                                   )
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
@@ -2013,7 +1990,7 @@ void LatexDocVisitor::endDiaFile(bool hasCaption)
 
 void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, const DocVerbatim &s)
 {
-  QCString shortName = makeShortName(baseName);
+  QCString shortName = stripPath(baseName);
   if (s.useBitmap())
   {
     if (shortName.find('.')==-1) shortName += ".png";
@@ -2046,8 +2023,8 @@ void LatexDocVisitor::startPlantUmlFile(const QCString &fileName,
   bool first = true;
   for (const auto &bName: baseNameVector)
   {
-    QCString baseName = makeBaseName(bName);
-    QCString shortName = makeShortName(baseName);
+    QCString baseName = makeBaseName(bName,".pu");
+    QCString shortName = stripPath(baseName);
     if (useBitmap)
     {
       if (shortName.find('.')==-1) shortName += ".png";

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -56,17 +56,6 @@ static QCString align(const DocHtmlCell &cell)
   return "";
 }
 
-static QCString makeBaseName(const QCString &name)
-{
-  QCString baseName = name;
-  int i = baseName.findRev('/');
-  if (i!=-1)
-  {
-    baseName=baseName.mid(i+1);
-  }
-  return baseName;
-}
-
 RTFDocVisitor::RTFDocVisitor(TextStream &t,OutputCodeList &ci,
                              const QCString &langExt, int hierarchyLevel)
   : m_t(t), m_ci(ci), m_langExt(langExt), m_hierarchyLevel(hierarchyLevel)
@@ -1743,7 +1732,7 @@ void RTFDocVisitor::writeDotFile(const DocDotFile &df)
 void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption,
                                  const QCString &srcFile, int srcLine)
 {
-  QCString baseName=makeBaseName(filename);
+  QCString baseName=makeBaseName(filename,".dot");
   QCString outDir = Config_getString(RTF_OUTPUT);
   writeDotGraphFromFile(filename,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine);
   QCString imgExt = getDotImageExtension();
@@ -1757,7 +1746,7 @@ void RTFDocVisitor::writeMscFile(const DocMscFile &df)
 void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption,
                                  const QCString &srcFile, int srcLine)
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".msc");
   QCString outDir = Config_getString(RTF_OUTPUT);
   writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
@@ -1765,7 +1754,7 @@ void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption,
 
 void RTFDocVisitor::writeDiaFile(const DocDiaFile &df)
 {
-  QCString baseName=makeBaseName(df.file());
+  QCString baseName=makeBaseName(df.file(),".dia");
   QCString outDir = Config_getString(RTF_OUTPUT);
   writeDiaGraphFromFile(df.file(),outDir,baseName,DiaOutputFormat::BITMAP,df.srcFile(),df.srcLine());
   includePicturePreRTF(baseName + ".png", true, df.hasCaption());
@@ -1773,7 +1762,7 @@ void RTFDocVisitor::writeDiaFile(const DocDiaFile &df)
 
 void RTFDocVisitor::writePlantUMLFile(const QCString &fileName, bool hasCaption)
 {
-  QCString baseName=makeBaseName(fileName);
+  QCString baseName=makeBaseName(fileName,".pu");
   QCString outDir = Config_getString(RTF_OUTPUT);
   PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
   includePicturePreRTF(baseName + ".png", true, hasCaption);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4915,6 +4915,11 @@ QCString stripPath(const QCString &s)
   return result;
 }
 
+QCString makeBaseName(const QCString &name, const QCString &ext)
+{
+  return stripExtensionGeneral(stripPath(name), ext);
+}
+
 /** returns \c TRUE iff string \a s contains word \a w */
 bool containsWord(const QCString &str,const char *word)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -348,6 +348,8 @@ QCString stripExtensionGeneral(const QCString &fName, const QCString &ext);
 
 QCString stripExtension(const QCString &fName);
 
+QCString makeBaseName(const QCString &name, const QCString &ext);
+
 int computeQualifiedIndex(const QCString &name);
 
 void addDirPrefix(QCString &fileName);


### PR DESCRIPTION
When having files like `base_dot.ex` and `base_dot.ex1` these files are in e.g. HTML output both showing the same output as the extension is stripped for the output (so only one e.g. `base_dot.png` file is generated). The "extension strip" function (`makeBaeName`) was incorrect as it stripped the extension regardless its name. The function has been replaced by a new function with content based on `stripExtensionGeneral` and `stripPath`).

The problem occurred for the graphical formats `dot`, `msc` and `dia` and the output formats `html`, `latex` and `docbook`. (Although not affected th fix has also been applied for the output format `rtf` and the graphical format `plantuml` as a matter of consistency).

Example: [example.tar.gz](https://github.com/user-attachments/files/24256531/example.tar.gz)
