### PR TITLE
Problems with detecting begin module / routine in Fortran

### DIFF
--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -466,7 +466,7 @@ FILEMASK  {VFILEMASK}|{HFILEMASK}
 
  /*------ ignore simple comment (not documentation yyextra->comments) */
 
-<*>"!"/[^<>\n]                         {  if (YY_START == String || YY_START == DocCopyBlock)
+<*>"!"/([^<>\n]|"<ff>"|"<FF>")          {  if (YY_START == String || YY_START == DocCopyBlock)
                                           { yyextra->colNr -= (int)yyleng;
                                             REJECT;
                                           } // "!" is ignored in strings
@@ -920,7 +920,7 @@ private                                 {
                                           }
                                         }
 {ID}                                    {
-                                          if (YY_START == Start)
+                                          if (YY_START == Start && QCString(yytext).stripWhiteSpace().lower()!="include")
                                           {
                                             addModule(yyscanner);
                                             yy_push_state(ModuleBody,yyscanner); //anon program


### PR DESCRIPTION
- `INCLUDE` statement before module / routine:
- `C<ff>` was not recognized as proper comment

both problems gave warning like:
 ```
  line: 34, state: 10(ModuleBody)
```

(Found by Fossies for the rlab package)