### PR TITLE
Inconsistency in representing file version

### DIFF
--- a/src/filedef.cpp
+++ b/src/filedef.cpp
@@ -885,7 +885,7 @@ void FileDefImpl::writeDocumentation(OutputList &ol)
   QCString versionTitle;
   if (!m_fileVersion.isEmpty())
   {
-    versionTitle=("("+m_fileVersion+")");
+    versionTitle=" ("+m_fileVersion+")";
   }
   QCString title = m_docname+versionTitle;
   QCString pageTitle;
@@ -1158,7 +1158,7 @@ void FileDefImpl::writeSourceHeader(OutputList &ol)
   QCString title = m_docname;
   if (!m_fileVersion.isEmpty())
   {
-    title+=(" ("+m_fileVersion+")");
+    title+=" ("+m_fileVersion+")";
   }
   QCString pageTitle = theTranslator->trSourceFile(title);
   ol.disable(OutputType::Man);


### PR DESCRIPTION
Based on bug 793649 (issue #6338) the was a difference (initial space) between representing the file version (from `FILE_VERSION_FILTER`) in case of the documentation and the source documentation. These versions have been aligned.