### PR TITLE
Special one line CPP comment in string

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -2063,8 +2063,7 @@ ENDQopt ("const"|"volatile"|"sealed"|"override")({BN}+("const"|"volatile"|"seale
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner,true);
                                         }
-<*>{CPPC}[!/][^\n]*                       { // strip special one-line comment
-                                          if (YY_START==SkipComment || YY_START==SkipString) REJECT;
+<SkipStringS,SkipVerbString,SkipCPP,SkipCxxComment,Body,BodyVar,FuncCall,MemberCall,MemberCall2,SkipInits,ClassName,AlignAs,AlignAsEnd,PackageName,ClassVar,CppCliTypeModifierFollowup,Bases,SkipSharp,ReadInclude,TemplDecl,TemplCast,CallEnd,ObjCMethod,ObjCParams,ObjCParamType,ObjCCall,ObjCMName,ObjCSkipStr,ObjCCallComment,OldStyleArgs,ConceptName,UsingName,RawString,InlineInit,ModuleName,ModuleImport>{CPPC}[!/][^\n]*                       { // strip special one-line comment, all states with the exception of SkipComment and SkipString which are handled separately
                                           startFontClass(yyscanner,"comment",true);
                                           codifyLines(yyscanner,yytext);
                                           endFontClass(yyscanner,true);


### PR DESCRIPTION
When having  special one line comment (`//!` or `///`) inside a string the rule `<*>{CPPC}[!/][^\n]*` would kick in and due to its greediness an error like:
```
input buffer overflow, can't enlarge buffer because scanner uses REJECT
    lexical analyzer: .../doxygen/src/code.l (for: Chart_bundle_js.cpp)
```
can appear when the, remainder, of the string is to large to fit in the lex buffer.

By specifying all states except those that were already rejected this problem can be overcome.

Example: [example.tar.gz](https://github.com/user-attachments/files/24332199/example.tar.gz)

(Found by Fossies for the proxysql package)
