### PR TITLE
issue #11828 Inconsistent vertical spacing of ordered list items in generated HTML

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -79,6 +79,11 @@ p.startli, p.startdd {
 	margin-top: 2px;
 }
 
+li:only-child > p.startli {
+	margin-top: 0px;
+	margin-bottom: 0px;
+}
+
 th p.starttd, th p.intertd, th p.endtd {
 	font-size: 100%;
 	font-weight: 700;
@@ -281,14 +286,18 @@ dl.el {
 
 ul.check {
 	list-style:none;
-	text-indent: -16px;
-	padding-left: 38px;
 }
-li.unchecked:before {
-	content: "\2610\A0";
+
+ul.check li > p.startli {
+        margin-top: 10px;
 }
-li.checked:before {
-	content: "\2611\A0";
+
+ul.unchecked  {
+       list-style-type: "\2610\A0";
+}
+
+ul.checked  {
+       list-style-type: "\2611\A0";
 }
 
 ol {


### PR DESCRIPTION
The current situation is a bit inconsistent as depending on the number of paragraphs in an item the `<p class="startli">` is added or not.

In case one of the items consists of multiple paragraphs the `<p class="startli">` is added for all paragraphs in the items in the current item block. Now the `<p class="startli">` is always added, though this gave some problems with checked / unchecked lists, this has been overcome by moving the "check" marker to the `<ul>`, so it is now the list marker and not the item marker, hence also for each item an own list and a correction regarding the margins.