### PR TITLE
Remove duplicated code LaTeX index

### DIFF
--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -662,11 +662,7 @@ void LatexDocVisitor::operator()(const DocFormula &f)
 void LatexDocVisitor::operator()(const DocIndexEntry &i)
 {
   if (m_hide) return;
-  m_t << "\\index{";
-  m_t << latexEscapeLabelName(i.entry());
-  m_t << "@{";
-  m_t << latexEscapeIndexChars(i.entry());
-  m_t << "}}";
+  latexWriteIndexItem(m_t,i.entry());
 }
 
 void LatexDocVisitor::operator()(const DocSimpleSectSep &)

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1492,11 +1492,7 @@ void LatexGenerator::endTitleHead(const QCString &fileName,const QCString &name)
   }
   if (!name.isEmpty())
   {
-    m_t << "\\index{";
-    m_t << latexEscapeLabelName(name);
-    m_t << "@{";
-    m_t << latexEscapeIndexChars(name);
-    m_t << "}}\n";
+    latexWriteIndexItem(m_t,name);
   }
 }
 
@@ -1557,33 +1553,8 @@ void LatexGenerator::startMemberDoc(const QCString &clname,
 {
   if (!memname.isEmpty() && memname[0]!='@')
   {
-    m_t << "\\index{";
-    if (!clname.isEmpty())
-    {
-      m_t << latexEscapeLabelName(clname);
-      m_t << "@{";
-      m_t << latexEscapeIndexChars(clname);
-      m_t << "}!";
-    }
-    m_t << latexEscapeLabelName(memname);
-    m_t << "@{";
-    m_t << latexEscapeIndexChars(memname);
-    m_t << "}}\n";
-
-    m_t << "\\index{";
-    m_t << latexEscapeLabelName(memname);
-    m_t << "@{";
-    m_t << latexEscapeIndexChars(memname);
-    m_t << "}";
-    if (!clname.isEmpty())
-    {
-      m_t << "!";
-      m_t << latexEscapeLabelName(clname);
-      m_t << "@{";
-      m_t << latexEscapeIndexChars(clname);
-      m_t << "}";
-    }
-    m_t << "}\n";
+    latexWriteIndexItem(m_t,clname,memname);
+    latexWriteIndexItem(m_t,memname,clname);
   }
   bool compactLatex = Config_getBool(COMPACT_LATEX);
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
@@ -1684,20 +1655,7 @@ void LatexGenerator::addIndexItem(const QCString &s1,const QCString &s2)
 {
   if (!s1.isEmpty())
   {
-    m_t << "\\index{";
-    m_t << latexEscapeLabelName(s1);
-    m_t << "@{";
-    m_t << latexEscapeIndexChars(s1);
-    m_t << "}";
-    if (!s2.isEmpty())
-    {
-      m_t << "!";
-      m_t << latexEscapeLabelName(s2);
-      m_t << "@{";
-      m_t << latexEscapeIndexChars(s2);
-      m_t << "}";
-    }
-    m_t << "}";
+    latexWriteIndexItem(m_t,s1,s2);
   }
 }
 
@@ -2708,6 +2666,27 @@ QCString latexFilterURL(const QCString &s)
     }
   }
   return t.str();
+}
+
+void latexWriteIndexItem(TextStream &m_t,const QCString &s1,const QCString &s2)
+{
+  if (!s1.isEmpty())
+  {
+    m_t << "\\index{";
+    m_t << latexEscapeLabelName(s1);
+    m_t << "@{";
+    m_t << latexEscapeIndexChars(s1);
+    m_t << "}";
+    if (!s2.isEmpty())
+    {
+      m_t << "!";
+      m_t << latexEscapeLabelName(s2);
+      m_t << "@{";
+      m_t << latexEscapeIndexChars(s2);
+      m_t << "}";
+    }
+    m_t << "}\n";
+  }
 }
 
 

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -347,6 +347,7 @@ QCString latexEscapeLabelName(const QCString &s);
 QCString latexEscapeIndexChars(const QCString &s);
 QCString latexEscapePDFString(const QCString &s);
 QCString latexFilterURL(const QCString &s);
+void latexWriteIndexItem(TextStream &t,const QCString &r1,const QCString &s2 = "");
 
 
 #endif


### PR DESCRIPTION
Remove duplicated code for writing LaTeX index.

(Note: in `LatexGenerator::startMemberDoc` when `clname` is empty the `memname` was written twice in an identical way, corrected as well)