### PR TITLE
Bug 742707 Doxygen gets confused when two copies of dot file exist

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1220,30 +1220,63 @@ void DocbookDocVisitor::operator()(const DocDotFile &df)
 {
 DB_VIS_C
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file()));
-  startDotFile(df.file(),df.relPath(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
-  visitChildren(df);
-  endDotFile(df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dot",                                                        // extension
+                                      inBuf,                                                         // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      startDotFile(fileName,df.relPath(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine(),!exists);
+      visitChildren(df);
+      endDotFile(df.hasCaption());
+    }
+  }
 }
 
 void DocbookDocVisitor::operator()(const DocMscFile &df)
 {
 DB_VIS_C
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file()));
-  startMscFile(df.file(),df.relPath(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
-  visitChildren(df);
-  endMscFile(df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".msc",                                                        // extension
+                                      inBuf,                                                         // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      startMscFile(fileName,df.relPath(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine(),!exists);
+      visitChildren(df);
+      endMscFile(df.hasCaption());
+    }
+  }
 }
 
 void DocbookDocVisitor::operator()(const DocDiaFile &df)
 {
 DB_VIS_C
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file()));
-  startDiaFile(df.file(),df.relPath(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine());
-  visitChildren(df);
-  endDiaFile(df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(DOCBOOK_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dia",                                                        // extension
+                                      inBuf,                                                         // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      startDiaFile(fileName,df.relPath(),df.width(),df.height(),df.hasCaption(),df.children(),df.srcFile(),df.srcLine(),!exists);
+      visitChildren(df);
+      endDiaFile(df.hasCaption());
+    }
+  }
 }
 
 void DocbookDocVisitor::operator()(const DocPlantUmlFile &df)
@@ -1564,14 +1597,14 @@ void DocbookDocVisitor::startMscFile(const QCString &fileName,
     bool hasCaption,
     const DocNodeList &children,
     const QCString &srcFile,
-    int srcLine
+    int srcLine, bool newFile
     )
 {
 DB_VIS_C
   QCString baseName=makeBaseName(fileName,".msc");
   baseName.prepend("msc_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, relPath + baseName + ".png",  width,  height);
 }
@@ -1602,14 +1635,14 @@ void DocbookDocVisitor::startDiaFile(const QCString &fileName,
     bool hasCaption,
     const DocNodeList &children,
     const QCString &srcFile,
-    int srcLine
+    int srcLine, bool newFile
     )
 {
 DB_VIS_C
   QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, relPath + baseName + ".png",  width,  height);
 }
@@ -1640,7 +1673,7 @@ void DocbookDocVisitor::startDotFile(const QCString &fileName,
     bool hasCaption,
     const DocNodeList &children,
     const QCString &srcFile,
-    int srcLine
+    int srcLine, bool newFile
     )
 {
 DB_VIS_C
@@ -1648,7 +1681,7 @@ DB_VIS_C
   baseName.prepend("dot_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   QCString imgExt = getDotImageExtension();
-  writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, relPath + baseName + "." + imgExt,  width,  height);
 }

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -116,17 +116,17 @@ class DocbookDocVisitor : public DocVisitor
     void endLink();
     void startMscFile(const QCString &fileName,const QCString &relPath, const QCString &width,
                       const QCString &height, bool hasCaption,const DocNodeList &children,
-                      const QCString &srcFile, int srcLine);
+                      const QCString &srcFile, int srcLine, bool newFile = true);
     void endMscFile(bool hasCaption);
     void writeMscFile(const QCString &fileName, const DocVerbatim &s, bool newFile = true);
     void startDiaFile(const QCString &fileName,const QCString &relPath, const QCString &width,
                       const QCString &height, bool hasCaption,const DocNodeList &children,
-                      const QCString &srcFile, int srcLine);
+                      const QCString &srcFile, int srcLine, bool newFile = true);
     void endDiaFile(bool hasCaption);
     void writeDiaFile(const QCString &fileName, const DocVerbatim &s);
     void startDotFile(const QCString &fileName,const QCString &relPath, const QCString &width,
                       const QCString &height, bool hasCaption,const DocNodeList &children,
-                      const QCString &srcFile, int srcLine);
+                      const QCString &srcFile, int srcLine, bool newFile = true);
     void endDotFile(bool hasCaption);
     void writeDotFile(const QCString &fileName, const DocVerbatim &s, bool newFile = true);
     void writePlantUMLFile(const QCString &fileName, const DocVerbatim &s);

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -1715,60 +1715,93 @@ void HtmlDocVisitor::operator()(const DocImage &img)
 void HtmlDocVisitor::operator()(const DocDotFile &df)
 {
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
   forceEndParagraph(df);
-  m_t << "<div class=\"dotgraph\">\n";
-  writeDotFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
-  if (df.hasCaption())
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
   {
-    m_t << "<div class=\"caption\">\n";
+    auto fileName = writeFileContents(Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dot",                                                     // extension
+                                      inBuf,                                                      // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      m_t << "<div class=\"dotgraph\">\n";
+      writeDotFile(fileName,df.relPath(),df.context(),df.srcFile(),df.srcLine(),!exists);
+      if (df.hasCaption())
+      {
+        m_t << "<div class=\"caption\">\n";
+      }
+      visitChildren(df);
+      if (df.hasCaption())
+      {
+        m_t << "</div>\n";
+      }
+      m_t << "</div>\n";
   }
-  visitChildren(df);
-  if (df.hasCaption())
-  {
-    m_t << "</div>\n";
   }
-  m_t << "</div>\n";
   forceStartParagraph(df);
 }
 
 void HtmlDocVisitor::operator()(const DocMscFile &df)
 {
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
   forceEndParagraph(df);
-  m_t << "<div class=\"mscgraph\">\n";
-  writeMscFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
-  if (df.hasCaption())
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
   {
-    m_t << "<div class=\"caption\">\n";
+    auto fileName = writeFileContents(Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".msc",                                                     // extension
+                                      inBuf,                                                      // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      m_t << "<div class=\"mscgraph\">\n";
+      writeMscFile(fileName,df.relPath(),df.context(),df.srcFile(),df.srcLine(),!exists);
+      if (df.hasCaption())
+      {
+        m_t << "<div class=\"caption\">\n";
+      }
+      visitChildren(df);
+      if (df.hasCaption())
+      {
+        m_t << "</div>\n";
+      }
+      m_t << "</div>\n";
+    }
   }
-  visitChildren(df);
-  if (df.hasCaption())
-  {
-    m_t << "</div>\n";
-  }
-  m_t << "</div>\n";
   forceStartParagraph(df);
 }
 
 void HtmlDocVisitor::operator()(const DocDiaFile &df)
 {
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file()));
   forceEndParagraph(df);
-  m_t << "<div class=\"diagraph\">\n";
-  writeDiaFile(df.file(),df.relPath(),df.context(),df.srcFile(),df.srcLine());
-  if (df.hasCaption())
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
   {
-    m_t << "<div class=\"caption\">\n";
+    auto fileName = writeFileContents(Config_getString(HTML_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dia",                                                     // extension
+                                      inBuf,                                                      // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      m_t << "<div class=\"diagraph\">\n";
+      writeDiaFile(fileName,df.relPath(),df.context(),df.srcFile(),df.srcLine(),!exists);
+      if (df.hasCaption())
+      {
+        m_t << "<div class=\"caption\">\n";
+      }
+      visitChildren(df);
+      if (df.hasCaption())
+      {
+        m_t << "</div>\n";
+      }
+      m_t << "</div>\n";
+    }
   }
-  visitChildren(df);
-  if (df.hasCaption())
-  {
-    m_t << "</div>\n";
-  }
-  m_t << "</div>\n";
   forceStartParagraph(df);
 }
 
@@ -2179,12 +2212,12 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPa
 }
 
 void HtmlDocVisitor::writeDiaFile(const QCString &fileName, const QCString &relPath,
-                                  const QCString &,const QCString &srcFile,int srcLine)
+                                  const QCString &,const QCString &srcFile,int srcLine, bool newFile)
 {
   QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
   QCString outDir = Config_getString(HTML_OUTPUT);
-  writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
 
   m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
 }

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -128,7 +128,7 @@ class HtmlDocVisitor : public DocVisitor
     void writeMscFile(const QCString &fileName,const QCString &relPath,const QCString &context,
                       const QCString &srcFile,int srcLine, bool newFile = true);
     void writeDiaFile(const QCString &fileName,const QCString &relPath,const QCString &context,
-                      const QCString &srcFile,int srcLine);
+                      const QCString &srcFile,int srcLine, bool newFile = true);
     void writePlantUMLFile(const QCString &fileName,const QCString &relPath,const QCString &context,
                            const QCString &srcFile,int srcLine);
 

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1482,28 +1482,61 @@ void LatexDocVisitor::operator()(const DocImage &img)
 void LatexDocVisitor::operator()(const DocDotFile &df)
 {
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file()));
-  startDotFile(df.file(),df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine());
-  visitChildren(df);
-  endDotFile(df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dot",                                                      // extension
+                                      inBuf,                                                       // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      startDotFile(fileName,df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine(),!exists);
+      visitChildren(df);
+      endDotFile(df.hasCaption());
+    }
+  }
 }
 
 void LatexDocVisitor::operator()(const DocMscFile &df)
 {
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file()));
-  startMscFile(df.file(),df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine());
-  visitChildren(df);
-  endMscFile(df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".msc",                                                      // extension
+                                      inBuf,                                                      // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      startMscFile(fileName,df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine(),!exists);
+      visitChildren(df);
+      endMscFile(df.hasCaption());
+    }
+  }
 }
 
 void LatexDocVisitor::operator()(const DocDiaFile &df)
 {
   if (m_hide) return;
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file()));
-  startDiaFile(df.file(),df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine());
-  visitChildren(df);
-  endDiaFile(df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(LATEX_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dia",                                                      // extension
+                                      inBuf,                                                      // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      startDiaFile(fileName,df.width(),df.height(),df.hasCaption(),df.srcFile(),df.srcLine(),!exists);
+      visitChildren(df);
+      endDiaFile(df.hasCaption());
+    }
+  }
 }
 
 void LatexDocVisitor::operator()(const DocPlantUmlFile &df)
@@ -1908,14 +1941,14 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
                                    const QCString &height,
                                    bool hasCaption,
                                    const QCString &srcFile,
-                                   int srcLine
+                                   int srcLine, bool newFile
                                   )
 {
   QCString baseName=makeBaseName(fileName,".msc");
   baseName.prepend("msc_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::EPS,srcFile,srcLine);
+  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::EPS,srcFile,srcLine);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1941,14 +1974,14 @@ void LatexDocVisitor::startDiaFile(const QCString &fileName,
                                    const QCString &height,
                                    bool hasCaption,
                                    const QCString &srcFile,
-                                   int srcLine
+                                   int srcLine, bool newFile
                                   )
 {
   QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::EPS,srcFile,srcLine);
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::EPS,srcFile,srcLine);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -146,13 +146,13 @@ class LatexDocVisitor : public DocVisitor
 
     void startMscFile(const QCString &fileName,const QCString &width,
                       const QCString &height, bool hasCaption,
-                      const QCString &srcFile,int srcLine);
+                      const QCString &srcFile,int srcLine,bool newFile = true);
     void endMscFile(bool hasCaption);
     void writeMscFile(const QCString &fileName, const DocVerbatim &s, bool newFile = true);
 
     void startDiaFile(const QCString &fileName,const QCString &width,
                       const QCString &height, bool hasCaption,
-                      const QCString &srcFile,int srcLine);
+                      const QCString &srcFile,int srcLine,bool newFile = true);
     void endDiaFile(bool hasCaption);
     void writePlantUMLFile(const QCString &fileName, const DocVerbatim &s);
     void startPlantUmlFile(const QCString &fileName,const QCString &width,

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1246,27 +1246,60 @@ void RTFDocVisitor::operator()(const DocImage &img)
 void RTFDocVisitor::operator()(const DocDotFile &df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::operator()(const DocDotFile &)}\n");
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(RTF_OUTPUT)+"/"+stripPath(df.file()));
-  writeDotFile(df);
-  visitChildren(df);
-  includePicturePostRTF(true, df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(RTF_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dot",                                                    // extension
+                                      inBuf,                                                     // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      writeDotFile(fileName, df.hasCaption(), df.srcFile(), df.srcLine(), !exists);
+      visitChildren(df);
+      includePicturePostRTF(true, df.hasCaption());
+    }
+  }
 }
 void RTFDocVisitor::operator()(const DocMscFile &df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::operator()(const DocMscFile &)}\n");
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(RTF_OUTPUT)+"/"+stripPath(df.file()));
-  writeMscFile(df);
-  visitChildren(df);
-  includePicturePostRTF(true, df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(RTF_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".msc",                                                    // extension
+                                      inBuf,                                                     // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      writeMscFile(fileName, df.hasCaption(), df.srcFile(), df.srcLine(), !exists);
+      visitChildren(df);
+      includePicturePostRTF(true, df.hasCaption());
+    }
+  }
 }
 
 void RTFDocVisitor::operator()(const DocDiaFile &df)
 {
   DBG_RTF("{\\comment RTFDocVisitor::operator()(const DocDiaFile &)}\n");
-  if (!Config_getBool(DOT_CLEANUP)) copyFile(df.file(),Config_getString(RTF_OUTPUT)+"/"+stripPath(df.file()));
-  writeDiaFile(df);
-  visitChildren(df);
-  includePicturePostRTF(true, df.hasCaption());
+  bool exists = false;
+  std::string inBuf;
+  if (readInputFile(df.file(),inBuf))
+  {
+    auto fileName = writeFileContents(Config_getString(RTF_OUTPUT)+"/"+stripPath(df.file())+"_", // baseName
+                                      ".dia",                                                    // extension
+                                      inBuf,                                                     // contents
+                                      exists);
+    if (!fileName.isEmpty())
+    {
+      writeDiaFile(fileName, df.hasCaption(), df.srcFile(), df.srcLine(), !exists);
+      visitChildren(df);
+      includePicturePostRTF(true, df.hasCaption());
+    }
+  }
 }
 
 void RTFDocVisitor::operator()(const DocPlantUmlFile &df)
@@ -1699,10 +1732,6 @@ void RTFDocVisitor::endLink(const QCString &ref)
   m_lastIsPara=FALSE;
 }
 
-void RTFDocVisitor::writeDotFile(const DocDotFile &df)
-{
-  writeDotFile(df.file(), df.hasCaption(), df.srcFile(), df.srcLine());
-}
 void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption,
                                  const QCString &srcFile, int srcLine, bool newFile)
 {
@@ -1713,10 +1742,6 @@ void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption,
   includePicturePreRTF(baseName + "." + imgExt, true, hasCaption);
 }
 
-void RTFDocVisitor::writeMscFile(const DocMscFile &df)
-{
-  writeMscFile(df.file(), df.hasCaption(), df.srcFile(), df.srcLine());
-}
 void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption,
                                  const QCString &srcFile, int srcLine, bool newFile)
 {
@@ -1726,12 +1751,13 @@ void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption,
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
-void RTFDocVisitor::writeDiaFile(const DocDiaFile &df)
+void RTFDocVisitor::writeDiaFile(const QCString &fileName, bool hasCaption,
+                                 const QCString &srcFile, int srcLine, bool newFile)
 {
-  QCString baseName=makeBaseName(df.file(),".dia");
+  QCString baseName=makeBaseName(fileName,".dia");
   QCString outDir = Config_getString(RTF_OUTPUT);
-  writeDiaGraphFromFile(df.file(),outDir,baseName,DiaOutputFormat::BITMAP,df.srcFile(),df.srcLine());
-  includePicturePreRTF(baseName + ".png", true, df.hasCaption());
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
+  includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
 void RTFDocVisitor::writePlantUMLFile(const QCString &fileName, bool hasCaption)

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -129,10 +129,8 @@ class RTFDocVisitor : public DocVisitor
     void includePicturePreRTF(const QCString &name, bool isTypeRTF, bool hasCaption, bool inlineImage = FALSE);
     void includePicturePostRTF(bool isTypeRTF, bool hasCaption, bool inlineImage = FALSE);
     void writeDotFile(const QCString &fileName, bool hasCaption,const QCString &srcFile,int srcLine,bool newFile = true);
-    void writeDotFile(const DocDotFile &);
     void writeMscFile(const QCString &fileName, bool hasCaption,const QCString &srcFile,int srcLine,bool newFile = true);
-    void writeMscFile(const DocMscFile &);
-    void writeDiaFile(const DocDiaFile &);
+    void writeDiaFile(const QCString &fileName, bool hasCaption,const QCString &srcFile,int srcLine,bool newFile = true);
     void writePlantUMLFile(const QCString &fileName, bool hasCaption);
 
     //--------------------------------------


### PR DESCRIPTION
Adding a md5 sum to the result file name so the filename will be unique, analogous to the #11902 (Protect counter with mutex) where this has been done for inline images.

Example; [example.tar.gz](https://github.com/user-attachments/files/24359591/example.tar.gz)
