### PR TITLE
Missing requirements chapter in doxygen PDF manual

### DIFF
--- a/doc/doxygen_manual.tex
+++ b/doc/doxygen_manual.tex
@@ -156,6 +156,7 @@ Written by Dimitri van Heesch\\[2ex]
 \input{additional}
 \input{markdown}
 \input{lists}
+\input{requirements}
 \input{grouping}
 \input{formulas}
 \input{tables}


### PR DESCRIPTION
The requirements chapter was missing in the doxygen PDF manual.