### PR TITLE
Problem with `\satisfies` documentation in Doxyfile and doxywizard

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -469,7 +469,7 @@ static QString getDocsForNode(const QDomElement &child)
   docs.replace(SA("\\endverbatim"),SA("</pre>"));
   // \sa -> <br>See also:
   // \par -> <br>
-  docs.replace(SA("\\sa"),SA("<br>See also:"));
+  docs.replace(SA("\\sa "),SA("<br>See also: "));
   docs.replace(SA("\\par"),SA("<br>"));
   // 2xbackslash -> backslash
   // \@ -> @

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -54,7 +54,7 @@ def transformDocs(doc):
     doc = doc.replace("\\#undef ", "#undef ")
     doc = doc.replace("-# ", "\n - ")
     doc = doc.replace(" - ", "\n - ")
-    doc = doc.replace("\\sa", "\nSee also: ")
+    doc = doc.replace("\\sa ", "\nSee also: ")
     doc = doc.replace("\\par", "\n")
     doc = doc.replace("@note", "\nNote:")
     doc = doc.replace("\\note", "\nNote:")


### PR DESCRIPTION
Due to the fact that in the generation of the documentation of the configuration settings for the Doxyfile and the doxywizard did a replacement of `\sa` to `See also:` this also influenced also the references for the command `\satisfies`:
```
# satisfies relation (through the command: \
# See also: tisfies). Similarly the setting UNVERIFIED_ONLY will show a list of
```
instead of:
```
# satisfies relation (through the command: \satisfies). Similarly the setting
# UNVERIFIED_ONLY will show a list of requirements that are missing a verifies
```

(Found by Fossies)