### PR TITLE
issue #11934 Damaged Doxyfile doc comments

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -431,6 +431,8 @@ static QString getDocsForNode(const QDomElement &child)
   regexp.setPattern(SA("`([^`]+)`"));
   docs.replace(regexp,SA("<code>\\1</code>"));
   // \ref key "desc" -> <code>desc</code>
+  regexp.setPattern(SA("\\\\ref[ ]+[^ ]+[ ]+\"\\\\\\\\ref\""));
+  docs.replace(regexp,SA("\\\\REF"));
   regexp.setPattern(SA("\\\\ref[ ]+[^ ]+[ ]+\"([^\"]+)\""));
   docs.replace(regexp,SA("<code>\\1</code> "));
   //\ref specials
@@ -445,6 +447,7 @@ static QString getDocsForNode(const QDomElement &child)
   docs.replace(regexp,SA("\"Including formulas\""));
   // fallback for not handled
   docs.replace(SA("\\\\ref"),SA(""));
+  docs.replace(SA("\\\\REF"),SA("\\\\ref"));
   // \b word -> <b>word<\b>
   regexp.setPattern(SA("\\\\b[ ]+([^ ]+) "));
   docs.replace(regexp,SA("<b>\\1</b> "));
@@ -453,8 +456,8 @@ static QString getDocsForNode(const QDomElement &child)
   docs.replace(regexp,SA("<em>\\1</em> "));
   // \note -> <br>Note:
   // @note -> <br>Note:
-  docs.replace(SA("\\note"),SA("<br>Note:"));
-  docs.replace(SA("@note"),SA("<br>Note:"));
+  docs.replace(SA("\\note "),SA("<br>Note: "));
+  docs.replace(SA("@note "),SA("<br>Note: "));
   // \#include -> #include
   // \#undef -> #undef
   docs.replace(SA("\\#include"),SA("#include"));
@@ -462,6 +465,7 @@ static QString getDocsForNode(const QDomElement &child)
   // -# -> <br>-
   // " - " -> <br>-
   docs.replace(SA("-#"),SA("<br>-"));
+  docs.replace(SA("\\# "),SA("# "));
   docs.replace(SA(" - "),SA("<br>-"));
   // \verbatim -> <pre>
   // \endverbatim -> </pre>
@@ -470,7 +474,7 @@ static QString getDocsForNode(const QDomElement &child)
   // \sa -> <br>See also:
   // \par -> <br>
   docs.replace(SA("\\sa "),SA("<br>See also: "));
-  docs.replace(SA("\\par"),SA("<br>"));
+  docs.replace(SA("\\par "),SA("<br>"));
   // 2xbackslash -> backslash
   // \@ -> @
   docs.replace(SA("\\\\"),SA("\\"));

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -52,12 +52,13 @@ def transformDocs(doc):
     doc = doc.replace("\\$", "$")
     doc = doc.replace("\\#include ", "#include ")
     doc = doc.replace("\\#undef ", "#undef ")
+    doc = doc.replace("\\# ", "# ")
     doc = doc.replace("-# ", "\n - ")
     doc = doc.replace(" - ", "\n - ")
     doc = doc.replace("\\sa ", "\nSee also: ")
-    doc = doc.replace("\\par", "\n")
-    doc = doc.replace("@note", "\nNote:")
-    doc = doc.replace("\\note", "\nNote:")
+    doc = doc.replace("\\par ", "\n")
+    doc = doc.replace("@note ", "\nNote: ")
+    doc = doc.replace("\\note ", "\nNote: ")
     doc = doc.replace("\\verbatim", "\n")
     doc = doc.replace("\\endverbatim", "\n")
     doc = doc.replace("<code>", "")
@@ -68,6 +69,7 @@ def transformDocs(doc):
     doc = doc.replace("\\@", "@")
     doc = doc.replace("\\\\", "\\")
     # \ref name "description" -> description
+    doc = re.sub('\\\\ref +[^ ]* +"\\\\ref"', '\\\\REF', doc)
     doc = re.sub('\\\\ref +[^ ]* +"([^"]*)"', '\\1', doc)
     # \ref specials
     # \ref <key> -> description
@@ -81,7 +83,8 @@ def transformDocs(doc):
                  doc)
     doc = re.sub('\\\\ref +formulas', '"Including formulas"', doc)
     # fallback for not handled
-    doc = re.sub('\\\\ref', '', doc)
+    doc = re.sub('\\\\ref ', ' ', doc)
+    doc = re.sub('\\\\REF', '\\\\ref', doc)
     #<a href="address">description</a> -> description (see: address)
     doc = re.sub('<a +href="([^"]*)" *>([^<]*)</a>', '\\2 (see: \n\\1)', doc)
     # LaTeX name as formula -> LaTeX


### PR DESCRIPTION
The original problem was solved in #11924 though looking at some other commands and settings a similar problem occurred (`\#` and `\ref`) for the setting `AUTOLINK_IGNORE_WORDS`.