### PR TITLE
Double index in LaTeX with citations and no hyperlinks

### DIFF
--- a/templates/latex/footer.tex
+++ b/templates/latex/footer.tex
@@ -13,7 +13,6 @@
 %%BEGIN !COMPACT_LATEX
    \addcontentsline{toc}{chapter}{$latexcitereference}
 %%END !COMPACT_LATEX
-  \printindex
 %%END !PDF_HYPERLINKS
 
   \bibliographystyle{$latexbibstyle}


### PR DESCRIPTION
When having citations, but no `hyperlink`s / `hyperref`s enabled the `Index` section (at end) was present twice.

Example: [example.tar.gz](https://github.com/user-attachments/files/24553794/example.tar.gz)
