### PR TITLE
Improve filename matching

### DIFF
--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -943,11 +943,11 @@ void GroupDefImpl::writeFiles(OutputList &ol,const QCString &title)
       if (!fd->hasDocumentation()) continue;
       ol.startMemberDeclaration();
       QCString anc = fd->anchor();
-      if (anc.isEmpty()) anc=fd->displayName(); else anc.prepend(fd->displayName()+"_");
+      if (anc.isEmpty()) anc=fd->docName(); else anc.prepend(fd->docName()+"_");
       ol.startMemberItem(anc,OutputGenerator::MemberItemType::Normal);
       ol.docify(theTranslator->trFile(FALSE,TRUE)+" ");
       ol.insertMemberAlign();
-      ol.writeObjectLink(fd->getReference(),fd->getOutputFileBase(),QCString(),fd->displayName());
+      ol.writeObjectLink(fd->getReference(),fd->getOutputFileBase(),QCString(),fd->docName());
       ol.endMemberItem(OutputGenerator::MemberItemType::Normal);
       if (!fd->briefDescription().isEmpty() && Config_getBool(BRIEF_MEMBER_DESC))
       {

--- a/src/groupdef.cpp
+++ b/src/groupdef.cpp
@@ -716,7 +716,9 @@ void GroupDefImpl::writeTagFile(TextStream &tagFile)
           {
             if (fd->isLinkableInProject())
             {
-              tagFile << "    <file>" << convertToXML(fd->name()) << "</file>\n";
+              tagFile << "    <file path=\""
+                << convertToXML(stripFromPath(fd->getPath())) << "\">"
+                << convertToXML(fd->name()) << "</file>\n";
             }
           }
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2929,6 +2929,13 @@ FileDef *findFileDef(const FileNameLinkedMap *fnMap,const QCString &n,bool &ambi
       {
         FileDef *fd = fd_p.get();
         QCString fdStripPath = stripFromIncludePath(fd->getPath());
+        if (fdStripPath == pathStripped)
+        {
+          // if the stripped paths are equal, we have a perfect match
+          count = 1;
+          lastMatch=fd;
+          break;
+        }
         if (path.isEmpty() ||
             (!pathStripped.isEmpty() && fdStripPath.endsWith(pathStripped)) ||
             (pathStripped.isEmpty() && fdStripPath.isEmpty()))

--- a/testing/116/116__tagfile_8cpp.xml
+++ b/testing/116/116__tagfile_8cpp.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="116__tagfile_8cpp" kind="file" language="C++">
+    <compoundname>116_tagfile.cpp</compoundname>
+    <innerclass refid="struct_struct" prot="public">Struct</innerclass>
+    <innerclass refid="union_union" prot="public">Union</innerclass>
+    <innerclass refid="class_namespace_1_1_class" prot="public">Namespace::Class</innerclass>
+    <innernamespace refid="namespace_namespace">Namespace</innernamespace>
+    <sectiondef kind="define">
+      <member refid="group___group_1gab0a66d73c921ab6fb0ba9f550fd77c23" kind="define">
+        <name>Define</name>
+      </member>
+      <member refid="group___group_1ga4ab59fbc11caf0f38d699ef980a378c8" kind="define">
+        <name>Macro</name>
+      </member>
+    </sectiondef>
+    <sectiondef kind="enum">
+      <member refid="group___group_1ga8150b7776c2a1749101acf22e868d091" kind="enum">
+        <name>Enum</name>
+      </member>
+    </sectiondef>
+    <sectiondef kind="typedef">
+      <member refid="group___group_1ga5cf05ddc8cf20a9eb9ce35b43c750790" kind="typedef">
+        <name>EnumTypedef</name>
+      </member>
+    </sectiondef>
+    <sectiondef kind="var">
+      <member refid="group___group_1ga83237bee02feeff4fc8a0dfcb9d53878" kind="variable">
+        <name>Object</name>
+      </member>
+    </sectiondef>
+    <sectiondef kind="func">
+      <member refid="group___group_1ga054c88794f4fcaae438dfb7aa8b8d9f7" kind="function">
+        <name>Function</name>
+      </member>
+      <member refid="group___group_1ga78afe45b73c401f184443bb2e2f80275" kind="function">
+        <name>InlineFunction</name>
+      </member>
+    </sectiondef>
+    <briefdescription>
+      <para>116_tagfile.cpp brief (in 116_tagfile.cpp) </para>
+    </briefdescription>
+    <detaileddescription>
+      <para>116_tagfile.cpp description (in 116_tagfile.cpp). </para>
+    </detaileddescription>
+    <location file="116_tagfile.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/116/class_namespace_1_1_class.xml
+++ b/testing/116/class_namespace_1_1_class.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="class_namespace_1_1_class" kind="class" language="C++" prot="public">
+    <compoundname>Namespace::Class</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="class_namespace_1_1_class_1ae278721b28b01a4c01b09de072ac98d6" prot="public" static="no" mutable="no">
+        <type>int</type>
+        <definition>int Namespace::Class::ClassMember</definition>
+        <argsstring/>
+        <name>ClassMember</name>
+        <qualifiedname>Namespace::Class::ClassMember</qualifiedname>
+        <briefdescription>
+          <para>ClassMember brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>ClassMember description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="171" column="11" bodyfile="116_tagfile.cpp" bodystart="171" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="public-func">
+      <memberdef kind="function" id="class_namespace_1_1_class_1a3728462d9de1e54c409d273c99bfe5a8" prot="public" static="no" const="no" explicit="no" inline="yes" virt="non-virtual">
+        <type/>
+        <definition>Namespace::Class::Class</definition>
+        <argsstring>()</argsstring>
+        <name>Class</name>
+        <qualifiedname>Namespace::Class::Class</qualifiedname>
+        <briefdescription>
+          <para><ref refid="class_namespace_1_1_class" kindref="compound">Class</ref> constructor brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para><ref refid="class_namespace_1_1_class" kindref="compound">Class</ref> constructor description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="164" column="7" bodyfile="116_tagfile.cpp" bodystart="164" bodyend="164"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para><ref refid="class_namespace_1_1_class" kindref="compound">Class</ref> brief (in 116_tagfile.cpp). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="class_namespace_1_1_class" kindref="compound">Class</ref> description (in 116_tagfile.cpp). </para>
+    </detaileddescription>
+    <location file="116_tagfile.cpp" line="157" column="3" bodyfile="116_tagfile.cpp" bodystart="157" bodyend="172"/>
+    <listofallmembers>
+      <member refid="class_namespace_1_1_class_1a3728462d9de1e54c409d273c99bfe5a8" prot="public" virt="non-virtual">
+        <scope>Namespace::Class</scope>
+        <name>Class</name>
+      </member>
+      <member refid="class_namespace_1_1_class_1ae278721b28b01a4c01b09de072ac98d6" prot="public" virt="non-virtual">
+        <scope>Namespace::Class</scope>
+        <name>ClassMember</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/116/f_8cpp.xml
+++ b/testing/116/f_8cpp.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="f_8cpp" kind="file" language="C++">
+    <compoundname>f.cpp</compoundname>
+    <briefdescription>
+      <para><ref refid="f_8cpp" kindref="compound">more_116/f.cpp</ref> brief (in <ref refid="f_8cpp" kindref="compound">more_116/f.cpp</ref>). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="f_8cpp" kindref="compound">more_116/f.cpp</ref> description (in 116_tagfile.cpp).</para>
+      <para><ref refid="f_8cpp" kindref="compound">more_116/f.cpp</ref> description (in <ref refid="f_8cpp" kindref="compound">more_116/f.cpp</ref>). </para>
+    </detaileddescription>
+    <location file="more_116/f.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/116/group___group.xml
+++ b/testing/116/group___group.xml
@@ -7,6 +7,7 @@
     <innerfile refid="f_8cpp">f.cpp</innerfile>
     <innerfile refid="more__116_2a_2116__tagfile_8cpp">116_tagfile.cpp</innerfile>
     <innerfile refid="more__116_2b_2116__tagfile_8cpp">116_tagfile.cpp</innerfile>
+    <innerfile refid="s_2h_8h">h.h</innerfile>
     <innerfile refid="t_2s_2h_8h">h.h</innerfile>
     <innerclass refid="struct_struct" prot="public">Struct</innerclass>
     <innerclass refid="union_union" prot="public">Union</innerclass>

--- a/testing/116/group___group.xml
+++ b/testing/116/group___group.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="group___group" kind="group">
+    <compoundname>Group</compoundname>
+    <title>Group</title>
+    <innerfile refid="116__tagfile_8cpp">116_tagfile.cpp</innerfile>
+    <innerfile refid="f_8cpp">f.cpp</innerfile>
+    <innerfile refid="more__116_2a_2116__tagfile_8cpp">116_tagfile.cpp</innerfile>
+    <innerfile refid="more__116_2b_2116__tagfile_8cpp">116_tagfile.cpp</innerfile>
+    <innerfile refid="t_2s_2h_8h">h.h</innerfile>
+    <innerclass refid="struct_struct" prot="public">Struct</innerclass>
+    <innerclass refid="union_union" prot="public">Union</innerclass>
+    <innernamespace refid="namespace_namespace">Namespace</innernamespace>
+    <sectiondef kind="enum">
+      <memberdef kind="enum" id="group___group_1ga8150b7776c2a1749101acf22e868d091" prot="public" static="no" strong="no">
+        <type/>
+        <name>Enum</name>
+        <enumvalue id="group___group_1gga8150b7776c2a1749101acf22e868d091aecdc2953d9df684d8dc2bc9b0237113a" prot="public">
+          <name>EnumVal</name>
+          <briefdescription>
+            <para>EnumVal brief (in 116_tagfile.cpp). </para>
+          </briefdescription>
+          <detaileddescription>
+            <para>EnumVal description (in 116_tagfile.cpp). </para>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+          <para><ref refid="group___group_1ga8150b7776c2a1749101acf22e868d091" kindref="member">Enum</ref> brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para><ref refid="group___group_1ga8150b7776c2a1749101acf22e868d091" kindref="member">Enum</ref> description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="68" column="1" bodyfile="116_tagfile.cpp" bodystart="68" bodyend="75"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="group___group_1ga5cf05ddc8cf20a9eb9ce35b43c750790" prot="public" static="no">
+        <type>
+          <ref refid="group___group_1ga8150b7776c2a1749101acf22e868d091" kindref="member">Enum</ref>
+        </type>
+        <definition>typedef Enum EnumTypedef</definition>
+        <argsstring/>
+        <name>EnumTypedef</name>
+        <briefdescription>
+          <para><ref refid="group___group_1ga5cf05ddc8cf20a9eb9ce35b43c750790" kindref="member">EnumTypedef</ref> brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para><ref refid="group___group_1ga5cf05ddc8cf20a9eb9ce35b43c750790" kindref="member">EnumTypedef</ref> description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="82" column="14" bodyfile="116_tagfile.cpp" bodystart="82" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="var">
+      <memberdef kind="variable" id="group___group_1ga83237bee02feeff4fc8a0dfcb9d53878" prot="public" static="no" extern="yes" mutable="no">
+        <type>int</type>
+        <definition>int Object</definition>
+        <argsstring/>
+        <name>Object</name>
+        <briefdescription>
+          <para>Object brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>Object description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="61" column="12" declfile="116_tagfile.cpp" declline="61" declcolumn="12"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="func">
+      <memberdef kind="function" id="group___group_1ga054c88794f4fcaae438dfb7aa8b8d9f7" prot="public" static="no" const="no" explicit="no" inline="no" virt="non-virtual">
+        <type>void</type>
+        <definition>void Function</definition>
+        <argsstring>(int a, const int *b, int *c, int *d)</argsstring>
+        <name>Function</name>
+        <param>
+          <type>int</type>
+          <declname>a</declname>
+        </param>
+        <param>
+          <type>const int *</type>
+          <declname>b</declname>
+        </param>
+        <param>
+          <type>int *</type>
+          <declname>c</declname>
+        </param>
+        <param>
+          <type>int *</type>
+          <declname>d</declname>
+        </param>
+        <briefdescription>
+          <para>Function brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>Function description (in 116_tagfile.cpp).</para>
+          <para>
+            <parameterlist kind="param">
+              <parameteritem>
+                <parameternamelist>
+                  <parametername>a</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the parameter.</para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="in">b</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the in parameter.</para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="out">c</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the out parameter.</para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="inout">d</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the in/out parameter. </para>
+                </parameterdescription>
+              </parameteritem>
+            </parameterlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="125" column="6" declfile="116_tagfile.cpp" declline="125" declcolumn="6"/>
+      </memberdef>
+      <memberdef kind="function" id="group___group_1ga78afe45b73c401f184443bb2e2f80275" prot="public" static="yes" const="no" explicit="no" inline="yes" virt="non-virtual">
+        <type>void</type>
+        <definition>static void InlineFunction</definition>
+        <argsstring>(int a, const int *b, int *c, int *d)</argsstring>
+        <name>InlineFunction</name>
+        <param>
+          <type>int</type>
+          <declname>a</declname>
+        </param>
+        <param>
+          <type>const int *</type>
+          <declname>b</declname>
+        </param>
+        <param>
+          <type>int *</type>
+          <declname>c</declname>
+        </param>
+        <param>
+          <type>int *</type>
+          <declname>d</declname>
+        </param>
+        <briefdescription>
+          <para>InlineFunction brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>InlineFunction description (in 116_tagfile.cpp).</para>
+          <para>
+            <parameterlist kind="param">
+              <parameteritem>
+                <parameternamelist>
+                  <parametername>a</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the parameter.</para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="in">b</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the in parameter.</para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="out">c</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the out parameter.</para>
+                </parameterdescription>
+              </parameteritem>
+              <parameteritem>
+                <parameternamelist>
+                  <parametername direction="inout">d</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the in/out parameter. </para>
+                </parameterdescription>
+              </parameteritem>
+            </parameterlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="140" column="20" bodyfile="116_tagfile.cpp" bodystart="140" bodyend="144"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="define">
+      <memberdef kind="define" id="group___group_1gab0a66d73c921ab6fb0ba9f550fd77c23" prot="public" static="no">
+        <name>Define</name>
+        <initializer>123</initializer>
+        <briefdescription>
+          <para>Define brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>Define description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="45" column="9" bodyfile="116_tagfile.cpp" bodystart="45" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="define" id="group___group_1ga4ab59fbc11caf0f38d699ef980a378c8" prot="public" static="no">
+        <name>Macro</name>
+        <param>
+          <defname>x</defname>
+        </param>
+        <initializer>((x) * 456)</initializer>
+        <briefdescription>
+          <para>Macro brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>Macro description (in 116_tagfile.cpp).</para>
+          <para>
+            <parameterlist kind="param">
+              <parameteritem>
+                <parameternamelist>
+                  <parametername>x</parametername>
+                </parameternamelist>
+                <parameterdescription>
+                  <para>is the parameter. </para>
+                </parameterdescription>
+              </parameteritem>
+            </parameterlist>
+          </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="54" column="9" bodyfile="116_tagfile.cpp" bodystart="54" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>Group brief (in 116_tagfile.cpp). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para>Group description (in 116_tagfile.cpp). </para>
+    </detaileddescription>
+  </compounddef>
+</doxygen>

--- a/testing/116/more__116_2a_2116__tagfile_8cpp.xml
+++ b/testing/116/more__116_2a_2116__tagfile_8cpp.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="more__116_2a_2116__tagfile_8cpp" kind="file" language="C++">
+    <compoundname>116_tagfile.cpp</compoundname>
+    <briefdescription>
+      <para><ref refid="more__116_2a_2116__tagfile_8cpp" kindref="compound">more_116/a/116_tagfile.cpp</ref> brief (in <ref refid="more__116_2a_2116__tagfile_8cpp" kindref="compound">more_116/a/116_tagfile.cpp</ref>). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="more__116_2a_2116__tagfile_8cpp" kindref="compound">more_116/a/116_tagfile.cpp</ref> description (in 116_tagfile.cpp).</para>
+      <para><ref refid="more__116_2a_2116__tagfile_8cpp" kindref="compound">more_116/a/116_tagfile.cpp</ref> description (in <ref refid="more__116_2a_2116__tagfile_8cpp" kindref="compound">more_116/a/116_tagfile.cpp</ref>). </para>
+    </detaileddescription>
+    <location file="more_116/a/116_tagfile.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/116/more__116_2b_2116__tagfile_8cpp.xml
+++ b/testing/116/more__116_2b_2116__tagfile_8cpp.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="more__116_2b_2116__tagfile_8cpp" kind="file" language="C++">
+    <compoundname>116_tagfile.cpp</compoundname>
+    <briefdescription>
+      <para><ref refid="more__116_2b_2116__tagfile_8cpp" kindref="compound">more_116/b/116_tagfile.cpp</ref> brief (in <ref refid="more__116_2b_2116__tagfile_8cpp" kindref="compound">more_116/b/116_tagfile.cpp</ref>). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="more__116_2b_2116__tagfile_8cpp" kindref="compound">more_116/b/116_tagfile.cpp</ref> description (in 116_tagfile.cpp).</para>
+      <para><ref refid="more__116_2b_2116__tagfile_8cpp" kindref="compound">more_116/b/116_tagfile.cpp</ref> description (in <ref refid="more__116_2b_2116__tagfile_8cpp" kindref="compound">more_116/b/116_tagfile.cpp</ref>). </para>
+    </detaileddescription>
+    <location file="more_116/b/116_tagfile.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/116/namespace_namespace.xml
+++ b/testing/116/namespace_namespace.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="namespace_namespace" kind="namespace" language="C++">
+    <compoundname>Namespace</compoundname>
+    <innerclass refid="class_namespace_1_1_class" prot="public">Namespace::Class</innerclass>
+    <briefdescription>
+      <para><ref refid="namespace_namespace" kindref="compound">Namespace</ref> brief (in 116_tagfile.cpp). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="namespace_namespace" kindref="compound">Namespace</ref> description (in 116_tagfile.cpp). </para>
+    </detaileddescription>
+    <location file="116_tagfile.cpp" line="151" column="1"/>
+  </compounddef>
+</doxygen>

--- a/testing/116/s_2h_8h.xml
+++ b/testing/116/s_2h_8h.xml
@@ -3,8 +3,11 @@
   <compounddef id="s_2h_8h" kind="file" language="C++">
     <compoundname>h.h</compoundname>
     <briefdescription>
+      <para><ref refid="s_2h_8h" kindref="compound">s/h.h</ref> brief (in <ref refid="s_2h_8h" kindref="compound">s/h.h</ref>). </para>
     </briefdescription>
     <detaileddescription>
+      <para><ref refid="s_2h_8h" kindref="compound">s/h.h</ref> description (in <ref refid="f_8cpp" kindref="compound">more_116/f.cpp</ref>).</para>
+      <para><ref refid="s_2h_8h" kindref="compound">s/h.h</ref> description (in <ref refid="s_2h_8h" kindref="compound">s/h.h</ref>). </para>
     </detaileddescription>
     <location file="more_116/include/s/h.h"/>
   </compounddef>

--- a/testing/116/s_2h_8h.xml
+++ b/testing/116/s_2h_8h.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="s_2h_8h" kind="file" language="C++">
+    <compoundname>h.h</compoundname>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="more_116/include/s/h.h"/>
+  </compounddef>
+</doxygen>

--- a/testing/116/struct_struct.xml
+++ b/testing/116/struct_struct.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="struct_struct" kind="struct" language="C++" prot="public">
+    <compoundname>Struct</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="struct_struct_1a077c7aa3a29e27af8dd56791844d3099" prot="public" static="no" mutable="no">
+        <type>int</type>
+        <definition>int Struct::StructMember</definition>
+        <argsstring/>
+        <name>StructMember</name>
+        <qualifiedname>Struct::StructMember</qualifiedname>
+        <briefdescription>
+          <para>StructMember brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>StructMember description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="95" column="7" bodyfile="116_tagfile.cpp" bodystart="95" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para><ref refid="struct_struct" kindref="compound">Struct</ref> brief (in 116_tagfile.cpp). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="struct_struct" kindref="compound">Struct</ref> description (in 116_tagfile.cpp). </para>
+    </detaileddescription>
+    <location file="116_tagfile.cpp" line="89" column="1" bodyfile="116_tagfile.cpp" bodystart="89" bodyend="96"/>
+    <listofallmembers>
+      <member refid="struct_struct_1a077c7aa3a29e27af8dd56791844d3099" prot="public" virt="non-virtual">
+        <scope>Struct</scope>
+        <name>StructMember</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/116/t_2s_2h_8h.xml
+++ b/testing/116/t_2s_2h_8h.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="t_2s_2h_8h" kind="file" language="C++">
+    <compoundname>h.h</compoundname>
+    <briefdescription>
+      <para><ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref> brief (in <ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref>). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref> description (in <ref refid="f_8cpp" kindref="compound">more_116/f.cpp</ref>).</para>
+      <para><ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref> description (in <ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref>). </para>
+    </detaileddescription>
+    <location file="more_116/include/t/s/h.h"/>
+  </compounddef>
+</doxygen>

--- a/testing/116/tagfile
+++ b/testing/116/tagfile
@@ -126,11 +126,11 @@
     <name>Group</name>
     <title>Group</title>
     <filename>group___group.xhtml</filename>
-    <file>116_tagfile.cpp</file>
-    <file>f.cpp</file>
-    <file>116_tagfile.cpp</file>
-    <file>116_tagfile.cpp</file>
-    <file>h.h</file>
+    <file path="">116_tagfile.cpp</file>
+    <file path="more_116/">f.cpp</file>
+    <file path="more_116/a/">116_tagfile.cpp</file>
+    <file path="more_116/b/">116_tagfile.cpp</file>
+    <file path="more_116/include/t/s/">h.h</file>
     <namespace>Namespace</namespace>
     <class kind="struct">Struct</class>
     <class kind="union">Union</class>

--- a/testing/116/tagfile
+++ b/testing/116/tagfile
@@ -74,6 +74,11 @@
   </compound>
   <compound kind="file">
     <name>h.h</name>
+    <path>more_116/include/s/</path>
+    <filename>s_2h_8h.xhtml</filename>
+  </compound>
+  <compound kind="file">
+    <name>h.h</name>
     <path>more_116/include/t/s/</path>
     <filename>t_2s_2h_8h.xhtml</filename>
   </compound>
@@ -130,6 +135,7 @@
     <file path="more_116/">f.cpp</file>
     <file path="more_116/a/">116_tagfile.cpp</file>
     <file path="more_116/b/">116_tagfile.cpp</file>
+    <file path="more_116/include/s/">h.h</file>
     <file path="more_116/include/t/s/">h.h</file>
     <namespace>Namespace</namespace>
     <class kind="struct">Struct</class>

--- a/testing/116/tagfile
+++ b/testing/116/tagfile
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tagfile doxygen_version="" doxygen_gitid="">
+  <compound kind="file">
+    <name>116_tagfile.cpp</name>
+    <path/>
+    <filename>116__tagfile_8cpp.xhtml</filename>
+    <class kind="struct">Struct</class>
+    <class kind="union">Union</class>
+    <class kind="class">Namespace::Class</class>
+    <namespace>Namespace</namespace>
+    <member kind="define">
+      <type>#define</type>
+      <name>Define</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>gab0a66d73c921ab6fb0ba9f550fd77c23</anchor>
+      <arglist/>
+    </member>
+    <member kind="define">
+      <type>#define</type>
+      <name>Macro</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga4ab59fbc11caf0f38d699ef980a378c8</anchor>
+      <arglist>(x)</arglist>
+    </member>
+    <member kind="typedef">
+      <type>Enum</type>
+      <name>EnumTypedef</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga5cf05ddc8cf20a9eb9ce35b43c750790</anchor>
+      <arglist/>
+    </member>
+    <member kind="enumeration">
+      <type/>
+      <name>Enum</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga8150b7776c2a1749101acf22e868d091</anchor>
+      <arglist/>
+    </member>
+    <member kind="enumvalue">
+      <name>EnumVal</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>gga8150b7776c2a1749101acf22e868d091aecdc2953d9df684d8dc2bc9b0237113a</anchor>
+      <arglist/>
+    </member>
+    <member kind="function">
+      <type>void</type>
+      <name>Function</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga054c88794f4fcaae438dfb7aa8b8d9f7</anchor>
+      <arglist>(int a, const int *b, int *c, int *d)</arglist>
+    </member>
+    <member kind="variable">
+      <type>int</type>
+      <name>Object</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga83237bee02feeff4fc8a0dfcb9d53878</anchor>
+      <arglist/>
+    </member>
+  </compound>
+  <compound kind="file">
+    <name>116_tagfile.cpp</name>
+    <path>more_116/a/</path>
+    <filename>more__116_2a_2116__tagfile_8cpp.xhtml</filename>
+  </compound>
+  <compound kind="file">
+    <name>116_tagfile.cpp</name>
+    <path>more_116/b/</path>
+    <filename>more__116_2b_2116__tagfile_8cpp.xhtml</filename>
+  </compound>
+  <compound kind="file">
+    <name>f.cpp</name>
+    <path>more_116/</path>
+    <filename>f_8cpp.xhtml</filename>
+  </compound>
+  <compound kind="file">
+    <name>h.h</name>
+    <path>more_116/include/t/s/</path>
+    <filename>t_2s_2h_8h.xhtml</filename>
+  </compound>
+  <compound kind="class">
+    <name>Namespace::Class</name>
+    <filename>class_namespace_1_1_class.xhtml</filename>
+    <member kind="function">
+      <type/>
+      <name>Class</name>
+      <anchorfile>class_namespace_1_1_class.xhtml</anchorfile>
+      <anchor>a3728462d9de1e54c409d273c99bfe5a8</anchor>
+      <arglist>()</arglist>
+    </member>
+    <member kind="variable">
+      <type>int</type>
+      <name>ClassMember</name>
+      <anchorfile>class_namespace_1_1_class.xhtml</anchorfile>
+      <anchor>ae278721b28b01a4c01b09de072ac98d6</anchor>
+      <arglist/>
+    </member>
+  </compound>
+  <compound kind="struct">
+    <name>Struct</name>
+    <filename>struct_struct.xhtml</filename>
+    <member kind="variable">
+      <type>int</type>
+      <name>StructMember</name>
+      <anchorfile>struct_struct.xhtml</anchorfile>
+      <anchor>a077c7aa3a29e27af8dd56791844d3099</anchor>
+      <arglist/>
+    </member>
+  </compound>
+  <compound kind="union">
+    <name>Union</name>
+    <filename>union_union.xhtml</filename>
+    <member kind="variable">
+      <type>int</type>
+      <name>UnionMember</name>
+      <anchorfile>union_union.xhtml</anchorfile>
+      <anchor>a24db4074bb5266a3bbc852c77f67aac3</anchor>
+      <arglist/>
+    </member>
+  </compound>
+  <compound kind="namespace">
+    <name>Namespace</name>
+    <filename>namespace_namespace.xhtml</filename>
+    <class kind="class">Namespace::Class</class>
+  </compound>
+  <compound kind="group">
+    <name>Group</name>
+    <title>Group</title>
+    <filename>group___group.xhtml</filename>
+    <file>116_tagfile.cpp</file>
+    <file>f.cpp</file>
+    <file>116_tagfile.cpp</file>
+    <file>116_tagfile.cpp</file>
+    <file>h.h</file>
+    <namespace>Namespace</namespace>
+    <class kind="struct">Struct</class>
+    <class kind="union">Union</class>
+    <member kind="define">
+      <type>#define</type>
+      <name>Define</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>gab0a66d73c921ab6fb0ba9f550fd77c23</anchor>
+      <arglist/>
+    </member>
+    <member kind="define">
+      <type>#define</type>
+      <name>Macro</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga4ab59fbc11caf0f38d699ef980a378c8</anchor>
+      <arglist>(x)</arglist>
+    </member>
+    <member kind="typedef">
+      <type>Enum</type>
+      <name>EnumTypedef</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga5cf05ddc8cf20a9eb9ce35b43c750790</anchor>
+      <arglist/>
+    </member>
+    <member kind="enumeration">
+      <type/>
+      <name>Enum</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga8150b7776c2a1749101acf22e868d091</anchor>
+      <arglist/>
+    </member>
+    <member kind="enumvalue">
+      <name>EnumVal</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>gga8150b7776c2a1749101acf22e868d091aecdc2953d9df684d8dc2bc9b0237113a</anchor>
+      <arglist/>
+    </member>
+    <member kind="function">
+      <type>void</type>
+      <name>Function</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga054c88794f4fcaae438dfb7aa8b8d9f7</anchor>
+      <arglist>(int a, const int *b, int *c, int *d)</arglist>
+    </member>
+    <member kind="variable">
+      <type>int</type>
+      <name>Object</name>
+      <anchorfile>group___group.xhtml</anchorfile>
+      <anchor>ga83237bee02feeff4fc8a0dfcb9d53878</anchor>
+      <arglist/>
+    </member>
+  </compound>
+</tagfile>

--- a/testing/116/union_union.xml
+++ b/testing/116/union_union.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="union_union" kind="union" language="C++" prot="public">
+    <compoundname>Union</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="union_union_1a24db4074bb5266a3bbc852c77f67aac3" prot="public" static="no" mutable="no">
+        <type>int</type>
+        <definition>int Union::UnionMember</definition>
+        <argsstring/>
+        <name>UnionMember</name>
+        <qualifiedname>Union::UnionMember</qualifiedname>
+        <briefdescription>
+          <para>UnionMember brief (in 116_tagfile.cpp). </para>
+        </briefdescription>
+        <detaileddescription>
+          <para>UnionMember description (in 116_tagfile.cpp). </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_tagfile.cpp" line="109" column="7" bodyfile="116_tagfile.cpp" bodystart="109" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para><ref refid="union_union" kindref="compound">Union</ref> brief (in 116_tagfile.cpp). </para>
+    </briefdescription>
+    <detaileddescription>
+      <para><ref refid="union_union" kindref="compound">Union</ref> description (in 116_tagfile.cpp). </para>
+    </detaileddescription>
+    <location file="116_tagfile.cpp" line="103" column="1" bodyfile="116_tagfile.cpp" bodystart="103" bodyend="110"/>
+    <listofallmembers>
+      <member refid="union_union_1a24db4074bb5266a3bbc852c77f67aac3" prot="public" virt="non-virtual">
+        <scope>Union</scope>
+        <name>UnionMember</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/116_tagfile.cpp
+++ b/testing/116_tagfile.cpp
@@ -1,0 +1,193 @@
+// objective: test the tagfile output
+// config: GENERATE_TAGFILE = "$TESTOUTDIR/out/tagfile"
+// config: STRIP_FROM_INC_PATH = "$INPUTDIR/more_116/include"
+// check: 116__tagfile_8cpp.xml
+// check: class_namespace_1_1_class.xml
+// check: f_8cpp.xml
+// check: group___group.xml
+// check: more__116_2a_2116__tagfile_8cpp.xml
+// check: more__116_2b_2116__tagfile_8cpp.xml
+// check: namespace_namespace.xml
+// check: s_2h_8h.xml
+// check: struct_struct.xml
+// check: t_2s_2h_8h.xml
+// check: tagfile
+// check: union_union.xml
+// input: more_116/f.cpp
+// input: more_116/a/116_tagfile.cpp
+// input: more_116/b/116_tagfile.cpp
+// input: more_116/include/s/h.h
+// input: more_116/include/t/s/h.h
+
+/**
+ * @defgroup Group Group
+ *
+ * @brief Group brief (in 116_tagfile.cpp)
+ *
+ * Group description (in 116_tagfile.cpp).
+ *
+ * @{
+ */
+
+/**
+ * @file
+ *
+ * @brief 116_tagfile.cpp brief (in 116_tagfile.cpp)
+ *
+ * 116_tagfile.cpp description (in 116_tagfile.cpp).
+ */
+
+/**
+ * @brief Define brief (in 116_tagfile.cpp).
+ *
+ * Define description (in 116_tagfile.cpp).
+ */
+#define Define 123
+
+/**
+ * @brief Macro brief (in 116_tagfile.cpp).
+ *
+ * Macro description (in 116_tagfile.cpp).
+ *
+ * @param x is the parameter.
+ */
+#define Macro(x) ((x) * 456)
+
+/**
+ * @brief Object brief (in 116_tagfile.cpp).
+ *
+ * Object description (in 116_tagfile.cpp).
+ */
+extern int Object;
+
+/**
+ * @brief Enum brief (in 116_tagfile.cpp).
+ *
+ * Enum description (in 116_tagfile.cpp).
+ */
+enum Enum {
+  /**
+   * @brief EnumVal brief (in 116_tagfile.cpp).
+   *
+   * EnumVal description (in 116_tagfile.cpp).
+   */
+  EnumVal
+};
+
+/**
+ * @brief EnumTypedef brief (in 116_tagfile.cpp).
+ *
+ * EnumTypedef description (in 116_tagfile.cpp).
+ */
+typedef Enum EnumTypedef;
+
+/**
+ * @brief Struct brief (in 116_tagfile.cpp).
+ *
+ * Struct description (in 116_tagfile.cpp).
+ */
+struct Struct {
+  /**
+   * @brief StructMember brief (in 116_tagfile.cpp).
+   *
+   * StructMember description (in 116_tagfile.cpp).
+   */
+  int StructMember;
+};
+
+/**
+ * @brief Union brief (in 116_tagfile.cpp).
+ *
+ * Union description (in 116_tagfile.cpp).
+ */
+union Union {
+  /**
+   * @brief UnionMember brief (in 116_tagfile.cpp).
+   *
+   * UnionMember description (in 116_tagfile.cpp).
+   */
+  int UnionMember;
+};
+
+/**
+ * @brief Function brief (in 116_tagfile.cpp).
+ *
+ * Function description (in 116_tagfile.cpp).
+ *
+ * @param a is the parameter.
+ *
+ * @param[in] b is the in parameter.
+ *
+ * @param[out] c is the out parameter.
+ *
+ * @param[in, out] d is the in/out parameter.
+ */
+void Function(int a, const int *b, int *c, int *d);
+
+/**
+ * @brief InlineFunction brief (in 116_tagfile.cpp).
+ *
+ * InlineFunction description (in 116_tagfile.cpp).
+ *
+ * @param a is the parameter.
+ *
+ * @param[in] b is the in parameter.
+ *
+ * @param[out] c is the out parameter.
+ *
+ * @param[in, out] d is the in/out parameter.
+ */
+static inline void InlineFunction(int a, const int *b, int *c, int *d)
+{
+  *c = a;
+  *d = *b;
+}
+
+/**
+ * @brief Namespace brief (in 116_tagfile.cpp).
+ *
+ * Namespace description (in 116_tagfile.cpp).
+ */
+namespace Namespace {
+  /**
+   * @brief Class brief (in 116_tagfile.cpp).
+   *
+   * Class description (in 116_tagfile.cpp).
+   */
+  class Class {
+    public:
+      /**
+       * @brief Class constructor brief (in 116_tagfile.cpp).
+       *
+       * Class constructor description (in 116_tagfile.cpp).
+       */
+      Class() : ClassMember(0) {}
+
+      /**
+       * @brief ClassMember brief (in 116_tagfile.cpp).
+       *
+       * ClassMember description (in 116_tagfile.cpp).
+       */
+      int ClassMember;
+  };
+}
+
+/**
+ * @file more_116/f.cpp
+ *
+ * more_116/f.cpp description (in 116_tagfile.cpp).
+ */
+
+/**
+ * @file more_116/a/116_tagfile.cpp
+ *
+ * more_116/a/116_tagfile.cpp description (in 116_tagfile.cpp).
+ */
+
+/**
+ * @file more_116/b/116_tagfile.cpp
+ *
+ * more_116/b/116_tagfile.cpp description (in 116_tagfile.cpp).
+ */
+
+/** @} */

--- a/testing/more_116/116_tagfile.cpp
+++ b/testing/more_116/116_tagfile.cpp
@@ -1,0 +1,9 @@
+/**
+ * @file
+ *
+ * @ingroup Group
+ *
+ * @brief more_116/f.cpp brief (in more_116/f.cpp).
+ *
+ * more_116/f.cpp description (in more_116/f.cpp).
+ */

--- a/testing/more_116/a/116_tagfile.cpp
+++ b/testing/more_116/a/116_tagfile.cpp
@@ -1,0 +1,9 @@
+/**
+ * @file
+ *
+ * @ingroup Group
+ *
+ * @brief more_116/a/116_tagfile.cpp brief (in more_116/a/116_tagfile.cpp).
+ *
+ * more_116/a/116_tagfile.cpp description (in more_116/a/116_tagfile.cpp).
+ */

--- a/testing/more_116/b/116_tagfile.cpp
+++ b/testing/more_116/b/116_tagfile.cpp
@@ -1,0 +1,9 @@
+/**
+ * @file
+ *
+ * @ingroup Group
+ *
+ * @brief more_116/b/116_tagfile.cpp brief (in more_116/b/116_tagfile.cpp).
+ *
+ * more_116/b/116_tagfile.cpp description (in more_116/b/116_tagfile.cpp).
+ */

--- a/testing/more_116/f.cpp
+++ b/testing/more_116/f.cpp
@@ -1,0 +1,17 @@
+/**
+ * @file
+ *
+ * @ingroup Group
+ *
+ * @brief more_116/f.cpp brief (in more_116/f.cpp).
+ *
+ * more_116/f.cpp description (in more_116/f.cpp).
+ */
+
+/**
+ * @file t/s/h.h
+ *
+ * @ingroup Group
+ *
+ * t/s/h.h description (in more_116/f.cpp).
+ */

--- a/testing/more_116/f.cpp
+++ b/testing/more_116/f.cpp
@@ -9,6 +9,14 @@
  */
 
 /**
+ * @file s/h.h
+ *
+ * @ingroup Group
+ *
+ * s/h.h description (in more_116/f.cpp).
+ */
+
+/**
  * @file t/s/h.h
  *
  * @ingroup Group

--- a/testing/more_116/include/s/h.h
+++ b/testing/more_116/include/s/h.h
@@ -1,0 +1,9 @@
+/**
+ * @file
+ *
+ * @ingroup Group
+ *
+ * @brief s/h.h brief (in s/h.h).
+ *
+ * s/h.h description (in s/h.h).
+ */

--- a/testing/more_116/include/t/s/h.h
+++ b/testing/more_116/include/t/s/h.h
@@ -1,0 +1,9 @@
+/**
+ * @file
+ *
+ * @ingroup Group
+ *
+ * @brief t/s/h.h brief (in t/s/h.h).
+ *
+ * t/s/h.h description (in t/s/h.h).
+ */

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -64,6 +64,11 @@ def clean_header(errmsg):
 
 class Tester:
     def __init__(self,args,test):
+        test_id = test.split('_')[0]
+        if args.updateref:
+            self.test_out = args.inputdir+'/'+test_id
+        else:
+            self.test_out = args.outputdir+'/test_output_'+test_id
         self.args      = args
         self.test      = test
         self.update    = args.updateref
@@ -72,11 +77,7 @@ class Tester:
             print("Test %s is missing the objective." % self.test)
             sys.exit(1)
         self.test_name = '[%s]: %s' % (self.test,self.config['objective'][0])
-        self.test_id   = self.test.split('_')[0]
-        if self.update:
-            self.test_out = self.args.inputdir+'/'+self.test_id
-        else:
-            self.test_out = self.args.outputdir+'/test_output_'+self.test_id
+        self.test_id   = test_id
         self.prepare_test()
 
     # Compares 'got_file' against 'expected_file'.
@@ -158,6 +159,7 @@ class Tester:
                     value = m.group('value')
                     if (key=='config'):
                         value = value.replace('$INPUTDIR',self.args.inputdir)
+                        value = value.replace('$TESTOUTDIR',self.test_out)
                     # print('key=%s value=%s' % (key,value))
                     config.setdefault(key, []).append(value)
         return config

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -343,6 +343,7 @@ class Tester:
                     data = xpopen('%s --format --noblanks --nowarning %s' % (self.args.xmllint,check_file))
                     if data:
                         # strip version
+                        data = re.sub(r'tagfile doxygen_version="[^"]+" doxygen_gitid="[^"]+"','tagfile doxygen_version="" doxygen_gitid=""',data)
                         data = re.sub(r'xsd" version="[0-9.-]+"','xsd" version=""',data).rstrip('\n')
                     else:
                         msg += ('Failed to run %s on the doxygen output file %s' % (self.args.xmllint,self.test_out),)


### PR DESCRIPTION
This patch set improves to items:

1. In the generated tagfile, the files of a group are fully specified. This helps in case filenames alone are ambiguous.
2. In `findFileDef()`, if multiple files have the same name, then return a unique match in case the stripped file paths are equal (perfect match). This helps if a project uses includes like this `#include <s/h.h>` and `#include <t/s/h.h>` where the `h.h` files are distinct files.