### PR TITLE
issue #11939 LaTeX output does not properly break lines with long doxylink

### DIFF
--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -896,3 +896,9 @@
 \makeatother
 \AddEnumerateCounter{\enumalphalphcnt}{\@enumalphalphcnt}{aa}
 \AddEnumerateCounter{\enumAlphAlphcnt}{\@enumAlphAlphcnt}{AA}
+
+\usepackage{xurl}
+\newcommand{\doxyIndexDescription}[1]{%
+  \begin{NoHyper}\url{#1}\end{NoHyper}%
+}
+

--- a/templates/latex/header.tex
+++ b/templates/latex/header.tex
@@ -42,11 +42,6 @@
   \newenvironment{NoHyper}{}{}
 %%END !PDF_HYPERLINKS
 
-  \usepackage{xurl}
-  \newcommand{\doxyIndexDescription}[1]{%
-    \begin{NoHyper}\url{#1}\end{NoHyper}%
-  }
-
   \usepackage{doxygen}
 
   $extralatexstylesheet


### PR DESCRIPTION
There following parts are fixed:
- 5 Index Introducing the LaTeX environment `doxyIndexDescription` and setting an extra flag `escapeUnderscore` for the function `latexEscapeIndexChars` to false.
- 4 Section title Using the `escapeUnderscore` flag to determine whether or not the "word breaking" doxygen LaTeX command `\+` can be used (was by default set to `true` in the `filterLatexString`, when always using `false` would lead to TeX capacity exceeded or to `\+` in the index output).
- 1 File Index Solved due to point 4.