### PR TITLE
Fix formatting of setParser function in TokenManager

### DIFF
--- a/vhdlparser/TokenManager.h
+++ b/vhdlparser/TokenManager.h
@@ -22,7 +22,7 @@ public:
    *  A token of kind 0 (`<EOF>`) should be returned on EOF.
    */
   virtual Token *getNextToken() = 0;
-  virtual void   setParser(void* parser) {};
+  virtual void   setParser(void* parser) {}
   virtual void   lexicalError() {
   	std::cerr << "Lexical error encountered." << std::endl;
   }


### PR DESCRIPTION
Fixes compiler warning:

```
/home/conda/feedstock_root/build_artifacts/doxygen_1769567959209/work/vhdlparser/TokenManager.h:25:44: warning: extra ';' after in-class function definition [-Wextra-semi]
   25 |   virtual void   setParser(void* parser) {};
      |                                            ^
```