### PR TITLE
Mismatch `#if` / `#endif` when "verbatim" command in non doxygen comment

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1583,8 +1583,11 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
 <SkipCComment>{LITERAL_BLOCK}           { // normal block command
                                           outputArray(yyscanner,yytext,yyleng);
                                           yyextra->yyLineNr+=QCString(yytext).contains('\n');
-                                          determineBlockName(yyscanner);
-                                          BEGIN(SkipVerbatim);
+                                          if (yyextra->isSpecialComment)
+                                          {
+                                            determineBlockName(yyscanner);
+                                            BEGIN(SkipVerbatim);
+                                          }
                                         }
 <SkipCond>{CMD}{CMD}"cond"[ \t]+        {}// escaped cond command
 <SkipCond>{CMD}"cond"/\n                |  


### PR DESCRIPTION
When having something like:
```
#if !defined(__linux__)

/*
@code
*/
#endif
```
we get a warning like:
```
warning: More #if's than #endif's found (might be in an included file).
```
as an attempt is made too match `@code` with `@endcode` even in a non doxygen comment

Example: [example.tar.gz](https://github.com/user-attachments/files/24993166/example.tar.gz)

(Found by Fossies)
