### PR TITLE
Extend C++ namespace alias syntax to C# + Various fixes

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -4833,10 +4833,28 @@ static void resolveTemplateInstanceInType(const Entry *root,const Definition *sc
   int ti=ttype.find('<');
   if (ti!=-1)
   {
+    int templateArity=-1;
     QCString templateClassName = ttype.left(ti);
+    if (root->lang==SrcLangExt::CSharp)
+    {
+       templateArity=1;
+       int level=0;
+       const char *p = ttype.data() + ti + 1;
+       char c;
+       while ((c=*p++))
+       {
+         if (c=='<') level++;
+         else if (c=='>')
+         {
+           if (level==0) break;
+           level--;
+         }
+         else if (c==',' && level==0) templateArity++;
+       }
+    }
     SymbolResolver resolver(root->fileDef());
     ClassDefMutable *baseClass = resolver.resolveClassMutable(scope ? scope : Doxygen::globalScope,
-                                           templateClassName, true, true);
+                                           templateClassName, true, true, templateArity);
     AUTO_TRACE_ADD("templateClassName={} baseClass={}",templateClassName,baseClass?baseClass->name():"<none>");
     if (baseClass)
     {

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -4833,25 +4833,9 @@ static void resolveTemplateInstanceInType(const Entry *root,const Definition *sc
   int ti=ttype.find('<');
   if (ti!=-1)
   {
-    int templateArity=-1;
     QCString templateClassName = ttype.left(ti);
-    if (root->lang==SrcLangExt::CSharp)
-    {
-       templateArity=1;
-       int level=0;
-       const char *p = ttype.data() + ti + 1;
-       char c;
-       while ((c=*p++))
-       {
-         if (c=='<') level++;
-         else if (c=='>')
-         {
-           if (level==0) break;
-           level--;
-         }
-         else if (c==',' && level==0) templateArity++;
-       }
-    }
+
+    int templateArity=(root->lang==SrcLangExt::CSharp) ? resolveTemplateArity(ttype) : 0;
     SymbolResolver resolver(root->fileDef());
     ClassDefMutable *baseClass = resolver.resolveClassMutable(scope ? scope : Doxygen::globalScope,
                                            templateClassName, true, true, templateArity);

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -2089,6 +2089,13 @@ NONLopt [^\n]*
                                           init.stripPrefix("class ");
                                           init.stripPrefix("struct ");
                                           init = init.stripWhiteSpace();
+
+                                          // Use same alias system early on for C#
+                                          if (yyextra->insideCS)
+                                          {
+                                            init = substitute(init,".","::");
+                                          }
+
                                           yyextra->current->type = "typedef "+init;
                                           yyextra->current->args.clear();
                                           yyextra->current->spec.setAlias(true);

--- a/src/symbolresolver.cpp
+++ b/src/symbolresolver.cpp
@@ -1171,6 +1171,7 @@ int SymbolResolver::Private::isAccessibleFromWithExpScope(
       if (accessibleViaUsingNamespace(visitedKeys,locVisitedNamespaceKeys,nscope->getUsedNamespaces(),item,explicitScopePart))
       {
         AUTO_TRACE_ADD("found in used class");
+        result=1;
         goto done;
       }
     }
@@ -1182,6 +1183,7 @@ int SymbolResolver::Private::isAccessibleFromWithExpScope(
         if (accessibleViaUsingNamespace(visitedKeys,locVisitedNamespaceKeys,m_fileScope->getUsedNamespaces(),item,explicitScopePart))
         {
           AUTO_TRACE_ADD("found in used namespace");
+          result=1;
           goto done;
         }
       }
@@ -1483,6 +1485,7 @@ int SymbolResolver::Private::isAccessibleFrom(VisitedKeys &visitedKeys,
       if (accessibleViaUsingNamespace(visitedKeys,visitedNamespaceKeys,m_fileScope->getUsedNamespaces(),item))
       {
         AUTO_TRACE_ADD("found via used namespace");
+        result=1;
         goto done;
       }
     }
@@ -1504,6 +1507,7 @@ int SymbolResolver::Private::isAccessibleFrom(VisitedKeys &visitedKeys,
       if (accessibleViaUsingNamespace(visitedKeys,visitedNamespaceKeys,nscope->getUsedNamespaces(),item,QCString()))
       {
         AUTO_TRACE_ADD("found via used namespace");
+        result=1;
         goto done;
       }
     }
@@ -1519,6 +1523,7 @@ int SymbolResolver::Private::isAccessibleFrom(VisitedKeys &visitedKeys,
       if (accessibleViaUsingNamespace(visitedKeys,visitedNamespaceKeys,nfile->getUsedNamespaces(),item,QCString()))
       {
         AUTO_TRACE_ADD("found via used namespace");
+        result=1;
         goto done;
       }
     }

--- a/src/symbolresolver.cpp
+++ b/src/symbolresolver.cpp
@@ -1666,7 +1666,7 @@ const ClassDef *SymbolResolver::resolveClass(const Definition *scope,
     QCString lookupName = lang==SrcLangExt::CSharp ? mangleCSharpGenericName(name) : name;
     
     // In C#, templates (generics) depend on arity, thus lookup name needs to be adjusted to include arity information
-    if (lang==SrcLangExt::CSharp && templateArity!=-1)
+    if (lang==SrcLangExt::CSharp && templateArity>0)
     {
       lookupName = name + "-" + QCString().setNum(templateArity) + "-g";
     }

--- a/src/symbolresolver.h
+++ b/src/symbolresolver.h
@@ -49,7 +49,8 @@ class SymbolResolver
     const ClassDef *resolveClass(const Definition *scope,
                                  const QCString &name,
                                  bool maybeUnlinkable=false,
-                                 bool mayBeHidden=false);
+                                 bool mayBeHidden=false,
+                                 int templateArity=-1);
 
     /** Wrapper around resolveClass that returns a mutable interface to
      *  the class object or a nullptr if the symbol is immutable.
@@ -57,9 +58,10 @@ class SymbolResolver
     ClassDefMutable *resolveClassMutable(const Definition *scope,
                                          const QCString &name,
                                          bool mayBeUnlinkable=false,
-                                         bool mayBeHidden=false)
+                                         bool mayBeHidden=false,
+                                         int templateArity=-1)
     {
-      return toClassDefMutable(const_cast<ClassDef*>(resolveClass(scope,name,mayBeUnlinkable,mayBeHidden)));
+      return toClassDefMutable(const_cast<ClassDef*>(resolveClass(scope,name,mayBeUnlinkable,mayBeHidden,templateArity)));
     }
 
     /** Find the symbool definition matching name within the scope set.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -890,6 +890,34 @@ bool leftScopeMatch(const QCString &scope, const QCString &name)
          );
 }
 
+int resolveTemplateArity(const QCString &s)
+{
+  if (s.at(0) != '<') return 0; // not a template 
+
+  int arity=0;
+  int templateDepth=0;
+
+  for (size_t i=0;i<s.length();i++)
+  {
+    char c=s.at(i);
+    if (c=='<')
+    {
+      if (templateDepth==0) arity++;
+      templateDepth++;
+    }
+    else if (c==',')
+    {
+      if (templateDepth==1) arity++;
+    }
+    else if (c=='>')
+    {
+      templateDepth--;
+      if (templateDepth==0) break;
+    }
+  }
+
+  return arity;
+}
 
 void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
     const FileDef *fileScope,const Definition *self,
@@ -983,26 +1011,10 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
       //printf("** Match word '%s'\n",qPrint(matchWord));
 
       // Use templateArity context for languages that need it (C#)
-      int templateArity=-1;
-      if (fileScope && fileScope->getLanguage()==SrcLangExt::CSharp) {
-        int level = 0;
-
-        for(size_t i=newIndex+matchLen; i<strLen; i++) {
-          char c = txtStr.at(i);
-
-          if (c=='<') {
-            if (level==0) templateArity=1;
-            level++;
-          }
-          else if (c==',' && level==1) {
-            templateArity++;
-          }
-          else if (c=='>') {
-            level--;
-            if (level==0) break;
-          }
-        }
-      }
+      int templateArity=
+        (fileScope && fileScope->getLanguage()==SrcLangExt::CSharp)
+          ? resolveTemplateArity(txtStr.substr(newIndex+matchLen))
+          : 0;
 
       SymbolResolver resolver(fileScope);
       cd=resolver.resolveClass(scope,matchWord,false,false,templateArity);
@@ -1039,7 +1051,7 @@ void linkifyText(const TextGeneratorIntf &out, const Definition *scope,
         //printf("   -> skip\n");
       }
        // C# generics, cd must have not been reassigned from resolver.resolveClass
-      else if (cd && fileScope->getLanguage()==SrcLangExt::CSharp && templateArity != -1)
+      else if (cd && fileScope->getLanguage()==SrcLangExt::CSharp && templateArity > 0)
       {
         writeCompoundName(cd);
       }

--- a/src/util.h
+++ b/src/util.h
@@ -236,6 +236,8 @@ bool rightScopeMatch(const QCString &scope, const QCString &name);
 
 bool leftScopeMatch(const QCString &scope, const QCString &name);
 
+int resolveTemplateArity(const QCString &s);
+
 struct KeywordSubstitution
 {
   const char *keyword;

--- a/testing/116/class_test_app_1_1_test_class.xml
+++ b/testing/116/class_test_app_1_1_test_class.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="class_test_app_1_1_test_class" kind="class" language="C#" prot="public">
+    <compoundname>TestApp::TestClass</compoundname>
+    <basecompoundref prot="public" virt="non-virtual">Bar</basecompoundref>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1ab5af62cc6d392b98f6dfa49072c20a30" prot="public" static="no" mutable="no">
+        <type>
+          <ref refid="116__csharp__using__alias_8cs_1a6f622c7af2438aaba261f5158f182804" kindref="member">Foo</ref>
+        </type>
+        <definition>Foo TestApp.TestClass.myFoo</definition>
+        <argsstring/>
+        <name>myFoo</name>
+        <qualifiedname>TestApp.TestClass.myFoo</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="24" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="24" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1a8ae7b8d812526c563af57512c6123be1" prot="public" static="no" mutable="no">
+        <type>
+          <ref refid="116__csharp__using__alias_8cs_1abfd48e6144f8dd8b2cbf976890bf45f4" kindref="member">Bar</ref>
+        </type>
+        <definition>Bar TestApp.TestClass.myBar</definition>
+        <argsstring/>
+        <name>myBar</name>
+        <qualifiedname>TestApp.TestClass.myBar</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="25" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="25" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1acec90deceefaa3a90dc2f8774f0092bb" prot="public" static="no" mutable="no">
+        <type>
+          <ref refid="namespace_test_app_1aa5bc03d12814a9e353e9563859528fb9" kindref="member">InnerFoo</ref>
+        </type>
+        <definition>InnerFoo TestApp.TestClass.myInnerFoo</definition>
+        <argsstring/>
+        <name>myInnerFoo</name>
+        <qualifiedname>TestApp.TestClass.myInnerFoo</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="26" column="25" bodyfile="116_csharp_using_alias.cs" bodystart="26" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1ad7c05a0e172dce2493017ff50d6fa262" prot="public" static="no" mutable="no">
+        <type>
+          <ref refid="116__csharp__using__alias_8cs_1a42c6d64febba0fe7e0d7da93e2e07fbd" kindref="member">Baz</ref>
+        </type>
+        <definition>Baz TestApp.TestClass.myBaz</definition>
+        <argsstring/>
+        <name>myBaz</name>
+        <qualifiedname>TestApp.TestClass.myBaz</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="27" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="27" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1a8b7fa1bc2aa6d0356ff3752e94730ef5" prot="public" static="no" mutable="no">
+        <type>
+          <ref refid="116__csharp__using__alias_8cs_1abe3a5c304344ea8e1f7138102a7639f6" kindref="member">GlobalFoo</ref>
+        </type>
+        <definition>GlobalFoo TestApp.TestClass.myGlobalFoo</definition>
+        <argsstring/>
+        <name>myGlobalFoo</name>
+        <qualifiedname>TestApp.TestClass.myGlobalFoo</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="28" column="26" bodyfile="116_csharp_using_alias.cs" bodystart="28" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1ad778b00cf9aa69e9e1b51405c07c2920" prot="public" static="no" mutable="no">
+        <type>
+          <ref refid="namespace_test_app_1a419879e8b1fbad59a408e37f06177d46" kindref="member">NestedBar</ref>
+        </type>
+        <definition>NestedBar TestApp.TestClass.myNestedBar</definition>
+        <argsstring/>
+        <name>myNestedBar</name>
+        <qualifiedname>TestApp.TestClass.myNestedBar</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="29" column="26" bodyfile="116_csharp_using_alias.cs" bodystart="29" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1a895d6eff6875dae53a9d35cd13c6b865" prot="public" static="no" mutable="no">
+        <type>System.Collections.Generic.List&lt; <ref refid="116__csharp__using__alias_8cs_1a6f622c7af2438aaba261f5158f182804" kindref="member">Foo</ref> &gt;</type>
+        <definition>System.Collections.Generic.List&lt;Foo&gt; TestApp.TestClass.myListOfFoos</definition>
+        <argsstring/>
+        <name>myListOfFoos</name>
+        <qualifiedname>TestApp.TestClass.myListOfFoos</qualifiedname>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="31" column="45" bodyfile="116_csharp_using_alias.cs" bodystart="31" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="public-func">
+      <memberdef kind="function" id="class_test_app_1_1_test_class_1acf6e9d14d4bc70b87adc5c0c8ad66fd3" prot="public" static="no" const="no" explicit="no" inline="yes" virt="non-virtual">
+        <type>
+          <ref refid="116__csharp__using__alias_8cs_1a42c6d64febba0fe7e0d7da93e2e07fbd" kindref="member">Baz</ref>
+        </type>
+        <definition>Baz TestApp.TestClass.Method</definition>
+        <argsstring>(Foo a, Bar b)</argsstring>
+        <name>Method</name>
+        <qualifiedname>TestApp.TestClass.Method</qualifiedname>
+        <param>
+          <type>
+            <ref refid="116__csharp__using__alias_8cs_1a6f622c7af2438aaba261f5158f182804" kindref="member">Foo</ref>
+          </type>
+          <declname>a</declname>
+        </param>
+        <param>
+          <type>
+            <ref refid="116__csharp__using__alias_8cs_1abfd48e6144f8dd8b2cbf976890bf45f4" kindref="member">Bar</ref>
+          </type>
+          <declname>b</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="33" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="33" bodyend="33"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <inheritancegraph>
+      <node id="2">
+        <label>Bar</label>
+      </node>
+      <node id="1">
+        <label>TestApp.TestClass</label>
+        <link refid="class_test_app_1_1_test_class"/>
+        <childnode refid="2" relation="public-inheritance">
+        </childnode>
+      </node>
+    </inheritancegraph>
+    <collaborationgraph>
+      <node id="2">
+        <label>Bar</label>
+      </node>
+      <node id="1">
+        <label>TestApp.TestClass</label>
+        <link refid="class_test_app_1_1_test_class"/>
+        <childnode refid="2" relation="public-inheritance">
+        </childnode>
+        <childnode refid="3" relation="usage">
+          <edgelabel>myNestedBar</edgelabel>
+        </childnode>
+      </node>
+      <node id="3">
+        <label>TestApp.Outer.Nested</label>
+        <link refid="class_test_app_1_1_outer_1_1_nested"/>
+      </node>
+    </collaborationgraph>
+    <location file="116_csharp_using_alias.cs" line="22" column="11" bodyfile="116_csharp_using_alias.cs" bodystart="23" bodyend="34"/>
+    <listofallmembers>
+      <member refid="class_test_app_1_1_test_class_1acf6e9d14d4bc70b87adc5c0c8ad66fd3" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>Method</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1a8ae7b8d812526c563af57512c6123be1" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myBar</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1ad7c05a0e172dce2493017ff50d6fa262" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myBaz</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1ab5af62cc6d392b98f6dfa49072c20a30" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myFoo</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1a8b7fa1bc2aa6d0356ff3752e94730ef5" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myGlobalFoo</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1acec90deceefaa3a90dc2f8774f0092bb" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myInnerFoo</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1a895d6eff6875dae53a9d35cd13c6b865" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myListOfFoos</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1ad778b00cf9aa69e9e1b51405c07c2920" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myNestedBar</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/116/class_test_app_1_1_test_class.xml
+++ b/testing/116/class_test_app_1_1_test_class.xml
@@ -6,7 +6,7 @@
     <sectiondef kind="public-attrib">
       <memberdef kind="variable" id="class_test_app_1_1_test_class_1ab5af62cc6d392b98f6dfa49072c20a30" prot="public" static="no" mutable="no">
         <type>
-          <ref refid="116__csharp__using__alias_8cs_1a6f622c7af2438aaba261f5158f182804" kindref="member">Foo</ref>
+          <ref refid="116__csharp__using__alias_8cs_1ae75c9f73964213f458197760249f45e7" kindref="member">Foo</ref>
         </type>
         <definition>Foo TestApp.TestClass.myFoo</definition>
         <argsstring/>
@@ -18,11 +18,11 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="24" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="24" bodyend="-1"/>
+        <location file="116_csharp_using_alias.cs" line="38" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="38" bodyend="-1"/>
       </memberdef>
       <memberdef kind="variable" id="class_test_app_1_1_test_class_1a8ae7b8d812526c563af57512c6123be1" prot="public" static="no" mutable="no">
         <type>
-          <ref refid="116__csharp__using__alias_8cs_1abfd48e6144f8dd8b2cbf976890bf45f4" kindref="member">Bar</ref>
+          <ref refid="116__csharp__using__alias_8cs_1aa2e3ed335781094c0da07481c8ec209c" kindref="member">Bar</ref>
         </type>
         <definition>Bar TestApp.TestClass.myBar</definition>
         <argsstring/>
@@ -34,11 +34,11 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="25" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="25" bodyend="-1"/>
+        <location file="116_csharp_using_alias.cs" line="39" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="39" bodyend="-1"/>
       </memberdef>
       <memberdef kind="variable" id="class_test_app_1_1_test_class_1acec90deceefaa3a90dc2f8774f0092bb" prot="public" static="no" mutable="no">
         <type>
-          <ref refid="namespace_test_app_1aa5bc03d12814a9e353e9563859528fb9" kindref="member">InnerFoo</ref>
+          <ref refid="namespace_test_app_1aea9a30a3fcbef1e4537f09dac477ce8f" kindref="member">InnerFoo</ref>
         </type>
         <definition>InnerFoo TestApp.TestClass.myInnerFoo</definition>
         <argsstring/>
@@ -50,27 +50,27 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="26" column="25" bodyfile="116_csharp_using_alias.cs" bodystart="26" bodyend="-1"/>
+        <location file="116_csharp_using_alias.cs" line="41" column="25" bodyfile="116_csharp_using_alias.cs" bodystart="41" bodyend="-1"/>
       </memberdef>
-      <memberdef kind="variable" id="class_test_app_1_1_test_class_1ad7c05a0e172dce2493017ff50d6fa262" prot="public" static="no" mutable="no">
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1af245c69b3fb0614f2ac7887c1ca02e60" prot="public" static="no" mutable="no">
         <type>
-          <ref refid="116__csharp__using__alias_8cs_1a42c6d64febba0fe7e0d7da93e2e07fbd" kindref="member">Baz</ref>
+          <ref refid="namespace_test_app_1a8cdb4c81bf85a92bbc3a8bef4f0a10c8" kindref="member">InnerBar</ref>
         </type>
-        <definition>Baz TestApp.TestClass.myBaz</definition>
+        <definition>InnerBar TestApp.TestClass.myInnerBar</definition>
         <argsstring/>
-        <name>myBaz</name>
-        <qualifiedname>TestApp.TestClass.myBaz</qualifiedname>
+        <name>myInnerBar</name>
+        <qualifiedname>TestApp.TestClass.myInnerBar</qualifiedname>
         <briefdescription>
         </briefdescription>
         <detaileddescription>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="27" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="27" bodyend="-1"/>
+        <location file="116_csharp_using_alias.cs" line="42" column="25" bodyfile="116_csharp_using_alias.cs" bodystart="42" bodyend="-1"/>
       </memberdef>
       <memberdef kind="variable" id="class_test_app_1_1_test_class_1a8b7fa1bc2aa6d0356ff3752e94730ef5" prot="public" static="no" mutable="no">
         <type>
-          <ref refid="116__csharp__using__alias_8cs_1abe3a5c304344ea8e1f7138102a7639f6" kindref="member">GlobalFoo</ref>
+          <ref refid="116__csharp__using__alias_8cs_1ac7ef973b93b0a9b102e0638795862563" kindref="member">GlobalFoo</ref>
         </type>
         <definition>GlobalFoo TestApp.TestClass.myGlobalFoo</definition>
         <argsstring/>
@@ -82,57 +82,53 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="28" column="26" bodyfile="116_csharp_using_alias.cs" bodystart="28" bodyend="-1"/>
+        <location file="116_csharp_using_alias.cs" line="44" column="26" bodyfile="116_csharp_using_alias.cs" bodystart="44" bodyend="-1"/>
       </memberdef>
-      <memberdef kind="variable" id="class_test_app_1_1_test_class_1ad778b00cf9aa69e9e1b51405c07c2920" prot="public" static="no" mutable="no">
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1a81c20b830057daabc77a301d04047316" prot="public" static="no" mutable="no">
         <type>
-          <ref refid="namespace_test_app_1a419879e8b1fbad59a408e37f06177d46" kindref="member">NestedBar</ref>
+          <ref refid="116__csharp__using__alias_8cs_1a5b74ab6142215be1502722a199929058" kindref="member">GlobalBar</ref>
         </type>
-        <definition>NestedBar TestApp.TestClass.myNestedBar</definition>
+        <definition>GlobalBar TestApp.TestClass.myGlobalBar</definition>
         <argsstring/>
-        <name>myNestedBar</name>
-        <qualifiedname>TestApp.TestClass.myNestedBar</qualifiedname>
+        <name>myGlobalBar</name>
+        <qualifiedname>TestApp.TestClass.myGlobalBar</qualifiedname>
         <briefdescription>
         </briefdescription>
         <detaileddescription>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="29" column="26" bodyfile="116_csharp_using_alias.cs" bodystart="29" bodyend="-1"/>
+        <location file="116_csharp_using_alias.cs" line="45" column="26" bodyfile="116_csharp_using_alias.cs" bodystart="45" bodyend="-1"/>
       </memberdef>
-      <memberdef kind="variable" id="class_test_app_1_1_test_class_1a895d6eff6875dae53a9d35cd13c6b865" prot="public" static="no" mutable="no">
-        <type>System.Collections.Generic.List&lt; <ref refid="116__csharp__using__alias_8cs_1a6f622c7af2438aaba261f5158f182804" kindref="member">Foo</ref> &gt;</type>
-        <definition>System.Collections.Generic.List&lt;Foo&gt; TestApp.TestClass.myListOfFoos</definition>
+      <memberdef kind="variable" id="class_test_app_1_1_test_class_1a2bbf27d0b7759d186d8d48b09151168e" prot="public" static="no" mutable="no">
+        <type>
+          <ref refid="namespace_test_app_1a8b8db320c5aed31596f429cfc60003d7" kindref="member">NestedAlias</ref>
+        </type>
+        <definition>NestedAlias TestApp.TestClass.myNestedAlias</definition>
         <argsstring/>
-        <name>myListOfFoos</name>
-        <qualifiedname>TestApp.TestClass.myListOfFoos</qualifiedname>
+        <name>myNestedAlias</name>
+        <qualifiedname>TestApp.TestClass.myNestedAlias</qualifiedname>
         <briefdescription>
         </briefdescription>
         <detaileddescription>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="31" column="45" bodyfile="116_csharp_using_alias.cs" bodystart="31" bodyend="-1"/>
+        <location file="116_csharp_using_alias.cs" line="47" column="28" bodyfile="116_csharp_using_alias.cs" bodystart="47" bodyend="-1"/>
       </memberdef>
     </sectiondef>
     <sectiondef kind="public-func">
-      <memberdef kind="function" id="class_test_app_1_1_test_class_1acf6e9d14d4bc70b87adc5c0c8ad66fd3" prot="public" static="no" const="no" explicit="no" inline="yes" virt="non-virtual">
+      <memberdef kind="function" id="class_test_app_1_1_test_class_1a080276d674da9e7c011e5c1f7fd1ef88" prot="public" static="no" const="no" explicit="no" inline="yes" virt="non-virtual">
         <type>
-          <ref refid="116__csharp__using__alias_8cs_1a42c6d64febba0fe7e0d7da93e2e07fbd" kindref="member">Baz</ref>
+          <ref refid="116__csharp__using__alias_8cs_1ae75c9f73964213f458197760249f45e7" kindref="member">Foo</ref>
         </type>
-        <definition>Baz TestApp.TestClass.Method</definition>
-        <argsstring>(Foo a, Bar b)</argsstring>
-        <name>Method</name>
-        <qualifiedname>TestApp.TestClass.Method</qualifiedname>
+        <definition>Foo TestApp.TestClass.fooMethod</definition>
+        <argsstring>(Bar b)</argsstring>
+        <name>fooMethod</name>
+        <qualifiedname>TestApp.TestClass.fooMethod</qualifiedname>
         <param>
           <type>
-            <ref refid="116__csharp__using__alias_8cs_1a6f622c7af2438aaba261f5158f182804" kindref="member">Foo</ref>
-          </type>
-          <declname>a</declname>
-        </param>
-        <param>
-          <type>
-            <ref refid="116__csharp__using__alias_8cs_1abfd48e6144f8dd8b2cbf976890bf45f4" kindref="member">Bar</ref>
+            <ref refid="116__csharp__using__alias_8cs_1aa2e3ed335781094c0da07481c8ec209c" kindref="member">Bar</ref>
           </type>
           <declname>b</declname>
         </param>
@@ -142,7 +138,51 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="116_csharp_using_alias.cs" line="33" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="33" bodyend="33"/>
+        <location file="116_csharp_using_alias.cs" line="49" column="20" bodyfile="116_csharp_using_alias.cs" bodystart="49" bodyend="49"/>
+      </memberdef>
+      <memberdef kind="function" id="class_test_app_1_1_test_class_1aaaa0162b354a511239bac8962c6c1121" prot="public" static="no" const="no" explicit="no" inline="yes" virt="non-virtual">
+        <type>
+          <ref refid="namespace_test_app_1aea9a30a3fcbef1e4537f09dac477ce8f" kindref="member">InnerFoo</ref>
+        </type>
+        <definition>InnerFoo TestApp.TestClass.innerFooMethod</definition>
+        <argsstring>(InnerBar b)</argsstring>
+        <name>innerFooMethod</name>
+        <qualifiedname>TestApp.TestClass.innerFooMethod</qualifiedname>
+        <param>
+          <type>
+            <ref refid="namespace_test_app_1a8cdb4c81bf85a92bbc3a8bef4f0a10c8" kindref="member">InnerBar</ref>
+          </type>
+          <declname>b</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="50" column="25" bodyfile="116_csharp_using_alias.cs" bodystart="50" bodyend="50"/>
+      </memberdef>
+      <memberdef kind="function" id="class_test_app_1_1_test_class_1a51b4e8ca0e1a53579fa3e0391ab85942" prot="public" static="no" const="no" explicit="no" inline="yes" virt="non-virtual">
+        <type>
+          <ref refid="116__csharp__using__alias_8cs_1ac7ef973b93b0a9b102e0638795862563" kindref="member">GlobalFoo</ref>
+        </type>
+        <definition>GlobalFoo TestApp.TestClass.globalFooMethod</definition>
+        <argsstring>(GlobalBar b)</argsstring>
+        <name>globalFooMethod</name>
+        <qualifiedname>TestApp.TestClass.globalFooMethod</qualifiedname>
+        <param>
+          <type>
+            <ref refid="116__csharp__using__alias_8cs_1a5b74ab6142215be1502722a199929058" kindref="member">GlobalBar</ref>
+          </type>
+          <declname>b</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="116_csharp_using_alias.cs" line="51" column="26" bodyfile="116_csharp_using_alias.cs" bodystart="51" bodyend="51"/>
       </memberdef>
     </sectiondef>
     <briefdescription>
@@ -164,53 +204,91 @@
       <node id="2">
         <label>Bar</label>
       </node>
+      <node id="3">
+        <label>N.A</label>
+        <link refid="class_n_1_1_a"/>
+      </node>
+      <node id="6">
+        <label>N.B</label>
+        <link refid="class_n_1_1_b"/>
+      </node>
+      <node id="5">
+        <label>N.C</label>
+        <link refid="class_n_1_1_c"/>
+      </node>
+      <node id="4">
+        <label>N.Collections.Dictionary&lt; TKey, TValue &gt;</label>
+        <link refid="class_n_1_1_collections_1_1_dictionary-2-g"/>
+      </node>
       <node id="1">
         <label>TestApp.TestClass</label>
         <link refid="class_test_app_1_1_test_class"/>
         <childnode refid="2" relation="public-inheritance">
         </childnode>
         <childnode refid="3" relation="usage">
-          <edgelabel>myNestedBar</edgelabel>
+          <edgelabel>myFoo</edgelabel>
+        </childnode>
+        <childnode refid="4" relation="usage">
+          <edgelabel>myBar</edgelabel>
+          <edgelabel>myGlobalBar</edgelabel>
+          <edgelabel>myInnerBar</edgelabel>
+        </childnode>
+        <childnode refid="5" relation="usage">
+          <edgelabel>myInnerFoo</edgelabel>
+        </childnode>
+        <childnode refid="6" relation="usage">
+          <edgelabel>myGlobalFoo</edgelabel>
+        </childnode>
+        <childnode refid="7" relation="usage">
+          <edgelabel>myNestedAlias</edgelabel>
         </childnode>
       </node>
-      <node id="3">
+      <node id="7">
         <label>TestApp.Outer.Nested</label>
         <link refid="class_test_app_1_1_outer_1_1_nested"/>
       </node>
     </collaborationgraph>
-    <location file="116_csharp_using_alias.cs" line="22" column="11" bodyfile="116_csharp_using_alias.cs" bodystart="23" bodyend="34"/>
+    <location file="116_csharp_using_alias.cs" line="36" column="11" bodyfile="116_csharp_using_alias.cs" bodystart="37" bodyend="52"/>
     <listofallmembers>
-      <member refid="class_test_app_1_1_test_class_1acf6e9d14d4bc70b87adc5c0c8ad66fd3" prot="public" virt="non-virtual">
+      <member refid="class_test_app_1_1_test_class_1a080276d674da9e7c011e5c1f7fd1ef88" prot="public" virt="non-virtual">
         <scope>TestApp::TestClass</scope>
-        <name>Method</name>
+        <name>fooMethod</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1a51b4e8ca0e1a53579fa3e0391ab85942" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>globalFooMethod</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1aaaa0162b354a511239bac8962c6c1121" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>innerFooMethod</name>
       </member>
       <member refid="class_test_app_1_1_test_class_1a8ae7b8d812526c563af57512c6123be1" prot="public" virt="non-virtual">
         <scope>TestApp::TestClass</scope>
         <name>myBar</name>
       </member>
-      <member refid="class_test_app_1_1_test_class_1ad7c05a0e172dce2493017ff50d6fa262" prot="public" virt="non-virtual">
-        <scope>TestApp::TestClass</scope>
-        <name>myBaz</name>
-      </member>
       <member refid="class_test_app_1_1_test_class_1ab5af62cc6d392b98f6dfa49072c20a30" prot="public" virt="non-virtual">
         <scope>TestApp::TestClass</scope>
         <name>myFoo</name>
+      </member>
+      <member refid="class_test_app_1_1_test_class_1a81c20b830057daabc77a301d04047316" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myGlobalBar</name>
       </member>
       <member refid="class_test_app_1_1_test_class_1a8b7fa1bc2aa6d0356ff3752e94730ef5" prot="public" virt="non-virtual">
         <scope>TestApp::TestClass</scope>
         <name>myGlobalFoo</name>
       </member>
+      <member refid="class_test_app_1_1_test_class_1af245c69b3fb0614f2ac7887c1ca02e60" prot="public" virt="non-virtual">
+        <scope>TestApp::TestClass</scope>
+        <name>myInnerBar</name>
+      </member>
       <member refid="class_test_app_1_1_test_class_1acec90deceefaa3a90dc2f8774f0092bb" prot="public" virt="non-virtual">
         <scope>TestApp::TestClass</scope>
         <name>myInnerFoo</name>
       </member>
-      <member refid="class_test_app_1_1_test_class_1a895d6eff6875dae53a9d35cd13c6b865" prot="public" virt="non-virtual">
+      <member refid="class_test_app_1_1_test_class_1a2bbf27d0b7759d186d8d48b09151168e" prot="public" virt="non-virtual">
         <scope>TestApp::TestClass</scope>
-        <name>myListOfFoos</name>
-      </member>
-      <member refid="class_test_app_1_1_test_class_1ad778b00cf9aa69e9e1b51405c07c2920" prot="public" virt="non-virtual">
-        <scope>TestApp::TestClass</scope>
-        <name>myNestedBar</name>
+        <name>myNestedAlias</name>
       </member>
     </listofallmembers>
   </compounddef>

--- a/testing/116_csharp_using_alias.cs
+++ b/testing/116_csharp_using_alias.cs
@@ -13,6 +13,10 @@ namespace N {
   }
 }
 
+namespace M {
+  public class A {}
+}
+
 using Foo = N.A;
 using Bar = N.Collections.Dictionary<string, N.Collections.List<N.A>>;
 
@@ -51,3 +55,8 @@ namespace TestApp
         public GlobalFoo globalFooMethod(GlobalBar b) { return null; }
     }
 }
+
+using N;
+using A = M.A;
+
+interface I : A {}

--- a/testing/116_csharp_using_alias.cs
+++ b/testing/116_csharp_using_alias.cs
@@ -1,0 +1,53 @@
+// objective: check C# using alias
+// config: EXTRACT_ALL=YES
+// check: class_test_app_1_1_test_class.xml
+
+namespace N {
+  public class A {}
+  public class B {}
+  public class C {}
+
+  namespace Collections {
+    public class Dictionary<TKey, TValue> {}
+    public class List<T> {}
+  }
+}
+
+using Foo = N.A;
+using Bar = N.Collections.Dictionary<string, N.Collections.List<N.A>>;
+
+using GlobalFoo = global::N.B;
+using GlobalBar = N.Collections.Dictionary<string, N.Collections.List<N.B>>;
+
+namespace TestApp
+{
+    public class Outer {
+        public class Nested {}
+    }
+}
+
+namespace TestApp
+{
+    using InnerFoo = N.C;
+    using InnerBar = N.Collections.Dictionary<string, N.Collections.List<N.C>>;
+
+    using NestedAlias = TestApp.Outer.Nested;
+
+    public class TestClass : Bar
+    {
+        public Foo myFoo;
+        public Bar myBar;
+
+        public InnerFoo myInnerFoo;
+        public InnerBar myInnerBar;
+
+        public GlobalFoo myGlobalFoo;
+        public GlobalBar myGlobalBar;
+
+        public NestedAlias myNestedAlias;
+
+        public Foo fooMethod(Bar b) { return null; }
+        public InnerFoo innerFooMethod(InnerBar b) { return null; }
+        public GlobalFoo globalFooMethod(GlobalBar b) { return null; }
+    }
+}


### PR DESCRIPTION
There are various bugs for C++ namespace alias linking due to the fact that

1. C# uses `.` for namespace member access than `::` as it is for C++
2. C# also allows `::` for `global::` and namespace access within namespace
3. When resolving competing identifiers, it fails to prioritize aliasing than namespace inclusion
4. Template aliasing resolution fails due to the differing tag scheme from C++ (C# makes it so that generics (templates) of differing arity refer to different references)

1 has been fixed by simply extending `scanner.l` to accept `.` but transform it into `::`

2 will be addressed in another feature PR

3 has been fixed by making `accessibleViaUsingNamespace` return `result = 1` instead to lower priority

4 has been fixed by calculating arity on parse time and adding a `templateArity` in `resolveClass` function call


---

<details>
<summary>old description</summary>

Cause:

In C#, aliasing with `using` statement is possible

`using X = Y.Z`;

However, under current parser, `Y.Z` will be noted as `typedef Y.Z`;

When `.` is not converted to `::`, symbol resolution at `getTypeDefRec(...)` fails as lookup for `FooNamespace.BarMember` cannot be processed because it doesn't have `::`

Thus, at `scanner.l`, a conversion is needed to fit the `::` representation convention

All tests pass

If you need a testing entry let me know
</details>