### PR TITLE
Large white space between grouping without names

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -976,7 +976,7 @@ void DocbookGenerator::startMemberGroupHeader(const QCString &,bool)
 DB_GEN_C
   m_t << "<simplesect><title>";
 }
-void DocbookGenerator::endMemberGroupHeader()
+void DocbookGenerator::endMemberGroupHeader(bool)
 {
 DB_GEN_C
   m_t << "</title>\n";

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -218,7 +218,7 @@ class DocbookGenerator : public OutputGenerator, public OutputGenIntf
     void startCompoundTemplateParams() override;
     void endCompoundTemplateParams() override;
     void startMemberGroupHeader(const QCString &,bool) override;
-    void endMemberGroupHeader() override;
+    void endMemberGroupHeader(bool) override;
     void startMemberGroupDocs() override {DB_GEN_EMPTY}
     void endMemberGroupDocs() override {DB_GEN_EMPTY}
     void startMemberGroup() override;

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2600,7 +2600,7 @@ void HtmlGenerator::startMemberGroupHeader(const QCString &id,bool)
   m_t << "<tr id=\"" << id << "\" class=\"groupHeader\"><td colspan=\"2\"><div class=\"groupHeader\">";
 }
 
-void HtmlGenerator::endMemberGroupHeader()
+void HtmlGenerator::endMemberGroupHeader(bool)
 {
   m_t << "</div></td></tr>\n";
 }

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -191,7 +191,7 @@ class HtmlGenerator : public OutputGenerator, public OutputGenIntf
     void endCompoundTemplateParams() override;
 
     void startMemberGroupHeader(const QCString &,bool) override;
-    void endMemberGroupHeader() override;
+    void endMemberGroupHeader(bool) override;
     void startMemberGroupDocs() override;
     void endMemberGroupDocs() override;
     void startMemberGroup() override;

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1926,8 +1926,11 @@ void LatexGenerator::endMemberList()
 
 void LatexGenerator::startMemberGroupHeader(const QCString &,bool hasHeader)
 {
-  if (hasHeader) m_t << "\\begin{Indent}";
-  m_t << "\\textbf{ ";
+  if (hasHeader)
+  {
+    m_t << "\\begin{Indent}";
+    m_t << "\\textbf{ ";
+  }
   // changed back to rev 756 due to bug 660501
   //if (Config_getBool(COMPACT_LATEX))
   //{
@@ -1939,10 +1942,10 @@ void LatexGenerator::startMemberGroupHeader(const QCString &,bool hasHeader)
   //}
 }
 
-void LatexGenerator::endMemberGroupHeader()
+void LatexGenerator::endMemberGroupHeader(bool hasHeader)
 {
   // changed back to rev 756 due to bug 660501
-  m_t << "}\\par\n";
+  if (hasHeader) m_t << "}\\par\n";
   //m_t << "}\n";
 }
 

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -182,7 +182,7 @@ class LatexGenerator : public OutputGenerator, public OutputGenIntf
     void endCompoundTemplateParams() override { m_t << "}\n"; }
 
     void startMemberGroupHeader(const QCString &,bool) override;
-    void endMemberGroupHeader() override;
+    void endMemberGroupHeader(bool) override;
     void startMemberGroupDocs() override;
     void endMemberGroupDocs() override;
     void startMemberGroup() override;

--- a/src/mangen.cpp
+++ b/src/mangen.cpp
@@ -640,7 +640,7 @@ void ManGenerator::startMemberGroupHeader(const QCString &,bool)
   m_t << "\n.PP\n.RI \"\\fB";
 }
 
-void ManGenerator::endMemberGroupHeader()
+void ManGenerator::endMemberGroupHeader(bool)
 {
   m_t << "\\fP\"\n.br\n";
   m_firstCol=TRUE;

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -155,7 +155,7 @@ class ManGenerator : public OutputGenerator, public OutputGenIntf
     void endCompoundTemplateParams() override;
 
     void startMemberGroupHeader(const QCString &,bool) override;
-    void endMemberGroupHeader() override;
+    void endMemberGroupHeader(bool) override;
     void startMemberGroupDocs() override;
     void endMemberGroupDocs() override;
     void startMemberGroup() override;

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -591,7 +591,7 @@ void MemberList::writeDeclarations(OutputList &ol,
         {
           ol.parseText(mg->header());
         }
-        ol.endMemberGroupHeader();
+        ol.endMemberGroupHeader(hasHeader);
         if (!mg->documentation().isEmpty())
         {
           //printf("Member group has docs!\n");

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -195,7 +195,7 @@ class OutputGenIntf
     virtual void startCompoundTemplateParams() = 0;
     virtual void endCompoundTemplateParams() = 0;
     virtual void startMemberGroupHeader(const QCString &id,bool b) = 0;
-    virtual void endMemberGroupHeader() = 0;
+    virtual void endMemberGroupHeader(bool b) = 0;
     virtual void startMemberGroupDocs() = 0;
     virtual void endMemberGroupDocs() = 0;
     virtual void startMemberGroup() = 0;

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -504,8 +504,8 @@ class OutputList
     { foreach(&OutputGenIntf::endCompoundTemplateParams); }
     void startMemberGroupHeader(const QCString &id,bool b)
     { foreach(&OutputGenIntf::startMemberGroupHeader,id,b); }
-    void endMemberGroupHeader()
-    { foreach(&OutputGenIntf::endMemberGroupHeader); }
+    void endMemberGroupHeader(bool b)
+    { foreach(&OutputGenIntf::endMemberGroupHeader,b); }
     void startMemberGroupDocs()
     { foreach(&OutputGenIntf::startMemberGroupDocs); }
     void endMemberGroupDocs()

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -2531,7 +2531,7 @@ void RTFGenerator::startMemberGroupHeader(const QCString &,bool hasHeader)
   m_t << rtf_Style_Reset << rtf_Style["GroupHeader"].reference();
 }
 
-void RTFGenerator::endMemberGroupHeader()
+void RTFGenerator::endMemberGroupHeader(bool)
 {
   DBG_RTF(m_t << "{\\comment endMemberGroupHeader}\n")
   newParagraph();

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -250,7 +250,7 @@ class RTFGenerator : public OutputGenerator, public OutputGenIntf
     void writeGraphicalHierarchy(DotGfxHierarchyTable &) override {}
 
     void startMemberGroupHeader(const QCString &,bool) override;
-    void endMemberGroupHeader() override;
+    void endMemberGroupHeader(bool) override;
     void startMemberGroupDocs() override;
     void endMemberGroupDocs() override;
     void startMemberGroup() override;

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -1786,7 +1786,7 @@ void VhdlDocGen::writeVHDLDeclarations(const MemberList* ml,OutputList &ol,
       {
         ol.parseText(mg->header());
       }
-      ol.endMemberGroupHeader();
+      ol.endMemberGroupHeader(hasHeader);
       if (!mg->documentation().isEmpty())
       {
         //printf("Member group has docs!\n");


### PR DESCRIPTION
When having something like"
```
/// \file

/// \{
void foo_g();
void bar_g();
void baz_g();
/// \}

/// \brief text
/// \{
void foo_b();
void bar_b();
void baz_b();
/// \}
```
The spacing in the LaTeX brief  description between the 2 (anonymous) groups is a bit large, this is corrected.

Example: [example.tar.gz](https://github.com/user-attachments/files/25181670/example.tar.gz)
