### PR TITLE
issue #11972 Incorrect indentation for custom command following list

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -4462,7 +4462,7 @@ static void addXRefItem(yyscan_t yyscanner,
     item->setAnchor(anchorLabel);
     yyextra->current->sli.push_back(item);
     QCString cmdString;
-    cmdString.sprintf(" \\xrefitem %s %d.",qPrint(listName),item->id());
+    cmdString.sprintf("\\ilinebr \\xrefitem %s %d.",qPrint(listName),item->id());
     if (yyextra->inBody)
     {
       yyextra->current->inbodyDocs += cmdString;

--- a/testing/009/class_bug.xml
+++ b/testing/009/class_bug.xml
@@ -12,8 +12,16 @@
         <briefdescription>
         </briefdescription>
         <detaileddescription>
-          <para>Description <xrefsect id="bug_1_bug000002"><xreftitle>Bug</xreftitle><xrefdescription><para>Function bug<itemizedlist><listitem><para>list item 1 in bug</para></listitem><listitem><para>list item 2 in bug</para></listitem></itemizedlist>
-</para></xrefdescription></xrefsect></para>
+          <para>Description</para>
+          <para>
+            <xrefsect id="bug_1_bug000002">
+              <xreftitle>Bug</xreftitle>
+              <xrefdescription>
+                <para>Function bug<itemizedlist><listitem><para>list item 1 in bug</para></listitem><listitem><para>list item 2 in bug</para></listitem></itemizedlist>
+</para>
+              </xrefdescription>
+            </xrefsect>
+          </para>
           <para>More text. </para>
         </detaileddescription>
         <inbodydescription>

--- a/testing/009/class_deprecated.xml
+++ b/testing/009/class_deprecated.xml
@@ -12,7 +12,15 @@
         <briefdescription>
         </briefdescription>
         <detaileddescription>
-          <para>Do deprecated things. <xrefsect id="deprecated_1_deprecated000002"><xreftitle>Deprecated</xreftitle><xrefdescription><para>No not use this function anymore. </para></xrefdescription></xrefsect></para>
+          <para>Do deprecated things.</para>
+          <para>
+            <xrefsect id="deprecated_1_deprecated000002">
+              <xreftitle>Deprecated</xreftitle>
+              <xrefdescription>
+                <para>No not use this function anymore. </para>
+              </xrefdescription>
+            </xrefsect>
+          </para>
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>


### PR DESCRIPTION
Creating an extra, invisible, linebreak to solve the issue. HTML output is, visually, the same (as well as PDF and RTF). XML slightly improved by creating the right / better paragraph structure