### PR TITLE
issue #11974 Example code not rendered correctly using Doxygen 1.16.1 when TAB_SIZE = 8

### DIFF
--- a/src/codefragment.cpp
+++ b/src/codefragment.cpp
@@ -200,7 +200,8 @@ static QCString readTextFileByName(const QCString &file)
     FileInfo fi(file.str());
     if (fi.exists())
     {
-      return fileToString(file,Config_getBool(FILTER_SOURCE_FILES));
+      size_t indent=0;
+      return detab(fileToString(file,Config_getBool(FILTER_SOURCE_FILES)),indent);
     }
   }
   const StringVector &examplePathList = Config_getList(EXAMPLE_PATH);

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1742,7 +1742,8 @@ void DocParser::readTextFileByName(const QCString &file,QCString &text)
   QCString filePath = findFilePath(file,ambig);
   if (!filePath.isEmpty())
   {
-    text = fileToString(filePath,Config_getBool(FILTER_SOURCE_FILES));
+    size_t indent = 0;
+    text = detab(fileToString(filePath,Config_getBool(FILTER_SOURCE_FILES)),indent);
     if (ambig)
     {
       warn_doc_error(context.fileName,tokenizer.getLineNr(),"included file name '{}' is ambiguous"


### PR DESCRIPTION
When reading a file the file should be "detabbed"