### PR TITLE
issue #11980 Documentation Python Class with two literals will not be compiled

### DIFF
--- a/src/pyscanner.l
+++ b/src/pyscanner.l
@@ -1402,6 +1402,9 @@ ID        [a-z_A-Z%]+{IDSYM}*
    {IDENTIFIER}       {
                         yyextra->current->initializer << yytext;
                       }
+   {POUNDCOMMENT}     { // normal comment
+                        yyextra->current->initializer << yytext;
+                      }
    .                  {
                         yyextra->current->initializer << *yytext;
                       }


### PR DESCRIPTION
Handle comments within variables as well.