### PR TITLE
issue #11984 C++20 concepts and doxygen 1.16.1 parsing problems

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -3290,7 +3290,8 @@ NONLopt [^\n]*
 <ReadInitializer>{CCS}                  {
                                           if (yyextra->keepComment)
                                           {
-                                            yyextra->current->initializer << yytext;
+                                            yyextra->lastCContext = YY_START ;
+                                            BEGIN( SkipComment ) ;
                                           }
                                           else
                                           {


### PR DESCRIPTION
Analogous to the  the problem with the `//` comments also with the `/*` type of comments the problem was present.

Example: [example.tar.gz](https://github.com/user-attachments/files/25364580/example.tar.gz)
