### PR TITLE
issue #11989 Doxyfile with UTF-8 BOM Doxyfile causes silent exit (no output, no error) in 1.16.1

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -1304,7 +1304,12 @@ REGEX_w [a-z_A-Z0-9\x80-\xFF]
 <*>\\[ \r\t]*\n                         { g_yyLineNr++; }
 <*>[ \t\r]
 <*>\n                                   { g_yyLineNr++ ; }
-<*>.                                    { ConfigImpl::config_warn("ignoring unknown character '{:c}' at line {}, file {}\n",yytext[0],g_yyLineNr,g_yyFileName); }
+<*>.                                    {
+                                          if (isprint(yytext[0]))
+                                            ConfigImpl::config_warn("ignoring unknown character '{:c}' at line {}, file {}\n",yytext[0],g_yyLineNr,g_yyFileName);
+                                          else
+                                            ConfigImpl::config_warn("ignoring unknown character '0x{:x}' at line {}, file {}\n",yytext[0],g_yyLineNr,g_yyFileName);
+                                        }
 
 %%
 


### PR DESCRIPTION
The BOM characters are not allowed by doxygen and under windows these non printable characters caused problems. Reformulated warning in case if a non printable character.