### PR TITLE
Missing closing round bracket with `\cite` description

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -2518,7 +2518,7 @@ Commands to create links
     - `shortauthor` just the surname of the first author is given, and in case
       multiple authors are present the text "et al." is added
     - `year`, the year of publication is mentioned (when specified in the bibtex
-      file.
+      file).
   - `nopar`, no (square) brackets are added
   - `nocite`, no link to a citation in the bibliography is made (and the
     reference is not added to the bibliography based on this item)


### PR DESCRIPTION
Missing closing round bracket.