### PR TITLE
Handling of line numbers with e.g.  `\example` command

### DIFF
--- a/src/fortrancode.l
+++ b/src/fortrancode.l
@@ -158,6 +158,7 @@ struct fortrancodeYY_state
 
   std::unique_ptr<FileDef> exampleFileDef;
   const FileDef *    sourceFileDef = nullptr;
+  bool          lineNumbers = FALSE;
   const Definition * currentDefinition = nullptr;
   const MemberDef *  currentMemberDef = nullptr;
   bool          includeCodeFragment = false;
@@ -953,7 +954,7 @@ static void codeFolding(yyscan_t yyscanner,const Definition *d)
 static void startCodeLine(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  if (yyextra->sourceFileDef)
+  if (yyextra->sourceFileDef && yyextra->lineNumbers)
   {
     //QCString lineNumber,lineAnchor;
     //lineNumber.sprintf("%05d",yyextra->yyLineNr);
@@ -1509,6 +1510,7 @@ void FortranCodeParser::parseCode(OutputCodeList & codeOutIntf,
   yyextra->exampleBlock       = options.isExample();
   yyextra->exampleName        = options.exampleName();
   yyextra->sourceFileDef      = options.fileDef();
+  yyextra->lineNumbers        = options.fileDef() && options.showLineNumbers();
   yyextra->foldStack.clear();
   yyextra->insideSpecialComment = false;
   if (options.isExample() && options.fileDef()==nullptr)

--- a/src/pycode.l
+++ b/src/pycode.l
@@ -85,6 +85,7 @@ struct pycodeYY_state
   int           yyLineNr = 0;        //!< current line number
   std::unique_ptr<FileDef> exampleFileDef;
   const FileDef *    sourceFileDef = nullptr;
+  bool          lineNumbers = false;
   const Definition * currentDefinition = nullptr;
   const MemberDef *  currentMemberDef = nullptr;
   bool          includeCodeFragment = FALSE;
@@ -949,7 +950,7 @@ static void startCodeLine(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   //if (yyextra->currentFontClass) { yyextra->code->endFontClass(yyscanner); }
-  if (yyextra->sourceFileDef)
+  if (yyextra->sourceFileDef && yyextra->lineNumbers)
   {
     //QCString lineNumber,lineAnchor;
     //lineNumber.sprintf("%05d",yyextra->yyLineNr);
@@ -1551,6 +1552,7 @@ void PythonCodeParser::parseCode(OutputCodeList &codeOutIntf,
   yyextra->exampleBlock  = options.isExample();
   yyextra->exampleName   = options.exampleName();
   yyextra->sourceFileDef = options.fileDef();
+  yyextra->lineNumbers   = options.fileDef() && options.showLineNumbers();
   yyextra->symbolResolver.setFileScope(options.fileDef());
   yyextra->foldStack.clear();
   yyextra->insideSpecialComment = false;

--- a/src/sqlcode.l
+++ b/src/sqlcode.l
@@ -67,6 +67,7 @@ struct sqlcodeYY_state
 
      std::unique_ptr<FileDef> exampleFileDef;
      const FileDef    *sourceFileDef = nullptr;
+     bool          lineNumbers = FALSE;
      const Definition *currentDefinition = nullptr;
      const MemberDef  *currentMemberDef = nullptr;
      bool          includeCodeFragment = false;
@@ -230,7 +231,7 @@ static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor)
 static void startCodeLine(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  if (yyextra->sourceFileDef)
+  if (yyextra->sourceFileDef && yyextra->lineNumbers)
   {
     const Definition *d = yyextra->sourceFileDef->getSourceDefinition(yyextra->yyLineNr);
 
@@ -432,6 +433,7 @@ void SQLCodeParser::parseCode(OutputCodeList &codeOutIntf,
   yyextra->exampleBlock      = options.isExample();
   yyextra->exampleName       = options.exampleName();
   yyextra->sourceFileDef     = options.fileDef();
+  yyextra->lineNumbers       = options.fileDef() && options.showLineNumbers();
 
   if (options.isExample() && options.fileDef()==0)
   {

--- a/src/vhdlcode.l
+++ b/src/vhdlcode.l
@@ -104,6 +104,7 @@ struct vhdlcodeYY_state
 
   std::unique_ptr<FileDef> exampleFileDef;
   const FileDef *     sourceFileDef = nullptr;
+  bool          lineNumbers = FALSE;
   const Definition *  currentDefinition = nullptr;
   const MemberDef *   currentMemberDef = nullptr;
   bool          includeCodeFragment = false;
@@ -1051,7 +1052,7 @@ static void startCodeLine(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
   //if (yyextra->currentFontClass) { yyextra->code->endFontClass(); }
-  if (yyextra->sourceFileDef)
+  if (yyextra->sourceFileDef && yyextra->lineNumbers)
   {
     //QCString lineNumber,lineAnchor;
     //lineNumber.sprintf("%05d",yyextra->yyLineNr);
@@ -1684,6 +1685,7 @@ void VHDLCodeParser::parseCode(OutputCodeList &od,
   yyextra->exampleBlock         = options.isExample();
   yyextra->exampleName          = options.exampleName();
   yyextra->sourceFileDef        = options.fileDef();
+  yyextra->lineNumbers          = options.fileDef() && options.showLineNumbers();
   if (options.isExample() && options.fileDef()==nullptr)
   {
     // create a dummy filedef for the example

--- a/src/xmlcode.l
+++ b/src/xmlcode.l
@@ -82,6 +82,7 @@ struct xmlcodeYY_state
 
   std::unique_ptr<FileDef> exampleFileDef;
   const FileDef *     sourceFileDef = nullptr;
+  bool          lineNumbers = FALSE;
   const Definition *  currentDefinition = nullptr;
   const MemberDef *   currentMemberDef = nullptr;
   bool          includeCodeFragment = false;
@@ -252,7 +253,7 @@ static void setCurrentDoc(yyscan_t yyscanner,const QCString &anchor)
 static void startCodeLine(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  if (yyextra->sourceFileDef)
+  if (yyextra->sourceFileDef && yyextra->lineNumbers)
   {
     const Definition *d = yyextra->sourceFileDef->getSourceDefinition(yyextra->yyLineNr);
 
@@ -439,6 +440,7 @@ void XMLCodeParser::parseCode(OutputCodeList &codeOutIntf,
   yyextra->exampleBlock      = options.isExample();
   yyextra->exampleName       = options.exampleName();
   yyextra->sourceFileDef     = options.fileDef();
+  yyextra->lineNumbers       = options.fileDef() && options.showLineNumbers();
 
   if (options.isExample() && options.fileDef()==nullptr)
   {


### PR DESCRIPTION
Until now only in `code.l` and `lexcode.l` the disabling or enabling of the line numbers was implemented (could be seen when using the `\example` command) resulting in that for the non mentioned parsers the line numbers were shown.