### PR TITLE
Discussion #12000 CHM Viewer JavaScript Problem with svg.min.js

### DIFF
--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2001,6 +2001,7 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     adjustBoolSetting(  depOption, "HTML_DYNAMIC_SECTIONS",false  );
     adjustBoolSetting(  depOption, "HTML_COPY_CLIPBOARD",  false  );
     adjustBoolSetting(  depOption, "HTML_CODE_FOLDING",    false  );
+    adjustBoolSetting(  depOption, "INTERACTIVE_SVG",      false  );
     adjustStringSetting(depOption, "HTML_FILE_EXTENSION", ".html");
     adjustColorStyleSetting(depOption);
     const StringVector &tagFileList = Config_getList(TAGFILES);


### PR DESCRIPTION
Disable `INTERACTIVE_SVG` when `GENERATE_HTMLHELP=YES`

Example: [example.tar.gz](https://github.com/user-attachments/files/25457693/example.tar.gz)
