### PR TITLE
Fix ObjC base list state leak between interface and protocol declarations

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7010,9 +7010,12 @@ NONLopt [^\n]*
                                           yyextra->current->bodyColumn = yyextra->yyColNr;
                                           yyextra->current->name = removeRedundantWhiteSpace(yyextra->current->name);
                                           if (!yyextra->baseName.isEmpty())
+                                          {
                                             yyextra->current->extends.emplace_back(
                                                yyextra->baseName,yyextra->baseProt,yyextra->baseVirt
                                             );
+                                            yyextra->baseName.clear();
+                                          }
                                           yyextra->curlyCount=0;
                                           if (yyextra->insideObjC)
                                           {

--- a/testing/116/interface_myinterface.xml
+++ b/testing/116/interface_myinterface.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="interface_myinterface" kind="class" language="Objective-C" prot="public">
+    <compoundname>Myinterface</compoundname>
+    <basecompoundref prot="public" virt="non-virtual">NSObject</basecompoundref>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <inheritancegraph>
+      <node id="1">
+        <label>Myinterface</label>
+        <link refid="interface_myinterface"/>
+        <childnode refid="2" relation="public-inheritance">
+        </childnode>
+      </node>
+      <node id="2">
+        <label>NSObject</label>
+      </node>
+    </inheritancegraph>
+    <collaborationgraph>
+      <node id="1">
+        <label>Myinterface</label>
+        <link refid="interface_myinterface"/>
+        <childnode refid="2" relation="public-inheritance">
+        </childnode>
+      </node>
+      <node id="2">
+        <label>NSObject</label>
+      </node>
+    </collaborationgraph>
+    <location file="116_objc_interface_protocol.h" line="8" column="12" bodyfile="116_objc_interface_protocol.h" bodystart="9" bodyend="-1"/>
+    <listofallmembers>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/116/protocol_myprotocol-p.xml
+++ b/testing/116/protocol_myprotocol-p.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="protocol_myprotocol-p" kind="protocol" language="Objective-C" prot="public">
+    <compoundname>Myprotocol-p</compoundname>
+    <basecompoundref prot="public" virt="non-virtual">&lt;NSCopying&gt;</basecompoundref>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <inheritancegraph>
+      <node id="1">
+        <label>&lt;Myprotocol&gt;</label>
+        <link refid="protocol_myprotocol-p"/>
+        <childnode refid="2" relation="public-inheritance">
+        </childnode>
+      </node>
+      <node id="2">
+        <label>&lt;NSCopying&gt;</label>
+      </node>
+    </inheritancegraph>
+    <collaborationgraph>
+      <node id="1">
+        <label>&lt;Myprotocol&gt;</label>
+        <link refid="protocol_myprotocol-p"/>
+        <childnode refid="2" relation="public-inheritance">
+        </childnode>
+      </node>
+      <node id="2">
+        <label>&lt;NSCopying&gt;</label>
+      </node>
+    </collaborationgraph>
+    <location file="116_objc_interface_protocol.h" line="11" column="11" bodyfile="116_objc_interface_protocol.h" bodystart="11" bodyend="-1"/>
+    <listofallmembers>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/116_objc_interface_protocol.h
+++ b/testing/116_objc_interface_protocol.h
@@ -1,0 +1,12 @@
+// objective: test ObjC interface->protocol base parsing does not leak previous base class name
+// check: interface_myinterface.xml
+// check: protocol_myprotocol-p.xml
+// config: EXTENSION_MAPPING = h=Objective-C
+
+#import <Foundation/Foundation.h>
+
+@interface Myinterface : NSObject
+@end
+
+@protocol Myprotocol <NSCopying>
+@end


### PR DESCRIPTION
 ## Summary
- Fixes an Objective-C parser state leak where the previous compound's base class name could be reused when parsing the next declaration.
- Specifically addresses the `@interface -> @protocol` ordering case in `.h` files, where protocol extensions could be emitted as concatenated names (e.g. `NSObjectNSCopying`).
- Clears the temporary `baseName` buffer after committing it to `extends` in the scanner base-handling path.

Input header:

```obj-c
#import <Foundation/Foundation.h>
@interface RCTInterface : NSObject
@end
@protocol RCTProtocol <NSCopying>
@end
```

Before fix:
```xml
<compounddef id="protocol_r_c_t_protocol-p" kind="protocol" ...>
  <basecompoundref prot="public" virt="non-virtual">&lt;NSObjectNSCopying&gt;</basecompoundref>
</compounddef>
```

After fix:
```xml
<compounddef id="protocol_r_c_t_protocol-p" kind="protocol" ...>
  <basecompoundref prot="public" virt="non-virtual">&lt;NSCopying&gt;</basecompoundref>
</compounddef>
```
 
## Root Cause
`src/scanner.l` reused `yyextra->baseName` across declarations and did not clear it after appending in the `{` transition for base parsing.  
This allowed stale interface base data to bleed into the next protocol extension list.
 Changes
- Updated `src/scanner.l` to clear `yyextra->baseName` after adding it to `current->extends` in the `<Bases>{B}*"{"{B}*` rule.
- Added regression test `testing/116_objc_interface_protocol.h`.
- Added reference outputs:
  - `testing/116/interface_myinterface.xml`
  - `testing/116/protocol_myprotocol-p.xml`

## Test plan
- `python3 testing/runtests.py --id 116 --doxygen build/bin/doxygen --inputdir testing --outputdir build/testing`
- Confirmed protocol base is now `<NSCopying>` (not concatenated with prior interface base).