### PR TITLE
Compacter layout of `HTML_DYNAMIC_MENUS`

### DIFF
--- a/templates/html/tabs.css
+++ b/templates/html/tabs.css
@@ -356,12 +356,14 @@
 }
 
 .sm-dox ul a span.sub-arrow {
-    transform: rotate(-45deg)
+    transform: rotate(-45deg);
+    top: 3px;
 }
 
 .sm-dox ul a,.sm-dox ul a.highlighted,.sm-dox ul a:active,.sm-dox ul a:focus,.sm-dox ul a:hover {
     color: var(--nav-menu-foreground-color);
     background-image: none;
+    line-height: normal;
     border: 0!important
 }
 


### PR DESCRIPTION
Small tweaks to get a nicer / compacter look of the submenus when `HTML_DYNAMIC_MENUS = YES`

Old:

<img width="720" height="295" alt="image" src="https://github.com/user-attachments/assets/22a7c9a3-27ce-4199-b990-82d3780a4e4d" />

New:

<img width="645" height="229" alt="image" src="https://github.com/user-attachments/assets/bebaf955-3c19-476a-bc1d-e2615aabeffc" />
