### PR TITLE
issue #12008 "namespacemembers.html" and "functions.html" only show items for one specific initial letter

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3125,7 +3125,6 @@ static void writeMemberIndex(OutputList &ol,
     alphaLinks += "<a class=\"qindex\" href=\"" + anchor +
                   li + "\">" +
                   letter + "</a>";
-    first=FALSE;
   }
   alphaLinks += "</div>\n";
   ol.writeString(alphaLinks);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3277,7 +3277,7 @@ static void writeClassMemberIndexFiltered(OutputList &ol, ClassMemberHighlight::
     ol.startTextBlock();
     ol.parseText(hl == ClassMemberHighlight::All && lne ? lne->intro() : theTranslator->trCompoundMembersDescriptionTotal(hl));
     ol.endTextBlock();
-    if (dynamicMenus)
+    if (dynamicMenus || disableIndex)
     {
       writeMemberIndex(ol,index.isClassIndexLetterUsed(hl),getCmhlInfo(hl)->fname,multiPageIndex);
     }
@@ -3467,7 +3467,7 @@ static void writeFileMemberIndexFiltered(OutputList &ol, FileMemberHighlight::En
     ol.startTextBlock();
     ol.parseText(hl == FileMemberHighlight::All && lne ? lne->intro() : theTranslator->trFileMembersDescriptionTotal(hl));
     ol.endTextBlock();
-    if (dynamicMenus)
+    if (dynamicMenus || disableIndex)
     {
       writeMemberIndex(ol,index.isFileIndexLetterUsed(hl),getCmhlInfo(hl)->fname,multiPageIndex);
     }
@@ -3832,7 +3832,7 @@ static void writeModuleMemberIndexFiltered(OutputList &ol,
     ol.startTextBlock();
     ol.parseText(hl == ModuleMemberHighlight::All && lne ? lne->intro() : theTranslator->trModuleMembersDescriptionTotal(hl));
     ol.endTextBlock();
-    if (dynamicMenus)
+    if (dynamicMenus || disableIndex)
     {
       writeMemberIndex(ol,index.isModuleIndexLetterUsed(hl),getCmhlInfo(hl)->fname,multiPageIndex);
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3100,6 +3100,37 @@ static void writeQuickMemberIndex(OutputList &ol,
   endQuickIndexList(ol);
 }
 
+static void writeMemberIndex(OutputList &ol,
+    const Index::MemberIndexMap &map, QCString fullName,bool multiPage)
+{
+  bool first=true;
+  ol.writeString("<br/>\n");
+  QCString alphaLinks = "<div class=\"qindex\">";
+  for (const auto &[letter,list] : map)
+  {
+    QCString ci(letter);
+    QCString is = letterToLabel(ci);
+    QCString anchor;
+    QCString extension=Doxygen::htmlFileExtension;
+    if (!multiPage)
+      anchor="#index_";
+    else if (first)
+      anchor=fullName+extension+"#index_";
+    else
+      anchor=fullName+"_"+is+extension+"#index_";
+
+    if (!first) alphaLinks += "&#160;|&#160;";
+    first=false;
+    QCString li = letterToLabel(letter);
+    alphaLinks += "<a class=\"qindex\" href=\"" + anchor +
+                  li + "\">" +
+                  letter + "</a>";
+    first=FALSE;
+  }
+  alphaLinks += "</div>\n";
+  ol.writeString(alphaLinks);
+}
+
 //----------------------------------------------------------------------------
 
 /** Helper class representing a class member in the navigation menu. */
@@ -3247,6 +3278,10 @@ static void writeClassMemberIndexFiltered(OutputList &ol, ClassMemberHighlight::
     ol.startTextBlock();
     ol.parseText(hl == ClassMemberHighlight::All && lne ? lne->intro() : theTranslator->trCompoundMembersDescriptionTotal(hl));
     ol.endTextBlock();
+    if (dynamicMenus)
+    {
+      writeMemberIndex(ol,index.isClassIndexLetterUsed(hl),getCmhlInfo(hl)->fname,multiPageIndex);
+    }
 
     writeMemberList(ol,quickIndex,
         multiPageIndex ? letter : std::string(),
@@ -3433,6 +3468,10 @@ static void writeFileMemberIndexFiltered(OutputList &ol, FileMemberHighlight::En
     ol.startTextBlock();
     ol.parseText(hl == FileMemberHighlight::All && lne ? lne->intro() : theTranslator->trFileMembersDescriptionTotal(hl));
     ol.endTextBlock();
+    if (dynamicMenus)
+    {
+      writeMemberIndex(ol,index.isFileIndexLetterUsed(hl),getCmhlInfo(hl)->fname,multiPageIndex);
+    }
 
     writeMemberList(ol,quickIndex,
         multiPageIndex ? letter : std::string(),
@@ -3794,6 +3833,10 @@ static void writeModuleMemberIndexFiltered(OutputList &ol,
     ol.startTextBlock();
     ol.parseText(hl == ModuleMemberHighlight::All && lne ? lne->intro() : theTranslator->trModuleMembersDescriptionTotal(hl));
     ol.endTextBlock();
+    if (dynamicMenus)
+    {
+      writeMemberIndex(ol,index.isModuleIndexLetterUsed(hl),getCmhlInfo(hl)->fname,multiPageIndex);
+    }
 
     writeMemberList(ol,quickIndex,
         multiPageIndex ? letter : std::string(),


### PR DESCRIPTION
Analogous to the case for the "Class index" also create an "alphabetical list" in the page (taking the multi page possibility into consideration) but do this only in case `HTML_DYNAMIC_MENUS=YES` as otherwise the list would be double.