### PR TITLE
Better arrow with `<details>` / `<summary>` tags

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -2116,14 +2116,17 @@ details > summary::-webkit-details-marker {
 }
 
 details>summary::before {
-	content: "\25ba";
-	padding-right:4px;
-	font-size: 80%;
+        content: "\25bc";
+        padding-right:4px;
+        font-size: 80%;
+        display: inline-block;
+        transform: rotate(-90deg);
 }
 
 details[open]>summary::before {
-	content: "\25bc";
-	padding-right:4px;
-	font-size: 80%;
+        content: "\25bc";
+        padding-right:4px;
+        font-size: 80%;
+        display: inline-block;
+        transform: rotate(0deg);
 }
-


### PR DESCRIPTION
When having a `<details>` / `<summary>` tags combination the "closed" arrow des not look good (Window / Firefox, Chrome, Edge). Using the "open" arrow and rotating this.

Example: [example.tar.gz](https://github.com/user-attachments/files/25577005/example.tar.gz)

Before:

<img width="262" height="241" alt="image" src="https://github.com/user-attachments/assets/3296d7d2-ffff-4ead-a93e-12c16e4dcecf" />

After:

<img width="288" height="220" alt="image" src="https://github.com/user-attachments/assets/b982a616-caa3-416e-849e-80172cbbd64f" />

(Found by CGAL)
