### PR TITLE
Ignore closing `</hr>` and `</br>`

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -5554,7 +5554,7 @@ Token DocPara::handleHtmlEndTag(const QCString &tagName)
       warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </caption> found");
       break;
     case HtmlTagType::HTML_BR:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </br> tag found");
+      //warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </br> tag found");
       break;
     case HtmlTagType::HTML_H1:
       warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </h1> found");
@@ -5577,7 +5577,7 @@ Token DocPara::handleHtmlEndTag(const QCString &tagName)
     case HtmlTagType::HTML_IMG:
       break;
     case HtmlTagType::HTML_HR:
-      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </hr> tag found");
+      // warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal </hr> tag found");
       break;
     case HtmlTagType::HTML_A:
       //warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Unexpected tag </a> found");


### PR DESCRIPTION
When having something like `<hr> </hr>` this gives a warning, though e.g. FireFox (with xhtml files) does not give a warning. `<hr />` is already accepted.
Silently ignore closing `</hr>` and `</br>` tag

Example: [example.tar.gz](https://github.com/user-attachments/files/25604517/example.tar.gz)


(Found by Fossies for Manip package)