### PR TITLE
change cache mutexes to thread locals

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <mutex>
 #include <unordered_map>
 #include <string>
 #include <optional>
@@ -53,6 +54,16 @@
 
 //-----------------------------------------------------------------------------------------
 
+/** once_flag wrapper that is copyable (copy default-initializes the flag) and resettable. */
+struct ResettableOnce
+{
+  mutable std::once_flag flag;
+  ResettableOnce() = default;
+  ResettableOnce(const ResettableOnce &) {} // copy: leave flag in not-yet-called state
+  ResettableOnce &operator=(const ResettableOnce &) { return *this; }
+  void reset() { flag.~once_flag(); new (&flag) std::once_flag{}; }
+};
+
 /** Private data associated with a Symbol DefinitionImpl object. */
 class DefinitionImpl::Private
 {
@@ -81,6 +92,7 @@ class DefinitionImpl::Private
     QCString localName;      // local (unqualified) name of the definition
                              // in the future m_name should become m_localName
     QCString qualifiedName;
+    ResettableOnce qualifiedNameOnce;
     QCString ref;   // reference to external documentation
 
     bool hidden = FALSE;
@@ -1268,47 +1280,28 @@ void DefinitionImpl::addInnerCompound(Definition *)
   err("DefinitionImpl::addInnerCompound() called\n");
 }
 
-static std::recursive_mutex g_qualifiedNameMutex;
-
 QCString DefinitionImpl::qualifiedName() const
 {
-  std::lock_guard<std::recursive_mutex> lock(g_qualifiedNameMutex);
-  if (!p->qualifiedName.isEmpty())
+  std::call_once(p->qualifiedNameOnce.flag, [this]()
   {
-    return p->qualifiedName;
-  }
-
-  //printf("start %s::qualifiedName() localName=%s\n",qPrint(name()),qPrint(p->localName));
-  if (p->outerScope==nullptr)
-  {
-    if (p->localName=="<globalScope>")
+    //printf("start %s::qualifiedName() localName=%s\n",qPrint(name()),qPrint(p->localName));
+    if (p->outerScope==nullptr || p->outerScope->name()=="<globalScope>")
     {
-      return "";
+      p->qualifiedName = (p->localName=="<globalScope>") ? QCString() : p->localName;
     }
     else
     {
-      return p->localName;
+      p->qualifiedName = p->outerScope->qualifiedName()+
+             getLanguageSpecificSeparator(getLanguage())+
+             p->localName;
     }
-  }
-
-  if (p->outerScope->name()=="<globalScope>")
-  {
-    p->qualifiedName = p->localName;
-  }
-  else
-  {
-    p->qualifiedName = p->outerScope->qualifiedName()+
-           getLanguageSpecificSeparator(getLanguage())+
-           p->localName;
-  }
-  //printf("end %s::qualifiedName()=%s\n",qPrint(name()),qPrint(p->qualifiedName));
-  //count--;
+    //printf("end %s::qualifiedName()=%s\n",qPrint(name()),qPrint(p->qualifiedName));
+  });
   return p->qualifiedName;
 }
 
 void DefinitionImpl::setOuterScope(Definition *d)
 {
-  std::lock_guard<std::recursive_mutex> lock(g_qualifiedNameMutex);
   //printf("%s::setOuterScope(%s)\n",qPrint(name()),d?qPrint(d->name()):"<none>");
   Definition *outerScope = p->outerScope;
   bool found=false;
@@ -1321,6 +1314,7 @@ void DefinitionImpl::setOuterScope(Definition *d)
   if (!found)
   {
     p->qualifiedName.clear(); // flush cached scope name
+    p->qualifiedNameOnce.reset();
     p->outerScope = d;
   }
   p->hidden = p->hidden || d->isHidden();

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -164,8 +164,6 @@ bool                  Doxygen::parseSourcesNeeded = FALSE;
 SearchIndexIntf       Doxygen::searchIndex;
 SymbolMap<Definition>*Doxygen::symbolMap;
 ClangUsrMap          *Doxygen::clangUsrMap = nullptr;
-Cache<std::string,LookupInfo> *Doxygen::typeLookupCache;
-Cache<std::string,LookupInfo> *Doxygen::symbolLookupCache;
 DirLinkedMap         *Doxygen::dirLinkedMap;
 DirRelationLinkedMap  Doxygen::dirRelations;
 ParserManager        *Doxygen::parserManager = nullptr;
@@ -9465,7 +9463,7 @@ static void flushCachedTemplateRelations()
   // to this class. Optimization: only remove those classes that
   // have inheritance instances as direct or indirect sub classes.
   StringVector elementsToRemove;
-  for (const auto &ci : *Doxygen::typeLookupCache)
+  for (const auto &ci : SymbolResolver::typeLookupCache())
   {
     const LookupInfo &li = ci.second;
     if (li.definition)
@@ -9475,7 +9473,7 @@ static void flushCachedTemplateRelations()
   }
   for (const auto &k : elementsToRemove)
   {
-    Doxygen::typeLookupCache->remove(k);
+    SymbolResolver::typeLookupCache().remove(k);
   }
 
   // remove all cached typedef resolutions whose target is a
@@ -9525,7 +9523,7 @@ static void flushUnresolvedRelations()
   // class C : public B::I {};
 
   StringVector elementsToRemove;
-  for (const auto &ci : *Doxygen::typeLookupCache)
+  for (const auto &ci : SymbolResolver::typeLookupCache())
   {
     const LookupInfo &li = ci.second;
     if (li.definition==nullptr && li.typeDef==nullptr)
@@ -9535,7 +9533,7 @@ static void flushUnresolvedRelations()
   }
   for (const auto &k : elementsToRemove)
   {
-    Doxygen::typeLookupCache->remove(k);
+    SymbolResolver::typeLookupCache().remove(k);
   }
 
   // for each global function name
@@ -12556,14 +12554,6 @@ void parseInput()
    *            Initialize global lists and dictionaries
    **************************************************************************/
 
-  // also scale lookup cache with SYMBOL_CACHE_SIZE
-  int cacheSize = Config_getInt(LOOKUP_CACHE_SIZE);
-  if (cacheSize<0) cacheSize=0;
-  if (cacheSize>9) cacheSize=9;
-  uint32_t lookupSize = 65536 << cacheSize;
-  Doxygen::typeLookupCache = new Cache<std::string,LookupInfo>(lookupSize);
-  Doxygen::symbolLookupCache = new Cache<std::string,LookupInfo>(lookupSize);
-
 #ifdef HAS_SIGNALS
   signal(SIGINT, stopDoxygen);
 #endif
@@ -12848,7 +12838,7 @@ void parseInput()
   // calling buildClassList may result in cached relations that
   // become invalid after resolveClassNestingRelations(), that's why
   // we need to clear the cache here
-  Doxygen::typeLookupCache->clear();
+  SymbolResolver::typeLookupCache().clear();
   // we don't need the list of using declaration anymore
   g_usingDeclarations.clear();
 
@@ -13489,18 +13479,11 @@ void generateOutput()
   cleanupInlineGraph();
 
   msg("type lookup cache used {}/{} hits={} misses={}\n",
-      Doxygen::typeLookupCache->size(),
-      Doxygen::typeLookupCache->capacity(),
-      Doxygen::typeLookupCache->hits(),
-      Doxygen::typeLookupCache->misses());
-  msg("symbol lookup cache used {}/{} hits={} misses={}\n",
-      Doxygen::symbolLookupCache->size(),
-      Doxygen::symbolLookupCache->capacity(),
-      Doxygen::symbolLookupCache->hits(),
-      Doxygen::symbolLookupCache->misses());
-  int typeCacheParam   = computeIdealCacheParam(static_cast<size_t>(Doxygen::typeLookupCache->misses()*2/3)); // part of the cache is flushed, hence the 2/3 correction factor
-  int symbolCacheParam = computeIdealCacheParam(static_cast<size_t>(Doxygen::symbolLookupCache->misses()));
-  int cacheParam = std::max(typeCacheParam,symbolCacheParam);
+      SymbolResolver::typeLookupCache().size(),
+      SymbolResolver::typeLookupCache().capacity(),
+      SymbolResolver::typeLookupCache().hits(),
+      SymbolResolver::typeLookupCache().misses());
+  int cacheParam = computeIdealCacheParam(static_cast<size_t>(SymbolResolver::typeLookupCache().misses()*2/3)); // part of the cache is flushed, hence the 2/3 correction factor
   if (cacheParam>Config_getInt(LOOKUP_CACHE_SIZE))
   {
     msg("Note: based on cache misses the ideal setting for LOOKUP_CACHE_SIZE is {} at the cost of higher memory usage.\n",cacheParam);

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -123,8 +123,6 @@ class Doxygen
     static SearchIndexIntf           searchIndex;
     static SymbolMap<Definition>    *symbolMap;
     static ClangUsrMap              *clangUsrMap;
-    static Cache<std::string,LookupInfo> *typeLookupCache;
-    static Cache<std::string,LookupInfo> *symbolLookupCache;
     static DirLinkedMap             *dirLinkedMap;
     static DirRelationLinkedMap      dirRelations;
     static ParserManager            *parserManager;

--- a/src/symbolresolver.cpp
+++ b/src/symbolresolver.cpp
@@ -35,11 +35,20 @@
 #define AUTO_TRACE_EXIT(...) (void)0
 #endif
 
-static std::mutex g_cacheMutex;
+//static std::mutex g_cacheMutex;
 static std::recursive_mutex g_cacheTypedefMutex;
 
-static std::mutex g_substMapMutex;
-static std::unordered_map<std::string, std::pair<QCString,const MemberDef *> > g_substMap;
+static Cache<std::string,LookupInfo> &getTypeLookupCache()
+{
+  int cacheSize = Config_getInt(LOOKUP_CACHE_SIZE);
+  if (cacheSize<0) cacheSize=0;
+  if (cacheSize>9) cacheSize=9;
+  static THREAD_LOCAL Cache<std::string,LookupInfo> s_cache(65536u << cacheSize);
+  return s_cache;
+}
+
+//static std::mutex g_substMapMutex;
+THREAD_LOCAL std::unordered_map<std::string, std::pair<QCString,const MemberDef *> > g_substMap;
 
 //--------------------------------------------------------------------------------------
 
@@ -131,6 +140,7 @@ struct SymbolResolver::Private
     QCString          templateSpec;
 
     const ClassDef *getResolvedTypeRec(
+                           Cache<std::string,LookupInfo> &cache, // in
                            VisitedKeys &visitedKeys, // in
                            const Definition *scope,     // in
                            const QCString &n,           // in
@@ -139,6 +149,7 @@ struct SymbolResolver::Private
                            QCString *pResolvedType);    // out
 
     const Definition *getResolvedSymbolRec(
+                           Cache<std::string,LookupInfo> &cache, // in
                            VisitedKeys &visitedKeys, // in
                            const Definition *scope,     // in
                            const QCString &n,           // in
@@ -164,7 +175,8 @@ struct SymbolResolver::Private
                            const QCString &explicitScopePart);
 
   private:
-    void getResolvedType(  VisitedKeys &visitedKeys,
+    void getResolvedType(  Cache<std::string,LookupInfo> &cache,
+                           VisitedKeys &visitedKeys,
                            const Definition *scope,                             // in
                            const Definition *d,                                 // in
                            const QCString &explicitScopePart,                   // in
@@ -193,6 +205,7 @@ struct SymbolResolver::Private
                           );
 
     const ClassDef *newResolveTypedef(
+                           Cache<std::string,LookupInfo> &cache,               // in
                            VisitedKeys &visitedKeys,                            // in
                            const Definition *scope,                             // in
                            const MemberDef *md,                                 // in
@@ -229,6 +242,7 @@ struct SymbolResolver::Private
 
 
 const ClassDef *SymbolResolver::Private::getResolvedTypeRec(
+           Cache<std::string,LookupInfo> &cache,
            VisitedKeys &visitedKeys,
            const Definition *scope,
            const QCString &n,
@@ -324,11 +338,7 @@ const ClassDef *SymbolResolver::Private::getResolvedTypeRec(
     // remember the key
     visitedKeys.push_back(key.str());
 
-    LookupInfo *pval = nullptr;
-    {
-      std::lock_guard lock(g_cacheMutex);
-      pval = Doxygen::typeLookupCache->find(key.str());
-    }
+    LookupInfo *pval = cache.find(key.str());
     AUTO_TRACE_ADD("key={} found={}",key,pval!=nullptr);
     if (pval)
     {
@@ -353,7 +363,7 @@ const ClassDef *SymbolResolver::Private::getResolvedTypeRec(
     {
       if (isCodeSymbol(d->definitionType()))
       {
-        getResolvedType(visitedKeys,scope,d,explicitScopePart,actTemplParams.get(),
+        getResolvedType(cache,visitedKeys,scope,d,explicitScopePart,actTemplParams.get(),
             minDistance,bestMatch,bestTypedef,bestTemplSpec,bestResolvedType);
       }
       if  (minDistance==0) break; // we can stop reaching if we already reached distance 0
@@ -372,11 +382,7 @@ const ClassDef *SymbolResolver::Private::getResolvedTypeRec(
       *pResolvedType = bestResolvedType;
     }
 
-    {
-      std::lock_guard lock(g_cacheMutex);
-      Doxygen::typeLookupCache->insert(key.str(),
-                            LookupInfo(bestMatch,bestTypedef,bestTemplSpec,bestResolvedType));
-    }
+    cache.insert(key.str(),LookupInfo(bestMatch,bestTypedef,bestTemplSpec,bestResolvedType));
     visitedKeys.erase(std::remove(visitedKeys.begin(), visitedKeys.end(), key.str()), visitedKeys.end());
 
     AUTO_TRACE_EXIT("found name={} templSpec={} typeDef={} resolvedTypedef={}",
@@ -389,6 +395,7 @@ const ClassDef *SymbolResolver::Private::getResolvedTypeRec(
 }
 
 const Definition *SymbolResolver::Private::getResolvedSymbolRec(
+           Cache<std::string,LookupInfo> &cache,
            VisitedKeys &visitedKeys,
            const Definition *scope,
            const QCString &n,
@@ -500,11 +507,7 @@ const Definition *SymbolResolver::Private::getResolvedSymbolRec(
     }
     // remember the key
     visitedKeys.push_back(key);
-    LookupInfo *pval = nullptr;
-    {
-      std::lock_guard lock(g_cacheMutex);
-      pval = Doxygen::symbolLookupCache->find(key);
-    }
+    LookupInfo *pval = cache.find(key);
     AUTO_TRACE_ADD("key={} found={}",key,pval!=nullptr);
     if (pval)
     {
@@ -579,12 +582,7 @@ const Definition *SymbolResolver::Private::getResolvedSymbolRec(
       *pResolvedType = bestResolvedType;
     }
 
-    {
-      LookupInfo lookupInfo(bestMatch,bestTypedef,bestTemplSpec,bestResolvedType);
-      std::lock_guard lock(g_cacheMutex);
-      // we need to insert the item in the cache again, as it could be removed in the meantime
-      Doxygen::symbolLookupCache->insert(key,std::move(lookupInfo));
-    }
+    cache.insert(key,LookupInfo(bestMatch,bestTypedef,bestTemplSpec,bestResolvedType));
     visitedKeys.erase(std::remove(visitedKeys.begin(),visitedKeys.end(),key),visitedKeys.end());
 
     AUTO_TRACE_EXIT("found name={} templSpec={} typeDef={} resolvedTypedef={}",
@@ -597,6 +595,7 @@ const Definition *SymbolResolver::Private::getResolvedSymbolRec(
 }
 
 void SymbolResolver::Private::getResolvedType(
+                         Cache<std::string,LookupInfo> &cache,
                          VisitedKeys &visitedKeys,                            // in
                          const Definition *scope,                             // in
                          const Definition *d,                                 // in
@@ -693,7 +692,7 @@ void SymbolResolver::Private::getResolvedType(
               QCString type;
               minDistance=distance;
               const MemberDef *enumType = nullptr;
-              const ClassDef *cd = newResolveTypedef(visitedKeys,scope,md,&enumType,&spec,&type,actTemplParams);
+              const ClassDef *cd = newResolveTypedef(cache,visitedKeys,scope,md,&enumType,&spec,&type,actTemplParams);
               if (cd)  // type resolves to a class
               {
                 AUTO_TRACE_ADD("found symbol={} at distance={} minDistance={}",cd->name(),distance,minDistance);
@@ -899,6 +898,7 @@ void SymbolResolver::Private::getResolvedSymbol(
 
 
 const ClassDef *SymbolResolver::Private::newResolveTypedef(
+                  Cache<std::string,LookupInfo> &cache,               // in
                   VisitedKeys &visitedKeys,                            // in
                   const Definition * /* scope */,                      // in
                   const MemberDef *md,                                 // in
@@ -955,13 +955,13 @@ const ClassDef *SymbolResolver::Private::newResolveTypedef(
   tl=static_cast<int>(type.length()); // length may have been changed
   while (sp<tl && type.at(sp)==' ') sp++;
   const MemberDef *memTypeDef = nullptr;
-  const ClassDef *result = getResolvedTypeRec(visitedKeys,md->getOuterScope(),type,
+  const ClassDef *result = getResolvedTypeRec(cache,visitedKeys,md->getOuterScope(),type,
                                                 &memTypeDef,nullptr,pResolvedType);
   // if type is a typedef then return what it resolves to.
   if (memTypeDef && memTypeDef->isTypedef())
   {
     AUTO_TRACE_ADD("resolving typedef");
-    result=newResolveTypedef(visitedKeys,m_fileScope,memTypeDef,pMemType,pTemplSpec,nullptr);
+    result=newResolveTypedef(cache,visitedKeys,m_fileScope,memTypeDef,pMemType,pTemplSpec,nullptr);
     goto done;
   }
   else if (memTypeDef && memTypeDef->isEnumerate() && pMemType)
@@ -977,7 +977,7 @@ const ClassDef *SymbolResolver::Private::newResolveTypedef(
     if (si==-1 && i!=-1) // typedef of a template => try the unspecialized version
     {
       if (pTemplSpec) *pTemplSpec = type.mid(i);
-      result = getResolvedTypeRec(visitedKeys,md->getOuterScope(),type.left(i),nullptr,nullptr,pResolvedType);
+      result = getResolvedTypeRec(cache,visitedKeys,md->getOuterScope(),type.left(i),nullptr,nullptr,pResolvedType);
     }
     else if (si!=-1) // A::B
     {
@@ -990,7 +990,7 @@ const ClassDef *SymbolResolver::Private::newResolveTypedef(
       {
         if (pTemplSpec) *pTemplSpec = type.mid(i);
       }
-      result = getResolvedTypeRec(visitedKeys,md->getOuterScope(),
+      result = getResolvedTypeRec(cache,visitedKeys,md->getOuterScope(),
            stripTemplateSpecifiersFromScope(type.left(i),FALSE),nullptr,nullptr,pResolvedType);
     }
   }
@@ -1218,7 +1218,7 @@ const Definition *SymbolResolver::Private::followPath(VisitedKeys &visitedKeys,
     const Definition *next = nullptr;
     if (memTypeDef)
     {
-      const ClassDef *type = newResolveTypedef(visitedKeys,m_fileScope,memTypeDef,nullptr,nullptr,nullptr);
+      const ClassDef *type = newResolveTypedef(SymbolResolver::typeLookupCache(),visitedKeys,m_fileScope,memTypeDef,nullptr,nullptr,nullptr);
       if (type)
       {
         AUTO_TRACE_EXIT("type={}",type->name());
@@ -1569,7 +1569,7 @@ QCString SymbolResolver::Private::substTypedef(
   key+=ptr_str;
   key+=name.str();
   {
-    std::lock_guard lock(g_substMapMutex);
+    //std::lock_guard lock(g_substMapMutex);
     auto it = g_substMap.find(key);
     if (it!=g_substMap.end())
     {
@@ -1610,7 +1610,7 @@ QCString SymbolResolver::Private::substTypedef(
   // cache the result of the computation to give a faster answers next time, especially relevant
   // if `range` has many arguments (i.e. there are many symbols with the same name in different contexts)
   {
-    std::lock_guard lock(g_substMapMutex);
+    //std::lock_guard lock(g_substMapMutex);
     g_substMap.emplace(key,std::make_pair(result,bestMatch));
   }
 
@@ -1628,6 +1628,11 @@ SymbolResolver::SymbolResolver(const FileDef *fileScope)
 
 SymbolResolver::~SymbolResolver()
 {
+}
+
+Cache<std::string,LookupInfo> &SymbolResolver::typeLookupCache()
+{
+  return getTypeLookupCache();
 }
 
 
@@ -1664,7 +1669,7 @@ const ClassDef *SymbolResolver::resolveClass(const Definition *scope,
     VisitedKeys visitedKeys;
     QCString lookupName = lang==SrcLangExt::CSharp ? mangleCSharpGenericName(name) : name;
     AUTO_TRACE_ADD("lookup={}",lookupName);
-    result = p->getResolvedTypeRec(visitedKeys,scope,lookupName,&p->typeDef,&p->templateSpec,&p->resolvedType);
+    result = p->getResolvedTypeRec(SymbolResolver::typeLookupCache(),visitedKeys,scope,lookupName,&p->typeDef,&p->templateSpec,&p->resolvedType);
     if (result==nullptr) // for nested classes imported via tag files, the scope may not
                    // present, so we check the class name directly as well.
                    // See also bug701314
@@ -1693,10 +1698,14 @@ const Definition *SymbolResolver::resolveSymbol(const Definition *scope,
 {
   AUTO_TRACE("scope={} name={} args={} checkCV={} insideCode={}",
              scope?scope->name():QCString(), name, args, checkCV, insideCode);
+  int cacheSize = Config_getInt(LOOKUP_CACHE_SIZE);
+  if (cacheSize<0) cacheSize=0;
+  if (cacheSize>9) cacheSize=9;
+  static THREAD_LOCAL Cache<std::string,LookupInfo> s_symbolLookupCache(65536u << cacheSize);
   p->reset();
   if (scope==nullptr) scope=Doxygen::globalScope;
   VisitedKeys visitedKeys;
-  const Definition *result = p->getResolvedSymbolRec(visitedKeys,scope,name,args,checkCV,insideCode,onlyLinkable,&p->typeDef,&p->templateSpec,&p->resolvedType);
+  const Definition *result = p->getResolvedSymbolRec(s_symbolLookupCache,visitedKeys,scope,name,args,checkCV,insideCode,onlyLinkable,&p->typeDef,&p->templateSpec,&p->resolvedType);
   AUTO_TRACE_EXIT("result={}{}", qPrint(result?result->qualifiedName():QCString()),
                                  qPrint(result && result->definitionType()==Definition::TypeMember ? toMemberDef(result)->argsString() : QCString()));
   return result;

--- a/src/symbolresolver.h
+++ b/src/symbolresolver.h
@@ -21,6 +21,8 @@
 #include "qcstring.h"
 #include "classdef.h"
 #include "construct.h"
+#include "cache.h"
+#include "doxygen.h"
 
 class Definition;
 class FileDef;
@@ -97,6 +99,9 @@ class SymbolResolver
 
     /** Sets or updates the file scope using when resolving symbols. */
     void setFileScope(const FileDef *fd);
+
+    /** Returns the per-thread type lookup cache. */
+    static Cache<std::string,LookupInfo> &typeLookupCache();
 
     // getters
 


### PR DESCRIPTION
These changes seemed to help llvm's doxygen build scale well with threads, instead of getting slower. With a mutex, all of the threads spend all of their time waiting, burning a lot more CPU time, but not getting any faster. With a local cache, all of the benefits of caching are achieved, with none of the concurrency contention.

Written by Claude, so this is certainly not the most clean implementation, but was intended to test the theory that thread performance could be much better by fixing this contention. That test seemed a success. Now, I can improve upon this if this is something of interest, particularly if there is anything particular you know is an issue or style that you would like to see.