### PR TITLE
fix traceablility typo

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1269,7 +1269,7 @@ Go to the <a href="commands.html">next</a> section or return to the
  The \c REQ_TRACEABILITY_INFO tag controls if traceability information
  is shown on the requirements page (only relevant when using
  \ref cmdrequirement "\\requirement" comment blocks).
- The setting \c NO will disable the traceablility information altogether.
+ The setting \c NO will disable the traceability information altogether.
  The setting \c UNSATISFIED_ONLY will show a list of requirements that are missing
  a satisfies relation (through the command: \ref cmdsatisfies "\\satisfies").
  Similarly the setting \c UNVERIFIED_ONLY will show a list of requirements that


### PR DESCRIPTION
fix 'traceablility' typo found by a simple spellchecker in the CI