### PR TITLE
bug 129682 Wrong function dependency is made

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -792,7 +792,7 @@ void DocParser::handleLinkedWord(DocNodeVariant *parent,DocNodeList &children,bo
   };
   QCString name = linkToText(context.lang,context.token->name,TRUE);
   AUTO_TRACE("word={}",name);
-  if ((!context.autolinkSupport && !ignoreAutoLinkFlag) || ignoreWord(context.token->name)) // no autolinking -> add as normal word
+  if (!context.autolinkSupport || ignoreAutoLinkFlag || ignoreWord(context.token->name)) // no autolinking -> add as normal word
   {
     children.append<DocWord>(this,parent,name);
     return;


### PR DESCRIPTION
The dummy argument names (parameters) should not be linked to an entity (function, variable, ...). The logic of the was incorrect, and thus the parameter name, could, appear as a link. (this fixes part 1 of the mentioned bug)