### PR TITLE
issue #12008 "namespacemembers.html" and "functions.html" only show items for one specific initial letter

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3134,7 +3134,12 @@ static void writeMemberIndex(OutputList &ol,
   bool first=true;
   ol.writeString("<br/>\n");
   QCString alphaLinks = "<div class=\"qindex\">";
+  StringMap usedLetters;
   for (const auto &[letter,list] : map)
+  {
+    usedLetters.emplace(convertUTF8ToUpper(letter),letter);
+  }
+  for (const auto &[letterUC,letter] : usedLetters)
   {
     QCString ci(letter);
     QCString is = letterToLabel(ci);
@@ -3152,7 +3157,7 @@ static void writeMemberIndex(OutputList &ol,
     QCString li = letterToLabel(letter);
     alphaLinks += "<a class=\"qindex\" href=\"" + anchor +
                   li + "\">" +
-                  letter + "</a>";
+                  letterUC + "</a>";
   }
   alphaLinks += "</div>\n";
   ol.writeString(alphaLinks);


### PR DESCRIPTION
in Pull request #12016 (with small correction in #12023) some more alphabetical lists were introduced, but they are a bit inconsistent with the alphabetical list e.g. the "Class Index":
- sorting
- representation ("Class Index" is upper case)

This has been adjusted (and labels and filenames are left unchanged).

Example: [example.tar.gz](https://github.com/user-attachments/files/25866485/example.tar.gz)
