### PR TITLE
Adding "engine" packetdiag for plantuml

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1131,6 +1131,7 @@ class DoxPlantumlEngine(str, Enum):
     REGEX='regex'
     EBNF='ebnf'
     FILES='files'
+    PACKETDIAG='packetdiag'
 
 
 class DoxProtectionKind(str, Enum):
@@ -24555,7 +24556,7 @@ class docPlantumlType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf', 'files']
+            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf', 'files', 'packetdiag']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxPlantumlEngine' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -3590,7 +3590,7 @@ class Receiver
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
   the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
   `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex`, `ebnf`,
-  `files`, `chen` and `chronology`.
+  `packetdiag`, `files`, `chen` and `chronology`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -72,7 +72,7 @@ static const StringUnorderedSet g_plantumlEngine {
   "salt", "math", "latex", "gantt", "mindmap",
   "wbs", "yaml", "creole", "json", "flow",
   "board", "git", "hcl", "regex", "ebnf",
-  "files", "chen", "chronology"
+  "files", "chen", "chronology", "packetdiag"
 };
 
 //---------------------------------------------------------------------------

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -1209,6 +1209,7 @@
       <xsd:enumeration value="regex"/>
       <xsd:enumeration value="ebnf"/>
       <xsd:enumeration value="files"/>
+      <xsd:enumeration value="packetdiag"/>
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
Small packetdiag example:
```
@startuml{packetdiag}
colwidth = 32
node_height = 72

0-15: Source Port
16-31: Destination Port
32-63: Sequence Number
@enduml
```

Example: [example.tar.gz](https://github.com/user-attachments/files/26058819/example.tar.gz)
