### PR TITLE
Adding "engine"s chart, nwdiag, packetdiag and project for plantuml

### DIFF
--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1135,6 +1135,7 @@ class DoxPlantumlEngine(str, Enum):
     NWDIAG='nwdiag'
     PACKETDIAG='packetdiag'
     PROJECT='project'
+    SPRITES='sprites'
 
 
 class DoxProtectionKind(str, Enum):
@@ -24559,7 +24560,7 @@ class docPlantumlType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf', 'files', 'chart', 'nwdiag', 'packetdiag', 'project']
+            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf', 'files', 'chart', 'nwdiag', 'packetdiag', 'project', 'sprites']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxPlantumlEngine' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/addon/doxmlparser/doxmlparser/compound.py
+++ b/addon/doxmlparser/doxmlparser/compound.py
@@ -1131,6 +1131,10 @@ class DoxPlantumlEngine(str, Enum):
     REGEX='regex'
     EBNF='ebnf'
     FILES='files'
+    CHART='chart'
+    NWDIAG='nwdiag'
+    PACKETDIAG='packetdiag'
+    PROJECT='project'
 
 
 class DoxProtectionKind(str, Enum):
@@ -24555,7 +24559,7 @@ class docPlantumlType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
                 return False
             value = value
-            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf', 'files']
+            enumerations = ['uml', 'bpm', 'wire', 'dot', 'ditaa', 'salt', 'math', 'latex', 'gantt', 'mindmap', 'wbs', 'yaml', 'creole', 'json', 'flow', 'board', 'git', 'hcl', 'regex', 'ebnf', 'files', 'chart', 'nwdiag', 'packetdiag', 'project']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on DoxPlantumlEngine' % {"value" : encode_str_2_3(value), "lineno": lineno} )

--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -3590,7 +3590,7 @@ class Receiver
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
   the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
   `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex`, `ebnf`,
-  `chart`, `nwdiag`, `packetdiag`, `project`, `files`, `chen` and `chronology`.
+  `chart`, `nwdiag`, `packetdiag`, `project`, `sprites`, `files`, `chen` and `chronology`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -3590,7 +3590,7 @@ class Receiver
   PlantUML `@start...` command. This will look like `@start<engine>` where currently supported are
   the following `<engine>`s: `uml`, `bpm`, `wire`, `dot`, `ditaa`, `salt`, `math`, `latex`,
   `gantt`, `mindmap`, `wbs`, `yaml`, `creole`, `json`, `flow`, `board`, `git`, `hcl`, `regex`, `ebnf`,
-  `files`, `chen` and `chronology`.
+  `chart`, `nwdiag`, `packetdiag`, `project`, `files`, `chen` and `chronology`.
   By default the `<engine>` is `uml`. The `<engine>` can be specified as an option.
   Also the file to write the resulting image to can be specified by means of an option, see the
   description of the first (optional) argument for details.

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -73,7 +73,7 @@ static const StringUnorderedSet g_plantumlEngine {
   "wbs", "yaml", "creole", "json", "flow",
   "board", "git", "hcl", "regex", "ebnf",
   "files", "chen", "chronology", "chart", "nwdiag",
-  "packetdiag", "project"
+  "packetdiag", "project", "sprites"
 };
 
 //---------------------------------------------------------------------------

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -72,7 +72,8 @@ static const StringUnorderedSet g_plantumlEngine {
   "salt", "math", "latex", "gantt", "mindmap",
   "wbs", "yaml", "creole", "json", "flow",
   "board", "git", "hcl", "regex", "ebnf",
-  "files", "chen", "chronology"
+  "files", "chen", "chronology", "chart", "nwdiag",
+  "packetdiag", "project"
 };
 
 //---------------------------------------------------------------------------

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -1213,6 +1213,7 @@
       <xsd:enumeration value="nwdiag"/>
       <xsd:enumeration value="packetdiag"/>
       <xsd:enumeration value="project"/>
+      <xsd:enumeration value="sprites"/>
     </xsd:restriction>
   </xsd:simpleType>
 

--- a/templates/xml/compound.xsd
+++ b/templates/xml/compound.xsd
@@ -1209,6 +1209,10 @@
       <xsd:enumeration value="regex"/>
       <xsd:enumeration value="ebnf"/>
       <xsd:enumeration value="files"/>
+      <xsd:enumeration value="chart"/>
+      <xsd:enumeration value="nwdiag"/>
+      <xsd:enumeration value="packetdiag"/>
+      <xsd:enumeration value="project"/>
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
Adding "engine"s chart, nwdiag, packetdiag and project for plantuml

Example: [example.tar.gz](https://github.com/user-attachments/files/26083527/example.tar.gz)
