### PR TITLE
be slightly more compatible parsing fenced blocks for markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2364,6 +2364,8 @@ static bool isFencedCodeBlock(std::string_view data,size_t refIndent,
     AUTO_TRACE_EXIT("result=false: no fence marker found #tildes={}",startTildes);
     return FALSE;
   } // not enough tildes
+  // skip whitespace
+  while (i<size && data[i]==' ') { i++; }
   if (i<size && data[i]=='{') // extract .py from ```{.py} ... ```
   {
     i++; // skip over {


### PR DESCRIPTION
ignore whitespaces after the fence, allow this common style:

~~~ markdown
``` plantuml
@startuml
class CBase
CBase <|-- CDerived
@enduml
```
~~~

see https://spec.commonmark.org/0.12/#fenced-code-blocks

Btw. is there a reason the code eschews regex for parsing?