### PR TITLE
Incorrect handling of comment in comment

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1222,10 +1222,10 @@ SLASHopt [/]*
                                                                   //   static void handleCondSectionId
 				     BEGIN(Scan);
                                    }
-<ReadLine>{CCS}"*"                 {
+<ReadLine,CopyLine>{CCS}"*"        {
 				     copyToOutput(yyscanner,"/&zwj;**");
 				   }
-<ReadLine>{CCE}                    {
+<ReadLine,CopyLine>{CCE}           {
 				     copyToOutput(yyscanner,"*&zwj;/");
 				   }
 <ReadLine,CopyLine>"*"             {


### PR DESCRIPTION
When having an example like:
```
package net.sourceforge.plantuml;

/** Class docu */
public class AnimatedGifEncoder {

//      /**
//       * @param oops
//       */

        /** the fie */
        protected void analyzePixels() {
        }
}
```
we get the warning:
```
AnimatedGifEncoder.java:10: warning: net.sourceforge.plantuml.AnimatedGifEncoder.analyzePixels has @param documentation sections but no arguments
```

The problem was introduced by:
```
Commit: 0fcc5c4d78e12954ad89bd8cfd21bf4e22974591 [0fcc5c4]

Date: Friday, February 9, 2024 9:39:48 PM

Fix issue where ALIAS argument was split over multiple lines (part 3)
```

Example: [example.tar.gz](https://github.com/user-attachments/files/26282459/example.tar.gz)

Found in the plantuml package.
