### PR TITLE
[ci] Replace deprecated set-output in GH Action for Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -27,7 +27,7 @@ jobs:
         continue-on-error: true
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "name=should_run::false" >> $GITHUB_OUTPUT
 
   scan:
     needs: check_date


### PR DESCRIPTION
Following advice from https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/