### PR TITLE
Incorrect line numbers in source code browser for lex files

### DIFF
--- a/src/lexcode.l
+++ b/src/lexcode.l
@@ -1216,7 +1216,7 @@ void LexCodeParser::parseCode(OutputCodeList &codeOutIntf,
   yyextra->currentMemberDef  = options.memberDef();
   yyextra->searchCtx         = options.searchCtx();
   yyextra->collectXRefs      = options.collectXRefs();
-  yyextra->yyLineNr          = options.startLine()!=1 ? options.startLine() : 1;
+  yyextra->yyLineNr          = options.startLine()!=-1 ? options.startLine() : 1;
   yyextra->inputLines        = options.endLine()!=-1  ? options.endLine()+1 : yyextra->yyLineNr + countLines(yyscanner) - 1;
   yyextra->startCCodeLine    = yyextra->yyLineNr;
   yyextra->stripCodeComments = stripCodeComments;


### PR DESCRIPTION
When looking at any source code lex file (e.g. in the doxygen internal documentation) we see that the counting of the line starts with `-1` and also the the first  2  lines have the same numbers as the lats 2 comment lines. Also some links between the "normal" documentation and the source code were not correct

(the double line numbers were signaled when running the `chmcmd` html help compiler on doxygen internal documentation)