### PR TITLE
Non existing anchors in "index" files

### DIFF
--- a/src/htmlhelp.cpp
+++ b/src/htmlhelp.cpp
@@ -602,6 +602,7 @@ void HtmlHelp::addIndexItem(const Definition *context,const MemberDef *md,
 {
   if (context && md)
   {
+    if (sectionAnchor.isEmpty() && !md->hasDocumentation()) return;
     QCString cfname  = md->getOutputFileBase();
     QCString argStr  = md->argsString();
     QCString level1  = context->name();

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -375,6 +375,7 @@ void Qhp::addIndexItem(const Definition *context,const MemberDef *md,
 
   if (context && md) // member
   {
+    if (sectionAnchor.isEmpty() && !md->hasDocumentation()) return;
     QCString cfname  = md->getOutputFileBase();
     QCString argStr  = md->argsString();
     QCString level1  = context->name();

--- a/src/sitemap.cpp
+++ b/src/sitemap.cpp
@@ -197,6 +197,7 @@ void Crawlmap::addIndexItem(const Definition *context, const MemberDef *md,
 {
   if (context && md) // member
   {
+    if (sectionAnchor.isEmpty() && !md->hasDocumentation()) return;
     QCString cfname  = md->getOutputFileBase();
     QCString anchor  = !sectionAnchor.isEmpty() ? sectionAnchor : md->anchor();
     QCString ref     = makeRef(cfname, anchor);


### PR DESCRIPTION
When having an undocumented enum value in e.g the doxygen_crawl list and other indices an anchor appears that does not exists. For the doxygen enum example this is illustrated by the `chmcmd` command (a replacement for `hhc`) by means of:
```
Error: Anchor examples/enum/html/class_enum___test.html#a8d096bc026dbb395991f02e3ca86eb1ca284b56694c3f4513699fc86ea30527b0 undefined; first use doxygen_crawl.html
```

Example: [example.tar.gz](https://github.com/user-attachments/files/26377916/example.tar.gz)


Appears to be the remaining problem of #10765
