### PR TITLE
issue #12073 Doxygen is confused by [[nodiscard]] in unconventional (but valid) position

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -1873,6 +1873,12 @@ NONLopt [^\n]*
                                           yyextra->current->name += "()";
                                           BEGIN( FindMembers );
                                         }
+<Operator>"("{BN}*")"{BNopt}/("[["[^\]]*"]]"){BNopt}"("        {
+                                          lineCount(yyscanner);
+                                          yyextra->current->name += yytext ;
+                                          yyextra->current->name = yyextra->current->name.simplifyWhiteSpace();
+                                          BEGIN( FindMembers ) ;
+                                        }
 <Operator>"("{BN}*")"{BNopt}/"("        {
                                           lineCount(yyscanner);
                                           yyextra->current->name += yytext ;


### PR DESCRIPTION
Add possibility of C++ attribute as well at the indicated place.