### PR TITLE
Warnings building Latex output

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -1628,7 +1628,14 @@ void LatexGenerator::addLabel(const QCString &fName, const QCString &anchor)
 void LatexGenerator::writeAnchor(const QCString &fName,const QCString &name)
 {
   //printf("LatexGenerator::writeAnchor(%s,%s)\n",fName,name);
-  m_t << "\\label{" << stripPath(name) << "}\n";
+  if (!fName.isEmpty())
+  {
+    m_t << "\\label{" << stripPath(fName) << "_" << stripPath(name) << "}\n";
+  }
+  else
+  {
+    m_t << "\\label{" << stripPath(name) << "}\n";
+  }
   bool pdfHyperlinks = Config_getBool(PDF_HYPERLINKS);
   bool usePDFLatex   = Config_getBool(USE_PDFLATEX);
   if (usePDFLatex && pdfHyperlinks)


### PR DESCRIPTION
When building the, Latex version, of the doxygen documentation or test we get in the log file te warnings like:
```
LaTeX Warning: Label `doc-func-members' multiply defined.
```
because the `\label` is not unique as this already was done for the `\Hypertarget`