### PR TITLE
Error running test 120 without `--xml`

### DIFF
--- a/testing/120/f_8cpp.xml
+++ b/testing/120/f_8cpp.xml
@@ -3,11 +3,11 @@
   <compounddef id="f_8cpp" kind="file" language="C++">
     <compoundname>f.cpp</compoundname>
     <briefdescription>
-      <para>more_116/f.cpp brief (in more_116/f.cpp). </para>
+      <para><ref refid="f_8cpp" kindref="compound">more_120/f.cpp</ref> brief (in <ref refid="f_8cpp" kindref="compound">more_120/f.cpp</ref>). </para>
     </briefdescription>
     <detaileddescription>
       <para><ref refid="f_8cpp" kindref="compound">more_120/f.cpp</ref> description (in 120_tagfile.cpp).</para>
-      <para>more_116/f.cpp description (in more_116/f.cpp). </para>
+      <para><ref refid="f_8cpp" kindref="compound">more_120/f.cpp</ref> description (in <ref refid="f_8cpp" kindref="compound">more_120/f.cpp</ref>). </para>
     </detaileddescription>
     <location file="more_120/f.cpp"/>
   </compounddef>

--- a/testing/120/s_2h_8h.xml
+++ b/testing/120/s_2h_8h.xml
@@ -6,7 +6,7 @@
       <para><ref refid="s_2h_8h" kindref="compound">s/h.h</ref> brief (in <ref refid="s_2h_8h" kindref="compound">s/h.h</ref>). </para>
     </briefdescription>
     <detaileddescription>
-      <para><ref refid="s_2h_8h" kindref="compound">s/h.h</ref> description (in more_116/f.cpp).</para>
+      <para><ref refid="s_2h_8h" kindref="compound">s/h.h</ref> description (in <ref refid="f_8cpp" kindref="compound">more_120/f.cpp</ref>).</para>
       <para><ref refid="s_2h_8h" kindref="compound">s/h.h</ref> description (in <ref refid="s_2h_8h" kindref="compound">s/h.h</ref>). </para>
     </detaileddescription>
     <location file="more_120/include/s/h.h"/>

--- a/testing/120/t_2s_2h_8h.xml
+++ b/testing/120/t_2s_2h_8h.xml
@@ -6,7 +6,7 @@
       <para><ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref> brief (in <ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref>). </para>
     </briefdescription>
     <detaileddescription>
-      <para><ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref> description (in more_116/f.cpp).</para>
+      <para><ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref> description (in <ref refid="f_8cpp" kindref="compound">more_120/f.cpp</ref>).</para>
       <para><ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref> description (in <ref refid="t_2s_2h_8h" kindref="compound">t/s/h.h</ref>). </para>
     </detaileddescription>
     <location file="more_120/include/t/s/h.h"/>

--- a/testing/120_tagfile.cpp
+++ b/testing/120_tagfile.cpp
@@ -1,5 +1,5 @@
 // objective: test the tagfile output
-// config: GENERATE_TAGFILE = "$TESTOUTDIR/out/tagfile"
+// config: GENERATE_TAGFILE = "$TESTOUTDIR/tagfile"
 // config: STRIP_FROM_INC_PATH = "$INPUTDIR/more_120/include"
 // check: 120__tagfile_8cpp.xml
 // check: class_namespace_1_1_class.xml

--- a/testing/more_120/f.cpp
+++ b/testing/more_120/f.cpp
@@ -3,9 +3,9 @@
  *
  * @ingroup Group
  *
- * @brief more_116/f.cpp brief (in more_116/f.cpp).
+ * @brief more_120/f.cpp brief (in more_120/f.cpp).
  *
- * more_116/f.cpp description (in more_116/f.cpp).
+ * more_120/f.cpp description (in more_120/f.cpp).
  */
 
 /**
@@ -13,7 +13,7 @@
  *
  * @ingroup Group
  *
- * s/h.h description (in more_116/f.cpp).
+ * s/h.h description (in more_120/f.cpp).
  */
 
 /**
@@ -21,5 +21,5 @@
  *
  * @ingroup Group
  *
- * t/s/h.h description (in more_116/f.cpp).
+ * t/s/h.h description (in more_120/f.cpp).
  */

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -159,7 +159,10 @@ class Tester:
                     value = m.group('value')
                     if (key=='config'):
                         value = value.replace('$INPUTDIR',self.args.inputdir)
-                        value = value.replace('$TESTOUTDIR',self.test_out)
+                        if (self.args.xml or self.args.xmlxsd):
+                            value = value.replace('$TESTOUTDIR',self.test_out+"/out")
+                        else:
+                            value = value.replace('$TESTOUTDIR',self.test_out)
                     # print('key=%s value=%s' % (key,value))
                     config.setdefault(key, []).append(value)
         return config


### PR DESCRIPTION
When testing the doxygen test 120 but without that `--xml` or `--xmlxsd` has been specified we get the error like:
```
error: cannot open tag file .../testing/test_output_120/out/tagfile for writing
```
due to the fact that in this case the `out` directory has not bee created.

Furthermore there were still a number of references to test `116` (the initial number of the test)