### PR TITLE
Warnings when generating diagrams with LaTeX and HTMLHelp / QHP enabled

### DIFF
--- a/src/dia.cpp
+++ b/src/dia.cpp
@@ -19,13 +19,15 @@
 #include "message.h"
 #include "util.h"
 #include "dir.h"
+#include "indexlist.h"
+#include "doxygen.h"
 
 
 static const int maxCmdLine = 40960;
 
 void writeDiaGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,DiaOutputFormat format,
-                           const QCString &srcFile,int srcLine)
+                           const QCString &srcFile,int srcLine,bool toIndex)
 {
   QCString absOutFile = outDir;
   absOutFile+=Portable::pathSeparator();
@@ -80,6 +82,7 @@ void writeDiaGraphFromFile(const QCString &inFile,const QCString &outDir,
       Dir().remove(outFile.str()+".eps");
     }
   }
+  if (toIndex) Doxygen::indexList->addImageFile(outFile+extension);
 
 error:
   Dir::setCurrent(oldDir);

--- a/src/dia.h
+++ b/src/dia.h
@@ -25,7 +25,7 @@ enum class DiaOutputFormat { BITMAP , EPS };
 
 void writeDiaGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,DiaOutputFormat format,
-                           const QCString &srcFile,int srcLine);
+                           const QCString &srcFile,int srcLine,bool toIndex);
 
 #endif
 

--- a/src/diagram.cpp
+++ b/src/diagram.cpp
@@ -1360,7 +1360,7 @@ void ClassDiagram::writeFigure(TextStream &output,const QCString &path,
 
 void ClassDiagram::writeImage(TextStream &t,const QCString &path,
                               const QCString &relPath,const QCString &fileName,
-                              bool generateMap) const
+                              bool generateMap,bool toIndex) const
 {
   uint32_t baseRows=p->base.computeRows();
   uint32_t superRows=p->super.computeRows();
@@ -1387,6 +1387,6 @@ void ClassDiagram::writeImage(TextStream &t,const QCString &path,
 
 #define IMAGE_EXT ".png"
   image.save(QCString(path)+"/"+fileName+IMAGE_EXT);
-  Doxygen::indexList->addImageFile(QCString(fileName)+IMAGE_EXT);
+  if (toIndex) Doxygen::indexList->addImageFile(QCString(fileName)+IMAGE_EXT);
 }
 

--- a/src/diagram.h
+++ b/src/diagram.h
@@ -36,7 +36,7 @@ class ClassDiagram
     void writeFigure(TextStream &t,const QCString &path,
                      const QCString &file) const;
     void writeImage(TextStream &t,const QCString &path,const QCString &relPath,
-                     const QCString &file,bool generateMap=true) const;
+                     const QCString &file,bool generateMap,bool toIndex) const;
   private:
     struct Private;
     std::unique_ptr<Private> p;

--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -1005,7 +1005,7 @@ DB_GEN_C
   m_t << "                <imagedata width=\"50%\" align=\"center\" valign=\"middle\" scalefit=\"0\" fileref=\""
                          << relPath << fileName << ".png\">" << "</imagedata>\n";
   m_t << "            </imageobject>\n";
-  d.writeImage(m_t,dir(),relPath,fileName,FALSE);
+  d.writeImage(m_t,dir(),relPath,fileName,false,false);
   m_t << "        </mediaobject>\n";
   m_t << "    </informalfigure>\n";
   m_t << "</para>\n";

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1560,7 +1560,7 @@ void DocbookDocVisitor::writeMscFile(const QCString &fileName, const DocVerbatim
 DB_VIS_C
   QCString shortName = makeBaseName(fileName,".msc");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  if (newFile) writeMscGraphFromFile(fileName,outDir,shortName,MscOutputFormat::BITMAP,s.srcFile(),s.srcLine());
+  if (newFile) writeMscGraphFromFile(fileName,outDir,shortName,MscOutputFormat::BITMAP,s.srcFile(),s.srcLine(),false);
   visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(), s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -1571,7 +1571,7 @@ void DocbookDocVisitor::writePlantUMLFile(const QCString &baseName, const DocVer
 DB_VIS_C
   QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
+  PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP,false);
   visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(),s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -1597,7 +1597,7 @@ DB_VIS_C
   for (const auto &bName: baseNameVector)
   {
     QCString baseName=makeBaseName(bName,".pu");
-    PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP);
+    PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,PlantumlManager::PUML_BITMAP,false);
     if (!first) endPlantUmlFile(hasCaption);
     first = false;
     m_t << "<para>\n";
@@ -1620,7 +1620,7 @@ DB_VIS_C
   if (Config_getBool(MERMAID_RENDER_MODE)==MERMAID_RENDER_MODE_t::CLIENT_SIDE) return;
   QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  MermaidManager::instance().generateMermaidOutput(baseName,outDir,MermaidManager::OutputFormat::Bitmap);
+  MermaidManager::instance().generateMermaidOutput(baseName,outDir,MermaidManager::OutputFormat::Bitmap,false);
   visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + ".png", s.width(),s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -1644,7 +1644,7 @@ DB_VIS_C
   QCString baseName = MermaidManager::instance().writeMermaidSource(outDir,
                            QCString(),inBuf,MermaidManager::OutputFormat::Bitmap,srcFile,srcLine);
   QCString shortName = stripPath(baseName);
-  MermaidManager::instance().generateMermaidOutput(baseName,outDir,MermaidManager::OutputFormat::Bitmap);
+  MermaidManager::instance().generateMermaidOutput(baseName,outDir,MermaidManager::OutputFormat::Bitmap,false);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, relPath + shortName + ".png", width, height);
 }
@@ -1672,7 +1672,7 @@ DB_VIS_C
   QCString baseName=makeBaseName(fileName,".msc");
   baseName.prepend("msc_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine,false);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, relPath + baseName + ".png",  width,  height);
 }
@@ -1690,7 +1690,7 @@ void DocbookDocVisitor::writeDiaFile(const QCString &baseName, const DocVerbatim
 DB_VIS_C
   QCString shortName = stripPath(baseName);
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DiaOutputFormat::BITMAP,s.srcFile(),s.srcLine());
+  writeDiaGraphFromFile(baseName+".dia",outDir,shortName,DiaOutputFormat::BITMAP,s.srcFile(),s.srcLine(),false);
   visitPreStart(m_t, s.children(), s.hasCaption(), shortName, s.width(),s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -1710,7 +1710,7 @@ DB_VIS_C
   QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine,false);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, relPath + baseName + ".png",  width,  height);
 }
@@ -1728,7 +1728,7 @@ void DocbookDocVisitor::writeDotFile(const QCString &fileName, const DocVerbatim
 DB_VIS_C
   QCString shortName = makeBaseName(fileName,".dot");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
-  if (newFile) writeDotGraphFromFile(fileName,outDir,shortName,GraphOutputFormat::BITMAP,s.srcFile(),s.srcLine());
+  if (newFile) writeDotGraphFromFile(fileName,outDir,shortName,GraphOutputFormat::BITMAP,s.srcFile(),s.srcLine(),false);
   visitPreStart(m_t, s.children(), s.hasCaption(), s.relPath() + shortName + "." + getDotImageExtension(), s.width(),s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -1749,7 +1749,7 @@ DB_VIS_C
   baseName.prepend("dot_");
   QCString outDir = Config_getString(DOCBOOK_OUTPUT);
   QCString imgExt = getDotImageExtension();
-  if (newFile) writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine,false);
   m_t << "<para>\n";
   visitPreStart(m_t, children, hasCaption, relPath + baseName + "." + imgExt,  width,  height);
 }

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -229,7 +229,7 @@ bool DotManager::run()
 
 void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,GraphOutputFormat format,
-                           const QCString &srcFile,int srcLine)
+                           const QCString &srcFile,int srcLine,bool toIndex)
 {
   Dir d(outDir.str());
   if (!d.exists())
@@ -265,7 +265,7 @@ void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
      return;
   }
 
-  Doxygen::indexList->addImageFile(imgName);
+  if (toIndex) Doxygen::indexList->addImageFile(imgName);
 
 }
 

--- a/src/dot.h
+++ b/src/dot.h
@@ -51,7 +51,7 @@ class DotManager
 
 void writeDotGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,GraphOutputFormat format,
-                           const QCString &srcFile,int srcLine);
+                           const QCString &srcFile,int srcLine,bool toIndex);
 void writeDotImageMapFromFile(TextStream &t,
                               const QCString &inFile, const QCString& outDir,
                               const QCString &relPath,const QCString& baseName,

--- a/src/dotclassgraph.cpp
+++ b/src/dotclassgraph.cpp
@@ -456,6 +456,8 @@ QCString DotClassGraph::writeGraph(TextStream &out,
   bool generateImageMap,
   int graphId)
 {
+  m_doNotAddImageToIndex = textFormat!=EmbeddedOutputFormat::Html;
+
   return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
 }
 

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -441,6 +441,9 @@ QCString DotDirDeps::writeGraph(TextStream &out, GraphOutputFormat graphFormat, 
 {
   m_linkRelations = linkRelations;
   m_urlOnly = TRUE;
+
+  m_doNotAddImageToIndex = textFormat!=EmbeddedOutputFormat::Html;
+
   return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
 }
 

--- a/src/dotincldepgraph.cpp
+++ b/src/dotincldepgraph.cpp
@@ -190,6 +190,8 @@ QCString DotInclDepGraph::writeGraph(TextStream &out,
                                      bool generateImageMap,
                                      int graphId)
 {
+  m_doNotAddImageToIndex = textFormat!=EmbeddedOutputFormat::Html;
+
   return DotGraph::writeGraph(out, graphFormat, textFormat, path, fileName, relPath, generateImageMap, graphId);
 }
 

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -10514,7 +10514,7 @@ static void copyStyleSheet()
   }
 }
 
-static void copyLogo(const QCString &outputOption)
+static void copyLogo(const QCString &outputOption, bool toIndex)
 {
   QCString projectLogo = projectLogoFile();
   if (!projectLogo.isEmpty())
@@ -10534,12 +10534,12 @@ static void copyLogo(const QCString &outputOption)
     {
       QCString destFileName = outputOption+"/"+fi.fileName();
       copyFile(projectLogo,destFileName);
-      Doxygen::indexList->addImageFile(fi.fileName());
+      if (toIndex) Doxygen::indexList->addImageFile(fi.fileName());
     }
   }
 }
 
-static void copyIcon(const QCString &outputOption)
+static void copyIcon(const QCString &outputOption, bool toIndex)
 {
   QCString projectIcon = Config_getString(PROJECT_ICON);
   if (!projectIcon.isEmpty())
@@ -10559,12 +10559,12 @@ static void copyIcon(const QCString &outputOption)
     {
       QCString destFileName = outputOption+"/"+fi.fileName();
       copyFile(projectIcon,destFileName);
-      Doxygen::indexList->addImageFile(fi.fileName());
+      if (toIndex) Doxygen::indexList->addImageFile(fi.fileName());
     }
   }
 }
 
-static void copyExtraFiles(const StringVector &files,const QCString &filesOption,const QCString &outputOption)
+static void copyExtraFiles(const StringVector &files,const QCString &filesOption,const QCString &outputOption, bool toIndex)
 {
   for (const auto &fileName : files)
   {
@@ -10582,8 +10582,8 @@ static void copyExtraFiles(const StringVector &files,const QCString &filesOption
       else
       {
         QCString destFileName = outputOption+"/"+fi.fileName();
-        Doxygen::indexList->addImageFile(fi.fileName());
         copyFile(fileName, destFileName);
+        if (toIndex) Doxygen::indexList->addImageFile(fi.fileName());
       }
     }
   }
@@ -13248,27 +13248,27 @@ void generateOutput()
   if (generateHtml)
   {
     copyStyleSheet();
-    copyLogo(Config_getString(HTML_OUTPUT));
-    copyIcon(Config_getString(HTML_OUTPUT));
-    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT));
+    copyLogo(Config_getString(HTML_OUTPUT),true);
+    copyIcon(Config_getString(HTML_OUTPUT),true);
+    copyExtraFiles(Config_getList(HTML_EXTRA_FILES),"HTML_EXTRA_FILES",Config_getString(HTML_OUTPUT),true);
   }
   if (generateLatex)
   {
     copyLatexStyleSheet();
-    copyLogo(Config_getString(LATEX_OUTPUT));
-    copyIcon(Config_getString(LATEX_OUTPUT));
-    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT));
+    copyLogo(Config_getString(LATEX_OUTPUT),false);
+    copyIcon(Config_getString(LATEX_OUTPUT),false);
+    copyExtraFiles(Config_getList(LATEX_EXTRA_FILES),"LATEX_EXTRA_FILES",Config_getString(LATEX_OUTPUT),false);
   }
   if (generateDocbook)
   {
-    copyLogo(Config_getString(DOCBOOK_OUTPUT));
-    copyIcon(Config_getString(DOCBOOK_OUTPUT));
+    copyLogo(Config_getString(DOCBOOK_OUTPUT),false);
+    copyIcon(Config_getString(DOCBOOK_OUTPUT),false);
   }
   if (generateRtf)
   {
-    copyLogo(Config_getString(RTF_OUTPUT));
-    copyIcon(Config_getString(RTF_OUTPUT));
-    copyExtraFiles(Config_getList(RTF_EXTRA_FILES),"RTF_EXTRA_FILES",Config_getString(RTF_OUTPUT));
+    copyLogo(Config_getString(RTF_OUTPUT),false);
+    copyIcon(Config_getString(RTF_OUTPUT),false);
+    copyExtraFiles(Config_getList(RTF_EXTRA_FILES),"RTF_EXTRA_FILES",Config_getString(RTF_OUTPUT),false);
   }
 
   FormulaManager &fm = FormulaManager::instance();
@@ -13276,21 +13276,21 @@ void generateOutput()
       && !Config_getBool(USE_MATHJAX))
   {
     g_s.begin("Generating images for formulas in HTML...\n");
-    fm.generateImages(Config_getString(HTML_OUTPUT), Config_getEnum(HTML_FORMULA_FORMAT)==HTML_FORMULA_FORMAT_t::svg ?
+    fm.generateImages(Config_getString(HTML_OUTPUT), true, Config_getEnum(HTML_FORMULA_FORMAT)==HTML_FORMULA_FORMAT_t::svg ?
         FormulaManager::Format::Vector : FormulaManager::Format::Bitmap, FormulaManager::HighDPI::On);
     g_s.end();
   }
   if (fm.hasFormulas() && generateRtf)
   {
     g_s.begin("Generating images for formulas in RTF...\n");
-    fm.generateImages(Config_getString(RTF_OUTPUT),FormulaManager::Format::Bitmap);
+    fm.generateImages(Config_getString(RTF_OUTPUT),false,FormulaManager::Format::Bitmap);
     g_s.end();
   }
 
   if (fm.hasFormulas() && generateDocbook)
   {
     g_s.begin("Generating images for formulas in Docbook...\n");
-    fm.generateImages(Config_getString(DOCBOOK_OUTPUT),FormulaManager::Format::Bitmap);
+    fm.generateImages(Config_getString(DOCBOOK_OUTPUT),false,FormulaManager::Format::Bitmap);
     g_s.end();
   }
 

--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -180,7 +180,7 @@ void FormulaManager::checkRepositories()
   }
 }
 
-void FormulaManager::createLatexFile(const QCString &fileName,Format format,Mode mode,IntVector &formulasToGenerate)
+void FormulaManager::createLatexFile(const QCString &fileName,Format format,Mode mode,IntVector &formulasToGenerate,bool toIndex)
 {
   // generate a latex file containing one formula per page.
   QCString texName=fileName+".tex";
@@ -229,7 +229,7 @@ void FormulaManager::createLatexFile(const QCString &fileName,Format format,Mode
       }
       QCString resultName;
       resultName.sprintf("form_%d%s.%s",id, mode==Mode::Light?"":"_dark", format==Format::Vector?"svg":"png");
-      Doxygen::indexList->addImageFile(resultName);
+      if (toIndex) Doxygen::indexList->addImageFile(resultName);
     }
     t << "\\end{document}\n";
     t.flush();
@@ -549,11 +549,11 @@ static StringVector generateFormula(const Dir &thisDir,const QCString &formulaFi
   return tempFiles;
 }
 
-void FormulaManager::createFormulasTexFile(Dir &thisDir,Format format,HighDPI hd,Mode mode)
+void FormulaManager::createFormulasTexFile(Dir &thisDir,Format format,HighDPI hd,Mode mode,bool toIndex)
 {
   IntVector formulasToGenerate;
   QCString formulaFileName = mode==Mode::Light ? "_formulas" : "_formulas_dark";
-  createLatexFile(formulaFileName,format,mode,formulasToGenerate);
+  createLatexFile(formulaFileName,format,mode,formulasToGenerate,toIndex);
 
   if (!formulasToGenerate.empty()) // there are new formulas
   {
@@ -632,7 +632,7 @@ void FormulaManager::createFormulasTexFile(Dir &thisDir,Format format,HighDPI hd
   }
 }
 
-void FormulaManager::generateImages(const QCString &path,Format format,HighDPI hd)
+void FormulaManager::generateImages(const QCString &path,bool toIndex,Format format,HighDPI hd)
 {
   Dir d(path.str());
   // store the original directory
@@ -660,12 +660,12 @@ void FormulaManager::generateImages(const QCString &path,Format format,HighDPI h
     copyFile(macroFile,stripMacroFile);
   }
 
-  createFormulasTexFile(thisDir,format,hd,Mode::Light);
+  createFormulasTexFile(thisDir,format,hd,Mode::Light,toIndex);
   if (Config_getEnum(HTML_COLORSTYLE)!=HTML_COLORSTYLE_t::LIGHT) // all modes other than light need a dark version
   {
     // note that the dark version reuses the bounding box of the light version so it needs to be
     // created after the light version.
-    createFormulasTexFile(thisDir,format,hd,Mode::Dark);
+    createFormulasTexFile(thisDir,format,hd,Mode::Dark,toIndex);
   }
 
   // clean up temporary files

--- a/src/formula.h
+++ b/src/formula.h
@@ -79,12 +79,12 @@ class FormulaManager
     enum class Format { Bitmap, Vector };
     enum class HighDPI { On, Off };
     enum class Mode { Dark, Light };
-    void generateImages(const QCString &outputDir,Format format,HighDPI hd = HighDPI::Off);
+    void generateImages(const QCString &outputDir,bool toIndex,Format format,HighDPI hd = HighDPI::Off);
     //! @}
 
   private:
-    void createFormulasTexFile(Dir &d,Format format,HighDPI hd,Mode mode);
-    void createLatexFile(const QCString &fileName,Format format,Mode mode,IntVector &formulasToGenerate);
+    void createFormulasTexFile(Dir &d,Format format,HighDPI hd,Mode mode,bool toIndex);
+    void createLatexFile(const QCString &fileName,Format format,Mode mode,IntVector &formulasToGenerate,bool toIndex);
     FormulaManager();
     struct Private;
     std::unique_ptr<Private> p;

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2283,7 +2283,7 @@ void HtmlDocVisitor::writeDotFile(const QCString &fileName,const QCString &relPa
   QCString baseName=makeBaseName(fileName,".dot");
   baseName.prepend("dot_");
   QCString outDir = Config_getString(HTML_OUTPUT);
-  if (newFile) writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine,true);
   writeDotImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,-1,srcFile,srcLine,newFile);
 }
 
@@ -2295,7 +2295,7 @@ void HtmlDocVisitor::writeMscFile(const QCString &fileName,const QCString &relPa
   QCString outDir = Config_getString(HTML_OUTPUT);
   QCString imgExt = getDotImageExtension();
   MscOutputFormat mscFormat = imgExt=="svg" ? MscOutputFormat::SVG : MscOutputFormat::BITMAP;
-  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,srcFile,srcLine);
+  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,mscFormat,srcFile,srcLine,true);
   writeMscImageMapFromFile(m_t,fileName,outDir,relPath,baseName,context,mscFormat,srcFile,srcLine);
 }
 
@@ -2305,7 +2305,7 @@ void HtmlDocVisitor::writeDiaFile(const QCString &fileName, const QCString &relP
   QCString baseName=makeBaseName(fileName,".dia");
   baseName.prepend("dia_");
   QCString outDir = Config_getString(HTML_OUTPUT);
-  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine,true);
 
   m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
 }
@@ -2318,7 +2318,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")
   {
-    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG);
+    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_SVG,true);
     //m_t << "<iframe scrolling=\"no\" frameborder=\"0\" src=\"" << relPath << baseName << ".svg" << "\" />\n";
     //m_t << "<p><b>This browser is not able to show SVG: try Firefox, Chrome, Safari, or Opera instead.</b></p>";
     //m_t << "</iframe>\n";
@@ -2326,7 +2326,7 @@ void HtmlDocVisitor::writePlantUMLFile(const QCString &fileName, const QCString 
   }
   else
   {
-    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
+    PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP,true);
     m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
   }
 }
@@ -2339,12 +2339,12 @@ void HtmlDocVisitor::writeMermaidFile(const QCString &fileName, const QCString &
   QCString imgExt = getDotImageExtension();
   if (imgExt=="svg")
   {
-    MermaidManager::instance().generateMermaidOutput(fileName,outDir,MermaidManager::OutputFormat::SVG);
+    MermaidManager::instance().generateMermaidOutput(fileName,outDir,MermaidManager::OutputFormat::SVG,true);
     m_t << "<object type=\"image/svg+xml\" data=\"" << relPath << baseName << ".svg\"></object>\n";
   }
   else
   {
-    MermaidManager::instance().generateMermaidOutput(fileName,outDir,MermaidManager::OutputFormat::Bitmap);
+    MermaidManager::instance().generateMermaidOutput(fileName,outDir,MermaidManager::OutputFormat::Bitmap,true);
     m_t << "<img src=\"" << relPath << baseName << ".png" << "\" />\n";
   }
 }

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -2165,7 +2165,7 @@ void HtmlGenerator::endClassDiagram(const ClassDiagram &d,
   endSectionSummary(m_t);
   startSectionContent(m_t,m_sectionCount);
   TextStream tt;
-  d.writeImage(tt,dir(),m_relPath,fileName);
+  d.writeImage(tt,dir(),m_relPath,fileName,true,true);
   if (!tt.empty())
   {
     m_t << " <div class=\"center\">\n";

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1944,7 +1944,7 @@ void LatexDocVisitor::startDotFile(const QCString &fileName,
   QCString baseName=makeBaseName(fileName,".dot");
   baseName.prepend("dot_");
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  if (newFile) writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::EPS,srcFile,srcLine);
+  if (newFile) writeDotGraphFromFile(fileName,outDir,baseName,GraphOutputFormat::EPS,srcFile,srcLine,false);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1966,7 +1966,7 @@ void LatexDocVisitor::startMscFile(const QCString &fileName,
   baseName.prepend("msc_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::EPS,srcFile,srcLine);
+  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::EPS,srcFile,srcLine,false);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -1981,7 +1981,7 @@ void LatexDocVisitor::writeMscFile(const QCString &fileName, const DocVerbatim &
 {
   QCString shortName=makeBaseName(fileName,".msc");
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  if (newFile) writeMscGraphFromFile(fileName,outDir,shortName,MscOutputFormat::EPS,s.srcFile(),s.srcLine());
+  if (newFile) writeMscGraphFromFile(fileName,outDir,shortName,MscOutputFormat::EPS,s.srcFile(),s.srcLine(),false);
   visitPreStart(m_t, s.hasCaption(), shortName, s.width(),s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -1999,7 +1999,7 @@ void LatexDocVisitor::startDiaFile(const QCString &fileName,
   baseName.prepend("dia_");
 
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::EPS,srcFile,srcLine);
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::EPS,srcFile,srcLine,false);
   visitPreStart(m_t,hasCaption, baseName, width, height);
 }
 
@@ -2018,7 +2018,7 @@ void LatexDocVisitor::writePlantUMLFile(const QCString &baseName, const DocVerba
   }
   QCString outDir = Config_getString(LATEX_OUTPUT);
   PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,
-                              s.useBitmap() ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS);
+                              s.useBitmap() ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS,false);
   visitPreStart(m_t, s.hasCaption(), shortName, s.width(), s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -2051,7 +2051,7 @@ void LatexDocVisitor::startPlantUmlFile(const QCString &fileName,
       if (shortName.find('.')==-1) shortName += ".png";
     }
     PlantumlManager::instance().generatePlantUMLOutput(baseName,outDir,
-                                useBitmap ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS);
+                                useBitmap ? PlantumlManager::PUML_BITMAP : PlantumlManager::PUML_EPS,false);
     if (!first) endPlantUmlFile(hasCaption);
     first = false;
     visitPreStart(m_t,hasCaption, shortName, width, height);
@@ -2071,7 +2071,7 @@ void LatexDocVisitor::writeMermaidFile(const QCString &baseName, const DocVerbat
   bool usePDFLatex = Config_getBool(USE_PDFLATEX);
   if (shortName.find('.')==-1) shortName += usePDFLatex ? ".pdf" : ".png";
   QCString outDir = Config_getString(LATEX_OUTPUT);
-  MermaidManager::instance().generateMermaidOutput(baseName,outDir,usePDFLatex ? MermaidManager::OutputFormat::PDF : MermaidManager::OutputFormat::Bitmap);
+  MermaidManager::instance().generateMermaidOutput(baseName,outDir,usePDFLatex ? MermaidManager::OutputFormat::PDF : MermaidManager::OutputFormat::Bitmap,false);
   visitPreStart(m_t, s.hasCaption(), shortName, s.width(), s.height());
   visitCaption(s.children());
   visitPostEnd(m_t, s.hasCaption());
@@ -2097,7 +2097,7 @@ void LatexDocVisitor::startMermaidFile(const QCString &fileName,
                               srcFile,srcLine);
   QCString shortName = stripPath(baseName);
   if (shortName.find('.')==-1) shortName += usePDFLatex ? ".pdf" : ".png";
-  MermaidManager::instance().generateMermaidOutput(baseName,outDir,usePDFLatex ? MermaidManager::OutputFormat::PDF : MermaidManager::OutputFormat::Bitmap);
+  MermaidManager::instance().generateMermaidOutput(baseName,outDir,usePDFLatex ? MermaidManager::OutputFormat::PDF : MermaidManager::OutputFormat::Bitmap,false);
   visitPreStart(m_t,hasCaption, shortName, width, height);
 }
 

--- a/src/mermaid.cpp
+++ b/src/mermaid.cpp
@@ -99,8 +99,9 @@ QCString MermaidManager::writeMermaidSource(const QCString &outDirArg, const QCS
 }
 
 void MermaidManager::generateMermaidOutput(const QCString &baseName, const QCString &/*outDir*/,
-                                           OutputFormat format)
+                                           OutputFormat format, bool toIndex)
 {
+  if (!toIndex) return;
   QCString imgName = baseName;
   int i = imgName.findRev('/');
   if (i != -1)

--- a/src/mermaid.h
+++ b/src/mermaid.h
@@ -65,8 +65,9 @@ class MermaidManager
      *  @param[in] baseName the name of the generated file (as returned by writeMermaidSource())
      *  @param[in] outDir   the directory containing the resulting image.
      *  @param[in] format   the image format that was generated.
+     *  @param[in] toIndex  add the file to the index lists for htmlhelp / qhc etc.
      */
-    void generateMermaidOutput(const QCString &baseName, const QCString &outDir, OutputFormat format);
+    void generateMermaidOutput(const QCString &baseName, const QCString &outDir, OutputFormat format, bool toIndex);
 
     struct MermaidDiagram
     {

--- a/src/msc.cpp
+++ b/src/msc.cpp
@@ -156,7 +156,7 @@ static bool do_mscgen_generate(const QCString& inFile,const QCString& outFile,ms
 
 void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,MscOutputFormat format,
-                           const QCString &srcFile,int srcLine
+                           const QCString &srcFile,int srcLine,bool toIndex
                           )
 {
   QCString absOutFile = outDir;
@@ -207,7 +207,7 @@ void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
   {
     imgName=imgName.right(imgName.length()-i-1);
   }
-  Doxygen::indexList->addImageFile(imgName);
+  if (toIndex) Doxygen::indexList->addImageFile(imgName);
 
 }
 

--- a/src/msc.h
+++ b/src/msc.h
@@ -23,7 +23,7 @@ enum class MscOutputFormat { BITMAP, EPS, SVG };
 
 void writeMscGraphFromFile(const QCString &inFile,const QCString &outDir,
                            const QCString &outFile,MscOutputFormat format,
-                           const QCString &srcFile,int srcLine);
+                           const QCString &srcFile,int srcLine,bool toIndex);
 
 QCString getMscImageMapFromFile(const QCString &inFile, const QCString &outDir,
                                 const QCString &relPath,const QCString &context,

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -199,8 +199,9 @@ void PlantumlManager::generatePlantUmlFileNames(const QCString &fileName,OutputF
   }
 }
 
-void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCString &/* outDir */,OutputFormat format)
+void PlantumlManager::generatePlantUMLOutput(const QCString &baseName,const QCString &/* outDir */,OutputFormat format,bool toIndex)
 {
+  if (!toIndex) return;
   QCString imgName = baseName;
   // The basename contains path, we need to strip the path from the filename in order
   // to create the image file name which should be included in the index.qhp (Qt help index file).

--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -69,8 +69,9 @@ class PlantumlManager
      *  @param[in] baseName the name of the generated file (as returned by writePlantUMLSource())
      *  @param[in] outDir   the directory to write the resulting image into.
      *  @param[in] format   the image format to generate.
+     *  @param[in] toIndex  add the file to the index lists for htmlhelp / qhc etc.
      */
-    void generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format);
+    void generatePlantUMLOutput(const QCString &baseName,const QCString &outDir,OutputFormat format,bool toIndex);
 
     using FilesMap   = std::map< std::string, StringVector    >;
     using ContentMap = std::map< std::string, PlantumlContent >;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1765,7 +1765,7 @@ void RTFDocVisitor::writeDotFile(const QCString &filename, bool hasCaption,
 {
   QCString baseName=makeBaseName(filename,".dot");
   QCString outDir = Config_getString(RTF_OUTPUT);
-  if (newFile) writeDotGraphFromFile(filename,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDotGraphFromFile(filename,outDir,baseName,GraphOutputFormat::BITMAP,srcFile,srcLine,false);
   QCString imgExt = getDotImageExtension();
   includePicturePreRTF(baseName + "." + imgExt, true, hasCaption);
 }
@@ -1775,7 +1775,7 @@ void RTFDocVisitor::writeMscFile(const QCString &fileName, bool hasCaption,
 {
   QCString baseName=makeBaseName(fileName,".msc");
   QCString outDir = Config_getString(RTF_OUTPUT);
-  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeMscGraphFromFile(fileName,outDir,baseName,MscOutputFormat::BITMAP,srcFile,srcLine,false);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
@@ -1784,7 +1784,7 @@ void RTFDocVisitor::writeDiaFile(const QCString &fileName, bool hasCaption,
 {
   QCString baseName=makeBaseName(fileName,".dia");
   QCString outDir = Config_getString(RTF_OUTPUT);
-  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine);
+  if (newFile) writeDiaGraphFromFile(fileName,outDir,baseName,DiaOutputFormat::BITMAP,srcFile,srcLine,false);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
@@ -1792,7 +1792,7 @@ void RTFDocVisitor::writePlantUMLFile(const QCString &fileName, bool hasCaption)
 {
   QCString baseName=makeBaseName(fileName,".pu");
   QCString outDir = Config_getString(RTF_OUTPUT);
-  PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP);
+  PlantumlManager::instance().generatePlantUMLOutput(fileName,outDir,PlantumlManager::PUML_BITMAP,false);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }
 
@@ -1801,6 +1801,6 @@ void RTFDocVisitor::writeMermaidFile(const QCString &fileName, bool hasCaption)
   if (Config_getBool(MERMAID_RENDER_MODE)==MERMAID_RENDER_MODE_t::CLIENT_SIDE) return;
   QCString baseName=makeBaseName(fileName,".mmd");
   QCString outDir = Config_getString(RTF_OUTPUT);
-  MermaidManager::instance().generateMermaidOutput(fileName,outDir,MermaidManager::OutputFormat::Bitmap);
+  MermaidManager::instance().generateMermaidOutput(fileName,outDir,MermaidManager::OutputFormat::Bitmap,false);
   includePicturePreRTF(baseName + ".png", true, hasCaption);
 }

--- a/src/rtfgen.cpp
+++ b/src/rtfgen.cpp
@@ -1867,7 +1867,7 @@ void RTFGenerator::endClassDiagram(const ClassDiagram &d,
   newParagraph();
 
   // create a png file
-  d.writeImage(m_t,dir(),m_relPath,fileName,FALSE);
+  d.writeImage(m_t,dir(),m_relPath,fileName,false,false);
 
   // display the file
   m_t << "{\n";

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3020,7 +3020,7 @@ void  FlowChart::printUmlTree()
   auto baseNameVector=PlantumlManager::instance().writePlantUMLSource(htmlOutDir,n,qcs,PlantumlManager::PUML_SVG,"uml",n,1,true);
   for (const auto &baseName: baseNameVector)
   {
-    PlantumlManager::instance().generatePlantUMLOutput(baseName,htmlOutDir,PlantumlManager::PUML_SVG);
+    PlantumlManager::instance().generatePlantUMLOutput(baseName,htmlOutDir,PlantumlManager::PUML_SVG,true);
   }
 }
 


### PR DESCRIPTION
When we have an example with dot / msc /plantuml /dia / mermaid / formulas/ class / call graph ... and we have LaTeX / Docbook / rtf enabled and chm and / or qhp we get warnings when we generate the chm / qch file due to files hat were added to the `hhp` / `ghp` file. Same occurs with the extra file specified for latex.

This PR obsoletes #8770 
Tested against the doxygen internal documentation and example of #8770