### PR TITLE
HtmlHelp and mermaid render mode

### DIFF
--- a/doc/Doxyfile_chm
+++ b/doc/Doxyfile_chm
@@ -27,3 +27,4 @@
       SEARCHENGINE           = NO
       HTML_EXTRA_STYLESHEET  = doxygen_manual_chm.css
       HTML_CODE_FOLDING      = NO
+      MERMAID_RENDER_MODE    = CLI

--- a/src/configimpl.l
+++ b/src/configimpl.l
@@ -2003,6 +2003,7 @@ void Config::checkAndCorrect(bool quiet, const bool check)
     adjustBoolSetting(  depOption, "HTML_CODE_FOLDING",    false  );
     adjustBoolSetting(  depOption, "INTERACTIVE_SVG",      false  );
     adjustStringSetting(depOption, "HTML_FILE_EXTENSION", ".html");
+    adjustStringSetting(depOption, "MERMAID_RENDER_MODE", "CLI");
     adjustColorStyleSetting(depOption);
     const StringVector &tagFileList = Config_getList(TAGFILES);
     StringVector filteredTagFileList;


### PR DESCRIPTION
When HtmlHelp is enabled the `MERMAID_RENDER_MODE` should have the value `CLI` as the JavaScript is not understood.