### PR TITLE
issue #12092 Regression in the parsing of titles of custom navbar tabs

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4052,6 +4052,10 @@ QCString convertToJSString(const QCString &s,bool keepEntities,bool singleQuotes
   {
     switch (c)
     {
+      case '<':  result+="&amp;lt;";
+                 break;
+      case '>':  result+="&amp;gt;";
+                 break;
       case '"':  if (!singleQuotes) result+="\\\""; else result+=c;
                  break;
       case '\'': if (singleQuotes) result+="\\\'"; else result+=c;


### PR DESCRIPTION
There should be the `&lt;` and `&gt;` in the output file, but it looks like that the `std::ostream` replaces these again with `<` and `>` so best is to escape the `&` as well again (so it will be `&amp;lt;` and `&amp;gt;` to the `std::ostream` resulting in the required text in the javascript file).