### PR TITLE
Incorrect link in configuration documentation doxywizard

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -462,11 +462,6 @@ static QString getDocsForNode(const QDomElement &child)
   // \#undef -> #undef
   docs.replace(SA("\\#include"),SA("#include"));
   docs.replace(SA("\\#undef"),SA("#undef"));
-  // -# -> <br>-
-  // " - " -> <br>-
-  docs.replace(SA("-#"),SA("<br>-"));
-  docs.replace(SA("\\# "),SA("# "));
-  docs.replace(SA(" - "),SA("<br>-"));
   // \verbatim -> <pre>
   // \endverbatim -> </pre>
   docs.replace(SA("\\verbatim"),SA("<pre>"));
@@ -499,6 +494,11 @@ static QString getDocsForNode(const QDomElement &child)
   docs.replace(regexp,SA("2^(16+LOOKUP_CACHE_SIZE)"));
   regexp.setPattern(SA("\\\\f\\$2\\^\\{16\\} = 65536\\\\f\\$"));
   docs.replace(regexp,SA("2^16=65536"));
+  // -# -> <br>-
+  // " - " -> <br>-
+  docs.replace(SA("-#"),SA("<br>-"));
+  docs.replace(SA("\\# "),SA("# "));
+  docs.replace(SA(" - "),SA("<br>-"));
 
   return docs.trimmed();
 }

--- a/src/config.xml
+++ b/src/config.xml
@@ -4289,14 +4289,14 @@ to be found in the default search path.
  The \c MERMAID_JS_URL tag specifies the URL to load \c mermaid.js from when using
  client-side rendering (\c MERMAID_RENDER_MODE is \c CLIENT_SIDE or \c AUTO).
  The default points to the latest Mermaid v11 release on the jsDelivr CDN.
+ <br>
+ The default CDN URL requires internet access when viewing the generated documentation.
+ For offline use, download \c mermaid.esm.min.mjs and set this to a relative path,
+ or use \c MERMAID_RENDER_MODE=CLI to pre-generate images instead.
  \par Examples:
  - Latest v11 (default): \c 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'
  - Pinned version: \c 'https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.esm.min.mjs'
  - Local copy: \c './mermaid.esm.min.mjs' (user must place file in HTML output directory)
- \par
- The default CDN URL requires internet access when viewing the generated documentation.
- For offline use, download \c mermaid.esm.min.mjs and set this to a relative path,
- or use \c MERMAID_RENDER_MODE=CLI to pre-generate images instead.
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
As noted in https://github.com/doxygen/doxygen/pull/12079#issuecomment-4267577103 there is an incorrect link for the the `MATHJAX_RELPATH` setting, apparently the order of replacements is  important, fixed. Fore the `MERMAID_JS_URL` there was also a small glitch that has been corrected.