### PR TITLE
Fix link parsing errors in Simplified Chinese, Traditional Chinese, and Japanese language settings in MATHJAX_RELPATH.

### DIFF
--- a/src/translations/config_ja.xml
+++ b/src/translations/config_ja.xml
@@ -1176,9 +1176,9 @@
  MathJaxのローカルコピーをインストールすることを強くお勧めします。
 
  デフォルト値は：
- - MathJaxバージョン2の場合：https://cdn.jsdelivr.net/npm/mathjax@2
- - MathJaxバージョン3の場合：https://cdn.jsdelivr.net/npm/mathjax@3
- - MathJaxバージョン4の場合：https://cdn.jsdelivr.net/npm/mathjax@4
+ - MathJaxバージョン2の場合: https://cdn.jsdelivr.net/npm/mathjax@2
+ - MathJaxバージョン3の場合: https://cdn.jsdelivr.net/npm/mathjax@3
+ - MathJaxバージョン4の場合: https://cdn.jsdelivr.net/npm/mathjax@4
 ]]>
       </docs>
     </option>

--- a/src/translations/config_zh_CN.xml
+++ b/src/translations/config_zh_CN.xml
@@ -1174,9 +1174,9 @@
  的本地副本。
 
  默认值为：
- - MathJax 版本 2 的情况：https://cdn.jsdelivr.net/npm/mathjax@2
- - MathJax 版本 3 的情况：https://cdn.jsdelivr.net/npm/mathjax@3
- - MathJax 版本 4 的情况：https://cdn.jsdelivr.net/npm/mathjax@4
+ - MathJax 版本 2 的情况: https://cdn.jsdelivr.net/npm/mathjax@2
+ - MathJax 版本 3 的情况: https://cdn.jsdelivr.net/npm/mathjax@3
+ - MathJax 版本 4 的情况: https://cdn.jsdelivr.net/npm/mathjax@4
 ]]>
       </docs>
     </option>

--- a/src/translations/config_zh_TW.xml
+++ b/src/translations/config_zh_TW.xml
@@ -1174,9 +1174,9 @@
  的本地副本。
 
  預設值為：
- - MathJax 版本 2 的情況：https://cdn.jsdelivr.net/npm/mathjax@2
- - MathJax 版本 3 的情況：https://cdn.jsdelivr.net/npm/mathjax@3
- - MathJax 版本 4 的情況：https://cdn.jsdelivr.net/npm/mathjax@4
+ - MathJax 版本 2 的情況: https://cdn.jsdelivr.net/npm/mathjax@2
+ - MathJax 版本 3 的情況: https://cdn.jsdelivr.net/npm/mathjax@3
+ - MathJax 版本 4 的情況: https://cdn.jsdelivr.net/npm/mathjax@4
 ]]>
       </docs>
     </option>


### PR DESCRIPTION
The URL detection regex in expert.cpp requires a space before URLs. In Chinese and Japanese translations, the full-width colon (：) was used instead of a space, causing MathJax CDN URLs to not be converted to clickable links.

Changed '：https://' to ': https://' in MATHJAX_RELPATH docs for:
- config_zh_CN.xml (Simplified Chinese)
- config_ja.xml (Japanese)
- config_zh_TW.xml (Traditional Chinese)