### PR TITLE
Add automatic backup when saving Doxyfile

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -461,6 +461,15 @@ void MainWindow::loadConfigFromFile(const QString & fileName)
 void MainWindow::saveConfig(const QString &fileName)
 {
   if (fileName.isEmpty()) return;
+  
+  // Create backup of existing file
+  if (QFile::exists(fileName))
+  {
+    QString backupFileName = fileName + QString::fromLatin1(".bak");
+    QFile::remove(backupFileName);
+    QFile::copy(fileName, backupFileName);
+  }
+  
   QFile f(fileName);
   if (!f.open(QIODevice::WriteOnly | QIODevice::Text ))
   {


### PR DESCRIPTION
When saving a Doxyfile configuration, automatically create a .bak backup of the existing file before overwriting it. This provides a safety net for users who want to revert to previous settings.