### PR TITLE
Added validation to verify whether the file is a valid Doxyfile.

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -446,45 +446,47 @@ void MainWindow::updateConfigFileName(const QString &fileName)
 
 void MainWindow::loadConfigFromFile(const QString & fileName)
 {
-  // Check if the file is a valid Doxyfile by looking for "# Doxyfile" in the first line
   QFile f(fileName);
-  if (f.open(QIODevice::ReadOnly | QIODevice::Text))
-  {
-    QString firstLine;
-    bool foundDoxyfileHeader = false;
-    
-    // Read lines until we find a non-empty, non-comment line or find the header
-    while (!f.atEnd())
-    {
-      QString line = QString::fromUtf8(f.readLine()).trimmed();
-      if (line.isEmpty())
-        continue;
-      firstLine = line;
-      break;
-    }
-    f.close();
-    
-    // Check if the first non-empty line starts with "# Doxyfile"
-    if (firstLine.startsWith(QString::fromLatin1("# Doxyfile"), Qt::CaseSensitive))
-    {
-      foundDoxyfileHeader = true;
-    }
-    
-    if (!foundDoxyfileHeader)
-    {
-      QMessageBox::warning(this,
-          tr("Invalid configuration file"),
-          tr("The file '%1' does not appear to be a valid Doxygen configuration file.\n\n"
-             "A valid Doxyfile should start with '# Doxyfile' on the first line.")
-          .arg(fileName));
-      return;
-    }
-  }
-  else
+  if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
   {
     QMessageBox::warning(this,
         tr("Error opening file"),
         tr("Cannot open the file %1 for reading.").arg(fileName));
+    return;
+  }
+
+  bool isValidDoxyfile = false;
+  QRegularExpression configPattern(QString::fromLatin1("^[A-Z_][A-Z0-9_]*\\s*(\\+?=)"));
+
+  while (!f.atEnd())
+  {
+    QString line = QString::fromUtf8(f.readLine()).trimmed();
+
+    if (line.isEmpty())
+      continue;
+
+    if (line.startsWith(QString::fromLatin1("# Doxyfile"), Qt::CaseSensitive))
+    {
+      isValidDoxyfile = true;
+      break;
+    }
+
+    if (configPattern.match(line).hasMatch())
+    {
+      isValidDoxyfile = true;
+      break;
+    }
+  }
+  f.close();
+
+  if (!isValidDoxyfile)
+  {
+    QMessageBox::warning(this,
+        tr("Invalid configuration file"),
+        tr("The file '%1' does not appear to be a valid Doxygen configuration file.\n\n"
+           "A valid Doxyfile should contain configuration entries in the format 'TAGNAME = VALUE' "
+           "or start with '# Doxyfile'.")
+        .arg(fileName));
     return;
   }
 

--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -465,12 +465,6 @@ void MainWindow::loadConfigFromFile(const QString & fileName)
     if (line.isEmpty())
       continue;
 
-    if (line.startsWith(QString::fromLatin1("# Doxyfile"), Qt::CaseSensitive))
-    {
-      isValidDoxyfile = true;
-      break;
-    }
-
     if (configPattern.match(line).hasMatch())
     {
       isValidDoxyfile = true;
@@ -484,8 +478,7 @@ void MainWindow::loadConfigFromFile(const QString & fileName)
     QMessageBox::warning(this,
         tr("Invalid configuration file"),
         tr("The file '%1' does not appear to be a valid Doxygen configuration file.\n\n"
-           "A valid Doxyfile should contain configuration entries in the format 'TAGNAME = VALUE' "
-           "or start with '# Doxyfile'.")
+           "A valid Doxyfile should contain configuration entries in the format 'TAGNAME = VALUE'.")
         .arg(fileName));
     return;
   }

--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -446,6 +446,48 @@ void MainWindow::updateConfigFileName(const QString &fileName)
 
 void MainWindow::loadConfigFromFile(const QString & fileName)
 {
+  // Check if the file is a valid Doxyfile by looking for "# Doxyfile" in the first line
+  QFile f(fileName);
+  if (f.open(QIODevice::ReadOnly | QIODevice::Text))
+  {
+    QString firstLine;
+    bool foundDoxyfileHeader = false;
+    
+    // Read lines until we find a non-empty, non-comment line or find the header
+    while (!f.atEnd())
+    {
+      QString line = QString::fromUtf8(f.readLine()).trimmed();
+      if (line.isEmpty())
+        continue;
+      firstLine = line;
+      break;
+    }
+    f.close();
+    
+    // Check if the first non-empty line starts with "# Doxyfile"
+    if (firstLine.startsWith(QString::fromLatin1("# Doxyfile"), Qt::CaseSensitive))
+    {
+      foundDoxyfileHeader = true;
+    }
+    
+    if (!foundDoxyfileHeader)
+    {
+      QMessageBox::warning(this,
+          tr("Invalid configuration file"),
+          tr("The file '%1' does not appear to be a valid Doxygen configuration file.\n\n"
+             "A valid Doxyfile should start with '# Doxyfile' on the first line.")
+          .arg(fileName));
+      return;
+    }
+  }
+  else
+  {
+    QMessageBox::warning(this,
+        tr("Error opening file"),
+        tr("Cannot open the file %1 for reading.").arg(fileName));
+    return;
+  }
+
   // save full path info of original file
   QString absFileName = QFileInfo(fileName).absoluteFilePath();
   // updates the current directory

--- a/addon/doxywizard/translations/doxywizard_de.ts
+++ b/addon/doxywizard/translations/doxywizard_de.ts
@@ -371,6 +371,26 @@ Angegebener Grund: %2</translation>
         <source>Language changed to: %1</source>
         <translation>Sprache geändert zu: %1</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>Ungültige Konfigurationsdatei</translation>
+    </message>
+    <message>
+        <source>The file '%1' does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with '# Doxyfile' on the first line.</source>
+        <translation>Die Datei '%1' scheint keine gültige Doxygen-Konfigurationsdatei zu sein.
+
+Eine gültige Doxyfile sollte mit '# Doxyfile' in der ersten Zeile beginnen.</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>Fehler beim Öffnen der Datei</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>Die Datei %1 kann nicht zum Lesen geöffnet werden.</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_de.ts
+++ b/addon/doxywizard/translations/doxywizard_de.ts
@@ -378,10 +378,10 @@ Angegebener Grund: %2</translation>
     <message>
         <source>The file '%1' does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with '# Doxyfile' on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format 'TAGNAME = VALUE' or start with '# Doxyfile'.</source>
         <translation>Die Datei '%1' scheint keine gültige Doxygen-Konfigurationsdatei zu sein.
 
-Eine gültige Doxyfile sollte mit '# Doxyfile' in der ersten Zeile beginnen.</translation>
+Eine gültige Doxyfile sollte Konfigurationseinträge im Format 'TAGNAME = VALUE' enthalten oder mit '# Doxyfile' beginnen.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_de.ts
+++ b/addon/doxywizard/translations/doxywizard_de.ts
@@ -378,10 +378,10 @@ Angegebener Grund: %2</translation>
     <message>
         <source>The file '%1' does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format 'TAGNAME = VALUE' or start with '# Doxyfile'.</source>
+A valid Doxyfile should contain configuration entries in the format 'TAGNAME = VALUE'.</source>
         <translation>Die Datei '%1' scheint keine gültige Doxygen-Konfigurationsdatei zu sein.
 
-Eine gültige Doxyfile sollte Konfigurationseinträge im Format 'TAGNAME = VALUE' enthalten oder mit '# Doxyfile' beginnen.</translation>
+Eine gültige Doxyfile sollte Konfigurationseinträge im Format 'TAGNAME = VALUE' enthalten.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_es.ts
+++ b/addon/doxywizard/translations/doxywizard_es.ts
@@ -378,10 +378,10 @@ Razón dada: %2</translation>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos;.</source>
         <translation>El archivo &apos;%1&apos; no parece ser un archivo de configuración de Doxygen válido.
 
-Un Doxyfile válido debe contener entradas de configuración en el formato &apos;TAGNAME = VALUE&apos; o comenzar con &apos;# Doxyfile&apos;.</translation>
+Un Doxyfile válido debe contener entradas de configuración en el formato &apos;TAGNAME = VALUE&apos;.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_es.ts
+++ b/addon/doxywizard/translations/doxywizard_es.ts
@@ -378,10 +378,10 @@ Razón dada: %2</translation>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
         <translation>El archivo &apos;%1&apos; no parece ser un archivo de configuración de Doxygen válido.
 
-Un Doxyfile válido debe comenzar con &apos;# Doxyfile&apos; en la primera línea.</translation>
+Un Doxyfile válido debe contener entradas de configuración en el formato &apos;TAGNAME = VALUE&apos; o comenzar con &apos;# Doxyfile&apos;.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_es.ts
+++ b/addon/doxywizard/translations/doxywizard_es.ts
@@ -371,6 +371,26 @@ Razón dada: %2</translation>
         <source>Doxygen GUI frontend</source>
         <translation>Interfaz gráfica de Doxygen</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>Archivo de configuración no válido</translation>
+    </message>
+    <message>
+        <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+        <translation>El archivo &apos;%1&apos; no parece ser un archivo de configuración de Doxygen válido.
+
+Un Doxyfile válido debe comenzar con &apos;# Doxyfile&apos; en la primera línea.</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>Error al abrir el archivo</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>No se puede abrir el archivo %1 para lectura.</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_fr.ts
+++ b/addon/doxywizard/translations/doxywizard_fr.ts
@@ -378,10 +378,10 @@ Raison donnée : %2</translation>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos;.</source>
         <translation>Le fichier &apos;%1&apos; ne semble pas être un fichier de configuration Doxygen valide.
 
-Un Doxyfile valide doit contenir des entrées de configuration au format &apos;TAGNAME = VALUE&apos; ou commencer par &apos;# Doxyfile&apos;.</translation>
+Un Doxyfile valide doit contenir des entrées de configuration au format &apos;TAGNAME = VALUE&apos;.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_fr.ts
+++ b/addon/doxywizard/translations/doxywizard_fr.ts
@@ -378,10 +378,10 @@ Raison donnée : %2</translation>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
         <translation>Le fichier &apos;%1&apos; ne semble pas être un fichier de configuration Doxygen valide.
 
-Un Doxyfile valide doit commencer par &apos;# Doxyfile&apos; sur la première ligne.</translation>
+Un Doxyfile valide doit contenir des entrées de configuration au format &apos;TAGNAME = VALUE&apos; ou commencer par &apos;# Doxyfile&apos;.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_fr.ts
+++ b/addon/doxywizard/translations/doxywizard_fr.ts
@@ -371,6 +371,26 @@ Raison donnée : %2</translation>
         <source>Language changed to: %1</source>
         <translation>Langue changée en : %1</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>Fichier de configuration invalide</translation>
+    </message>
+    <message>
+        <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+        <translation>Le fichier &apos;%1&apos; ne semble pas être un fichier de configuration Doxygen valide.
+
+Un Doxyfile valide doit commencer par &apos;# Doxyfile&apos; sur la première ligne.</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>Erreur lors de l&apos;ouverture du fichier</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>Impossible d&apos;ouvrir le fichier %1 en lecture.</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_ja.ts
+++ b/addon/doxywizard/translations/doxywizard_ja.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos;.</source>
         <translation>ファイル &apos;%1&apos; は有効なDoxygen設定ファイルではないようです。
 
-有効なDoxyfileは &apos;TAGNAME = VALUE&apos; 形式の設定エントリを含むか、&apos;# Doxyfile&apos; で始まる必要があります。</translation>
+有効なDoxyfileは &apos;TAGNAME = VALUE&apos; 形式の設定エントリを含む必要があります。</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_ja.ts
+++ b/addon/doxywizard/translations/doxywizard_ja.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
         <translation>ファイル &apos;%1&apos; は有効なDoxygen設定ファイルではないようです。
 
-有効なDoxyfileは最初の行に &apos;# Doxyfile&apos; で始まる必要があります。</translation>
+有効なDoxyfileは &apos;TAGNAME = VALUE&apos; 形式の設定エントリを含むか、&apos;# Doxyfile&apos; で始まる必要があります。</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_ja.ts
+++ b/addon/doxywizard/translations/doxywizard_ja.ts
@@ -371,6 +371,26 @@ Reason given: %2</source>
         <source>Doxygen GUI frontend</source>
         <translation>Doxygen GUIフロントエンド</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>無効な設定ファイル</translation>
+    </message>
+    <message>
+        <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+        <translation>ファイル &apos;%1&apos; は有効なDoxygen設定ファイルではないようです。
+
+有効なDoxyfileは最初の行に &apos;# Doxyfile&apos; で始まる必要があります。</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>ファイルを開く際のエラー</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>ファイル %1 を読み取り用に開けません。</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_ko.ts
+++ b/addon/doxywizard/translations/doxywizard_ko.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos;.</source>
         <translation>파일 &apos;%1&apos;은(는) 유효한 Doxygen 구성 파일이 아닌 것 같습니다.
 
-유효한 Doxyfile은 &apos;TAGNAME = VALUE&apos; 형식의 구성 항목을 포함하거나 &apos;# Doxyfile&apos;로 시작해야 합니다.</translation>
+유효한 Doxyfile은 &apos;TAGNAME = VALUE&apos; 형식의 구성 항목을 포함해야 합니다.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_ko.ts
+++ b/addon/doxywizard/translations/doxywizard_ko.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
         <translation>파일 &apos;%1&apos;은(는) 유효한 Doxygen 구성 파일이 아닌 것 같습니다.
 
-유효한 Doxyfile은 첫 번째 줄에 &apos;# Doxyfile&apos;로 시작해야 합니다.</translation>
+유효한 Doxyfile은 &apos;TAGNAME = VALUE&apos; 형식의 구성 항목을 포함하거나 &apos;# Doxyfile&apos;로 시작해야 합니다.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_ko.ts
+++ b/addon/doxywizard/translations/doxywizard_ko.ts
@@ -371,6 +371,26 @@ Reason given: %2</source>
         <source>Doxygen GUI frontend</source>
         <translation>Doxygen GUI 프론트엔드</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>잘못된 구성 파일</translation>
+    </message>
+    <message>
+        <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+        <translation>파일 &apos;%1&apos;은(는) 유효한 Doxygen 구성 파일이 아닌 것 같습니다.
+
+유효한 Doxyfile은 첫 번째 줄에 &apos;# Doxyfile&apos;로 시작해야 합니다.</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>파일 열기 오류</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>파일 %1을(를) 읽기용으로 열 수 없습니다.</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_ru.ts
+++ b/addon/doxywizard/translations/doxywizard_ru.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
         <translation>Файл &apos;%1&apos; не является допустимым файлом конфигурации Doxygen.
 
-Допустимый Doxyfile должен начинаться с &apos;# Doxyfile&apos; в первой строке.</translation>
+Допустимый Doxyfile должен содержать записи конфигурации в формате &apos;TAGNAME = VALUE&apos; или начинаться с &apos;# Doxyfile&apos;.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_ru.ts
+++ b/addon/doxywizard/translations/doxywizard_ru.ts
@@ -371,6 +371,26 @@ Reason given: %2</source>
         <source>Doxygen GUI frontend</source>
         <translation>Графический интерфейс Doxygen</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>Неверный файл конфигурации</translation>
+    </message>
+    <message>
+        <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+        <translation>Файл &apos;%1&apos; не является допустимым файлом конфигурации Doxygen.
+
+Допустимый Doxyfile должен начинаться с &apos;# Doxyfile&apos; в первой строке.</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>Ошибка открытия файла</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>Невозможно открыть файл %1 для чтения.</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_ru.ts
+++ b/addon/doxywizard/translations/doxywizard_ru.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos;.</source>
         <translation>Файл &apos;%1&apos; не является допустимым файлом конфигурации Doxygen.
 
-Допустимый Doxyfile должен содержать записи конфигурации в формате &apos;TAGNAME = VALUE&apos; или начинаться с &apos;# Doxyfile&apos;.</translation>
+Допустимый Doxyfile должен содержать записи конфигурации в формате &apos;TAGNAME = VALUE&apos;.</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_zh_CN.ts
+++ b/addon/doxywizard/translations/doxywizard_zh_CN.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos;.</source>
         <translation>文件 &apos;%1&apos; 似乎不是有效的 Doxygen 配置文件。
 
-有效的 Doxyfile 应包含格式为 &apos;TAGNAME = VALUE&apos; 的配置项，或以 &apos;# Doxyfile&apos; 开头。</translation>
+有效的 Doxyfile 应包含格式为 &apos;TAGNAME = VALUE&apos; 的配置项。</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_zh_CN.ts
+++ b/addon/doxywizard/translations/doxywizard_zh_CN.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
         <translation>文件 &apos;%1&apos; 似乎不是有效的 Doxygen 配置文件。
 
-有效的 Doxyfile 应在第一行以 &apos;# Doxyfile&apos; 开头。</translation>
+有效的 Doxyfile 应包含格式为 &apos;TAGNAME = VALUE&apos; 的配置项，或以 &apos;# Doxyfile&apos; 开头。</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_zh_CN.ts
+++ b/addon/doxywizard/translations/doxywizard_zh_CN.ts
@@ -371,6 +371,26 @@ Reason given: %2</source>
         <source>Doxygen GUI frontend</source>
         <translation>Doxygen 图形界面前端</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>无效的配置文件</translation>
+    </message>
+    <message>
+        <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+        <translation>文件 &apos;%1&apos; 似乎不是有效的 Doxygen 配置文件。
+
+有效的 Doxyfile 应在第一行以 &apos;# Doxyfile&apos; 开头。</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>打开文件错误</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>无法打开文件 %1 进行读取。</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_zh_TW.ts
+++ b/addon/doxywizard/translations/doxywizard_zh_TW.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos;.</source>
         <translation>檔案 &apos;%1&apos; 似乎不是有效的 Doxygen 設定檔。
 
-有效的 Doxyfile 應包含格式為 &apos;TAGNAME = VALUE&apos; 的設定項，或以 &apos;# Doxyfile&apos; 開頭。</translation>
+有效的 Doxyfile 應包含格式為 &apos;TAGNAME = VALUE&apos; 的設定項。</translation>
     </message>
     <message>
         <source>Error opening file</source>

--- a/addon/doxywizard/translations/doxywizard_zh_TW.ts
+++ b/addon/doxywizard/translations/doxywizard_zh_TW.ts
@@ -371,6 +371,26 @@ Reason given: %2</source>
         <source>Doxygen GUI frontend</source>
         <translation>Doxygen 圖形介面前端</translation>
     </message>
+    <message>
+        <source>Invalid configuration file</source>
+        <translation>無效的設定檔</translation>
+    </message>
+    <message>
+        <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
+
+A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+        <translation>檔案 &apos;%1&apos; 似乎不是有效的 Doxygen 設定檔。
+
+有效的 Doxyfile 應在第一行以 &apos;# Doxyfile&apos; 開頭。</translation>
+    </message>
+    <message>
+        <source>Error opening file</source>
+        <translation>開啟檔案錯誤</translation>
+    </message>
+    <message>
+        <source>Cannot open the file %1 for reading.</source>
+        <translation>無法開啟檔案 %1 進行讀取。</translation>
+    </message>
 </context>
 <context>
     <name>TranslationManager</name>

--- a/addon/doxywizard/translations/doxywizard_zh_TW.ts
+++ b/addon/doxywizard/translations/doxywizard_zh_TW.ts
@@ -378,10 +378,10 @@ Reason given: %2</source>
     <message>
         <source>The file &apos;%1&apos; does not appear to be a valid Doxygen configuration file.
 
-A valid Doxyfile should start with &apos;# Doxyfile&apos; on the first line.</source>
+A valid Doxyfile should contain configuration entries in the format &apos;TAGNAME = VALUE&apos; or start with &apos;# Doxyfile&apos;.</source>
         <translation>檔案 &apos;%1&apos; 似乎不是有效的 Doxygen 設定檔。
 
-有效的 Doxyfile 應在第一行以 &apos;# Doxyfile&apos; 開頭。</translation>
+有效的 Doxyfile 應包含格式為 &apos;TAGNAME = VALUE&apos; 的設定項，或以 &apos;# Doxyfile&apos; 開頭。</translation>
     </message>
     <message>
         <source>Error opening file</source>


### PR DESCRIPTION
When opening a file, validate that it is a valid Doxygen configuration file by checking if the first non-empty line starts with '# Doxyfile'. If not, show a warning dialog to inform the user.


- Use case-sensitive matching for '# Doxyfile' header
- Add translations for error messages in all supported languages

