### PR TITLE
Fix translation resource embedding for static Qt builds

### DIFF
--- a/addon/doxywizard/CMakeLists.txt
+++ b/addon/doxywizard/CMakeLists.txt
@@ -185,16 +185,20 @@ else()
   endif()
 endif()
 
-set(TRANSLATIONS_QRC_CONTENT "<!DOCTYPE RCC>\n<RCC version=\"1.0\">\n    <qresource prefix=\"/translations\">\n")
-foreach(qm_file ${doxywizard_QM_FILES})
-  get_filename_component(qm_name ${qm_file} NAME)
-  string(APPEND TRANSLATIONS_QRC_CONTENT "        <file>${qm_name}</file>\n")
-endforeach()
-string(APPEND TRANSLATIONS_QRC_CONTENT "    </qresource>\n</RCC>\n")
+if(doxywizard_QM_FILES)
+  set(TRANSLATIONS_QRC_CONTENT "<!DOCTYPE RCC>\n<RCC version=\"1.0\">\n    <qresource prefix=\"/translations\">\n")
+  foreach(qm_file ${doxywizard_QM_FILES})
+    get_filename_component(qm_name ${qm_file} NAME)
+    string(APPEND TRANSLATIONS_QRC_CONTENT "        <file>${qm_name}</file>\n")
+  endforeach()
+  string(APPEND TRANSLATIONS_QRC_CONTENT "    </qresource>\n</RCC>\n")
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc "${TRANSLATIONS_QRC_CONTENT}")
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc "${TRANSLATIONS_QRC_CONTENT}")
 
-qt_add_resources(doxywizard_TRANSLATION_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc)
+  qt_add_resources(doxywizard_TRANSLATION_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc)
+else()
+  set(doxywizard_TRANSLATION_RESOURCES)
+endif()
 
 add_executable(doxywizard WIN32
 config_msg.cpp

--- a/addon/doxywizard/translationmanager.cpp
+++ b/addon/doxywizard/translationmanager.cpp
@@ -301,7 +301,7 @@ QString TranslationManager::qmFilePath(const QString &langCode) const
   }
 
   QString resourcePath = QString::fromLatin1(":/translations/") + info.qmFile;
-  if (QFileInfo::exists(resourcePath))
+  if (QFile::exists(resourcePath))
   {
     return resourcePath;
   }
@@ -309,7 +309,7 @@ QString TranslationManager::qmFilePath(const QString &langCode) const
   QString appDir = QCoreApplication::applicationDirPath();
   QString qmPath = appDir + QDir::separator() + info.qmFile;
 
-  if (QFileInfo::exists(qmPath))
+  if (QFile::exists(qmPath))
   {
     return qmPath;
   }


### PR DESCRIPTION
- Changed QFileInfo::exists() to QFile::exists() in qmFilePath() to properly detect Qt resource files (QFileInfo does not work with the ':/' resource path prefix)
- Added conditional check in CMakeLists.txt to only generate translations.qrc when QM files are available
- This fixes language switching in release builds with static Qt linking

@doxygen 