### PR TITLE
issue #12116 Test suite's test tagfile fails

### DIFF
--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -346,6 +346,7 @@ class Tester:
                     data = xpopen('%s --format --noblanks --nowarning %s' % (self.args.xmllint,check_file))
                     if data:
                         # strip version
+                        data = re.sub(r'<tagfile doxygen_version="[^"]+">','<tagfile doxygen_version="" doxygen_gitid="">',data)
                         data = re.sub(r'tagfile doxygen_version="[^"]+" doxygen_gitid="[^"]+"','tagfile doxygen_version="" doxygen_gitid=""',data)
                         data = re.sub(r'xsd" version="[0-9.-]+"','xsd" version=""',data).rstrip('\n')
                     else:


### PR DESCRIPTION
In case building without git the `doxygen_gitid` is not present in the tag file though the test required it.
Added extra replacement statement