### PR TITLE
issue #12111 Requirements output for LaTeX is not good

### DIFF
--- a/src/requirement.cpp
+++ b/src/requirement.cpp
@@ -218,7 +218,7 @@ void RequirementManager::generatePage()
     doc += "</span> ";
     doc += "</td><td>";
     doc += "<div class=\"req_title\">"+req->title()+"</div>";
-    doc += "<div class=\"req_docs\">";
+    doc += "<p/><div class=\"req_docs\">";
     doc += req->doc();
     req->sortReferences();
     auto symToString = [](const Definition *sym)


### PR DESCRIPTION
`<div>` tags are only shown in HTML output, so we need a "breaking" tag in between.