### PR TITLE
Problem switching between topics in expert tab

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -282,7 +282,7 @@ void Expert::createTopics(const QDomElement &rootElem)
         QString translatedName = DoxygenWizard::translateExpertTopic(name);
         items.append(new QTreeWidgetItem((QTreeWidget*)nullptr,QStringList() << translatedName << docs));
         QWidget *widget = createTopicWidget(childElem);
-        m_topics[name] = widget;
+        m_topics[translatedName] = widget;
         m_topicStack->addWidget(widget);
       }
     }


### PR DESCRIPTION
The application returns, when clicking on one of the topics in the expert tab, the translated value, but the `m_topics` was "ordered" according to the original English texts, now the translated value is stored.