### PR TITLE
Recognize _Nullable and _Nonnull in C prototypes

### DIFF
--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -1435,6 +1435,8 @@ DB_VIS_C
       {
         m_t << "in,out";
       }
+      if (pl.isNullable()) m_t << ",null";
+      if (pl.isNonnull())  m_t << ",!null";
     }
     m_t << "</entry>";
   }

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -3325,6 +3325,29 @@ Token DocParamList::parse(const QCString &cmdName)
         context.hasParamCommand=TRUE;
       }
       parser()->checkArgumentName();
+      if (context.memberDef)
+      {
+        const ArgumentList &al = context.memberDef->isDocsForDefinition() ?
+            context.memberDef->argumentList() :
+            context.memberDef->declArgumentList();
+        for (const Argument &a : al)
+        {
+          QCString argName = context.memberDef->isDefine() ? a.type : a.name;
+          QCString stripped = argName.stripWhiteSpace();
+          if (stripped == context.token->name)
+          {
+            if (a.type.find("_Nullable") != -1) m_isNullable = true;
+            if (a.type.find("_Nonnull")  != -1) m_isNonnull  = true;
+            if (m_isNullable && m_isNonnull)
+            {
+              warn_doc_error(context.fileName,context.memberDef->getDefLine(),
+                  "parameter '{}' is marked both _Nullable and _Nonnull",
+                  context.token->name);
+            }
+            break;
+          }
+        }
+      }
     }
     else if (m_type==DocParamSect::RetVal)
     {

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -1140,6 +1140,8 @@ class DocParamList : public DocNode
     void markLast(bool b=TRUE)      { m_isLast=b; }
     bool isFirst() const            { return m_isFirst; }
     bool isLast() const             { return m_isLast; }
+    bool isNullable() const         { return m_isNullable; }
+    bool isNonnull() const          { return m_isNonnull; }
     Token parse(const QCString &cmdName);
     Token parseXml(const QCString &paramName);
 
@@ -1151,6 +1153,8 @@ class DocParamList : public DocNode
     DocParamSect::Direction m_dir = DocParamSect::Unspecified;
     bool                    m_isFirst = false;
     bool                    m_isLast = false;
+    bool                    m_isNullable = false;
+    bool                    m_isNonnull = false;
 };
 
 /** Node representing a simple list item */

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2039,6 +2039,8 @@ void HtmlDocVisitor::operator()(const DocParamList &pl)
       {
         m_t << "in,out";
       }
+      if (pl.isNullable()) m_t << ",null";
+      if (pl.isNonnull())  m_t << ",!null";
       m_t << "]";
     }
     m_t << "</td>";

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1740,6 +1740,8 @@ void LatexDocVisitor::operator()(const DocParamList &pl)
       {
         m_t << "in,out";
       }
+      if (pl.isNullable()) m_t << ",null";
+      if (pl.isNonnull())  m_t << ",!null";
       m_t << "}} ";
     }
     if (useTable) m_t << " & ";

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1518,6 +1518,8 @@ void RTFDocVisitor::operator()(const DocParamList &pl)
       {
         m_t << "in,out";
       }
+      if (pl.isNullable()) m_t << ",null";
+      if (pl.isNonnull())  m_t << ",!null";
     }
 
     if (useTable)

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -1114,6 +1114,8 @@ void XmlDocVisitor::operator()(const DocParamList &pl)
         m_t << "inout";
       }
       m_t << "\"";
+      if (pl.isNullable()) m_t << " nonnull=\"False\"";
+      if (pl.isNonnull())  m_t << " nonnull=\"True\"";
     }
     m_t << ">";
     std::visit(*this,param);


### PR DESCRIPTION
It has become common to use _Nullable and _Nonnull to indicate if a pointer argument can be or must not be NULL, see for example manual pages of GNU libc.

Extend the rendering of direction in param command to show this information if it's part of the prototype.

In the XML output, render it as "nonnull" attribute.