### PR TITLE
I've fixed some issues, such as language switching problems, translation resource problems, and more.

### DIFF
--- a/addon/doxywizard/CMakeLists.txt
+++ b/addon/doxywizard/CMakeLists.txt
@@ -170,9 +170,13 @@ else()
 endif()
 
 set(TRANSLATIONS_QRC_CONTENT "<!DOCTYPE RCC>\n<RCC version=\"1.0\">\n    <qresource prefix=\"/i18n\">\n")
-foreach(qm_file ${doxywizard_QM_FILES})
-  get_filename_component(qm_name ${qm_file} NAME)
-  string(REGEX REPLACE ".*/doxywizard_(.+)\\.qm$" "\\1" LOCALE "${qm_file}")
+set(doxywizard_QM_FILES_PATHS)
+foreach(ts_file ${DOXYWIZARD_TRANSLATION_FILES})
+  get_filename_component(ts_name ${ts_file} NAME_WE)
+  string(REGEX REPLACE "doxywizard_(.+)" "\\1" LOCALE "${ts_name}")
+  set(qm_file "${CMAKE_CURRENT_BINARY_DIR}/${ts_name}.qm")
+  list(APPEND doxywizard_QM_FILES_PATHS ${qm_file})
+  
   if (QT_TRANSLATIONS_DIR)
     if (EXISTS "${QT_TRANSLATIONS_DIR}/qtbase_${LOCALE}.qm")
       string(APPEND TRANSLATIONS_QRC_CONTENT "        <file alias=\"qtbase_${LOCALE}.qm\">${QT_TRANSLATIONS_DIR}/qtbase_${LOCALE}.qm</file>\n")
@@ -181,13 +185,17 @@ foreach(qm_file ${doxywizard_QM_FILES})
     endif()
   endif()
   string(APPEND TRANSLATIONS_QRC_CONTENT "        <file alias=\"config_${LOCALE}.xml\">${PROJECT_SOURCE_DIR}/src/i18n/config_${LOCALE}.xml</file>\n")
-  string(APPEND TRANSLATIONS_QRC_CONTENT "        <file>${qm_name}</file>\n")
+  string(APPEND TRANSLATIONS_QRC_CONTENT "        <file alias=\"${ts_name}.qm\">${qm_file}</file>\n")
 endforeach()
 string(APPEND TRANSLATIONS_QRC_CONTENT "    </qresource>\n</RCC>\n")
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc "${TRANSLATIONS_QRC_CONTENT}")
 
 qt_add_resources(doxywizard_TRANSLATION_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc)
+
+if(doxywizard_QM_FILES_PATHS)
+  set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc PROPERTIES OBJECT_DEPENDS "${doxywizard_QM_FILES_PATHS}")
+endif()
 qt_add_resources(doxywizard_RESOURCES_RCC doxywizard.qrc)
 
 add_executable(doxywizard WIN32

--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -61,6 +61,11 @@ const int messageTimeout = 5000; //!< status bar message timeout in milliseconds
 // check if a translation for langCode is stored as resource
 static bool isLanguageCodeSupported(const QString &langCode)
 {
+  // English is the default language, always supported
+  if (langCode == QString::fromLatin1("en"))
+  {
+    return true;
+  }
   QDir resourceDir(QString::fromLatin1(":/i18n"));
   QFileInfoList fileList = resourceDir.entryInfoList();
   foreach (QFileInfo fileInfo, fileList)
@@ -480,8 +485,8 @@ void MainWindow::switchLanguage()
     qDebug() << "selected language" << langCode;
     if (langCode!=DoxygenWizard::langCode)
     {
-      QSettings settings(QString::fromLatin1("Doxygen.org"), QString::fromLatin1("Doxywizard"));
-      m_settings.setValue(QString::fromLatin1("language/code"), languageDialog.selectedLocale());
+      m_settings.setValue(QString::fromLatin1("language/code"), langCode);
+      m_settings.sync();
       quit();
     }
   }

--- a/addon/doxywizard/i18n/doxywizard_de.ts
+++ b/addon/doxywizard/i18n/doxywizard_de.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>Formeln einbinden</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>Beschreibung</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>

--- a/addon/doxywizard/i18n/doxywizard_es.ts
+++ b/addon/doxywizard/i18n/doxywizard_es.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>Inclusión de fórmulas</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>Descripción</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>

--- a/addon/doxywizard/i18n/doxywizard_fr.ts
+++ b/addon/doxywizard/i18n/doxywizard_fr.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>Inclusion de formules</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>Description</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>

--- a/addon/doxywizard/i18n/doxywizard_ja.ts
+++ b/addon/doxywizard/i18n/doxywizard_ja.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>数式の含め方</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>説明</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>

--- a/addon/doxywizard/i18n/doxywizard_ko.ts
+++ b/addon/doxywizard/i18n/doxywizard_ko.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>수식 포함</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>설명</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>

--- a/addon/doxywizard/i18n/doxywizard_ru.ts
+++ b/addon/doxywizard/i18n/doxywizard_ru.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>Включение формул</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>

--- a/addon/doxywizard/i18n/doxywizard_zh_CN.ts
+++ b/addon/doxywizard/i18n/doxywizard_zh_CN.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>包含公式</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>描述</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>

--- a/addon/doxywizard/i18n/doxywizard_zh_TW.ts
+++ b/addon/doxywizard/i18n/doxywizard_zh_TW.ts
@@ -89,6 +89,10 @@
         <source>Including formulas</source>
         <translation>包含公式</translation>
     </message>
+    <message>
+        <source>Description</source>
+        <translation>描述</translation>
+    </message>
 </context>
 <context>
     <name>HelpLabel</name>


### PR DESCRIPTION
@doxygen 
CMakeLists.txt fixes:
- Use DOXYWIZARD_TRANSLATION_FILES to compute .qm file paths at configure time
  instead of relying on qt_add_translation output variable which may be empty
- Add OBJECT_DEPENDS property to ensure .qm files are generated before resource compilation
- Use full paths in .qrc file for reliable resource embedding

doxywizard.cpp fixes:
- Add support for English language code 'en' in isLanguageCodeSupported()
  (English is the default language and has no doxywizard_en.qm file)
- Fix switchLanguage() to properly save language setting with sync() call
- Remove redundant local QSettings variable