### PR TITLE
Fix nondeterministic input ordering of duplicate basenames

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -11140,7 +11140,7 @@ static void readDir(FileInfo *fi,
           FileName *fn=nullptr;
           if (!name.empty())
           {
-            fn = fnMap->add(name,fullName);
+            fn = fnMap->add(name);
             fn->push_back(std::move(fd));
           }
         }
@@ -11228,7 +11228,7 @@ void readFileOrDirectory(const QCString &s,
             auto fd = createFileDef(dirPath+"/",name);
             if (!name.empty())
             {
-              FileName *fn = fnMap->add(name,filePath);
+              FileName *fn = fnMap->add(name);
               fn->push_back(std::move(fd));
             }
           }
@@ -12424,12 +12424,6 @@ void searchInputFiles()
   }
 
   // Sort the FileDef objects by full path to get a predictable ordering over multiple runs
-  std::stable_sort(Doxygen::inputNameLinkedMap->begin(),
-            Doxygen::inputNameLinkedMap->end(),
-            [](const auto &f1,const auto &f2)
-            {
-              return  qstricmp_sort(f1->fullName(),f2->fullName())<0;
-            });
   for (auto &fileName : *Doxygen::inputNameLinkedMap)
   {
     if (fileName->size()>1)
@@ -12440,6 +12434,12 @@ void searchInputFiles()
         });
     }
   }
+  std::stable_sort(Doxygen::inputNameLinkedMap->begin(),
+            Doxygen::inputNameLinkedMap->end(),
+            [](const auto &f1,const auto &f2)
+            {
+              return qstricmp_sort(f1->front()->absFilePath(),f2->front()->absFilePath())<0;
+            });
   if (Doxygen::inputNameLinkedMap->empty())
   {
     warn_uncond("No files to be processed, please check your settings, in particular INPUT, FILE_PATTERNS, and RECURSIVE\n");

--- a/src/filename.h
+++ b/src/filename.h
@@ -29,15 +29,11 @@ class FileDef;
 class FileName : public std::vector< std::unique_ptr<FileDef> >
 {
   public:
-    FileName(const QCString &nm,const QCString &fn) : m_name(nm), m_fName(fn), m_pathName("tmp") {}
+    explicit FileName(const QCString &nm) : m_name(nm) {}
     QCString fileName() const { return m_name; }
-    QCString fullName() const { return m_fName; }
-    QCString path() const { return m_pathName; }
 
   private:
     QCString m_name;
-    QCString m_fName;
-    QCString m_pathName;
 };
 
 //! Custom combined key compare and hash functor that uses a lower case string in

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -1676,7 +1676,7 @@ void TagFileParser::buildLists(const std::shared_ptr<Entry> &root)
       }
       else
       {
-        mn = Doxygen::inputNameLinkedMap->add(tfi->name,fullName);
+        mn = Doxygen::inputNameLinkedMap->add(tfi->name);
         mn->push_back(std::move(fd));
       }
       buildMemberList(fe,tfi->members);


### PR DESCRIPTION
inputNameLinkedMap is a LinkedMap containing list of file definitions indexed by their basenames. The first time we encounter a basename, we create a new list and store the path to that file in fullName, and fullName is not updated again. The problem is this path depends on filesystem ordering (we use the path we happen to hit first).

Later on we sort the inputs list using fullName but since fullName itself is nondeterministic this doesn't always produce the same result.

Fix this by sorting each basename list first, then sorting using the path of the first file in each list. Afterwards, remove FileName::fullName and FileName::path which are no longer used anywhere.

-----

This was found while investigating a reproducibility issue with the SFML docs, and it solves my issue. I also found #8584 which this might fix as well but I'm not sure.