### PR TITLE
issue #12140 Concatenating pages with same name behaves different in V.1.15 and 1.17

### DIFF
--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -1416,7 +1416,7 @@ void DocParser::handleIFile(char cmdChar,const QCString &cmdName)
       cmdChar,cmdName);
     return;
   }
-  tokenizer.setStateFile();
+  tokenizer.setStateIFile();
   tok=tokenizer.lex();
   tokenizer.setStatePara();
   if (!tok.is(TokenRetval::TK_WORD))
@@ -1426,7 +1426,6 @@ void DocParser::handleIFile(char cmdChar,const QCString &cmdName)
     return;
   }
   context.fileName = context.token->name;
-  tokenizer.setStatePara();
 }
 
 void DocParser::handleILine(char cmdChar,const QCString &cmdName)
@@ -1434,13 +1433,13 @@ void DocParser::handleILine(char cmdChar,const QCString &cmdName)
   AUTO_TRACE();
   tokenizer.setStateILine();
   Token tok = tokenizer.lex();
+  tokenizer.setStatePara();
   if (!tok.is(TokenRetval::TK_WORD))
   {
     warn_doc_error(context.fileName,tokenizer.getLineNr(),"invalid argument for command '{:c}{}'",
       cmdChar,cmdName);
     return;
   }
-  tokenizer.setStatePara();
 }
 
 /* Helper function that deals with the most common tokens allowed in

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -1380,13 +1380,17 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          return Token::make_TK_NONE();
                        }
 <St_IFile>{BLANK}*{FILEMASK} {
-                         yyextra->fileName = QCString(yytext).stripWhiteSpace();
+                         QCString text(yytext);
+                         text = text.stripWhiteSpace();
+                         yyextra->fileName = text;
+                         yyextra->token.name = text;
                          return Token::make_TK_WORD();
                        }
 <St_IFile>{BLANK}*"\""[^\n\"]+"\"" {
                          QCString text(yytext);
                          text = text.stripWhiteSpace();
                          yyextra->fileName = text.mid(1,text.length()-2);
+                         yyextra->token.name = text.mid(1,text.length()-2);
                          return Token::make_TK_WORD();
                        }
 <St_File>{FILEMASK}    {


### PR DESCRIPTION
- wrong state was called and also reset on wrong place / double reset
- wrong variable was used to to handle filename