### PR TITLE
fix: HTML docs for files starting with a digit

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -575,6 +575,8 @@ static QCString convertFileId2Var(const QCString &fileId)
   QCString varId = fileId;
   int i=varId.findRev('/');
   if (i>=0) varId = varId.mid(i+1);
+  if (isdigit(varId[0])) varId.prepend("_");
+
   return substitute(varId,"-","_");
 }
 

--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -62,6 +62,11 @@ void SearchTerm::makeTitle()
 QCString SearchTerm::termEncoded() const
 {
   TextStream t;
+  if (word.length() && (isdigit(word.at(0)) || !isIdJS(word.at(0))))
+  {
+    t << '_'; // ensure result starts with character valid for identifier
+  }
+
   for (size_t i=0;i<word.length();i++)
   {
     if (isIdJS(word.at(i)))

--- a/templates/html/navtree.js
+++ b/templates/html/navtree.js
@@ -123,7 +123,9 @@ function initNavTree(toroot,relpath,allMembersFile) {
     const i = varName.lastIndexOf('/');
     const n = i>=0 ? varName.substring(i+1) : varName;
     const e = n.replace(/-/g,'_');
-    return window[e];
+    const r = (e[0] >= '0' && e[0] <= '9') ? '_' + e : e;
+
+    return window[r];
   }
 
   const stripPath = (uri) => uri.substring(uri.lastIndexOf('/')+1);


### PR DESCRIPTION
Prepend an underscore to JavaScript variable names if a file starts with a digit.