### PR TITLE
Incorrect formatting of "language" with `EXTENSION_MAPPING`

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -670,7 +670,7 @@ Go to the <a href="commands.html">next</a> section or return to the
  Doxygen selects the parser to use depending on the extension of the files it parses.
  With this tag you can assign which parser to use for a given extension.
  Doxygen has a built-in mapping, but you can override or extend it using this tag.
- The format is <code>ext=language</code>, where \c ext is a file extension, and language is one of
+ The format is `ext=language`, where `ext` is a file extension, and `language` is one of
  the parsers supported by Doxygen: IDL, Java, JavaScript, Csharp (C#), C, C++, Lex, D, PHP,
  md (Markdown), Objective-C, Python, Slice, VHDL, Fortran (fixed format Fortran: FortranFixed,
  free formatted Fortran: FortranFree, unknown formatted Fortran: Fortran. In


### PR DESCRIPTION
During work on translations for the doxywizard the word `language` was also translated, this should not be the case it is here just meant as a placeholder and as such should be between backticks