### PR TITLE
issue #12148 HTML output generated from C-project contains invalid JavaScript if a source file starts with a number.

### DIFF
--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -62,10 +62,6 @@ void SearchTerm::makeTitle()
 QCString SearchTerm::termEncoded() const
 {
   TextStream t;
-  if (word.length() && (isdigit(word.at(0)) || !isIdJS(word.at(0))))
-  {
-    t << '_'; // ensure result starts with character valid for identifier
-  }
 
   for (size_t i=0;i<word.length();i++)
   {


### PR DESCRIPTION
In the PR #12149 a regression was introduce, it was not possible anymore to search for files that started with a number as also in the search terms (`term_encoding`) a `_` was added.