### PR TITLE
issue #12155 Link names to internal anchors in a md file are duplicated in HTML page when including the md in a doxygen page

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1640,6 +1640,7 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
     }
     else if ((lp=link.find('#'))!=-1 || link.find('/')!=-1 || link.find('.')!=-1)
     { // file/url link
+      bool isRef = false;
       if (lp==0 || (lp>0 && !isURL(link) && Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB))
       {
         out+="@ref \"";
@@ -1647,6 +1648,7 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
         out+="\" \"";
         out+=substitute(content.simplifyWhiteSpace(),"\"","&quot;");
         out+="\"";
+        isRef = true;
       }
       else
       {
@@ -1680,11 +1682,14 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
           foundNameRef = true;
         }
       }
-      if (!foundNameRef)
+      if (!isRef)
       {
-        processInline(std::string_view(content.str()));
+        if (!foundNameRef)
+        {
+          processInline(std::string_view(content.str()));
+        }
+        out+="</a>";
       }
-      out+="</a>";
     }
     else // avoid link to e.g. F[x](y)
     {


### PR DESCRIPTION
Due to #7339 the text of the linked text was double mentioned (and also a `</a>` was added that shouldn't be there, had no effect as doxygen filters it out)