### PR TITLE
Incorrect handling of just a backslash in doxygen documentation / doxywizard

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -567,6 +567,7 @@ QString Expert::getDocsForNode(const QDomElement &child) const
   // remove <br> at end
   regexp.setPattern(SA("<br> *$"));
   docs.replace(regexp,SA(" "));
+  docs.replace(SA("(\\c \\\\)"),SA("(\\c JUST_WIZARD_BACKSLASH)"));
   // \c word -> <code>word</code>; word ends with ')', ',', '.' or ' '
   regexp.setPattern(SA("\\\\c[ ]+([^ \\)]+)\\)"));
   docs.replace(regexp,SA("<code>\\1</code>)"));
@@ -652,6 +653,7 @@ QString Expert::getDocsForNode(const QDomElement &child) const
   docs.replace(SA("-#"),SA("<br>-"));
   docs.replace(SA("\\# "),SA("# "));
   docs.replace(SA(" - "),SA("<br>-"));
+  docs.replace(SA("JUST_WIZARD_BACKSLASH"),SA("\\"));
 
   return docs.trimmed();
 }

--- a/doc/custcmd.dox
+++ b/doc/custcmd.dox
@@ -46,7 +46,7 @@ insert a newline as if a physical newline was in the original file.
 
 Note when you need a literal `{` or `}` or `,` (or non default separator)
 in the value part of an alias you have to
-escape it by means of a backslash (`\`), this can lead to conflicts with the
+escape it by means of a backslash (\c \\), this can lead to conflicts with the
 commands \c \\{ and \c \\} for these it is advised to use the version \c @@{ and \c @@} or
 use a double escape (\c \\\\{ and \c \\\\})
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -596,7 +596,7 @@ Go to the <a href="commands.html">next</a> section or return to the
       <docs doxyfile='0' documentation='0'>
 <![CDATA[
  When you need a literal `{` or `}` or `,` in the value part of an alias you have to
- escape them by means of a backslash, this can lead to conflicts with the
+ escape them by means of a backslash (\c \\), this can lead to conflicts with the
  commands \c \\{ and \c \\} for these it is advised to use the version \c @{ and \c @} or
  use a double escape (\c \\\\{ and \c \\\\})
 ]]>
@@ -612,7 +612,7 @@ Go to the <a href="commands.html">next</a> section or return to the
       <docs doxyfile='0' doxywizard='0'>
 <![CDATA[
  When you need a literal `{` or `}` or `,` in the value part of an alias you have to
- escape them by means of a backslash (`\`), this can lead to conflicts with the
+ escape them by means of a backslash (\c \\), this can lead to conflicts with the
  commands \c \\{ and \c \\} for these it is advised to use the version \c @@{ and \c @@} or
  use a double escape (\c \\\\{ and \c \\\\})
 ]]>
@@ -3095,7 +3095,7 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
       <docs>
 <![CDATA[
  The \c LATEX_MAKEINDEX_CMD tag can be used to specify the command name to
- generate index for \f$\mbox{\LaTeX}\f$. In case there is no backslash (`\`) as first character it
+ generate index for \f$\mbox{\LaTeX}\f$. In case there is no backslash (\c \\) as first character it
  will be automatically added in the \f$\mbox{\LaTeX}\f$ code.
 
  @note This tag is used in the generated output file (`.tex`).


### PR DESCRIPTION
The showing of just a backslash in the different output parts of the doxygen documentation, Doxyfile and doxywizard was incorrect (e.g. `(\\endiskip),` )