### PR TITLE
Remove, debug, dump of qrc file.

### DIFF
--- a/addon/doxywizard/CMakeLists.txt
+++ b/addon/doxywizard/CMakeLists.txt
@@ -190,7 +190,7 @@ if(Qt${QT_VERSION_MAJOR}LinguistTools_FOUND)
   endforeach()
   string(APPEND TRANSLATIONS_QRC_CONTENT "    </qresource>\n</RCC>\n")
 
-  message(STATUS "i18n.qrc:\n${TRANSLATIONS_QRC_CONTENT}")
+  # message(STATUS "i18n.qrc:\n${TRANSLATIONS_QRC_CONTENT}")
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc "${TRANSLATIONS_QRC_CONTENT}")
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc PROPERTIES OBJECT_DEPENDS "${doxywizard_QM_FILES_PATHS}")
   qt_add_resources(doxywizard_TRANSLATION_RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/i18n.qrc)


### PR DESCRIPTION
The dump of the qrc file might be useful during debugging but not in daily use.