### PR TITLE
Obsolete / not to translate sentences

### DIFF
--- a/addon/doxywizard/i18n/doxywizard_de.ts
+++ b/addon/doxywizard/i18n/doxywizard_de.ts
@@ -74,26 +74,6 @@
         <translation>Siehe auch:</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Doxygen-Verwendung</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>Externe Indizierung und Suche</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>Verknüpfung mit externer Dokumentation</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>Formeln einbinden</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>Beschreibung</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>Einstellungen suchen...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_es.ts
+++ b/addon/doxywizard/i18n/doxywizard_es.ts
@@ -74,26 +74,6 @@
         <translation>Ver también:</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Uso de Doxygen</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>Indexación y búsqueda externa</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>Enlace a documentación externa</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>Inclusión de fórmulas</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>Descripción</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>Buscar ajustes...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_fr.ts
+++ b/addon/doxywizard/i18n/doxywizard_fr.ts
@@ -74,26 +74,6 @@
         <translation>Voir aussi :</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Utilisation de Doxygen</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>Indexation et recherche externes</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>Lien vers la documentation externe</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>Inclusion de formules</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>Description</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>Rechercher les paramètres...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_ja.ts
+++ b/addon/doxywizard/i18n/doxywizard_ja.ts
@@ -74,26 +74,6 @@
         <translation>参照:</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Doxygenの使用方法</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>外部インデックス作成と検索</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>外部ドキュメントへのリンク</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>数式の含め方</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>説明</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>設定を検索...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_ko.ts
+++ b/addon/doxywizard/i18n/doxywizard_ko.ts
@@ -74,26 +74,6 @@
         <translation>참조:</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Doxygen 사용법</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>외부 인덱싱 및 검색</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>외부 문서 연결</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>수식 포함</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>설명</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>설정 검색...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_ru.ts
+++ b/addon/doxywizard/i18n/doxywizard_ru.ts
@@ -74,26 +74,6 @@
         <translation>См. также:</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Использование Doxygen</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>Внешнее индексирование и поиск</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>Ссылка на внешнюю документацию</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>Включение формул</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>Описание</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>Поиск настроек...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_zh_CN.ts
+++ b/addon/doxywizard/i18n/doxywizard_zh_CN.ts
@@ -74,26 +74,6 @@
         <translation>另请参阅：</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Doxygen 用法</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>外部索引和搜索</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>链接到外部文档</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>包含公式</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>搜索设置...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_zh_TW.ts
+++ b/addon/doxywizard/i18n/doxywizard_zh_TW.ts
@@ -74,26 +74,6 @@
         <translation>另請參閱：</translation>
     </message>
     <message>
-        <source>Doxygen usage</source>
-        <translation>Doxygen 用法</translation>
-    </message>
-    <message>
-        <source>External Indexing and Searching</source>
-        <translation>外部索引和搜尋</translation>
-    </message>
-    <message>
-        <source>Linking to external documentation</source>
-        <translation>連結到外部文件</translation>
-    </message>
-    <message>
-        <source>Including formulas</source>
-        <translation>包含公式</translation>
-    </message>
-    <message>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
         <source>Search settings...</source>
         <translation>搜尋設定...</translation>
     </message>


### PR DESCRIPTION
- The following are chapter titles in the documentation and should not be translated (unless in future there are translations of the manual)
  - Doxygen usage
  - External Indexing and Searching
  - Linking to external documentation
  - Including formulas
- The following is a non used translation
  - Description