### PR TITLE
Consistency in documentation panel of doxywizard

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -516,7 +516,13 @@ void Expert::createOptionCard(GroupEntry &group, const QDomElement &child)
     docsLabel->setOpenExternalLinks(true);
     docsLabel->setContentsMargins(0, 2, 0, 4);
     // Use a smaller, muted style for the description text
-    docsLabel->setText(SMALL_FONT_START + docs + SMALL_FONT_END);
+    QString display = SMALL_FONT_START + SA("<b>") + id + SA("</b>");
+    if (!docs.isEmpty())
+    {
+      display += SA(" &mdash; ") + docs;
+    }
+    display += SMALL_FONT_END;
+    docsLabel->setText(display);
     // Dim the label using PlaceholderText, which is calibrated for readable
     // secondary text in both light and dark modes (available since Qt 5.12).
     QColor textColor = docsLabel->palette().color(QPalette::Text);
@@ -1138,7 +1144,14 @@ void Expert::filterChanged(const QString &text)
         }
         if (opt.docsLabel && opt.labelHighlighted)
         {
-          opt.docsLabel->setText(SMALL_FONT_START + opt.docs + SMALL_FONT_END);
+          QString display = SMALL_FONT_START + SA("<b>") + opt.id + SA("</b>");
+          if (!opt.docs.isEmpty())
+          {
+            display += SA(" &mdash; ") + opt.docs;
+          }
+          display += SMALL_FONT_END;
+          opt.docsLabel->setText(display);
+          opt.input->setText(opt.id);
           opt.labelHighlighted = false;
         }
       }
@@ -1177,6 +1190,7 @@ void Expert::filterChanged(const QString &text)
         {
           QString hiDocs = matchesDocs ? highlightInHtml(opt.docs, filter) : opt.docs;
           QString hiId   = matchesId   ? highlightInHtml(opt.id,   filter) : opt.id;
+          opt.input->setText(hiId);
           QString display = SMALL_FONT_START + SA("<b>") + hiId + SA("</b>");
           if (!opt.docs.isEmpty())
           {

--- a/addon/doxywizard/input.h
+++ b/addon/doxywizard/input.h
@@ -44,6 +44,7 @@ class Input
     virtual bool isDefault() = 0;
     virtual void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert) = 0;
     virtual void setTemplateDocs(const QString &docs) = 0;
+    virtual void setText(const QString &txt) = 0;
     virtual bool isEmpty() { return false; };
 };
 

--- a/addon/doxywizard/inputbool.h
+++ b/addon/doxywizard/inputbool.h
@@ -15,10 +15,10 @@
 
 #include "input.h"
 #include <QObject>
+#include <QLabel>
 
 class QCheckBox;
 class QGridLayout;
-class QLabel;
 
 class InputBool : public QObject, public Input
 {
@@ -41,6 +41,7 @@ class InputBool : public QObject, public Input
     bool isDefault();
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
+    void setText(const QString &txt) { m_lab->setText(txt); }
     static bool convertToBool(const QVariant &v,bool &isValid);
 
   public slots:

--- a/addon/doxywizard/inputint.h
+++ b/addon/doxywizard/inputint.h
@@ -15,9 +15,9 @@
 
 #include "input.h"
 #include <QObject>
+#include <QLabel>
 
 class QGridLayout;
-class QLabel;
 class QSpinBox;
 
 class InputInt : public QObject, public Input
@@ -44,6 +44,7 @@ class InputInt : public QObject, public Input
     bool isDefault();
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
+    void setText(const QString &txt) { m_lab->setText(txt); }
 
   public slots:
     void reset();

--- a/addon/doxywizard/inputobsolete.h
+++ b/addon/doxywizard/inputobsolete.h
@@ -32,6 +32,7 @@ class InputObsolete : public Input
     bool isDefault()             { return false; }
     void writeValue(QTextStream &,TextCodecAdapter *,bool) {}
     void setTemplateDocs(const QString &) {}
+    void setText(const QString &txt) {}
     bool isEmpty()               { return false; };
     Kind orgKind() const         { return m_orgKind; }
   private:

--- a/addon/doxywizard/inputstring.h
+++ b/addon/doxywizard/inputstring.h
@@ -18,8 +18,8 @@
 #include <QObject>
 #include <QMap>
 #include <QStringList>
+#include <QLabel>
 
-class QLabel;
 class QLineEdit;
 class QToolBar;
 class QComboBox;
@@ -62,6 +62,7 @@ class InputString : public QObject, public Input
     bool isDefault();
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
+    void setText(const QString &txt) { m_lab->setText(txt); }
     bool isEmpty() { return m_str.isEmpty(); }
     QString checkEnumVal(const QString &value);
 

--- a/addon/doxywizard/inputstrlist.h
+++ b/addon/doxywizard/inputstrlist.h
@@ -17,8 +17,8 @@
 
 #include <QObject>
 #include <QStringList>
+#include <QLabel>
 
-class QLabel;
 class QLineEdit;
 class QPushButton;
 class QListWidget;
@@ -53,6 +53,7 @@ class InputStrList : public QObject, public Input
     bool isDefault();
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
+    void setText(const QString &txt) { m_lab->setText(txt); }
     bool isEmpty();
 
   public slots:


### PR DESCRIPTION
Make the documentation panel of the doxywizard more consistent:
- repeat field name (and corresponding mdash) in all cases
- highlight field name before the input field when text is part of search text.