### PR TITLE
Incorrect handling of `\exception` command in markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -642,7 +642,7 @@ size_t Markdown::Private::isSpecialCommand(std::string_view data,size_t offset)
     { "emoji",          endOfLabel },
     { "enum",           endOfLabel },
     { "example",        endOfLine  },
-    { "exception",      endOfLine  },
+    { "exception",      endOfLabel },
     { "extends",        endOfLabel },
     { "file",           endOfLine  },
     { "fn",             endOfFunc  },


### PR DESCRIPTION
When having a construction like:
```
\exception docu backtick plain `std::runtime_error`
```
this is properly rendered in doxygen 1.9.1, though with doxygen 1.9.6 and the current doxygen version (1.17.0) we see that the backticks are still present  (and the content is not properly rendered. With doxygen 1.9.6 we even get a warning like:
```
warning: explicit link request to 'runtime_error' could not be resolved
```

The handling of the `\exception` command was incorrect (now analogous to the `\throw` command.

Found by the CGAL package
Example: [example.tar.gz](https://github.com/user-attachments/files/28052230/example.tar.gz)

