### PR TITLE
Possibility to blend out documentation in doxywizard

### DIFF
--- a/addon/doxywizard/doxywizard.cpp
+++ b/addon/doxywizard/doxywizard.cpp
@@ -51,6 +51,7 @@
 
 // globally accessible variables
 bool DoxygenWizard::debugFlag = false;
+bool DoxygenWizard::hideDocumentation = false;
 QString DoxygenWizard::langCode;
 static QList<QString> newArgs;
 
@@ -148,6 +149,10 @@ MainWindow::MainWindow()
                   this,SLOT(resetToDefaults()));
   settings->addAction(tr("Use current settings at startup"),
                   this,SLOT(makeDefaults()));
+  m_hideDocumentation = settings->addAction(tr("Hide documentation"),
+                  this,SLOT(hideDocumentation()));
+  m_hideDocumentation->setCheckable(true);
+  m_hideDocumentation->setChecked(DoxygenWizard::hideDocumentation);
   settings->addAction(tr("Switch language..."),
                   this,SLOT(switchLanguage()));
   m_clearRecent = settings->addAction(tr("Clear recent list"),
@@ -454,6 +459,15 @@ void MainWindow::makeDefaults()
     m_settings.setValue(QString::fromLatin1("wizard/loadsettings"), true);
     m_settings.sync();
   }
+}
+
+void MainWindow::hideDocumentation()
+{
+  // New state
+  DoxygenWizard::hideDocumentation = m_hideDocumentation->isChecked();
+  m_settings.setValue(QString::fromLatin1("documentation/hide"), DoxygenWizard::hideDocumentation);
+  m_settings.sync();
+  m_expert-> hideDocumentation();
 }
 
 void MainWindow::switchLanguage()
@@ -1040,6 +1054,9 @@ int main(int argc,char **argv)
 
   {
     qDebug() << "Starting doxywizard...";
+
+    QSettings settings(QString::fromLatin1("Doxygen.org"), QString::fromLatin1("Doxywizard"));
+    DoxygenWizard::hideDocumentation = settings.value(QString::fromLatin1("documentation/hide")).toBool();
 
     if (langSet)
     {

--- a/addon/doxywizard/doxywizard.h
+++ b/addon/doxywizard/doxywizard.h
@@ -64,6 +64,7 @@ class MainWindow : public QMainWindow
     void selectTab(int);
     void quit();
     void switchLanguage();
+    void hideDocumentation();
 
   private slots:
     void openRecent(QAction *action);
@@ -106,6 +107,7 @@ class MainWindow : public QMainWindow
     QWidget *m_runTab;
     QString m_fileName;
     QSettings m_settings;
+    QAction *m_hideDocumentation;
     QMenu *m_recentMenu;
     QStringList m_recentFiles;
     QAction *m_resetDefault;
@@ -121,6 +123,7 @@ class MainWindow : public QMainWindow
 namespace DoxygenWizard
 {
   extern bool    debugFlag;
+  extern bool    hideDocumentation;
   extern QString langCode;
   QString msgFileNotFound(const QString &fileName);
   QString msgNoPreviewAvailable(const QString &fileName);

--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -570,6 +570,7 @@ void Expert::createOptionCard(GroupEntry &group, const QDomElement &child)
   entry.docs      = docs;
   entry.card      = container;
   entry.docsLabel = docsLabel;
+  entry.sep       = sep;
   entry.treeItem  = optTreeItem;
   entry.input     = input;
   group.options.append(entry);
@@ -642,6 +643,23 @@ void Expert::ensureGroupCardsCreated(GroupEntry &group)
     }
   }
 }
+void Expert::hideDocumentation()
+{
+  for (GroupEntry &group : m_groups)
+  {
+    for (const OptionEntry &opt : group.options)
+    {
+      if (opt.sep)
+      {
+        opt.sep->setHidden(DoxygenWizard::hideDocumentation);
+      }
+      if (opt.docsLabel)
+      {
+        opt.docsLabel->setHidden(DoxygenWizard::hideDocumentation);
+      }
+    }
+  }
+}
 
 // Create cards for every group that hasn't been created yet, then do a full
 // dependency update (needed when cross-group deps span newly-created groups).
@@ -651,6 +669,7 @@ void Expert::ensureAllGroupsCreated()
   {
     ensureGroupCardsCreated(group);
   }
+  hideDocumentation();
 
   // Re-run update so cross-group dependencies are fully applied
   QHashIterator<QString,Input*> i(m_options);

--- a/addon/doxywizard/expert.h
+++ b/addon/doxywizard/expert.h
@@ -61,6 +61,7 @@ class Expert : public QWidget, public DocIntf
 
   public slots:
     void refresh();
+    void hideDocumentation();
 
   private slots:
     void filterChanged(const QString &text);
@@ -81,6 +82,7 @@ class Expert : public QWidget, public DocIntf
       QString           docs;
       QWidget          *card;             ///< card widget (docs label + control holder)
       QLabel           *docsLabel;        ///< docs label inside the card
+      QFrame           *sep;              ///< separator settings inside the card
       QTreeWidgetItem  *treeItem;         ///< child item in the left tree (nullptr when showAll)
       Input            *input;            ///< the Input object
       bool              labelHighlighted = false; ///< true when docsLabel shows highlighted text

--- a/addon/doxywizard/i18n/doxywizard_de.ts
+++ b/addon/doxywizard/i18n/doxywizard_de.ts
@@ -360,6 +360,10 @@ Angegebener Grund: %2</translation>
         <translation>Sprache geändert zu: %1</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>Dokumentation ausblenden</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>Sprache wechseln...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_es.ts
+++ b/addon/doxywizard/i18n/doxywizard_es.ts
@@ -360,6 +360,10 @@ Razón dada: %2</translation>
         <translation>Interfaz gráfica de Doxygen</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>Ocultar documentación</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>Cambiar idioma...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_fr.ts
+++ b/addon/doxywizard/i18n/doxywizard_fr.ts
@@ -360,6 +360,10 @@ Raison donnée : %2</translation>
         <translation>Langue changée en : %1</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>Masquer la documentation</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>Changer de langue...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_ja.ts
+++ b/addon/doxywizard/i18n/doxywizard_ja.ts
@@ -360,6 +360,10 @@ Reason given: %2</source>
         <translation>Doxygen GUIフロントエンド</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>ドキュメントを非表示にする</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>言語を切り替える...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_ko.ts
+++ b/addon/doxywizard/i18n/doxywizard_ko.ts
@@ -360,6 +360,10 @@ Reason given: %2</source>
         <translation>Doxygen GUI 프론트엔드</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>문서 숨기기</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>언어 전환...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_ru.ts
+++ b/addon/doxywizard/i18n/doxywizard_ru.ts
@@ -360,6 +360,10 @@ Reason given: %2</source>
         <translation>Графический интерфейс Doxygen</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>Скрыть документацию</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>Сменить язык...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_zh_CN.ts
+++ b/addon/doxywizard/i18n/doxywizard_zh_CN.ts
@@ -360,6 +360,10 @@ Reason given: %2</source>
         <translation>Doxygen 图形界面前端</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>隐藏文档</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>切换语言...</translation>
     </message>

--- a/addon/doxywizard/i18n/doxywizard_zh_TW.ts
+++ b/addon/doxywizard/i18n/doxywizard_zh_TW.ts
@@ -360,6 +360,10 @@ Reason given: %2</source>
         <translation>Doxygen 圖形介面前端</translation>
     </message>
     <message>
+        <source>Hide documentation</source>
+        <translation>隱藏文檔</translation>
+    </message>
+    <message>
         <source>Switch language...</source>
         <translation>切換語言...</translation>
     </message>


### PR DESCRIPTION
Create the possibility to blend out the documentation in the righthand panel of the doxywizard so it is clearer where the different settings are.