### PR TITLE
Create tooltips in case documentation is hidden

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -661,6 +661,18 @@ void Expert::setDocumentationVisibility(bool hidden)
       if (opt.docsLabel)
       {
         opt.docsLabel->setHidden(hidden);
+        // only enable tooltips when documentation is hidden
+        if (opt.input)
+        {
+          if (hidden)
+          {
+            opt.input->setToolTip(SA("<qt>") + opt.docsLabel->text() + SA("</qt>"));
+          }
+          else
+          {
+            opt.input->setToolTip(SA(""));
+          }
+        }
       }
     }
   }
@@ -1223,6 +1235,8 @@ void Expert::filterChanged(const QString &text)
     m_rightContainer->setUpdatesEnabled(true);
     m_treeWidget->setUpdatesEnabled(true);
   }
+  bool hidden = QSettings(QString::fromLatin1("Doxygen.org"), QString::fromLatin1("Doxywizard")).value(QString::fromLatin1("documentation/hide")).toBool();
+  setDocumentationVisibility(hidden);
 }
 
 void Expert::groupSelected(QTreeWidgetItem *item, QTreeWidgetItem *)

--- a/addon/doxywizard/input.h
+++ b/addon/doxywizard/input.h
@@ -45,6 +45,7 @@ class Input
     virtual void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert) = 0;
     virtual void setTemplateDocs(const QString &docs) = 0;
     virtual void setText(const QString &txt) = 0;
+    virtual void setToolTip(const QString &txt) = 0;
     virtual bool isEmpty() { return false; };
 };
 

--- a/addon/doxywizard/inputbool.h
+++ b/addon/doxywizard/inputbool.h
@@ -42,6 +42,7 @@ class InputBool : public QObject, public Input
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     void setText(const QString &txt) { m_lab->setText(txt); }
+    void setToolTip(const QString &txt) { m_lab->setToolTip(txt); }
     static bool convertToBool(const QVariant &v,bool &isValid);
 
   public slots:

--- a/addon/doxywizard/inputint.h
+++ b/addon/doxywizard/inputint.h
@@ -45,6 +45,7 @@ class InputInt : public QObject, public Input
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     void setText(const QString &txt) { m_lab->setText(txt); }
+    void setToolTip(const QString &txt) { m_lab->setToolTip(txt); }
 
   public slots:
     void reset();

--- a/addon/doxywizard/inputobsolete.h
+++ b/addon/doxywizard/inputobsolete.h
@@ -33,6 +33,7 @@ class InputObsolete : public Input
     void writeValue(QTextStream &,TextCodecAdapter *,bool) {}
     void setTemplateDocs(const QString &) {}
     void setText(const QString &txt) {}
+    void setToolTip(const QString &txt) {}
     bool isEmpty()               { return false; };
     Kind orgKind() const         { return m_orgKind; }
   private:

--- a/addon/doxywizard/inputstring.h
+++ b/addon/doxywizard/inputstring.h
@@ -63,6 +63,7 @@ class InputString : public QObject, public Input
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     void setText(const QString &txt) { m_lab->setText(txt); }
+    void setToolTip(const QString &txt) { m_lab->setToolTip(txt); }
     bool isEmpty() { return m_str.isEmpty(); }
     QString checkEnumVal(const QString &value);
 

--- a/addon/doxywizard/inputstrlist.h
+++ b/addon/doxywizard/inputstrlist.h
@@ -54,6 +54,7 @@ class InputStrList : public QObject, public Input
     void writeValue(QTextStream &t,TextCodecAdapter *codec,bool convert);
     void setTemplateDocs(const QString &docs) { m_tdocs = docs; }
     void setText(const QString &txt) { m_lab->setText(txt); }
+    void setToolTip(const QString &txt) { m_lab->setToolTip(txt); }
     bool isEmpty();
 
   public slots:


### PR DESCRIPTION
In PR #12173 the possibility was created to to hide the documentation of the different fields, the disadvantage is (from review):
> The problem I see with this change is that if one searches for something, the matches in the documentation are not visible when the documentation is hidden.

by adding a tooltip in case the documentation is hidden this problem can be overcome.