### PR TITLE
Add tooltip to group names

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -379,6 +379,7 @@ void Expert::createGroups(const QDomElement &rootElem)
 
         // Tree widget item for this group
         group.treeItem = new QTreeWidgetItem(m_treeWidget, QStringList() << translatedName);
+        group.treeItem->setToolTip(0,SA("<qt>") + group.docs + SA("</qt>"));
 
         group.section->hide();
         m_rightLayout->addWidget(group.section);


### PR DESCRIPTION
In the left side panel of the doxywizard the groups are named with their "mnemonics", a bit larger description is shown in the right side panel, but these names are not always visible. Adding a tooltip  to the items in the left side panel overcomes this deficiency.