### PR TITLE
Error due to insufficient internal buffer size

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -1493,7 +1493,14 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                           yyextra->insideComment=FALSE;
                                         }
   */
-<DefineText>{CCS}[!*]?                  {
+<DefineText>{CCS}[^!*]                  {
+                                          yyextra->defLitText+=' ';
+                                          outputArray(yyscanner,yytext,yyleng);
+                                          yyextra->lastCContext=YY_START;
+                                          yyextra->commentCount=1;
+                                          BEGIN(SkipCComment);
+                                        }
+<DefineText>{CCS}[!*]                   {
                                           yyextra->defText+=yytext;
                                           yyextra->defLitText+=yytext;
                                           yyextra->lastCContext=YY_START;


### PR DESCRIPTION
When having a source file with a lot of `#define` with normal C-style comments like:

```
#define c_function_symbol(F)           T_Sym(c_function_data(F)->sam.c_sym)        /* f is c_function or c_macro, but not c_function* -- doesn't fit current checks */
```

There is a chance of getting an error like:
```
input buffer overflow, can't enlarge buffer because scanner uses REJECT
    lexical analyzer: .../doxygen/src/pre.l (for: .../s7.c)
```

this type of comment is of no interest to the `#define` / doxygen and should not be copied into the "define" buffer.

Example: [example.tar.gz](https://github.com/user-attachments/files/28228890/example.tar.gz)

(Found by Fossies for the snd-26.4 package, workaround would be enlarging all buffers).
