### PR TITLE
Small corrections doxywizard generator translations

### DIFF
--- a/src/i18n/config_de.xml
+++ b/src/i18n/config_de.xml
@@ -1826,7 +1826,7 @@
   </group>
   <generator>
     <message name="minmaxdef"><![CDATA[Mindestwert: {0}, Höchstwert: {1}, Standardwert: {2}.]]></message>
-    <message name="minmaxdefcode"><![CDATA[ Mindestwert: <code></code>{0}, Höchstwert: <code>{1}</code>, Standardwert: <code>{2}</code>, ]]></message>
+    <message name="minmaxdefcode"><![CDATA[ Mindestwert: <code>{0}</code>, Höchstwert: <code>{1}</code>, Standardwert: <code>{2}</code>, ]]></message>
     <message name="possible"><![CDATA[Mögliche Werte sind: ]]></message>
     <message name="defvaltxt"><![CDATA[Der Standardwert ist: {0}.]]></message>
     <message name="defvalcode"><![CDATA[Der Standardwert ist: <code>{0}</code>.]]></message>

--- a/src/i18n/config_es.xml
+++ b/src/i18n/config_es.xml
@@ -1826,23 +1826,23 @@
     </option>
   </group>
   <generator>
-    <message name='andtxt'><![CDATA[y]]></message>
     <message name='minmaxdef'><![CDATA[Valor mínimo: {0}, valor máximo: {1}, valor predeterminado: {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[Valor mínimo: <code>{0}</code>, valor máximo: <code>{1}</code>, valor predeterminado: <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[Los valores posibles son:]]></message>
     <message name='defvaltxt'><![CDATA[El valor predeterminado es: {0}.]]></message>
-    <message name='defvalcode'><![CDATA[El valor predeterminado es: <code&>{0}</code&>.]]></message>
+    <message name='defvalcode'><![CDATA[El valor predeterminado es: <code>{0}</code>.]]></message>
     <message name='defsysdep'><![CDATA[El valor predeterminado es: dependiente del sistema.]]></message>
     <message name='sysdep'><![CDATA[dependiente del sistema]]></message>
-    <message name='defdir'><![CDATA[El directorio predeterminado es: <code&>{0}</code&>.]]></message>
-    <message name='deffile'><![CDATA[El archivo predeterminado es: <code&>{0}</code&>.]]></message>
-    <message name='deffileabs'><![CDATA[El archivo predeterminado (con ruta absoluta) es: <code&>{0}</code&>.]]></message>
+    <message name='defdir'><![CDATA[El directorio predeterminado es: <code>{0}</code>.]]></message>
+    <message name='deffile'><![CDATA[El archivo predeterminado es: <code>{0}</code>.]]></message>
+    <message name='deffileabs'><![CDATA[El archivo predeterminado (con ruta absoluta) es: <code>{0}</code>.]]></message>
     <message name='deffilefull'><![CDATA[El archivo debe especificarse con la ruta completa.]]></message>
-    <message name='defimg'><![CDATA[La imagen predeterminada es: <code&>{0}</code&>.]]></message>
-    <message name='defimgabs'><![CDATA[La imagen predeterminada (con ruta absoluta) es: <code&>{0}</code&>.]]></message>
+    <message name='defimg'><![CDATA[La imagen predeterminada es: <code>{0}</code>.]]></message>
+    <message name='defimgabs'><![CDATA[La imagen predeterminada (con ruta absoluta) es: <code>{0}</code>.]]></message>
     <message name='defimgfull'><![CDATA[La imagen debe especificarse con la ruta completa.]]></message>
-    <message name='depstxt'><![CDATA[Esta etiqueta requiere que la etiqueta {0} esté establecida en <code&>YES</code&>.]]></message>
-    <message name='depstxtref'><![CDATA[Esta etiqueta requiere que la etiqueta \ref cfg_{0} "{1}" esté establecida en <code&>YES</code&>.]]></message>
+    <message name='depstxt'><![CDATA[Esta etiqueta requiere que la etiqueta {0} esté establecida en <code>YES</code>.]]></message>
+    <message name='depstxtref'><![CDATA[Esta etiqueta requiere que la etiqueta \ref cfg_{0} "{1}" esté establecida en <code>YES</code>.]]></message>
+    <message name='andtxt'><![CDATA[y]]></message>
     <message name='notetxt'><![CDATA[Nota:]]></message>
     <message name='seealsotxt'><![CDATA[Ver también:]]></message>
   </generator>

--- a/src/i18n/config_fr.xml
+++ b/src/i18n/config_fr.xml
@@ -1825,23 +1825,23 @@
     </option>
   </group>
   <generator>
-    <message name='andtxt'><![CDATA[et]]></message>
     <message name='minmaxdef'><![CDATA[Valeur minimum : {0}, valeur maximum : {1}, valeur par défaut : {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[Valeur minimum : <code>{0}</code>, valeur maximum : <code>{1}</code>, valeur par défaut : <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[Les valeurs possibles sont :]]></message>
     <message name='defvaltxt'><![CDATA[La valeur par défaut est : {0}.]]></message>
-    <message name='defvalcode'><![CDATA[La valeur par défaut est : <code&>{0}</code&>.]]></message>
+    <message name='defvalcode'><![CDATA[La valeur par défaut est : <code>{0}</code>.]]></message>
     <message name='defsysdep'><![CDATA[La valeur par défaut dépend du système.]]></message>
     <message name='sysdep'><![CDATA[dépend du système]]></message>
-    <message name='defdir'><![CDATA[Le répertoire par défaut est : <code&>{0}</code&>.]]></message>
-    <message name='deffile'><![CDATA[Le fichier par défaut est : <code&>{0}</code&>.]]></message>
-    <message name='deffileabs'><![CDATA[Le fichier par défaut (avec chemin absolu) est : <code&>{0}</code&>.]]></message>
+    <message name='defdir'><![CDATA[Le répertoire par défaut est : <code>{0}</code>.]]></message>
+    <message name='deffile'><![CDATA[Le fichier par défaut est : <code>{0}</code>.]]></message>
+    <message name='deffileabs'><![CDATA[Le fichier par défaut (avec chemin absolu) est : <code>{0}</code>.]]></message>
     <message name='deffilefull'><![CDATA[Le fichier doit être spécifié avec un chemin complet.]]></message>
-    <message name='defimg'><![CDATA[L'image par défaut est : <code&>{0}</code&>.]]></message>
-    <message name='defimgabs'><![CDATA[L'image par défaut (avec chemin absolu) est : <code&>{0}</code&>.]]></message>
+    <message name='defimg'><![CDATA[L'image par défaut est : <code>{0}</code>.]]></message>
+    <message name='defimgabs'><![CDATA[L'image par défaut (avec chemin absolu) est : <code>{0}</code>.]]></message>
     <message name='defimgfull'><![CDATA[L'image doit être spécifiée avec un chemin complet.]]></message>
-    <message name='depstxt'><![CDATA[Cette balise nécessite que la balise {0} soit définie sur <code&>YES</code&>.]]></message>
-    <message name='depstxtref'><![CDATA[Cette balise nécessite que la balise \ref cfg_{0} "{1}" soit définie sur <code&>YES</code&>.]]></message>
+    <message name='depstxt'><![CDATA[Cette balise nécessite que la balise {0} soit définie sur <code>YES</code>.]]></message>
+    <message name='depstxtref'><![CDATA[Cette balise nécessite que la balise \ref cfg_{0} "{1}" soit définie sur <code>YES</code>.]]></message>
+    <message name='andtxt'><![CDATA[et]]></message>
     <message name='notetxt'><![CDATA[Note :]]></message>
     <message name='seealsotxt'><![CDATA[Voir aussi :]]></message>
   </generator>

--- a/src/i18n/config_ja.xml
+++ b/src/i18n/config_ja.xml
@@ -1824,23 +1824,23 @@
     </option>
   </group>
   <generator>
-    <message name='andtxt'><![CDATA[と]]></message>
     <message name='minmaxdef'><![CDATA[最小値: {0}, 最大値: {1}, デフォルト値: {2}。]]></message>
     <message name='minmaxdefcode'><![CDATA[最小値: <code>{0}</code>, 最大値: <code>{1}</code>, デフォルト値: <code>{2}</code>。]]></message>
     <message name='possible'><![CDATA[可能な値は:]]></message>
     <message name='defvaltxt'><![CDATA[デフォルト値は {0} です。]]></message>
-    <message name='defvalcode'><![CDATA[デフォルト値は <code&>{0}</code&> です。]]></message>
+    <message name='defvalcode'><![CDATA[デフォルト値は <code>{0}</code> です。]]></message>
     <message name='defsysdep'><![CDATA[デフォルト値はシステム依存です。]]></message>
     <message name='sysdep'><![CDATA[システム依存で]]></message>
-    <message name='defdir'><![CDATA[デフォルトのディレクトリは <code&>{0}</code&> です。]]></message>
-    <message name='deffile'><![CDATA[デフォルトのファイルは <code&>{0}</code&> です。]]></message>
-    <message name='deffileabs'><![CDATA[デフォルトのファイル（絶対パス）は <code&>{0}</code&> です。]]></message>
+    <message name='defdir'><![CDATA[デフォルトのディレクトリは <code>{0}</code> です。]]></message>
+    <message name='deffile'><![CDATA[デフォルトのファイルは <code>{0}</code> です。]]></message>
+    <message name='deffileabs'><![CDATA[デフォルトのファイル（絶対パス）は <code>{0}</code> です。]]></message>
     <message name='deffilefull'><![CDATA[ファイルは完全パスで指定する必要があります。]]></message>
-    <message name='defimg'><![CDATA[デフォルトの画像は <code&>{0}</code&> です。]]></message>
-    <message name='defimgabs'><![CDATA[デフォルトの画像（絶対パス）は <code&>{0}</code&> です。]]></message>
+    <message name='defimg'><![CDATA[デフォルトの画像は <code>{0}</code> です。]]></message>
+    <message name='defimgabs'><![CDATA[デフォルトの画像（絶対パス）は <code>{0}</code> です。]]></message>
     <message name='defimgfull'><![CDATA[画像は完全パスで指定する必要があります。]]></message>
-    <message name='depstxt'><![CDATA[このタグはタグ {0} を <code&>YES</code&> に設定する必要があります。]]></message>
-    <message name='depstxtref'><![CDATA[このタグはタグ \ref cfg_{0} "{1}" を <code&>YES</code&> に設定する必要があります。]]></message>
+    <message name='depstxt'><![CDATA[このタグはタグ {0} を <code>YES</code> に設定する必要があります。]]></message>
+    <message name='depstxtref'><![CDATA[このタグはタグ \ref cfg_{0} "{1}" を <code>YES</code> に設定する必要があります。]]></message>
+    <message name='andtxt'><![CDATA[と]]></message>
     <message name='notetxt'><![CDATA[注:]]></message>
     <message name='seealsotxt'><![CDATA[参照:]]></message>
   </generator>

--- a/src/i18n/config_ko.xml
+++ b/src/i18n/config_ko.xml
@@ -1823,23 +1823,23 @@
     </option>
   </group>
   <generator>
-    <message name='andtxt'><![CDATA[그리고]]></message>
     <message name='minmaxdef'><![CDATA[최소값: {0}, 최대값: {1}, 기본값: {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[최소값: <code>{0}</code>, 최대값: <code>{1}</code>, 기본값: <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[가능한 값:]]></message>
     <message name='defvaltxt'><![CDATA[기본값은 {0}입니다.]]></message>
-    <message name='defvalcode'><![CDATA[기본값은 <code&>{0}</code&>입니다.]]></message>
+    <message name='defvalcode'><![CDATA[기본값은 <code>{0}</code>입니다.]]></message>
     <message name='defsysdep'><![CDATA[기본값은 시스템에 따라 다릅니다.]]></message>
     <message name='sysdep'><![CDATA[시스템 종속적]]></message>
-    <message name='defdir'><![CDATA[기본 디렉토리는 <code&>{0}</code&>입니다.]]></message>
-    <message name='deffile'><![CDATA[기본 파일은 <code&>{0}</code&>입니다.]]></message>
-    <message name='deffileabs'><![CDATA[기본 파일(절대 경로)은 <code&>{0}</code&>입니다.]]></message>
+    <message name='defdir'><![CDATA[기본 디렉토리는 <code>{0}</code>입니다.]]></message>
+    <message name='deffile'><![CDATA[기본 파일은 <code>{0}</code>입니다.]]></message>
+    <message name='deffileabs'><![CDATA[기본 파일(절대 경로)은 <code>{0}</code>입니다.]]></message>
     <message name='deffilefull'><![CDATA[파일은 전체 경로로 지정해야 합니다.]]></message>
-    <message name='defimg'><![CDATA[기본 이미지는 <code&>{0}</code&>입니다.]]></message>
-    <message name='defimgabs'><![CDATA[기본 이미지(절대 경로)는 <code&>{0}</code&>입니다.]]></message>
+    <message name='defimg'><![CDATA[기본 이미지는 <code>{0}</code>입니다.]]></message>
+    <message name='defimgabs'><![CDATA[기본 이미지(절대 경로)는 <code>{0}</code>입니다.]]></message>
     <message name='defimgfull'><![CDATA[이미지는 전체 경로로 지정해야 합니다.]]></message>
-    <message name='depstxt'><![CDATA[이 태그는 태그 {0}을 <code&>YES</code&>로 설정해야 합니다.]]></message>
-    <message name='depstxtref'><![CDATA[이 태그는 태그 \ref cfg_{0} "{1}"을 <code&>YES</code&>로 설정해야 합니다.]]></message>
+    <message name='depstxt'><![CDATA[이 태그는 태그 {0}을 <code>YES</code>로 설정해야 합니다.]]></message>
+    <message name='depstxtref'><![CDATA[이 태그는 태그 \ref cfg_{0} "{1}"을 <code>YES</code>로 설정해야 합니다.]]></message>
+    <message name='andtxt'><![CDATA[그리고]]></message>
     <message name='notetxt'><![CDATA[참고:]]></message>
     <message name='seealsotxt'><![CDATA[참조:]]></message>
   </generator>

--- a/src/i18n/config_ru.xml
+++ b/src/i18n/config_ru.xml
@@ -229,7 +229,7 @@
     </option>
     <option type="list" id="EXTENSION_MAPPING" format="string">
       <docs>
-<![CDATA[Doxygen выбирает парсер для использования на основе расширения анализируемого файла. С этим тегом вы можете назначить парсер для использования с данным расширением. Doxygen имеет встроенное сопоставление, но вы можете переопределить или расширить его с помощью этого тега. Формат: `ext=language`, где `ext` — расширение файла, а `language` — один из парсеров, поддерживаемых Doxygen: IDL, Java, JavaScript, Csharp (C#), C, C++, Lex, D, PHP, md (Markdown), Objective-C, Python, Slice, VHDL, Fortran (Fortran с фиксированным форматом: FortranFixed, Fortran со свободным форматом: FortranFree, Fortran с неизвестным форматом: Fortran. В последнем случае парсер попытается угадать, является ли код фиксированным или свободным форматом, что является значением по умолчанию для файлов типа Fortran). Например, чтобы Doxygen обрабатывал файлы &lt;code&gt;.inc&lt;/code&gt; как файлы Fortran (по умолчанию PHP), а файлы &lt;code&gt;.f&lt;/code&gt; как файлы C (по умолчанию Fortran), используйте: `inc=Fortran f=C`. &lt;br&gt;Примечание: Для файлов без расширения вы можете использовать `no_extension` как заполнитель. &lt;br&gt;Обратите внимание, что для пользовательских расширений вам также нужно установить \ref cfg_file_patterns "FILE_PATTERNS", иначе Doxygen не будет читать эти файлы. Когда указан `no_extension`, вы должны добавить `*` в \ref cfg_file_patterns "FILE_PATTERNS". &lt;br&gt;Примечание, см. также список \ref default_file_extension_mapping "сопоставления расширений файлов по умолчанию".]]>
+<![CDATA[Doxygen выбирает парсер для использования на основе расширения анализируемого файла. С этим тегом вы можете назначить парсер для использования с данным расширением. Doxygen имеет встроенное сопоставление, но вы можете переопределить или расширить его с помощью этого тега. Формат: `ext=language`, где `ext` — расширение файла, а `language` — один из парсеров, поддерживаемых Doxygen: IDL, Java, JavaScript, Csharp (C#), C, C++, Lex, D, PHP, md (Markdown), Objective-C, Python, Slice, VHDL, Fortran (Fortran с фиксированным форматом: FortranFixed, Fortran со свободным форматом: FortranFree, Fortran с неизвестным форматом: Fortran. В последнем случае парсер попытается угадать, является ли код фиксированным или свободным форматом, что является значением по умолчанию для файлов типа Fortran). Например, чтобы Doxygen обрабатывал файлы &lt;codegt;.inc&lt;/codegt; как файлы Fortran (по умолчанию PHP), а файлы &lt;codegt;.f&lt;/codegt; как файлы C (по умолчанию Fortran), используйте: `inc=Fortran f=C`. &lt;br&gt;Примечание: Для файлов без расширения вы можете использовать `no_extension` как заполнитель. &lt;br&gt;Обратите внимание, что для пользовательских расширений вам также нужно установить \ref cfg_file_patterns "FILE_PATTERNS", иначе Doxygen не будет читать эти файлы. Когда указан `no_extension`, вы должны добавить `*` в \ref cfg_file_patterns "FILE_PATTERNS". &lt;br&gt;Примечание, см. также список \ref default_file_extension_mapping "сопоставления расширений файлов по умолчанию".]]>
       </docs>
     </option>
     <option type="bool" id="MARKDOWN_SUPPORT" defval="1">
@@ -311,7 +311,7 @@
     </option>
     <option type="bool" id="TYPEDEF_HIDES_STRUCT" defval="0">
       <docs>
-<![CDATA[Когда тег \c TYPEDEF_HIDES_STRUCT включен, typedef для структуры, объединения или перечисления будет документирован как структура, объединение или перечисление с именем typedef. Таким образом, &lt;code&gt;typedef struct TypeS {} TypeT&lt;/code&gt; будет отображаться в документации как структура с именем \c TypeT. Когда отключено, typedef будет отображаться как член файла, пространства имен или класса. Структура будет называться \c TypeS. Это обычно полезно для кода C, если соглашение о кодировании требует, чтобы все составные типы были typedef, и на typedef ссылаются только по имени, никогда по имени тега.]]>
+<![CDATA[Когда тег \c TYPEDEF_HIDES_STRUCT включен, typedef для структуры, объединения или перечисления будет документирован как структура, объединение или перечисление с именем typedef. Таким образом, &lt;codegt;typedef struct TypeS {} TypeT&lt;/codegt; будет отображаться в документации как структура с именем \c TypeT. Когда отключено, typedef будет отображаться как член файла, пространства имен или класса. Структура будет называться \c TypeS. Это обычно полезно для кода C, если соглашение о кодировании требует, чтобы все составные типы были typedef, и на typedef ссылаются только по имени, никогда по имени тега.]]>
       </docs>
     </option>
     <option type="int" id="LOOKUP_CACHE_SIZE" minval="0" maxval="9" defval="0">
@@ -545,7 +545,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[Тег \c FILE_VERSION_FILTER можно использовать для указания программы или скрипта, который Doxygen должен вызвать для получения текущей версии каждого файла (обычно из системы контроля версий). Doxygen вызовет программу, выполнив (через &lt;code&gt;popen()&lt;/code&gt;) команду &lt;code&gt;command input-file&lt;/code&gt;, где \c command — значение тега \c FILE_VERSION_FILTER, а \c input-file — имя входного файла, предоставленного Doxygen. Все, что программа выведет в стандартный вывод, будет использовано как версия файла.]]>
+<![CDATA[Тег \c FILE_VERSION_FILTER можно использовать для указания программы или скрипта, который Doxygen должен вызвать для получения текущей версии каждого файла (обычно из системы контроля версий). Doxygen вызовет программу, выполнив (через &lt;codegt;popen()&lt;/codegt;) команду &lt;codegt;command input-file&lt;/codegt;, где \c command — значение тега \c FILE_VERSION_FILTER, а \c input-file — имя входного файла, предоставленного Doxygen. Все, что программа выведет в стандартный вывод, будет использовано как версия файла.]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -555,7 +555,7 @@
     </option>
     <option type="list" id="CITE_BIB_FILES" format="file">
       <docs>
-<![CDATA[Тег \c CITE_BIB_FILES можно использовать для указания одного или нескольких файлов \c bib, содержащих определения ссылок. Это должен быть список файлов &lt;code&gt;.bib&lt;/code&gt;. Расширение &lt;code&gt;.bib&lt;/code&gt; будет добавлено автоматически, если опущено. Это требует, чтобы инструмент \c bibtex был установлен. См. также https://en.wikipedia.org/wiki/BibTeX для дополнительной информации. Для \f$\mbox{\LaTeX}\f$ стиль ссылок может контролироваться с помощью \ref cfg_latex_bib_style "LATEX_BIB_STYLE". Чтобы использовать эту функцию, вам нужно иметь \c bibtex и \c perl доступными в пути поиска. См. также \ref cmdcite "\cite" для информации о создании цитат.]]>
+<![CDATA[Тег \c CITE_BIB_FILES можно использовать для указания одного или нескольких файлов \c bib, содержащих определения ссылок. Это должен быть список файлов &lt;codegt;.bib&lt;/codegt;. Расширение &lt;codegt;.bib&lt;/codegt; будет добавлено автоматически, если опущено. Это требует, чтобы инструмент \c bibtex был установлен. См. также https://en.wikipedia.org/wiki/BibTeX для дополнительной информации. Для \f$\mbox{\LaTeX}\f$ стиль ссылок может контролироваться с помощью \ref cfg_latex_bib_style "LATEX_BIB_STYLE". Чтобы использовать эту функцию, вам нужно иметь \c bibtex и \c perl доступными в пути поиска. См. также \ref cmdcite "\cite" для информации о создании цитат.]]>
       </docs>
     </option>
     <option type="list" id="EXTERNAL_TOOL_PATH" format="dir" defval="">
@@ -2397,23 +2397,23 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
     </option>
   </group>
   <generator>
-    <message name='andtxt'><![CDATA[и]]></message>
     <message name='minmaxdef'><![CDATA[Минимальное значение: {0}, максимальное значение: {1}, значение по умолчанию: {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[Минимальное значение: <code>{0}</code>, максимальное значение: <code>{1}</code>, значение по умолчанию: <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[Возможные значения:]]></message>
     <message name='defvaltxt'><![CDATA[Значение по умолчанию: {0}.]]></message>
-    <message name='defvalcode'><![CDATA[Значение по умолчанию: <code&>{0}</code&>.]]></message>
+    <message name='defvalcode'><![CDATA[Значение по умолчанию: <code>{0}</code>.]]></message>
     <message name='defsysdep'><![CDATA[Значение по умолчанию зависит от системы.]]></message>
     <message name='sysdep'><![CDATA[зависит от системы]]></message>
-    <message name='defdir'><![CDATA[Каталог по умолчанию: <code&>{0}</code&>.]]></message>
-    <message name='deffile'><![CDATA[Файл по умолчанию: <code&>{0}</code&>.]]></message>
-    <message name='deffileabs'><![CDATA[Файл по умолчанию (с абсолютным путём): <code&>{0}</code&>.]]></message>
+    <message name='defdir'><![CDATA[Каталог по умолчанию: <code>{0}</code>.]]></message>
+    <message name='deffile'><![CDATA[Файл по умолчанию: <code>{0}</code>.]]></message>
+    <message name='deffileabs'><![CDATA[Файл по умолчанию (с абсолютным путём): <code>{0}</code>.]]></message>
     <message name='deffilefull'><![CDATA[Файл должен быть указан с полным путём.]]></message>
-    <message name='defimg'><![CDATA[Изображение по умолчанию: <code&>{0}</code&>.]]></message>
-    <message name='defimgabs'><![CDATA[Изображение по умолчанию (с абсолютным путём): <code&>{0}</code&>.]]></message>
+    <message name='defimg'><![CDATA[Изображение по умолчанию: <code>{0}</code>.]]></message>
+    <message name='defimgabs'><![CDATA[Изображение по умолчанию (с абсолютным путём): <code>{0}</code>.]]></message>
     <message name='defimgfull'><![CDATA[Изображение должно быть указано с полным путём.]]></message>
-    <message name='depstxt'><![CDATA[Этот тег требует, чтобы тег {0} был установлен в <code&>YES</code&>.]]></message>
-    <message name='depstxtref'><![CDATA[Этот тег требует, чтобы тег \ref cfg_{0} "{1}" был установлен в <code&>YES</code&>.]]></message>
+    <message name='depstxt'><![CDATA[Этот тег требует, чтобы тег {0} был установлен в <code>YES</code>.]]></message>
+    <message name='depstxtref'><![CDATA[Этот тег требует, чтобы тег \ref cfg_{0} "{1}" был установлен в <code>YES</code>.]]></message>
+    <message name='andtxt'><![CDATA[и]]></message>
     <message name='notetxt'><![CDATA[Примечание:]]></message>
     <message name='seealsotxt'><![CDATA[См. также:]]></message>
   </generator>

--- a/src/i18n/config_zh_CN.xml
+++ b/src/i18n/config_zh_CN.xml
@@ -1821,23 +1821,23 @@
     </option>
   </group>
   <generator>
-    <message name='andtxt'><![CDATA[和]]></message>
     <message name='minmaxdef'><![CDATA[最小值：{0}，最大值：{1}，默认值：{2}。]]></message>
     <message name='minmaxdefcode'><![CDATA[最小值：<code>{0}</code>，最大值：<code>{1}</code>，默认值：<code>{2}</code>。]]></message>
     <message name='possible'><![CDATA[可能的值有：]]></message>
     <message name='defvaltxt'><![CDATA[默认值为：{0}。]]></message>
-    <message name='defvalcode'><![CDATA[默认值为：<code&>{0}</code&>。]]></message>
+    <message name='defvalcode'><![CDATA[默认值为：<code>{0}</code>。]]></message>
     <message name='defsysdep'><![CDATA[默认值：取决于系统。]]></message>
     <message name='sysdep'><![CDATA[系统相关取]]></message>
-    <message name='defdir'><![CDATA[默认目录为：<code&>{0}</code&>。]]></message>
-    <message name='deffile'><![CDATA[默认文件为：<code&>{0}</code&>。]]></message>
-    <message name='deffileabs'><![CDATA[默认文件（带绝对路径）为：<code&>{0}</code&>。]]></message>
+    <message name='defdir'><![CDATA[默认目录为：<code>{0}</code>。]]></message>
+    <message name='deffile'><![CDATA[默认文件为：<code>{0}</code>。]]></message>
+    <message name='deffileabs'><![CDATA[默认文件（带绝对路径）为：<code>{0}</code>。]]></message>
     <message name='deffilefull'><![CDATA[文件必须使用完整路径指定。]]></message>
-    <message name='defimg'><![CDATA[默认图像为：<code&>{0}</code&>。]]></message>
-    <message name='defimgabs'><![CDATA[默认图像（带绝对路径）为：<code&>{0}</code&>。]]></message>
+    <message name='defimg'><![CDATA[默认图像为：<code>{0}</code>。]]></message>
+    <message name='defimgabs'><![CDATA[默认图像（带绝对路径）为：<code>{0}</code>。]]></message>
     <message name='defimgfull'><![CDATA[图像必须使用完整路径指定。]]></message>
-    <message name='depstxt'><![CDATA[此标签要求标签 {0} 设置为 <code&>YES</code&>。]]></message>
-    <message name='depstxtref'><![CDATA[此标签要求标签 \ref cfg_{0} "{1}" 设置为 <code&>YES</code&>。]]></message>
+    <message name='depstxt'><![CDATA[此标签要求标签 {0} 设置为 <code>YES</code>。]]></message>
+    <message name='depstxtref'><![CDATA[此标签要求标签 \ref cfg_{0} "{1}" 设置为 <code>YES</code>。]]></message>
+    <message name='andtxt'><![CDATA[和]]></message>
     <message name='notetxt'><![CDATA[注意：]]></message>
     <message name='seealsotxt'><![CDATA[另请参阅：]]></message>
   </generator>

--- a/src/i18n/config_zh_TW.xml
+++ b/src/i18n/config_zh_TW.xml
@@ -1821,23 +1821,23 @@
     </option>
   </group>
   <generator>
-    <message name='andtxt'><![CDATA[和]]></message>
     <message name='minmaxdef'><![CDATA[最小值：{0}，最大值：{1}，預設值：{2}。]]></message>
     <message name='minmaxdefcode'><![CDATA[最小值：<code>{0}</code>，最大值：<code>{1}</code>，預設值：<code>{2}</code>。]]></message>
     <message name='possible'><![CDATA[可能的值有：]]></message>
     <message name='defvaltxt'><![CDATA[預設值為：{0}。]]></message>
-    <message name='defvalcode'><![CDATA[預設值為：<code&>{0}</code&>。]]></message>
+    <message name='defvalcode'><![CDATA[預設值為：<code>{0}</code>。]]></message>
     <message name='defsysdep'><![CDATA[預設值：取決於系統。]]></message>
     <message name='sysdep'><![CDATA[預系統相關]]></message>
-    <message name='defdir'><![CDATA[預設目錄為：<code&>{0}</code&>。]]></message>
-    <message name='deffile'><![CDATA[預設檔案為：<code&>{0}</code&>。]]></message>
-    <message name='deffileabs'><![CDATA[預設檔案（帶絕對路徑）為：<code&>{0}</code&>。]]></message>
+    <message name='defdir'><![CDATA[預設目錄為：<code>{0}</code>。]]></message>
+    <message name='deffile'><![CDATA[預設檔案為：<code>{0}</code>。]]></message>
+    <message name='deffileabs'><![CDATA[預設檔案（帶絕對路徑）為：<code>{0}</code>。]]></message>
     <message name='deffilefull'><![CDATA[檔案必須使用完整路徑指定。]]></message>
-    <message name='defimg'><![CDATA[預設影像為：<code&>{0}</code&>。]]></message>
-    <message name='defimgabs'><![CDATA[預設影像（帶絕對路徑）為：<code&>{0}</code&>。]]></message>
+    <message name='defimg'><![CDATA[預設影像為：<code>{0}</code>。]]></message>
+    <message name='defimgabs'><![CDATA[預設影像（帶絕對路徑）為：<code>{0}</code>。]]></message>
     <message name='defimgfull'><![CDATA[影像必須使用完整路徑指定。]]></message>
-    <message name='depstxt'><![CDATA[此標籤要求標籤 {0} 設定為 <code&>YES</code&>。]]></message>
-    <message name='depstxtref'><![CDATA[此標籤要求標籤 \ref cfg_{0} "{1}" 設定為 <code&>YES</code&>。]]></message>
+    <message name='depstxt'><![CDATA[此標籤要求標籤 {0} 設定為 <code>YES</code>。]]></message>
+    <message name='depstxtref'><![CDATA[此標籤要求標籤 \ref cfg_{0} "{1}" 設定為 <code>YES</code>。]]></message>
+    <message name='andtxt'><![CDATA[和]]></message>
     <message name='notetxt'><![CDATA[注意：]]></message>
     <message name='seealsotxt'><![CDATA[另請參閱：]]></message>
   </generator>


### PR DESCRIPTION
Small corrections doxywizard generator translations
- correction to `<code>` tag
- order of statements
- German translation correction (`{0}` now inside code)