### PR TITLE
Remove obsolete attribute `altdefval` from configuration settings

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -856,16 +856,9 @@ QString Expert::getDocsForNode(const QDomElement &child) const
   {
     if (!docs.endsWith(SA("<br/>"))) docs += SA("<br/>");
     docs+=SA("<br/>");
-    if (child.hasAttribute(SA("altdefval")))
-    {
-      docs+=SA(" ")+m_messages[SA("defsysdep")];
-    }
-    else
-    {
-      QString defval = child.attribute(SA("defval"));
-      QString valStr = (defval==SA("1")?SA("YES"):SA("NO"));
-      docs+=SA(" ")+m_messages[SA("defvalcode")].arg(valStr);
-    }
+    QString defval = child.attribute(SA("defval"));
+    QString valStr = (defval==SA("1")?SA("YES"):SA("NO"));
+    docs+=SA(" ")+m_messages[SA("defvalcode")].arg(valStr);
   }
   else if (type==SA("list"))
   {

--- a/src/config.xml
+++ b/src/config.xml
@@ -4434,8 +4434,6 @@ This setting is not only used for dot files but also for msc temporary files.
     <message name='possible'><![CDATA[Possible values are: ]]></message>
     <message name='defvaltxt'><![CDATA[The default value is: {0}.]]></message>
     <message name='defvalcode'><![CDATA[The default value is: <code>{0}</code>.]]></message>
-    <message name='defsysdep'><![CDATA[The default value is: system dependent]]></message>
-    <message name='sysdep'><![CDATA[system dependent]]></message>
     <message name='defdir'><![CDATA[The default directory is: <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[The default file is: <code>{0}</code>.]]></message>
     <message name='deffileabs'><![CDATA[The default file (with absolute path) is <code>{0}</code>]]></message>

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -165,7 +165,6 @@ def prepCDocs(node):
     type = node.getAttribute('type')
     format = node.getAttribute('format')
     defval = node.getAttribute('defval')
-    #adefval = node.getAttribute('altdefval')
     doc = ""
     if (type != 'obsolete'):
         for n in node.childNodes:
@@ -249,7 +248,6 @@ def parseOption(node):
     type = node.getAttribute('type')
     format = node.getAttribute('format')
     defval = node.getAttribute('defval')
-    adefval = node.getAttribute('altdefval')
     depends = node.getAttribute('depends')
     setting = node.getAttribute('setting')
     orgtype = node.getAttribute('orgtype')
@@ -258,9 +256,7 @@ def parseOption(node):
         print("#if %s" % (setting))
     print("  //----")
     if type == 'bool':
-        if len(adefval) > 0:
-            enabled = adefval
-        elif defval == '1':
+        if defval == '1':
             enabled = "TRUE"
         else:
             enabled = "FALSE"
@@ -556,7 +552,6 @@ def parseOptionDoc(node, first):
     type = node.getAttribute('type')
     format = node.getAttribute('format')
     defval = node.getAttribute('defval')
-    #adefval = node.getAttribute('altdefval')
     depends = node.getAttribute('depends')
     #setting = node.getAttribute('setting')
     doc = ""

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -192,10 +192,7 @@ def prepCDocs(node):
             maxval = node.getAttribute('maxval')
             doc += "<br/>" + messages['minmaxdef'].format(minval, maxval, defval)
         elif (type == 'bool'):
-            if (node.hasAttribute('altdefval')):
-                doc += "<br/>" + messages['defvaltxt'].format(messages['sysdep'])
-            else:
-                doc += "<br/>" + messages['defvaltxt'].format("YES" if (defval == "1") else "NO")
+            doc += "<br/>" + messages['defvaltxt'].format("YES" if (defval == "1") else "NO")
         elif (type == 'list'):
             if format == 'string':
                 values = collectValues(node)
@@ -607,10 +604,7 @@ def parseOptionDoc(node, first):
         elif (type == 'bool'):
             print("")
             print("")
-            if (node.hasAttribute('altdefval')):
-                print(messages['defvaltxt'].format(messages['sysdep']))
-            else:
-                print(messages['defvalcode'].format("YES" if (defval == "1") else "NO"))
+            print(messages['defvalcode'].format("YES" if (defval == "1") else "NO"))
             print("")
         elif (type == 'list'):
             if format == 'string':

--- a/src/i18n/config_de.xml
+++ b/src/i18n/config_de.xml
@@ -1830,8 +1830,6 @@
     <message name="possible"><![CDATA[Mögliche Werte sind: ]]></message>
     <message name="defvaltxt"><![CDATA[Der Standardwert ist: {0}.]]></message>
     <message name="defvalcode"><![CDATA[Der Standardwert ist: <code>{0}</code>.]]></message>
-    <message name="defsysdep"><![CDATA[Der Standardwert ist: systemabhängig.]]></message>
-    <message name="sysdep"><![CDATA[systemabhängig]]></message>
     <message name="defdir"><![CDATA[Das Standardverzeichnis ist: <code>{0}</code>.]]></message>
     <message name="deffile"><![CDATA[Die Standarddatei ist: <code>{0}</code>.]]></message>
     <message name="deffileabs"><![CDATA[Die Standarddatei (mit absolutem Pfad) ist: <code>{0}</code>.]]></message>

--- a/src/i18n/config_es.xml
+++ b/src/i18n/config_es.xml
@@ -1831,8 +1831,6 @@
     <message name='possible'><![CDATA[Los valores posibles son:]]></message>
     <message name='defvaltxt'><![CDATA[El valor predeterminado es: {0}.]]></message>
     <message name='defvalcode'><![CDATA[El valor predeterminado es: <code>{0}</code>.]]></message>
-    <message name='defsysdep'><![CDATA[El valor predeterminado es: dependiente del sistema.]]></message>
-    <message name='sysdep'><![CDATA[dependiente del sistema]]></message>
     <message name='defdir'><![CDATA[El directorio predeterminado es: <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[El archivo predeterminado es: <code>{0}</code>.]]></message>
     <message name='deffileabs'><![CDATA[El archivo predeterminado (con ruta absoluta) es: <code>{0}</code>.]]></message>

--- a/src/i18n/config_fr.xml
+++ b/src/i18n/config_fr.xml
@@ -1830,8 +1830,6 @@
     <message name='possible'><![CDATA[Les valeurs possibles sont :]]></message>
     <message name='defvaltxt'><![CDATA[La valeur par défaut est : {0}.]]></message>
     <message name='defvalcode'><![CDATA[La valeur par défaut est : <code>{0}</code>.]]></message>
-    <message name='defsysdep'><![CDATA[La valeur par défaut dépend du système.]]></message>
-    <message name='sysdep'><![CDATA[dépend du système]]></message>
     <message name='defdir'><![CDATA[Le répertoire par défaut est : <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[Le fichier par défaut est : <code>{0}</code>.]]></message>
     <message name='deffileabs'><![CDATA[Le fichier par défaut (avec chemin absolu) est : <code>{0}</code>.]]></message>

--- a/src/i18n/config_ja.xml
+++ b/src/i18n/config_ja.xml
@@ -1829,8 +1829,6 @@
     <message name='possible'><![CDATA[可能な値は:]]></message>
     <message name='defvaltxt'><![CDATA[デフォルト値は {0} です。]]></message>
     <message name='defvalcode'><![CDATA[デフォルト値は <code>{0}</code> です。]]></message>
-    <message name='defsysdep'><![CDATA[デフォルト値はシステム依存です。]]></message>
-    <message name='sysdep'><![CDATA[システム依存で]]></message>
     <message name='defdir'><![CDATA[デフォルトのディレクトリは <code>{0}</code> です。]]></message>
     <message name='deffile'><![CDATA[デフォルトのファイルは <code>{0}</code> です。]]></message>
     <message name='deffileabs'><![CDATA[デフォルトのファイル（絶対パス）は <code>{0}</code> です。]]></message>

--- a/src/i18n/config_ko.xml
+++ b/src/i18n/config_ko.xml
@@ -1828,8 +1828,6 @@
     <message name='possible'><![CDATA[가능한 값:]]></message>
     <message name='defvaltxt'><![CDATA[기본값은 {0}입니다.]]></message>
     <message name='defvalcode'><![CDATA[기본값은 <code>{0}</code>입니다.]]></message>
-    <message name='defsysdep'><![CDATA[기본값은 시스템에 따라 다릅니다.]]></message>
-    <message name='sysdep'><![CDATA[시스템 종속적]]></message>
     <message name='defdir'><![CDATA[기본 디렉토리는 <code>{0}</code>입니다.]]></message>
     <message name='deffile'><![CDATA[기본 파일은 <code>{0}</code>입니다.]]></message>
     <message name='deffileabs'><![CDATA[기본 파일(절대 경로)은 <code>{0}</code>입니다.]]></message>

--- a/src/i18n/config_ru.xml
+++ b/src/i18n/config_ru.xml
@@ -2402,8 +2402,6 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
     <message name='possible'><![CDATA[Возможные значения:]]></message>
     <message name='defvaltxt'><![CDATA[Значение по умолчанию: {0}.]]></message>
     <message name='defvalcode'><![CDATA[Значение по умолчанию: <code>{0}</code>.]]></message>
-    <message name='defsysdep'><![CDATA[Значение по умолчанию зависит от системы.]]></message>
-    <message name='sysdep'><![CDATA[зависит от системы]]></message>
     <message name='defdir'><![CDATA[Каталог по умолчанию: <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[Файл по умолчанию: <code>{0}</code>.]]></message>
     <message name='deffileabs'><![CDATA[Файл по умолчанию (с абсолютным путём): <code>{0}</code>.]]></message>

--- a/src/i18n/config_zh_CN.xml
+++ b/src/i18n/config_zh_CN.xml
@@ -1826,8 +1826,6 @@
     <message name='possible'><![CDATA[可能的值有：]]></message>
     <message name='defvaltxt'><![CDATA[默认值为：{0}。]]></message>
     <message name='defvalcode'><![CDATA[默认值为：<code>{0}</code>。]]></message>
-    <message name='defsysdep'><![CDATA[默认值：取决于系统。]]></message>
-    <message name='sysdep'><![CDATA[系统相关取]]></message>
     <message name='defdir'><![CDATA[默认目录为：<code>{0}</code>。]]></message>
     <message name='deffile'><![CDATA[默认文件为：<code>{0}</code>。]]></message>
     <message name='deffileabs'><![CDATA[默认文件（带绝对路径）为：<code>{0}</code>。]]></message>

--- a/src/i18n/config_zh_TW.xml
+++ b/src/i18n/config_zh_TW.xml
@@ -1826,8 +1826,6 @@
     <message name='possible'><![CDATA[可能的值有：]]></message>
     <message name='defvaltxt'><![CDATA[預設值為：{0}。]]></message>
     <message name='defvalcode'><![CDATA[預設值為：<code>{0}</code>。]]></message>
-    <message name='defsysdep'><![CDATA[預設值：取決於系統。]]></message>
-    <message name='sysdep'><![CDATA[預系統相關]]></message>
     <message name='defdir'><![CDATA[預設目錄為：<code>{0}</code>。]]></message>
     <message name='deffile'><![CDATA[預設檔案為：<code>{0}</code>。]]></message>
     <message name='deffileabs'><![CDATA[預設檔案（帶絕對路徑）為：<code>{0}</code>。]]></message>


### PR DESCRIPTION
With issue #9236 (and resulting PR #9526) the possibility to have a "system dependent value" through the attribute `altdefval` has been removed from the configuration file, though in the coded references still existed as well as (now) in the translation files. The possibility has been removed completely now.