### PR TITLE
Incorrect display of images in the treeview.

### DIFF
--- a/templates/html/navtree.css
+++ b/templates/html/navtree.css
@@ -59,7 +59,6 @@
 #nav-tree .item {
   margin: 0 6px 0 -5px;
   padding: 0 0 0 5px;
-  height: 22px;
 }
 
 #nav-tree {


### PR DESCRIPTION
When having an example like:
```
# [![Vim The editor](https://github.com/vim/vim/raw/master/runtime/vimlogo.gif)](https://www.vim.org)

## sect

## sect

### sub sect

### sub sect
```
the text of the sections will be , in the treeview, left panel, mixed with the image whilst in the right panel (the local table of contents) it will be properly displayed (as it will also be properly displayed in the main window).

Example: [example.tar.gz](https://github.com/user-attachments/files/28397926/example.tar.gz)

(Found by Fossies for the Vim package).


The limiting factor here is the setting of the "height" for the image and this looks like not topo be necessary. The "height was introduced with:
```
Commit: b5d08f673469d337f956c92e2583c99a8efcdba3 [b5d08f6]

Commit Date: Wednesday, March 19, 2025 9:35:42 PM

Modernize HTML look and feel for dir/section arrows
```