### PR TITLE
Navigation tree doesn't render due to `\n` in output

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -556,6 +556,7 @@ static void generateJSLink(TextStream &t,const FTVNodePtr &n)
 {
   bool nameAsHtml = !n->nameAsHtml.isEmpty();
   QCString link = nameAsHtml ? convertToJSString(n->nameAsHtml,true) : convertToJSString(n->name);
+  link = substitute(link,"\n","");
   if (n->file.isEmpty()) // no link
   {
     t << "\"" << link << "\", null, ";


### PR DESCRIPTION
Due to a construct like:
```
---
Example:
  - -w '%{response_code}\n' $URL
---

# Section

Section

## Sub Section
subsection
```

where the GitHub construct with the `---` is always interpreted as a header. By removing the the `\n` from the navtree JavaScript output the problem is solved.

Example: [example.tar.gz](https://github.com/user-attachments/files/28502949/example.tar.gz)

(Found by Fossies for the curl package, problem looks like to be introduced in doxygen 1.14.0, most likely with:
```
Commit: 3c5255e0ad809fd86543744195df8b7a9814f785 [3c5255e]

Date: Friday, May 9, 2025 8:57:44 PM

issue #6998 Markdown: Links in ATX headings processed incorrectly?
```
)
