### PR TITLE
Incorrect display of images in the treeview(2)

### DIFF
--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -593,6 +593,10 @@ img.formulaInl, img.inline {
 	vertical-align: middle;
 }
 
+div.toc img.inline {
+        float: none;
+        vertical-align: top
+}
 div.center {
 	text-align: center;
 	margin-top: 0px;

--- a/templates/html/navtree.css
+++ b/templates/html/navtree.css
@@ -31,6 +31,7 @@
   padding:0px;
   border:0px;
   vertical-align: middle;
+  float: none;
 }
 
 #nav-tree a {
@@ -241,6 +242,10 @@ div.nav-sync-icon:hover span.sync-icon-right {
 	box-sizing: content-box;
         position: relative;
 	border-left: 1px solid var(--nav-border-color);
+}
+
+#page-nav img.inline {
+  float: none;
 }
 
 #page-nav-tree {


### PR DESCRIPTION
This is a similar problem as solved with https://github.com/doxygen/doxygen/pull/12187, but now as complicating factor to have an `align` attribute with the `img` tag. Now it does not only influence the treeview in the left panel but also the treeview in the outline panel (right)  and the the table of contents. The example is now like:
```
# Vega-Altair <a href="https://altair-viz.github.io/"><img align="right" src="https://altair-viz.github.io/_static/altair-logo-light.png" height="50"></img></a>

## sect

## sect

### sub sect

### sub sect
```

Example: [example.tar.gz](https://github.com/user-attachments/files/28661746/example.tar.gz)


(Found by Fossies for the Altair package).