### PR TITLE
Improve display of documentation in doxywizard

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -1022,18 +1022,28 @@ QString Expert::getDocsForNode(const QDomElement &child) const
   regexp.setPattern(SA("<br> *$"));
   docs.replace(regexp,SA(" "));
   docs.replace(SA("(\\c \\\\)"),SA("(\\c JUST_WIZARD_BACKSLASH)"));
-  // \c word -> <code>word</code>; word ends with ')', ',', '.' or ' '
-  regexp.setPattern(SA("\\\\c[ ]+([^ \\)]+)\\)"));
-  docs.replace(regexp,SA("<code>\\1</code>)"));
 
-  regexp.setPattern(SA("\\\\c[ ]+([^ ,]+),"));
-  docs.replace(regexp,SA("<code>\\1</code>,"));
+  regexp.setPattern(SA("\\\\c[ ]+([A-Za-z]+\\.[a-z]+\\.[a-z]+\\.[a-z]+)"));
+  docs.replace(regexp,SA("<code>\\1</code>"));
 
-  regexp.setPattern(SA("\\\\c[ ]+([^ \\.]+)\\."));
-  docs.replace(regexp,SA("<code>\\1</code>."));
+  regexp.setPattern(SA("\\\\c[ ]+([A-Za-z]+\\.[a-z]+)"));
+  docs.replace(regexp,SA("<code>\\1</code>"));
 
-  regexp.setPattern(SA("\\\\c[ ]+([^ ]+) "));
-  docs.replace(regexp,SA("<code>\\1</code> "));
+  regexp.setPattern(SA("\\\\c[ ]+(\\\\#[a-z]+)"));
+  docs.replace(regexp,SA("<code>\\1</code>"));
+
+  regexp.setPattern(SA("\\\\c[ ]+(\\\\[@\\\\])?([%=!\\\"/A-Za-z0-9_]+)(\\([0-9]*\\))?"));
+  docs.replace(regexp,SA("<code>\\1\\2\\3</code>"));
+
+  regexp.setPattern(SA("\\\\c[ ]+(\\\\\\\\[{}])"));
+  docs.replace(regexp,SA("<code>\\1</code>"));
+
+  regexp.setPattern(SA("\\\\c[ ]+(\\\\\\\\\\\\\\\\[{}])"));
+  docs.replace(regexp,SA("<code>\\1</code>"));
+
+  regexp.setPattern(SA("\\\\c[ ]+(@[{}])"));
+  docs.replace(regexp,SA("<code>\\1</code>"));
+
   // `word` -> <code>word</code>
   docs.replace(SA("``"),SA(""));
   regexp.setPattern(SA("`([^`]+)`"));

--- a/src/config.xml
+++ b/src/config.xml
@@ -1338,8 +1338,8 @@ Go to the <a href="commands.html">next</a> section or return to the
  The \c FILE_VERSION_FILTER tag can be used to specify a program or script that
  Doxygen should invoke to get the current version for each file (typically from the
  version control system). Doxygen will invoke the program by executing (via
- <code>popen()</code>) the command <code>command input-file</code>, where \c command is
- the value of the \c FILE_VERSION_FILTER tag, and \c input-file is the name
+ <code>popen()</code>) the command <code>command input_file</code>, where \c command is
+ the value of the \c FILE_VERSION_FILTER tag, and \c input_file is the name
  of an input file provided by Doxygen.
  Whatever the program writes to standard output is used as the file version.
 ]]>
@@ -1445,7 +1445,7 @@ PATH=/Library/TeX/texbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
  generated to standard error (\c stderr) by Doxygen. If \c WARNINGS is set to
  \c YES this implies that the warnings are on.
 <br>
- \b Tip: Turn warnings on while writing the documentation.
+ <b>Tip:</b> Turn warnings on while writing the documentation.
 ]]>
       </docs>
     </option>
@@ -2859,7 +2859,7 @@ obfuscate email addresses.
       </docs>
       <value name="HTML-CSS" desc="(which is slower, but has the best compatibility. This is the name for Mathjax version 2, for MathJax version 3 this will be translated into \c chtml)"/>
       <value name="NativeMML" desc="(i.e. MathML. Only supported for MathJax 2. For MathJax version 3 \c chtml will be used instead.)"/>
-      <value name="chtml" desc="(This is the name for Mathjax version 3, for MathJax version 2 this will be translated into \c HTML-CSS)"/>
+      <value name="chtml" desc="(This is the name for Mathjax version 3, for MathJax version 2 this will be translated into &lt;code&gt;HTML-CSS&lt;/code&gt;)"/>
       <value name="SVG"/>
     </option>
     <option type='string' id='MATHJAX_RELPATH' format='string' depends='USE_MATHJAX'>
@@ -3793,8 +3793,7 @@ Adding location for the tag files is done as follows:
 where `loc1` and `loc2` can be relative or absolute paths or URLs.
  See the section \ref external for more information about the use of tag files.
 
- \note
-  Each tag file must have a unique name
+ \note Each tag file must have a unique name
   (where the name does \e NOT include the path).
   If a tag file is not located in the directory in which Doxygen
   is run, you must also specify the path to the tagfile here.
@@ -4292,7 +4291,7 @@ to be found in the default search path.
 ]]>
       </docs>
       <value name='AUTO' desc='(use client-side rendering for HTML and \c mmdc for LaTeX/PDF and other formats. If \c MERMAID_PATH is not set, non-HTML diagrams will produce a warning)'/>
-      <value name='CLI' desc='(use the \c mmdc tool to pre-generate images (requires \c Node.js and \c mermaid-js/mermaid-cli). Works for all output formats)'/>
+      <value name='CLI' desc='(use the \c mmdc tool to pre-generate images (requires \c Node.js and &lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;). Works for all output formats)'/>
       <value name='CLIENT_SIDE' desc='(embed \c mermaid.js in HTML output for client-side rendering. Does not require \c mmdc but only works for HTML output)'/>
     </option>
     <option type='string' id='MERMAID_JS_URL' format='string'

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -62,6 +62,8 @@ def transformDocs(doc):
     doc = doc.replace("\\note ", "\n"+messages['notetxt']+" ")
     doc = doc.replace("\\verbatim", "\n")
     doc = doc.replace("\\endverbatim", "\n")
+    doc = doc.replace("<b>", "")
+    doc = doc.replace("</b>", "")
     doc = doc.replace("<code>", "")
     doc = doc.replace("</code>", "")
     doc = doc.replace("`", "")

--- a/src/i18n/config_de.xml
+++ b/src/i18n/config_de.xml
@@ -544,7 +544,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[Das \c FILE_VERSION_FILTER-Tag kann verwendet werden, um ein Programm oder Skript anzugeben, das Doxygen aufrufen soll, um die aktuelle Version für jede Datei zu erhalten (typischerweise vom Versionskontrollsystem). Doxygen ruft das Programm auf, indem es (über <code>popen()</code>) den Befehl <code>command input-file</code> ausführt, wobei \c command der Wert des \c FILE_VERSION_FILTER-Tags ist und \c input-file der Name einer von Doxygen bereitgestellten Eingabedatei ist. Was auch immer das Programm auf die Standardausgabe schreibt, wird als Dateiversion verwendet. Für ein Beispiel siehe die Dokumentation.]]>
+<![CDATA[Das \c FILE_VERSION_FILTER-Tag kann verwendet werden, um ein Programm oder Skript anzugeben, das Doxygen aufrufen soll, um die aktuelle Version für jede Datei zu erhalten (typischerweise vom Versionskontrollsystem). Doxygen ruft das Programm auf, indem es (über <code>popen()</code>) den Befehl <code>command input_file</code> ausführt, wobei \c command der Wert des \c FILE_VERSION_FILTER-Tags ist und \c input_file der Name einer von Doxygen bereitgestellten Eingabedatei ist. Was auch immer das Programm auf die Standardausgabe schreibt, wird als Dateiversion verwendet. Für ein Beispiel siehe die Dokumentation.]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -571,7 +571,7 @@
     </option>
     <option type="bool" id="WARNINGS" defval="1">
       <docs>
-<![CDATA[Das \c WARNINGS-Tag kann verwendet werden, um die Warnmeldungen ein- oder auszuschalten, die von Doxygen auf die Standardfehlerausgabe (\c stderr) generiert werden. Wenn \c WARNINGS auf \c YES gesetzt ist, bedeutet dies, dass die Warnungen eingeschaltet sind. <br> \b Tipp: Schalten Sie Warnungen ein, während Sie die Dokumentation schreiben.]]>
+<![CDATA[Das \c WARNINGS-Tag kann verwendet werden, um die Warnmeldungen ein- oder auszuschalten, die von Doxygen auf die Standardfehlerausgabe (\c stderr) generiert werden. Wenn \c WARNINGS auf \c YES gesetzt ist, bedeutet dies, dass die Warnungen eingeschaltet sind. <br> <b>Tipp:</b> Schalten Sie Warnungen ein, während Sie die Dokumentation schreiben.]]>
       </docs>
     </option>
     <option type="bool" id="WARN_IF_UNDOCUMENTED" defval="1">
@@ -1158,7 +1158,7 @@
       </docs>
       <value name="HTML-CSS" desc="(langsamer, aber mit bester Kompatibilität. Dies ist der Name für MathJax Version 2, für MathJax Version 3 wird dies in \c chtml übersetzt)"/>
       <value name="NativeMML" desc="(d.h. MathML. Nur für MathJax 2 unterstützt. Für MathJax Version 3 wird stattdessen \c chtml verwendet.)"/>
-      <value name="chtml" desc="(Dies ist der Name für MathJax Version 3, für MathJax Version 2 wird dies in \c HTML-CSS übersetzt)"/>
+      <value name="chtml" desc="(Dies ist der Name für MathJax Version 3, für MathJax Version 2 wird dies in &lt;code&gt;HTML-CSS&lt;/code&gt; übersetzt)"/>
       <value name="SVG"/>
     </option>
         <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1523,7 +1523,7 @@
   <group name="External" trname="Externe Referenzen" docs="Konfigurationsoptionen für externe Referenzen">
     <option type="list" id="TAGFILES" format="file">
       <docs>
-<![CDATA[Das \c TAGFILES-Tag kann verwendet werden, um eine oder mehrere Tag-Dateien anzugeben. Für jede Tag-Datei sollte der Speicherort der externen Dokumentation hinzugefügt werden. Das Format einer Tag-Datei ohne diesen Speicherort ist wie folgt: \verbatim TAGFILES = file1 file2 ... \endverbatim Das Hinzufügen des Speicherorts für die Tag-Dateien erfolgt wie folgt: \verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim wobei `loc1` und `loc2` relative oder absolute Pfade oder URLs sein können. Siehe den Abschnitt \ref external für weitere Informationen zur Verwendung von Tag-Dateien. \note Jede Tag-Datei muss einen eindeutigen Namen haben (wobei der Name den Pfad NICHT enthält). Wenn eine Tag-Datei nicht in dem Verzeichnis liegt, in dem Doxygen ausgeführt wird, müssen Sie auch den Pfad zur Tag-Datei hier angeben.]]>
+<![CDATA[Das \c TAGFILES-Tag kann verwendet werden, um eine oder mehrere Tag-Dateien anzugeben. Für jede Tag-Datei sollte der Speicherort der externen Dokumentation hinzugefügt werden. Das Format einer Tag-Datei ohne diesen Speicherort ist wie folgt: \verbatim TAGFILES = file1 file2 ... \endverbatim Das Hinzufügen des Speicherorts für die Tag-Dateien erfolgt wie folgt: \verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim wobei `loc1` und `loc2` relative oder absolute Pfade oder URLs sein können. Siehe den Abschnitt \ref external für weitere Informationen zur Verwendung von Tag-Dateien. \note Jede Tag-Datei muss einen eindeutigen Namen haben (wobei der Name den Pfad \e NICHT enthält). Wenn eine Tag-Datei nicht in dem Verzeichnis liegt, in dem Doxygen ausgeführt wird, müssen Sie auch den Pfad zur Tag-Datei hier angeben.]]>
       </docs>
     </option>
     <option type="string" id="GENERATE_TAGFILE" format="file" defval="">
@@ -1780,7 +1780,7 @@
 <![CDATA[Das \c MERMAID_RENDER_MODE-Tag steuert, wie Mermaid-Diagramme gerendert werden. Mögliche Werte sind: \c CLI (verwendet das `mmdc`-Tool von der Befehlszeile), \c CLIENT (verwendet mermaid.js im Browser) oder \c SERVER (verwendet mermaid.ink als externen Dienst). Standardmäßig ist dies auf \c CLIENT gesetzt.]]>
       </docs>
       <value name="AUTO" desc="(verwendet Client-Side-Rendering für HTML und \c mmdc für LaTeX/PDF und andere Formate. Wenn \c MERMAID_PATH nicht gesetzt ist, erzeugen Nicht-HTML-Diagramme eine Warnung)"/>
-      <value name="CLI" desc="(verwendet das \c mmdc-Tool zum Vorgenerieren von Bildern (erfordert \c Node.js und \c mermaid-js/mermaid-cli). Funktioniert für alle Ausgabeformate)"/>
+      <value name="CLI" desc="(verwendet das \c mmdc-Tool zum Vorgenerieren von Bildern (erfordert \c Node.js und &lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;). Funktioniert für alle Ausgabeformate)"/>
       <value name="CLIENT_SIDE" desc="(bettet \c mermaid.js in die HTML-Ausgabe für Client-Side-Rendering ein. Erfordert kein \c mmdc, funktioniert aber nur für HTML-Ausgabe)"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">

--- a/src/i18n/config_es.xml
+++ b/src/i18n/config_es.xml
@@ -545,7 +545,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[La etiqueta \c FILE_VERSION_FILTER se puede usar para especificar un programa o script que Doxygen debe invocar para obtener la versión actual de cada archivo (típicamente del sistema de control de versiones). Doxygen invocará el programa ejecutando (via <code>popen()</code>) el comando <code>command input-file</code>, donde \c command es el valor de la etiqueta \c FILE_VERSION_FILTER y \c input-file es el nombre de un archivo de entrada proporcionado por Doxygen. Lo que sea que el programa escriba en la salida estándar se usará como la versión del archivo. Para un ejemplo, vea la documentación.]]>
+<![CDATA[La etiqueta \c FILE_VERSION_FILTER se puede usar para especificar un programa o script que Doxygen debe invocar para obtener la versión actual de cada archivo (típicamente del sistema de control de versiones). Doxygen invocará el programa ejecutando (via <code>popen()</code>) el comando <code>command input_file</code>, donde \c command es el valor de la etiqueta \c FILE_VERSION_FILTER y \c input_file es el nombre de un archivo de entrada proporcionado por Doxygen. Lo que sea que el programa escriba en la salida estándar se usará como la versión del archivo. Para un ejemplo, vea la documentación.]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -572,7 +572,7 @@
     </option>
     <option type="bool" id="WARNINGS" defval="1">
       <docs>
-<![CDATA[La etiqueta \c WARNINGS se puede usar para activar/desactivar los mensajes de advertencia generados a la salida de error estándar (\c stderr) por Doxygen. Si \c WARNINGS está configurado en \c YES, esto implica que las advertencias están activadas. <br> \b Consejo: Active las advertencias mientras escribe la documentación.]]>
+<![CDATA[La etiqueta \c WARNINGS se puede usar para activar/desactivar los mensajes de advertencia generados a la salida de error estándar (\c stderr) por Doxygen. Si \c WARNINGS está configurado en \c YES, esto implica que las advertencias están activadas. <br> <b>Consejo:</b> Active las advertencias mientras escribe la documentación.]]>
       </docs>
     </option>
     <option type="bool" id="WARN_IF_UNDOCUMENTED" defval="1">
@@ -1159,7 +1159,7 @@
       </docs>
       <value name="HTML-CSS" desc="(más lento, pero con mejor compatibilidad. Este es el nombre para MathJax versión 2, para MathJax versión 3 se traducirá a \c chtml)"/>
       <value name="NativeMML" desc="(es decir, MathML. Solo compatible con MathJax 2. Para MathJax versión 3 se usará \c chtml en su lugar.)"/>
-      <value name="chtml" desc="(Este es el nombre para MathJax versión 3, para MathJax versión 2 se traducirá a \c HTML-CSS)"/>
+      <value name="chtml" desc="(Este es el nombre para MathJax versión 3, para MathJax versión 2 se traducirá a &lt;code&gt;HTML-CSS&lt;/code&gt;)"/>
       <value name="SVG"/>
     </option>
         <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1524,7 +1524,7 @@
   <group name="External" trname="Referencias externas" docs="Opciones de configuración relacionadas con las referencias externas">
     <option type="list" id="TAGFILES" format="file">
       <docs>
-<![CDATA[La etiqueta \c TAGFILES se puede usar para especificar uno o más archivos de etiquetas. Para cada archivo de etiquetas se debe agregar la ubicación de la documentación externa. El formato de un archivo de etiquetas sin esta ubicación es el siguiente: \verbatim TAGFILES = file1 file2 ... \endverbatim Agregar ubicación para los archivos de etiquetas se hace de la siguiente manera: \verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim donde `loc1` y `loc2` pueden ser rutas relativas o absolutas o URLs. Vea la sección \ref external para más información sobre el uso de archivos de etiquetas. \note Cada archivo de etiquetas debe tener un nombre único (donde el nombre NO incluye la ruta). Si un archivo de etiquetas no está ubicado en el directorio en el que se ejecuta Doxygen, también debe especificar la ruta al archivo de etiquetas aquí.]]>
+<![CDATA[La etiqueta \c TAGFILES se puede usar para especificar uno o más archivos de etiquetas. Para cada archivo de etiquetas se debe agregar la ubicación de la documentación externa. El formato de un archivo de etiquetas sin esta ubicación es el siguiente: \verbatim TAGFILES = file1 file2 ... \endverbatim Agregar ubicación para los archivos de etiquetas se hace de la siguiente manera: \verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim donde `loc1` y `loc2` pueden ser rutas relativas o absolutas o URLs. Vea la sección \ref external para más información sobre el uso de archivos de etiquetas. \note Cada archivo de etiquetas debe tener un nombre único (donde el nombre \e NO incluye la ruta). Si un archivo de etiquetas no está ubicado en el directorio en el que se ejecuta Doxygen, también debe especificar la ruta al archivo de etiquetas aquí.]]>
       </docs>
     </option>
     <option type="string" id="GENERATE_TAGFILE" format="file" defval="">
@@ -1781,7 +1781,7 @@
 <![CDATA[La etiqueta \c MERMAID_RENDER_MODE controla cómo se renderizan los diagramas Mermaid.]]>
       </docs>
       <value name="AUTO" desc="(usar renderizado del lado del cliente para HTML y \c mmdc para LaTeX/PDF y otros formatos. Si \c MERMAID_PATH no está configurado, los diagramas no HTML producirán una advertencia)"/>
-      <value name="CLI" desc="(usar la herramienta \c mmdc para pregenerar imagenes (requiere \c Node.js y \c mermaid-js/mermaid-cli). Funciona para todos los formatos de salida)"/>
+      <value name="CLI" desc="(usar la herramienta \c mmdc para pregenerar imagenes (requiere \c Node.js y &lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;). Funciona para todos los formatos de salida)"/>
       <value name="CLIENT_SIDE" desc="(incrustar \c mermaid.js en la salida HTML para renderizado del lado del cliente. No requiere \c mmdc pero solo funciona para salida HTML)"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">

--- a/src/i18n/config_fr.xml
+++ b/src/i18n/config_fr.xml
@@ -545,7 +545,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[La balise \c FILE_VERSION_FILTER peut être utilisée pour spécifier un programme ou script que Doxygen devrait invoquer pour obtenir la version actuelle de chaque fichier (généralement à partir du système de contrôle de version). Doxygen invoquera le programme en executant (via <code>popen()</code>) la commande <code>command input-file</code>, ou \c command est la valeur de la balise \c FILE_VERSION_FILTER, et \c input-file est le nom d'un fichier d'entrée fourni par Doxygen. Ce que le programme écrit sur la sortie standard est utilisé comme version de fichier.]]>
+<![CDATA[La balise \c FILE_VERSION_FILTER peut être utilisée pour spécifier un programme ou script que Doxygen devrait invoquer pour obtenir la version actuelle de chaque fichier (généralement à partir du système de contrôle de version). Doxygen invoquera le programme en executant (via <code>popen()</code>) la commande <code>command input_file</code>, ou \c command est la valeur de la balise \c FILE_VERSION_FILTER, et \c input_file est le nom d'un fichier d'entrée fourni par Doxygen. Ce que le programme écrit sur la sortie standard est utilisé comme version de fichier.]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -1159,7 +1159,7 @@
       </docs>
       <value name="HTML-CSS" desc="(plus lent, mais avec la meilleure compatibilité. C'est le nom pour MathJax version 2, pour MathJax version 3 cela sera traduit en \c chtml)"/>
       <value name="NativeMML" desc="(c'est-à-dire MathML. Pris en charge uniquement pour MathJax 2. Pour MathJax version 3, \c chtml sera utilisé à la place.)"/>
-      <value name="chtml" desc="(C'est le nom pour MathJax version 3, pour MathJax version 2 cela sera traduit en \c HTML-CSS)"/>
+      <value name="chtml" desc="(C'est le nom pour MathJax version 3, pour MathJax version 2 cela sera traduit en &lt;code&gt;HTML-CSS&lt;/code&gt;)"/>
       <value name="SVG"/>
     </option>
         <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1523,7 +1523,7 @@
   <group name="External" trname="Références externes" docs="Options de configuration relatives aux références externes">
     <option type="list" id="TAGFILES" format="file">
       <docs>
-<![CDATA[La balise \c TAGFILES peut être utilisée pour spécifier un ou plusieurs fichiers de balises. Pour chaque fichier de balises, l'emplacement de la documentation externe doit être ajouté. Le format d'un fichier de balises sans cet emplacement est le suivant: \verbatim TAGFILES = file1 file2 ... \endverbatim L'ajout d'un emplacement pour les fichiers de balises se fait comme suit: \verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim ou `loc1` et `loc2` peuvent être des chemins relatifs ou absolus ou des URL. Voir la section \ref external pour plus d'informations sur l'utilisation des fichiers de balises. \note Chaque fichier de balises doit avoir un nom unique (ou le nom n'inclut PAS le chemin). Si un fichier de balises n'est pas situe dans le répertoire dans lequel Doxygen est exécuté, vous devez également spécifier le chemin d'accès au fichier de balises ici.]]>
+<![CDATA[La balise \c TAGFILES peut être utilisée pour spécifier un ou plusieurs fichiers de balises. Pour chaque fichier de balises, l'emplacement de la documentation externe doit être ajouté. Le format d'un fichier de balises sans cet emplacement est le suivant: \verbatim TAGFILES = file1 file2 ... \endverbatim L'ajout d'un emplacement pour les fichiers de balises se fait comme suit: \verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim ou `loc1` et `loc2` peuvent être des chemins relatifs ou absolus ou des URL. Voir la section \ref external pour plus d'informations sur l'utilisation des fichiers de balises. \note Chaque fichier de balises doit avoir un nom unique (ou le nom n'inclut \e PAS le chemin). Si un fichier de balises n'est pas situe dans le répertoire dans lequel Doxygen est exécuté, vous devez également spécifier le chemin d'accès au fichier de balises ici.]]>
       </docs>
     </option>
     <option type="string" id="GENERATE_TAGFILE" format="file" defval="">
@@ -1780,7 +1780,7 @@
 <![CDATA[La balise \c MERMAID_RENDER_MODE sélectionne la manière dont les diagrammes Mermaid sont rendus.]]>
       </docs>
       <value name="AUTO" desc="(utiliser le rendu côté client pour HTML et \c mmdc pour LaTeX/PDF et autres formats. Si \c MERMAID_PATH n'est pas défini, les diagrammes non-HTML produiront un avertissement)"/>
-      <value name="CLI" desc="(utiliser l'outil \c mmdc pour pre-générer les images (nécessite \c Node.js et \c mermaid-js/mermaid-cli). Fonctionne pour tous les formats de sortie)"/>
+      <value name="CLI" desc="(utiliser l'outil \c mmdc pour pre-générer les images (nécessite \c Node.js et &lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;). Fonctionne pour tous les formats de sortie)"/>
       <value name="CLIENT_SIDE" desc="(integrer \c mermaid.js dans la sortie HTML pour le rendu côté client. Ne nécessite pas \c mmdc mais fonctionne uniquement pour la sortie HTML)"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">

--- a/src/i18n/config_ja.xml
+++ b/src/i18n/config_ja.xml
@@ -545,7 +545,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[\c FILE_VERSION_FILTERタグを使用して、各ファイルの現在のバージョンを取得するためにDoxygenが呼び出すプログラムまたはスクリプトを指定できます（通常はバージョン管理システムから取得）。Doxygenは<code>popen()</code>経由で<code>command input-file</code>コマンドを実行してプログラムを呼び出します。ここで\c commandは\c FILE_VERSION_FILTERタグの値、\c input-fileはDoxygenが提供する入力ファイル名です。プログラムが標準出力に書き込んだ内容がファイルバージョンとして使用されます。]]>
+<![CDATA[\c FILE_VERSION_FILTERタグを使用して、各ファイルの現在のバージョンを取得するためにDoxygenが呼び出すプログラムまたはスクリプトを指定できます（通常はバージョン管理システムから取得）。Doxygenは<code>popen()</code>経由で<code>command input_file</code>コマンドを実行してプログラムを呼び出します。ここで\c commandは\c FILE_VERSION_FILTERタグの値、\c input_fileはDoxygenが提供する入力ファイル名です。プログラムが標準出力に書き込んだ内容がファイルバージョンとして使用されます。]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -572,7 +572,7 @@
     </option>
     <option type="bool" id="WARNINGS" defval="1">
       <docs>
-<![CDATA[\c WARNINGSタグを使用して、Doxygenによって標準エラー（\c stderr）に生成される警告メッセージのオン/オフを切り替えることができます。\c WARNINGSが\c YESに設定されている場合、警告が有効になります。<br>\b ヒント：ドキュメントの作成中は警告を有効にしてください。]]>
+<![CDATA[\c WARNINGSタグを使用して、Doxygenによって標準エラー（\c stderr）に生成される警告メッセージのオン/オフを切り替えることができます。\c WARNINGSが\c YESに設定されている場合、警告が有効になります。<br><b>ヒント：</b>ドキュメントの作成中は警告を有効にしてください。]]>
       </docs>
     </option>
     <option type="bool" id="WARN_IF_UNDOCUMENTED" defval="1">
@@ -1159,7 +1159,7 @@
       </docs>
       <value name="HTML-CSS" desc="(より遅いですが、最高の互換性があります。これはMathJaxバージョン2の名称で、MathJaxバージョン3では\c chtmlに変換されます)"/>
       <value name="NativeMML" desc="(MathML。MathJax 2のみサポート。MathJaxバージョン3では\c chtmlが代わりに使用されます。)"/>
-      <value name="chtml" desc="(これはMathJaxバージョン3の名称で、MathJaxバージョン2では\c HTML-CSSに変換されます)"/>
+      <value name="chtml" desc="(これはMathJaxバージョン3の名称で、MathJaxバージョン2では&lt;code&gt;HTML-CSS&lt;/code&gt;に変換されます)"/>
       <value name="SVG"/>
     </option>
         <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1524,7 +1524,7 @@
   <group name="External" trname="外部参照" docs="外部参照に関連する設定オプション">
     <option type="list" id="TAGFILES" format="file">
       <docs>
-<![CDATA[\c TAGFILESタグを使用して、1つ以上のタグファイルを指定できます。各タグファイルについて、外部ドキュメントの場所を追加する必要があります。場所なしのタグファイルの形式は次のとおりです：\verbatim TAGFILES = file1 file2 ... \endverbatim タグファイルの場所の追加は次のように行います：\verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim ここで`loc1`と`loc2`は相対パス、絶対パス、またはURLにすることができます。タグファイルの使用の詳細については、セクション\ref externalを参照してください。\note 各タグファイルは一意の名前を持つ必要があります（名前にはパスを\e 含みません）。タグファイルがDoxygenを実行するディレクトリにない場合は、ここでタグファイルへのパスも指定する必要があります。]]>
+<![CDATA[\c TAGFILESタグを使用して、1つ以上のタグファイルを指定できます。各タグファイルについて、外部ドキュメントの場所を追加する必要があります。場所なしのタグファイルの形式は次のとおりです：\verbatim TAGFILES = file1 file2 ... \endverbatim タグファイルの場所の追加は次のように行います：\verbatim TAGFILES = file1=loc1 "file2 = loc2" ... \endverbatim ここで`loc1`と`loc2`は相対パス、絶対パス、またはURLにすることができます。タグファイルの使用の詳細については、セクション\ref externalを参照してください。\note 各タグファイルは一意の名前を持つ必要があります（名前にはパスを含みません）。タグファイルがDoxygenを実行するディレクトリにない場合は、ここでタグファイルへのパスも指定する必要があります。]]>
       </docs>
     </option>
     <option type="string" id="GENERATE_TAGFILE" format="file" defval="">
@@ -1779,7 +1779,7 @@
 <![CDATA[\c MERMAID_RENDER_MODEタグは、Mermaidダイアグラムのレンダリング方法を選択します。]]>
       </docs>
       <value name="AUTO" desc="(HTMLにはクライアント側レンダリングを使用し、LaTeX/PDFおよびその他の形式には\c mmdcを使用。\c MERMAID_PATHが設定されていない場合、非HTMLダイアグラムは警告を生成します)"/>
-      <value name="CLI" desc="(\c mmdcツールを使用して画像を事前生成(\c Node.jsと\c mermaid-js/mermaid-cliが必要)。すべての出力形式で動作)"/>
+      <value name="CLI" desc="(\c mmdcツールを使用して画像を事前生成(\c Node.jsと&lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;が必要)。すべての出力形式で動作)"/>
       <value name="CLIENT_SIDE" desc="(クライアント側レンダリングのために\c mermaid.jsをHTML出力に埋め込み。\c mmdcは不要ですが、HTML出力でのみ動作)"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">

--- a/src/i18n/config_ko.xml
+++ b/src/i18n/config_ko.xml
@@ -545,7 +545,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[\c FILE_VERSION_FILTER 태그를 사용하여 Doxygen이 각 파일의 현재 버전을 가져오기 위해 호출하는 프로그램 또는 스크립트를 지정할 수 있습니다(일반적으로 버전 관리 시스템에서). Doxygen은 <code>popen()</code>을 통해 명령<code>command input-file</code>을 실행하여 프로그램을 호출합니다. 여기서 \c command는 \c FILE_VERSION_FILTER 태그의 값, \c input-file은 Doxygen이 제공하는 입력 파일의 이름입니다. 프로그램이 표준 출력에 쓰는 모든 것은 파일 버전으로 사용됩니다.]]>
+<![CDATA[\c FILE_VERSION_FILTER 태그를 사용하여 Doxygen이 각 파일의 현재 버전을 가져오기 위해 호출하는 프로그램 또는 스크립트를 지정할 수 있습니다(일반적으로 버전 관리 시스템에서). Doxygen은 <code>popen()</code>을 통해 명령<code>command input_file</code>을 실행하여 프로그램을 호출합니다. 여기서 \c command는 \c FILE_VERSION_FILTER 태그의 값, \c input_file은 Doxygen이 제공하는 입력 파일의 이름입니다. 프로그램이 표준 출력에 쓰는 모든 것은 파일 버전으로 사용됩니다.]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -572,7 +572,7 @@
     </option>
     <option type="bool" id="WARNINGS" defval="1">
       <docs>
-<![CDATA[\c WARNINGS 태그를 사용하여 Doxygen에 의해 표준 오류(\c stderr)에 생성되는 경고 메시지를 켜거나 끌 수 있습니다. \c WARNINGS가 \c YES로 설정되면 경고가 켜져 있음을 의미합니다.<br>\b 팁: 문서 작성 중에 경고를 켜두세요.]]>
+<![CDATA[\c WARNINGS 태그를 사용하여 Doxygen에 의해 표준 오류(\c stderr)에 생성되는 경고 메시지를 켜거나 끌 수 있습니다. \c WARNINGS가 \c YES로 설정되면 경고가 켜져 있음을 의미합니다.<br><b> 팁:</b> 문서 작성 중에 경고를 켜두세요.]]>
       </docs>
     </option>
     <option type="bool" id="WARN_IF_UNDOCUMENTED" defval="1">
@@ -1159,7 +1159,7 @@
       </docs>
       <value name="HTML-CSS" desc="(느리지만 최상의 호환성 제공. MathJax 버전 2의 이름이며, MathJax 버전 3에서는 \c chtml로 변환됨)"/>
       <value name="NativeMML" desc="(즉, MathML. MathJax 2만 지원. MathJax 버전 3에서는 대신 \c chtml이 사용됨.)"/>
-      <value name="chtml" desc="(MathJax 버전 3의 이름이며, MathJax 버전 2에서는 \c HTML-CSS로 변환됨)"/>
+      <value name="chtml" desc="(MathJax 버전 3의 이름이며, MathJax 버전 2에서는 &lt;code&gt;HTML-CSS&lt;/code&gt;로 변환됨)"/>
       <value name="SVG"/>
     </option>
         <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1778,7 +1778,7 @@
 <![CDATA[\c MERMAID_RENDER_MODE 태그는 Mermaid 다이어그램이 렌더링되는 방식을 선택합니다.]]>
       </docs>
       <value name="AUTO" desc="(HTML은 클라이언트 측 렌더링 사용, LaTeX/PDF 및 기타 형식은 \c mmdc 사용. \c MERMAID_PATH가 설정되지 않은 경우 비 HTML 다이어그램은 경고를 생성함)"/>
-      <value name="CLI" desc="(\c mmdc 도구를 사용하여 이미지 사전 생성(\c Node.js 및 \c mermaid-js/mermaid-cli 필요). 모든 출력 형식에서 작동)"/>
+      <value name="CLI" desc="(\c mmdc 도구를 사용하여 이미지 사전 생성(\c Node.js 및 &lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt; 필요). 모든 출력 형식에서 작동)"/>
       <value name="CLIENT_SIDE" desc="(클라이언트 측 렌더링을 위해 \c mermaid.js를 HTML 출력에 포함. \c mmdc가 필요 없지만 HTML 출력에서만 작동)"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">

--- a/src/i18n/config_ru.xml
+++ b/src/i18n/config_ru.xml
@@ -108,7 +108,7 @@
     </option>
     <option type="bool" id="REPEAT_BRIEF" defval="1">
       <docs>
-<![CDATA[Если тег \c REPEAT_BRIEF установлен в \c YES, Doxygen добавит краткое описание члена или функции перед подробным описанием. &lt;br&gt;Примечание: Если оба тега \ref cfg_hide_undoc_members "HIDE_UNDOC_MEMBERS" и \ref cfg_brief_member_desc "BRIEF_MEMBER_DESC" установлены в \c NO, краткие описания будут полностью подавлены.]]>
+<![CDATA[Если тег \c REPEAT_BRIEF установлен в \c YES, Doxygen добавит краткое описание члена или функции перед подробным описанием. <br>Примечание: Если оба тега \ref cfg_hide_undoc_members "HIDE_UNDOC_MEMBERS" и \ref cfg_brief_member_desc "BRIEF_MEMBER_DESC" установлены в \c NO, краткие описания будут полностью подавлены.]]>
       </docs>
     </option>
     <option type="list" id="ABBREVIATE_BRIEF" format="string">
@@ -144,7 +144,7 @@
     </option>
     <option type="list" id="STRIP_FROM_PATH" format="dir" depends="FULL_PATH_NAMES">
       <docs>
-<![CDATA[Тег \c STRIP_FROM_PATH можно использовать для удаления пользовательской части пути. Удаление выполняется только если одна из указанных строк совпадает с левой частью пути. Этот тег можно использовать для отображения относительных путей в списке файлов. Если оставить пустым, будет использоваться каталог, в котором запущен Doxygen, как путь для удаления. &lt;br&gt;Обратите внимание, что вы можете указать здесь абсолютные пути, но также и относительные пути, которые будут относительными к каталогу, в котором был запущен Doxygen.]]>
+<![CDATA[Тег \c STRIP_FROM_PATH можно использовать для удаления пользовательской части пути. Удаление выполняется только если одна из указанных строк совпадает с левой частью пути. Этот тег можно использовать для отображения относительных путей в списке файлов. Если оставить пустым, будет использоваться каталог, в котором запущен Doxygen, как путь для удаления. <br>Обратите внимание, что вы можете указать здесь абсолютные пути, но также и относительные пути, которые будут относительными к каталогу, в котором был запущен Doxygen.]]>
       </docs>
     </option>
     <option type="list" id="STRIP_FROM_INC_PATH" format="dir">
@@ -174,7 +174,7 @@
     </option>
     <option type="bool" id="MULTILINE_CPP_IS_BRIEF" defval="0">
       <docs>
-<![CDATA[Тег \c MULTILINE_CPP_IS_BRIEF можно установить в \c YES, чтобы Doxygen обрабатывал многострочные блоки специальных комментариев C++ (т.е. блоки комментариев \c //! или \c ///) как краткие описания. Это раньше было поведением по умолчанию. Новое значение по умолчанию — обрабатывать многострочные блоки комментариев C++ как подробные описания. Если вы предпочитаете старое поведение, установите этот тег в \c YES. &lt;br&gt;Обратите внимание, что установка этого тега в \c YES также означает, что комментарии Rational Rose больше не будут распознаваться.]]>
+<![CDATA[Тег \c MULTILINE_CPP_IS_BRIEF можно установить в \c YES, чтобы Doxygen обрабатывал многострочные блоки специальных комментариев C++ (т.е. блоки комментариев \c //! или \c ///) как краткие описания. Это раньше было поведением по умолчанию. Новое значение по умолчанию — обрабатывать многострочные блоки комментариев C++ как подробные описания. Если вы предпочитаете старое поведение, установите этот тег в \c YES. <br>Обратите внимание, что установка этого тега в \c YES также означает, что комментарии Rational Rose больше не будут распознаваться.]]>
       </docs>
     </option>
     <option type="bool" id="PYTHON_DOCSTRING" defval="1">
@@ -229,7 +229,7 @@
     </option>
     <option type="list" id="EXTENSION_MAPPING" format="string">
       <docs>
-<![CDATA[Doxygen выбирает парсер для использования на основе расширения анализируемого файла. С этим тегом вы можете назначить парсер для использования с данным расширением. Doxygen имеет встроенное сопоставление, но вы можете переопределить или расширить его с помощью этого тега. Формат: `ext=language`, где `ext` — расширение файла, а `language` — один из парсеров, поддерживаемых Doxygen: IDL, Java, JavaScript, Csharp (C#), C, C++, Lex, D, PHP, md (Markdown), Objective-C, Python, Slice, VHDL, Fortran (Fortran с фиксированным форматом: FortranFixed, Fortran со свободным форматом: FortranFree, Fortran с неизвестным форматом: Fortran. В последнем случае парсер попытается угадать, является ли код фиксированным или свободным форматом, что является значением по умолчанию для файлов типа Fortran). Например, чтобы Doxygen обрабатывал файлы &lt;codegt;.inc&lt;/codegt; как файлы Fortran (по умолчанию PHP), а файлы &lt;codegt;.f&lt;/codegt; как файлы C (по умолчанию Fortran), используйте: `inc=Fortran f=C`. &lt;br&gt;Примечание: Для файлов без расширения вы можете использовать `no_extension` как заполнитель. &lt;br&gt;Обратите внимание, что для пользовательских расширений вам также нужно установить \ref cfg_file_patterns "FILE_PATTERNS", иначе Doxygen не будет читать эти файлы. Когда указан `no_extension`, вы должны добавить `*` в \ref cfg_file_patterns "FILE_PATTERNS". &lt;br&gt;Примечание, см. также список \ref default_file_extension_mapping "сопоставления расширений файлов по умолчанию".]]>
+<![CDATA[Doxygen выбирает парсер для использования на основе расширения анализируемого файла. С этим тегом вы можете назначить парсер для использования с данным расширением. Doxygen имеет встроенное сопоставление, но вы можете переопределить или расширить его с помощью этого тега. Формат: `ext=language`, где `ext` — расширение файла, а `language` — один из парсеров, поддерживаемых Doxygen: IDL, Java, JavaScript, Csharp (C#), C, C++, Lex, D, PHP, md (Markdown), Objective-C, Python, Slice, VHDL, Fortran (Fortran с фиксированным форматом: FortranFixed, Fortran со свободным форматом: FortranFree, Fortran с неизвестным форматом: Fortran. В последнем случае парсер попытается угадать, является ли код фиксированным или свободным форматом, что является значением по умолчанию для файлов типа Fortran). Например, чтобы Doxygen обрабатывал файлы <code>.inc</code> как файлы Fortran (по умолчанию PHP), а файлы <code>.f</code> как файлы C (по умолчанию Fortran), используйте: `inc=Fortran f=C`. <br>Примечание: Для файлов без расширения вы можете использовать `no_extension` как заполнитель. <br>Обратите внимание, что для пользовательских расширений вам также нужно установить \ref cfg_file_patterns "FILE_PATTERNS", иначе Doxygen не будет читать эти файлы. Когда указан `no_extension`, вы должны добавить `*` в \ref cfg_file_patterns "FILE_PATTERNS". <br>Примечание, см. также список \ref default_file_extension_mapping "сопоставления расширений файлов по умолчанию".]]>
       </docs>
     </option>
     <option type="bool" id="MARKDOWN_SUPPORT" defval="1">
@@ -276,7 +276,7 @@
     </option>
     <option type="bool" id="SIP_SUPPORT" defval="0">
       <docs>
-<![CDATA[Если ваш проект содержит только &lt;a href="https://www.riverbankcomputing.com/software"&gt;sip&lt;/a&gt; исходный код, установите тег \c SIP_SUPPORT в \c YES. Doxygen будет анализировать их как обычный C++, но будет предполагать, что все классы используют публичное наследование, когда нет явного ключевого слова защиты, вместо приватного наследования.]]>
+<![CDATA[Если ваш проект содержит только <a href="https://www.riverbankcomputing.com/software">sip</a> исходный код, установите тег \c SIP_SUPPORT в \c YES. Doxygen будет анализировать их как обычный C++, но будет предполагать, что все классы используют публичное наследование, когда нет явного ключевого слова защиты, вместо приватного наследования.]]>
       </docs>
     </option>
     <option type="bool" id="IDL_PROPERTY_SUPPORT" defval="1">
@@ -301,7 +301,7 @@
     </option>
     <option type="bool" id="INLINE_GROUPED_CLASSES" defval="0">
       <docs>
-<![CDATA[Когда тег \c INLINE_GROUPED_CLASSES установлен в \c YES, классы, структуры и объединения отображаются в содержащей их группе (например, с использованием \ref cmdingroup "\ingroup"), а не на отдельных страницах (для HTML и страниц Man) или в разделах (для \f$\mbox{\LaTeX}\f$ и RTF). &lt;br&gt;Обратите внимание, что эта функция не может быть объединена с \ref cfg_separate_member_pages "SEPARATE_MEMBER_PAGES".]]>
+<![CDATA[Когда тег \c INLINE_GROUPED_CLASSES установлен в \c YES, классы, структуры и объединения отображаются в содержащей их группе (например, с использованием \ref cmdingroup "\ingroup"), а не на отдельных страницах (для HTML и страниц Man) или в разделах (для \f$\mbox{\LaTeX}\f$ и RTF). <br>Обратите внимание, что эта функция не может быть объединена с \ref cfg_separate_member_pages "SEPARATE_MEMBER_PAGES".]]>
       </docs>
     </option>
     <option type="bool" id="INLINE_SIMPLE_STRUCTS" defval="0">
@@ -311,7 +311,7 @@
     </option>
     <option type="bool" id="TYPEDEF_HIDES_STRUCT" defval="0">
       <docs>
-<![CDATA[Когда тег \c TYPEDEF_HIDES_STRUCT включен, typedef для структуры, объединения или перечисления будет документирован как структура, объединение или перечисление с именем typedef. Таким образом, &lt;codegt;typedef struct TypeS {} TypeT&lt;/codegt; будет отображаться в документации как структура с именем \c TypeT. Когда отключено, typedef будет отображаться как член файла, пространства имен или класса. Структура будет называться \c TypeS. Это обычно полезно для кода C, если соглашение о кодировании требует, чтобы все составные типы были typedef, и на typedef ссылаются только по имени, никогда по имени тега.]]>
+<![CDATA[Когда тег \c TYPEDEF_HIDES_STRUCT включен, typedef для структуры, объединения или перечисления будет документирован как структура, объединение или перечисление с именем typedef. Таким образом, <code>typedef struct TypeS {} TypeT</code> будет отображаться в документации как структура с именем \c TypeT. Когда отключено, typedef будет отображаться как член файла, пространства имен или класса. Структура будет называться \c TypeS. Это обычно полезно для кода C, если соглашение о кодировании требует, чтобы все составные типы были typedef, и на typedef ссылаются только по имени, никогда по имени тега.]]>
       </docs>
     </option>
     <option type="int" id="LOOKUP_CACHE_SIZE" minval="0" maxval="9" defval="0">
@@ -520,7 +520,7 @@
     </option>
     <option type="list" id="ENABLED_SECTIONS" format="string">
       <docs>
-<![CDATA[Тег \c ENABLED_SECTIONS можно использовать для включения условных разделов документации, помеченных блоками \ref cmdif "\if" \&lt;section_label\&gt; ... \ref cmdendif "\endif" и \ref cmdcond "\cond" \&lt;section_label\&gt; ... \ref cmdendcond "\endcond".]]>
+<![CDATA[Тег \c ENABLED_SECTIONS можно использовать для включения условных разделов документации, помеченных блоками \ref cmdif "\if" \<section_label\> ... \ref cmdendif "\endif" и \ref cmdcond "\cond" \<section_label\> ... \ref cmdendcond "\endcond".]]>
       </docs>
     </option>
     <option type="int" id="MAX_INITIALIZER_LINES" minval="0" maxval="10000" defval="30">
@@ -545,17 +545,17 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[Тег \c FILE_VERSION_FILTER можно использовать для указания программы или скрипта, который Doxygen должен вызвать для получения текущей версии каждого файла (обычно из системы контроля версий). Doxygen вызовет программу, выполнив (через &lt;codegt;popen()&lt;/codegt;) команду &lt;codegt;command input-file&lt;/codegt;, где \c command — значение тега \c FILE_VERSION_FILTER, а \c input-file — имя входного файла, предоставленного Doxygen. Все, что программа выведет в стандартный вывод, будет использовано как версия файла.]]>
+<![CDATA[Тег \c FILE_VERSION_FILTER можно использовать для указания программы или скрипта, который Doxygen должен вызвать для получения текущей версии каждого файла (обычно из системы контроля версий). Doxygen вызовет программу, выполнив (через <code>popen()</code>) команду <code>command input_file</code>, где \c command — значение тега \c FILE_VERSION_FILTER, а \c input_file — имя входного файла, предоставленного Doxygen. Все, что программа выведет в стандартный вывод, будет использовано как версия файла.]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
       <docs>
-<![CDATA[Тег \c LAYOUT_FILE можно использовать для указания файла макета, который Doxygen проанализирует. Файл макета управляет глобальной структурой сгенерированных выходных файлов независимым от формата вывода способом. Чтобы создать файл макета, представляющий настройки Doxygen по умолчанию, запустите Doxygen с опцией `-l`. Вы можете опционально указать имя файла после опции, если опустите, \c DoxygenLayout.xml будет использовано как имя файла макета. См. также раздел \ref layout для информации. &lt;br&gt;Обратите внимание, что если вы запускаете Doxygen из каталога, содержащего файл с именем \c DoxygenLayout.xml, Doxygen автоматически проанализирует его, даже если тег \c LAYOUT_FILE пуст.]]>
+<![CDATA[Тег \c LAYOUT_FILE можно использовать для указания файла макета, который Doxygen проанализирует. Файл макета управляет глобальной структурой сгенерированных выходных файлов независимым от формата вывода способом. Чтобы создать файл макета, представляющий настройки Doxygen по умолчанию, запустите Doxygen с опцией `-l`. Вы можете опционально указать имя файла после опции, если опустите, \c DoxygenLayout.xml будет использовано как имя файла макета. См. также раздел \ref layout для информации. <br>Обратите внимание, что если вы запускаете Doxygen из каталога, содержащего файл с именем \c DoxygenLayout.xml, Doxygen автоматически проанализирует его, даже если тег \c LAYOUT_FILE пуст.]]>
       </docs>
     </option>
     <option type="list" id="CITE_BIB_FILES" format="file">
       <docs>
-<![CDATA[Тег \c CITE_BIB_FILES можно использовать для указания одного или нескольких файлов \c bib, содержащих определения ссылок. Это должен быть список файлов &lt;codegt;.bib&lt;/codegt;. Расширение &lt;codegt;.bib&lt;/codegt; будет добавлено автоматически, если опущено. Это требует, чтобы инструмент \c bibtex был установлен. См. также https://en.wikipedia.org/wiki/BibTeX для дополнительной информации. Для \f$\mbox{\LaTeX}\f$ стиль ссылок может контролироваться с помощью \ref cfg_latex_bib_style "LATEX_BIB_STYLE". Чтобы использовать эту функцию, вам нужно иметь \c bibtex и \c perl доступными в пути поиска. См. также \ref cmdcite "\cite" для информации о создании цитат.]]>
+<![CDATA[Тег \c CITE_BIB_FILES можно использовать для указания одного или нескольких файлов \c bib, содержащих определения ссылок. Это должен быть список файлов <code>.bib</code>. Расширение <code>.bib</code> будет добавлено автоматически, если опущено. Это требует, чтобы инструмент \c bibtex был установлен. См. также https://en.wikipedia.org/wiki/BibTeX для дополнительной информации. Для \f$\mbox{\LaTeX}\f$ стиль ссылок может контролироваться с помощью \ref cfg_latex_bib_style "LATEX_BIB_STYLE". Чтобы использовать эту функцию, вам нужно иметь \c bibtex и \c perl доступными в пути поиска. См. также \ref cmdcite "\cite" для информации о создании цитат.]]>
       </docs>
     </option>
     <option type="list" id="EXTERNAL_TOOL_PATH" format="dir" defval="">
@@ -572,7 +572,7 @@
     </option>
     <option type="bool" id="WARNINGS" defval="1">
       <docs>
-<![CDATA[Тег \c WARNINGS можно использовать для включения/выключения предупреждающих сообщений, генерируемых Doxygen на стандартный поток ошибок (\c stderr). Если \c WARNINGS установлен в \c YES, это означает, что предупреждения включены. &lt;br&gt;\b Совет: Включите предупреждения при написании документации.]]>
+<![CDATA[Тег \c WARNINGS можно использовать для включения/выключения предупреждающих сообщений, генерируемых Doxygen на стандартный поток ошибок (\c stderr). Если \c WARNINGS установлен в \c YES, это означает, что предупреждения включены. <br><b>Совет:</b> Включите предупреждения при написании документации.]]>
       </docs>
     </option>
     <option type="bool" id="WARN_IF_UNDOCUMENTED" defval="1">
@@ -1361,7 +1361,7 @@ doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFil
       </docs>
       <value name="HTML-CSS" desc="(медленнее, но имеет лучшую совместимость. Это имя для MathJax версии 2, для MathJax версии 3 будет переведено в \c chtml)"/>
       <value name="NativeMML" desc="(т.е. MathML. Поддерживается только для MathJax 2. Для MathJax версии 3 вместо этого будет использоваться \c chtml.)"/>
-      <value name="chtml" desc="(Это имя для MathJax версии 3, для MathJax версии 2 будет переведено в \c HTML-CSS)"/>
+      <value name="chtml" desc="(Это имя для MathJax версии 3, для MathJax версии 2 будет переведено в &lt;code&gt;HTML-CSS&lt;/code&gt;)"/>
       <value name="SVG"/>
     </option>
         <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1901,8 +1901,7 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
 где `loc1` и `loc2` могут быть относительными или абсолютными путями или URL-адресами.
  Дополнительные сведения об использовании файлов тегов см. в разделе \ref external.
 
- \note
-  Каждый файл тегов должен иметь уникальное имя
+ \note Каждый файл тегов должен иметь уникальное имя
   (при этом имя \e НЕ включает путь).
   Если файл тегов не находится в каталоге, из которого запускается Doxygen,
   необходимо также указать путь к файлу тегов здесь.]]>
@@ -2316,7 +2315,7 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
 <![CDATA[Тег \c MERMAID_RENDER_MODE выбирает, как рендерить диаграммы Mermaid.]]>
       </docs>
       <value name="AUTO" desc="(использовать рендеринг на стороне клиента для HTML и \c mmdc для LaTeX/PDF и других форматов. Если \c MERMAID_PATH не установлен, не-HTML диаграммы выдадут предупреждение)"/>
-      <value name="CLI" desc="(использовать инструмент \c mmdc для предварительной генерации изображений (требуется \c Node.js и \c mermaid-js/mermaid-cli). Работает для всех форматов вывода)"/>
+      <value name="CLI" desc="(использовать инструмент \c mmdc для предварительной генерации изображений (требуется \c Node.js и &lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;). Работает для всех форматов вывода)"/>
       <value name="CLIENT_SIDE" desc="(встроить \c mermaid.js в вывод HTML для рендеринга на стороне клиента. Не требует \c mmdc, но работает только для вывода HTML)"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">
@@ -2374,7 +2373,7 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
     </option>
     <option type="bool" id="DOT_CLEANUP" defval="1">
       <docs>
-<![CDATA[Если тег \c DOT_CLEANUP установлен в \c YES, Doxygen удалит промежуточные файлы, использованные для генерации различных графов. &lt;br&gt;Примечание: Эта настройка используется не только для файлов dot, но и для временных файлов msc.]]>
+<![CDATA[Если тег \c DOT_CLEANUP установлен в \c YES, Doxygen удалит промежуточные файлы, использованные для генерации различных графов. <br>Примечание: Эта настройка используется не только для файлов dot, но и для временных файлов msc.]]>
       </docs>
     </option>
     <option type="string" id="MSCGEN_TOOL" format="file" defval="">

--- a/src/i18n/config_zh_CN.xml
+++ b/src/i18n/config_zh_CN.xml
@@ -545,7 +545,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[\c FILE_VERSION_FILTER 标签可用于指定 Doxygen 应调用的程序或脚本，以获取每个文件的当前版本（通常来自版本控制系统）。Doxygen 将通过执行（通过 <code>popen()</code>）命令 <code>command input-file</code> 来调用程序，其中 \c command 是 \c FILE_VERSION_FILTER 标签的值，\c input-file 是 Doxygen 提供的输入文件的名称。程序写入标准输出的任何内容都用作文件版本。]]>
+<![CDATA[\c FILE_VERSION_FILTER 标签可用于指定 Doxygen 应调用的程序或脚本，以获取每个文件的当前版本（通常来自版本控制系统）。Doxygen 将通过执行（通过 <code>popen()</code>）命令 <code>command input_file</code> 来调用程序，其中 \c command 是 \c FILE_VERSION_FILTER 标签的值，\c input_file 是 Doxygen 提供的输入文件的名称。程序写入标准输出的任何内容都用作文件版本。]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -572,7 +572,7 @@
     </option>
     <option type="bool" id="WARNINGS" defval="1">
       <docs>
-<![CDATA[\c WARNINGS 标签可用于打开/关闭 Doxygen 生成到标准错误（\c stderr）的警告消息。如果 \c WARNINGS 设置为 \c YES，这意味着警告已打开。<br>\b 提示：在编写文档时打开警告。]]>
+<![CDATA[\c WARNINGS 标签可用于打开/关闭 Doxygen 生成到标准错误（\c stderr）的警告消息。如果 \c WARNINGS 设置为 \c YES，这意味着警告已打开。<br><b>提示：</b>在编写文档时打开警告。]]>
       </docs>
     </option>
     <option type="bool" id="WARN_IF_UNDOCUMENTED" defval="1">
@@ -1159,7 +1159,7 @@
       </docs>
       <value name="HTML-CSS" desc="（较慢，但兼容性最好。这是MathJax版本2的名称，对于MathJax版本3将被转换为\c chtml）"/>
       <value name="NativeMML" desc="（即MathML。仅MathJax 2支持。对于MathJax版本3将使用\c chtml代替。）"/>
-      <value name="chtml" desc="（这是MathJax版本3的名称，对于MathJax版本2将被转换为\c HTML-CSS）"/>
+      <value name="chtml" desc="（这是MathJax版本3的名称，对于MathJax版本2将被转换为&lt;code&gt;HTML-CSS&lt;/code&gt;）"/>
       <value name="SVG"/>
     </option>
     <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1776,7 +1776,7 @@
 <![CDATA[\c MERMAID_RENDER_MODE 标签选择如何呈现 Mermaid 图表。]]>
       </docs>
       <value name="AUTO" desc="（HTML使用客户端渲染，LaTeX/PDF和其他格式使用\c mmdc。如果未设置\c MERMAID_PATH，非HTML图表将产生警告）"/>
-      <value name="CLI" desc="（使用\c mmdc工具预生成图像（需要\c Node.js和\c mermaid-js/mermaid-cli）。适用于所有输出格式）"/>
+      <value name="CLI" desc="（使用\c mmdc工具预生成图像（需要\c Node.js和&lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;）。适用于所有输出格式）"/>
       <value name="CLIENT_SIDE" desc="（在HTML输出中嵌入\c mermaid.js进行客户端渲染。不需要\c mmdc但仅适用于HTML输出）"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">

--- a/src/i18n/config_zh_TW.xml
+++ b/src/i18n/config_zh_TW.xml
@@ -545,7 +545,7 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[\c FILE_VERSION_FILTER 標籤可用於指定 Doxygen 應呼叫的程式或脚本，以取得每個檔案的目前版本（通常來自版本控制系統）。Doxygen 將通過執行（通過 <code>popen()</code>）命令 <code>command input-file</code> 來呼叫程式，其中 \c command 是 \c FILE_VERSION_FILTER 標籤的值，\c input-file 是 Doxygen 提供的輸入檔案的名稱。程式寫入標准輸出的任何內容都用作檔案版本。]]>
+<![CDATA[\c FILE_VERSION_FILTER 標籤可用於指定 Doxygen 應呼叫的程式或脚本，以取得每個檔案的目前版本（通常來自版本控制系統）。Doxygen 將通過執行（通過 <code>popen()</code>）命令 <code>command input_file</code> 來呼叫程式，其中 \c command 是 \c FILE_VERSION_FILTER 標籤的值，\c input_file 是 Doxygen 提供的輸入檔案的名稱。程式寫入標准輸出的任何內容都用作檔案版本。]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -572,7 +572,7 @@
     </option>
     <option type="bool" id="WARNINGS" defval="1">
       <docs>
-<![CDATA[\c WARNINGS 標籤可用於開啟/關閉 Doxygen 產生到標准錯誤（\c stderr）的警告訊息。如果 \c WARNINGS 設定為 \c YES，這意味着警告已開啟。<br>\b 提示：在編寫檔案時開啟警告。]]>
+<![CDATA[\c WARNINGS 標籤可用於開啟/關閉 Doxygen 產生到標准錯誤（\c stderr）的警告訊息。如果 \c WARNINGS 設定為 \c YES，這意味着警告已開啟。<br><b>提示：</b>在編寫檔案時開啟警告。]]>
       </docs>
     </option>
     <option type="bool" id="WARN_IF_UNDOCUMENTED" defval="1">
@@ -1159,7 +1159,7 @@
       </docs>
       <value name="HTML-CSS" desc="（較慢，但相容性最好。這是MathJax版本2的名稱，對於MathJax版本3將被轉換為\c chtml）"/>
       <value name="NativeMML" desc="（即MathML。僅MathJax 2支援。對於MathJax版本3將使用\c chtml代替。）"/>
-      <value name="chtml" desc="（這是MathJax版本3的名稱，對於MathJax版本2將被轉換為\c HTML-CSS）"/>
+      <value name="chtml" desc="（這是MathJax版本3的名稱，對於MathJax版本2將被轉換為&lt;code&gt;HTML-CSS&lt;/code&gt;）"/>
       <value name="SVG"/>
     </option>
         <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
@@ -1776,7 +1776,7 @@
 <![CDATA[\c MERMAID_RENDER_MODE 標籤選择如何呈現 Mermaid 圖資料表。]]>
       </docs>
       <value name="AUTO" desc="（HTML使用客戶端渲染，LaTeX/PDF和其他格式使用\c mmdc。如果未設定\c MERMAID_PATH，非HTML圖表將產生警告）"/>
-      <value name="CLI" desc="（使用\c mmdc工具預產生影像（需要\c Node.js和\c mermaid-js/mermaid-cli）。適用於所有輸出格式）"/>
+      <value name="CLI" desc="（使用\c mmdc工具預產生影像（需要\c Node.js和&lt;code&gt;mermaid-js/mermaid-cli&lt;/code&gt;）。適用於所有輸出格式）"/>
       <value name="CLIENT_SIDE" desc="（在HTML輸出中嵌入\c mermaid.js進行客戶端渲染。不需要\c mmdc但僅適用於HTML輸出）"/>
     </option>
     <option type="string" id="MERMAID_JS_URL" format="string" defval="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs">


### PR DESCRIPTION
- better support for the `\c` command as these were not always properly ended in non Latin based fonts
- better support for the `\c` command in the German language as here construct like `\c PROJECT_NAME-Tag` appeared and this was translated to `<code>PROJECT_NAME-Tag</code>` instead of `<code>PROJECT_NAME</code>-Tag`

In both cases by means of specific rules and not general wildcard rules
- translating some `\c` commands to `<code>` to prevent very specific rules
- translating some `\b` commands to `<b>` to prevent very specific rule (appeared only  once).