### PR TITLE
Missing return type assignment

### DIFF
--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -2546,7 +2546,7 @@ class TranslatorBrazilian : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Estrutura"; break;

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -2351,7 +2351,7 @@ class TranslatorChinese : public TranslatorAdapter_1_16_0
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="结构体"; break;

--- a/src/translator_cz.h
+++ b/src/translator_cz.h
@@ -2474,7 +2474,7 @@ class TranslatorCzech : public TranslatorAdapter_1_9_6
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result = "Struktury"; break;

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -2448,7 +2448,7 @@ class TranslatorGerman : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Struct"; break;

--- a/src/translator_en.h
+++ b/src/translator_en.h
@@ -2349,7 +2349,7 @@ class TranslatorEnglish : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Struct"; break;

--- a/src/translator_es.h
+++ b/src/translator_es.h
@@ -2512,7 +2512,7 @@ class TranslatorSpanish : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Estructura"; break;

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -2286,7 +2286,7 @@ class TranslatorGreek : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Δομής"; break;

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -2380,7 +2380,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_16_0
       switch(compType)
       {
       case ClassDef::Class:
-        if (lang == SrcLangExt::Fortran) trType(true,true);
+        if (lang == SrcLangExt::Fortran) result=trType(true,true);
         else result=trClass(true,true);
         break;
       case ClassDef::Struct:     result="Struktūra"; break;

--- a/src/translator_nl.h
+++ b/src/translator_nl.h
@@ -2008,7 +2008,7 @@ class TranslatorDutch : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Struct"; break;

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -2297,7 +2297,7 @@ class TranslatorPolish : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Struktura"; break;

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -2413,7 +2413,7 @@ class TranslatorPortuguese : public Translator
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Estrutura"; break;

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -2312,7 +2312,7 @@ class TranslatorRussian : public TranslatorAdapter_1_16_0
     switch (compType) {
     case ClassDef::Class:
       if (lang == SrcLangExt::Fortran)
-        trType(true, true);
+        result = trType(true, true);
       else
         result = trClass(true, true);
       break;

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -2429,7 +2429,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
       switch(compType)
       {
         case ClassDef::Class:
-          if (lang == SrcLangExt::Fortran) trType(true,true);
+          if (lang == SrcLangExt::Fortran) result=trType(true,true);
           else result=trClass(true,true);
           break;
         case ClassDef::Struct:     result="Strukt"; break;


### PR DESCRIPTION
In the function `trCompoundType` the return type of `trType` was not assigned to a variable. (see in Japanese and Korean translations adjustments in #12199 and #12200)