### PR TITLE
Unifying output in respect to `min/max/def` values.

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -855,7 +855,7 @@ QString Expert::getDocsForNode(const QDomElement &child) const
     QString minval = child.attribute(SA("minval"));
     QString maxval = child.attribute(SA("maxval"));
     QString defval = child.attribute(SA("defval"));
-    docs+=m_messages[SA("minmaxdef")].arg(minval).arg(maxval).arg(defval);
+    docs+=m_messages[SA("minmaxdefcode")].arg(minval).arg(maxval).arg(defval);
   }
   else if (type==SA("bool"))
   {

--- a/src/config.xml
+++ b/src/config.xml
@@ -4428,10 +4428,8 @@ This setting is not only used for dot files but also for msc temporary files.
     <option type='obsolete' orgtype='bool' id='DOT_MULTI_TARGETS'/>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[Minimum value: {0}, maximum value: {1}, default value: {2}.]]></message>
-    <message name='minmaxdefcode'><![CDATA[ Minimum value: <code>{0}</code>, maximum value: <code>{1}</code>, default value: <code>{2}</code>.]]></message>
+    <message name='minmaxdefcode'><![CDATA[Minimum value: <code>{0}</code>, maximum value: <code>{1}</code>, default value: <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[Possible values are: ]]></message>
-    <message name='defvaltxt'><![CDATA[The default value is: {0}.]]></message>
     <message name='defvalcode'><![CDATA[The default value is: <code>{0}</code>.]]></message>
     <message name='defdir'><![CDATA[The default directory is: <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[The default file is: <code>{0}</code>.]]></message>

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -191,9 +191,9 @@ def prepCDocs(node):
         elif (type == 'int'):
             minval = node.getAttribute('minval')
             maxval = node.getAttribute('maxval')
-            doc += "<br/>" + messages['minmaxdef'].format(minval, maxval, defval)
+            doc += "<br/>" + messages['minmaxdefcode'].format(minval, maxval, defval)
         elif (type == 'bool'):
-            doc += "<br/>" + messages['defvaltxt'].format("YES" if (defval == "1") else "NO")
+            doc += "<br/>" + messages['defvalcode'].format("YES" if (defval == "1") else "NO")
         elif (type == 'list'):
             if format == 'string':
                 values = collectValues(node)

--- a/src/i18n/config_de.xml
+++ b/src/i18n/config_de.xml
@@ -1825,10 +1825,8 @@
     </option>
   </group>
   <generator>
-    <message name="minmaxdef"><![CDATA[Mindestwert: {0}, Höchstwert: {1}, Standardwert: {2}.]]></message>
-    <message name="minmaxdefcode"><![CDATA[ Mindestwert: <code>{0}</code>, Höchstwert: <code>{1}</code>, Standardwert: <code>{2}</code>, ]]></message>
+    <message name="minmaxdefcode"><![CDATA[Mindestwert: <code>{0}</code>, Höchstwert: <code>{1}</code>, Standardwert: <code>{2}</code>.]]></message>
     <message name="possible"><![CDATA[Mögliche Werte sind: ]]></message>
-    <message name="defvaltxt"><![CDATA[Der Standardwert ist: {0}.]]></message>
     <message name="defvalcode"><![CDATA[Der Standardwert ist: <code>{0}</code>.]]></message>
     <message name="defdir"><![CDATA[Das Standardverzeichnis ist: <code>{0}</code>.]]></message>
     <message name="deffile"><![CDATA[Die Standarddatei ist: <code>{0}</code>.]]></message>

--- a/src/i18n/config_es.xml
+++ b/src/i18n/config_es.xml
@@ -1826,10 +1826,8 @@
     </option>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[Valor mínimo: {0}, valor máximo: {1}, valor predeterminado: {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[Valor mínimo: <code>{0}</code>, valor máximo: <code>{1}</code>, valor predeterminado: <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[Los valores posibles son:]]></message>
-    <message name='defvaltxt'><![CDATA[El valor predeterminado es: {0}.]]></message>
     <message name='defvalcode'><![CDATA[El valor predeterminado es: <code>{0}</code>.]]></message>
     <message name='defdir'><![CDATA[El directorio predeterminado es: <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[El archivo predeterminado es: <code>{0}</code>.]]></message>

--- a/src/i18n/config_fr.xml
+++ b/src/i18n/config_fr.xml
@@ -1825,10 +1825,8 @@
     </option>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[Valeur minimum : {0}, valeur maximum : {1}, valeur par défaut : {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[Valeur minimum : <code>{0}</code>, valeur maximum : <code>{1}</code>, valeur par défaut : <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[Les valeurs possibles sont :]]></message>
-    <message name='defvaltxt'><![CDATA[La valeur par défaut est : {0}.]]></message>
     <message name='defvalcode'><![CDATA[La valeur par défaut est : <code>{0}</code>.]]></message>
     <message name='defdir'><![CDATA[Le répertoire par défaut est : <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[Le fichier par défaut est : <code>{0}</code>.]]></message>

--- a/src/i18n/config_ja.xml
+++ b/src/i18n/config_ja.xml
@@ -1824,10 +1824,8 @@
     </option>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[最小値: {0}, 最大値: {1}, デフォルト値: {2}。]]></message>
     <message name='minmaxdefcode'><![CDATA[最小値: <code>{0}</code>, 最大値: <code>{1}</code>, デフォルト値: <code>{2}</code>。]]></message>
     <message name='possible'><![CDATA[可能な値は:]]></message>
-    <message name='defvaltxt'><![CDATA[デフォルト値は {0} です。]]></message>
     <message name='defvalcode'><![CDATA[デフォルト値は <code>{0}</code> です。]]></message>
     <message name='defdir'><![CDATA[デフォルトのディレクトリは <code>{0}</code> です。]]></message>
     <message name='deffile'><![CDATA[デフォルトのファイルは <code>{0}</code> です。]]></message>

--- a/src/i18n/config_ko.xml
+++ b/src/i18n/config_ko.xml
@@ -1838,4 +1838,5 @@
     <message name='andtxt'><![CDATA[그리고]]></message>
     <message name='notetxt'><![CDATA[참고:]]></message>
     <message name='seealsotxt'><![CDATA[참조:]]></message>
+  </generator>
 </doxygenconfig>

--- a/src/i18n/config_ko.xml
+++ b/src/i18n/config_ko.xml
@@ -1823,10 +1823,8 @@
     </option>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[최소값: {0}, 최대값: {1}, 기본값: {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[최소값: <code>{0}</code>, 최대값: <code>{1}</code>, 기본값: <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[가능한 값:]]></message>
-    <message name='defvaltxt'><![CDATA[기본값은 {0}입니다.]]></message>
     <message name='defvalcode'><![CDATA[기본값은 <code>{0}</code>입니다.]]></message>
     <message name='defdir'><![CDATA[기본 디렉토리는 <code>{0}</code>입니다.]]></message>
     <message name='deffile'><![CDATA[기본 파일은 <code>{0}</code>입니다.]]></message>
@@ -1840,5 +1838,4 @@
     <message name='andtxt'><![CDATA[그리고]]></message>
     <message name='notetxt'><![CDATA[참고:]]></message>
     <message name='seealsotxt'><![CDATA[참조:]]></message>
-  </generator>
 </doxygenconfig>

--- a/src/i18n/config_ru.xml
+++ b/src/i18n/config_ru.xml
@@ -2396,10 +2396,8 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
     </option>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[Минимальное значение: {0}, максимальное значение: {1}, значение по умолчанию: {2}.]]></message>
     <message name='minmaxdefcode'><![CDATA[Минимальное значение: <code>{0}</code>, максимальное значение: <code>{1}</code>, значение по умолчанию: <code>{2}</code>.]]></message>
     <message name='possible'><![CDATA[Возможные значения:]]></message>
-    <message name='defvaltxt'><![CDATA[Значение по умолчанию: {0}.]]></message>
     <message name='defvalcode'><![CDATA[Значение по умолчанию: <code>{0}</code>.]]></message>
     <message name='defdir'><![CDATA[Каталог по умолчанию: <code>{0}</code>.]]></message>
     <message name='deffile'><![CDATA[Файл по умолчанию: <code>{0}</code>.]]></message>

--- a/src/i18n/config_zh_CN.xml
+++ b/src/i18n/config_zh_CN.xml
@@ -1821,10 +1821,8 @@
     </option>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[最小值：{0}，最大值：{1}，默认值：{2}。]]></message>
     <message name='minmaxdefcode'><![CDATA[最小值：<code>{0}</code>，最大值：<code>{1}</code>，默认值：<code>{2}</code>。]]></message>
     <message name='possible'><![CDATA[可能的值有：]]></message>
-    <message name='defvaltxt'><![CDATA[默认值为：{0}。]]></message>
     <message name='defvalcode'><![CDATA[默认值为：<code>{0}</code>。]]></message>
     <message name='defdir'><![CDATA[默认目录为：<code>{0}</code>。]]></message>
     <message name='deffile'><![CDATA[默认文件为：<code>{0}</code>。]]></message>

--- a/src/i18n/config_zh_TW.xml
+++ b/src/i18n/config_zh_TW.xml
@@ -1821,10 +1821,8 @@
     </option>
   </group>
   <generator>
-    <message name='minmaxdef'><![CDATA[最小值：{0}，最大值：{1}，預設值：{2}。]]></message>
     <message name='minmaxdefcode'><![CDATA[最小值：<code>{0}</code>，最大值：<code>{1}</code>，預設值：<code>{2}</code>。]]></message>
     <message name='possible'><![CDATA[可能的值有：]]></message>
-    <message name='defvaltxt'><![CDATA[預設值為：{0}。]]></message>
     <message name='defvalcode'><![CDATA[預設值為：<code>{0}</code>。]]></message>
     <message name='defdir'><![CDATA[預設目錄為：<code>{0}</code>。]]></message>
     <message name='deffile'><![CDATA[預設檔案為：<code>{0}</code>。]]></message>


### PR DESCRIPTION
The representation in the the doxywizard of some values was not correct, they should be represented as "code", as such `minmaxdef` is replaced by minmaxdefcode`and consequently `minmaxdef` became obsolete. Analogous for `defvaltxt` and `defvalcode`.