### PR TITLE
Unnecessary line break signs in LaTeX

### DIFF
--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2450,9 +2450,9 @@ void filterLatexString(TextStream &t,const QCString &str,
                    }
                    break;
         case '*':  processEntity(t,pdfHyperlinks,"$\\ast$","*");    break;
-        case '_':  if (!insideTabbing) t << "\\+";
+        case '_':  if (!insideTabbing && *p) t << "\\+";
                    t << "\\_";
-                   if (!insideTabbing) t << "\\+";
+                   if (!insideTabbing && *p) t << "\\+";
                    break;
         case '{':  t << "\\{";           break;
         case '}':  t << "\\}";           break;
@@ -2466,7 +2466,7 @@ void filterLatexString(TextStream &t,const QCString &str,
                      t << "[";
                    break;
         case ']':  if (pc=='[') t << "$\\,$";
-                     if (Config_getBool(PDF_HYPERLINKS) || insideItem)
+                     if ((Config_getBool(PDF_HYPERLINKS) || insideItem) && *p)
                        t << "]\\+";
                      else
                        t << "]";
@@ -2510,7 +2510,7 @@ void filterLatexString(TextStream &t,const QCString &str,
                    {
                      t << static_cast<char>(c);
                    }
-                   if (!insideTabbing && ((c==':' && *p!=':') || c=='/'))
+                   if (!insideTabbing && *p && ((c==':' && *p!=':') || c=='/'))
                    {
                      t << "\\+";
                    }


### PR DESCRIPTION
For the doxygen documentation (internationalization table) some code is generated like:
```
  <tr bgcolor="#ffffff">
    <td bgcolor="#ff5555">Serbian</td>
    <td>Dejan Milosavljevic</td>
    <td><span style="color: brown">[unreachable]</span></td>
    <td bgcolor="#ff5555">1\.6\.0</td>
  </tr>
```
in LaTeX this results in:
```
Serbian&Dejan Milosavljevic&\+[unreachable]\+&1.6.0\\
```

and in the resulting pdf file we see some strange line-break signs (due to the `\+`). The `\+` at the end of the string does not really make sense, so removed (with the `\_` command also the `\+` had to be removed).

Example: [example.tar.gz](https://github.com/user-attachments/files/28925213/example.tar.gz)
