### PR TITLE
Remove redundant QCString conversions

### DIFF
--- a/src/translator_am.h
+++ b/src/translator_am.h
@@ -1693,7 +1693,7 @@ class TranslatorArmenian : public TranslatorAdapter_1_8_0
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Կապ";
+      return name+" Կապ";
     }
 
     /*! Loading message shown when loading search results */

--- a/src/translator_bg.h
+++ b/src/translator_bg.h
@@ -1729,7 +1729,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Връзка";
+      return name+" Връзка";
     }
 
     /*! Loading message shown when loading search results */
@@ -1868,11 +1868,11 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Изброяване Справка"; }
+    { return name+" Изброяване Справка"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" наследен от "+what; }
+    { return members+" наследен от "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2106,7 +2106,7 @@ class TranslatorBulgarian : public TranslatorAdapter_1_9_4
       }
     }
     QCString trCustomReference(const QCString &name) override
-    { return QCString(name)+" Отнася се"; }
+    { return name+" Отнася се"; }
 
     /* Slice */
     QCString trConstants() override

--- a/src/translator_br.h
+++ b/src/translator_br.h
@@ -1902,7 +1902,7 @@ class TranslatorBrazilian : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Relação " + QCString(name);
+      return "Relação " + name;
     }
 
     /*! Loading message shown when loading search results */
@@ -2059,7 +2059,7 @@ class TranslatorBrazilian : public Translator
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" herdados de "+what; }
+    { return members+" herdados de "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2303,7 +2303,7 @@ class TranslatorBrazilian : public Translator
       }
     }
     QCString trCustomReference(const QCString &name) override
-    { return "Referência de " + QCString(name); }
+    { return "Referência de " + name; }
 
     /* Slice */
     QCString trConstants() override

--- a/src/translator_ca.h
+++ b/src/translator_ca.h
@@ -1716,7 +1716,7 @@ class TranslatorCatalan : public TranslatorAdapter_1_8_0
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Relació";
+      return name+" Relació";
     }
 
     /*! Loading message shown when loading search results */

--- a/src/translator_cn.h
+++ b/src/translator_cn.h
@@ -1760,9 +1760,9 @@ class TranslatorChinese : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      // return QCString(name)+" Relation";
+      // return name+" Relation";
       // unsure
-      return QCString(name)+CN_SPC "关系";
+      return name+CN_SPC "关系";
     }
 
     /*! Loading message shown when loading search results */
@@ -1876,7 +1876,7 @@ class TranslatorChinese : public Translator
     /*! Header for the graph showing the directory dependencies */
     QCString trDirDepGraph(const QCString &name) override
     {
-      return QCString(name)+CN_SPC "的目录依赖关系图";
+      return name+CN_SPC "的目录依赖关系图";
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1901,11 +1901,11 @@ class TranslatorChinese : public Translator
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+CN_SPC "枚举类型参考"; }
+    { return name+CN_SPC "枚举类型参考"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+CN_SPC "继承自" CN_SPC+what; }
+    { return members+CN_SPC "继承自" CN_SPC+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2111,7 +2111,7 @@ class TranslatorChinese : public Translator
       }
     }
     QCString trCustomReference(const QCString &name) override
-    { return QCString(name)+" 引用"; }
+    { return name+" 引用"; }
 
     /* Slice */
     QCString trConstants() override

--- a/src/translator_de.h
+++ b/src/translator_de.h
@@ -1855,7 +1855,7 @@ class TranslatorGerman : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Bezug " + QCString(name);
+      return "Bezug " + name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1999,11 +1999,11 @@ class TranslatorGerman : public Translator
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Enum-Referenz"; }
+    { return name+" Enum-Referenz"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" geerbt von "+what; }
+    { return members+" geerbt von "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2238,7 +2238,7 @@ class TranslatorGerman : public Translator
       }
     }
     QCString trCustomReference(const QCString &name) override
-    { return QCString(name)+"-Referenz"; }
+    { return name+"-Referenz"; }
 
 //////////////////////////////////////////////////////////////////////////
 // new since 1.8.19

--- a/src/translator_dk.h
+++ b/src/translator_dk.h
@@ -1659,7 +1659,7 @@ class TranslatorDanish : public TranslatorAdapter_1_8_0
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Relation";        // " Relation"
+      return name+" Relation";        // " Relation"
     }
 
     /*! Loading message shown when loading search results */

--- a/src/translator_eo.h
+++ b/src/translator_eo.h
@@ -1712,7 +1712,7 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Rilato";
+      return name+" Rilato";
     }
 
     /*! Loading message shown when loading search results */
@@ -1863,11 +1863,11 @@ class TranslatorEsperanto : public TranslatorAdapter_1_8_4
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Enum Referenco"; }
+    { return name+" Enum Referenco"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" heredita el "+what; }
+    { return members+" heredita el "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_fa.h
+++ b/src/translator_fa.h
@@ -608,7 +608,7 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
         default: break;
       }
       if (isTemplate) result+=" قالب";
-      result=QCString(clName) + " مرجع" +result ;
+      result=clName + " مرجع" +result ;
       return result;
     }
 
@@ -1698,7 +1698,7 @@ class TranslatorPersian : public TranslatorAdapter_1_7_5
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name) + " Relation";
+      return name + " Relation";
     }
 
     /*! Loading message shown when loading search results */

--- a/src/translator_fr.h
+++ b/src/translator_fr.h
@@ -1796,7 +1796,7 @@ class TranslatorFrench : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Relation " + QCString(name);
+      return "Relation " + name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1940,11 +1940,11 @@ class TranslatorFrench : public Translator
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Référence de l'énumération"; }
+    { return name+" Référence de l'énumération"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" hérités de "+what; }
+    { return members+" hérités de "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2178,7 +2178,7 @@ class TranslatorFrench : public Translator
       }
     }
     QCString trCustomReference(const QCString &name) override
-    { return QCString("Référence ") + QCString(name); }
+    { return QCString("Référence ") + name; }
 
     QCString trConstants() override
     {

--- a/src/translator_gr.h
+++ b/src/translator_gr.h
@@ -1713,7 +1713,7 @@ class TranslatorGreek : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Σχέση του "+QCString(name);
+      return "Σχέση του "+name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1859,7 +1859,7 @@ class TranslatorGreek : public Translator
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" κληρονόμησαν από "+what; }
+    { return members+" κληρονόμησαν από "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_hr.h
+++ b/src/translator_hr.h
@@ -1405,7 +1405,7 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-        return QCString("Relacije ") + QCString(name);
+        return QCString("Relacije ") + name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1547,11 +1547,11 @@ class TranslatorCroatian : public TranslatorAdapter_1_8_2
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return "Opis enumeracije " + QCString(name); }
+    { return "Opis enumeracije " + name; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" naslijeđeni od "+what; }
+    { return members+" naslijeđeni od "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_hu.h
+++ b/src/translator_hu.h
@@ -1740,7 +1740,7 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" kapcsolat";
+      return name+" kapcsolat";
     }
 
     /*! Loading message shown when loading search results */
@@ -1883,11 +1883,11 @@ class TranslatorHungarian : public TranslatorAdapter_1_8_15
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" felsoroló referencia"; }
+    { return name+" felsoroló referencia"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" a(z) "+what+" osztályból származnak"; }
+    { return members+" a(z) "+what+" osztályból származnak"; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_id.h
+++ b/src/translator_id.h
@@ -1693,7 +1693,7 @@ class TranslatorIndonesian : public TranslatorAdapter_1_8_0
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Relasi "+QCString(name);
+      return "Relasi "+name;
     }
 
     /*! Loading message shown when loading search results */

--- a/src/translator_it.h
+++ b/src/translator_it.h
@@ -1693,7 +1693,7 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Relazione per "+QCString(name);
+      return "Relazione per "+name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1837,11 +1837,11 @@ class TranslatorItalian : public TranslatorAdapter_1_8_15
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString("Riferimenti per il tipo enumerato ") + QCString(name); }
+    { return QCString("Riferimenti per il tipo enumerato ") + name; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" ereditati da "+what; }
+    { return members+" ereditati da "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_jp.h
+++ b/src/translator_jp.h
@@ -1740,7 +1740,7 @@ class TranslatorJapanese : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" 関係";
+      return name+" 関係";
     }
 
     /*! Loading message shown when loading search results */
@@ -1852,7 +1852,7 @@ class TranslatorJapanese : public Translator
 
     /*! Header for the graph showing the directory dependencies */
     QCString trDirDepGraph(const QCString &name) override
-    { return QCString(name)+" のディレクトリ依存関係図"; }
+    { return name+" のディレクトリ依存関係図"; }
 
 //////////////////////////////////////////////////////////////////////////
 // new since 1.8.0

--- a/src/translator_kr.h
+++ b/src/translator_kr.h
@@ -1728,7 +1728,7 @@ class TranslatorKorean : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" 관계";
+      return name+" 관계";
     }
 
     /*! Loading message shown when loading search results */
@@ -1765,7 +1765,7 @@ class TranslatorKorean : public Translator
      */
     QCString trFileIn(const QCString &name) override
     {
-      return QCString(name) + "의 파일";
+      return name + "의 파일";
     }
 
     /*! when clicking a directory dependency label, a page with a
@@ -1774,7 +1774,7 @@ class TranslatorKorean : public Translator
      */
     QCString trIncludesFileIn(const QCString &name) override
     {
-      return QCString(name) + "의 파일 포함";
+      return name + "의 파일 포함";
     }
 
     /** Compiles a date string.
@@ -1841,7 +1841,7 @@ class TranslatorKorean : public Translator
 
     /*! Header for the graph showing the directory dependencies */
     QCString trDirDepGraph(const QCString &name) override
-    { return QCString(name) + QCString("에 대한 디렉토리 의존성 그래프:"); }
+    { return name + QCString("에 대한 디렉토리 의존성 그래프:"); }
 
 //////////////////////////////////////////////////////////////////////////
 // new since 1.8.0
@@ -1867,11 +1867,11 @@ class TranslatorKorean : public Translator
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Enum Reference"; }
+    { return name+" Enum Reference"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(what) + QCString("(으)로부터 상속된 ") + QCString(members); }
+    { return what + QCString("(으)로부터 상속된 ") + members; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2541,7 +2541,7 @@ class TranslatorKorean : public Translator
     { return "다음은 모든 토픽들의 목록입니다. (간략한 설명만을 보여줍니다):"; }
 
     QCString trCustomReference(const QCString &name) override
-    { return QCString(name)+" 참조"; }
+    { return name+" 참조"; }
 
 //////////////////////////////////////////////////////////////////////////
 // new since 1.10.0

--- a/src/translator_lv.h
+++ b/src/translator_lv.h
@@ -1720,7 +1720,7 @@ class TranslatorLatvian : public TranslatorAdapter_1_16_0
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" relācija";
+      return name+" relācija";
     }
 
     /*! Loading message shown when loading search results */
@@ -1865,11 +1865,11 @@ class TranslatorLatvian : public TranslatorAdapter_1_16_0
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" uzskaitījumliterāļa atsauce"; }
+    { return name+" uzskaitījumliterāļa atsauce"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" manto no "+what; }
+    { return members+" manto no "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_pl.h
+++ b/src/translator_pl.h
@@ -1671,7 +1671,7 @@ class TranslatorPolish : public Translator
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Relacja "+ QCString(name);
+      return "Relacja "+ name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1817,7 +1817,7 @@ class TranslatorPolish : public Translator
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" dziedziczone z "+what; }
+    { return members+" dziedziczone z "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_pt.h
+++ b/src/translator_pt.h
@@ -1766,7 +1766,7 @@ class TranslatorPortuguese : public Translator
      */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Relação " + QCString(name);
+      return "Relação " + name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1923,7 +1923,7 @@ class TranslatorPortuguese : public Translator
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" herdados de "+what; }
+    { return members+" herdados de "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2170,7 +2170,7 @@ class TranslatorPortuguese : public Translator
       }
     }
     QCString trCustomReference(const QCString &name) override
-    { return "Referência de " + QCString(name); }
+    { return "Referência de " + name; }
 
     /* Slice */
     QCString trConstants() override

--- a/src/translator_ro.h
+++ b/src/translator_ro.h
@@ -1723,7 +1723,7 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Relație";
+      return name+" Relație";
     }
 
     /*! Loading message shown when loading search results */
@@ -1868,11 +1868,11 @@ class TranslatorRomanian : public TranslatorAdapter_1_8_15
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Referință Enum"; }
+    { return name+" Referință Enum"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" moștenit(e) din "+what; }
+    { return members+" moștenit(e) din "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_ru.h
+++ b/src/translator_ru.h
@@ -1687,7 +1687,7 @@ class TranslatorRussian : public TranslatorAdapter_1_16_0
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Связь";
+      return name+" Связь";
     }
 
     /*! Loading message shown when loading search results */
@@ -1828,11 +1828,11 @@ class TranslatorRussian : public TranslatorAdapter_1_16_0
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Ссылки на перечисление"; }
+    { return name+" Ссылки на перечисление"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" унаследованные от "+what; }
+    { return members+" унаследованные от "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_sk.h
+++ b/src/translator_sk.h
@@ -1674,7 +1674,7 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Relácia " + QCString(name);
+      return "Relácia " + name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1824,11 +1824,11 @@ class TranslatorSlovak : public TranslatorAdapter_1_8_15
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return "Referencia k enumerácii "+QCString(name); }
+    { return "Referencia k enumerácii "+name; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" dedí sa z "+what; }
+    { return members+" dedí sa z "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)

--- a/src/translator_sv.h
+++ b/src/translator_sv.h
@@ -1833,7 +1833,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return QCString(name)+" Relation";
+      return name+" Relation";
     }
 
     /*! Loading message shown when loading search results */
@@ -1976,11 +1976,11 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Enum-referens"; }
+    { return name+" Enum-referens"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" ärvd ifrån "+what; }
+    { return members+" ärvd ifrån "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)
@@ -2213,7 +2213,7 @@ class TranslatorSwedish : public TranslatorAdapter_1_9_6
       }
     }
     QCString trCustomReference(const QCString &name) override
-    { return QCString(name)+"referens"; }
+    { return name+"referens"; }
 
     /* Slice */
     QCString trConstants() override

--- a/src/translator_tr.h
+++ b/src/translator_tr.h
@@ -1706,7 +1706,7 @@ class TranslatorTurkish : public TranslatorAdapter_1_7_5
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-    return QCString(name)+" İlişkisi";
+    return name+" İlişkisi";
     }
 
     /*! Loading message shown when loading search results */

--- a/src/translator_ua.h
+++ b/src/translator_ua.h
@@ -1686,7 +1686,7 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
     /*! directory relation for \a name */
     QCString trDirRelation(const QCString &name) override
     {
-      return "Зв'язок з "+QCString(name);
+      return "Зв'язок з "+name;
     }
 
     /*! Loading message shown when loading search results */
@@ -1827,11 +1827,11 @@ class TranslatorUkrainian : public TranslatorAdapter_1_8_4
 
     /*! Header of a Java enum page (Java enums are represented as classes). */
     QCString trEnumReference(const QCString &name) override
-    { return QCString(name)+" Перелік"; }
+    { return name+" Перелік"; }
 
     /*! Used for a section containing inherited members */
     QCString trInheritedFrom(const QCString &members,const QCString &what) override
-    { return QCString(members)+" успадковано з "+what; }
+    { return members+" успадковано з "+what; }
 
     /*! Header of the sections with inherited members specific for the
      *  base class(es)


### PR DESCRIPTION
Remove redundant QCString conversions in translation files (found in PR #12209, here handled separately)