### PR TITLE
Improve brief part internal doxygen documentation

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -2428,7 +2428,7 @@ void ClassDefImpl::writeTagFile(TextStream &tagFile) const
   tagFile << "  </compound>\n";
 }
 
-/** Write class documentation inside another container (i.e. a group) */
+/** Write class documentation inside another container (i.e\. a group) */
 void ClassDefImpl::writeInlineDocumentation(OutputList &ol) const
 {
   bool isSimple = m_isSimple;

--- a/src/classdef.h
+++ b/src/classdef.h
@@ -141,7 +141,7 @@ class ClassDef : public Definition
     /** returns the file name to use for the inheritance graph */
     virtual QCString inheritanceGraphFileName() const = 0;
 
-    /** Returns the type of compound this is, i.e. class/struct/union/.. */
+    /** Returns the type of compound this is, i.e\. class/struct/union/..\. */
     virtual CompoundType compoundType() const = 0;
 
     /** Returns the type of compound as a string */

--- a/src/dirdef.h
+++ b/src/dirdef.h
@@ -78,17 +78,17 @@ class UsedDir
     const DirDef *dir() const { return m_dir; }
 
     /** Returns true iff any of the dependencies between source and destination files are
-     *  direct (i.e. not "inherited" from sub directories)
+     *  direct (i.e\. not "inherited" from sub directories)
      */
     bool hasDirectDeps() const { return m_hasDirectDeps; }
 
     /** Returns true iff any of the dependencies from the source file to the destination file are
-     *  directly coming from a file in the source directory (i.e. not inherited via sub directories)
+     *  directly coming from a file in the source directory (i.e\. not inherited via sub directories)
      */
     bool hasDirectSrcDeps() const { return m_hasDirectSrcDeps; }
 
     /** Returns true iff any of the dependencies from the source file to the destination file are
-     *  directly targeting a file in the destination directory (i.e. not inherited via sub directories)
+     *  directly targeting a file in the destination directory (i.e\. not inherited via sub directories)
      */
     bool hasDirectDstDeps() const { return m_hasDirectDstDeps; }
 

--- a/src/searchindex.h
+++ b/src/searchindex.h
@@ -107,7 +107,7 @@ class SearchIndex
 };
 
 /** Writes search index that should be used with an externally provided search engine,
- *  e.g. doxyindexer and doxysearch.cgi.
+ *  e.g\. doxyindexer and doxysearch.cgi.
  */
 class SearchIndexExternal
 {

--- a/src/symbolresolver.h
+++ b/src/symbolresolver.h
@@ -107,7 +107,7 @@ class SymbolResolver
 
     // getters
 
-    /** In case a call to resolveClass() resolves to a type member (e.g. an enum)
+    /** In case a call to resolveClass() resolves to a type member (e.g\. an enum)
      *  this method will return it.
      */
     const MemberDef *getTypedef() const;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1350,7 +1350,7 @@ QCString tempArgListToString(const ArgumentList &al,SrcLangExt lang,bool include
 /*! takes the \a buf of the given length \a len and converts CR LF (DOS)
  * or CR (MAC) line ending to LF (Unix).  Returns the length of the
  * converted content (i.e. the same as \a len (Unix, MAC) or
- * smaller (DOS).
+ * smaller (DOS)).
  */
 static void filterCRLF(std::string &contents)
 {
@@ -6189,7 +6189,7 @@ uint32_t getUtf8CodeToUpper( const QCString& s, int idx )
 
 //----------------------------------------------------------------------------
 
-/** Strip the direction part from docs and return it as a string in canonical form
+/** Strip the direction part from docs and return it as a string in canonical form.
  *  The input \a docs string can start with e.g. "[in]", "[in, out]", "[inout]", "[out,in]"...
  *  @returns either "[in,out]", "[in]", or "[out]" or the empty string.
  */


### PR DESCRIPTION
Some brief internal doxygen documentation was cut-off at the end of `i.e.` or `e.g.` this has been corrected