### PR TITLE
Creating some helper functions for the `enum class MemberType`

### DIFF
--- a/src/defgen.cpp
+++ b/src/defgen.cpp
@@ -87,27 +87,9 @@ static void generateDEFForMember(const MemberDef *md,
   memPrefix.append( prefix );
   memPrefix.append( "-mem-" );
 
-  QCString memType;
-  bool isFunc=FALSE;
-  switch (md->memberType())
-  {
-    case MemberType::Define:      memType="define";     break;
-    case MemberType::EnumValue:   ASSERT(0);            break;
-    case MemberType::Property:    memType="property";   break;
-    case MemberType::Event:       memType="event";      break;
-    case MemberType::Variable:    memType="variable";   break;
-    case MemberType::Typedef:     memType="typedef";    break;
-    case MemberType::Enumeration: memType="enum";       break;
-    case MemberType::Interface:   memType="interface";  break;
-    case MemberType::Service:     memType="service";    break;
-    case MemberType::Sequence:    memType="sequence";   break;
-    case MemberType::Dictionary:  memType="dictionary"; break;
-    case MemberType::Function:    memType="function";   isFunc=TRUE; break;
-    case MemberType::Signal:      memType="signal";     isFunc=TRUE; break;
-    case MemberType::Friend:      memType="friend";     isFunc=TRUE; break;
-    case MemberType::DCOP:        memType="dcop";       isFunc=TRUE; break;
-    case MemberType::Slot:        memType="slot";       isFunc=TRUE; break;
-  }
+  if (md->memberType() == MemberType::EnumValue) ASSERT(0);
+  bool isFunc=to_isFunction(md->memberType());
+  QCString memType = to_string_lower(md->memberType());
 
   t << memPrefix << "kind = '" << memType << "';\n";
   t << memPrefix << "id   = '"

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4097,26 +4097,15 @@ void MemberDefImpl::writeMemberDocSimple(OutputList &ol, const Definition *conta
 
 QCString MemberDefImpl::memberTypeName() const
 {
-  switch (m_mtype)
+  if (m_mtype == MemberType::Define)
   {
-    case MemberType::Define:      return "macro definition";
-    case MemberType::Function:    return "function";
-    case MemberType::Variable:    return "variable";
-    case MemberType::Typedef:     return "typedef";
-    case MemberType::Enumeration: return "enumeration";
-    case MemberType::EnumValue:   return "enumvalue";
-    case MemberType::Signal:      return "signal";
-    case MemberType::Slot:        return "slot";
-    case MemberType::Friend:      return "friend";
-    case MemberType::DCOP:        return "dcop";
-    case MemberType::Property:    return "property";
-    case MemberType::Event:       return "event";
-    case MemberType::Interface:   return "interface";
-    case MemberType::Service:     return "service";
-    case MemberType::Sequence:    return "sequence";
-    case MemberType::Dictionary:  return "dictionary";
-    default:          return "unknown";
+    return "macro definition";
   }
+  else if (m_mtype == MemberType::Enumeration)
+  {
+    return "enumeration";
+  }
+  return to_string_lower(m_mtype);
 }
 
 void MemberDefImpl::warnIfUndocumented() const
@@ -4627,24 +4616,13 @@ void MemberDefImpl::writeTagFile(TextStream &tagFile,bool useQualifiedName,bool 
   if (!isLinkableInProject()) return;
   if (!showNamespaceMembers && getNamespaceDef()) return;
   tagFile << "    <member kind=\"";
-  switch (m_mtype)
+  if (m_mtype == MemberType::Enumeration)
   {
-    case MemberType::Define:      tagFile << "define";      break;
-    case MemberType::EnumValue:   tagFile << "enumvalue";   break;
-    case MemberType::Property:    tagFile << "property";    break;
-    case MemberType::Event:       tagFile << "event";       break;
-    case MemberType::Variable:    tagFile << "variable";    break;
-    case MemberType::Typedef:     tagFile << "typedef";     break;
-    case MemberType::Enumeration: tagFile << "enumeration"; break;
-    case MemberType::Function:    tagFile << "function";    break;
-    case MemberType::Signal:      tagFile << "signal";      break;
-    case MemberType::Friend:      tagFile << "friend";      break;
-    case MemberType::DCOP:        tagFile << "dcop";        break;
-    case MemberType::Slot:        tagFile << "slot";        break;
-    case MemberType::Interface:   tagFile << "interface";   break;
-    case MemberType::Service:     tagFile << "service";     break;
-    case MemberType::Sequence:    tagFile << "sequence";    break;
-    case MemberType::Dictionary:  tagFile << "dictionary";  break;
+    tagFile << "enumeration";
+  }
+  else
+  {
+    tagFile << to_string_lower(m_mtype);
   }
   if (m_prot!=Protection::Public)
   {

--- a/src/message.h
+++ b/src/message.h
@@ -204,27 +204,7 @@ template<> struct fmt::formatter<SrcLangExt> : formatter<std::string>
 template<> struct fmt::formatter<MemberType> : formatter<std::string>
 {
   auto format(MemberType mtype, format_context& ctx) const {
-    std::string result="Unknown";
-    switch (mtype)
-    {
-      case MemberType::Define:      result="Define";      break;
-      case MemberType::Function:    result="Function";    break;
-      case MemberType::Variable:    result="Variable";    break;
-      case MemberType::Typedef:     result="Typedef";     break;
-      case MemberType::Enumeration: result="Enumeration"; break;
-      case MemberType::EnumValue:   result="EnumValue";   break;
-      case MemberType::Signal:      result="Signal";      break;
-      case MemberType::Slot:        result="Slot";        break;
-      case MemberType::Friend:      result="Friend";      break;
-      case MemberType::DCOP:        result="DCOP";        break;
-      case MemberType::Property:    result="Property";    break;
-      case MemberType::Event:       result="Event";       break;
-      case MemberType::Interface:   result="Interface";   break;
-      case MemberType::Service:     result="Service";     break;
-      case MemberType::Sequence:    result="Sequence";    break;
-      case MemberType::Dictionary:  result="Dictionary";  break;
-    }
-    return formatter<std::string>::format(result, ctx);
+    return formatter<std::string>::format(to_string(mtype), ctx);
   }
 };
 

--- a/src/perlmodgen.cpp
+++ b/src/perlmodgen.cpp
@@ -1498,28 +1498,9 @@ void PerlModGenerator::generatePerlModForMember(const MemberDef *md,const Defini
   // - template arguments
   //     (templateArguments(), definitionTemplateParameterLists())
 
-  QCString memType;
+  QCString memType = to_string_lower(md->memberType());
   QCString name;
-  bool isFunc=FALSE;
-  switch (md->memberType())
-  {
-    case MemberType::Define:      memType="define";     break;
-    case MemberType::EnumValue:   memType="enumvalue";  break;
-    case MemberType::Property:    memType="property";   break;
-    case MemberType::Variable:    memType="variable";   break;
-    case MemberType::Typedef:     memType="typedef";    break;
-    case MemberType::Enumeration: memType="enum";       break;
-    case MemberType::Function:    memType="function";   isFunc=TRUE; break;
-    case MemberType::Signal:      memType="signal";     isFunc=TRUE; break;
-    case MemberType::Friend:      memType="friend";     isFunc=TRUE; break;
-    case MemberType::DCOP:        memType="dcop";       isFunc=TRUE; break;
-    case MemberType::Slot:        memType="slot";       isFunc=TRUE; break;
-    case MemberType::Event:       memType="event";      break;
-    case MemberType::Interface:   memType="interface";  break;
-    case MemberType::Service:     memType="service";    break;
-    case MemberType::Sequence:    memType="sequence";   break;
-    case MemberType::Dictionary:  memType="dictionary"; break;
-  }
+  bool isFunc=to_isFunction(md->memberType());
 
   bool isFortran = md->getLanguage()==SrcLangExt::Fortran;
   name = md->name();

--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -1660,19 +1660,7 @@ static void generateSqlite3ForMember(const MemberDef *md, struct Refid scope_ref
   bindIntParameter(memberdef_insert,":static",md->isStatic());
   bindIntParameter(memberdef_insert,":extern",md->isExternal());
 
-  bool isFunc=FALSE;
-  switch (md->memberType())
-  {
-    case MemberType::Function: // fall through
-    case MemberType::Signal:   // fall through
-    case MemberType::Friend:   // fall through
-    case MemberType::DCOP:     // fall through
-    case MemberType::Slot:
-      isFunc=TRUE;
-      break;
-    default:
-      break;
-  }
+  bool isFunc=to_isFunction(md->memberType());
 
   if (isFunc)
   {

--- a/src/types.h
+++ b/src/types.h
@@ -548,25 +548,65 @@ constexpr const char *codeSymbolType2Str(CodeSymbolType type) noexcept
 }
 
 
-enum class MemberType
-{
-  Define,
-  Function,
-  Variable,
-  Typedef,
-  Enumeration,
-  EnumValue,
-  Signal,
-  Slot,
-  Friend,
-  DCOP,
-  Property,
-  Event,
-  Interface,
-  Service,
-  Sequence,
-  Dictionary
+#define MEMBERTYPE_SPECIFICATIONS \
+  MEMBERTYPE(Define,      define,     false) \
+  MEMBERTYPE(Function,    function,   true) \
+  MEMBERTYPE(Variable,    variable,   false) \
+  MEMBERTYPE(Typedef,     typedef,    false) \
+  MEMBERTYPE(Enumeration, enum,       false) \
+  MEMBERTYPE(EnumValue,   enumvalue,  false) \
+  MEMBERTYPE(Signal,      signal,     true) \
+  MEMBERTYPE(Slot,        slot,       true) \
+  MEMBERTYPE(Friend,      friend,     true) \
+  MEMBERTYPE(DCOP,        dcop,       true) \
+  MEMBERTYPE(Property,    property,   false) \
+  MEMBERTYPE(Event,       event,      false) \
+  MEMBERTYPE(Interface,   interface,  false) \
+  MEMBERTYPE(Service,     service,    false) \
+  MEMBERTYPE(Sequence,    sequence,   false) \
+  MEMBERTYPE(Dictionary,  dictionary, false)
+
+enum class MemberType {
+#define MEMBERTYPE(x,y,z) x,
+  MEMBERTYPE_SPECIFICATIONS
+#undef MEMBERTYPE
 };
+
+[[maybe_unused]] static constexpr const char *to_string(MemberType mt) noexcept
+{
+  const char *result = "Unknown";
+  switch (mt)
+  {
+#define MEMBERTYPE(x,y,z) case MemberType::x: result = #x; break;
+    MEMBERTYPE_SPECIFICATIONS
+#undef MEMBERTYPE
+  }
+  return result;
+}
+
+[[maybe_unused]] static constexpr const char *to_string_lower(MemberType mt) noexcept
+{
+  const char *result = "unknown";
+  switch (mt)
+  {
+#define MEMBERTYPE(x,y,z) case MemberType::x: result = #y; break;
+  MEMBERTYPE_SPECIFICATIONS
+#undef MEMBERTYPE
+  }
+  return result;
+}
+
+[[maybe_unused]] static constexpr bool to_isFunction(MemberType mt) noexcept
+{
+  bool result = false;
+  switch (mt)
+  {
+#define MEMBERTYPE(x,y,z) case MemberType::x: result = z; break;
+  MEMBERTYPE_SPECIFICATIONS
+#undef MEMBERTYPE
+  }
+  return result;
+}
 
 enum class FortranFormat
 {

--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -696,27 +696,9 @@ static void generateXMLForMember(const MemberDef *md,TextStream &ti,TextStream &
   // group members are only visible in their group
   bool groupMember = md->getGroupDef() && def->definitionType()!=Definition::TypeGroup;
 
-  QCString memType;
-  bool isFunc=FALSE;
-  switch (md->memberType())
-  {
-    case MemberType::Define:      memType="define";      break;
-    case MemberType::Function:    memType="function";    isFunc=TRUE; break;
-    case MemberType::Variable:    memType="variable";    break;
-    case MemberType::Typedef:     memType="typedef";     break;
-    case MemberType::Enumeration: memType="enum";        break;
-    case MemberType::EnumValue:   ASSERT(0);             break;
-    case MemberType::Signal:      memType="signal";      isFunc=TRUE; break;
-    case MemberType::Slot:        memType="slot";        isFunc=TRUE; break;
-    case MemberType::Friend:      memType="friend";      isFunc=TRUE; break;
-    case MemberType::DCOP:        memType="dcop";        isFunc=TRUE; break;
-    case MemberType::Property:    memType="property";    break;
-    case MemberType::Event:       memType="event";       break;
-    case MemberType::Interface:   memType="interface";   break;
-    case MemberType::Service:     memType="service";     break;
-    case MemberType::Sequence:    memType="sequence";    break;
-    case MemberType::Dictionary:  memType="dictionary";  break;
-  }
+  if (md->memberType() == MemberType::EnumValue) ASSERT(0);
+  bool isFunc=to_isFunction(md->memberType());
+  QCString memType = to_string_lower(md->memberType());
 
   QCString nameStr = md->name();
   QCString typeStr = md->typeString();


### PR DESCRIPTION
Creating some helper functions for the `enum class MemberType`  analogous to e.g. `SrcLangExt`