### PR TITLE
Remove some not necessary `(void)` constructs

### DIFF
--- a/src/docsets.cpp
+++ b/src/docsets.cpp
@@ -222,7 +222,7 @@ void DocSets::decContentsDepth()
   //printf("DocSets::decContentsDepth() depth=%zu\n",p->indentStack.size());
 }
 
-void DocSets::addContentsItem(bool isDir,
+void DocSets::addContentsItem(bool /*isDir*/,
                               const QCString &name,
                               const QCString &ref,
                               const QCString &file,
@@ -232,7 +232,6 @@ void DocSets::addContentsItem(bool isDir,
                               const Definition * /*def*/,
                               const QCString & /* nameAsHtml */)
 {
-  (void)isDir;
   //printf("DocSets::addContentsItem(%s) depth=%zu\n",name,p->indentStack.size());
   if (ref==nullptr)
   {
@@ -508,8 +507,7 @@ void DocSets::writeToken(TextStream &t,
   t << "  </Token>\n";
 }
 
-void DocSets::addIndexFile(const QCString &name)
+void DocSets::addIndexFile(const QCString &/*name*/)
 {
-  (void)name;
 }
 

--- a/src/fortranscanner.l
+++ b/src/fortranscanner.l
@@ -3116,10 +3116,9 @@ static void subrHandleCommentBlock(yyscan_t yyscanner,const QCString &doc,bool b
   yyextra->current->inbodyDocs = "";
 
   // strip \\param or @param, so we can do some extra checking. We will add it later on again.
-  if (!loc_doc.stripPrefix("\\param") &&
-      !loc_doc.stripPrefix("@param")
-     ) (void)loc_doc; // Do nothing work has been done by stripPrefix; (void)loc_doc: to overcome 'empty controlled statement' warning
-  loc_doc.stripWhiteSpace();
+  if (loc_doc.stripPrefix("\\param") ||
+      loc_doc.stripPrefix("@param")
+     ) loc_doc = loc_doc.stripWhiteSpace();
 
   // direction as defined with the declaration of the parameter
   int dir1 = yyextra->modifiers[yyextra->current_root][yyextra->argName.lower().str()].direction;
@@ -3220,12 +3219,11 @@ static void subrHandleCommentBlockResult(yyscan_t yyscanner,const QCString &doc,
   yyextra->current->inbodyDocs = "";
 
   // strip \\returns or @returns. We will add it later on again.
-  if (!loc_doc.stripPrefix("\\returns") &&
-      !loc_doc.stripPrefix("\\return") &&
-      !loc_doc.stripPrefix("@returns") &&
-      !loc_doc.stripPrefix("@return")
-     ) (void)loc_doc; // Do nothing work has been done by stripPrefix; (void)loc_doc: to overcome 'empty controlled statement' warning
-  loc_doc.stripWhiteSpace();
+  if (loc_doc.stripPrefix("\\returns") ||
+      loc_doc.stripPrefix("\\return") ||
+      loc_doc.stripPrefix("@returns") ||
+      loc_doc.stripPrefix("@return")
+     ) loc_doc = loc_doc.stripWhiteSpace();
 
   if (!loc_doc.isEmpty() && (loc_doc.lower() != yyextra->argName.lower()))
   {

--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -496,11 +496,9 @@ void MemberList::writePlainDeclarations(OutputList &ol, bool inGroup,
  */
 void MemberList::writeDeclarations(OutputList &ol,
              const ClassDef *cd,const NamespaceDef *nd,const FileDef *fd,const GroupDef *gd,const ModuleDef *mod,
-             const QCString &title,const QCString &subtitle, bool showEnumValues,
+             const QCString &title,const QCString &subtitle, bool /*showEnumValues*/,
              bool showInline,const ClassDef *inheritedFrom,MemberListType lt,bool showSectionTitle) const
 {
-  (void)showEnumValues; // unused
-
   //printf("----- writeDeclaration() this=%p ---- inheritedFrom=%p\n",this,inheritedFrom);
   bool optimizeVhdl = Config_getBool(OPTIMIZE_OUTPUT_VHDL);
   QCString inheritId;

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -367,7 +367,6 @@ void Qhp::addContentsItem(bool /* isDir */, const QCString & name, const QCStrin
 void Qhp::addIndexItem(const Definition *context,const MemberDef *md,
                        const QCString &sectionAnchor,const QCString &word)
 {
-  (void)word;
   //printf("addIndexItem(%s %s %s\n",
   //       context?context->name().data():"<none>",
   //       md?md->name().data():"<none>",

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -628,10 +628,9 @@ QCString VHDLOutlineParser::popLabel(QCString & q)
 
 
 void VHDLOutlineParser::addProto(const QCString &s1,const QCString &s2,const QCString &s3,
-                                 const QCString &s4,const QCString &s5,const QCString &s6)
+                                 const QCString &s4,const QCString &/*s5*/,const QCString &s6)
 {
   VhdlParser::SharedState *s = &p->shared;
-  (void)s5; // avoid unused warning
   StringVector ql=split(s2.str(),",");
 
   for (const auto &n : ql)


### PR DESCRIPTION
- commenting the argument name
- `fortranscanner.l`: `stripWhiteSpace` is not an inplace operations, so needs assignment. It can be done, after reformulating the `if` condition when as prefix has been stripped (in that case string has been changed and some space might have occurred, otherwise it was already remove a couple of lines before).