### PR TITLE
Display Additional inherited members in HTML

### DIFF
--- a/src/memberlist.cpp
+++ b/src/memberlist.cpp
@@ -422,7 +422,7 @@ void MemberList::writePlainDeclarations(OutputList &ol, bool inGroup,
                             };
                 if (!ast->isEmpty())
                 {
-                  ol.startMemberDescription(md->anchor());
+                  ol.startMemberDescription(md->anchor(),inheritId);
                   ol.writeDoc(ast.get(),cd,md);
                   if (md->hasDetailedDescription())
                   {


### PR DESCRIPTION
When we have additional inherited members and `HTML_DYNAMIC_SECTIONS=YES` the brief description of the additional member is displayed outside the collapsed item. This can be seen for the additional inherited members of `ClassDefImpl` in the doxygen internal documentation.