### PR TITLE
Representation of (long) inline simple structs

### DIFF
--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -3517,15 +3517,15 @@ void HtmlGenerator::startInlineHeader()
 {
   if (m_emptySection)
   {
-    m_t << "<table class=\"memberdecls\">\n";
+    m_t << "<table class=\"memberdecls memberdecls-inline\">\n";
     m_emptySection=FALSE;
   }
-  m_t << "<tr><td colspan=\"2\"><h3>";
+  m_t << "<tr><th colspan=\"2\"><h3>";
 }
 
 void HtmlGenerator::endInlineHeader()
 {
-  m_t << "</h3></td></tr>\n";
+  m_t << "</h3></th></tr>\n";
 }
 
 void HtmlGenerator::startMemberDocSimple(bool isEnum)

--- a/templates/html/doxygen.css
+++ b/templates/html/doxygen.css
@@ -723,6 +723,11 @@ table.memberdecls {
 	padding: 0px;
 }
 
+table.memberdecls-inline {
+	border: 1px solid var(--memdef-border-color);
+	border-radius: 4px;
+}
+
 .memberdecls td, .fieldtable tr {
 	transition-property: background-color, box-shadow;
 	transition-duration: 0.5s;
@@ -1377,7 +1382,11 @@ table.fieldtable {
 	border-bottom: none;
 }
 
-.fieldtable th {
+.memberdecls-inline th h3 {
+  margin-left: 15px;
+}
+
+.memberdecls-inline th, .fieldtable th {
 	background-color: var(--memdef-title-background-color);
 	font-size: 90%;
 	color: var(--memdef-proto-text-color);


### PR DESCRIPTION
When we have the setting `INLINE_SIMPLE_STRUCTS` set to `YES`  the representation of the long form (as can be seen with the `struct my_struct_t` of the second example in #12228) is not correct, the header of the table is missing.
Introducing here the css class `memberdecls-inline` as adding the settings directly to the css class `memberdecls` leads to problem with other `memberdecls` headers. 
The words "Data fields" are also representing a header and should be noted as such.