### PR TITLE
Remove conditionals from `ALIASES`  in configuration file.

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -1053,6 +1053,9 @@ QString Expert::getDocsForNode(const QDomElement &child, const QString &mode) co
   regexp.setPattern(SA("\\\\c[ ]+(@[{}])"));
   docs.replace(regexp,SA("<code>\\1</code>"));
 
+  regexp.setPattern(SA("\\\\c[ ]+(@@[{}])"));
+  docs.replace(regexp,SA("<code>\\1</code>"));
+
   // `word` -> <code>word</code>
   docs.replace(SA("``"),SA(""));
   regexp.setPattern(SA("`([^`]+)`"));
@@ -1101,6 +1104,7 @@ QString Expert::getDocsForNode(const QDomElement &child, const QString &mode) co
   // \@ -> @
   docs.replace(SA("\\\\"),SA("\\"));
   docs.replace(SA("\\@"),SA("@"));
+  docs.replace(SA("@@"),SA("@"));
   // \& -> &
   // \$ -> $
   docs.replace(SA("\\&"),SA("&"));

--- a/src/config.xml
+++ b/src/config.xml
@@ -593,15 +593,7 @@ Go to the <a href="commands.html">next</a> section or return to the
  a physical newline was in the original file.
 ]]>
       </docs>
-      <docs filter="doxywizard,doxyfile">
-<![CDATA[
- When you need a literal `{` or `}` or `,` in the value part of an alias you have to
- escape them by means of a backslash (\c \\), this can lead to conflicts with the
- commands \c \\{ and \c \\} for these it is advised to use the version \c @{ and \c @} or
- use a double escape (\c \\\\{ and \c \\\\})
-]]>
-      </docs>
-      <docs filter="documentation">
+      <docs>
 <![CDATA[
  When you need a literal `{` or `}` or `,` in the value part of an alias you have to
  escape them by means of a backslash (\c \\), this can lead to conflicts with the

--- a/src/configgen.py
+++ b/src/configgen.py
@@ -71,6 +71,7 @@ def transformDocs(doc):
     doc = doc.replace("\\>", ">")
     doc = doc.replace("\\@", "@")
     doc = doc.replace("\\\\", "\\")
+    doc = doc.replace("@@", "@")
     # \ref name "description" -> description
     doc = re.sub('\\\\ref +[^ ]* +"\\\\ref"', '\\\\REF', doc)
     doc = re.sub('\\\\ref +[^ ]* +"([^"]*)"', '\\1', doc)


### PR DESCRIPTION
Make the texts for the different types of output identical. (Note: the sectioning has been kept so no difference occurs, i.e. properly retaining the new line, in the different output versions, doxyfile, documentation, doxywizard).