### PR TITLE
Handling of multiple `<docs>` sections in an `<option>` section

### DIFF
--- a/addon/doxywizard/expert.cpp
+++ b/addon/doxywizard/expert.cpp
@@ -117,25 +117,32 @@ static void translateOption(QDomElement &configRoot,const QDomElement &translati
 {
   QDomElement docsVal   = configRoot.firstChildElement();
   QDomElement trDocsVal = translationRoot.firstChildElement();
-  bool first=true;
-  if (!docsVal.isNull()   && docsVal.tagName()==SA("docs") &&
-      !trDocsVal.isNull() && trDocsVal.tagName()==SA("docs"))
+  while (!docsVal.isNull() && !trDocsVal.isNull())
   {
-    //qDebug() << "id=" << configRoot.attribute(SA("id")) << "trId=" << translationRoot.attribute(SA("id"));
-    docsVal.parentNode().replaceChild(trDocsVal,docsVal);
-  }
-  docsVal = configRoot.firstChildElement().nextSiblingElement();
-  // disable options docs (already part of the translation)
-  while (!docsVal.isNull())
-  {
-    //qDebug() << "tagName" << docsVal.tagName();
     if (docsVal.tagName()==SA("docs") && getFilter(docsVal, mode))
     {
-      docsVal.removeAttribute(SA("filter"));
-      // we just need a value so we don't have an empty filter (and thus potential a match on doxywizard later on).
-      docsVal.setAttribute(SA("filter"),SA("dummy"));
+      if (trDocsVal.tagName()==SA("docs") && getFilter(trDocsVal, mode))
+      {
+        QDomNode oldText = docsVal.firstChild();
+        oldText.setNodeValue (trDocsVal.text());
+        docsVal = docsVal.nextSiblingElement();
+        trDocsVal = trDocsVal.nextSiblingElement();
+      }
+      else
+      {
+        trDocsVal = trDocsVal.nextSiblingElement();
+      }
     }
-    else if (docsVal.tagName()==SA("value") && docsVal.hasAttribute(SA("desc")))
+    else
+    {
+      docsVal = docsVal.nextSiblingElement();
+    }
+  }
+  docsVal = configRoot.firstChildElement();
+  // Just handle value tags
+  while (!docsVal.isNull())
+  {
+    if (docsVal.tagName()==SA("value") && docsVal.hasAttribute(SA("desc")))
     {
       //qDebug() << "attribute" << docsVal.attribute(SA("desc"));
       translateEnumDescription(docsVal,translationRoot);

--- a/src/config.xml
+++ b/src/config.xml
@@ -3153,11 +3153,11 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
  @note The header is subject to change so you typically
  have to regenerate the default header when upgrading to a newer version of
  Doxygen.
- The following commands have a special meaning inside the header (and footer):
 ]]>
       </docs>
       <docs filter="documentation">
 <![CDATA[
+ The following markers have a special meaning inside the header and footer:
  <dl>
  <dt><code>$title</code><dd>will be replaced with the project name.
  <dt><code>$datetime</code><dd>will be replaced with the current date and time.

--- a/src/i18n/config_de.xml
+++ b/src/i18n/config_de.xml
@@ -199,8 +199,15 @@
     </option>
     <option type="list" id="ALIASES" format="string">
       <docs>
-<![CDATA[Dieses Tag kann verwendet werden, um eine Reihe von Aliasnamen anzugeben, die als Befehle in der Dokumentation fungieren. Ein Alias hat die Form: \verbatim name=wert\endverbatim Zum Beispiel wurde das Hinzufügen von \verbatim "sideeffect=@par Nebeneffekte:^^"\endverbatim es Ihnen ermöglichen, den Befehl \c \sideeffect (oder \c \@sideeffect) in der Dokumentation zu platzieren, was einen benutzerdefinierten Absatz mit der Überschrift "Nebeneffekte:" erzeugt. Beachten Sie, dass Sie im Werteteil eines Alias kein \ref cmdn "\n" einfügen können, um einen Zeilenumbruch einzufügen (in der resultierenden Ausgabe). Sie können `^^` im Werteteil eines Alias einfügen, um einen Zeilenumbruch einzufügen, als ob ein physikalischer Zeilenumbruch in der Originaldatei vorhanden wäre. Wenn Sie ein wörtliches `{` oder `}` oder `,` im Werteteil eines Alias benötigen, müssen Sie diese mit einem Backslash maskieren (\c \\).]]>
+<![CDATA[Dieses Tag kann verwendet werden, um eine Reihe von Aliasnamen anzugeben, die als Befehle in der Dokumentation fungieren. Ein Alias hat die Form: \verbatim name=wert\endverbatim Zum Beispiel wurde das Hinzufügen von \verbatim "sideeffect=@par Nebeneffekte:^^"\endverbatim es Ihnen ermöglichen, den Befehl \c \sideeffect (oder \c \@sideeffect) in der Dokumentation zu platzieren, was einen benutzerdefinierten Absatz mit der Überschrift "Nebeneffekte:" erzeugt. Beachten Sie, dass Sie im Werteteil eines Alias kein \ref cmdn "\n" einfügen können, um einen Zeilenumbruch einzufügen (in der resultierenden Ausgabe). Sie können `^^` im Werteteil eines Alias einfügen, um einen Zeilenumbruch einzufügen, als ob ein physikalischer Zeilenumbruch in der Originaldatei vorhanden wäre.]]>
       </docs>
+      <docs>
+<![CDATA[
+Wenn Sie in einem Alias im Wertteil ein Literal wie `{`, `}` oder `,` benötigen, müssen Sie diese
+mit einem Backslash (\c \\) maskieren. Dies kann zu Konflikten mit den
+Befehlen \c \\{ und \c \\} führen. Für diese empfiehlt es sich, die Versionen \c @@{ und \c @@} zu verwenden oder
+eine doppelte Maskierung (\c \\\\{ und \c \\\\}) zu verwenden.]]>
+    </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
       <docs>
@@ -544,7 +551,12 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[Das \c FILE_VERSION_FILTER-Tag kann verwendet werden, um ein Programm oder Skript anzugeben, das Doxygen aufrufen soll, um die aktuelle Version für jede Datei zu erhalten (typischerweise vom Versionskontrollsystem). Doxygen ruft das Programm auf, indem es (über <code>popen()</code>) den Befehl <code>command input_file</code> ausführt, wobei \c command der Wert des \c FILE_VERSION_FILTER-Tags ist und \c input_file der Name einer von Doxygen bereitgestellten Eingabedatei ist. Was auch immer das Programm auf die Standardausgabe schreibt, wird als Dateiversion verwendet. Für ein Beispiel siehe die Dokumentation.]]>
+<![CDATA[Das \c FILE_VERSION_FILTER-Tag kann verwendet werden, um ein Programm oder Skript anzugeben, das Doxygen aufrufen soll, um die aktuelle Version für jede Datei zu erhalten (typischerweise vom Versionskontrollsystem). Doxygen ruft das Programm auf, indem es (über <code>popen()</code>) den Befehl <code>command input_file</code> ausführt, wobei \c command der Wert des \c FILE_VERSION_FILTER-Tags ist und \c input_file der Name einer von Doxygen bereitgestellten Eingabedatei ist. Was auch immer das Programm auf die Standardausgabe schreibt, wird als Dateiversion verwendet.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+ Für ein Beispiel siehe die Dokumentation.
+ ]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -879,7 +891,12 @@
     </option>
     <option type="string" id="HTML_HEADER" format="file" defval="" depends="GENERATE_HTML">
       <docs>
-<![CDATA[Das \c HTML_HEADER-Tag kann verwendet werden, um eine benutzerdefinierte HTML-Header-Datei für jede generierte HTML-Seite anzugeben. Wenn das Tag leer gelassen wird, generiert Doxygen einen Standard-Header. <br>Um gültiges HTML zu erhalten, muss die Header-Datei alle Skripte und Stylesheets enthalten, die Doxygen benötigt, was von den verwendeten Konfigurationsoptionen abhängt (z.B. die Einstellung \ref cfg_generate_treeview "GENERATE_TREEVIEW"). Es wird dringend empfohlen, mit einem Standard-Header zu beginnen, indem Sie \verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim verwenden und dann die Datei \c new_header.html ändern. Siehe auch Abschnitt \ref doxygen_usage für Informationen zum Generieren des Standard-Headers, den Doxygen normalerweise verwendet. @note Der Header kann sich ändern, daher müssen Sie normalerweise den Standard-Header regenerieren, wenn Sie auf eine neuere Version von Doxygen aktualisieren. Für eine Beschreibung der möglichen Marker und Blocknamen siehe die Dokumentation.]]>
+<![CDATA[Das \c HTML_HEADER-Tag kann verwendet werden, um eine benutzerdefinierte HTML-Header-Datei für jede generierte HTML-Seite anzugeben. Wenn das Tag leer gelassen wird, generiert Doxygen einen Standard-Header. <br>Um gültiges HTML zu erhalten, muss die Header-Datei alle Skripte und Stylesheets enthalten, die Doxygen benötigt, was von den verwendeten Konfigurationsoptionen abhängt (z.B. die Einstellung \ref cfg_generate_treeview "GENERATE_TREEVIEW"). Es wird dringend empfohlen, mit einem Standard-Header zu beginnen, indem Sie \verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim verwenden und dann die Datei \c new_header.html ändern. Siehe auch Abschnitt \ref doxygen_usage für Informationen zum Generieren des Standard-Headers, den Doxygen normalerweise verwendet. @note Der Header kann sich ändern, daher müssen Sie normalerweise den Standard-Header regenerieren, wenn Sie auf eine neuere Version von Doxygen aktualisieren.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+ Für eine Beschreibung der möglichen Marker und Blocknamen siehe die Dokumentation.
+ ]]>
       </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
@@ -894,7 +911,12 @@
     </option>
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
-<![CDATA[Das \c HTML_EXTRA_STYLESHEET-Tag kann verwendet werden, um zusätzliche benutzerdefinierte Cascading Stylesheets anzugeben, die nach den von Doxygen erstellten Standard-Stylesheets eingebunden werden. Mit dieser Option können bestimmte Stilaspekte überschrieben werden. Dies ist der Verwendung von \ref cfg_html_stylesheet "HTML_STYLESHEET" vorzuziehen, da es das Standard-Stylesheet nicht ersetzt und daher robuster gegen zukünftige Updates ist. Doxygen kopiert die Stylesheet-Dateien in das Ausgabeverzeichnis. \note Die Reihenfolge der zusätzlichen Stylesheet-Dateien ist wichtig (z.B. überschreibt das letzte Stylesheet in der Liste die Einstellungen der vorherigen in der Liste). \note Da die Gestaltung von Scrollleisten in Webkit/Chromium derzeit nicht überschrieben werden kann, wird die Gestaltung aus der Standard-datei doxygen.css weggelassen, wenn ein oder mehrere zusätzliche Stylesheets angegeben wurden. Wenn also eine Anpassung der Scrollleisten gewünscht wird, muss diese explizit hinzugefügt werden. Für ein Beispiel siehe die Dokumentation.]]>
+<![CDATA[Das \c HTML_EXTRA_STYLESHEET-Tag kann verwendet werden, um zusätzliche benutzerdefinierte Cascading Stylesheets anzugeben, die nach den von Doxygen erstellten Standard-Stylesheets eingebunden werden. Mit dieser Option können bestimmte Stilaspekte überschrieben werden. Dies ist der Verwendung von \ref cfg_html_stylesheet "HTML_STYLESHEET" vorzuziehen, da es das Standard-Stylesheet nicht ersetzt und daher robuster gegen zukünftige Updates ist. Doxygen kopiert die Stylesheet-Dateien in das Ausgabeverzeichnis. \note Die Reihenfolge der zusätzlichen Stylesheet-Dateien ist wichtig (z.B. überschreibt das letzte Stylesheet in der Liste die Einstellungen der vorherigen in der Liste). \note Da die Gestaltung von Scrollleisten in Webkit/Chromium derzeit nicht überschrieben werden kann, wird die Gestaltung aus der Standard-datei doxygen.css weggelassen, wenn ein oder mehrere zusätzliche Stylesheets angegeben wurden. Wenn also eine Anpassung der Scrollleisten gewünscht wird, muss diese explizit hinzugefügt werden.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+ Für ein Beispiel siehe die Dokumentation.
+ ]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1161,7 +1183,7 @@
       <value name="chtml" desc="(Dies ist der Name für MathJax Version 3, für MathJax Version 2 wird dies in &lt;code&gt;HTML-CSS&lt;/code&gt; übersetzt)"/>
       <value name="SVG"/>
     </option>
-        <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
+    <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
       <docs>
 <![CDATA[
  Wenn MathJax aktiviert ist, müssen Sie den Speicherort relativ zum HTML-Ausgabeverzeichnis
@@ -1188,7 +1210,12 @@
     </option>
     <option type="string" id="MATHJAX_CODEFILE" format="string" depends="USE_MATHJAX">
       <docs>
-<![CDATA[Das \c MATHJAX_CODEFILE-Tag kann verwendet werden, um eine Datei mit JavaScript-Code-Stucken anzugeben, die beim Start des MathJax-Codes verwendet werden. Siehe die MathJax-Website für weitere Details: - <a href="https://docs.mathjax.org/en/v2.7/">MathJax version 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax version 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax version 4</a> Für ein Beispiel siehe die Dokumentation.]]>
+<![CDATA[Das \c MATHJAX_CODEFILE-Tag kann verwendet werden, um eine Datei mit JavaScript-Code-Stucken anzugeben, die beim Start des MathJax-Codes verwendet werden. Siehe die MathJax-Website für weitere Details: - <a href="https://docs.mathjax.org/en/v2.7/">MathJax version 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax version 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax version 4</a>]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+ Für ein Beispiel siehe die Dokumentation.
+ ]]>
       </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
@@ -1274,7 +1301,12 @@
     </option>
     <option type="string" id="LATEX_HEADER" format="file" defval="" depends="GENERATE_LATEX">
       <docs>
-<![CDATA[Das \c LATEX_HEADER-Tag kann verwendet werden, um einen benutzerdefinierten \f$\mbox{\LaTeX}\f$-Header für das generierte \f$\mbox{\LaTeX}\f$-Dokument anzugeben. Der Header sollte alles bis zum ersten Kapitel enthalten. Wenn er leer gelassen wird, generiert Doxygen einen Standard-Header. Es wird dringend empfohlen, mit einem Standard-Header zu beginnen, indem Sie \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim verwenden und dann die Datei \c new_header.tex ändern. Siehe auch Abschnitt \ref doxygen_usage für Informationen zum Generieren des Standard-Headers, den Doxygen normalerweise verwendet. <br>Hinweis: Verwenden Sie nur einen benutzerdefinierten Header, wenn Sie wissen, was Sie tun! @note Der Header kann sich ändern, daher müssen Sie normalerweise den Standard-Header regenerieren, wenn Sie auf eine neuere Version von Doxygen aktualisieren. Für eine Beschreibung der möglichen Marker und Blocknamen siehe die Dokumentation.]]>
+<![CDATA[Das \c LATEX_HEADER-Tag kann verwendet werden, um einen benutzerdefinierten \f$\mbox{\LaTeX}\f$-Header für das generierte \f$\mbox{\LaTeX}\f$-Dokument anzugeben. Der Header sollte alles bis zum ersten Kapitel enthalten. Wenn er leer gelassen wird, generiert Doxygen einen Standard-Header. Es wird dringend empfohlen, mit einem Standard-Header zu beginnen, indem Sie \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim verwenden und dann die Datei \c new_header.tex ändern. Siehe auch Abschnitt \ref doxygen_usage für Informationen zum Generieren des Standard-Headers, den Doxygen normalerweise verwendet. <br>Hinweis: Verwenden Sie nur einen benutzerdefinierten Header, wenn Sie wissen, was Sie tun! @note Der Header kann sich ändern, daher müssen Sie normalerweise den Standard-Header regenerieren, wenn Sie auf eine neuere Version von Doxygen aktualisieren.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+ Für eine Beschreibung der möglichen Marker und Blocknamen siehe die Dokumentation.
+ ]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">

--- a/src/i18n/config_es.xml
+++ b/src/i18n/config_es.xml
@@ -199,8 +199,13 @@
     </option>
     <option type="list" id="ALIASES" format="string">
       <docs>
-<![CDATA[Esta etiqueta se puede usar para especificar varios alias que actuen como comandos en la documentación. Un alias tiene la forma: \verbatim nombre=valor\endverbatim Por ejemplo, agregar \verbatim "sideeffect=@par Efectos secundarios:^^"\endverbatim le permitirá colocar el comando \c \sideeffect (o \c \@sideeffect) en la documentación, lo que resultará en un párrafo definido por el usuario con el encabezado "Efectos secundarios:". Tenga en cuenta que no puede poner \ref cmdn "\n" en el valor de un alias para insertar un salto de línea (en la salida resultante). Puede poner `^^` en el valor de un alias para insertar un salto de línea como si hubiera un salto de línea físico en el archivo original. Si necesita un `{` o `}` o `,` literal en el valor de un alias, debe escaparlos con una barra invertida; esto puede generar conflictos con los comandos `\{` y `\}`, por lo que para estos se recomienda usar la versión `@{` y `@}` o usar una doble barra invertida (`\\\\{` y `\\\\}`).]]>
+<![CDATA[Esta etiqueta se puede usar para especificar varios alias que actuen como comandos en la documentación. Un alias tiene la forma: \verbatim nombre=valor\endverbatim Por ejemplo, agregar \verbatim "sideeffect=@par Efectos secundarios:^^"\endverbatim le permitirá colocar el comando \c \sideeffect (o \c \@sideeffect) en la documentación, lo que resultará en un párrafo definido por el usuario con el encabezado "Efectos secundarios:". Tenga en cuenta que no puede poner \ref cmdn "\n" en el valor de un alias para insertar un salto de línea (en la salida resultante). Puede poner `^^` en el valor de un alias para insertar un salto de línea como si hubiera un salto de línea físico en el archivo original.]]>
       </docs>
+      <docs>
+<![CDATA[
+Cuando necesites usar literalmente `{`, `}` o `,` en el valor de un alias, debes escaparlos con una barra invertida (\c \\). Esto puede generar conflictos con los comandos `\c \\{` y `\c \\}`. Para estos últimos, se recomienda usar la versión `\c @@{` y `\c @@}` o usar una doble secuencia de escape (`\c \\\\{` y `\c \\\\}`).
+]]>
+    </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
       <docs>
@@ -545,7 +550,12 @@
     </option>
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
-<![CDATA[La etiqueta \c FILE_VERSION_FILTER se puede usar para especificar un programa o script que Doxygen debe invocar para obtener la versión actual de cada archivo (típicamente del sistema de control de versiones). Doxygen invocará el programa ejecutando (via <code>popen()</code>) el comando <code>command input_file</code>, donde \c command es el valor de la etiqueta \c FILE_VERSION_FILTER y \c input_file es el nombre de un archivo de entrada proporcionado por Doxygen. Lo que sea que el programa escriba en la salida estándar se usará como la versión del archivo. Para un ejemplo, vea la documentación.]]>
+<![CDATA[La etiqueta \c FILE_VERSION_FILTER se puede usar para especificar un programa o script que Doxygen debe invocar para obtener la versión actual de cada archivo (típicamente del sistema de control de versiones). Doxygen invocará el programa ejecutando (via <code>popen()</code>) el comando <code>command input_file</code>, donde \c command es el valor de la etiqueta \c FILE_VERSION_FILTER y \c input_file es el nombre de un archivo de entrada proporcionado por Doxygen. Lo que sea que el programa escriba en la salida estándar se usará como la versión del archivo.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Para un ejemplo, vea la documentación.
+]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -880,7 +890,12 @@
     </option>
     <option type="string" id="HTML_HEADER" format="file" defval="" depends="GENERATE_HTML">
       <docs>
-<![CDATA[La etiqueta \c HTML_HEADER se puede usar para especificar un archivo de encabezado HTML personalizado para cada página HTML generada. Si la etiqueta se deja vacía, Doxygen generará un encabezado estándar. <br>Para obtener HTML válido, el archivo de encabezado debe contener todos los scripts y hojas de estilo que Doxygen necesita, lo cual depende de las opciones de configuración usadas (por ejemplo, la configuración \ref cfg_generate_treeview "GENERATE_TREEVIEW"). Se recomienda encarecidamente comenzar con un encabezado estándar usando \verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim y luego modificar el archivo \c new_header.html. Vea también la sección \ref doxygen_usage para información sobre como generar el encabezado estándar que Doxygen normalmente usa. @note El encabezado puede cambiar, por lo que generalmente necesita regenerar el encabezado estándar cuando actualiza a una versión más nueva de Doxygen. Para una descripción de los posibles marcadores y nombres de bloques, vea la documentación.]]>
+<![CDATA[La etiqueta \c HTML_HEADER se puede usar para especificar un archivo de encabezado HTML personalizado para cada página HTML generada. Si la etiqueta se deja vacía, Doxygen generará un encabezado estándar. <br>Para obtener HTML válido, el archivo de encabezado debe contener todos los scripts y hojas de estilo que Doxygen necesita, lo cual depende de las opciones de configuración usadas (por ejemplo, la configuración \ref cfg_generate_treeview "GENERATE_TREEVIEW"). Se recomienda encarecidamente comenzar con un encabezado estándar usando \verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim y luego modificar el archivo \c new_header.html. Vea también la sección \ref doxygen_usage para información sobre como generar el encabezado estándar que Doxygen normalmente usa. @note El encabezado puede cambiar, por lo que generalmente necesita regenerar el encabezado estándar cuando actualiza a una versión más nueva de Doxygen.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Para una descripción de los posibles marcadores y nombres de bloques, vea la documentación.
+]]>
       </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
@@ -895,7 +910,12 @@
     </option>
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
-<![CDATA[La etiqueta \c HTML_EXTRA_STYLESHEET se puede usar para especificar hojas de estilo en cascada personalizadas adicionales que se incluirán después de las hojas de estilo estándar creadas por Doxygen. Con esta opción puede anular ciertos aspectos de estilo. Esto es preferible al uso de \ref cfg_html_stylesheet "HTML_STYLESHEET" ya que no reemplaza la hoja de estilo estándar y por lo tanto es más robusto frente a actualizaciones futuras. Doxygen copiará los archivos de hoja de estilo en el directorio de salida. \nota El orden de los archivos de hoja de estilo adicionales es importante (por ejemplo, la última hoja de estilo en la lista anula la configuración de las anteriores en la lista). \nota Dado que el estilo de las barras de desplazamiento en webkit/Chromium actualmente no se puede anular, el estilo del archivo estándar doxygen.css se omite cuando se especifican una o más hojas de estilo adicionales. Entonces, si se desea personalizar las barras de desplazamiento, debe agregarse explícitamente. Para un ejemplo, vea la documentación.]]>
+<![CDATA[La etiqueta \c HTML_EXTRA_STYLESHEET se puede usar para especificar hojas de estilo en cascada personalizadas adicionales que se incluirán después de las hojas de estilo estándar creadas por Doxygen. Con esta opción puede anular ciertos aspectos de estilo. Esto es preferible al uso de \ref cfg_html_stylesheet "HTML_STYLESHEET" ya que no reemplaza la hoja de estilo estándar y por lo tanto es más robusto frente a actualizaciones futuras. Doxygen copiará los archivos de hoja de estilo en el directorio de salida. \nota El orden de los archivos de hoja de estilo adicionales es importante (por ejemplo, la última hoja de estilo en la lista anula la configuración de las anteriores en la lista). \nota Dado que el estilo de las barras de desplazamiento en webkit/Chromium actualmente no se puede anular, el estilo del archivo estándar doxygen.css se omite cuando se especifican una o más hojas de estilo adicionales. Entonces, si se desea personalizar las barras de desplazamiento, debe agregarse explícitamente.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Para un ejemplo, vea la documentación.
+]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1162,7 +1182,7 @@
       <value name="chtml" desc="(Este es el nombre para MathJax versión 3, para MathJax versión 2 se traducirá a &lt;code&gt;HTML-CSS&lt;/code&gt;)"/>
       <value name="SVG"/>
     </option>
-        <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
+    <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
       <docs>
 <![CDATA[
  Cuando MathJax está activado, necesita especificar la ubicación relativa al directorio
@@ -1189,7 +1209,12 @@
     </option>
     <option type="string" id="MATHJAX_CODEFILE" format="string" depends="USE_MATHJAX">
       <docs>
-<![CDATA[La etiqueta \c MATHJAX_CODEFILE se puede usar para especificar un archivo con fragmentos de código JavaScript que se usarán cuando se inicie el código MathJax. Vea el sitio web de MathJax para más detalles: - <a href="https://docs.mathjax.org/en/v2.7/">MathJax versión 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax versión 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax versión 4</a> Para un ejemplo, vea la documentación.]]>
+<![CDATA[La etiqueta \c MATHJAX_CODEFILE se puede usar para especificar un archivo con fragmentos de código JavaScript que se usarán cuando se inicie el código MathJax. Vea el sitio web de MathJax para más detalles: - <a href="https://docs.mathjax.org/en/v2.7/">MathJax versión 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax versión 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax versión 4</a>]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Para un ejemplo, vea la documentación.
+]]>
       </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
@@ -1275,7 +1300,12 @@
     </option>
     <option type="string" id="LATEX_HEADER" format="file" defval="" depends="GENERATE_LATEX">
       <docs>
-<![CDATA[La etiqueta \c LATEX_HEADER se puede usar para especificar un encabezado \f$\mbox{\LaTeX}\f$ personalizado para el documento \f$\mbox{\LaTeX}\f$ generado. El encabezado debe contener todo hasta el primer capítulo. Si se deja vacío, Doxygen generará un encabezado estándar. Se recomienda encarecidamente comenzar con un encabezado estándar usando \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim y luego modificar el archivo \c new_header.tex. Vea también la sección \ref doxygen_usage para información sobre como generar el encabezado estándar que Doxygen normalmente usa. <br>Nota: ¡Solo use un encabezado personalizado si sabe lo que está haciendo! @note El encabezado puede cambiar, por lo que generalmente necesita regenerar el encabezado estándar cuando actualiza a una versión más nueva de Doxygen. Para una descripción de los posibles marcadores y nombres de bloques, vea la documentación.]]>
+<![CDATA[La etiqueta \c LATEX_HEADER se puede usar para especificar un encabezado \f$\mbox{\LaTeX}\f$ personalizado para el documento \f$\mbox{\LaTeX}\f$ generado. El encabezado debe contener todo hasta el primer capítulo. Si se deja vacío, Doxygen generará un encabezado estándar. Se recomienda encarecidamente comenzar con un encabezado estándar usando \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim y luego modificar el archivo \c new_header.tex. Vea también la sección \ref doxygen_usage para información sobre como generar el encabezado estándar que Doxygen normalmente usa. <br>Nota: ¡Solo use un encabezado personalizado si sabe lo que está haciendo! @note El encabezado puede cambiar, por lo que generalmente necesita regenerar el encabezado estándar cuando actualiza a una versión más nueva de Doxygen.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Para una descripción de los posibles marcadores y nombres de bloques, vea la documentación.
+ ]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">

--- a/src/i18n/config_fr.xml
+++ b/src/i18n/config_fr.xml
@@ -199,7 +199,15 @@
     </option>
     <option type="list" id="ALIASES" format="string">
       <docs>
-<![CDATA[Cette balise peut être utilisée pour spécifier un certain nombre d'alias qui agissent comme des commandes dans la documentation. Un alias à la forme: \verbatim name=value \endverbatim Par exemple, ajouter \verbatim "sideeffect=@par Side Effects:^^" \endverbatim vous permettra de placer la commande \c \\sideeffect (ou \c \@sideeffect) dans la documentation, ce qui résultera en un paragraphe défini par l'utilisateur avec le titre "Side Effects:". Notez que vous ne pouvez pas mettre de \ref cmdn "\\n" dans la partie valeur d'un alias pour insérer des sauts de ligne (dans la sortie résultante). Vous pouvez mettre `^^` dans la partie valeur d'un alias pour insérer un saut de ligne comme si un saut de ligne physique était dans le fichier original. Si vous avez besoin d'un `{` ou `}` ou `,` littéral dans la partie valeur d'un alias, vous devez les échapper avec une barre oblique inverse (\c \\).]]>
+<![CDATA[Cette balise peut être utilisée pour spécifier un certain nombre d'alias qui agissent comme des commandes dans la documentation. Un alias à la forme: \verbatim name=value \endverbatim Par exemple, ajouter \verbatim "sideeffect=@par Side Effects:^^" \endverbatim vous permettra de placer la commande \c \\sideeffect (ou \c \@sideeffect) dans la documentation, ce qui résultera en un paragraphe défini par l'utilisateur avec le titre "Side Effects:". Notez que vous ne pouvez pas mettre de \ref cmdn "\\n" dans la partie valeur d'un alias pour insérer des sauts de ligne (dans la sortie résultante). Vous pouvez mettre `^^` dans la partie valeur d'un alias pour insérer un saut de ligne comme si un saut de ligne physique était dans le fichier original.]]>
+      </docs>
+      <docs>
+<![CDATA[
+Lorsque vous avez besoin d'un caractère littéral `{` ou `}` ou `,` dans la valeur d'un alias, vous devez
+les échapper à l'aide d'une barre oblique inverse (\c \\). Cela peut entraîner des conflits avec les
+commandes \c \\{ et \c \\}. Pour celles-ci, il est conseillé d'utiliser la version \c @@{ et \c @@} ou
+d'utiliser une double échappement (\c \\\\{ et \c \\\\}).
+]]>
       </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
@@ -547,6 +555,11 @@
       <docs>
 <![CDATA[La balise \c FILE_VERSION_FILTER peut être utilisée pour spécifier un programme ou script que Doxygen devrait invoquer pour obtenir la version actuelle de chaque fichier (généralement à partir du système de contrôle de version). Doxygen invoquera le programme en executant (via <code>popen()</code>) la commande <code>command input_file</code>, ou \c command est la valeur de la balise \c FILE_VERSION_FILTER, et \c input_file est le nom d'un fichier d'entrée fourni par Doxygen. Ce que le programme écrit sur la sortie standard est utilisé comme version de fichier.]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Pour un exemple, consultez la documentation.
+]]>
+      </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
       <docs>
@@ -882,6 +895,11 @@
       <docs>
 <![CDATA[La balise \c HTML_HEADER peut être utilisée pour spécifier un fichier d'en-tête HTML défini par l'utilisateur pour chaque page HTML générée. Si la balise est laissée vide, Doxygen générera un en-tête standard. <br>Pour obtenir un HTML valide, le fichier d'en-tête doit inclure tous les scripts et feuilles de style dont Doxygen a besoin, ce qui dépend des options de configuration utilisées (par exemple le paramètre \ref cfg_generate_treeview "GENERATE_TREEVIEW"). Il est fortement recommandé de commencer avec un en-tête par défaut en utilisant \verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim puis de modifier le fichier \c new_header.html. Voir aussi la section \ref doxygen_usage pour plus d'informations sur la génération de l'en-tête par défaut que Doxygen utilise normalement. @note L'en-tête est sujet à changement, donc vous devez généralement régénérer l'en-tête par défaut lors de la mise à jour vers une version plus récente de Doxygen.]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Pour une description des marqueurs et noms de blocs possibles, consultez la documentation.
+]]>
+      </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
       <docs>
@@ -896,6 +914,11 @@
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
 <![CDATA[La balise \c HTML_EXTRA_STYLESHEET peut être utilisée pour spécifier des feuilles de style en cascade supplémentaires définies par l'utilisateur qui sont incluses après les feuilles de style standard créées par Doxygen. En utilisant cette option, on peut redéfinir certains aspects de style. Ceci est préférable à l'utilisation de \ref cfg_html_stylesheet "HTML_STYLESHEET" car elle ne remplace pas la feuille de style standard et est donc plus robuste face aux mises à jour futures. Doxygen copiera les fichiers de feuille de style dans le répertoire de sortie. \note L'ordre des fichiers de feuille de style supplémentaires est important (par exemple, la dernière feuille de style de la liste redéfinit les paramètres des précédentes dans la liste). \note Comme le style des barres de défilement ne peut actuellement pas être remplace dans Webkit/Chromium, le style sera omis du doxygen.css par défaut si une ou plusieurs feuilles de style supplémentaires ont été spécifiées. Donc si la personnalisation des barres de défilement est souhaitée, elle doit être ajoutée explicitement.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Pour un exemple, consultez la documentation.
+]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1162,7 +1185,7 @@
       <value name="chtml" desc="(C'est le nom pour MathJax version 3, pour MathJax version 2 cela sera traduit en &lt;code&gt;HTML-CSS&lt;/code&gt;)"/>
       <value name="SVG"/>
     </option>
-        <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
+    <option type="string" id="MATHJAX_RELPATH" format="string" depends="USE_MATHJAX">
       <docs>
 <![CDATA[
  Lorsque MathJax est activé, vous devez spécifier l'emplacement relatif au répertoire
@@ -1189,6 +1212,11 @@
     <option type="string" id="MATHJAX_CODEFILE" format="string" depends="USE_MATHJAX">
       <docs>
 <![CDATA[La balise \c MATHJAX_CODEFILE peut être utilisée pour spécifier un fichier avec des morceaux de code JavaScript qui seront utilisés au démarrage du code MathJax. Voir le site Mathjax pour plus de détails: - <a href="https://docs.mathjax.org/en/v2.7/">MathJax version 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax version 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax version 4</a>]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Pour un exemple, consultez la documentation.
+]]>
       </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
@@ -1274,7 +1302,12 @@
     </option>
     <option type="string" id="LATEX_HEADER" format="file" defval="" depends="GENERATE_LATEX">
       <docs>
-<![CDATA[La balise \c LATEX_HEADER peut être utilisée pour spécifier un en-tête \f$\mbox{\LaTeX}\f$ défini par l'utilisateur pour le document \f$\mbox{\LaTeX}\f$ généré. L'en-tête doit contenir tout jusqu'au premier chapitre. S'il est laissé vide, Doxygen générera un en-tête standard. Il est fortement recommandé de commencer avec un en-tête par défaut en utilisant \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim puis de modifier le fichier \c new_header.tex. Voir aussi la section \ref doxygen_usage pour plus d'informations sur la génération de l'en-tête par défaut que Doxygen utilise normalement. <br>Note: N'utilisez un en-tête défini par l'utilisateur que si vous savez ce que vous faites! @note L'en-tête est sujet à changement, donc vous devez généralement régénérer l'en-tête par défaut lors de la mise à jour vers une version plus récente de Doxygen. Les commandes suivantes ont une signification spéciale dans l'en-tête (et le pied de page):]]>
+<![CDATA[La balise \c LATEX_HEADER peut être utilisée pour spécifier un en-tête \f$\mbox{\LaTeX}\f$ défini par l'utilisateur pour le document \f$\mbox{\LaTeX}\f$ généré. L'en-tête doit contenir tout jusqu'au premier chapitre. S'il est laissé vide, Doxygen générera un en-tête standard. Il est fortement recommandé de commencer avec un en-tête par défaut en utilisant \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim puis de modifier le fichier \c new_header.tex. Voir aussi la section \ref doxygen_usage pour plus d'informations sur la génération de l'en-tête par défaut que Doxygen utilise normalement. <br>Note: N'utilisez un en-tête défini par l'utilisateur que si vous savez ce que vous faites! @note L'en-tête est sujet à changement, donc vous devez généralement régénérer l'en-tête par défaut lors de la mise à jour vers une version plus récente de Doxygen.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Pour une description des marqueurs et noms de blocs possibles, consultez la documentation.
+]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">

--- a/src/i18n/config_ja.xml
+++ b/src/i18n/config_ja.xml
@@ -201,6 +201,11 @@
       <docs>
 <![CDATA[このタグを使用して、ドキュメント内でコマンドとして機能するエイリアスを指定できます。エイリアスの形式は次のとおりです：\verbatim name=value\endverbatim 例えば、\verbatim "sideeffect=@par Side Effects:^^"\endverbatim を追加すると、ドキュメントに\c \sideeffect（または\c \@sideeffect）コマンドを記述でき、「Side Effects:」という見出しのユーザー定義段落が生成されます。なお、エイリアスの値部分に\ref cmdn "\n"を入れて改行を挿入することはできません（出力結果において）。エイリアスの値部分に`^^`を入れると、元のファイルに物理的な改行があるかのように改行を挿入できます。]]>
       </docs>
+      <docs>
+<![CDATA[
+エイリアスの値部分にリテラルの `{`、`}`、または `,` が必要な場合は、バックスラッシュ (\c \\) でエスケープする必要があります。これは、コマンド \c \\{ および \c \\} と競合する可能性があります。これらのコマンドには、バージョン \c @@{ および \c @@} を使用するか、二重エスケープ (\c \\\\{ および \c \\\\}) を使用することをお勧めします。
+]]>
+    </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
       <docs>
@@ -547,6 +552,11 @@
       <docs>
 <![CDATA[\c FILE_VERSION_FILTERタグを使用して、各ファイルの現在のバージョンを取得するためにDoxygenが呼び出すプログラムまたはスクリプトを指定できます（通常はバージョン管理システムから取得）。Doxygenは<code>popen()</code>経由で<code>command input_file</code>コマンドを実行してプログラムを呼び出します。ここで\c commandは\c FILE_VERSION_FILTERタグの値、\c input_fileはDoxygenが提供する入力ファイル名です。プログラムが標準出力に書き込んだ内容がファイルバージョンとして使用されます。]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例についてはドキュメントを参照してください。
+]]>
+      </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
       <docs>
@@ -882,6 +892,11 @@
       <docs>
 <![CDATA[\c HTML_HEADERタグを使用して、生成される各HTMLページのユーザー定義HTMLヘッダーファイルを指定できます。タグが空白のままの場合、Doxygenは標準ヘッダーを生成します。<br>有効なHTMLを取得するには、ヘッダーファイルにDoxygenが必要とするすべてのスクリプトとスタイルシートを含める必要があります。これは使用される設定オプションに依存します（例：\ref cfg_generate_treeview "GENERATE_TREEVIEW"の設定）。次を使用してデフォルトのヘッダーから始めることを強くお勧めします：\verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim 次にファイル\c new_header.htmlを変更します。Doxygenが通常使用するデフォルトヘッダーの生成方法については、セクション\ref doxygen_usageも参照してください。@note ヘッダーは変更される可能性があるため、通常はDoxygenの新しいバージョンにアップグレードする際にデフォルトヘッダーを再生成する必要があります。]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+使用可能なマーカー名とブロック名の説明については、ドキュメントを参照してください。
+]]>
+      </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
       <docs>
@@ -896,6 +911,11 @@
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
 <![CDATA[\c HTML_EXTRA_STYLESHEETタグを使用して、Doxygenによって作成された標準スタイルシートの後にインクルードされる追加のユーザー定義カスケーディングスタイルシートを指定できます。このオプションを使用すると、特定のスタイルの側面をオーバーライドできます。これは、標準スタイルシートを置き換えないため、将来の更新に対してより堅牢な\ref cfg_html_stylesheet "HTML_STYLESHEET"を使用するよりも推奨されます。Doxygenはスタイルシートファイルを出力ディレクトリにコピーします。\note 追加のスタイルシートファイルの順序は重要です（例：リストの最後のスタイルシートは、リスト内の前のものの設定をオーバーライドします）。\note スクロールバーのスタイル設定は現在Webkit/Chromiumでオーバーライドできないため、1つ以上の追加スタイルシートが指定されている場合、スタイル設定はデフォルトのdoxygen.cssから除外されます。したがって、スクロールバーのカスタマイズが必要な場合は、明示的に追加する必要があります。]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例についてはドキュメントを参照してください。
+]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1191,6 +1211,11 @@
       <docs>
 <![CDATA[\c MATHJAX_CODEFILEタグを使用して、MathJaxコードの起動時に使用されるJavaScriptコードを含むファイルを指定できます。詳細については、MathJaxサイトを参照してください：- <a href="https://docs.mathjax.org/en/v2.7/">MathJaxバージョン2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJaxバージョン3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJaxバージョン4</a>]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例についてはドキュメントを参照してください。
+]]>
+      </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
       <docs>
@@ -1275,7 +1300,12 @@
     </option>
     <option type="string" id="LATEX_HEADER" format="file" defval="" depends="GENERATE_LATEX">
       <docs>
-<![CDATA[\c LATEX_HEADERタグを使用して、生成された\f$\mbox{\LaTeX}\f$ドキュメントのユーザー定義\f$\mbox{\LaTeX}\f$ヘッダーを指定できます。ヘッダーは最初の章までのすべてを含む必要があります。空白のままにすると、Doxygenは標準ヘッダーを生成します。次を使用してデフォルトのヘッダーから始めることを強くお勧めします：\verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim 次にファイル\c new_header.texを変更します。Doxygenが通常使用するデフォルトヘッダーの生成方法については、セクション\ref doxygen_usageも参照してください。<br>注意：自分が何をしているかを理解している場合にのみ、ユーザー定義ヘッダーを使用してください！@note ヘッダーは変更される可能性があるため、通常はDoxygenの新しいバージョンにアップグレードする際にデフォルトヘッダーを再生成する必要があります。次のコマンドはヘッダー（およびフッター）内で特別な意味を持ちます：]]>
+<![CDATA[\c LATEX_HEADERタグを使用して、生成された\f$\mbox{\LaTeX}\f$ドキュメントのユーザー定義\f$\mbox{\LaTeX}\f$ヘッダーを指定できます。ヘッダーは最初の章までのすべてを含む必要があります。空白のままにすると、Doxygenは標準ヘッダーを生成します。次を使用してデフォルトのヘッダーから始めることを強くお勧めします：\verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim 次にファイル\c new_header.texを変更します。Doxygenが通常使用するデフォルトヘッダーの生成方法については、セクション\ref doxygen_usageも参照してください。<br>注意：自分が何をしているかを理解している場合にのみ、ユーザー定義ヘッダーを使用してください！@note ヘッダーは変更される可能性があるため、通常はDoxygenの新しいバージョンにアップグレードする際にデフォルトヘッダーを再生成する必要があります。]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+使用可能なマーカー名とブロック名の説明については、ドキュメントを参照してください。
+]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">

--- a/src/i18n/config_ko.xml
+++ b/src/i18n/config_ko.xml
@@ -201,6 +201,11 @@
       <docs>
 <![CDATA[이 태그를 사용하여 문서에서 명령으로 작동하는 여러 별칭을 지정할 수 있습니다. 별칭의 형식은 다음과 같습니다: \verbatim name=value\endverbatim 예를 들어, \verbatim "sideeffect=@par Side Effects:^^"\endverbatim 를 추가하면 문서에 \c \sideeffect(또는 \c \@sideeffect) 명령을 배치할 수 있으며, "Side Effects:"라는 제목의 사용자 정의 단락이 생성됩니다. 별칭의 값 부분에 \ref cmdn "\n"을 넣어 줄 바꿈을 삽입할 수 없습니다(결과 출력에서). 별칭의 값 부분에 `^^`를 넣으면 원본 파일에 물리적 줄 바꿈이 있는 것처럼 줄 바꿈을 삽입할 수 있습니다.]]>
       </docs>
+      <docs>
+<![CDATA[
+별칭의 값 부분에 리터럴 `{`, `}` 또는 `,`가 필요한 경우 백슬래시(\c \\)를 사용하여 이스케이프해야 합니다. 이로 인해 `\c \\{` 및 `\c \\}` 명령과 충돌이 발생할 수 있습니다. 이러한 명령의 경우 `\c @@{` 및 `\c @@}` 버전을 사용하거나 이중 이스케이프(`\c \\\\{` 및 `\c \\\\}`)를 사용하는 것이 좋습니다.
+]]>
+    </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
       <docs>
@@ -547,6 +552,11 @@
       <docs>
 <![CDATA[\c FILE_VERSION_FILTER 태그를 사용하여 Doxygen이 각 파일의 현재 버전을 가져오기 위해 호출하는 프로그램 또는 스크립트를 지정할 수 있습니다(일반적으로 버전 관리 시스템에서). Doxygen은 <code>popen()</code>을 통해 명령<code>command input_file</code>을 실행하여 프로그램을 호출합니다. 여기서 \c command는 \c FILE_VERSION_FILTER 태그의 값, \c input_file은 Doxygen이 제공하는 입력 파일의 이름입니다. 프로그램이 표준 출력에 쓰는 모든 것은 파일 버전으로 사용됩니다.]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+예시는 설명서를 참조하십시오.
+]]>
+      </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
       <docs>
@@ -882,6 +892,11 @@
       <docs>
 <![CDATA[\c HTML_HEADER 태그를 사용하여 생성되는 각 HTML 페이지의 사용자 정의 HTML 헤더 파일을 지정할 수 있습니다. 태그가 비워 두면 Doxygen은 표준 헤더를 생성합니다. <br>유효한 HTML을 얻으려면 헤더 파일에 Doxygen이 필요로 하는 모든 스크립트와 스타일시트를 포함해야 합니다. 이는 사용되는 설정 옵션에 따라 다릅니다(예: \ref cfg_generate_treeview "GENERATE_TREEVIEW" 설정). 다음을 사용하여 기본 헤더에서 시작하는 것이 좋습니다: \verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim 그런 다음 파일 \c new_header.html을 수정하세요. Doxygen이 일반적으로 사용하는 기본 헤더 생성 방법에 대해서는 섹션 \ref doxygen_usage도 참조하세요. @note 헤더는 변경될 수 있으므로 일반적으로 Doxygen의 새 버전으로 업그레이드할 때 기본 헤더를 다시 생성해야 합니다.]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+사용 가능한 마커 및 블록 이름에 대한 설명은 설명서를 참조하십시오.
+]]>
+      </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
       <docs>
@@ -896,6 +911,11 @@
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
 <![CDATA[\c HTML_EXTRA_STYLESHEET 태그를 사용하여 Doxygen에 의해 생성된 표준 스타일시트 이후에 포함되는 추가 사용자 정의 계단식 스타일시트를 지정할 수 있습니다. 이 옵션을 사용하면 특정 스타일 측면을 재정의할 수 있습니다. 이는 표준 스타일시트를 대체하지 않으므로 향후 업데이트에 대해 더 견고한 \ref cfg_html_stylesheet "HTML_STYLESHEET"를 사용하는 것보다 권장됩니다. Doxygen은 스타일시트 파일을 출력 디렉터리에 복사합니다. \note 추가 스타일시트 파일의 순서는 중요합니다(예: 목록의 마지막 스타일시트는 목록에서 이전 것의 설정을 재정의함). \note 스크롤바 스타일링은 현재 Webkit/Chromium에서 재정의할 수 없으므로 하나 이상의 추가 스타일시트가 지정된 경우 스타일링은 기본 doxygen.css에서 제외됩니다. 따라서 스크롤바 사용자 정의가 필요한 경우 명시적으로 추가해야 합니다.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+예시는 설명서를 참조하십시오.
+]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1190,6 +1210,11 @@
       <docs>
 <![CDATA[\c MATHJAX_CODEFILE 태그를 사용하여 MathJax 코드의 시작 시 사용되는 JavaScript 코드 조각을 포함하는 파일을 지정할 수 있습니다. 자세한 내용은 Mathjax 사이트를 참조하세요: - <a href="https://docs.mathjax.org/en/v2.7/">MathJax 버전 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax 버전 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax 버전 4</a>]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+예시는 설명서를 참조하십시오.
+]]>
+      </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
       <docs>
@@ -1274,7 +1299,12 @@
     </option>
     <option type="string" id="LATEX_HEADER" format="file" defval="" depends="GENERATE_LATEX">
       <docs>
-<![CDATA[\c LATEX_HEADER 태그를 사용하여 생성된 \f$\mbox{\LaTeX}\f$ 문서의 사용자 정의 \f$\mbox{\LaTeX}\f$ 헤더를 지정할 수 있습니다. 헤더는 첫 번째 장까지의 모든 것을 포함해야 합니다. 비워 두면 Doxygen은 표준 헤더를 생성합니다. 다음을 사용하여 기본 헤더에서 시작하는 것이 좋습니다: \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim 그런 다음 파일 \c new_header.tex를 수정하세요. Doxygen이 일반적으로 사용하는 기본 헤더 생성 방법에 대해서는 섹션 \ref doxygen_usage도 참조하세요. <br>참고: 자신이 무엇을 하고 있는지 이해하는 경우에만 사용자 정의 헤더를 사용하세요! @note 헤더는 변경될 수 있으므로 일반적으로 Doxygen의 새 버전으로 업그레이드할 때 기본 헤더를 다시 생성해야 합니다. 다음 명령은 헤더(및 푸터) 내에서 특별한 의미를 갖습니다:]]>
+<![CDATA[\c LATEX_HEADER 태그를 사용하여 생성된 \f$\mbox{\LaTeX}\f$ 문서의 사용자 정의 \f$\mbox{\LaTeX}\f$ 헤더를 지정할 수 있습니다. 헤더는 첫 번째 장까지의 모든 것을 포함해야 합니다. 비워 두면 Doxygen은 표준 헤더를 생성합니다. 다음을 사용하여 기본 헤더에서 시작하는 것이 좋습니다: \verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim 그런 다음 파일 \c new_header.tex를 수정하세요. Doxygen이 일반적으로 사용하는 기본 헤더 생성 방법에 대해서는 섹션 \ref doxygen_usage도 참조하세요. <br>참고: 자신이 무엇을 하고 있는지 이해하는 경우에만 사용자 정의 헤더를 사용하세요! @note 헤더는 변경될 수 있으므로 일반적으로 Doxygen의 새 버전]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+사용 가능한 마커 및 블록 이름에 대한 설명은 설명서를 참조하십시오.
+]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">

--- a/src/i18n/config_ru.xml
+++ b/src/i18n/config_ru.xml
@@ -201,6 +201,11 @@
       <docs>
 <![CDATA[Этот тег можно использовать для указания нескольких псевдонимов, которые будут действовать как команды в документации. Псевдоним имеет форму: \verbatim имя=значение\endverbatim Например, добавление \verbatim "sideeffect=@par Побочные эффекты:^^"\endverbatim позволит вам разместить команду \c \sideeffect (или \c \@sideeffect) в документации, что приведет к созданию пользовательского абзаца с заголовком "Побочные эффекты:". Обратите внимание, что вы не можете поместить \ref cmdn "\n" в часть значения псевдонима для вставки разрыва строки (в результирующем выводе). Вы можете поместить `^^` в часть значения псевдонима для вставки разрыва строки, как если бы в исходном файле был физический разрыв строки.]]>
       </docs>
+      <docs>
+<![CDATA[
+Когда вам нужен литерал `{` или `}` или `,` в значении псевдонима, вам необходимо экранировать их с помощью обратной косой черты (\c \\), это может привести к конфликтам с командами \c \\{ и \c \\}, для них рекомендуется использовать вариант \c @@{ и \c @@} или использовать двойное экранирование (\c \\\\{ и \c \\\\})
+]]>
+    </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
       <docs>
@@ -546,6 +551,11 @@
     <option type="string" id="FILE_VERSION_FILTER" format="file" defval="">
       <docs>
 <![CDATA[Тег \c FILE_VERSION_FILTER можно использовать для указания программы или скрипта, который Doxygen должен вызвать для получения текущей версии каждого файла (обычно из системы контроля версий). Doxygen вызовет программу, выполнив (через <code>popen()</code>) команду <code>command input_file</code>, где \c command — значение тега \c FILE_VERSION_FILTER, а \c input_file — имя входного файла, предоставленного Doxygen. Все, что программа выведет в стандартный вывод, будет использовано как версия файла.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Пример см. в документации.
+]]>
       </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
@@ -1000,7 +1010,12 @@ doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFil
  см. в разделе \ref doxygen_usage.
 
  @note Заголовок может изменяться, поэтому как правило необходимо повторно генерировать заголовок по умолчанию
- при обновлении до более новой версии Doxygen. Описание возможных маркеров и имён блоков см. в документации.]]>
+ при обновлении до более новой версии Doxygen.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Описание возможных маркеров и названий блоков см. в документации.
+]]>
       </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
@@ -1025,6 +1040,11 @@ doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFil
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
 <![CDATA[Тег \c HTML_EXTRA_STYLESHEET можно использовать для указания дополнительных пользовательских каскадных таблиц стилей, которые будут включены после стандартной таблицы стилей, созданной Doxygen. Используйте эту опцию для переопределения некоторых аспектов стиля. Это предпочтительнее, чем использование \ref cfg_html_stylesheet "HTML_STYLESHEET", так как это не заменяет стандартную таблицу стилей и поэтому более надёжно для будущих обновлений. Doxygen скопирует файл таблицы стилей в выходной каталог. \note Порядок дополнительных файлов таблиц стилей важен (например, последняя таблица стилей в списке переопределяет настройки предыдущей таблицы стилей в списке). \note Поскольку в настоящее время невозможно переопределить стиль полосы прокрутки в Webkit/Chromium, стиль полосы прокрутки будет опущен в стандартном doxygen.css, если указана одна или несколько дополнительных таблиц стилей. Поэтому, если требуется пользовательская полоса прокрутки, её необходимо добавить явно.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Пример см. в документации.
+]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1393,6 +1413,11 @@ doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFil
       <docs>
 <![CDATA[Тег \c MATHJAX_CODEFILE можно использовать для указания файла с фрагментами кода JavaScript, которые будут использоваться при запуске кода MathJax. Для получения дополнительной информации см. сайт MathJax: - <a href="https://docs.mathjax.org/en/v2.7/">MathJax версии 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax версии 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax версии 4</a>]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Пример см. в документации.
+]]>
+      </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
       <docs>
@@ -1524,9 +1549,12 @@ doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty
  <br>Примечание: используйте пользовательский заголовок только если вы знаете, что делаете!
 
  @note Заголовок может изменяться, поэтому как правило
- необходимо повторно генерировать заголовок по умолчанию при обновлении до более новой версии Doxygen.
- Следующие команды имеют особое значение внутри заголовка (и нижнего колонтитула):
-Описание возможных маркеров и имён блоков см. в документации.]]>
+ необходимо повторно генерировать заголовок по умолчанию при обновлении до более новой версии Doxygen.]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+Описание возможных маркеров и названий блоков см. в документации.
+]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">

--- a/src/i18n/config_zh_CN.xml
+++ b/src/i18n/config_zh_CN.xml
@@ -201,6 +201,11 @@
       <docs>
 <![CDATA[此标签可用于指定多个在文档中充当命令的别名。别名的形式为：\verbatim name=value\endverbatim 例如添加 \verbatim "sideeffect=@par Side Effects:^^"\endverbatim 将允许您在文档中放置命令 \c \sideeffect（或 \c \@sideeffect），这将产生一个带有标题"Side Effects:"的用户定义段落。请注意，您不能在别名的值部分放置 \ref cmdn "\n" 来插入换行符（在结果输出中）。您可以在别名的值部分放置 `^^` 来插入换行符，就像原始文件中有物理换行符一样。]]>
       </docs>
+      <docs>
+<![CDATA[
+当别名的值部分需要使用字面值 `{`、`}` 或 `,` 时，必须使用反斜杠 (\c \\) 进行转义。这可能会与命令 `\c \\{` 和 `\c \\}` 冲突。建议使用版本 `\c @@{` 和 `\c @@}`，或者使用双重转义 (\c \\\\{` 和 `\c \\\\})
+]]>
+      </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
       <docs>
@@ -547,6 +552,11 @@
       <docs>
 <![CDATA[\c FILE_VERSION_FILTER 标签可用于指定 Doxygen 应调用的程序或脚本，以获取每个文件的当前版本（通常来自版本控制系统）。Doxygen 将通过执行（通过 <code>popen()</code>）命令 <code>command input_file</code> 来调用程序，其中 \c command 是 \c FILE_VERSION_FILTER 标签的值，\c input_file 是 Doxygen 提供的输入文件的名称。程序写入标准输出的任何内容都用作文件版本。]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例如，请参阅文档。
+]]>
+      </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
       <docs>
@@ -882,6 +892,11 @@
       <docs>
 <![CDATA[\c HTML_HEADER 标签可用于为每个生成的 HTML 页面指定用户定义的 HTML 头文件。如果标签留空，Doxygen 将生成标准头文件。<br>要获得有效的 HTML，头文件需要包含 Doxygen 需要的任何脚本和样式表，这取决于使用的配置选项（例如设置 \ref cfg_generate_treeview "GENERATE_TREEVIEW"）。强烈建议使用默认头文件开始：\verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim 然后修改文件 \c new_header.html。另请参阅第 \ref doxygen_usage 节以获取有关如何生成 Doxygen 通常使用的默认头文件的信息。@note 头文件可能会更改，因此通常在升级到更新版本的 Doxygen 时必须重新生成默认头文件。]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+有关可用标记和代码块名称的说明，请参阅文档。
+]]>
+      </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
       <docs>
@@ -896,6 +911,11 @@
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
 <![CDATA[\c HTML_EXTRA_STYLESHEET 标签可用于指定在 Doxygen 创建的标准样式表之后包含的其他用户定义的级联样式表。使用此选项可以覆盖某些样式方面。这比使用 \ref cfg_html_stylesheet "HTML_STYLESHEET" 更可取，因为它不会替换标准样式表，因此对未来的更新更加健壮。Doxygen 会将样式表文件复制到输出目录。\note 额外样式表文件的顺序很重要（例如，列表中的最后一个样式表覆盖列表中前一个样式表的设置）。\note 由于目前无法在 Webkit/Chromium 中覆盖滚动条的样式，如果指定了一个或多个额外样式表，默认 doxygen.css 中将省略滚动条样式。因此，如果需要自定义滚动条，必须显式添加。]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例如，请参阅文档。
+]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1189,6 +1209,11 @@
       <docs>
 <![CDATA[\c MATHJAX_CODEFILE 标签可用于指定一个包含 JavaScript 代码片段的文件，这些代码将在 MathJax 代码启动时使用。有关更多详细信息，请参阅 Mathjax 网站：- <a href="https://docs.mathjax.org/en/v2.7/">MathJax 版本 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax 版本 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax 版本 4</a>]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例如，请参阅文档。
+]]>
+      </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
       <docs>
@@ -1274,6 +1299,11 @@
     <option type="string" id="LATEX_HEADER" format="file" defval="" depends="GENERATE_LATEX">
       <docs>
 <![CDATA[\c LATEX_HEADER 标签可用于为生成的 \f$\mbox{\LaTeX}\f$ 文档指定用户定义的 \f$\mbox{\LaTeX}\f$ 头文件。头文件应包含直到第一章的所有内容。如果留空，Doxygen 将生成标准头文件。强烈建议使用默认头文件开始：\verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim 然后修改文件 \c new_header.tex。另请参阅第 \ref doxygen_usage 节以获取有关如何生成 Doxygen 通常使用的默认头文件的信息。<br>注意：只有在您知道自己在做什么时才使用用户定义的头文件！@note 头文件可能会更改，因此通常在升级到更新版本的 Doxygen 时必须重新生成默认头文件。]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+有关可用标记和代码块名称的说明，请参阅文档。
+]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">

--- a/src/i18n/config_zh_TW.xml
+++ b/src/i18n/config_zh_TW.xml
@@ -201,6 +201,11 @@
       <docs>
 <![CDATA[此標籤可用於指定多個在檔案中充當命令的別名。別名的形式為：\verbatim name=value\endverbatim 例如添加 \verbatim "sideeffect=@par Side Effects:^^"\endverbatim 將允許您在檔案中放置命令 \c \sideeffect（或 \c \@sideeffect），這將產生一個带有標题"Side Effects:"的使用者定義段落。請注意，您不能在別名的值部分放置 \ref cmdn "\n" 來插入換行符（在結果輸出中）。您可以在別名的值部分放置 `^^` 來插入換行符，就像原始檔案中有物理換行符一樣。]]>
       </docs>
+      <docs>
+<![CDATA[
+當別名的值部分需要使用字面值 `{`、`}` 或 `,` 時，必須使用反斜線 (\c \\) 來轉義。這可能會與命令 `\c \\{` 和 `\c \\}` 衝突。建議使用版本 `\c @@{` 和 `\c @@}`，或使用雙重轉義 (\c \\\\{` 和 `\c \\\})
+]]>
+    </docs>
     </option>
     <option type="bool" id="OPTIMIZE_OUTPUT_FOR_C" defval="0">
       <docs>
@@ -547,6 +552,11 @@
       <docs>
 <![CDATA[\c FILE_VERSION_FILTER 標籤可用於指定 Doxygen 應呼叫的程式或脚本，以取得每個檔案的目前版本（通常來自版本控制系統）。Doxygen 將通過執行（通過 <code>popen()</code>）命令 <code>command input_file</code> 來呼叫程式，其中 \c command 是 \c FILE_VERSION_FILTER 標籤的值，\c input_file 是 Doxygen 提供的輸入檔案的名稱。程式寫入標准輸出的任何內容都用作檔案版本。]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例如，請參閱文件。
+]]>
+      </docs>
     </option>
     <option type="string" id="LAYOUT_FILE" format="file" defval="">
       <docs>
@@ -882,6 +892,11 @@
       <docs>
 <![CDATA[\c HTML_HEADER 標籤可用於為每個產生的 HTML 頁面指定使用者定義的 HTML 頭檔案。如果標籤留空，Doxygen 將產生標准頭檔案。<br>要獲得有效的 HTML，頭檔案需要包含 Doxygen 需要的任何脚本和樣式資料表，這取决于使用的設定選項（例如設定 \ref cfg_generate_treeview "GENERATE_TREEVIEW"）。强烈建议使用預設頭檔案開始：\verbatim doxygen -w html new_header.html new_footer.html new_stylesheet.css YourConfigFile \endverbatim 然後修改檔案 \c new_header.html。另請參閱第 \ref doxygen_usage 節以取得有關如何產生 Doxygen 通常使用的預設頭檔案的資訊。@note 頭檔案可能會更改，因此通常在升級到更新版本的 Doxygen 時必须重新產生預設頭檔案。]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+有關可用標記和程式碼區塊名稱的說明，請參閱文件。
+]]>
+      </docs>
     </option>
     <option type="string" id="HTML_FOOTER" format="file" defval="" depends="GENERATE_HTML">
       <docs>
@@ -896,6 +911,11 @@
     <option type="list" id="HTML_EXTRA_STYLESHEET" format="file" defval="" depends="GENERATE_HTML">
       <docs>
 <![CDATA[\c HTML_EXTRA_STYLESHEET 標籤可用於指定在 Doxygen 建立的標准樣式資料表之後包含的其他使用者定義的層聯樣式資料表。使用此選項可以覆寫某些樣式方面。這比使用 \ref cfg_html_stylesheet "HTML_STYLESHEET" 更可取，因為它不會取代標准樣式資料表，因此對未來的更新更加健壮。Doxygen 會將樣式資料表檔案複製到輸出目錄。\note 额外樣式資料表檔案的顺序很重要（例如，列資料表中的最後一個樣式資料表覆寫列資料表中前一個樣式資料表的設定）。\note 由於目前無法在 Webkit/Chromium 中覆寫捲軸的樣式，如果指定了一個或多個额外樣式資料表，預設 doxygen.css 中將省略捲軸樣式。因此，如果需要自定義捲軸，必须顯式添加。]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例如，請參閱文件。
+]]>
       </docs>
     </option>
     <option type="list" id="HTML_EXTRA_FILES" format="file" depends="GENERATE_HTML">
@@ -1189,6 +1209,11 @@
       <docs>
 <![CDATA[\c MATHJAX_CODEFILE 標籤可用於指定一個包含 JavaScript 程式碼片段的檔案，這些程式碼將在 MathJax 程式碼啟動時使用。有關更多詳細資訊，請參閱 Mathjax 網站：- <a href="https://docs.mathjax.org/en/v2.7/">MathJax 版本 2</a> - <a href="https://docs.mathjax.org/en/v3.2/">MathJax 版本 3</a> - <a href="https://docs.mathjax.org/en/v4.0/">MathJax 版本 4</a>]]>
       </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+例如，請參閱文件。
+]]>
+      </docs>
     </option>
     <option type="bool" id="SEARCHENGINE" defval="1" depends="GENERATE_HTML">
       <docs>
@@ -1274,6 +1299,11 @@
     <option type="string" id="LATEX_HEADER" format="file" defval="" depends="GENERATE_LATEX">
       <docs>
 <![CDATA[\c LATEX_HEADER 標籤可用於為產生的 \f$\mbox{\LaTeX}\f$ 檔案指定使用者定義的 \f$\mbox{\LaTeX}\f$ 頭檔案。頭檔案應包含直到第一章的所有內容。如果留空，Doxygen 將產生標准頭檔案。强烈建议使用預設頭檔案開始：\verbatim doxygen -w latex new_header.tex new_footer.tex new_stylesheet.sty \endverbatim 然後修改檔案 \c new_header.tex。另請參閱第 \ref doxygen_usage 節以取得有關如何產生 Doxygen 通常使用的預設頭檔案的資訊。<br>注意：只有在您知道自己在做什么時才使用使用者定義的頭檔案！@note 頭檔案可能會更改，因此通常在升級到更新版本的 Doxygen 時必须重新產生預設頭檔案。]]>
+      </docs>
+      <docs filter="doxyfile,doxywizard">
+<![CDATA[
+有關可用標記和程式碼區塊名稱的說明，請參閱文件。
+]]>
       </docs>
     </option>
     <option type="string" id="LATEX_FOOTER" format="file" defval="" depends="GENERATE_LATEX">


### PR DESCRIPTION
In the doxywizard the from translated configuration files only the first `<docs>` section in an `<option>` section was handled.
In the different translated configuration files the handling of the specific parts for the doxywizard was, incorrectly, done with the main `<docs>` part, was missing or was incomplete. 
In the config.xml a sentence that just belongs to the documentation was placed in a main section and thus visible everywhere.