### PR TITLE
Incorrect representation of accented characters with `\cite{shortauthor}`

### DIFF
--- a/src/docbookgen.cpp
+++ b/src/docbookgen.cpp
@@ -1481,7 +1481,7 @@ void DocbookGenerator::endTocEntry(const SectionInfo *si)
 static constexpr auto hex="0123456789ABCDEF";
 
 /*! Converts a string to an DocBook-encoded string */
-QCString convertToDocBook(const QCString &s, const bool retainNewline)
+QCString convertToDocBook(const QCString &s, const bool retainNewline, const bool /* citeEntry */)
 {
   if (s.isEmpty()) return s;
   QCString result;

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -352,7 +352,7 @@ private:
     TocState m_tocState;
 };
 
-QCString convertToDocBook(const QCString &s, const bool retainNewline = false);
+QCString convertToDocBook(const QCString &s, const bool retainNewline = false, const bool citeEntry = false);
 
 
 #endif

--- a/src/docbookvisitor.cpp
+++ b/src/docbookvisitor.cpp
@@ -579,7 +579,7 @@ DB_VIS_C
   {
     if (!opt.noCite()) startLink(cite.file(),filterId(cite.anchor()));
 
-    filter(cite.getText());
+    filter(cite.getText(), false, true);
 
     if (!opt.noCite()) endLink();
   }
@@ -1533,10 +1533,10 @@ DB_VIS_C
 }
 
 
-void DocbookDocVisitor::filter(const QCString &str, const bool retainNewLine)
+void DocbookDocVisitor::filter(const QCString &str, const bool retainNewLine, const bool citeEntry)
 {
 DB_VIS_C
-  m_t << convertToDocBook(str, retainNewLine);
+  m_t << convertToDocBook(str, retainNewLine, citeEntry);
 }
 
 void DocbookDocVisitor::startLink(const QCString &file,const QCString &anchor)

--- a/src/docbookvisitor.h
+++ b/src/docbookvisitor.h
@@ -111,7 +111,7 @@ class DocbookDocVisitor final : public DocVisitor
     //--------------------------------------
     // helper functions
     //--------------------------------------
-    void filter(const QCString &str, const bool retainNewLine = false);
+    void filter(const QCString &str, const bool retainNewLine = false, const bool citeEntry = false);
     void startLink(const QCString &file,
     const QCString &anchor);
     void endLink();

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -967,7 +967,7 @@ void HtmlDocVisitor::operator()(const DocCite &cite)
   if (!cite.file().isEmpty())
   {
     if (!opt.noCite()) startLink(cite.ref(),cite.file(),cite.relPath(),cite.anchor());
-    filter(cite.getText());
+    filter(cite.getText(), false, true);
     if (!opt.noCite()) endLink();
   }
   else
@@ -2153,10 +2153,12 @@ void HtmlDocVisitor::operator()(const DocParBlock &pb)
   visitChildren(pb);
 }
 
-void HtmlDocVisitor::filter(const QCString &str, const bool retainNewline)
+void HtmlDocVisitor::filter(const QCString &str, const bool retainNewline, const bool citeEntry)
 {
   if (str.isEmpty()) return;
   const char *p=str.data();
+  const char *q = nullptr;
+  int cnt = 0;
   while (*p)
   {
     char c=*p++;
@@ -2165,7 +2167,37 @@ void HtmlDocVisitor::filter(const QCString &str, const bool retainNewline)
       case '\n': if(retainNewline) m_t << "<br/>"; m_t << c; break;
       case '<':  m_t << "&lt;"; break;
       case '>':  m_t << "&gt;"; break;
-      case '&':  m_t << "&amp;"; break;
+      case '&':  // possibility to have a special symbol
+        if (!citeEntry) {m_t << "&amp;"; break;}
+        q = p;
+        cnt = 2; // we have to count & and ; as well
+        while ((*q >= 'a' && *q <= 'z') || (*q >= 'A' && *q <= 'Z') || (*q >= '0' && *q <= '9'))
+        {
+          cnt++;
+          q++;
+        }
+        if (*q == ';')
+        {
+           --p; // we need & as well
+           HtmlEntityMapper::SymType res = HtmlEntityMapper::instance().name2sym(QCString(p).left(cnt));
+           if (res == HtmlEntityMapper::Sym_Unknown)
+           {
+             p++;
+             m_t << "&amp;";
+           }
+           else
+           {
+             m_t << HtmlEntityMapper::instance().html(res);
+             q++;
+             p = q;
+           }
+        }
+        else
+        {
+          m_t << "&amp;";
+        }
+        break;
+
       case '\\':
         if ((*p == '(') || (*p == ')') || (*p == '[') || (*p == ']'))
           m_t << "\\&zwj;" << *p++;

--- a/src/htmldocvisitor.h
+++ b/src/htmldocvisitor.h
@@ -118,7 +118,7 @@ class HtmlDocVisitor final : public DocVisitor
     //--------------------------------------
 
     void writeObfuscatedMailAddress(const QCString &url);
-    void filter(const QCString &str, const bool retainNewline = false);
+    void filter(const QCString &str, const bool retainNewline = false, const bool citeEntry = false);
     QCString filterQuotedCdataAttr(const QCString &str);
     void startLink(const QCString &ref,const QCString &file,
                    const QCString &relPath,const QCString &anchor,

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -1848,7 +1848,7 @@ void LatexDocVisitor::operator()(const DocParBlock &pb)
   visitChildren(pb);
 }
 
-void LatexDocVisitor::filter(const QCString &str, const bool retainNewLine)
+void LatexDocVisitor::filter(const QCString &str, const bool retainNewLine, const bool /* citeEntry */)
 {
   //printf("LatexDocVisitor::filter(%s) m_insideTabbing=%d m_insideTable=%d\n",qPrint(str),m_lcg.insideTabbing(),m_lcg.usedTableLevel()>0);
   filterLatexString(m_t,str,

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -135,7 +135,7 @@ class LatexDocVisitor final : public DocVisitor
     // helper functions
     //--------------------------------------
 
-    void filter(const QCString &str, const bool retainNewLine = false);
+    void filter(const QCString &str, const bool retainNewLine = false, const bool citeEntry = false);
     void startLink(const QCString &ref,const QCString &file,
                    const QCString &anchor,bool refToTable=false,bool refToSection=false);
     void endLink(const QCString &ref,const QCString &file,

--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -424,14 +424,15 @@ void ManDocVisitor::operator()(const DocCite &cite)
   if (!cite.file().isEmpty())
   {
     txt = cite.getText();
+    filter(txt, false, true);
   }
   else
   {
     if (!opt.noPar()) txt += "[";
     txt += cite.target();
     if (!opt.noPar()) txt += "]";
+    filter(txt);
   }
-  filter(txt);
   m_t << "\\fP";
 }
 
@@ -991,13 +992,15 @@ void ManDocVisitor::operator()(const DocParBlock &pb)
   visitChildren(pb);
 }
 
-void ManDocVisitor::filter(const QCString &str, const bool retainNewline)
+void ManDocVisitor::filter(const QCString &str, const bool retainNewline, const bool citeEntry)
 {
   if (!str.isEmpty())
   {
     const char *p=str.data();
     char c=0;
     bool insideDoubleQuote = false;
+    const char *q = nullptr;
+    int cnt = 0;
     while ((c=*p++))
     {
       switch(c)
@@ -1006,6 +1009,37 @@ void ManDocVisitor::filter(const QCString &str, const bool retainNewline)
         case '\\': m_t << "\\\\"; break;
         case '\"': m_t << "\""; insideDoubleQuote = !insideDoubleQuote; break;
         case '\n': if (retainNewline || !insideDoubleQuote) m_t << c; break;
+        case '&':  // possibility to have a special symbol
+          if (!citeEntry) { m_t << c; break;}
+          q = p;
+          cnt = 2; // we have to count & and ; as well
+          while ((*q >= 'a' && *q <= 'z') || (*q >= 'A' && *q <= 'Z') || (*q >= '0' && *q <= '9'))
+          {
+            cnt++;
+            q++;
+          }
+          if (*q == ';')
+          {
+             --p; // we need & as well
+             HtmlEntityMapper::SymType res = HtmlEntityMapper::instance().name2sym(QCString(p).left(cnt));
+             if (res == HtmlEntityMapper::Sym_Unknown)
+             {
+               p++;
+               m_t << "&";
+             }
+             else
+             {
+               m_t << HtmlEntityMapper::instance().man(res);
+               q++;
+               p = q;
+             }
+          }
+          else
+          {
+            m_t << "&";
+          }
+          break;
+
         default: m_t << c; break;
       }
     }

--- a/src/mandocvisitor.h
+++ b/src/mandocvisitor.h
@@ -118,7 +118,7 @@ class ManDocVisitor final : public DocVisitor
     // helper functions
     //--------------------------------------
 
-    void filter(const QCString &str, const bool retainNewline = false);
+    void filter(const QCString &str, const bool retainNewline = false, const bool citeEntry = false);
 
     //--------------------------------------
     // state variables

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -623,7 +623,7 @@ void RTFDocVisitor::operator()(const DocCite &cite)
   {
     if (!opt.noCite()) startLink(cite.ref(),cite.file(),cite.anchor());
 
-    filter(cite.getText());
+    filter(cite.getText(),false, true);
 
     if (!opt.noCite()) endLink(cite.ref());
   }
@@ -1693,11 +1693,13 @@ void RTFDocVisitor::operator()(const DocParBlock &pb)
 //    return s;
 //}
 
-void RTFDocVisitor::filter(const QCString &str,bool verbatim)
+void RTFDocVisitor::filter(const QCString &str,bool verbatim, const bool citeEntry)
 {
   if (!str.isEmpty())
   {
     const char *p=str.data();
+    const char *q = nullptr;
+    int cnt = 0;
     while (*p)
     {
       char c=*p++;
@@ -1706,6 +1708,36 @@ void RTFDocVisitor::filter(const QCString &str,bool verbatim)
         case '{':  m_t << "\\{";            break;
         case '}':  m_t << "\\}";            break;
         case '\\': m_t << "\\\\";           break;
+        case '&':  // possibility to have a special symbol
+          if (!citeEntry) { m_t << c; break;}
+          q = p;
+          cnt = 2; // we have to count & and ; as well
+          while ((*q >= 'a' && *q <= 'z') || (*q >= 'A' && *q <= 'Z') || (*q >= '0' && *q <= '9'))
+          {
+            cnt++;
+            q++;
+          }
+          if (*q == ';')
+          {
+             --p; // we need & as well
+             HtmlEntityMapper::SymType res = HtmlEntityMapper::instance().name2sym(QCString(p).left(cnt));
+             if (res == HtmlEntityMapper::Sym_Unknown)
+             {
+               p++;
+               m_t << "&";
+             }
+             else
+             {
+               m_t << HtmlEntityMapper::instance().rtf(res);
+               q++;
+               p = q;
+             }
+          }
+          else
+          {
+            m_t << "&";
+          }
+          break;
         case '\n': if (verbatim)
                    {
                      m_t << "\\par\n";

--- a/src/rtfdocvisitor.h
+++ b/src/rtfdocvisitor.h
@@ -116,7 +116,7 @@ class RTFDocVisitor final : public DocVisitor
     // helper functions
     //--------------------------------------
 
-    void filter(const QCString &str,bool verbatim=FALSE);
+    void filter(const QCString &str, bool verbatim = false, const bool citeEntry = false);
     void startLink(const QCString &ref,const QCString &file,
                    const QCString &anchor);
     void endLink(const QCString &ref);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3930,12 +3930,14 @@ QCString correctId(const QCString &s)
 }
 
 /*! Converts a string to an XML-encoded string */
-QCString convertToXML(const QCString &s, bool keepEntities)
+QCString convertToXML(const QCString &s, bool keepEntities, const bool citeEntry)
 {
   if (s.isEmpty()) return s;
   QCString result;
   result.reserve(s.length()+32);
   const char *p = s.data();
+  const char *q = nullptr;
+  int cnt = 0;
   char c = 0;
   while ((c=*p++))
   {
@@ -3961,6 +3963,36 @@ QCString convertToXML(const QCString &s, bool keepEntities)
                    {
                      result+="&amp;";
                    }
+                 }
+                 else if (citeEntry)
+                 {
+                    q = p;
+                    cnt = 2; // we have to count & and ; as well
+                    while ((*q >= 'a' && *q <= 'z') || (*q >= 'A' && *q <= 'Z') || (*q >= '0' && *q <= '9'))
+                    {
+                      cnt++;
+                      q++;
+                    }
+                    if (*q == ';')
+                    {
+                       --p; // we need & as well
+                       HtmlEntityMapper::SymType res = HtmlEntityMapper::instance().name2sym(QCString(p).left(cnt));
+                       if (res == HtmlEntityMapper::Sym_Unknown)
+                       {
+                         p++;
+                         result+="&amp;";
+                       }
+                       else
+                       {
+                         result+=HtmlEntityMapper::instance().xml(res);
+                         q++;
+                         p = q;
+                       }
+                    }
+                    else
+                    {
+                      result+="&amp;";
+                    }
                  }
                  else
                  {

--- a/src/util.h
+++ b/src/util.h
@@ -323,7 +323,7 @@ QCString correctId(const QCString &s);
 
 QCString convertToHtml(const QCString &s,bool keepEntities=true);
 
-QCString convertToXML(const QCString &s, bool keepEntities=false);
+QCString convertToXML(const QCString &s, bool keepEntities=false, bool citeEntry = false);
 
 QCString convertToJSString(const QCString &s,bool keepEntities=false,bool singleQuotes=false);
 

--- a/src/xmldocvisitor.cpp
+++ b/src/xmldocvisitor.cpp
@@ -589,7 +589,7 @@ void XmlDocVisitor::operator()(const DocCite &cite)
   {
     if (!opt.noCite()) startLink(cite.ref(),cite.file(),cite.anchor());
 
-    filter(cite.getText());
+    filter(cite.getText(), false, true);
 
     if (!opt.noCite()) endLink();
   }
@@ -1181,9 +1181,9 @@ void XmlDocVisitor::operator()(const DocParBlock &pb)
 }
 
 
-void XmlDocVisitor::filter(const QCString &str)
+void XmlDocVisitor::filter(const QCString &str, const bool keepEntities, const bool citeEntry)
 {
-  m_t << convertToXML(str);
+  m_t << convertToXML(str, keepEntities, citeEntry);
 }
 
 void XmlDocVisitor::startLink(const QCString &ref,const QCString &file,const QCString &anchor)

--- a/src/xmldocvisitor.h
+++ b/src/xmldocvisitor.h
@@ -118,7 +118,7 @@ class XmlDocVisitor final : public DocVisitor
     // helper functions
     //--------------------------------------
 
-    void filter(const QCString &str);
+    void filter(const QCString &str, const bool keepEntities = false, const bool citeEntry = false);
     void startLink(const QCString &ref,const QCString &file,
                    const QCString &anchor);
     void endLink();


### PR DESCRIPTION
In case we have in the bibliography author something like:
```
author       = "Herv{\'e} Br{\"o}nnimann"
```
and we give `\cite{shortauthor}` this is shown as:
```
Br&ouml;nnimann
```
instead of
```
Brönnimann
```

Example: [example.tar.gz](https://github.com/user-attachments/files/29749891/example.tar.gz)

(Found for the CGAL package)
