### PR TITLE
Problems with `--` in `\cite` command name.

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -1150,7 +1150,7 @@ STopt  [^\n@\\]*
 <Comment>{CMD}"---"                     { // escaped mdash
                                           addOutput(yyscanner,yytext);
                                         }
-<Comment>{CMD}"--"                      { // escaped mdash
+<Comment>{CMD}"--"                      { // escaped ndash
                                           addOutput(yyscanner,yytext);
                                         }
 <Comment>"---"                          { // mdash

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -624,7 +624,7 @@ size_t Markdown::Private::isSpecialCommand(std::string_view data,size_t offset)
     { "b",              endOfLabel },
     { "c",              endOfLabel },
     { "category",       endOfLine  },
-    { "cite",           endOfLabel },
+    { "cite",           endOfLabelOpt },
     { "class",          endOfLine  },
     { "concept",        endOfLine  },
     { "copybrief",      endOfFunc  },

--- a/templates/html/bib2xhtml.pl
+++ b/templates/html/bib2xhtml.pl
@@ -58,8 +58,8 @@ sub html_ent {
 	s/\!\`/&iexcl;/g;
 	s/\-\-\-/&mdash;/g;
 	s/([^\!])\-\-([^\>])/$1&ndash;$2/g;
-	s/(CITEREF_[^\!])&ndash;([^\>])/$1--$2/g;
-	s/(CITEREF_[^\!])&mdash;([^\>])/$1---$2/g;
+	s/(CITEREF_[^\!]+)&ndash;([^\>])/$1--$2/g;
+	s/(CITEREF_[^\!]+)&mdash;([^\>])/$1---$2/g;
 	s/\\([aA]lpha)\b/&$1;/g;
 	s/\\([bB]eta)\b/&$1;/g;
 	s/\\([gG]amma)\b/&$1;/g;


### PR DESCRIPTION
When having:
```
@article{b--94
...
```
or
```
@article{do--93
...
```

and a definition like:
```
ALIASES                = "cgalCite{1}=<!-- -->\cite{shortauthor,nopar} \1 \cite \1"
```
this gave problems:
- the option of the `\cite` command was not taken into account
- the part before the `&ndash;` in the back substitution was not correct (in the perl file) as only 1 character was taken into account.

Example: [example.tar.gz](https://github.com/user-attachments/files/29798331/example.tar.gz)

(found for the CGAL package)