### PR TITLE
issue #12249 HTML mobile view: expanding and closing the hamburger menu creates a gap at the bottom.

### DIFF
--- a/templates/html/menu.js
+++ b/templates/html/menu.js
@@ -27,6 +27,7 @@ function initMenu(relPath,treeview) {
   const SHOW_DELAY = 250;  // 250ms delay before showing
   const HIDE_DELAY = 500;  // 500ms delay before hiding
   const SLIDE_DELAY = 250; // 250ms slide up/down delay
+  const SLIDE_DELAY_MAIN = 0; // 0ms slide up/down delay for main menu
   const WHEEL_STEP = 30;   // 30 pixel per mouse wheel tick
   const ARROW_STEP = 5;    // 5 pixel when hovering arrow up/down
   const ARROW_POLL_INTERVAL = 20; // 20ms per arrow up/down check
@@ -138,8 +139,9 @@ function initMenu(relPath,treeview) {
           initResizableIfExists();
         });
       } else {
-        slideUp(mainMenu, SLIDE_DELAY, () => {
+        slideUp(mainMenu, SLIDE_DELAY_MAIN, () => {
           mainMenu.style.display = 'none';
+          initResizableIfExists();
         });
       }
     });


### PR DESCRIPTION
- add missing resize call
- remove delay when "slideUp" as it gave a strange jump of the bottom breadcrumb