### PR TITLE
Preprocessor problem with `'` in comment inside a define call

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -2656,6 +2656,22 @@ static inline void addTillEndOfString(yyscan_t yyscanner,const QCString &expr,QC
   }
 }
 
+static inline void addTillEndOfComment(yyscan_t yyscanner,const QCString &expr,QCString *rest,
+                                       uint32_t &pos,char term,QCString &arg)
+{
+  int cc;
+  while ((cc=getNextChar(yyscanner,expr,rest,pos))!=EOF && cc!=0)
+  {
+    if (cc=='*' && getCurrentChar(yyscanner,expr,rest,pos)=='/')
+    {
+      arg+=(char)cc;
+      cc = getNextChar(yyscanner,expr,rest,pos);
+      return;
+    }
+    arg+=(char)cc;
+  }
+}
+
 static void skipCommentMacroName(yyscan_t yyscanner, const QCString &expr, QCString *rest,
                                  int &cc, uint32_t &j, int &len)
 {
@@ -2796,6 +2812,17 @@ static bool replaceFunctionMacro(yyscan_t yyscanner,const QCString &expr,QCStrin
             arg+=c;
             addTillEndOfString(yyscanner,expr,rest,j,c,arg);
           }
+          else if (c=='/')
+          {
+            int nxtChar = getCurrentChar(yyscanner,expr,rest,j);
+            if (nxtChar == '*')
+            {
+              arg+=c;
+              addTillEndOfComment(yyscanner,expr,rest,j,c,arg);
+            }
+            // We don't need to handle the // case as this has already been converted into a /* .. */ comment.
+          }
+
           if (c==')')
           {
             lvl--;


### PR DESCRIPTION
When having something like:
```
  SVN_ERR(svn_stream_open_unique(x,
    /* Don't delete automatically! */
    y));
```
where
```
#define SVN_ERR(expr)                           \
  do {                                          \
    svn_error_t *svn_err__temp = (expr);        \
    if (svn_err__temp)                          \
      return svn_error_trace(svn_err__temp);    \
  } while (0)
```
this leads to the fact that functions after the current function are not documented and for large files (after the problematic call to the define) this can lead also to:
```
input buffer overflow, can't enlarge buffer because scanner uses REJECT
    lexical analyzer: .../doxygen/src/pre.l (for: .../conflicts.c)
```

The problem is cased because the comment is not seen and thus the `'` is seen as start of a character string.


Example: [example.tar.gz](https://github.com/user-attachments/files/30263631/example.tar.gz)


(Found by Fossies for the subversion package)