### PR TITLE
Error with Fortran string concatenation (`//`) and preprocessing

### DIFF
--- a/src/pre.l
+++ b/src/pre.l
@@ -965,6 +965,7 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                           }
                                         }
 <FindDefineArgs>{CPPC}.*\n              { // replace C++ single line style comment by C style comment
+                                          if (getLanguageFromFileName(yyextra->fileName)==SrcLangExt::Fortran) REJECT;
                                           yyextra->defArgsStr+=QCString("/*")+&yytext[2]+" */";
                                         }
 <FindDefineArgs>\"                      {


### PR DESCRIPTION
When having a Fortran program with string concatenation (`//`) and preprocessing (e.g. `aa.F90`) like:
```
Program test

#define PR(x) print *,x

 PR("a"//"b")
 print *, "A"//"B"
end program
```
we get from the preprocessor:
```
Preprocessor output of .../aa.F90 (size: 41 bytes):
---------
00001 Program test
00002
00003 #define PR(x)
00004
00005
---------
```
and later on from the Fortran scanner:
```
Error in file .../bug_ftn_concatination/aa.F90 line: 6, state: 10(ModuleBody), starting command: 'program test' probable line reference: 1
```

This is due to the fact that an attempt is made to concert the concatenation characters (`//`) to C-comment style ('/*'), this is now prevented.

Example: [example.tar.gz](https://github.com/user-attachments/files/30269157/example.tar.gz)

(Found as a byproduct when working on #12252)
