### PR TITLE
Regression in (image) fenced code block when the block starts with newlines / whitespace

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -3337,6 +3337,7 @@ QCString Markdown::Private::processQuotations(std::string_view data,size_t refIn
             // ```                               @enduml
             // ----------------------------------------------------
             pl = "@"+startCmd+"\n" + pl + "@"+endCmd;
+            ii=0;
             addNewLines = false;
           }
           else // we have a @start... command inside the code block


### PR DESCRIPTION
When having a markdown part like:
~~~
```dot

digraph G {
    "Welcome spacing" -> "To"
    "To" -> "Web"
    "To" -> "GraphViz!"
  }
```
~~~
this block is completely ignored in the output.

This looks like a regression introduced in doxygen version 1.9.7 by the handling as added in: 
~~~
Commit: dac50e860d2a083c5ac28fede3706d132715922e [dac50e8]

Date: Sunday, April 9, 2023 2:32:42 PM
Also handle the case with newlines before the @startuml command

Example:
```{plantuml}

@startuml
A -> B
@enduml
```
~~~

When adding `@<cmd>` the `pl` string contains just the command with its contents but no leading newlines or whitespace so we have to look from the beginning of the `pl` string.

Example: [example.tar.gz](https://github.com/user-attachments/files/30305839/example.tar.gz)
