### PR TITLE
issue #12268 Initializer should not be shown as inline sources

### DIFF
--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -1052,7 +1052,7 @@ void DefinitionImpl::writeInlineCode(OutputList &ol,const QCString &scopeName) c
   {
     thisMd = toMemberDef(p->def);
   }
-  bool inlineSources = thisMd && thisMd->hasInlineSource();
+  bool inlineSources = thisMd && thisMd->hasInlineSource() && thisMd->initializer().isEmpty();
   //printf("Source Fragment %s: %d-%d\n",qPrint(name()),
   //        p->body->startLine,p->body->endLine);
   if (inlineSources && hasSources())


### PR DESCRIPTION
Due to the change:
```
Commit: b117bea3ec8db63ca7b79f88dfbfab701b60b7d6 [b117bea]

Date: Saturday, July 22, 2023 6:33:09 PM

Add foldable sections for variables with multiline brace initializers
```
the initializer is also shown as `INLINE_SOURCES`, this is not the intention.

Example: [example.tar.gz](https://github.com/user-attachments/files/30783504/example.tar.gz)
