### PR TITLE
issue #12270 `@code{.shell-session}` is broken since 1.14.0

### DIFF
--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -183,7 +183,7 @@ BLANKopt  {BLANK}*
 ID        [$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
 REQID     [a-z_A-Z0-9\x80-\xFF\-]+
-CODEID    [a-zA-Z][a-zA-Z0-9+-]*
+CODEID    [a-zA-Z][a-zA-Z0-9_+-]*
 PHPTYPE   [?]?[\\:a-z_A-Z0-9\x80-\xFF\-]+
 CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
 CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -183,7 +183,7 @@ BLANKopt  {BLANK}*
 ID        [$a-z_A-Z\x80-\xFF][$a-z_A-Z0-9\x80-\xFF]*
 LABELID   [a-z_A-Z\x80-\xFF][a-z_A-Z0-9\x80-\xFF\-]*
 REQID     [a-z_A-Z0-9\x80-\xFF\-]+
-CODEID    [a-zA-Z][a-zA-Z0-9+]*
+CODEID    [a-zA-Z][a-zA-Z0-9+-]*
 PHPTYPE   [?]?[\\:a-z_A-Z0-9\x80-\xFF\-]+
 CITESCHAR [a-z_A-Z0-9\x80-\xFF\-\?]
 CITEECHAR [a-z_A-Z0-9\x80-\xFF\-\+:\/\?]


### PR DESCRIPTION
Before adding the numbers and plus sign in a "language name" (`CODEID`) it was possible to have a minus sign as well, this has been re-added.