### PR TITLE
issue #11760 `\doxyconfig` does not work as an if-argument

### DIFF
--- a/doc/commands.dox
+++ b/doc/commands.dox
@@ -1658,7 +1658,15 @@ Section indicators
   The section between \c \\cond and \ref cmdendcond "\\endcond" can be included by
   adding its section label to the \ref cfg_enabled_sections "ENABLED_SECTIONS"
   configuration option. If the section label is omitted, the section will
-  be excluded from processing unconditionally. The section label can be a
+  be excluded from processing unconditionally.
+  Besides literal section labels you can also use the
+  \ref cmddoxyconfig "\\doxyconfig" command as section label or as end part of a section label.
+  The section label created with the \ref cmddoxyconfig "\\doxyconfig" command has to be in the
+  \ref cfg_enabled_sections "ENABLED_SECTIONS" to be effective.
+  Note the section-label `YES` this always evaluates to `true` and the section-label
+  `NO` always evaluates to `false`.
+
+  The section label can be a
   logical expression build of section labels, round brackets, && (AND), || (OR) and ! (NOT).
   If you use an expression you need to wrap it in round brackets, i.e
   <tt>\\cond (!LABEL1 && LABEL2)</tt>.
@@ -1960,7 +1968,13 @@ ALIASES += warnNoDoc{1}="\raisewarning Incomplete documentation: \1"
   with a matching \ref cmdendif "\\endif" command. A conditional section is
   disabled by default. To enable it you must put the
   section-label after the \ref cfg_enabled_sections "ENABLED_SECTIONS"
-  tag in the configuration file.
+  tag in the configuration file. Besides literal section labels you can also use the 
+  \ref cmddoxyconfig "\\doxyconfig" command as section label or as end part of a section label.
+  The section label created with the \ref cmddoxyconfig "\\doxyconfig" command has to be in the
+  \ref cfg_enabled_sections "ENABLED_SECTIONS" to be effective.
+  Note the section-label `YES` this always evaluates to `true` and the section-label
+  `NO` always evaluates to `false`.
+
 
   The section label can be a logical expression
   build of section names, round brackets, && (AND), || (OR) and ! (NOT).

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -232,6 +232,8 @@ HFILEMASK {FILEICHAR}*("."{FILEICHAR}+)+{FILECHARS}*
 VFILEMASK {FILECHARS}("."{FILECHARS})*
 FILEMASK  {VFILEMASK}|{HFILEMASK}
 
+DOXYCFG   [A-Z][A-Z_0-9]*
+
 B         [ \t]
 
 OPTS      "{"[^}]*"}"{B}*
@@ -1352,8 +1354,11 @@ SLASHopt [/]*
 					 }
 				       }
     				     }
-				    }
-<CondLine>[!()&| \ta-z_A-Z0-9.\-]+ {
+				   }
+<CondLine>{B}*{CMD}doxyconfig{B}+{DOXYCFG} {
+                                     handleCondSectionId(yyscanner,yytext);
+				   }
+<CondLine>([!()&| \ta-z_A-Z0-9.\-]|{CMD}"doxyconfig")+ {
                                      handleCondSectionId(yyscanner,yytext);
   				   }
 <CComment,ReadLine,IncludeFile>{CMD}"cond"{WSopt}/\n {

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -634,6 +634,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 MODULE_ID ({ID}".")*{ID}
 LINENR    {Bopt}[1-9][0-9]*
 IFILELINE  ("\\ifile \""[^"]*"\" \\iline "[0-9]+" "("iprefix \""[^"]*"\" ")?("iraise "[0-9]+" ")?)
+DOXYCFG   [A-Z][A-Z_0-9]*
 
   // C start comment 
 CCS   "/\*"
@@ -2503,7 +2504,10 @@ STopt  [^\n@\\]*
                                           unput(*yytext);
                                           BEGIN(GuardParam);
                                         }
-<GuardParam>{B}*[a-z_A-Z0-9.\-]+        { // parameter of if/ifnot yyextra->guards
+<GuardParam>{B}*{CMD}doxyconfig{B}+{DOXYCFG} {
+                                          handleGuard(yyscanner,yytext);
+                                        }
+<GuardParam>{B}*[a-z_A-Z0-9.\-]+({B}*{CMD}doxyconfig{B}+{DOXYCFG})? { // parameter of if/ifnot yyextra->guards
                                           handleGuard(yyscanner,yytext);
                                         }
 <GuardParam>{DOCNL}                     { // end of argument

--- a/src/condparser.cpp
+++ b/src/condparser.cpp
@@ -23,9 +23,14 @@
 
 #include "condparser.h"
 #include "config.h"
+#include "configimpl.h"
+#include "configoptions.h"
 #include "message.h"
 
 // declarations
+static DString error_str = "doxyconfig_error";
+static DString resolveConfig(const DString &fileName,int lineNr, const DString &expr);
+static DString getConfig(const DString &fileName,int lineNr, const DString &expr);
 
 /**
  * parses and evaluates the given expression.
@@ -36,8 +41,8 @@
 bool CondParser::parse(const DString &fileName,int lineNr,const DString &expr)
 {
   if (expr.empty()) return false;
-  m_expr      = expr;
   m_tokenType = NOTHING;
+  m_expr = resolveConfig(fileName, lineNr, expr);
 
   // initialize all variables
   m_e = m_expr.data();    // let m_e point to the start of the expression
@@ -278,7 +283,102 @@ bool CondParser::evalOperator(int opId, bool lhs, bool rhs)
  */
 bool CondParser::evalVariable(const DString &varName)
 {
+  if (varName == "YES") return true;
+  if (varName == "NO") return false;
   StringVector list = Config_getList(ENABLED_SECTIONS);
   return std::find(list.begin(),list.end(),varName.str())!=list.end();
 }
 
+static DString getConfig(const DString &fileName,int lineNr, const DString &expr)
+{
+  if (expr.empty())
+  {
+    return error_str;
+  }
+  ConfigOption * opt = ConfigImpl::instance()->get(expr);
+  if (opt)
+  {
+    switch (opt->kind())
+    {
+      case ConfigOption::O_Bool:
+        return((static_cast<ConfigBool*>(opt)->valueRef())? "YES" : "NO");
+      case ConfigOption::O_String:
+        // due to the fact that there can be any character in the string
+        warn(fileName,lineNr,
+             "String setting '{}' not possible in conditional statement, ignored", expr);
+        return error_str;
+      case ConfigOption::O_Enum:
+        return(*(static_cast<ConfigEnum*>(opt)->valueRef()));
+      case ConfigOption::O_Int:
+        return (DString().setNum(*(static_cast<ConfigInt*>(opt)->valueRef())));
+      case ConfigOption::O_List:
+        warn(fileName,lineNr,
+             "List setting '{}' not possible in conditional statement, ignored", expr);
+        return error_str;
+      case ConfigOption::O_Obsolete:
+        warn(fileName,lineNr,
+             "Obsolete setting '{}' not possible in conditional statement, ignored", expr);
+        return error_str;
+      case ConfigOption::O_Disabled:
+        warn(fileName,lineNr,
+             "Disabled setting '{}' not possible in conditional statement, ignored", expr);
+        return error_str;
+      case ConfigOption::O_Info:
+        warn(fileName,lineNr,
+             "Info setting '{}' not possible in conditional statement, ignored", expr);
+        return error_str;
+      default:
+        warn(fileName,lineNr,
+             "Unknown error occurence '{}', ignored", expr);
+        return error_str;
+    }
+  }
+  else
+  {
+    warn(fileName,lineNr,
+         "Unknown setting '{}' not possible in conditional statement, ignored", expr);
+    return error_str;
+  }
+}
+
+static DString resolveConfig(const DString &fileName,int lineNr, const DString &expr)
+{
+  if (expr.empty())
+  {
+    return "";
+  }
+
+  DString loc_expr;
+  signed char c = 0;
+  const char *p=expr.data();
+  size_t len = expr.length();
+  while ((c=*p++)!=0)
+  {
+    switch(c)
+    {
+      case '\\':
+      case '@':
+        if (*p == 'd' && DString(p).startsWith("doxyconfig"))
+        {
+          p+=10; // skip doxyconfig
+          while (*p==' ' || *p=='\t') {p++;}
+          DString bufConfig;
+          while ((c=*p++)!=0)
+          {
+             if ((c>='A' && c<='Z') || (c>='0' && c<='9') || c=='_') bufConfig += c;
+             else
+             {
+               break;
+             }
+          }
+          p--;
+          loc_expr += getConfig(fileName, lineNr, bufConfig);
+        }
+        break;
+      default:
+        loc_expr += c;
+        break;
+    }
+  }
+  return loc_expr;
+}

--- a/src/pre.l
+++ b/src/pre.l
@@ -391,6 +391,7 @@ EscapeRulesCharOpen  "\\["|"\\<"|"\\{"|"\\("|"\\\""|"\\ "|"\\\\"
 EscapeRulesCharClose "\\]"|"\\>"|"\\}"|"\\)"
 EscapeRulesChar      {EscapeRulesCharOpen}|{EscapeRulesCharClose}
 CHARCE    "[:"[^:]*":]"
+DOXYCFG   [A-Z][A-Z_0-9]*
 
   // C start comment
 CCS   "/\*"
@@ -1636,7 +1637,7 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                           yyextra->condCtx=YY_START;
                                           BEGIN(CondLineC);
                                         }
-<CondLineC,CondLineCpp>[!()&| \ta-z_A-Z0-9\x80-\xFF.\-]+      {
+<CondLineC,CondLineCpp>([!()&| \ta-z_A-Z0-9\x80-\xFF.\-]|{CMD}"doxyconfig")+ {
                                           startCondSection(yyscanner,yytext);
                                           if (yyextra->skip)
                                           {
@@ -1656,6 +1657,9 @@ NUMBER {INTEGER_NUMBER}|{FLOAT_NUMBER}
                                           {
                                             BEGIN(yyextra->condCtx);
                                           }
+                                        }
+CondLine>{B}*{CMD}doxyconfig{B}+{DOXYCFG} {
+                                          startCondSection(yyscanner,yytext);
                                         }
 <CondLineC,CondLineCpp>.                { // non-guard character
                                           unput(*yytext);


### PR DESCRIPTION
Adding the possibility to use the `\doxyconfig` command in the section label of `\if` and `\cond`