### PR TITLE
Double html extension in references

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4972,7 +4972,7 @@ void addHtmlExtensionIfMissing(DString &fName)
   size_t i_fs = fName.rfind('/');
   size_t i_bs = fName.rfind('\\');
   size_t p    = i_fs!=DString::npos && i_bs!=DString::npos ? std::max(i_fs, i_bs) :
-                i_fs!=DString::npos ? i_fs : i_bs;
+                i_fs!=DString::npos ? i_fs : i_bs!=DString::npos ? i_bs : 0;
   size_t i    = fName.find('.',p); // search for . after path part
   if (i==DString::npos)
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2952,7 +2952,7 @@ FileDef *findFileDef(const FileNameLinkedMap *fnMap,const DString &n,bool &ambig
   size_t sp0 = name.rfind('/');
   size_t sp1 = name.rfind('\\');
   size_t slashPos = sp0!=DString::npos && sp1!=DString::npos ? std::max(sp0,sp1) :
-                    sp0!=DString::npos ? sp0 : sp1;
+                    sp0!=DString::npos ? sp0 : sp1!=DString::npos ? sp1 : 0;
   if (slashPos!=DString::npos)
   {
     path=removeLongPathMarker(name.left(slashPos+1));
@@ -3066,7 +3066,7 @@ DString showFileDefMatches(const FileNameLinkedMap *fnMap,const DString &n)
   size_t sp0 = name.rfind('/');
   size_t sp1 = name.rfind('\\');
   size_t slashPos = sp0!=DString::npos && sp1!=DString::npos ? std::max(sp0,sp1) :
-                    sp0!=DString::npos ? sp0 : sp1;
+                    sp0!=DString::npos ? sp0 : sp1!=DString::npos ? sp1 : 0;
   if (slashPos!=DString::npos)
   {
     path=removeLongPathMarker(name.left(slashPos+1));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2952,7 +2952,7 @@ FileDef *findFileDef(const FileNameLinkedMap *fnMap,const DString &n,bool &ambig
   size_t sp0 = name.rfind('/');
   size_t sp1 = name.rfind('\\');
   size_t slashPos = sp0!=DString::npos && sp1!=DString::npos ? std::max(sp0,sp1) :
-                    sp0!=DString::npos ? sp0 : sp1!=DString::npos ? sp1 : 0;
+                    sp0!=DString::npos ? sp0 : sp1;
   if (slashPos!=DString::npos)
   {
     path=removeLongPathMarker(name.left(slashPos+1));
@@ -3066,7 +3066,7 @@ DString showFileDefMatches(const FileNameLinkedMap *fnMap,const DString &n)
   size_t sp0 = name.rfind('/');
   size_t sp1 = name.rfind('\\');
   size_t slashPos = sp0!=DString::npos && sp1!=DString::npos ? std::max(sp0,sp1) :
-                    sp0!=DString::npos ? sp0 : sp1!=DString::npos ? sp1 : 0;
+                    sp0!=DString::npos ? sp0 : sp1;
   if (slashPos!=DString::npos)
   {
     path=removeLongPathMarker(name.left(slashPos+1));


### PR DESCRIPTION
When looking at in the source mode of a browser at the file `doxygen_crawl.html` of (a.o.) the doxygen internal documentation we see lines like:
```
...
<a href="annotated.html.html"/>
...
```
note the double `.html.html`

This is due to:
```
commit 772ac869946245992ee79d6245d88b95812cb4cd (HEAD)

Date:   Sun Aug 2 21:32:35 2026 +0200

    Refactoring: Better align interface of QCString with std::string

    Notable changes
    int  s.find    -> size_t s.find
    int  s.findRev -> size_t s.rfind
    bool s.isEmpty -> bool   s.empty
```

in case no path separators at all the value of p should be `0` and not `...::npos`