### PR TITLE
Incorrect python 3.7.5 string

### DIFF
--- a/src/configgen.py
+++ b/src/configgen.py
@@ -521,11 +521,12 @@ def parseGroupMapInit(node):
             type = n.getAttribute('type')
             name = n.getAttribute('id')
             if type in map:
+                quotedName = '"'+name+'",'
                 if type == "enum":
                     mappingStr = "{%s}" % (', '.join(getEnum2BoolMapping(n)))
-                    print(f"    {{ {'\"'+name+'\",':<26} Info{{ {'Info::'+map[type]+',':<13} &ConfigValues::m_{name+',':<23} {mappingStr}}}}},")
+                    print(f"    {{ {quotedName:<26} Info{{ {'Info::'+map[type]+',':<13} &ConfigValues::m_{name+',':<23} {mappingStr}}}}},")
                 else:
-                    print(f"    {{ {'\"'+name+'\",':<26} Info{{ {'Info::'+map[type]+',':<13} &ConfigValues::m_{name:<24}}}}},")
+                    print(f"    {{ {quotedName:<26} Info{{ {'Info::'+map[type]+',':<13} &ConfigValues::m_{name:<24}}}}},")
             if len(setting) > 0:
                 print("#endif")
 


### PR DESCRIPTION
Regression on:
```
Refactoring: use more modern print(f"") style prints in configgen.py for formatting
```
with python 3.7.5 we got an error like:
```
  File ".../src/configgen.py", line 528
    print(f"    {{ {'\"'+name+'\",':<26} Info{{ {'Info::'+map[type]+',':<13} &ConfigValues::m_{name+',':<23} {mappingStr}}}}},")
         ^
SyntaxError: f-string expression part cannot include a backslash
NMAKE : fatal error U1077: 'D:\Programs\Python\Python37\python.exe' : return code '0x1'
```