### PR TITLE
Remove compilation warning

### DIFF
--- a/vhdlparser/CMakeLists.txt
+++ b/vhdlparser/CMakeLists.txt
@@ -21,8 +21,10 @@ if (JAVACC_FOUND)
     else()
         add_custom_command(
 	    COMMAND ${JAVACC_EXECUTABLE} ${JAVACC_FLAGS} -OUTPUT_DIRECTORY=${PROJECT_SOURCE_DIR}/vhdlparser ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj
+	    COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/vhdlparser/vhdl_adj.py ${PROJECT_SOURCE_DIR}/vhdlparser/TokenManager.h ${GENERATED_SRC}/TokenManager_adj.h
+            COMMAND ${CMAKE_COMMAND} -E copy ${GENERATED_SRC}/TokenManager_adj.h  ${PROJECT_SOURCE_DIR}/vhdlparser/TokenManager.h
             DEPENDS ${PROJECT_SOURCE_DIR}/vhdlparser/vhdlparser.jj
-            OUTPUT ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.cc ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.h ${PROJECT_SOURCE_DIR}/vhdlparser/ErrorHandler.h ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.cc ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.h ${PROJECT_SOURCE_DIR}/vhdlparser/Token.cc ${PROJECT_SOURCE_DIR}/vhdlparser/Token.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenManager.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.cc ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserConstants.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.h
+            OUTPUT ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.cc ${PROJECT_SOURCE_DIR}/vhdlparser/CharStream.h ${PROJECT_SOURCE_DIR}/vhdlparser/ErrorHandler.h ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.cc ${PROJECT_SOURCE_DIR}/vhdlparser/ParseException.h ${PROJECT_SOURCE_DIR}/vhdlparser/Token.cc ${PROJECT_SOURCE_DIR}/vhdlparser/Token.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenManager.h ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.cc ${PROJECT_SOURCE_DIR}/vhdlparser/TokenMgrError.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParser.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserConstants.h ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.cc ${PROJECT_SOURCE_DIR}/vhdlparser/VhdlParserTokenManager.h ${PROJECT_SOURCE_DIR}/vhdlparser/vhdl_adj.py
         )
     endif()
 endif()

--- a/vhdlparser/TokenManager.h
+++ b/vhdlparser/TokenManager.h
@@ -22,7 +22,7 @@ public:
    *  A token of kind 0 (`<EOF>`) should be returned on EOF.
    */
   virtual Token *getNextToken() = 0;
-  virtual void   setParser(void* parser) {};
+  virtual void   setParser(void* parser) {}
   virtual void   lexicalError() {
   	std::cerr << "Lexical error encountered." << std::endl;
   }

--- a/vhdlparser/vhdl_adj.py
+++ b/vhdlparser/vhdl_adj.py
@@ -23,6 +23,7 @@ def main():
     for line in inputFile:
         # fix literal strings
         line = re.sub(message_re,'message += reinterpret_cast<const JJChar*>(\\1)',line)
+        line = line.replace("virtual void   setParser(void* parser) {};", "virtual void   setParser(void* parser) {}");
         # fix missing return statements
         outputFile.write(line.replace("assert(false);","assert(false);return DString();"))
 


### PR DESCRIPTION
During compilation we get  warnings like:
```
In file included from .../vhdlparser/VhdlParser.h:6,
                 from .../src/vhdldocgen.cpp:60:
.../vhdlparser/TokenManager.h:25:44: warning: extra ‘;’ after in-class function definition [-Wextra-semi]
   25 |   virtual void   setParser(void* parser) {};
      |                                            ^
      |
```
Even though it is an upstream warning, with already an proposed PR (https://github.com/javacc/javacc/pull/315), better to have a small workaround here as well.