### PR TITLE
Warnings regarding md5

### DIFF
--- a/deps/libmd5/md5.c
+++ b/deps/libmd5/md5.c
@@ -99,7 +99,7 @@ MD5Update(struct MD5Context *ctx, md5byte const *buf, size_t len)
 	/* Update byte count */
 
 	UWORD32 t = ctx->bytes[0];
-	if ((ctx->bytes[0] = t + len) < t)
+	if ((ctx->bytes[0] = t + (UWORD32)len) < t)
 		ctx->bytes[1]++;	/* Carry from low to high */
 
 	t = 64 - (t & 0x3f);	/* Space available in ctx->in (at least 1) */

--- a/deps/libmd5/md5.c
+++ b/deps/libmd5/md5.c
@@ -94,7 +94,7 @@ MD5Init(struct MD5Context *ctx)
  * of bytes.
  */
 void
-MD5Update(struct MD5Context *ctx, md5byte const *buf, unsigned len)
+MD5Update(struct MD5Context *ctx, md5byte const *buf, size_t len)
 {
 	/* Update byte count */
 
@@ -266,7 +266,7 @@ MD5Transform(UWORD32 buf[4], UWORD32 const in[16])
 
 #endif
 
-void MD5Buffer (const char *buf,unsigned int len,unsigned char sig[16])
+void MD5Buffer (const char *buf,size_t len,unsigned char sig[16])
 {
   struct MD5Context md5;
   MD5Init(&md5);

--- a/deps/libmd5/md5.h
+++ b/deps/libmd5/md5.h
@@ -45,9 +45,9 @@ struct MD5Context {
 };
 
 void MD5Init(struct MD5Context *context);
-void MD5Update(struct MD5Context *context, md5byte const *buf, unsigned len);
+void MD5Update(struct MD5Context *context, md5byte const *buf, size_t len);
 void MD5Final(unsigned char digest[16], struct MD5Context *context);
-void MD5Buffer (const char *buf,unsigned int len,unsigned char sig[16]);
+void MD5Buffer (const char *buf,size_t len,unsigned char sig[16]);
 void MD5SigToString(unsigned char sig[16],char str[33]);
 
 #ifdef __cplusplus


### PR DESCRIPTION
On GitHub Actions under MSVC compilation we get warnings like:
```
md5hash.h(29): warning C4267: 'argument': conversion from 'size_t' to 'unsigned int', possible loss of data
```
this has been corrected