### PR TITLE
Errors in doxywizard due to `qsizetype`

### DIFF
--- a/addon/doxywizard/config_doxyw.l
+++ b/addon/doxywizard/config_doxyw.l
@@ -44,6 +44,10 @@
 
 #define USE_STATE2STRING 0
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    typedef int qsizetype;
+#endif
+
 /* -----------------------------------------------------------------
  *
  * static variables


### PR DESCRIPTION
The `qsizetype` was introduced in Qt 5.14.0.
Cygwin still has Qt 5.9.4 as newest version so a small workaround is due (also the type was `int` at that moment for the different functions).