### PR TITLE
Compilation warnings regarding size_t

### DIFF
--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -1777,7 +1777,7 @@ static void handleCondSectionId(yyscan_t yyscanner,const char *expression)
  *  Full lines are returned, excluding the lines on which the markers appear.
  *  \sa routine lineBlock
  */
-static DString extractBlock(const DString &text,const DString &marker,int &blockPos)
+static DString extractBlock(const DString &text,const DString &marker,size_t &blockPos)
 {
   DString result;
   size_t p=0, i = DString::npos;
@@ -1932,7 +1932,7 @@ static bool readIncludeFile(yyscan_t yyscanner,const DString &inc,const DString 
         return false;
       }
       lineNr = lineBlock(incText, blockId);
-      int blockPos = 0;
+      size_t blockPos = 0;
       incText = extractBlock(incText, blockId, blockPos);
       fs->fileBuf.clear();
       if (!incText.empty())

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1757,7 +1757,7 @@ DString extractLanguageSpecificTitle(const DString &input,SrcLangExt lang)
 {
   size_t s=0,e=input.find('|');
   if (e==DString::npos) return input; // simple title case
-  int e1=e;
+  size_t e1=e;
   while (e!=DString::npos) // look for 'number=title' pattern separated by '|'
   {
     s=e+1;

--- a/src/pre.l
+++ b/src/pre.l
@@ -3705,7 +3705,7 @@ static void addMacroDefinition(yyscan_t yyscanner)
   else if (l!=DString::npos && l>0)
   {
     // align the items on the first line with the items on the second line
-    int k=l+1;
+    size_t k=l+1;
     const char *p=litText.data()+k;
     char c = 0;
     while ((c=*p++) && (c==' ' || c=='\t')) k++;

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -4914,7 +4914,7 @@ NONLopt [^\n]*
                                               {
                                                 //printf("Trying scope '%s'\n",qPrint(p->name));
                                                 size_t i=p->name.rfind("::");
-                                                int pi = i==DString::npos ? 0 : i+2;
+                                                size_t pi = i==DString::npos ? 0 : i+2;
                                                 if (p->name.at(pi)=='@')
                                                 {
                                                   // anonymous compound yyextra->inside -> insert dummy variable name

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5796,7 +5796,7 @@ DString stripIndentation(const DString &s,bool skipFirstLine)
 
 // strip up to \a indentationLevel spaces from each line in \a doc (excluding the first line
 //  when skipFirstLine is set to true)
-void stripIndentationVerbatim(DString &doc,const int indentationLevel, bool skipFirstLine)
+void stripIndentationVerbatim(DString &doc,size_t indentationLevel, bool skipFirstLine)
 {
   //printf("stripIndentationVerbatim(level=%d):\n%s\n------\n",indentationLevel,qPrint(doc));
   if (indentationLevel <= 0 || doc.empty()) return; // nothing to strip
@@ -5807,7 +5807,7 @@ void stripIndentationVerbatim(DString &doc,const int indentationLevel, bool skip
   const char *src = doc.data();
   char *dst = doc.rawData();
   bool insideIndent = !skipFirstLine; // skip the initial line from stripping
-  int cnt = 0;
+  size_t cnt = 0;
   if (!skipFirstLine) cnt = indentationLevel;
   while ((c=*src++))
   {

--- a/src/util.h
+++ b/src/util.h
@@ -395,7 +395,7 @@ DString processMarkup(const DString &s);
 bool protectionLevelVisible(Protection prot);
 
 DString stripIndentation(const DString &s,bool skipFirstLine=false);
-void stripIndentationVerbatim(DString &doc,const int indentationLevel, bool skipFirstLine=true);
+void stripIndentationVerbatim(DString &doc,size_t indentationLevel, bool skipFirstLine=true);
 
 DString getDotImageExtension();
 


### PR DESCRIPTION
Correcting some "simple" compilation warnings regarding `size_t` / `int` conversions