### PR TITLE
Compilation warnings regarding `size_t`

### DIFF
--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -196,7 +196,7 @@ static DString getCompoundTypeString(SrcLangExt lang,ClassDef::CompoundType comp
 class ClassDefImpl final : public DefinitionMixin<ClassDefMutable>
 {
   public:
-    ClassDefImpl(const DString &fileName,int startLine,int startColumn,
+    ClassDefImpl(const DString &fileName,int startLine,size_t startColumn,
              const DString &name,CompoundType ct,
              const DString &ref=DString(),const DString &fName=DString(),
              bool isSymbol=true,bool isJavaEnum=false);
@@ -286,7 +286,7 @@ class ClassDefImpl final : public DefinitionMixin<ClassDefMutable>
     bool containsOverload(const MemberDef *md) const override;
     bool isImplicitTemplateInstance() const override;
 
-    ClassDef *insertTemplateInstance(const DString &fileName,int startLine,int startColumn,
+    ClassDef *insertTemplateInstance(const DString &fileName,int startLine,size_t startColumn,
                                 const DString &templSpec,bool &freshInstance) override;
     void insertBaseClass(ClassDef *,const DString &name,Protection p,Specifier s,const DString &t=DString()) override;
     void insertSubClass(ClassDef *,Protection p,Specifier s,const DString &t=DString()) override;
@@ -571,7 +571,7 @@ class ClassDefImpl final : public DefinitionMixin<ClassDefMutable>
 };
 
 std::unique_ptr<ClassDef> createClassDef(
-             const DString &fileName,int startLine,int startColumn,
+             const DString &fileName,int startLine,size_t startColumn,
              const DString &name,ClassDef::CompoundType ct,
              const DString &ref,const DString &fName,
              bool isSymbol,bool isJavaEnum)
@@ -809,7 +809,7 @@ std::unique_ptr<ClassDef> createClassDefAlias(const Definition *newScope,const C
 
 // constructs a new class definition
 ClassDefImpl::ClassDefImpl(
-    const DString &defFileName,int defLine,int defColumn,
+    const DString &defFileName,int defLine,size_t defColumn,
     const DString &nm,CompoundType ct,
     const DString &lref,const DString &fName,
     bool isSymbol,bool isJavaEnum)
@@ -4330,7 +4330,7 @@ const Definition *ClassDefImpl::findInnerCompound(const DString &name) const
 }
 
 ClassDef *ClassDefImpl::insertTemplateInstance(const DString &fileName,
-    int startLine, int startColumn, const DString &templSpec,bool &freshInstance)
+    int startLine, size_t startColumn, const DString &templSpec,bool &freshInstance)
 {
   freshInstance = false;
   auto it = std::find_if(m_templateInstances.begin(),

--- a/src/classdef.h
+++ b/src/classdef.h
@@ -410,7 +410,7 @@ class ClassDefMutable : public DefinitionMutable, public ClassDef
     // --- helpers ----
     //-----------------------------------------------------------------------------------
 
-    virtual ClassDef *insertTemplateInstance(const DString &fileName,int startLine,int startColumn,
+    virtual ClassDef *insertTemplateInstance(const DString &fileName,int startLine,size_t startColumn,
                                 const DString &templSpec,bool &freshInstance) = 0;
 
     //-----------------------------------------------------------------------------------
@@ -450,7 +450,7 @@ class ClassDefMutable : public DefinitionMutable, public ClassDef
 
 /** Factory method to create a new ClassDef object */
 std::unique_ptr<ClassDef> createClassDef(
-             const DString &fileName,int startLine,int startColumn,
+             const DString &fileName,int startLine,size_t startColumn,
              const DString &name,ClassDef::CompoundType ct,
              const DString &ref=DString(),const DString &fName=DString(),
              bool isSymbol=true,bool isJavaEnum=false);

--- a/src/codefragment.cpp
+++ b/src/codefragment.cpp
@@ -34,7 +34,7 @@ struct CodeFragmentManager::Private
 {
   struct BlockMarker
   {
-    int indent=0;
+    size_t indent=0;
     std::string key;
     std::vector<int> lines;
   };
@@ -130,7 +130,7 @@ void CodeFragmentManager::Private::FragmentInfo::findBlockMarkers()
     }
     return startPos;
   };
-  static auto lineIndent = [](const char *&ss, int orgCol) -> int
+  static auto lineIndent = [](const char *&ss, size_t orgCol) -> size_t
   {
     int tabSize=Config_getInt(TAB_SIZE);
     int col = 0;
@@ -159,8 +159,8 @@ void CodeFragmentManager::Private::FragmentInfo::findBlockMarkers()
     const char *e = gotoLine(startBuf,s,marker.lines[0]+1,lineNr);
 
     const char *ss = s;
-    int minIndent=100000;
-    int indent = minIndent;
+    size_t minIndent=100000;
+    size_t indent = minIndent;
     while (ss<e)
     {
       indent = lineIndent(ss, indent);
@@ -315,7 +315,7 @@ void CodeFragmentManager::parseCodeFragment(OutputCodeList & codeOutList,
     const auto &marker = blockKv->second;
     int startLine = marker->lines[0];
     int endLine   = marker->lines[1];
-    int indent    = marker->indent;
+    size_t indent = marker->indent;
     AUTO_TRACE_ADD("replay(start={},end={},indent={}) fileContentsTrimLeft.empty()={}",
         startLine,endLine,indent,codeFragment->fileContentsTrimLeft.empty());
     auto recorder = codeFragment->recorderCodeList.get<OutputCodeRecorder>(OutputType::Recorder);
@@ -324,7 +324,7 @@ void CodeFragmentManager::parseCodeFragment(OutputCodeList & codeOutList,
                     endLine,
                     showLineNumbers,
                     stripCodeComments,
-                    trimLeft ? static_cast<size_t>(indent) : 0
+                    trimLeft ? indent : 0
                    );
   }
   else

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -98,9 +98,9 @@ struct commentcnvYY_state
   const std::string *inBuf;
   std::string &outBuf;
   int      inBufPos = 0;
-  int      col = 0;
-  int      blockHeadCol = 0;        // column at which the start of a special comment block was found
-  int      insertCommentCol = 0;    // column at which an include or snippet command was found
+  size_t   col = 0;
+  size_t   blockHeadCol = 0;        // column at which the start of a special comment block was found
+  size_t   insertCommentCol = 0;    // column at which an include or snippet command was found
   bool     mlBrief = false;
   int      readLineCtx = 0;
   int      includeCtx = 0;
@@ -1394,7 +1394,7 @@ SLASHopt [/]*
 				     BEGIN( ReadAliasArgs );
   				   }
 <ReadAliasArgs>^[ \t]*"*"          {
-                                     int indent=computeIndent(yytext)-1;
+                                     size_t indent=computeIndent(yytext)-1;
                                      if (indent>yyextra->blockHeadCol) // assume part of block marker
                                      {
                                        yyextra->aliasString+=yytext;
@@ -1823,9 +1823,9 @@ static DString extractBlock(const DString &text,const DString &marker,size_t &bl
 static void insertCommentStart(yyscan_t yyscanner)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  int startCol=yyextra->blockHeadCol;
-  int contentCol=yyextra->insertCommentCol;
-  int markerSpace=contentCol-startCol;
+  size_t startCol=yyextra->blockHeadCol;
+  size_t contentCol=yyextra->insertCommentCol;
+  size_t markerSpace=contentCol-startCol;
   //printf("insertCommentStart startCol=%d contentCol=%d mlBrief=%d insertCppCommentMarker=%d\n",
   //    yyextra->blockHeadCol,yyextra->insertCommentCol,yyextra->mlBrief,yyextra->insertCppCommentMarker);
   std::string marker;
@@ -1862,12 +1862,12 @@ static void insertCommentStart(yyscan_t yyscanner)
   {
     marker="* ";
   }
-  int i=0;
+  size_t i=0;
   for (;i<startCol;i++)
   {
     copyToOutput(yyscanner," ");
   }
-  if (static_cast<int>(marker.length())<=markerSpace && !yyextra->firstIncludeLine)
+  if (marker.length()<=markerSpace && !yyextra->firstIncludeLine)
   {
     copyToOutput(yyscanner,marker);
     i+=static_cast<int>(marker.length());
@@ -2085,7 +2085,7 @@ static void replaceComment(yyscan_t yyscanner,int offset)
   }
   else
   {
-    int i=computeIndent(&yytext[offset]);
+    size_t i=computeIndent(&yytext[offset]);
     //printf("i=%d blockHeadCol=%d\n",i,yyextra->blockHeadCol);
     if (i==yyextra->blockHeadCol || i+1==yyextra->blockHeadCol)
     {
@@ -2094,7 +2094,11 @@ static void replaceComment(yyscan_t yyscanner,int offset)
     else
     {
       copyToOutput(yyscanner," */");
-      for (i=(int)yyleng-1;i>=0;i--) unput(yytext[i]);
+      for (i = yyleng; i>0; )
+      {
+        --i;
+        unput(yytext[i]);
+      }
       yyextra->inSpecialComment=false;
       BEGIN(Scan);
     }

--- a/src/conceptdef.cpp
+++ b/src/conceptdef.cpp
@@ -31,7 +31,7 @@
 class ConceptDefImpl final : public DefinitionMixin<ConceptDefMutable>
 {
   public:
-    ConceptDefImpl(const DString &fileName,int startLine,int startColumn,
+    ConceptDefImpl(const DString &fileName,int startLine,size_t startColumn,
                    const DString &name,const DString &tagRef=DString(),const DString &tagFile=DString());
    ~ConceptDefImpl() override;
     NON_COPYABLE(ConceptDefImpl)
@@ -68,8 +68,8 @@ class ConceptDefImpl final : public DefinitionMixin<ConceptDefMutable>
     void setInitializer(const DString &init) override;
     void findSectionsInDocumentation() override;
     void setGroupId(int id) override;
-    void addDocPart(const DString &doc,int lineNr,int colNr) override;
-    void addCodePart(const DString &code,int lineNr,int colNr) override;
+    void addDocPart(const DString &doc,int lineNr,size_t colNr) override;
+    void addCodePart(const DString &code,int lineNr,size_t colNr) override;
     void addListReferences() override;
     void addRequirementReferences() override;
 
@@ -94,7 +94,7 @@ class ConceptDefImpl final : public DefinitionMixin<ConceptDefMutable>
 };
 
 std::unique_ptr<ConceptDef> createConceptDef(
-             const DString &fileName,int startLine,int startColumn,
+             const DString &fileName,int startLine,size_t startColumn,
              const DString &name, const DString &tagRef,const DString &tagFile)
 {
   return std::make_unique<ConceptDefImpl>(fileName,startLine,startColumn,name,tagRef,tagFile);
@@ -161,7 +161,7 @@ std::unique_ptr<ConceptDef> createConceptDefAlias(const Definition *newScope,con
 
 //------------------------------------------------------------------------------------
 
-ConceptDefImpl::ConceptDefImpl(const DString &fileName,int startLine,int startColumn,
+ConceptDefImpl::ConceptDefImpl(const DString &fileName,int startLine,size_t startColumn,
     const DString &name,const DString &tagRef,const DString &tagFile) : DefinitionMixin(fileName,startLine,startColumn,name)
 {
   if (!tagFile.empty())
@@ -777,12 +777,12 @@ void ConceptDefImpl::findSectionsInDocumentation()
   docFindSections(inbodyDocumentation(),this,docFile());
 }
 
-void ConceptDefImpl::addDocPart(const DString &doc,int lineNr,int colNr)
+void ConceptDefImpl::addDocPart(const DString &doc,int lineNr,size_t colNr)
 {
   m_parts.emplace_back(PartType::Doc,doc,lineNr,colNr);
 }
 
-void ConceptDefImpl::addCodePart(const DString &code,int lineNr,int colNr)
+void ConceptDefImpl::addCodePart(const DString &code,int lineNr,size_t colNr)
 {
   m_parts.emplace_back(PartType::Code,code,lineNr,colNr);
 }

--- a/src/conceptdef.h
+++ b/src/conceptdef.h
@@ -31,11 +31,11 @@ class ConceptDef : public Definition
     enum class PartType { Code, Doc };
     struct Part
     {
-      Part(PartType t,const DString &s,int ln,int col) : type(t), content(s), lineNr(ln), colNr(col) {}
+      Part(PartType t,const DString &s,int ln,size_t col) : type(t), content(s), lineNr(ln), colNr(col) {}
       PartType type;
       DString content;
       int lineNr;
-      int colNr;
+      size_t colNr;
     };
     using Parts = std::vector<Part>;
 
@@ -70,12 +70,12 @@ class ConceptDefMutable : public DefinitionMutable, public ConceptDef
     virtual void setModuleDef(ModuleDef *mod) = 0;
     virtual void addListReferences() = 0;
     virtual void addRequirementReferences() = 0;
-    virtual void addDocPart(const DString &doc,int lineNr,int colNr) = 0;
-    virtual void addCodePart(const DString &code,int lineNr,int colNr) = 0;
+    virtual void addDocPart(const DString &doc,int lineNr,size_t colNr) = 0;
+    virtual void addCodePart(const DString &code,int lineNr,size_t colNr) = 0;
 };
 
 std::unique_ptr<ConceptDef> createConceptDef(
-    const DString &fileName,int startLine,int startColumn,const DString &name,
+    const DString &fileName,int startLine,size_t startColumn,const DString &name,
     const DString &tagRef=DString(),const DString &tagFile=DString());
 
 std::unique_ptr<ConceptDef> createConceptDefAlias(const Definition *newScope,const ConceptDef *cd);

--- a/src/define.h
+++ b/src/define.h
@@ -36,7 +36,7 @@ class Define
     DString args;
     FileDef *fileDef = nullptr;
     int lineNr = 1;
-    int columnNr = 1;
+    size_t columnNr = 1;
     int nargs = -1;
     bool undef = false;
     bool varArgs = false;

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -114,7 +114,7 @@ class DefinitionImpl::Private
     bool isSymbol;
     DString symbolName;
     int defLine;
-    int defColumn;
+    size_t defColumn;
 
     MemberVector referencesMembers;    // cache for getReferencesMembers()
     MemberVector referencedByMembers;  // cache for getReferencedByMembers()
@@ -157,7 +157,7 @@ void DefinitionImpl::Private::init(const DString &df, const DString &n)
   lang            = SrcLangExt::Unknown;
 }
 
-void DefinitionImpl::setDefFile(const DString &df,int defLine,int defCol)
+void DefinitionImpl::setDefFile(const DString &df,int defLine,size_t defCol)
 {
   p->setDefFileName(df);
   p->defLine = defLine;
@@ -248,7 +248,7 @@ static void removeFromMap(const DString &name,Definition *d)
 }
 
 DefinitionImpl::DefinitionImpl(Definition *def,
-                       const DString &df,int dl,int dc,
+                       const DString &df,int dl,size_t dc,
                        const DString &name,const char *b,
                        const char *d,bool isSymbol)
   : p(std::make_unique<Private>())
@@ -1921,7 +1921,7 @@ int DefinitionImpl::getDefLine() const
   return p->defLine;
 }
 
-int DefinitionImpl::getDefColumn() const
+size_t DefinitionImpl::getDefColumn() const
 {
   return p->defColumn;
 }

--- a/src/definition.h
+++ b/src/definition.h
@@ -190,7 +190,7 @@ class Definition
     virtual int getDefLine() const = 0;
 
     /*! returns the column number at which the definition was found */
-    virtual int getDefColumn() const = 0;
+    virtual size_t getDefColumn() const = 0;
 
     /*! Returns true iff the definition is documented
      *  (which could be generated documentation)
@@ -321,7 +321,7 @@ class DefinitionMutable
     virtual void setId(const DString &name) = 0;
 
     /*! Set a new file name and position */
-    virtual void setDefFile(const DString& df,int defLine,int defColumn) = 0;
+    virtual void setDefFile(const DString& df,int defLine,size_t defColumn) = 0;
 
     /*! Sets the documentation of this definition to \a d. */
     virtual void setDocumentation(const DString &d,const DString &docFile,int docLine,bool stripWhiteSpace=true) = 0;

--- a/src/definitionimpl.h
+++ b/src/definitionimpl.h
@@ -29,7 +29,7 @@ class DefinitionImpl
   public:
     DefinitionImpl(
         Definition *def,
-        const DString &defFileName,int defLine,int defColumn,
+        const DString &defFileName,int defLine,size_t defColumn,
         const DString &name,const char *b=nullptr,const char *d=nullptr,
         bool isSymbol=true);
     ~DefinitionImpl();
@@ -58,7 +58,7 @@ class DefinitionImpl
     DString getDefFileName() const;
     DString getDefFileExtension() const;
     int getDefLine() const;
-    int getDefColumn() const;
+    size_t getDefColumn() const;
     bool hasDocumentation() const;
     bool hasUserDocumentation() const;
     bool isVisibleInProject() const;
@@ -89,7 +89,7 @@ class DefinitionImpl
     const SectionRefs &getSectionRefs() const;
     void setName(const DString &name);
     void setId(const DString &name);
-    void setDefFile(const DString& df,int defLine,int defColumn);
+    void setDefFile(const DString& df,int defLine,size_t defColumn);
     void setDocumentation(const DString &d,const DString &docFile,int docLine,bool stripWhiteSpace=true);
     void setBriefDescription(const DString &b,const DString &briefFile,int briefLine);
     void setInbodyDocumentation(const DString &d,const DString &docFile,int docLine);
@@ -154,7 +154,7 @@ class DefinitionMixin : public Base
   public:
     /*! Create a new definition */
     DefinitionMixin(
-        const DString &defFileName,int defLine,int defColumn,
+        const DString &defFileName,int defLine,size_t defColumn,
         const DString &name,const char *b=nullptr,const char *d=nullptr,
         bool isSymbol=true) : m_impl(this,defFileName,defLine,defColumn,name,b,d,isSymbol) {}
     DefinitionMixin(const DefinitionMixin &other) : Base(other), m_impl(other.m_impl) {}
@@ -186,7 +186,7 @@ class DefinitionMixin : public Base
     DString getDefFileName() const override { return m_impl.getDefFileName(); }
     DString getDefFileExtension() const override { return m_impl.getDefFileExtension(); }
     int getDefLine() const override { return m_impl.getDefLine(); }
-    int getDefColumn() const override { return m_impl.getDefColumn(); }
+    size_t getDefColumn() const override { return m_impl.getDefColumn(); }
     bool hasDocumentation() const override { return m_impl.hasDocumentation(); }
     bool hasUserDocumentation() const override { return m_impl.hasUserDocumentation(); }
     bool isVisibleInProject() const override { return m_impl.isVisibleInProject(); }
@@ -219,7 +219,7 @@ class DefinitionMixin : public Base
     //======== DefinitionMutable
     void setName(const DString &name) override { m_impl.setName(name); }
     void setId(const DString &name) override { m_impl.setId(name); }
-    void setDefFile(const DString& df,int defLine,int defColumn) override
+    void setDefFile(const DString& df,int defLine,size_t defColumn) override
     { m_impl.setDefFile(df,defLine,defColumn); }
     void setDocumentation(const DString &doc,const DString &docFile,int docLine,bool stripWhiteSpace=true) override
     { m_impl.setDocumentation(doc,docFile,docLine,stripWhiteSpace); }
@@ -386,7 +386,7 @@ class DefinitionAliasMixin : public Base
     { return m_alias->getDefFileExtension(); }
     int getDefLine() const override
     { return m_alias->getDefLine(); }
-    int getDefColumn() const override
+    size_t getDefColumn() const override
     { return m_alias->getDefColumn(); }
     bool hasDocumentation() const override
     { return m_alias->hasDocumentation(); }

--- a/src/docbookgen.h
+++ b/src/docbookgen.h
@@ -320,7 +320,7 @@ class DocbookGenerator final : public OutputGenerator, public OutputGenIntf
     void startPlainFile(const DString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }
 
-    void startEmbeddedDoc(int) override {}
+    void startEmbeddedDoc(size_t) override {}
     void endEmbeddedDoc() override {}
     static DString convertToDocbook(const DString &s, bool retainNewline = false, bool citeEntry = false);
 

--- a/src/dotnode.cpp
+++ b/src/dotnode.cpp
@@ -340,7 +340,7 @@ void DotNode::addChild(DotNode *n,
   EdgeInfo::Styles edgeStyle,
   const DString &edgeLab,
   const DString &edgeURL,
-  int edgeLabCol
+  int edgeLabColor
 )
 {
   m_children.push_back(n);
@@ -349,7 +349,7 @@ void DotNode::addChild(DotNode *n,
       edgeStyle,
       edgeLab,
       edgeURL,
-      edgeLabCol==-1 ? edgeColor : edgeLabCol);
+      edgeLabColor==-1 ? edgeColor : edgeLabColor);
 }
 
 void DotNode::addParent(DotNode *n)

--- a/src/dotnode.h
+++ b/src/dotnode.h
@@ -81,7 +81,7 @@ class DotNode
                   EdgeInfo::Styles edgeStyle=EdgeInfo::Solid,
                   const DString &edgeLab=DString(),
                   const DString &edgeURL=DString(),
-                  int edgeLabCol=-1);
+                  int edgeLabColor=-1);
     void addParent(DotNode *n);
     void deleteNode(DotNodeRefVector &deletedList);
     void removeChild(DotNode *n);

--- a/src/dstring.h
+++ b/src/dstring.h
@@ -280,10 +280,10 @@ class DString
      *  @note the string will be resized to contain \a len characters. The contents of the
      *  string will be lost.
      */
-    DString fill( char c, int len = -1 )
+    DString fill( char c, size_t len)
     {
-      int l = len==-1 ? static_cast<int>(m_rep.size()) : len;
-      m_rep = std::string(l,c);
+      //int l = len==-1 ? static_cast<int>(m_rep.size()) : len;
+      m_rep = std::string(len,c);
       return *this;
     }
 

--- a/src/entry.h
+++ b/src/entry.h
@@ -216,7 +216,7 @@ class Entry
     DString      exception;   //!< throw specification
     ArgumentList typeConstr;  //!< where clause (C#) for type constraints
     int          bodyLine;    //!< line number of the body in the source
-    int          bodyColumn;  //!< column of the body in the source
+    size_t       bodyColumn;  //!< column of the body in the source
     int          endBodyLine; //!< line number where the definition ends
     int          mGrpId;      //!< member group id
     std::vector<BaseInfo> extends; //!< list of base classes
@@ -224,7 +224,7 @@ class Entry
     std::vector<const SectionInfo*> anchors; //!< list of anchors defined in this entry
     DString	fileName;     //!< file this entry was extracted from
     int		startLine;    //!< start line of entry in the source
-    int		startColumn;  //!< start column of entry in the source
+    size_t      startColumn;  //!< start column of entry in the source
     RefItemVector sli;        //!< special lists (test/todo/bug/deprecated/..) this entry is in
     RequirementRefs rqli;     //!< references to requirements
     SrcLangExt  lang;         //!< programming language in which this entry was found

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -3625,7 +3625,7 @@ void HtmlGenerator::endInlineMemberDoc()
   m_t << "</td></tr>\n";
 }
 
-void HtmlGenerator::startEmbeddedDoc(int indent)
+void HtmlGenerator::startEmbeddedDoc(size_t indent)
 {
   DBG_HTML(m_t << "<!-- startEmbeddedDoc -->\n";)
   m_t << "<div class=\"embeddoc indent-" << indent << "\">";

--- a/src/htmlgen.h
+++ b/src/htmlgen.h
@@ -334,7 +334,7 @@ class HtmlGenerator final : public OutputGenerator, public OutputGenIntf
     void startPlainFile(const DString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }
 
-    void startEmbeddedDoc(int) override;
+    void startEmbeddedDoc(size_t) override;
     void endEmbeddedDoc() override;
 
   private:

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -2286,7 +2286,7 @@ void LatexGenerator::startLocalToc(int level)
   m_t << "\\localtableofcontents\n";
 }
 
-void LatexGenerator::startEmbeddedDoc(int indent)
+void LatexGenerator::startEmbeddedDoc(size_t indent)
 {
   m_t << "\\begin{DoxyEmbeddedDoc}[" << indent << "]\n";
 }

--- a/src/latexgen.h
+++ b/src/latexgen.h
@@ -316,7 +316,7 @@ class LatexGenerator final : public OutputGenerator, public OutputGenIntf
     void startPlainFile(const DString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }
 
-    void startEmbeddedDoc(int) override;
+    void startEmbeddedDoc(size_t) override;
     void endEmbeddedDoc() override;
 
   private:

--- a/src/mangen.h
+++ b/src/mangen.h
@@ -289,7 +289,7 @@ class ManGenerator final : public OutputGenerator, public OutputGenIntf
     void startPlainFile(const DString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }
 
-    void startEmbeddedDoc(int) override {}
+    void startEmbeddedDoc(size_t) override {}
     void endEmbeddedDoc() override {}
 
   private:

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1597,7 +1597,7 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
   else
   {
     SrcLangExt lang = getLanguageFromFileName(link);
-    size_t lp=-1;
+    size_t lp=DString::npos;
     if ((lp = link.find("@ref "))!=DString::npos ||
         (lp = link.find("\\ref "))!=DString::npos ||
         (lang==SrcLangExt::Markdown && !isURL(link)))

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -509,7 +509,7 @@ class MemberDefImpl final : public DefinitionMixin<MemberDefMutable>
     const MemberDef *m_categoryRelation = nullptr;
     DString m_declFileName;
     int m_declLine = -1;
-    size_t m_declColumn = -1;
+    size_t m_declColumn = 1;
     int m_numberOfFlowKW = 0;
     int m_redefineCount = 0;
 };

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -53,7 +53,7 @@
 class MemberDefImpl final : public DefinitionMixin<MemberDefMutable>
 {
   public:
-    MemberDefImpl(const DString &defFileName,int defLine,int defColumn,
+    MemberDefImpl(const DString &defFileName,int defLine,size_t defColumn,
               const DString &type,const DString &name,const DString &args,
               const DString &excp,Protection prot,Specifier virt,bool stat,
               Relationship related,MemberType t,const ArgumentList &tal,
@@ -253,7 +253,7 @@ class MemberDefImpl final : public DefinitionMixin<MemberDefMutable>
     bool isReference() const override;
     DString getDeclFileName() const override;
     int getDeclLine() const override;
-    int getDeclColumn() const override;
+    size_t getDeclColumn() const override;
     void setMemberType(MemberType t) override;
     void setDefinition(const DString &d) override;
     void setFileDef(FileDef *fd) override;
@@ -287,9 +287,9 @@ class MemberDefImpl final : public DefinitionMixin<MemberDefMutable>
     void setDocumentedEnumValues(bool value) override;
     void setAnonymousEnumType(const MemberDef *md) override;
     bool addExample(const DString &anchor,const DString &name,const DString &file) override;
-    void setPrototype(bool p,const DString &df,int line, int column) override;
-    void setExplicitExternal(bool b,const DString &df,int line,int column) override;
-    void setDeclFile(const DString &df,int line,int column) override;
+    void setPrototype(bool p,const DString &df,int line, size_t column) override;
+    void setExplicitExternal(bool b,const DString &df,int line,size_t column) override;
+    void setDeclFile(const DString &df,int line,size_t column) override;
     void moveArgumentList(std::unique_ptr<ArgumentList> al) override;
     void moveDeclArgumentList(std::unique_ptr<ArgumentList> al) override;
     void setDefinitionTemplateParameterLists(const ArgumentLists &lists) override;
@@ -509,12 +509,12 @@ class MemberDefImpl final : public DefinitionMixin<MemberDefMutable>
     const MemberDef *m_categoryRelation = nullptr;
     DString m_declFileName;
     int m_declLine = -1;
-    int m_declColumn = -1;
+    size_t m_declColumn = -1;
     int m_numberOfFlowKW = 0;
     int m_redefineCount = 0;
 };
 
-std::unique_ptr<MemberDef> createMemberDef(const DString &defFileName,int defLine,int defColumn,
+std::unique_ptr<MemberDef> createMemberDef(const DString &defFileName,int defLine,size_t defColumn,
               const DString &type,const DString &name,const DString &args,
               const DString &excp,Protection prot,Specifier virt,bool stat,
               Relationship related,MemberType t,const ArgumentList &tal,
@@ -925,7 +925,7 @@ class MemberDefAliasImpl final : public DefinitionAliasMixin<MemberDef>
     { return getMdAlias()->getDeclFileName(); }
     int getDeclLine() const override
     { return getMdAlias()->getDeclLine(); }
-    int getDeclColumn() const override
+    size_t getDeclColumn() const override
     { return getMdAlias()->getDeclColumn(); }
     DString requiresClause() const override
     { return getMdAlias()->requiresClause(); }
@@ -1449,7 +1449,7 @@ void MemberDefImpl::init(Definition *d,
  * \param meta Slice metadata.
  */
 
-MemberDefImpl::MemberDefImpl(const DString &df,int dl,int dc,
+MemberDefImpl::MemberDefImpl(const DString &df,int dl,size_t dc,
                      const DString &t,const DString &na,const DString &a,const DString &e,
                      Protection p,Specifier v,bool s,Relationship r,MemberType mt,
                      const ArgumentList &tal,const ArgumentList &al,const DString &meta
@@ -5746,7 +5746,7 @@ int MemberDefImpl::getDeclLine() const
   return m_declLine;
 }
 
-int MemberDefImpl::getDeclColumn() const
+size_t MemberDefImpl::getDeclColumn() const
 {
   return m_declColumn;
 }
@@ -5888,7 +5888,7 @@ void MemberDefImpl::setAnonymousEnumType(const MemberDef *md)
   m_annEnumType = md;
 }
 
-void MemberDefImpl::setPrototype(bool p,const DString &df,int line,int column)
+void MemberDefImpl::setPrototype(bool p,const DString &df,int line,size_t column)
 {
   m_proto=p;
   if (p)
@@ -5901,7 +5901,7 @@ void MemberDefImpl::setPrototype(bool p,const DString &df,int line,int column)
   }
 }
 
-void MemberDefImpl::setExplicitExternal(bool b,const DString &df,int line,int column)
+void MemberDefImpl::setExplicitExternal(bool b,const DString &df,int line,size_t column)
 {
   m_explExt=b;
   if (b)
@@ -5914,7 +5914,7 @@ void MemberDefImpl::setExplicitExternal(bool b,const DString &df,int line,int co
   }
 }
 
-void MemberDefImpl::setDeclFile(const DString &df,int line,int column)
+void MemberDefImpl::setDeclFile(const DString &df,int line,size_t column)
 {
   m_declFileName = df;
   m_declLine = line;

--- a/src/memberdef.h
+++ b/src/memberdef.h
@@ -274,7 +274,7 @@ class MemberDef : public Definition
 
     virtual DString getDeclFileName() const = 0;
     virtual int getDeclLine() const = 0;
-    virtual int getDeclColumn() const = 0;
+    virtual size_t getDeclColumn() const = 0;
 
     virtual std::unique_ptr<MemberDef> createTemplateInstanceMember(const ArgumentList &formalArgs,
                const std::unique_ptr<ArgumentList> &actualArgs) const = 0;
@@ -354,9 +354,9 @@ class MemberDefMutable : public DefinitionMutable, public MemberDef
     virtual bool addExample(const DString &anchor,const DString &name,const DString &file) = 0;
 
     // prototype related members
-    virtual void setPrototype(bool p,const DString &df,int line, int column) = 0;
-    virtual void setExplicitExternal(bool b,const DString &df,int line,int column) = 0;
-    virtual void setDeclFile(const DString &df,int line,int column) = 0;
+    virtual void setPrototype(bool p,const DString &df,int line, size_t column) = 0;
+    virtual void setExplicitExternal(bool b,const DString &df,int line,size_t column) = 0;
+    virtual void setDeclFile(const DString &df,int line,size_t column) = 0;
 
     // argument related members
     virtual void moveArgumentList(std::unique_ptr<ArgumentList> al) = 0;
@@ -447,7 +447,7 @@ MemberDefMutable     *toMemberDefMutable(Definition *d);
 
 
 /** Factory method to create a new instance of a MemberDef */
-std::unique_ptr<MemberDef> createMemberDef(const DString &defFileName,int defLine,int defColumn,
+std::unique_ptr<MemberDef> createMemberDef(const DString &defFileName,int defLine,size_t defColumn,
               const DString &type,const DString &name,const DString &args,
               const DString &excp,Protection prot,Specifier virt,bool stat,
               Relationship related,MemberType t,const ArgumentList &tal,

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -49,9 +49,9 @@ using HeaderInfoVector = std::vector<HeaderInfo>;
 class ModuleDefImpl final : public DefinitionMixin<ModuleDef>
 {
   public:
-    ModuleDefImpl(const DString &fileName,int startLine,int startColom,
+    ModuleDefImpl(const DString &fileName,int startLine,size_t startColumn,
                   const DString &name, Type type, const DString &partitionName)
-      : DefinitionMixin<ModuleDef>(fileName,startLine,startColom,name,nullptr,nullptr,true),
+      : DefinitionMixin<ModuleDef>(fileName,startLine,startColumn,name,nullptr,nullptr,true),
         m_type(type), m_partitionName(partitionName) {}
 
     // --- Definition
@@ -1268,7 +1268,7 @@ ModuleManager::ModuleManager() : p(std::make_unique<Private>())
 {
 }
 
-void ModuleManager::createModuleDef(const DString &fileName,int line,int column,bool exported,
+void ModuleManager::createModuleDef(const DString &fileName,int line,size_t column,bool exported,
                                     const DString &moduleName,const DString &partitionName)
 {
   AUTO_TRACE("{}:{}: Found module name='{}' partition='{}' exported='{}'",

--- a/src/moduledef.h
+++ b/src/moduledef.h
@@ -111,7 +111,7 @@ class ModuleManager
 {
   public:
     static ModuleManager &instance();
-    void createModuleDef(const DString &fileName, int line, int column, bool exported,
+    void createModuleDef(const DString &fileName, int line, size_t column, bool exported,
                          const DString &moduleName, const DString &partitionName=DString());
     void clear();
     void addHeader(const DString &moduleFile,int line,const DString &headerName,bool isSystem);

--- a/src/namespacedef.cpp
+++ b/src/namespacedef.cpp
@@ -54,7 +54,7 @@ static DString makeDisplayName(const NamespaceDef *nd,bool includeScope)
 class NamespaceDefImpl final : public DefinitionMixin<NamespaceDefMutable>
 {
   public:
-    NamespaceDefImpl(const DString &defFileName,int defLine,int defColumn,
+    NamespaceDefImpl(const DString &defFileName,int defLine,size_t defColumn,
                  const DString &name,const DString &ref=DString(),
                  const DString &refFile=DString(),const DString &type=DString(),
                  bool isPublished=false);
@@ -170,7 +170,7 @@ class NamespaceDefImpl final : public DefinitionMixin<NamespaceDefMutable>
     bool                  m_inline = false;
 };
 
-std::unique_ptr<NamespaceDef> createNamespaceDef(const DString &defFileName,int defLine,int defColumn,
+std::unique_ptr<NamespaceDef> createNamespaceDef(const DString &defFileName,int defLine,size_t defColumn,
                  const DString &name,const DString &ref,
                  const DString &refFile,const DString &type,
                  bool isPublished)
@@ -269,7 +269,7 @@ std::unique_ptr<NamespaceDef> createNamespaceDefAlias(const Definition *newScope
 
 //------------------------------------------------------------------
 
-NamespaceDefImpl::NamespaceDefImpl(const DString &df,int dl,int dc,
+NamespaceDefImpl::NamespaceDefImpl(const DString &df,int dl,size_t dc,
                            const DString &name,const DString &lref,
                            const DString &fName, const DString &type,
                            bool isPublished) :

--- a/src/namespacedef.h
+++ b/src/namespacedef.h
@@ -128,7 +128,7 @@ class NamespaceDefMutable : public DefinitionMutable, public NamespaceDef
 };
 
 /** Factory method to create new NamespaceDef instance */
-std::unique_ptr<NamespaceDef> createNamespaceDef(const DString &defFileName,int defLine,int defColumn,
+std::unique_ptr<NamespaceDef> createNamespaceDef(const DString &defFileName,int defLine,size_t defColumn,
                  const DString &name,const DString &ref=DString(),
                  const DString &refFile=DString(),const DString &type=DString(),
                  bool isPublished=false);

--- a/src/outputgen.h
+++ b/src/outputgen.h
@@ -323,7 +323,7 @@ class OutputGenIntf
     virtual void cleanup() = 0;
     virtual void startPlainFile(const DString &name) = 0;
     virtual void endPlainFile() = 0;
-    virtual void startEmbeddedDoc(int) = 0;
+    virtual void startEmbeddedDoc(size_t) = 0;
     virtual void endEmbeddedDoc() = 0;
 };
 

--- a/src/outputlist.h
+++ b/src/outputlist.h
@@ -755,7 +755,7 @@ class OutputList
     { foreach(&OutputGenIntf::startPlainFile,name); }
     void endPlainFile()
     { foreach(&OutputGenIntf::endPlainFile); }
-    void startEmbeddedDoc(int indent)
+    void startEmbeddedDoc(size_t indent)
     { foreach(&OutputGenIntf::startEmbeddedDoc,indent); }
     void endEmbeddedDoc()
     { foreach(&OutputGenIntf::endEmbeddedDoc); }

--- a/src/pre.l
+++ b/src/pre.l
@@ -245,7 +245,7 @@ struct preYY_state
 {
   int                yyLineNr       = 1;
   int                yyMLines       = 1;
-  int                yyColNr        = 1;
+  size_t             yyColNr        = 1;
   DString           fileName;
   FileDef           *yyFileDef      = nullptr;
   FileDef           *inputFileDef   = nullptr;

--- a/src/rtfgen.h
+++ b/src/rtfgen.h
@@ -306,7 +306,7 @@ class RTFGenerator final : public OutputGenerator, public OutputGenIntf
     void startPlainFile(const DString &name) override { OutputGenerator::startPlainFile(name); }
     void endPlainFile() override { OutputGenerator::endPlainFile(); }
 
-    void startEmbeddedDoc(int) override {}
+    void startEmbeddedDoc(size_t) override {}
     void endEmbeddedDoc() override {}
 
   private:
@@ -331,7 +331,7 @@ class RTFGenerator final : public OutputGenerator, public OutputGenIntf
 
     bool m_bstartedBody = false;  // has startbody been called yet?
     bool m_omitParagraph = false; // should a the next paragraph command be ignored?
-    int  m_numCols = 0; // number of columns in a table
+    size_t  m_numCols = 0; // number of columns in a table
     DString m_relPath;
     int  m_hierarchyLevel = 0;
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -111,8 +111,8 @@ struct scannerYY_state
   std::shared_ptr<Entry> memspecEntry;
   int              yyLineNr     = 1 ;
   int              yyBegLineNr  = 1 ;
-  int              yyColNr      = 1 ;
-  int              yyBegColNr   = 1 ;
+  size_t           yyColNr      = 1 ;
+  size_t           yyBegColNr   = 1 ;
   DString         fileName;
   MethodTypes      mtype = MethodTypes::Method;
   bool             isStatic = false;
@@ -228,7 +228,7 @@ struct scannerYY_state
 //-----------------------------------------------------------------------------
 
 // forward declarations for stateless functions
-static inline int computeIndent(const char *s,int startIndent);
+static inline size_t computeIndent(const char *s,size_t startIndent);
 static inline void initMethodProtection(yyscan_t yyscanner,Protection prot);
 static DString stripQuotes(const char *s);
 static DString stripFuncPtr(const DString &type);
@@ -3278,7 +3278,7 @@ NONLopt [^\n]*
                                           yyextra->current->bodyLine = yyextra->yyLineNr;
                                           yyextra->current->bodyColumn = yyextra->yyColNr;
                                           yyextra->current->initializer.str(" ");
-                                          for (int ii = 2 ; ii <  yyextra->yyColNr; ii++)
+                                          for (size_t ii = 2 ; ii <  yyextra->yyColNr; ii++)
                                             yyextra->current->initializer << " ";
                                           yyextra->current->initializer << "=";
                                           yyextra->lastInitializerContext = YY_START;
@@ -8161,9 +8161,9 @@ static void lineCount(yyscan_t yyscanner)
   //printf("lineCount()=%d\n",yyextra->column);
 }
 
-static inline int computeIndent(const char *s,int startIndent)
+static inline size_t computeIndent(const char *s,size_t startIndent)
 {
-  int col=startIndent;
+  size_t col=startIndent;
   int tabSize=Config_getInt(TAB_SIZE);
   const char *p=s;
   char c;
@@ -8794,7 +8794,7 @@ static void parseConcepts(yyscan_t yyscanner,const std::shared_ptr<Entry> &rt)
 
       // hack to reconstruct what was in the code before the concept expression
       DString indent;
-      indent.fill(' ',std::max(0,ce->startColumn-1));
+      indent.fill(' ',ce->startColumn?ce->startColumn-1:0);
       DString templArgs;
       if (!ce->args.empty())
       {

--- a/src/sqlite3gen.cpp
+++ b/src/sqlite3gen.cpp
@@ -892,6 +892,11 @@ static bool bindIntParameter(SqlStmt &s,const char *name,int value)
   return true;
 }
 
+static bool bindIntParameter(SqlStmt &s,const char *name,size_t value)
+{
+  return bindIntParameter(s,name,static_cast<int>(value));
+}
+
 static int step(SqlStmt &s,bool getRowId=false, bool select=false)
 {
   int rowid=-1;

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -273,16 +273,16 @@ void VHDLOutlineParser::handleFlowComment(const DString &doc)
   }
 }
 
-int VHDLOutlineParser::checkInlineCode(DString &doc)
+size_t VHDLOutlineParser::checkInlineCode(DString &doc)
 {
   static const reg::Ex csRe(R"([\\@]code)");
   static const reg::Ex cendRe(R"(\s*[\\@]endcode)");
   static const reg::Ex cbriefRe(R"([\\@]brief)");
 
   // helper to simulate behavior of QString.find(const QRegExp &re,int pos)
-  auto findRe = [](const DString &str,const reg::Ex &re,int pos=0) -> size_t
+  auto findRe = [](const DString &str,const reg::Ex &re,size_t pos=0) -> size_t
   {
-    if ((int)str.length()<pos) return -1;
+    if (str.length()<pos) return DString::npos;
     reg::Match match;
     if (reg::search(str.str(),match,re,pos)) // match found
     {

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -398,7 +398,7 @@ void VHDLOutlineParser::handleCommentBlock(const DString &doc1, bool brief)
     return;
   }
 
-  if (checkInlineCode(doc) > 0)
+  if (checkInlineCode(doc) != DString::npos)
   {
     return;
   }

--- a/src/vhdljjparser.h
+++ b/src/vhdljjparser.h
@@ -67,7 +67,7 @@ class VHDLOutlineParser final : public OutlineParserInterface
     bool checkMultiComment(DString& qcs,int line);
     void insertEntryAtLine(std::shared_ptr<Entry> ce,int line);
     DString getNameID();
-    int checkInlineCode(DString & doc);
+    size_t checkInlineCode(DString & doc);
   private:
     struct Private;
     std::unique_ptr<Private> p;


### PR DESCRIPTION
- a column number cannot be negative, so better to use `size_t
- correcting some other compilation warnings regarding size_t / int conversions