### PR TITLE
Reverting `VhdlParser.h` and `TokenManager.h` from "Replace tabs and end spacing"

### DIFF
--- a/vhdlparser/TokenManager.h
+++ b/vhdlparser/TokenManager.h
@@ -33,4 +33,4 @@ public:
 }
 
 #endif
-/* JavaCC - OriginalChecksum=ca665ddedf5f5b0cb69e76d90eb70fe0 (do not edit this line) */
+/* JavaCC - OriginalChecksum=7e58763dad45cd52c4e0e51f618ab41e (do not edit this line) */

--- a/vhdlparser/VhdlParser.h
+++ b/vhdlparser/VhdlParser.h
@@ -11112,7 +11112,7 @@ void parseInline();
   }
 
 
-public:
+public: 
   void setErrorHandler(ErrorHandler *eh) {
     if (errorHandler) delete errorHandler;
     errorHandler = eh;
@@ -11125,7 +11125,7 @@ public:
   /** Next token. */
   Token        *jj_nt = nullptr;
 
-private:
+private: 
   int           jj_ntk;
   JJCalls       jj_2_rtns[169];
   bool          jj_rescan;
@@ -11139,11 +11139,11 @@ private:
   int           jj_la1[388];
   ErrorHandler *errorHandler = nullptr;
 
-protected:
+protected: 
   bool          hasError;
 
-  Token *head;
-public:
+  Token *head; 
+public: 
   VhdlParser(TokenManager *tokenManager);
   virtual ~VhdlParser();
 void ReInit(TokenManager* tokenManager);
@@ -11162,7 +11162,7 @@ protected:
   /** Generate ParseException. */
   virtual void  parseError();
 private:
-  int  indent;        // trace indentation
+  int  indent;	// trace indentation
   bool trace = false; // trace enabled if true
 
 public:


### PR DESCRIPTION
The files `VhdlParser.h` and  `TokenManager.h` were changed due to "Replace tabs and end spacing" though they are generated and only a checksum can be changed.