### PR TITLE
issue #11469 Configurable PlantUML command: PLANTUML_JAVA_PATH and PLANTUML_TOOL

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -4219,6 +4219,7 @@ to be found in the default search path.
  If left blank, it is assumed PlantUML is not used or
  called during a preprocessing step. Doxygen will generate a warning when it encounters a
  \ref cmdstartuml "\\startuml" command in this case and will not generate output for the diagram.
+ <br>Note that this tag is not used when \ref cfg_plantuml_tool "PLANTUML_TOOL" is set.
 ]]>
       </docs>
     </option>
@@ -4229,8 +4230,22 @@ to be found in the default search path.
  \c java executable that is used to run the jar file given via
  \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH".
  If left blank, the \c java executable is searched for in the default search path.
- <br>Note that this tag is only used when
- \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH" is set.
+ <br>Note that this tag is not used when \ref cfg_plantuml_tool "PLANTUML_TOOL" is set.
+]]>
+      </docs>
+    </option>
+    <option type='string' id='PLANTUML_TOOL' format='file' defval=''>
+      <docs>
+<![CDATA[
+ The \c PLANTUML_TOOL tag can be used to specify a PlantUML executable, e.g. a
+ PlantUML native image or a script wrapping PlantUML, that is run instead of the jar
+ file given via \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH". As such an executable
+ does not need a Java runtime environment, the tags
+ \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH" and
+ \ref cfg_plantuml_java_path "PLANTUML_JAVA_PATH" are not used in this case.
+ <br>Note that the paths given via
+ \ref cfg_plantuml_include_path "PLANTUML_INCLUDE_PATH" are passed to the executable
+ by means of the \c PLANTUML_INCLUDE_PATH environment variable.
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -4229,7 +4229,9 @@ to be found in the default search path.
  When using PlantUML, the \c PLANTUML_JAVA_PATH tag can be used to specify the
  \c java executable that is used to run the jar file given via
  \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH".
- If left blank, the \c java executable is searched for in the default search path.
+ If left blank, the \c java executable of the Java runtime environment the
+ \c JAVA_HOME environment variable points to is used, if that variable is set, and
+ otherwise the \c java executable is searched for in the default search path.
  <br>Note that this tag is not used when \ref cfg_plantuml_tool "PLANTUML_TOOL" is set.
 ]]>
       </docs>

--- a/src/config.xml
+++ b/src/config.xml
@@ -4222,6 +4222,18 @@ to be found in the default search path.
 ]]>
       </docs>
     </option>
+    <option type='string' id='PLANTUML_JAVA_PATH' format='file' defval=''>
+      <docs>
+<![CDATA[
+ When using PlantUML, the \c PLANTUML_JAVA_PATH tag can be used to specify the
+ \c java executable that is used to run the jar file given via
+ \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH".
+ If left blank, the \c java executable is searched for in the default search path.
+ <br>Note that this tag is only used when
+ \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH" is set.
+]]>
+      </docs>
+    </option>
     <option type='string' id='PLANTUML_CFG_FILE' format='file' defval=''>
       <docs>
 <![CDATA[

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -4534,7 +4534,7 @@ Token DocPara::handleCommand(char cmdChar, const DString &cmdName)
       break;
     case CommandType::CMD_STARTUML:
       {
-        DString jarPath = Config_getString(PLANTUML_JAR_PATH);
+        bool plantumlEnabled = PlantumlManager::isEnabled();
         parser()->tokenizer.setStatePlantUMLOpt();
         parser()->tokenizer.lex();
         DString fullMatch = parser()->context.token->sectionId;
@@ -4620,9 +4620,9 @@ Token DocPara::handleCommand(char cmdChar, const DString &cmdName)
         dv->setWidth(width);
         dv->setHeight(height);
         dv->setLocation(parser()->context.fileName,parser()->tokenizer.getLineNr());
-        if (jarPath.empty())
+        if (!plantumlEnabled)
         {
-          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"ignoring \\startuml command because PLANTUML_JAR_PATH is not set");
+          warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"ignoring \\startuml command because neither PLANTUML_JAR_PATH nor PLANTUML_TOOL is set");
           children().pop_back();
         }
         if (retval.is_any_of(TokenRetval::TK_NONE,TokenRetval::TK_EOF))

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -56,6 +56,7 @@
 #include "anchor.h"
 #include "stringutil.h"
 #include "filename.h"
+#include "plantuml.h"
 
 #if !ENABLE_MARKDOWN_TRACING
 #undef  AUTO_TRACE
@@ -3362,7 +3363,7 @@ DString Markdown::Private::processQuotations(std::string_view data,size_t refInd
           if (addNewLines) out+='\n';
         };
 
-        if (!Config_getString(PLANTUML_JAR_PATH).empty() && lang=="plantuml")
+        if (PlantumlManager::isEnabled() && lang=="plantuml")
         {
           addSpecialCommand("startuml","enduml");
         }

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -248,6 +248,13 @@ static DString javaExecutable()
 {
   DString javaPath = Config_getString(PLANTUML_JAVA_PATH);
   if (!javaPath.empty()) return javaPath;
+  DString javaHome = Portable::getenv("JAVA_HOME");
+  if (!javaHome.empty())
+  {
+    DString javaHomeExe = javaHome+"/bin/java"+Portable::commandExtension();
+    FileInfo fi(javaHomeExe.str());
+    if (fi.exists() && fi.isFile()) return javaHomeExe;
+  }
   return "java";
 }
 

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -237,6 +237,20 @@ PlantumlManager::PlantumlManager()
 {
 }
 
+bool PlantumlManager::isEnabled()
+{
+  return !Config_getString(PLANTUML_JAR_PATH).empty() ||
+         !Config_getString(PLANTUML_TOOL).empty();
+}
+
+/** Returns the java executable used to run the PlantUML jar file. */
+static DString javaExecutable()
+{
+  DString javaPath = Config_getString(PLANTUML_JAVA_PATH);
+  if (!javaPath.empty()) return javaPath;
+  return "java";
+}
+
 static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
                                const PlantumlManager::ContentMap &plantumlContent,
                                PlantumlManager::OutputFormat format)
@@ -253,14 +267,16 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
   int exitCode = 0;
   DString plantumlJarPath = Config_getString(PLANTUML_JAR_PATH);
   DString plantumlConfigFile = Config_getString(PLANTUML_CFG_FILE);
+  DString plantumlTool = Config_getString(PLANTUML_TOOL);
+  bool useJar = plantumlTool.empty(); // no PlantUML executable given, so run the jar file via java
 
-  DString pumlExe = Config_getString(PLANTUML_JAVA_PATH);
-  if (pumlExe.empty()) pumlExe = "java";
+  DString pumlExe = useJar ? javaExecutable() : plantumlTool;
   DString pumlArgs = "";
   DString pumlType = "";
   DString pumlOutDir = "";
 
   StringVector pumlIncludePathList = Config_getList(PLANTUML_INCLUDE_PATH);
+  if (useJar)
   {
     auto it = pumlIncludePathList.begin();
     if (it!=pumlIncludePathList.end())
@@ -275,9 +291,23 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
       pumlArgs += it->c_str();
       ++it;
     }
+    if (!pumlIncludePathList.empty()) pumlArgs += "\" ";
+    pumlArgs += "-Djava.awt.headless=true -jar \""+plantumlJarPath+"\" ";
   }
-  if (!pumlIncludePathList.empty()) pumlArgs += "\" ";
-  pumlArgs += "-Djava.awt.headless=true -jar \""+plantumlJarPath+"\" ";
+  else if (!pumlIncludePathList.empty())
+  {
+    // a PlantUML executable does not take java system properties, but PlantUML also
+    // accepts the include path via the environment.
+    DString includePath;
+    bool first = true;
+    for (const auto &path : pumlIncludePathList)
+    {
+      if (!first) includePath += Portable::pathListSeparator();
+      includePath += path.c_str();
+      first = false;
+    }
+    Portable::setenv("PLANTUML_INCLUDE_PATH",includePath);
+  }
   if (!plantumlConfigFile.empty())
   {
     pumlArgs += "-config \"";
@@ -355,8 +385,8 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
 
       if ((exitCode=Portable::system(pumlExe.data(),pumlArguments.data(),true))!=0)
       {
-        err_full(nb.srcFile,nb.srcLine,"Problems running PlantUML. Verify that the command '{} -jar \"{}\" -h' works from the command line. Exit code: {}.",
-            pumlExe,plantumlJarPath,exitCode);
+        err_full(nb.srcFile,nb.srcLine,"Problems running PlantUML. Verify that the command '{} -h' works from the command line. Exit code: {}.",
+            useJar ? pumlExe+" -jar \""+plantumlJarPath+"\"" : pumlExe,exitCode);
       }
 
       if ( (format==PlantumlManager::PUML_EPS) && (Config_getBool(USE_PDFLATEX)) )

--- a/src/plantuml.cpp
+++ b/src/plantuml.cpp
@@ -254,7 +254,8 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
   DString plantumlJarPath = Config_getString(PLANTUML_JAR_PATH);
   DString plantumlConfigFile = Config_getString(PLANTUML_CFG_FILE);
 
-  DString pumlExe = "java";
+  DString pumlExe = Config_getString(PLANTUML_JAVA_PATH);
+  if (pumlExe.empty()) pumlExe = "java";
   DString pumlArgs = "";
   DString pumlType = "";
   DString pumlOutDir = "";
@@ -354,8 +355,8 @@ static void runPlantumlContent(const PlantumlManager::FilesMap &plantumlFiles,
 
       if ((exitCode=Portable::system(pumlExe.data(),pumlArguments.data(),true))!=0)
       {
-        err_full(nb.srcFile,nb.srcLine,"Problems running PlantUML. Verify that the command 'java -jar \"{}\" -h' works from the command line. Exit code: {}.",
-            plantumlJarPath,exitCode);
+        err_full(nb.srcFile,nb.srcLine,"Problems running PlantUML. Verify that the command '{} -jar \"{}\" -h' works from the command line. Exit code: {}.",
+            pumlExe,plantumlJarPath,exitCode);
       }
 
       if ( (format==PlantumlManager::PUML_EPS) && (Config_getBool(USE_PDFLATEX)) )

--- a/src/plantuml.h
+++ b/src/plantuml.h
@@ -45,6 +45,11 @@ class PlantumlManager
 
     static PlantumlManager &instance();
 
+    /** Returns true if doxygen has been configured to run PlantUML, i.e. when
+     *  PLANTUML_JAR_PATH or PLANTUML_TOOL has been set.
+     */
+    static bool isEnabled();
+
     bool needToRun() const
     {
       return !m_pngPlantumlContent.empty() ||

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -3100,7 +3100,7 @@ void FlowChart::writeFlowChart()
    printFlowTree();
 #endif
 
-  if (!Config_getString(PLANTUML_JAR_PATH).empty())
+  if (PlantumlManager::isEnabled())
   {
     printUmlTree();
     delFlowList();


### PR DESCRIPTION
## Motivation

Doxygen runs PlantUML as `java -jar <PLANTUML_JAR_PATH>`, with both the JVM and the
"has to be a jar file" assumption hardcoded in `runPlantumlContent()`. That causes two
independent problems:

1. **There is no way to say *which* `java` to run.** `Portable::system()` resolves the bare
   name `java` via `PATH`. Every other external tool doxygen invokes can be pointed at
   explicitly (`DOT_PATH`, `DIA_PATH`, `PERL_PATH`, `MSCGEN_TOOL`, `HHC_LOCATION`,
   `LATEX_CMD_NAME`, `MAKEINDEX_CMD_NAME`, `MERMAID_PATH`), but the JVM cannot be.
   For hermetic/pinned documentation toolchains (Doxygen, Graphviz, PlantUML and a JRE all
   pinned by a package manager) the only workaround is mutating `PATH` around every target
   that runs doxygen. On a machine with several JREs installed - a system JRE plus one from
   a toolchain or an IDE, which is very common - the wrong one silently wins, and the failure
   surfaces as a PlantUML error rather than a Java one.

2. **PlantUML no longer necessarily needs a JVM.** It is distributed as a native image
   (plantuml/plantuml#1344) and as wrapper scripts, and doxygen cannot use either.
   That is issue #11469.

Both are really the same question - *what command should doxygen run for PlantUML?* - so
this PR answers it with two explicit configuration options instead of a hardcoded command.

## What this adds

| Option | Meaning |
|---|---|
| `PLANTUML_JAVA_PATH` | the `java` executable used to run the jar file. Empty (default): `java` from the search path, exactly as today. |
| `PLANTUML_TOOL` | a PlantUML executable (native image, wrapper script, ...) that is run directly. Empty (default): the jar file is run via java, exactly as today. |

Resulting command lines (verified, see below):

```
# today, and unchanged when both options are empty
java -Djava.awt.headless=true -jar "…/plantuml.jar" -o "…" -charset UTF-8 -tpng "….pu"

# PLANTUML_JAVA_PATH = /opt/env/bin/java
/opt/env/bin/java -Djava.awt.headless=true -jar "…/plantuml.jar" -o "…" -charset UTF-8 -tpng "….pu"

# PLANTUML_TOOL = /opt/env/bin/plantuml
/opt/env/bin/plantuml -o "…" -charset UTF-8 -tpng "….pu"
```

Both are `type='string' format='file'` with an empty default, in the PlantUML section of
`config.xml`, so the documentation in `doc/config.doc` and the doxywizard entries are
generated as usual.

## Why not sniff the `.jar` extension (cf. #11477)

PR #11477 solves the native-image half by deriving the invocation from the file extension of
`PLANTUML_JAR_PATH`. That overloads one option with two meanings and leaves the *first*
problem (which JVM?) unsolved, so a user cannot express "this JRE with this jar". Giving each
way of running PlantUML its own option keeps both the configuration and the code explicit,
and it composes: `PLANTUML_JAVA_PATH` + `PLANTUML_JAR_PATH` for the jar, `PLANTUML_TOOL` for
everything else. Happy to rebase/close in either direction if you prefer #11477's approach.

## Java-specific arguments

Only the jar invocation gets the java-specific arguments:

* `-Djava.awt.headless=true` is a JVM property and is meaningless for a native image.
* `-Dplantuml.include.path=…` (from `PLANTUML_INCLUDE_PATH`) is a JVM system property as
  well. For an executable, doxygen sets the `PLANTUML_INCLUDE_PATH` environment variable
  instead: PlantUML looks the value up as a system property first, then as an environment
  variable of the same name, then as the upper-cased/underscored name
  (`SecurityUtils.getenv()`), so both routes end up in the same place. The jar invocation is
  untouched.

## Naming

`PLANTUML_JAVA_PATH` rather than a tool-agnostic `JAVA_PATH`: PlantUML is the only thing
doxygen runs through Java, the option lives in the PlantUML section, and it is meaningless
without `PLANTUML_JAR_PATH`. Doxygen's convention is tool-specific names anyway (`DOT_PATH`,
`DIA_PATH`, `MERMAID_PATH`). A generic `JAVA_PATH` would also read as if it applied to
`PLANTUML_TOOL`, which it does not. `PLANTUML_TOOL` follows `MSCGEN_TOOL`: the path to an
external executable that replaces doxygen's default way of producing the diagrams. Renaming
either is a one-line change if you prefer other names.

Neither option uses `depends=`, although both are only meaningful in combination with
another option: `depends=` requires the parent to be a boolean (`InputInt`/`InputString`/
`InputStrList::addDependency()` in doxywizard is `Q_ASSERT(false)`), and `PLANTUML_JAR_PATH`
is a string. The dependency is documented in the `<docs>` prose instead.

## Backwards compatibility

With both options empty - i.e. every existing Doxyfile - the generated command line is
byte-for-byte what it is today. Verified by diffing `-d extcmd` output of a build of this
branch against a build of current master: identical for the plain case, for
`PLANTUML_INCLUDE_PATH`, and for `PLANTUML_CFG_FILE`.

The one user-visible change with an unset option: `\startuml` is now also honoured when only
`PLANTUML_TOOL` is set, so the "PlantUML is available" checks in `docnode.cpp`,
`markdown.cpp` and `vhdldocgen.cpp` moved into `PlantumlManager::isEnabled()`, and the
warning text became "ignoring \startuml command because neither PLANTUML_JAR_PATH nor
PLANTUML_TOOL is set". The error message on a failed run now names the command that was
actually run instead of a hardcoded `java -jar …`.

## The last commit is optional

`Use the java executable from JAVA_HOME when PLANTUML_JAVA_PATH is empty` is a separate,
droppable commit. It is convenient, but it does change behaviour of existing configurations
on systems where `JAVA_HOME` and `PATH` point at different JREs (I hit exactly that while
testing on a machine with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64`). The first two
commits are entirely self-contained without it.

## Testing

Built cleanly (`cmake -G Ninja -DCMAKE_BUILD_TYPE=Release`, gcc, Linux); `ctest` passes
(`012_cite` fails on master too in my container, missing bibtex).

Manually verified with a stub `java` / stub PlantUML executable that logs `$0 "$@"`, using
`-d extcmd` plus the stub's own log:

* option unset -> `java` from `PATH`, command identical to master's;
* `PLANTUML_JAVA_PATH` absolute -> that binary is executed;
* `PLANTUML_JAVA_PATH` containing a space (`…/my java/java`) -> quoted correctly by
  `Portable::system()` and executed (`$0` in the stub confirms which binary ran);
* `PLANTUML_TOOL` -> executed directly, no `java`, no `-jar`, no `-D…` arguments;
* `PLANTUML_TOOL` containing a space -> quoted correctly;
* `PLANTUML_TOOL` with `PLANTUML_INCLUDE_PATH` -> passed via the environment variable;
* `PLANTUML_TOOL` without `PLANTUML_JAR_PATH` -> `\startuml` is processed, no warning;
* neither option -> the (updated) warning, no external command.

Quoting is left to `Portable::system()`, which already quotes the command when it contains a
space and is not quoted yet, and converts slashes on Windows; no `.exe` is appended, matching
the other `format='file'` tool options (`MSCGEN_TOOL`, `HHC_LOCATION`).

I did not add a regression test: `testing/runtests.py` compares generated XML/HTML and fails
on warnings, and the constructed PlantUML command line is not observable there without a real
JVM or PlantUML binary. I would rather not contort the design to make it testable, but if you
would like a test that, say, asserts the `\startuml` warning for the "neither option set"
case, I am happy to add one.