### PR TITLE
Incorrect column number in XML in case of `<tab>`

### DIFF
--- a/src/scanner.l
+++ b/src/scanner.l
@@ -8170,6 +8170,7 @@ static void lineCount(yyscan_t yyscanner)
     else if (*p=='\t')
     {
       yyextra->column+=tabSize - (yyextra->column%tabSize);
+      yyextra->yyColNr=1+yyextra->column;
     }
     else
     {

--- a/testing/058/class_class.xml
+++ b/testing/058/class_class.xml
@@ -22,7 +22,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="058_strong_enum.cpp" line="98" column="1" bodyfile="058_strong_enum.cpp" bodystart="98" bodyend="100"/>
+        <location file="058_strong_enum.cpp" line="98" column="5" bodyfile="058_strong_enum.cpp" bodystart="98" bodyend="100"/>
       </memberdef>
       <memberdef kind="enum" id="class_class_1af09ec8b7238c8a302c251b1cfe1de13d" prot="public" static="no" strong="yes">
         <type/>
@@ -43,7 +43,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="058_strong_enum.cpp" line="102" column="1" bodyfile="058_strong_enum.cpp" bodystart="102" bodyend="104"/>
+        <location file="058_strong_enum.cpp" line="102" column="5" bodyfile="058_strong_enum.cpp" bodystart="102" bodyend="104"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/058/classns2_1_1_class.xml
+++ b/testing/058/classns2_1_1_class.xml
@@ -22,7 +22,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="058_strong_enum.cpp" line="62" column="1" bodyfile="058_strong_enum.cpp" bodystart="62" bodyend="64"/>
+        <location file="058_strong_enum.cpp" line="62" column="5" bodyfile="058_strong_enum.cpp" bodystart="62" bodyend="64"/>
       </memberdef>
       <memberdef kind="enum" id="classns2_1_1_class_1ae96c8ec290b0bdb3b718ccd891450b5d" prot="public" static="no" strong="yes">
         <type/>
@@ -43,7 +43,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="058_strong_enum.cpp" line="66" column="1" bodyfile="058_strong_enum.cpp" bodystart="66" bodyend="68"/>
+        <location file="058_strong_enum.cpp" line="66" column="5" bodyfile="058_strong_enum.cpp" bodystart="66" bodyend="68"/>
       </memberdef>
     </sectiondef>
     <briefdescription>

--- a/testing/058/classns_1_1_class.xml
+++ b/testing/058/classns_1_1_class.xml
@@ -22,7 +22,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="058_strong_enum.cpp" line="21" column="1" bodyfile="058_strong_enum.cpp" bodystart="21" bodyend="23"/>
+        <location file="058_strong_enum.cpp" line="21" column="5" bodyfile="058_strong_enum.cpp" bodystart="21" bodyend="23"/>
       </memberdef>
       <memberdef kind="enum" id="classns_1_1_class_1a2f5b74a27a12bfc86e653a13178317e4" prot="public" static="no" strong="yes">
         <type/>
@@ -43,7 +43,7 @@
         </detaileddescription>
         <inbodydescription>
         </inbodydescription>
-        <location file="058_strong_enum.cpp" line="25" column="1" bodyfile="058_strong_enum.cpp" bodystart="25" bodyend="27"/>
+        <location file="058_strong_enum.cpp" line="25" column="5" bodyfile="058_strong_enum.cpp" bodystart="25" bodyend="27"/>
       </memberdef>
     </sectiondef>
     <briefdescription>


### PR DESCRIPTION
In case we have an example with `<tabs>` the determination of the column number is not correct and will result (with XML output to e.g.):
```
xml/058__strong__enum_8cpp.xml:        <location file="058_strong_enum.cpp" line="30" column="6" bodyfile="058_strong_enum.cpp" bodystart="30" bodyend="31"/>
xml/058__strong__enum_8cpp.xml:        <location file="058_strong_enum.cpp" line="33" column="10" bodyfile="058_strong_enum.cpp" bodystart="33" bodyend="34"/>
```
as the code at line 30 contains a `<tab>` whilst line 33 doesn't. Both should (in case of the proper `TAB_SIZE               = 4` setting) return:
```
xml/058__strong__enum_8cpp.xml:        <location file="058_strong_enum.cpp" line="30" column="10" bodyfile="058_strong_enum.cpp" bodystart="30" bodyend="31"/>
xml/058__strong__enum_8cpp.xml:        <location file="058_strong_enum.cpp" line="33" column="10" bodyfile="058_strong_enum.cpp" bodystart="33" bodyend="34"/>
```

Example: [example.tar.gz](https://github.com/user-attachments/files/31257189/example.tar.gz)
