### PR TITLE
Incorrect reference relations

### DIFF
--- a/src/code.l
+++ b/src/code.l
@@ -3393,7 +3393,7 @@ static void generateFunctionLink(yyscan_t yyscanner,OutputCodeList &ol,const DSt
     i=locFunc.rfind("\\");
     len=1; // for PHP
   }
-  if (i>0)
+  if (i!=DString::npos && i>0)
   {
     funcScope=locFunc.left(i);
     locFunc=locFunc.mid(i+len).stripWhiteSpace();


### PR DESCRIPTION
When having something like:
```
void without_colon()
{
}

void with_colon()
{
}

int main(int argc, char ** argv)
{
  without_colon();
  with_colon();
  return 0;
}
```
we get, for the main function, when `REFERENCED_BY_RELATION` and `REFERENCES_RELATION` are set, a.o.:
```
References main(), with_colon(), and without_colon().

Referenced by main().
```
Note the recursive mentioning of main.
This is due to:
```
Commit: 772ac869946245992ee79d6245d88b95812cb4cd [772ac86]

Date: Sunday, August 2, 2026 9:32:35 PM

Commit Date: Saturday, August 8, 2026 9:29:19 PM
Refactoring: Better align interface of QCString with std::string
```

Example: [example.tar.gz](https://github.com/user-attachments/files/31370107/example.tar.gz)
