### PR TITLE
XML output for function pointers is no longer a valid C declaration

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3320,7 +3320,7 @@ static void addVariable(const Entry *root,int isFuncPtr=-1)
     {
       size_t ii = i;
       size_t ai = type.find('[',ii);
-      if (ai>ii) // function pointer array
+      if (ai!=DString::npos && ai>ii) // function pointer array
       {
         args.prepend(type.mid(ai));
         type=type.left(ai);

--- a/testing/123/123__function__pointer_8c.xml
+++ b/testing/123/123__function__pointer_8c.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="123__function__pointer_8c" kind="file" language="C++">
+    <compoundname>123_function_pointer.c</compoundname>
+    <innerclass refid="struct_my_iface" prot="public">MyIface</innerclass>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="123__function__pointer_8c_1af03e798d107bf0e5d3800db992ae5680" prot="public" static="no">
+        <type>int(*</type>
+        <definition>typedef int(* MyCallback) (int a, int b)</definition>
+        <argsstring>)(int a, int b)</argsstring>
+        <name>MyCallback</name>
+        <briefdescription>
+          <para>A function pointer typedef. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="123_function_pointer.c" line="8" column="9" bodyfile="123_function_pointer.c" bodystart="8" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="typedef" id="123__function__pointer_8c_1ac9c7aa030435b71d75fcc61bdd26e308" prot="public" static="no">
+        <type>int(*</type>
+        <definition>typedef int(* MyCallbackArray[10])(int a, int b)</definition>
+        <argsstring>[10])(int a, int b)</argsstring>
+        <name>MyCallbackArray</name>
+        <briefdescription>
+          <para>A function pointer array typedef. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="123_function_pointer.c" line="11" column="9" bodyfile="123_function_pointer.c" bodystart="11" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="123_function_pointer.c"/>
+  </compounddef>
+</doxygen>

--- a/testing/123/struct_my_iface.xml
+++ b/testing/123/struct_my_iface.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="struct_my_iface" kind="struct" language="C++" prot="public">
+    <compoundname>MyIface</compoundname>
+    <sectiondef kind="public-attrib">
+      <memberdef kind="variable" id="struct_my_iface_1a078379ec89963a0ac5ce07e74b414749" prot="public" static="no" mutable="no">
+        <type>int(*</type>
+        <definition>int(* MyIface::do_it) (struct MyIface *self, int x)</definition>
+        <argsstring>)(struct MyIface *self, int x)</argsstring>
+        <name>do_it</name>
+        <qualifiedname>MyIface::do_it</qualifiedname>
+        <briefdescription>
+          <para>a member function pointer </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="123_function_pointer.c" line="17" column="3" bodyfile="123_function_pointer.c" bodystart="17" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+      <para>A struct with a function pointer member. </para>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="123_function_pointer.c" line="14" column="1" bodyfile="123_function_pointer.c" bodystart="15" bodyend="18"/>
+    <listofallmembers>
+      <member refid="struct_my_iface_1a078379ec89963a0ac5ce07e74b414749" prot="public" virt="non-virtual">
+        <scope>MyIface</scope>
+        <name>do_it</name>
+      </member>
+    </listofallmembers>
+  </compounddef>
+</doxygen>

--- a/testing/123_function_pointer.c
+++ b/testing/123_function_pointer.c
@@ -1,0 +1,18 @@
+// objective: test that function pointers are split correctly into type and args
+// check: 123__function__pointer_8c.xml
+// check: struct_my_iface.xml
+
+/** \file */
+
+/** \brief A function pointer typedef. */
+typedef int (*MyCallback)(int a, int b);
+
+/** \brief A function pointer array typedef. */
+typedef int (*MyCallbackArray[10])(int a, int b);
+
+/** \brief A struct with a function pointer member. */
+struct MyIface
+{
+  /** \brief a member function pointer */
+  int (*do_it)(struct MyIface *self, int x);
+};


### PR DESCRIPTION
In 1.18.0 the XML output for function pointers (both `typedef`s and struct/class members) changed shape. `<definition>` is no longer valid C, and `<type>` + `<name>` + `<argsstring>` no longer concatenate into a valid declaration, which they did in every earlier release.

`git bisect` points at 772ac869 ("Refactoring: Better align interface of QCString with std::string"), whose commit message notes `int s.find -> size_t s.find`, so this looks like an unintended side effect of that migration rather than a deliberate format change.

## Minimal example

`src/test.h`:

```c
/*! \file test.h */

/*! \brief A function pointer typedef. */
typedef int (*MyCallback) (int a, int b);

/*! \brief A struct with a function pointer member. */
struct MyIface {
  /*! \brief a member function pointer */
  int (*do_it) (struct MyIface *self, int x);
};
```

`Doxyfile`:

```
PROJECT_NAME = min
INPUT = src
OUTPUT_DIRECTORY = out
GENERATE_HTML = NO
GENERATE_LATEX = NO
GENERATE_XML = YES
QUIET = YES
```

## Expected (1.17.0 and earlier)

```xml
<type>int(*</type>
<definition>typedef int(* MyCallback) (int a, int b)</definition>
<argsstring>)(int a, int b)</argsstring>
<name>MyCallback</name>
```

`type + " " + name + argsstring` → `int(* MyCallback) (int a, int b)` — valid C.

## Actual (1.18.0)

```xml
<type>int(*)</type>
<definition>typedef int(*) MyCallback(int a, int b)</definition>
<argsstring>(int a, int b)</argsstring>
<name>MyCallback</name>
```

`type + " " + name + argsstring` → `int(*) MyCallback(int a, int b)` — not valid C. `<definition>` on its own is not valid C either.

The struct member `MyIface::do_it` changes identically.

## Root cause

`src/doxygen.cpp`, the function-pointer correction in `addVariable()`.

1.17.0, where `QCString::find()` returns `int` and `-1` when not found:

```c
int ai = type.find('[', i);
if (ai > i)                          // no '[' → -1 > i → false
{
  ...                                //   → correctly skipped
}
else if (type.find(')', i) != -1)    // function ptr, not "int (*bla)[10]"
{
  type = type.left(type.length()-1); // "int(*)" → "int(*"
  args.prepend(") ");                // "(a,b)"  → ")(a,b)"
}
```

1.18.0, where `DString::find()` returns `size_t` and `npos` (`src/dstring.h:244`):

```c
size_t ii = i;
size_t ai = type.find('[', ii);
if (ai > ii)                         // no '[' → npos > ii → TRUE
{
  args.prepend(type.mid(ai));        // mid(npos) → "" → no-op
  type = type.left(ai);              // left(npos) → whole string → no-op
}
else if (...)                        // never reached
```

The `find()` return type was migrated but the `ai > i` comparison was not. When the type contains no `[`, `npos > ii` is true, so the "function pointer array" branch is taken instead — and both of its statements are silently no-ops, because `DString::mid()` returns empty for `index > size` and `DString::left(npos)` returns the whole string. The correction never runs and the scanner's raw `int(*)` / `(a, b)` reach the output.

## Impact

Reported downstream in WirePlumber as https://gitlab.freedesktop.org/pipewire/wireplumber/-/issues/995: the Sphinx C domain rejects the declarations Breathe builds from this XML and the affected typedefs and vfunc members drop out of the C domain index, losing all their cross-references.