### PR TITLE
Replace  `assert` calls with `ASSERT` macro

### DIFF
--- a/addon/doxyapp/CMakeLists.txt
+++ b/addon/doxyapp/CMakeLists.txt
@@ -7,6 +7,12 @@ include_directories(
         ${Iconv_INCLUDE_DIRS}
         ${CLANG_INCLUDEDIR}
 )
+if (NOT use_sys_spdlog)
+    include_directories(${PROJECT_SOURCE_DIR}/deps/spdlog/include)
+endif()
+if (NOT use_sys_fmt)
+    include_directories(${PROJECT_SOURCE_DIR}/deps/fmt/include)
+endif()
 
 add_executable(doxyapp
 doxyapp.cpp

--- a/addon/doxyparse/CMakeLists.txt
+++ b/addon/doxyparse/CMakeLists.txt
@@ -7,6 +7,12 @@ include_directories(
         ${Iconv_INCLUDE_DIRS}
         ${CLANG_INCLUDEDIR}
 )
+if (NOT use_sys_spdlog)
+    include_directories(${PROJECT_SOURCE_DIR}/deps/spdlog/include)
+endif()
+if (NOT use_sys_fmt)
+    include_directories(${PROJECT_SOURCE_DIR}/deps/fmt/include)
+endif()
 
 add_executable(doxyparse
 doxyparse.cpp

--- a/src/aliases.cpp
+++ b/src/aliases.cpp
@@ -17,7 +17,6 @@
 #include "aliases.h"
 
 // standard includes
-#include <cassert>
 #include <unordered_map>
 
 // other includes
@@ -71,8 +70,8 @@ static void addValidAliasToMap(std::string_view alias)
   if (reg::search(alias,m,re)) // valid name= or name{...}= part
   {
     size_t i=m.length();
-    assert(i!=std::string::npos); // based on re is always a =
-    assert(m.size()==3); // m[0]=full match including '=', m[1]=name, m[2]=optional params
+    ASSERT(i!=std::string::npos); // based on re is always a =
+    ASSERT(m.size()==3); // m[0]=full match including '=', m[1]=name, m[2]=optional params
     aliasName  = m[1].str();
     aliasValue = alias.substr(i);
     //printf("Alias: found name='%s' value='%s'\n",qPrint(name),qPrint(aliasValue));

--- a/src/clangparser.cpp
+++ b/src/clangparser.cpp
@@ -143,9 +143,9 @@ void ClangTUParser::parse()
   StringVector clangOptions = Config_getList(CLANG_OPTIONS);
   if (!clangAssistedParsing) return;
   //printf("ClangParser::start(%s)\n",fileName);
-  assert(p->index==nullptr);
-  assert(p->tokens==nullptr);
-  assert(p->numTokens==0);
+  ASSERT(p->index==nullptr);
+  ASSERT(p->tokens==nullptr);
+  ASSERT(p->numTokens==0);
   p->index    = clang_createIndex(0, 0);
   p->curToken = 0;
   p->cursors.clear();

--- a/src/classdef.cpp
+++ b/src/classdef.cpp
@@ -5190,7 +5190,7 @@ void ClassDefImpl::setCompoundType(CompoundType t)
 
 void ClassDefImpl::setTemplateMaster(const ClassDef *tm)
 {
-  assert(tm!=this);
+  ASSERT(tm!=this);
   m_templateMaster=tm;
 }
 

--- a/src/commentcnv.l
+++ b/src/commentcnv.l
@@ -59,8 +59,6 @@ typedef yyguts_t *yyscan_t;
 #include "stringutil.h"
 #include "util.h"
 
-#include <assert.h>
-
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
@@ -2044,7 +2042,7 @@ static void replaceAliases(yyscan_t yyscanner,std::string_view s,bool replaceCpp
                            // their expansion contains the matching end block marker.
   {
     std::string blk = yyextra->blockName.str();
-    assert(!blk.empty());
+    ASSERT(!blk.empty());
     bool isNamedCommand=isId(blk[0]); // true for e.g. @endcode, false for e.g. ~~~
     size_t i=0,p=0;
     bool found=false;

--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -36,7 +36,6 @@ typedef yyguts_t *yyscan_t;
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <cctype>
 #include <functional>
 #include <mutex>
@@ -4371,7 +4370,7 @@ static bool checkStructuralIndicator(yyscan_t yyscanner)
 static bool makeStructuralIndicator(yyscan_t yyscanner,MakeEntryType maker)
 {
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  assert(maker!=nullptr); // detect programming error
+  ASSERT(maker!=nullptr); // detect programming error
   //printf("yyextra->current->section=%x\n",yyextra->current->section);
   if (yyextra->current->section.isDoc())
   {

--- a/src/cppvalue.cpp
+++ b/src/cppvalue.cpp
@@ -17,11 +17,12 @@
 #include "cppvalue.h"
 
 // standard includes
-#include <cassert>
 #include <string>
 
 // other includes
 #include "constexp.h"
+#include "dstring.h"
+#include "message.h"
 
 CPPValue CPPValue::parseOctal(const std::string &token)
 {
@@ -68,10 +69,10 @@ CPPValue CPPValue::parseBinary(const std::string &token)
 
 CPPValue CPPValue::parseCharacter(const std::string &token) // does not work for '\n' and the alike
 {
-  assert(!token.empty());
+  ASSERT(!token.empty());
   if (token[1]=='\\')
   {
-    assert(token.length()>1);
+    ASSERT(token.length()>1);
     switch(token[2])
     {
       case 'n':  return CPPValue('\n');

--- a/src/definition.cpp
+++ b/src/definition.cpp
@@ -18,7 +18,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -580,7 +579,7 @@ class FilterCache
                fileName,Doxygen::filterDBFileName,item.filePos,item.fileSize);
 
         auto it_off = m_lineOffsets.find(fileName.str());
-        assert(it_off!=m_lineOffsets.end());
+        ASSERT(it_off!=m_lineOffsets.end());
         auto [ startLineOffset, fragmentSize] = getFragmentLocation(it_off->second,startLine,endLine);
         //printf("%s: existing file [%zu-%zu]->[%zu-%zu] size=%zu\n",
         //    qPrint(fileName),startLine,endLine,startLineOffset,endLineOffset,fragmentSize);
@@ -694,11 +693,11 @@ class FilterCache
     auto getFragmentLocation(const LineOffsets &lineOffsets,
                              size_t startLine,size_t endLine) -> std::tuple<size_t,size_t>
     {
-      assert(startLine > 0);
-      assert(startLine <= endLine);
+      ASSERT(startLine > 0);
+      ASSERT(startLine <= endLine);
       const size_t startLineOffset = lineOffsets[std::min(startLine-1,lineOffsets.size()-1)];
       const size_t endLineOffset   = lineOffsets[std::min(endLine,    lineOffsets.size()-1)];
-      assert(startLineOffset <= endLineOffset);
+      ASSERT(startLineOffset <= endLineOffset);
       const size_t fragmentSize = endLineOffset-startLineOffset;
       return std::tie(startLineOffset,fragmentSize);
     }
@@ -710,7 +709,7 @@ class FilterCache
       // compute offsets from start for each line
       compileLineOffsets(fileName,str);
       auto it = m_lineOffsets.find(fileName.str());
-      assert(it!=m_lineOffsets.end());
+      ASSERT(it!=m_lineOffsets.end());
       const LineOffsets &lineOffsets = it->second;
       auto [ startLineOffset, fragmentSize] = getFragmentLocation(lineOffsets,startLine,endLine);
       //printf("%s: new file [%zu-%zu]->[%zu-%zu] size=%zu\n",
@@ -1312,7 +1311,7 @@ void DefinitionImpl::setOuterScope(Definition *d)
     p->outerScope = d;
   }
   p->hidden = p->hidden || d->isHidden();
-  assert(p->def!=p->outerScope);
+  ASSERT(p->def!=p->outerScope);
 }
 
 const DString &DefinitionImpl::localName() const

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -4588,7 +4588,7 @@ Token DocPara::handleCommand(char cmdChar, const DString &cmdName)
         {
           parser()->tokenizer.setStatePlantUMLOpt();
           retval = parser()->tokenizer.lex();
-          assert(retval.is(TokenRetval::RetVal_OK));
+          ASSERT(retval.is(TokenRetval::RetVal_OK));
 
           sectionId = parser()->context.token->sectionId;
           sectionId = sectionId.stripWhiteSpace();
@@ -4656,7 +4656,7 @@ Token DocPara::handleCommand(char cmdChar, const DString &cmdName)
         {
           parser()->tokenizer.setStateMermaidOpt();
           retval = parser()->tokenizer.lex();
-          assert(retval.is(TokenRetval::RetVal_OK));
+          ASSERT(retval.is(TokenRetval::RetVal_OK));
 
           sectionId = parser()->context.token->sectionId;
           sectionId = sectionId.stripWhiteSpace();

--- a/src/docparser.cpp
+++ b/src/docparser.cpp
@@ -17,7 +17,6 @@
 #include "docparser.h"
 
 // standard includes
-#include <cassert>
 #include <cstdint>
 #include <cstdio>
 
@@ -2205,7 +2204,7 @@ IDocNodeASTPtr validatingParseDoc(IDocParser &parserIntf,
                                   const DocOptions &options)
 {
   DocParser *parser = dynamic_cast<DocParser*>(&parserIntf);
-  assert(parser!=nullptr);
+  ASSERT(parser!=nullptr);
   if (parser==nullptr) return nullptr;
   //printf("validatingParseDoc(%s,%s)=[%s]\n",ctx?qPrint(ctx->name()):"<none>",
   //                                     md?qPrint(md->name()):"<none>",
@@ -2341,7 +2340,7 @@ IDocNodeASTPtr validatingParseDoc(IDocParser &parserIntf,
 IDocNodeASTPtr validatingParseTitle(IDocParser &parserIntf,const DString &fileName,int lineNr,const DString &input)
 {
   DocParser *parser = dynamic_cast<DocParser*>(&parserIntf);
-  assert(parser!=nullptr);
+  ASSERT(parser!=nullptr);
   if (parser==nullptr) return nullptr;
 
   // set initial token
@@ -2394,7 +2393,7 @@ IDocNodeASTPtr validatingParseTitle(IDocParser &parserIntf,const DString &fileNa
 IDocNodeASTPtr validatingParseText(IDocParser &parserIntf,const DString &input)
 {
   DocParser *parser = dynamic_cast<DocParser*>(&parserIntf);
-  assert(parser!=nullptr);
+  ASSERT(parser!=nullptr);
   if (parser==nullptr) return nullptr;
 
   // set initial token
@@ -2453,7 +2452,7 @@ IDocNodeASTPtr validatingParseText(IDocParser &parserIntf,const DString &input)
 IDocNodeASTPtr createRef(IDocParser &parserIntf,const DString &target,const DString &context, const DString &srcFile, int srcLine )
 {
   DocParser *parser = dynamic_cast<DocParser*>(&parserIntf);
-  assert(parser!=nullptr);
+  ASSERT(parser!=nullptr);
   if (parser==nullptr) return nullptr;
   if (!srcFile.empty())
   {

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -34,7 +34,6 @@ typedef yyguts_t *yyscan_t;
 #include "doctokenizer.h"
 
 // standard includes
-#include <cassert>
 #include <cctype>
 #include <stack>
 #include <string>
@@ -345,7 +344,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          lineCount(yytext,yyleng);
                          DString text(yytext);
                          size_t dashPos = text.rfind('-');
-                         assert(dashPos!=DString::npos);
+                         ASSERT(dashPos!=DString::npos);
                          yyextra->token.isEnumList = text.at(dashPos+1)=='#';
                          yyextra->token.isCheckedList = false;
                          yyextra->token.id         = -1;
@@ -376,7 +375,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                            reg::Match match;
                            reg::search(text,match,re);
                            size_t listPos = match.position();
-                           assert(listPos!=std::string::npos);
+                           ASSERT(listPos!=std::string::npos);
                            yyextra->token.isEnumList = false;
                            yyextra->token.isCheckedList = false;
                            yyextra->token.id         = -1;
@@ -396,7 +395,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                            reg::Match match;
                            reg::search(text,match,re);
                            size_t markPos = match.position();
-                           assert(markPos!=std::string::npos);
+                           ASSERT(markPos!=std::string::npos);
                            yyextra->token.isEnumList = true;
                            yyextra->token.isCheckedList = false;
                            bool ok = false;
@@ -415,7 +414,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          lineCount(yytext,yyleng);
                          DString text=extractPartAfterNewLine(yytext);
                          size_t dashPos = text.rfind('-');
-                         assert(dashPos!=DString::npos);
+                         ASSERT(dashPos!=DString::npos);
                          yyextra->token.isEnumList = text.at(dashPos+1)=='#';
                          yyextra->token.isCheckedList = false;
                          yyextra->token.id         = -1;
@@ -447,7 +446,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                            reg::Match match;
                            reg::search(text,match,re);
                            size_t markPos = match.position();
-                           assert(markPos!=std::string::npos);
+                           ASSERT(markPos!=std::string::npos);
                            yyextra->token.isEnumList = false;
                            yyextra->token.isCheckedList = false;
                            yyextra->token.id         = -1;
@@ -468,7 +467,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                            reg::Match match;
                            reg::search(text,match,re);
                            size_t markPos = match.position();
-                           assert(markPos!=std::string::npos);
+                           ASSERT(markPos!=std::string::npos);
                            yyextra->token.isEnumList = true;
                            yyextra->token.isCheckedList = false;
                            bool ok = false;
@@ -2308,7 +2307,7 @@ void DocTokenizer::popState()
 {
   yyscan_t yyscanner = p->yyscanner;
   struct yyguts_t *yyg = (struct yyguts_t*)yyscanner;
-  assert(!yyextra->stateStack.empty());
+  ASSERT(!yyextra->stateStack.empty());
   BEGIN(yyextra->stateStack.top());
   yyextra->stateStack.pop();
 }

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -18,7 +18,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <mutex>
 #include <sstream>
 
@@ -113,7 +112,7 @@ DotFilePatcher *DotManager::createFilePatcher(const DString &fileName)
   if (patcher != m_filePatchers.end()) return &(patcher->second);
 
   auto rv = m_filePatchers.emplace(fileName.str(), fileName);
-  assert(rv.second);
+  ASSERT(rv.second);
   return &(rv.first->second);
 }
 

--- a/src/dotclassgraph.cpp
+++ b/src/dotclassgraph.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "containers.h"
 #include "dotnode.h"
+#include "message.h"
 #include "textstream.h"
 #include "util.h"
 

--- a/src/dotdirdeps.cpp
+++ b/src/dotdirdeps.cpp
@@ -17,7 +17,6 @@
 #include "dotdirdeps.h"
 
 // standard includes
-#include <cassert>
 #include <cmath>
 #include <map>
 #include <memory>
@@ -69,7 +68,7 @@ static DString getDirectoryBackgroundColor(int depthIndex)
   int hue   = Config_getInt(HTML_COLORSTYLE_HUE);
   int sat   = Config_getInt(HTML_COLORSTYLE_SAT);
   int gamma = Config_getInt(HTML_COLORSTYLE_GAMMA);
-  assert(depthIndex>=0 && depthIndex<=Config_getInt(DIR_GRAPH_MAX_DEPTH));
+  ASSERT(depthIndex>=0 && depthIndex<=Config_getInt(DIR_GRAPH_MAX_DEPTH));
   float fraction = static_cast<float>(depthIndex)/static_cast<float>(Config_getInt(DIR_GRAPH_MAX_DEPTH));
   const char hex[] = "0123456789abcdef";
   int range = 0x40; // range from darkest color to lightest color
@@ -80,9 +79,9 @@ static DString getDirectoryBackgroundColor(int depthIndex)
   int red   = static_cast<int>(r*255.0);
   int green = static_cast<int>(g*255.0);
   int blue  = static_cast<int>(b*255.0);
-  assert(red>=0   && red<=255);
-  assert(green>=0 && green<=255);
-  assert(blue>=0  && blue<=255);
+  ASSERT(red>=0   && red<=255);
+  ASSERT(green>=0 && green<=255);
+  ASSERT(blue>=0  && blue<=255);
   char colStr[8];
   colStr[0]='#';
   colStr[1]=hex[red>>4];

--- a/src/dotrunner.cpp
+++ b/src/dotrunner.cpp
@@ -18,7 +18,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <cmath>
 #include <map>
 #include <numeric>

--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3740,7 +3740,7 @@ static void buildInterfaceAndServiceList(const Entry *root)
     {
       DString scope = root->parent()->name;
       ClassDefMutable *cd = getClassMutable(scope);
-      assert(cd);
+      ASSERT(cd);
       if (cd && ((ClassDef::Interface == cd->compoundType()) ||
                  (ClassDef::Service   == cd->compoundType()) ||
                  (ClassDef::Singleton == cd->compoundType())))
@@ -3749,7 +3749,7 @@ static void buildInterfaceAndServiceList(const Entry *root)
       }
       else
       {
-        assert(false); // was checked by scanner.l
+        ASSERT(false); // was checked by scanner.l
       }
     }
     else if (rname.empty())

--- a/src/dstring.h
+++ b/src/dstring.h
@@ -25,10 +25,6 @@
 
 #include "utf8.h"
 
-#define ASSERT(x)  if ( !(x) )\
-        fprintf(stderr,"ASSERT: \"%s\" in %s (%d)\n",#x,__FILE__,__LINE__)
-
-
 /*****************************************************************************
   Safe and portable C string functions; extensions to standard string.h
  *****************************************************************************/

--- a/src/htmlentity.h
+++ b/src/htmlentity.h
@@ -15,13 +15,13 @@
 #ifndef HTMLENTITY_H
 #define HTMLENTITY_H
 
-#include <cassert>
 #include <functional>
 #include <string>
 #include <unordered_map>
 
 #include "dstring.h"
 #include "construct.h"
+#include "message.h"
 
 class TextStream;
 
@@ -126,8 +126,8 @@ class HtmlEntityMapper
     template<class T>
     const char *writeHtmlEntity(T &result, const char *s, HtmlEntityMapperFunc &&mapper, const char *fallback)
     {
-      assert(s!=nullptr);
-      assert(s[0]=='&');
+      ASSERT(s!=nullptr);
+      ASSERT(s[0]=='&');
       const char *q = s+1;
       size_t cnt = 2; // we have to count & and ; as well
       while ((*q >= 'a' && *q <= 'z') || (*q >= 'A' && *q <= 'Z') || (*q >= '0' && *q <= '9'))

--- a/src/htmlgen.cpp
+++ b/src/htmlgen.cpp
@@ -17,7 +17,6 @@
 #include "htmlgen.h"
 
 // standard includes
-#include <cassert>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -750,10 +749,10 @@ static void fillColorStyleMap(const DString &definitions,StringUnorderedMap &map
     if (line.startsWith("--"))
     {
       size_t separator = line.find(':');
-      assert(separator!=DString::npos);
+      ASSERT(separator!=DString::npos);
       std::string key = line.left(separator).str();
       size_t semi = line.rfind(';');
-      assert(semi!=DString::npos);
+      ASSERT(semi!=DString::npos);
       std::string value = line.mid(separator+1,semi-separator-1).stripWhiteSpace().str();
       map.emplace(key,value);
       //printf("var(%s)=%s\n",qPrint(key),qPrint(value));
@@ -787,7 +786,7 @@ static DString replaceVariables(const DString &input)
     {
       result+=input.mid(p,i-p);
       size_t j=input.find(")",i+4);
-      assert(j!=DString::npos);
+      ASSERT(j!=DString::npos);
       auto it = mapping.find(input.mid(i+4,j-i-4).str()); // find variable
       if (it==mapping.end())
       {                            // should be found
@@ -2926,7 +2925,7 @@ static bool quickLinkVisible(LayoutNavEntry::Kind kind)
     case LayoutNavEntry::ExceptionIndex:     return index.numAnnotatedExceptions()>0;
     case LayoutNavEntry::ExceptionHierarchy: return index.numHierarchyExceptions()>0;
     case LayoutNavEntry::None:             // should never happen, means not properly initialized
-      assert(kind != LayoutNavEntry::None);
+      ASSERT(kind != LayoutNavEntry::None);
       return false;
   }
   return false;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -22,7 +22,6 @@
 
 // standard includes
 #include <array>
-#include <cassert>
 #include <cstdlib>
 #include <map>
 #include <set>
@@ -5607,7 +5606,7 @@ static void writeIndexHierarchyEntries(OutputList &ol,const LayoutNavEntryList &
           writeUserGroupStubPage(ol,lne.get());
           break;
         case LayoutNavEntry::None:
-          assert(kind != LayoutNavEntry::None); // should never happen, means not properly initialized
+          ASSERT(kind != LayoutNavEntry::None); // should never happen, means not properly initialized
           break;
       }
       if (kind!=LayoutNavEntry::User && kind!=LayoutNavEntry::UserGroup) // User entry may appear multiple times
@@ -5679,7 +5678,7 @@ static bool quickLinkVisible(LayoutNavEntry::Kind kind)
     case LayoutNavEntry::FileGlobals:        return index.numDocumentedFileMembers(FileMemberHighlight::All)>0;
     case LayoutNavEntry::Examples:           return !Doxygen::exampleLinkedMap->empty();
     case LayoutNavEntry::None:             // should never happen, means not properly initialized
-      assert(kind != LayoutNavEntry::None);
+      ASSERT(kind != LayoutNavEntry::None);
       return false;
   }
   return false;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -18,7 +18,6 @@
 
 // standard includes
 #include <array>
-#include <cassert>
 
 // other includes
 #include "config.h"
@@ -1766,7 +1765,7 @@ DString extractLanguageSpecificTitle(const DString &input,SrcLangExt lang)
     s=e+1;
     e=input.find('|',s);
     size_t i=input.find('=',s);
-    assert(i!=DString::npos && i>s);
+    ASSERT(i!=DString::npos && i>s);
     SrcLangExt key= static_cast<SrcLangExt>(input.mid(s,i-s).toUInt());
     if (key==lang) // found matching key
     {

--- a/src/memberlist.h
+++ b/src/memberlist.h
@@ -24,6 +24,7 @@
 #include "linkedmap.h"
 #include "memberdef.h"
 #include "membergroup.h"
+#include "message.h"
 #include "types.h"
 
 class GroupDef;

--- a/src/message.h
+++ b/src/message.h
@@ -139,6 +139,8 @@ constexpr bool has_newline_at_end(const char (&str)[N])
     term_fmt(FMT_STRING(fmt),##__VA_ARGS__); \
   } while (0)
 
+#define ASSERT(x)  if ( !(x) )\
+  warn_uncond("ASSERT: Internal inconsistency: \"{}\" in {} ({})\n",#x,__FILE__,__LINE__)
 
 #ifdef DOXYGEN_ONLY
 namespace fmt { template<typename T> struct formatter {}; }

--- a/src/portable.cpp
+++ b/src/portable.cpp
@@ -17,7 +17,6 @@
 #include "portable.h"
 
 // standard includes
-#include <cassert>
 #include <cctype>
 #include <chrono>
 #include <cstdio>

--- a/src/qhp.cpp
+++ b/src/qhp.cpp
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string.h>
 #include <vector>
-#include <cassert>
 #include <mutex>
 
 // other includes
@@ -137,7 +136,7 @@ class QhpSectionTree
     }
     void decLevel()
     {
-      assert(m_current->parent!=nullptr);
+      ASSERT(m_current->parent!=nullptr);
       if (m_current->parent)
       {
         m_current = m_current->parent;

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -18,13 +18,13 @@
 
 // standard headers
 #include <algorithm>
-#include <cassert>
 #include <cctype>
 #include <cstdint>
 #include <vector>
 
 #define ENABLE_DEBUG 0
 #if ENABLE_DEBUG
+#include <cassert>
 #define DBG(fmt,...) do { fprintf(stderr,fmt,__VA_ARGS__); } while(0)
 #else
 #define DBG(fmt,...) do {} while(0)

--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -17,7 +17,6 @@
 #include "searchindex.h"
 
 // standard includes
-#include <cassert>
 #include <cctype>
 #include <mutex>
 
@@ -74,7 +73,7 @@ void SearchIndex::setCurrentDoc(const Definition *ctx,const DString &anchor,bool
 {
   if (ctx==nullptr) return;
   std::lock_guard<std::mutex> lock(g_searchIndexMutex);
-  assert(!isSourceFile || ctx->definitionType()==Definition::TypeFile);
+  ASSERT(!isSourceFile || ctx->definitionType()==Definition::TypeFile);
   //printf("SearchIndex::setCurrentDoc(%s,%s,%s)\n",name,baseName,anchor);
   DString url=isSourceFile ? (toFileDef(ctx))->getSourceFileBase() : ctx->getOutputFileBase();
   url+=Config_getString(HTML_FILE_EXTENSION);

--- a/src/searchindex_js.cpp
+++ b/src/searchindex_js.cpp
@@ -18,7 +18,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <utility>
 
 // other includes
@@ -60,7 +59,7 @@ void SearchTerm::makeTitle()
   }
   else
   {
-    assert(false);
+    ASSERT(false);
   }
 }
 
@@ -639,7 +638,7 @@ static void writeJavasScriptSearchDataPage(const DString &baseName,const DString
     const SearchTerm::LinkInfo info = term.info;
     const Definition *d             = getDef(info);
     const SectionInfo *si           = getSection(info);
-    assert(d || si); // either d or si should be valid
+    ASSERT(d || si); // either d or si should be valid
     DString word                   = term.word;
     DString id                     = term.termEncoded();
     ++it;

--- a/src/symbolmap.h
+++ b/src/symbolmap.h
@@ -17,7 +17,6 @@
 #define SYMBOLMAP_H
 
 #include <algorithm>
-#include <cassert>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -74,7 +73,7 @@ class SymbolMap
     //! Returns a pair of iterators pointing to the start and end of the range of matching symbols
     const VectorPtr &find(const DString &name)
     {
-      assert(m_noMatch.empty());
+      ASSERT(m_noMatch.empty());
       auto it = m_map.find(name.str());
       return it==m_map.end() ? m_noMatch : it->second;
     }

--- a/src/symbolresolver.cpp
+++ b/src/symbolresolver.cpp
@@ -18,7 +18,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -1630,7 +1629,7 @@ DString SymbolResolver::Private::substTypedef(
   const int maxAddrSize = 20;
   char ptr_str[maxAddrSize];
   int num = snprintf(ptr_str,maxAddrSize,"%p:",(void *)scope);
-  assert(num>0);
+  ASSERT(num>0);
   key.reserve(num+name.length()+1);
   key+=ptr_str;
   key+=name.str();

--- a/src/tagreader.cpp
+++ b/src/tagreader.cpp
@@ -18,7 +18,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <cstdarg>
 #include <functional>
 #include <map>
@@ -1570,7 +1569,7 @@ void TagFileParser::buildClassEntry(const std::shared_ptr<Entry> &root, const Ta
     case TagClassInfo::Kind::Service:   ce->spec = TypeSpecifier().setService(true);   break;
     case TagClassInfo::Kind::Singleton: ce->spec = TypeSpecifier().setSingleton(true); break;
     case TagClassInfo::Kind::None:      // should never happen, means not properly initialized
-                                        assert(tci->kind != TagClassInfo::Kind::None);
+                                        ASSERT(tci->kind != TagClassInfo::Kind::None);
                                         break;
   }
   ce->name     = tci->name;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -18,7 +18,6 @@
 
 // std includes (sorted)
 #include <algorithm>
-#include <cassert>
 #include <cctype>
 #include <cinttypes>
 #include <cstdlib>
@@ -4971,7 +4970,7 @@ DString getDotImageExtension()
 
 bool openOutputFile(const DString &outFile,std::ofstream &f)
 {
-  assert(!f.is_open());
+  ASSERT(!f.is_open());
   bool fileOpened=false;
   bool writeToStdout=outFile=="-";
   if (writeToStdout) // write to stdout
@@ -5341,7 +5340,7 @@ DString extractBeginRawStringDelimiter(const char *rawStart)
 {
   DString text=rawStart;
   size_t i = text.find('"');
-  assert(i!=DString::npos);
+  ASSERT(i!=DString::npos);
   return text.mid(i+1,text.length()-i-2); // text=...R"xyz( -> delimiter=xyz
 }
 

--- a/src/vhdldocgen.cpp
+++ b/src/vhdldocgen.cpp
@@ -24,7 +24,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <map>
 #include <mutex>
 #include <unordered_set>
@@ -2956,7 +2955,7 @@ DString FlowChart::printPlantUmlNode(const FlowChart &flo,bool ca,bool endL)
     case EMPTY_NO:   break;
     case COMMENT_NO: t="\n note left \n "+flo.label+"\nend note \n"; break;
     case BEGIN_NO:   t="\n:begin;"; break;
-    default:         assert(false); break;
+    default:         ASSERT(false); break;
   }
   return t;
 }
@@ -3076,7 +3075,7 @@ void FlowChart::endDot(TextStream &t)
 
 void FlowChart::writeFlowChart()
 {
-  //  assert(VhdlDocGen::flowMember);
+  //  ASSERT(VhdlDocGen::flowMember);
 
   DString ov = Config_getString(HTML_OUTPUT);
   DString fileName = ov+"/flow_design.dot";
@@ -3232,8 +3231,8 @@ void FlowChart::writeEdge(TextStream &t,const FlowChart &fl_from,const FlowChart
   auto it = g_keyMap.find(s1.str());
   auto it1 = g_keyMap.find(s2.str());
   // checks if the link is connected to a valid node
-  assert(it!=g_keyMap.end());
-  assert(it1!=g_keyMap.end());
+  ASSERT(it!=g_keyMap.end());
+  ASSERT(it1!=g_keyMap.end());
 #endif
 
   writeEdge(t,fl_from.id,fl_to.id,i,b,c);
@@ -3453,7 +3452,7 @@ void FlowChart::writeFlowLinks(TextStream &t)
     {
       writeEdge(t,fll,flowList[j+1],0);
       size_t z=getNextIfLink(fll,j);
-      // assert(z>-1);
+      // ASSERT(z>-1);
       writeEdge(t,fll,flowList[z],1);
     }
     else if (kind & LOOP_NO)
@@ -3477,7 +3476,7 @@ void FlowChart::writeFlowLinks(TextStream &t)
       size_t z=findNode(j+1,fll.stamp,kind);
       z=getNextNode(z,flowList[z].stamp);
 
-      // assert(z>-1);
+      // ASSERT(z>-1);
       writeEdge(t,fll,flowList[z],1);
       continue;
     }

--- a/src/vhdljjparser.cpp
+++ b/src/vhdljjparser.cpp
@@ -660,7 +660,7 @@ void VHDLOutlineParser::addProto(const DString &s1,const DString &s2,const DStri
 
     if (s->parse_sec==VhdlSection::PARAM_SEC)
     {
-    //  assert(false);
+    //  ASSERT(false);
     }
 
     arg.defval+=s1;
@@ -738,7 +738,7 @@ int VHDLOutlineParser::getLine(int tok)
 {
   int val=p->lineParse[tok];
   if (val<0) val=0;
-  //assert(val>=0 && val<=yyLineNr);
+  //ASSERT(val>=0 && val<=yyLineNr);
   return val;
 }
 


### PR DESCRIPTION
Replace  `assert` calls with `ASSERT` macro so that potential problems are also shown in non debug mode. 
Don't write to stderr, but use doxygen's `warn_uncond`so it is harder that they under in normal informational  messages 
Replace only the ones that are not further protected by debug settings.