### PR TITLE
issue #12315 `@ref` is illegal in `<caption>`

### DIFF
--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -1833,6 +1833,85 @@ Token DocHtmlCaption::parse()
             }
           }
           break;
+        case TokenRetval::TK_COMMAND_AT:
+        // fall through
+        case TokenRetval::TK_COMMAND_BS:
+          {
+            DString cmdName=parser()->context.token->name;
+            bool isJavaLink=false;
+            switch (Mappers::cmdMapper->map(cmdName))
+            {
+              case CommandType::CMD_REF:
+                {
+                  tok=parser()->tokenizer.lex();
+                  if (!tok.is(TokenRetval::TK_WHITESPACE))
+                  {
+                    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after '{:c}{}' command",
+                        tok.command_to_char(),cmdName);
+                  }
+                  else
+                  {
+                    parser()->tokenizer.setStateRef();
+                    tok=parser()->tokenizer.lex(); // get the reference id
+                    if (!tok.is(TokenRetval::TK_WORD))
+                    {
+                      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token {} as the argument of '{:c}{}' command",
+                          tok.to_string(),tok.command_to_char(),cmdName);
+                    }
+                    else
+                    {
+                      children().append<DocRef>(parser(),thisVariant(),parser()->context.token->name,parser()->context.context);
+                      children().get_last<DocRef>()->parse(tok.command_to_char(),cmdName);
+                    }
+                    parser()->tokenizer.setStatePara();
+                  }
+                }
+                break;
+              case CommandType::CMD_JAVALINK:
+                isJavaLink=true;
+                // fall through
+              case CommandType::CMD_LINK:
+                {
+                  tok=parser()->tokenizer.lex();
+                  if (!tok.is(TokenRetval::TK_WHITESPACE))
+                  {
+                    warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"expected whitespace after \\{} command",
+                        cmdName);
+                  }
+                  else
+                  {
+                    parser()->tokenizer.setStateLink();
+                    tok=parser()->tokenizer.lex();
+                    if (!tok.is(TokenRetval::TK_WORD))
+                    {
+                      warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"unexpected token {} as the argument of \\{} command",
+                          tok.to_string(),cmdName);
+                    }
+                    else
+                    {
+                      parser()->tokenizer.setStatePara();
+                      children().append<DocLink>(parser(),thisVariant(),parser()->context.token->name);
+                      DocLink *lnk  = children().get_last<DocLink>();
+                      DString leftOver = lnk->parse(isJavaLink);
+                      if (!leftOver.empty())
+                      {
+                        children().append<DocWord>(parser(),thisVariant(),leftOver);
+                      }
+                    }
+                  }
+                }
+                break;
+              case CommandType::CMD_LINEBREAK:
+                {
+                  children().append<DocLineBreak>(parser(),thisVariant(),parser()->context.token->attribs);
+                }
+                break;
+              default:
+                warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"Illegal command '{:c}{}' found as part of a <caption> tag",
+                  tok.command_to_char(),cmdName);
+            }
+          }
+          break;
         default:
           parser()->errorHandleDefaultToken(thisVariant(),tok,children(),"<caption> tag");
           break;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -220,7 +220,7 @@ void LatexDocVisitor::visitCaption(const DocNodeList &children)
 LatexDocVisitor::LatexDocVisitor(TextStream &t,OutputCodeList &ci,LatexCodeGenerator &lcg,
                                  const DString &langExt, int hierarchyLevel)
   : m_t(t), m_ci(ci), m_lcg(lcg), m_insidePre(false),
-    m_insideItem(false), m_hide(false),
+    m_insideItem(false), m_hide(false), m_captionTable(false),
     m_langExt(langExt), m_hierarchyLevel(hierarchyLevel)
 {
 }
@@ -332,11 +332,15 @@ void LatexDocVisitor::operator()(const DocLineBreak &)
   if (m_hide) return;
   if (m_insideItem)
   {
-  m_t << "\\\\\n";
+    m_t << "\\\\\n";
+  }
+  else if (m_captionTable)
+  {
+    m_t << "\\hspace{\\textwidth minus \\textwidth}\\mbox{}\\\\ ";
   }
   else
   {
-  m_t << "~\\newline\n";
+    m_t << "~\\newline\n";
   }
 }
 
@@ -1245,7 +1249,9 @@ void LatexDocVisitor::operator()(const DocHtmlTable &t)
     m_t << "{";
     if (c)
     {
+      m_captionTable = true;
       std::visit(*this, *t.caption());
+      m_captionTable = false;
     }
     m_t << "}";
     // write label
@@ -1875,12 +1881,12 @@ void LatexDocVisitor::startLink(const DString &ref,const DString &file,const DSt
     }
     else if (refToSection)
     {
-      if (m_texOrPdf == TexOrPdf::TEX) m_t << "\\protect";
+      if (m_texOrPdf == TexOrPdf::TEX || m_captionTable) m_t << "\\protect";
       if (m_texOrPdf != TexOrPdf::PDF) m_t << "\\doxysectlink{";
     }
     else
     {
-      if (m_texOrPdf == TexOrPdf::TEX) m_t << "\\protect";
+      if (m_texOrPdf == TexOrPdf::TEX || m_captionTable) m_t << "\\protect";
       if (m_texOrPdf != TexOrPdf::PDF) m_t << "\\doxylink{";
     }
     if (refToTable || m_texOrPdf != TexOrPdf::PDF)

--- a/src/latexdocvisitor.h
+++ b/src/latexdocvisitor.h
@@ -183,6 +183,7 @@ class LatexDocVisitor final : public DocVisitor
     bool m_insidePre;
     bool m_insideItem;
     bool m_hide;
+    bool m_captionTable;
     DString m_langExt;
     int m_hierarchyLevel;
     TexOrPdf m_texOrPdf = TexOrPdf::NO;

--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -1018,7 +1018,7 @@ void RTFDocVisitor::operator()(const DocHtmlTable &t)
       m_t << "{\\bkmkstart " << rtfFormatBmkStr(stripPath(c.file())+"_"+c.anchor()) << "}\n";
       m_t << "{\\bkmkend " << rtfFormatBmkStr(stripPath(c.file())+"_"+c.anchor()) << "}\n";
     }
-    m_t << "{Table \\field\\flddirty{\\*\\fldinst { SEQ Table \\\\*Arabic }}{\\fldrslt {\\noproof 1}} ";
+    m_t << "{Table {\\field\\flddirty{\\*\\fldinst { SEQ Table \\\\*Arabic }}}{\\fldrslt {\\noproof 1}} ";
     std::visit(*this,*t.caption());
   }
   visitChildren(t);


### PR DESCRIPTION
Added possibilities to the <caption>` tag analogous to the <dt>` tag, i.e. commands `\ref`, `\link`, `\javalink` and `\n`