### PR TITLE
doxygen.cpp: fix parsing of typedef of C function pointers (1.8.0 regression)

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -3345,7 +3345,7 @@ static void addVariable(const Entry *root,int isFuncPtr=-1)
     {
       size_t ii = i;
       size_t ai = type.find('[',ii);
-      if (ai>ii) // function pointer array
+      if (ai!=QCString::npos && ai>ii) // function pointer array
       {
         args.prepend(type.mid(ai));
         type=type.left(ai);

--- a/testing/123/123__typedef__func__pointer_8cpp.xml
+++ b/testing/123/123__typedef__func__pointer_8cpp.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="123__typedef__func__pointer_8cpp" kind="file" language="C++">
+    <compoundname>123_typedef_func_pointer.cpp</compoundname>
+    <sectiondef kind="typedef">
+      <memberdef kind="typedef" id="123__typedef__func__pointer_8cpp_1a00117f01793f6df7d5c9188a938c86a8" prot="public" static="no">
+        <type>void(*</type>
+        <definition>typedef void(* foo) (int bar)</definition>
+        <argsstring>)(int bar)</argsstring>
+        <name>foo</name>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+<para>foo function pointer </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="123_typedef_func_pointer.cpp" line="5" column="9" bodyfile="123_typedef_func_pointer.cpp" bodystart="5" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="123_typedef_func_pointer.cpp"/>
+  </compounddef>
+</doxygen>

--- a/testing/123_typedef_func_pointer.cpp
+++ b/testing/123_typedef_func_pointer.cpp
@@ -1,0 +1,5 @@
+// objective: test typedef of function pointer
+// check: 123__typedef__func__pointer_8cpp.xml
+
+/** foo function pointer */
+typedef void (*foo)(int bar);


### PR DESCRIPTION
Commit 772ac869946245992ee79d6245d88b95812cb4cd ("Refactoring: Better align interface of QCString with std::string") broke parsing of typedef of C function pointers
like ``typedef void(* foo) (int bar)`` where the definition field after that commit became ``typedef void(*) foo(int bar)`` instead of the expected ``typedef void(* foo) (int bar)``

The reason is that the change of the type of the ``ai`` variable from ``int`` to ``size_t`` causes a test like ``if (ai>ii)`` to be true when ai==npos, which is not expected.

While debugging to spot the offending site, I found other similar patterns, so is likely there might be other bugs due to that commit lurking.

This commit adds a regression test for that use case.