### PR TITLE
issue #12314 Hyperlink mailto:… fails to parse in Markdown

### DIFF
--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -328,7 +328,7 @@ void HtmlDocVisitor::writeObfuscatedMailAddress(const DString &url)
   }
   else
   {
-    m_t << "<a href=\"mai'+'lto:";
+    m_t << "<a href=\"mailto:";
     if (!url.empty())
     {
       const char *p = url.data();

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1647,11 +1647,11 @@ int Markdown::Private::processLink(const std::string_view data,size_t offset)
       out+="\"";
     }
     else if ((lp = link.find('#'))!=DString::npos ||
-             (lp = link.find('/'))!=DString::npos ||
-             (lp = link.find('.'))!=DString::npos)
+             (link.find('/'))!=DString::npos ||
+             (link.find('.'))!=DString::npos)
     { // file/url link
       bool isRef = false;
-      if (lp==0 || (lp>0 && !isURL(link) && Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB))
+      if (lp==0 || (lp!=DString::npos && lp>0 && !isURL(link) && Config_getEnum(MARKDOWN_ID_STYLE)==MARKDOWN_ID_STYLE_t::GITHUB))
       {
         out+="@ref \"";
         out+=AnchorGenerator::addPrefixIfNeeded(link.mid(lp+1).str());


### PR DESCRIPTION
Correcting the change in markdown.cpp:
```
    else if ((lp=link.find('#'))!=-1 || link.find('/')!=-1 || link.find('.')!=-1)
```
into
```
    else if ((lp = link.find('#'))!=QCString::npos ||
             (lp = link.find('/'))!=QCString::npos ||
             (lp = link.find('.'))!=QCString::npos)
```
in
```
Commit: 772ac869946245992ee79d6245d88b95812cb4cd [772ac86]

Commit Date: Saturday, August 8, 2026 9:29:19 PM
Refactoring: Better align interface of QCString with std::string
```

Also adjusting it for `size_t` usage.