### PR TITLE
issue #11368 Make function-like macro inlining configurable

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1289,6 +1289,17 @@ Go to the <a href="commands.html">next</a> section or return to the
 ]]>
       </docs>
     </option>
+     <option type='bool' id='INLINE_FUNCTION_MACROS' defval='0'>
+      <docs>
+<![CDATA[
+   Setting the \c INLINE_FUNCTION_MACROS tag to \c YES will show the body
+ of a function-like macro on the same line as its declaration when the body
+ consists of a single line. The body is only shown when it also satisfies the
+ \c MAX_INITIALIZER_LINES setting. Multi-line macro bodies are not affected by
+ this option.
+]]>
+      </docs>
+    </option>
     <option type='bool' id='SHOW_USED_FILES' defval='1'>
       <docs>
 <![CDATA[

--- a/src/memberdef.cpp
+++ b/src/memberdef.cpp
@@ -4458,7 +4458,7 @@ bool MemberDefImpl::hasOneLineInitializer() const
   //    m_maxInitLines,m_userInitLines);
   bool isFuncLikeMacro = m_mtype==MemberType::Define && m_defArgList.hasParameters();
   return !m_initializer.empty() && m_initLines==0 && // one line initializer
-         !isFuncLikeMacro &&
+         (!isFuncLikeMacro || Config_getBool(INLINE_FUNCTION_MACROS)) &&
          ((m_maxInitLines>0 && m_userInitLines==-1) || m_userInitLines>0); // enabled by default or explicitly
 }
 
@@ -4467,7 +4467,8 @@ bool MemberDefImpl::hasMultiLineInitializer() const
   //printf("initLines=%d userInitLines=%d maxInitLines=%d\n",
   //    initLines,userInitLines,maxInitLines);
   bool isFuncLikeMacro = m_mtype==MemberType::Define && m_defArgList.hasParameters();
-  return (m_initLines>0 || (!m_initializer.empty() && isFuncLikeMacro)) &&
+  return (m_initLines>0 || (!m_initializer.empty() && isFuncLikeMacro &&
+                            !Config_getBool(INLINE_FUNCTION_MACROS))) &&
          ((m_initLines<m_maxInitLines && m_userInitLines==-1) // implicitly enabled
           || m_initLines<m_userInitLines // explicitly enabled
          );

--- a/testing/124/124__inline__function__like__macros_8c.xml
+++ b/testing/124/124__inline__function__like__macros_8c.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="" xml:lang="en-US">
+  <compounddef id="124__inline__function__like__macros_8c" kind="file" language="C++">
+    <compoundname>124_inline_function_like_macros.c</compoundname>
+    <sectiondef kind="user-defined">
+      <header>Named group for macros with arguments.</header>
+      <memberdef kind="define" id="124__inline__function__like__macros_8c_1a81130110dc3ee971a48c5a01f8e20bca" prot="public" static="no">
+        <name>MACRO_GROUP_ARG_0</name>
+        <param>
+          <defname>arg</defname>
+        </param>
+        <initializer>(arg) + 0</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>First grouped function-like macro. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="124_inline_function_like_macros.c" line="15" column="9" bodyfile="124_inline_function_like_macros.c" bodystart="15" bodyend="-1"/>
+      </memberdef>
+      <memberdef kind="define" id="124__inline__function__like__macros_8c_1a8e60a615d0dc6a4be11f2962e9fe678a" prot="public" static="no">
+        <name>MACRO_GROUP_ARG_1</name>
+        <param>
+          <defname>arg</defname>
+        </param>
+        <initializer>(arg) + 0</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>Second grouped function-like macro. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="124_inline_function_like_macros.c" line="17" column="9" bodyfile="124_inline_function_like_macros.c" bodystart="17" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <sectiondef kind="define">
+      <memberdef kind="define" id="124__inline__function__like__macros_8c_1ab175e1d43b23236e98095941ea0f726e" prot="public" static="no">
+        <name>ADD_ZERO</name>
+        <param>
+          <defname>value</defname>
+        </param>
+        <initializer>(value) + 0</initializer>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+          <para>A function-like macro with a one-line body. </para>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="124_inline_function_like_macros.c" line="8" column="9" bodyfile="124_inline_function_like_macros.c" bodystart="8" bodyend="-1"/>
+      </memberdef>
+    </sectiondef>
+    <briefdescription>
+    </briefdescription>
+    <detaileddescription>
+    </detaileddescription>
+    <location file="124_inline_function_like_macros.c"/>
+  </compounddef>
+</doxygen>

--- a/testing/124_inline_function_like_macros.c
+++ b/testing/124_inline_function_like_macros.c
@@ -1,0 +1,18 @@
+// objective: test INLINE_FUNCTION_MACROS (the layout difference is not observable in XML output)
+// check: 124__inline__function__like__macros_8c.xml
+// config: INLINE_FUNCTION_MACROS = YES
+
+/** \file */
+
+/** A function-like macro with a one-line body. */
+#define ADD_ZERO(value) (value) + 0
+
+/**
+ * \name Named group for macros with arguments.
+ *
+ * \{ */
+/** First grouped function-like macro. */
+#define MACRO_GROUP_ARG_0(arg) (arg) + 0
+/** Second grouped function-like macro. */
+#define MACRO_GROUP_ARG_1(arg) (arg) + 0
+/** \} */


### PR DESCRIPTION
Add the INLINE_FUNCTION_MACROS option to preserve the current behavior by default while allowing one-line function-like macro bodies to be shown inline. Add regression coverage for the new configuration option.

This addresses issue #11368 where changes were made without adding an option to keep the previous behaviour.