### PR TITLE
issue #9921 `HIDE_SCOPE_NAMES` does not hide names in Modules list or `@ref` link text

### DIFF
--- a/src/ftvhelp.cpp
+++ b/src/ftvhelp.cpp
@@ -559,6 +559,7 @@ static void generateJSLink(TextStream &t,const FTVNodePtr &n)
 {
   bool nameAsHtml = !n->nameAsHtml.empty();
   DString link = nameAsHtml ? convertToJSString(n->nameAsHtml,true) : convertToJSString(n->name);
+  if (Config_getBool(HIDE_SCOPE_NAMES)) link=stripScope(link);
   link = substitute(link,"\n","");
   if (n->file.empty()) // no link
   {


### PR DESCRIPTION

Reintroduced the code regarding `HIDE_SCOPE_NAMES` that was, accidentally, lost during:
```
Commit: 92c33c43583086649af80ca6f57be7a0bafae489 [92c33c4]

Date: Monday, April 27, 2026 1:26:19 PM

PR #12093 Minor refactoring to reduce impact
```