### PR TITLE
Add optional LaTeX listings backend for Markdown code fences

### DIFF
--- a/doc/markdown.dox
+++ b/doc/markdown.dox
@@ -461,6 +461,20 @@ int func(int a,int b) { return a*b; }
 The dot is optional, the curly braces are optional when the that language name begins with an
 alphabetical character and further characters are alphanumerical characters or a plus sign.
 
+Following the Pandoc fenced-code attribute syntax, an attribute block can also contain
+an identifier and a caption. The identifier is converted to the corresponding Doxygen
+\ref cmdanchor "\\anchor" command and the caption is shown after the code block:
+
+    ~~~~~~~~~~~~~~~{.c #multiply-example caption="Multiplication function"}
+    int multiply(int a,int b) { return a*b; }
+    ~~~~~~~~~~~~~~~
+
+The language, identifier, and caption are independent. Use a class beginning with a
+dot for the language, an identifier beginning with c # for the anchor, and a quoted
+c caption value. This syntax is currently supported for ordinary fenced code blocks;
+fences for diagrams such as c dot, c msc, c plantuml, and c mermaid retain their
+existing specialized handling.
+
 Another way to denote fenced code blocks is to use 3 or more backticks (```):
 
 ~~~~~~{.unparsed}

--- a/doc/markdown.dox
+++ b/doc/markdown.dox
@@ -463,7 +463,9 @@ alphabetical character and further characters are alphanumerical characters or a
 
 Following the Pandoc fenced-code attribute syntax, an attribute block can also contain
 an identifier and a caption. The identifier is converted to the corresponding Doxygen
-\ref cmdanchor "\\anchor" command and the caption is shown after the code block:
+\ref cmdanchor "\\anchor" command and the caption is shown after the code block.
+In LaTeX, the caption uses Doxygen's common code-listing caption type with either
+the standard c DoxyCode or optional c listings renderer:
 
     ~~~~~~~~~~~~~~~{.c #multiply-example caption="Multiplication function"}
     int multiply(int a,int b) { return a*b; }
@@ -471,9 +473,11 @@ an identifier and a caption. The identifier is converted to the corresponding Do
 
 The language, identifier, and caption are independent. Use a class beginning with a
 dot for the language, an identifier beginning with c # for the anchor, and a quoted
-c caption value. This syntax is currently supported for ordinary fenced code blocks;
-fences for diagrams such as c dot, c msc, c plantuml, and c mermaid retain their
-existing specialized handling.
+c caption value. For LaTeX listings, c numbers=left, c numbers=right, or
+c numbers=none overrides the global c listings line-number setting for that block.
+This syntax is currently supported for ordinary fenced code blocks; fences for diagrams
+such as c dot, c msc, c plantuml, and c mermaid retain their existing specialized
+handling.
 
 Another way to denote fenced code blocks is to use 3 or more backticks (```):
 

--- a/src/config.xml
+++ b/src/config.xml
@@ -3104,11 +3104,11 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
  environments. This leaves syntax highlighting to the LaTeX \c listings package
  and preserves the source text without Doxygen's LaTeX escaping.
 
- This option is disabled by default. When enabled, the user must load and configure
- the \c listings package, for example by using a custom LaTeX header or an extra
- stylesheet. A global style can control line numbers:
+ This option is disabled by default. When enabled, Doxygen's generated
+ \c doxygen.sty loads the \c listings package and provides the \c DoxyCode
+ style, so no custom LaTeX setup is required. A global \c listings configuration
+ can customize options such as line numbers:
 \verbatim
-\usepackage{listings}
 \lstset{numbers=left,numberstyle=\tiny}
 \endverbatim
 A Markdown fence can override its line-number position with c numbers=left,
@@ -3119,7 +3119,7 @@ reliably in table cells.
  The language from a Markdown fence is passed to \c listings when it is a safe
  identifier. The special language \c none, and an empty language, do not set a
  language option. Doxygen does not translate fence language names: the selected
- name must be supported by the installed \c listings package. Markdown fences for
+ name must be supported by the bundled \c listings package. Markdown fences for
  \c mermaid, \c msc, \c dot (when Graphviz is enabled), and \c plantuml (when
  \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH" is set) are special diagram blocks;
  they retain their existing diagram handling. Other code constructs, such as included
@@ -3127,14 +3127,14 @@ reliably in table cells.
 ]]>
       </docs>
     </option>
-    <option type='string' id='LATEX_LISTINGS_STYLE' format='string' defval='' depends='LATEX_USE_LISTINGS'>
+    <option type='string' id='LATEX_LISTINGS_STYLE' format='string' defval='DoxyCode' depends='LATEX_USE_LISTINGS'>
       <docs>
 <![CDATA[
  The \c LATEX_LISTINGS_STYLE tag specifies the \c listings style to use when
- \ref cfg_latex_use_listings "LATEX_USE_LISTINGS" is enabled. For example,
- setting this tag to \c MyStyle emits \c style=MyStyle in each \c lstlisting
- environment. The style must be defined by the user's LaTeX configuration. If
- this tag is left empty, no \c style option is emitted.
+ \ref cfg_latex_use_listings "LATEX_USE_LISTINGS" is enabled. The default,
+ \c DoxyCode, is defined by Doxygen's generated \c doxygen.sty and provides
+ a framed, syntax-highlighted code block. Set this tag to the name of a style
+ defined in a custom LaTeX header or extra stylesheet to override the default.
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -3096,6 +3096,41 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 ]]>
       </docs>
     </option>
+    <option type='bool' id='LATEX_USE_LISTINGS' defval='0' depends='GENERATE_LATEX'>
+      <docs>
+<![CDATA[
+ When the \c LATEX_USE_LISTINGS tag is set to \c YES, ordinary code blocks are
+ emitted as \c lstlisting environments instead of Doxygen's \c DoxyCode
+ environments. This leaves syntax highlighting to the LaTeX \c listings package
+ and preserves the source text without Doxygen's LaTeX escaping.
+
+ This option is disabled by default. When enabled, the user must load and configure
+ the \c listings package, for example by using a custom LaTeX header or an extra
+ stylesheet. Code blocks in tables continue to use the standard \c DoxyCode
+ backend because \c lstlisting environments cannot be used reliably in table cells.
+
+ The language from a Markdown fence is passed to \c listings when it is a safe
+ identifier. The special language \c none, and an empty language, do not set a
+ language option. Doxygen does not translate fence language names: the selected
+ name must be supported by the installed \c listings package. Markdown fences for
+ \c mermaid, \c msc, \c dot (when Graphviz is enabled), and \c plantuml (when
+ \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH" is set) are special diagram blocks;
+ they retain their existing diagram handling. Other code constructs, such as included
+ snippets and generated source listings, also retain the standard backend.
+]]>
+      </docs>
+    </option>
+    <option type='string' id='LATEX_LISTINGS_STYLE' format='string' defval='' depends='LATEX_USE_LISTINGS'>
+      <docs>
+<![CDATA[
+ The \c LATEX_LISTINGS_STYLE tag specifies the \c listings style to use when
+ \ref cfg_latex_use_listings "LATEX_USE_LISTINGS" is enabled. For example,
+ setting this tag to \c MyStyle emits \c style=MyStyle in each \c lstlisting
+ environment. The style must be defined by the user's LaTeX configuration. If
+ this tag is left empty, no \c style option is emitted.
+]]>
+      </docs>
+    </option>
     <option type='enum' id='PAPER_TYPE' defval='a4' depends='GENERATE_LATEX'>
       <docs>
 <![CDATA[

--- a/src/config.xml
+++ b/src/config.xml
@@ -3106,8 +3106,15 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 
  This option is disabled by default. When enabled, the user must load and configure
  the \c listings package, for example by using a custom LaTeX header or an extra
- stylesheet. Code blocks in tables continue to use the standard \c DoxyCode
- backend because \c lstlisting environments cannot be used reliably in table cells.
+ stylesheet. A global style can control line numbers:
+\verbatim
+\usepackage{listings}
+\lstset{numbers=left,numberstyle=\tiny}
+\endverbatim
+A Markdown fence can override its line-number position with c numbers=left,
+c numbers=right, or c numbers=none. Code blocks in tables continue to use the
+standard \c DoxyCode backend because \c lstlisting environments cannot be used
+reliably in table cells.
 
  The language from a Markdown fence is passed to \c listings when it is a safe
  identifier. The special language \c none, and an empty language, do not set a
@@ -3128,6 +3135,16 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
  setting this tag to \c MyStyle emits \c style=MyStyle in each \c lstlisting
  environment. The style must be defined by the user's LaTeX configuration. If
  this tag is left empty, no \c style option is emitted.
+]]>
+      </docs>
+    </option>
+    <option type='bool' id='LATEX_LISTINGS_NUMBERED' defval='1' depends='GENERATE_LATEX'>
+      <docs>
+<![CDATA[
+ When the \c LATEX_LISTINGS_NUMBERED tag is set to \c YES, captions on ordinary
+ code blocks are numbered. When set to \c NO, code-block captions are
+ unnumbered. Captions use Doxygen's shared \c DoxyListing caption type, so this
+ setting applies to both the standard \c DoxyCode and \c listings backends.
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -3101,40 +3101,51 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 <![CDATA[
  When the \c LATEX_USE_LISTINGS tag is set to \c YES, ordinary code blocks are
  emitted as \c lstlisting environments instead of Doxygen's \c DoxyCode
- environments. This leaves syntax highlighting to the LaTeX \c listings package
- and preserves the source text without Doxygen's LaTeX escaping.
+ environments. This lets the LaTeX \c listings package perform syntax
+ highlighting and preserves source text without Doxygen's LaTeX escaping.
 
  This option is disabled by default. When enabled, Doxygen's generated
- \c doxygen.sty loads the \c listings package and provides the \c DoxyCode
- style, so no custom LaTeX setup is required. A global \c listings configuration
- can customize options such as line numbers:
+ \c doxygen.sty file loads the \c listings package and provides the default
+ \c DoxyCode style. No custom LaTeX setup is required.
+
+ Use \ref cfg_latex_listings_style "LATEX_LISTINGS_STYLE" to select a different
+ style. A global \c listings configuration can customize options such as line
+ numbers:
 \verbatim
 \lstset{numbers=left,numberstyle=\tiny}
 \endverbatim
 A Markdown fence can override its line-number position with c numbers=left,
-c numbers=right, or c numbers=none. Code blocks in tables continue to use the
-standard \c DoxyCode backend because \c lstlisting environments cannot be used
-reliably in table cells.
+c numbers=right, or c numbers=none.
 
  The language from a Markdown fence is passed to \c listings when it is a safe
  identifier. The special language \c none, and an empty language, do not set a
  language option. Doxygen does not translate fence language names: the selected
- name must be supported by the bundled \c listings package. Markdown fences for
- \c mermaid, \c msc, \c dot (when Graphviz is enabled), and \c plantuml (when
- \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH" is set) are special diagram blocks;
- they retain their existing diagram handling. Other code constructs, such as included
- snippets and generated source listings, also retain the standard backend.
+ name must be recognized by the installed \c listings package. Additional
+ languages can be defined with the LaTeX \c lstdefinelanguage command in a
+ custom LaTeX header or extra stylesheet.
+
+ Code blocks in tables continue to use the standard \c DoxyCode backend because
+ \c lstlisting environments cannot be used reliably in table cells. Markdown
+ fences for \c mermaid, \c msc, \c dot (when Graphviz is enabled), and
+ \c plantuml (when \ref cfg_plantuml_jar_path "PLANTUML_JAR_PATH" is set) are
+ special diagram blocks; they retain their existing diagram handling. Other code
+ constructs, such as included snippets and generated source listings, also retain
+ the standard backend.
 ]]>
       </docs>
     </option>
     <option type='string' id='LATEX_LISTINGS_STYLE' format='string' defval='DoxyCode' depends='LATEX_USE_LISTINGS'>
       <docs>
 <![CDATA[
- The \c LATEX_LISTINGS_STYLE tag specifies the \c listings style to use when
- \ref cfg_latex_use_listings "LATEX_USE_LISTINGS" is enabled. The default,
- \c DoxyCode, is defined by Doxygen's generated \c doxygen.sty and provides
- a framed, syntax-highlighted code block. Set this tag to the name of a style
- defined in a custom LaTeX header or extra stylesheet to override the default.
+ The default value of \c LATEX_LISTINGS_STYLE is \c DoxyCode. When
+ \ref cfg_latex_use_listings "LATEX_USE_LISTINGS" is enabled, Doxygen defines
+ this style in the generated \c doxygen.sty file:
+\verbatim
+\lstdefinestyle{DoxyCode}{...}
+\endverbatim
+To override the default, set \c LATEX_LISTINGS_STYLE to a custom style name and
+define that style using \c lstdefinestyle in a custom LaTeX header or extra
+stylesheet.
 ]]>
       </docs>
     </option>

--- a/src/config.xml
+++ b/src/config.xml
@@ -3107,6 +3107,8 @@ EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
  This option is disabled by default. When enabled, Doxygen's generated
  \c doxygen.sty file loads the \c listings package and provides the default
  \c DoxyCode style. No custom LaTeX setup is required.
+ The bundled \c DoxyCode style marks visible line numbers as empty PDF text, so
+ copying a code block from the PDF does not include them.
 
  Use \ref cfg_latex_listings_style "LATEX_LISTINGS_STYLE" to select a different
  style. A global \c listings configuration can customize options such as line

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -4141,6 +4141,17 @@ Token DocPara::handleStartCode()
   AUTO_TRACE();
   Token retval = parser()->tokenizer.lex();
   DString lang = parser()->context.token->name;
+  DString caption;
+  size_t attrStart=lang.find('\x1f');
+  if (attrStart!=DString::npos)
+  {
+    size_t captionStart=lang.find('\x1f',attrStart+1);
+    if (captionStart!=DString::npos)
+    {
+      caption=lang.mid(captionStart+1);
+    }
+    lang=lang.left(attrStart);
+  }
   if (!lang.empty() && lang.at(0)!='.')
   {
     lang="."+lang;
@@ -4163,6 +4174,12 @@ Token DocPara::handleStartCode()
                                  parser()->context.isExample,
                                  parser()->context.exampleName,
                                  false,lang);
+  if (!caption.empty())
+  {
+    DocVerbatim *dv = children().get_last<DocVerbatim>();
+    DocParser::AutoSaveContext saveContext(*parser());
+    parser()->internalValidatingParseDoc(&children().back(),dv->children(),caption);
+  }
   if (retval.is_any_of(TokenRetval::TK_NONE,TokenRetval::TK_EOF))
   {
     warn_doc_error(parser()->context.fileName,parser()->tokenizer.getLineNr(),"code section ended without end marker");

--- a/src/docnode.cpp
+++ b/src/docnode.cpp
@@ -264,8 +264,9 @@ DocAnchor::DocAnchor(DocParser *parser,DocNodeVariant *parent,const DString &id,
 
 DocVerbatim::DocVerbatim(DocParser *parser,DocNodeVariant *parent,const DString &context,
     const DString &text, Type t,bool isExample,
-    const DString &exampleFile,bool isBlock,const DString &lang)
-  : DocNode(parser,parent), p(std::make_unique<Private>(context, text, t, isExample, exampleFile, parser->context.relPath, lang, isBlock))
+    const DString &exampleFile,bool isBlock,const DString &lang,const DString &listingsNumbers)
+  : DocNode(parser,parent), p(std::make_unique<Private>(context, text, t, isExample, exampleFile,
+      parser->context.relPath, lang, isBlock, listingsNumbers))
 {
 }
 
@@ -4142,13 +4143,23 @@ Token DocPara::handleStartCode()
   Token retval = parser()->tokenizer.lex();
   DString lang = parser()->context.token->name;
   DString caption;
+  DString listingsNumbers;
   size_t attrStart=lang.find('\x1f');
   if (attrStart!=DString::npos)
   {
     size_t captionStart=lang.find('\x1f',attrStart+1);
     if (captionStart!=DString::npos)
     {
-      caption=lang.mid(captionStart+1);
+      size_t numbersStart=lang.find('\x1f',captionStart+1);
+      if (numbersStart!=DString::npos)
+      {
+        caption=lang.mid(captionStart+1,numbersStart-captionStart-1);
+        listingsNumbers=lang.mid(numbersStart+1);
+      }
+      else
+      {
+        caption=lang.mid(captionStart+1);
+      }
     }
     lang=lang.left(attrStart);
   }
@@ -4173,7 +4184,7 @@ Token DocPara::handleStartCode()
                                  DocVerbatim::Code,
                                  parser()->context.isExample,
                                  parser()->context.exampleName,
-                                 false,lang);
+                                 false,lang,listingsNumbers);
   if (!caption.empty())
   {
     DocVerbatim *dv = children().get_last<DocVerbatim>();

--- a/src/docnode.h
+++ b/src/docnode.h
@@ -378,7 +378,8 @@ class DocVerbatim final : public DocNode
     enum Type { Code, HtmlOnly, ManOnly, LatexOnly, RtfOnly, XmlOnly, Verbatim, Dot, Msc, DocbookOnly, PlantUML, Mermaid, JavaDocCode, JavaDocLiteral };
     DocVerbatim(DocParser *parser,DocNodeVariant *parent,const DString &context,
                 const DString &text, Type t,bool isExample,
-                const DString &exampleFile,bool isBlock=false,const DString &lang=DString());
+                const DString &exampleFile,bool isBlock=false,const DString &lang=DString(),
+                const DString &listingsNumbers=DString());
     Type type() const            { return p->type; }
     DString text() const         { return p->text; }
     DString context() const      { return p->context; }
@@ -386,6 +387,7 @@ class DocVerbatim final : public DocNode
     DString exampleFile() const  { return p->exampleFile; }
     DString relPath() const      { return p->relPath; }
     DString language() const     { return p->lang; }
+    DString listingsNumbers() const { return p->listingsNumbers; }
     bool isBlock() const         { return p->isBlock; }
     bool hasCaption() const      { return !p->children.empty(); }
     DString width() const        { return p->width; }
@@ -407,9 +409,11 @@ class DocVerbatim final : public DocNode
     struct Private
     {
       Private(const DString &context_,const DString &text_, Type type_, bool isExample_,
-              const DString &exampleFile_, const DString &relPath_,const DString &lang_, bool isBlock_)
+              const DString &exampleFile_, const DString &relPath_,const DString &lang_, bool isBlock_,
+              const DString &listingsNumbers_)
         : context(context_),         text(text_),       type(type_),       isExample(isExample_),
-          exampleFile(exampleFile_), relPath(relPath_), lang(lang_), isBlock(isBlock_) {}
+          exampleFile(exampleFile_), relPath(relPath_), lang(lang_), isBlock(isBlock_),
+          listingsNumbers(listingsNumbers_) {}
       DString   context;
       DString   text;
       Type      type = Code;
@@ -418,6 +422,7 @@ class DocVerbatim final : public DocNode
       DString   relPath;
       DString   lang;
       bool      isBlock;
+      DString   listingsNumbers;
       DString   width;
       DString   height;
       DString   engine;

--- a/src/doctokenizer.l
+++ b/src/doctokenizer.l
@@ -759,7 +759,7 @@ SHOWDATE ([0-9]{4}"-"[0-9]{1,2}"-"[0-9]{1,2})?({WS}*[0-9]{1,2}":"[0-9]{1,2}(":"[
                          yyextra->token.name = yyextra->token.name.mid(i+1,yyextra->token.name.length()-i-2);
                          BEGIN(St_Code);
                        }
-<St_iCodeOpt>{BLANK}*"{"(".")?{CODEID}"}" {
+<St_iCodeOpt>{BLANK}*"{"([^}\n])*"}" {
                          yyextra->token.name = yytext;
                          size_t i=yyextra->token.name.find('{'); /* } to keep vi happy */
                          yyextra->token.name = yyextra->token.name.mid(i+1,yyextra->token.name.length()-i-2);

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -554,6 +554,7 @@ void HtmlDocVisitor::operator()(const DocVerbatim &s)
                                         .setSearchCtx(m_ctx)
                                        );
       m_ci.endCodeFragment("DoxyCode");
+      visitCaption(m_t,s);
       forceStartParagraph(s);
       break;
     case DocVerbatim::Verbatim:
@@ -2494,4 +2495,3 @@ void HtmlDocVisitor::forceStartParagraph(const Node &n)
     if (needsTag) m_t << "<p>";
   }
 }
-

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -19,6 +19,7 @@
 // standard includes
 #include <algorithm>
 #include <array>
+#include <cctype>
 
 // other includes
 #include "cite.h"
@@ -58,6 +59,15 @@ static const std::array<const char *,g_maxLevels> g_secLabels =
 
 static const char *g_paragraphLabel = "doxyparagraph";
 static const char *g_subparagraphLabel = "doxysubparagraph";
+
+static bool isListingsIdentifier(const DString &value)
+{
+  if (value.empty()) return false;
+  return std::all_of(value.begin(),value.end(),[](unsigned char c)
+  {
+    return std::isalnum(c) || c=='+' || c=='-' || c=='_';
+  });
+}
 
 const char *LatexDocVisitor::getSectionName(int level) const
 {
@@ -423,11 +433,41 @@ void LatexDocVisitor::operator()(const DocVerbatim &s)
   {
     case DocVerbatim::Code:
       {
-        m_ci.startCodeFragment("DoxyCode");
-        getCodeParser(lang).parseCode(m_ci,s.context(),s.text(),langExt,
-                                      Config_getBool(STRIP_CODE_COMMENTS),
-                                      CodeParserOptions().setExample(s.isExample(),s.exampleFile()));
-        m_ci.endCodeFragment("DoxyCode");
+        if (Config_getBool(LATEX_USE_LISTINGS) && !isTableNested(s.parent()))
+        {
+          DString style = Config_getString(LATEX_LISTINGS_STYLE);
+          DString language = s.language();
+          if (!language.empty() && language.at(0)=='.') language=language.mid(1);
+          m_t << "\n\\begin{lstlisting}";
+          if (isListingsIdentifier(style) ||
+              (!language.empty() && language != "none" && isListingsIdentifier(language)))
+          {
+            m_t << "[";
+            bool hasOption = false;
+            if (isListingsIdentifier(style))
+            {
+              m_t << "style=" << style;
+              hasOption = true;
+            }
+            if (!language.empty() && language != "none" && isListingsIdentifier(language))
+            {
+              if (hasOption) m_t << ",";
+              m_t << "language=" << language;
+            }
+            m_t << "]";
+          }
+          m_t << "\n" << s.text();
+          if (!s.text().empty() && s.text().back() != '\n') m_t << "\n";
+          m_t << "\\end{lstlisting}\n";
+        }
+        else
+        {
+          m_ci.startCodeFragment("DoxyCode");
+          getCodeParser(lang).parseCode(m_ci,s.context(),s.text(),langExt,
+                                        Config_getBool(STRIP_CODE_COMMENTS),
+                                        CodeParserOptions().setExample(s.isExample(),s.exampleFile()));
+          m_ci.endCodeFragment("DoxyCode");
+        }
       }
       break;
     case DocVerbatim::JavaDocLiteral:
@@ -2138,4 +2178,3 @@ void LatexDocVisitor::decIndentLevel()
     m_indentLevel--;
   }
 }
-

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -69,6 +69,11 @@ static bool isListingsIdentifier(const DString &value)
   });
 }
 
+static bool isListingsNumberPosition(const DString &value)
+{
+  return value=="left" || value=="right" || value=="none";
+}
+
 const char *LatexDocVisitor::getSectionName(int level) const
 {
   bool compactLatex = Config_getBool(COMPACT_LATEX);
@@ -423,6 +428,17 @@ void LatexDocVisitor::operator()(const DocStyleChange &s)
 void LatexDocVisitor::operator()(const DocVerbatim &s)
 {
   if (m_hide) return;
+  auto writeCodeCaption = [&]()
+  {
+    if (s.hasCaption())
+    {
+      m_t << "\\captionof";
+      if (!Config_getBool(LATEX_LISTINGS_NUMBERED)) m_t << "*";
+      m_t << "{DoxyListing}{";
+      visitCaption(s.children());
+      m_t << "}\n";
+    }
+  };
   DString lang = m_langExt;
   if (!s.language().empty()) // explicit language setting
   {
@@ -438,28 +454,39 @@ void LatexDocVisitor::operator()(const DocVerbatim &s)
           DString style = Config_getString(LATEX_LISTINGS_STYLE);
           DString language = s.language();
           if (!language.empty() && language.at(0)=='.') language=language.mid(1);
+          bool hasStyle = isListingsIdentifier(style);
+          bool hasLanguage = !language.empty() && language != "none" &&
+                             isListingsIdentifier(language);
+          DString numbers = s.listingsNumbers();
+          bool hasNumbers = isListingsNumberPosition(numbers);
           m_t << "\n\\begin{lstlisting}";
-          if (isListingsIdentifier(style) ||
-              (!language.empty() && language != "none" && isListingsIdentifier(language)))
+          if (hasStyle || hasLanguage || hasNumbers)
           {
             m_t << "[";
             bool hasOption = false;
-            if (isListingsIdentifier(style))
+            if (hasStyle)
             {
               m_t << "style=" << style;
               hasOption = true;
             }
-            if (!language.empty() && language != "none" && isListingsIdentifier(language))
+            if (hasLanguage)
             {
               if (hasOption) m_t << ",";
               m_t << "language=" << language;
+              hasOption = true;
+            }
+            if (hasNumbers)
+            {
+              if (hasOption) m_t << ",";
+              m_t << "numbers=" << numbers;
+              hasOption = true;
             }
             m_t << "]";
           }
           m_t << "\n" << s.text();
           if (!s.text().empty() && s.text().back() != '\n') m_t << "\n";
           m_t << "\\end{lstlisting}\n";
-          if (s.hasCaption()) visitCaption(s.children());
+          writeCodeCaption();
         }
         else
         {
@@ -468,7 +495,7 @@ void LatexDocVisitor::operator()(const DocVerbatim &s)
                                         Config_getBool(STRIP_CODE_COMMENTS),
                                         CodeParserOptions().setExample(s.isExample(),s.exampleFile()));
           m_ci.endCodeFragment("DoxyCode");
-          if (s.hasCaption()) visitCaption(s.children());
+          writeCodeCaption();
         }
       }
       break;

--- a/src/latexdocvisitor.cpp
+++ b/src/latexdocvisitor.cpp
@@ -459,6 +459,7 @@ void LatexDocVisitor::operator()(const DocVerbatim &s)
           m_t << "\n" << s.text();
           if (!s.text().empty() && s.text().back() != '\n') m_t << "\n";
           m_t << "\\end{lstlisting}\n";
+          if (s.hasCaption()) visitCaption(s.children());
         }
         else
         {
@@ -467,6 +468,7 @@ void LatexDocVisitor::operator()(const DocVerbatim &s)
                                         Config_getBool(STRIP_CODE_COMMENTS),
                                         CodeParserOptions().setExample(s.isExample(),s.exampleFile()));
           m_ci.endCodeFragment("DoxyCode");
+          if (s.hasCaption()) visitCaption(s.children());
         }
       }
       break;

--- a/src/latexgen.cpp
+++ b/src/latexgen.cpp
@@ -686,6 +686,10 @@ void LatexGenerator::cleanup()
 
 static void writeDefaultStyleSheet(TextStream &t)
 {
+  if (Config_getBool(LATEX_USE_LISTINGS))
+  {
+    t << "\\def\\DoxyUseListingsEnabled{}\n";
+  }
   t << ResourceMgr::instance().getAsString("doxygen.sty");
 }
 

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -166,7 +166,8 @@ struct Markdown::Private
       bool *pIsIdGenerated=nullptr);
   void writeOneLineHeaderOrRuler(std::string_view data);
   void writeFencedCodeBlock(std::string_view data, std::string_view lang,
-      std::string_view anchor,std::string_view caption,size_t blockStart,size_t blockEnd);
+      std::string_view anchor,std::string_view caption,std::string_view listingsNumbers,
+      size_t blockStart,size_t blockEnd);
   size_t writeBlockQuote(std::string_view data);
   size_t writeCodeBlock(std::string_view,size_t refIndent);
   size_t writeTableBlock(std::string_view data);
@@ -2365,7 +2366,7 @@ static bool isEndOfList(std::string_view data)
 }
 
 static void parseFencedCodeAttributes(std::string_view attributes,DString &lang,
-                                      DString &anchor,DString &caption)
+                                      DString &anchor,DString &caption,DString &listingsNumbers)
 {
   size_t i=0;
   while (i<attributes.size())
@@ -2389,6 +2390,13 @@ static void parseFencedCodeAttributes(std::string_view attributes,DString &lang,
       caption=attributes.substr(start,i-start);
       i++;
     }
+    else if (literal_at(attributes.substr(i),"numbers="))
+    {
+      i += 8;
+      size_t start=i;
+      while (i<attributes.size() && !disspace(attributes[i])) i++;
+      listingsNumbers=attributes.substr(start,i-start);
+    }
     else
     {
       size_t start=i;
@@ -2399,7 +2407,7 @@ static void parseFencedCodeAttributes(std::string_view attributes,DString &lang,
 }
 
 static bool isFencedCodeBlock(std::string_view data,size_t refIndent,
-                             DString &lang,DString &anchor,DString &caption,
+                             DString &lang,DString &anchor,DString &caption,DString &listingsNumbers,
                              size_t &start,size_t &end,size_t &offset,
                              DString &fileName,int lineNr)
 {
@@ -2438,8 +2446,10 @@ static bool isFencedCodeBlock(std::string_view data,size_t refIndent,
   } // not enough tildes
   // skip whitespace
   while (i<size && data[i]==' ') { i++; }
+  lang="";
   anchor="";
   caption="";
+  listingsNumbers="";
   if (i<size && data[i]=='{') // extract attributes from ```{.py #id caption="..."} ... ```
   {
     i++; // skip over {
@@ -2447,7 +2457,7 @@ static bool isFencedCodeBlock(std::string_view data,size_t refIndent,
     while (i<size && (data[i]!='\n' && data[i]!='}')) i++; // find matching }
     if (i<size && data[i]=='}')
     {
-      parseFencedCodeAttributes(data.substr(startAttributes,i-startAttributes),lang,anchor,caption);
+      parseFencedCodeAttributes(data.substr(startAttributes,i-startAttributes),lang,anchor,caption,listingsNumbers);
       i++;
     }
     else // missing closing bracket, treat `{` as part of the content
@@ -3275,7 +3285,8 @@ size_t Markdown::Private::findEndOfLine(std::string_view data,size_t offset)
 }
 
 void Markdown::Private::writeFencedCodeBlock(std::string_view data,std::string_view lang,
-                std::string_view anchor,std::string_view caption,size_t blockStart,size_t blockEnd)
+                std::string_view anchor,std::string_view caption,std::string_view listingsNumbers,
+                size_t blockStart,size_t blockEnd)
 {
   AUTO_TRACE("data='{}' lang={} blockStart={} blockEnd={}",Trace::trunc(data),lang,blockStart,blockEnd);
   if (!lang.empty() && lang[0]=='.') lang=lang.substr(1);
@@ -3294,14 +3305,19 @@ void Markdown::Private::writeFencedCodeBlock(std::string_view data,std::string_v
     out += " ";
   }
   out+="@icode";
-  if (!lang.empty() || !caption.empty())
+  if (!lang.empty() || !caption.empty() || !listingsNumbers.empty())
   {
     out+="{"+lang;
-    if (!caption.empty())
+    if (!caption.empty() || !listingsNumbers.empty())
     {
       out += "\x1f";
       out += "\x1f";
       out += caption;
+      if (!listingsNumbers.empty())
+      {
+        out += "\x1f";
+        out += listingsNumbers;
+      }
     }
     out+="}";
   }
@@ -3368,8 +3384,8 @@ DString Markdown::Private::processQuotations(std::string_view data,size_t refInd
     if (pi!=std::string::npos)
     {
       size_t blockStart=0, blockEnd=0, blockOffset=0;
-      DString anchor,caption;
-      if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,anchor,caption,blockStart,blockEnd,blockOffset,fileName,lineNr))
+      DString anchor,caption,listingsNumbers;
+      if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,anchor,caption,listingsNumbers,blockStart,blockEnd,blockOffset,fileName,lineNr))
       {
         auto addSpecialCommand = [&](const DString &startCmd,const DString &endCmd)
         {
@@ -3434,7 +3450,7 @@ DString Markdown::Private::processQuotations(std::string_view data,size_t refInd
         }
         else // normal code block
         {
-          writeFencedCodeBlock(data.substr(pi),lang.view(),anchor.view(),caption.view(),blockStart,blockEnd);
+          writeFencedCodeBlock(data.substr(pi),lang.view(),anchor.view(),caption.view(),listingsNumbers.view(),blockStart,blockEnd);
         }
         i=pi+blockOffset;
         pi=std::string::npos;
@@ -3556,7 +3572,7 @@ DString Markdown::Private::processBlocks(std::string_view data,const size_t inde
     {
       size_t blockStart=0, blockEnd=0, blockOffset=0;
       DString lang;
-      DString anchor,caption;
+      DString anchor,caption,listingsNumbers;
       size_t blockIndent = currentIndent;
       size_t ref = 0;
       //printf("isHeaderLine(%s)=%d\n",DString(data+i).left(size-i).data(),level);
@@ -3634,11 +3650,11 @@ DString Markdown::Private::processBlocks(std::string_view data,const size_t inde
         i=ref+pi;
         end=i+1;
       }
-      else if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,anchor,caption,blockStart,blockEnd,blockOffset,fileName,lineNr))
+      else if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,anchor,caption,listingsNumbers,blockStart,blockEnd,blockOffset,fileName,lineNr))
       {
         //printf("Found FencedCodeBlock lang='%s' start=%d end=%d code={%s}\n",
         //       qPrint(lang),blockStart,blockEnd,DString(data+pi+blockStart).left(blockEnd-blockStart).data());
-        writeFencedCodeBlock(data.substr(pi),lang.view(),anchor.view(),caption.view(),blockStart,blockEnd);
+        writeFencedCodeBlock(data.substr(pi),lang.view(),anchor.view(),caption.view(),listingsNumbers.view(),blockStart,blockEnd);
         i=pi+blockOffset;
         pi=std::string::npos;
         end=i+1;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -166,7 +166,7 @@ struct Markdown::Private
       bool *pIsIdGenerated=nullptr);
   void writeOneLineHeaderOrRuler(std::string_view data);
   void writeFencedCodeBlock(std::string_view data, std::string_view lang,
-      size_t blockStart,size_t blockEnd);
+      std::string_view anchor,std::string_view caption,size_t blockStart,size_t blockEnd);
   size_t writeBlockQuote(std::string_view data);
   size_t writeCodeBlock(std::string_view,size_t refIndent);
   size_t writeTableBlock(std::string_view data);
@@ -2364,8 +2364,43 @@ static bool isEndOfList(std::string_view data)
   return dots==1;
 }
 
+static void parseFencedCodeAttributes(std::string_view attributes,DString &lang,
+                                      DString &anchor,DString &caption)
+{
+  size_t i=0;
+  while (i<attributes.size())
+  {
+    while (i<attributes.size() && disspace(attributes[i])) i++;
+    if (i>=attributes.size()) break;
+    if (attributes[i]=='.' || attributes[i]=='#')
+    {
+      char marker=attributes[i++];
+      size_t start=i;
+      while (i<attributes.size() && !disspace(attributes[i])) i++;
+      if (marker=='.') lang=attributes.substr(start,i-start);
+      else             anchor=attributes.substr(start,i-start);
+    }
+    else if (literal_at(attributes.substr(i),"caption=\""))
+    {
+      i += 9;
+      size_t start=i;
+      while (i<attributes.size() && attributes[i]!='\"') i++;
+      if (i>=attributes.size()) break;
+      caption=attributes.substr(start,i-start);
+      i++;
+    }
+    else
+    {
+      size_t start=i;
+      while (i<attributes.size() && !disspace(attributes[i])) i++;
+      if (lang.empty()) lang=attributes.substr(start,i-start);
+    }
+  }
+}
+
 static bool isFencedCodeBlock(std::string_view data,size_t refIndent,
-                             DString &lang,size_t &start,size_t &end,size_t &offset,
+                             DString &lang,DString &anchor,DString &caption,
+                             size_t &start,size_t &end,size_t &offset,
                              DString &fileName,int lineNr)
 {
   AUTO_TRACE("data='{}' refIndent={}",Trace::trunc(data),refIndent);
@@ -2403,20 +2438,21 @@ static bool isFencedCodeBlock(std::string_view data,size_t refIndent,
   } // not enough tildes
   // skip whitespace
   while (i<size && data[i]==' ') { i++; }
-  if (i<size && data[i]=='{') // extract .py from ```{.py} ... ```
+  anchor="";
+  caption="";
+  if (i<size && data[i]=='{') // extract attributes from ```{.py #id caption="..."} ... ```
   {
     i++; // skip over {
-    if (data[i] == dot) i++; // skip over initial dot
-    size_t startLang=i;
+    size_t startAttributes=i;
     while (i<size && (data[i]!='\n' && data[i]!='}')) i++; // find matching }
     if (i<size && data[i]=='}')
     {
-      lang = data.substr(startLang,i-startLang);
+      parseFencedCodeAttributes(data.substr(startAttributes,i-startAttributes),lang,anchor,caption);
       i++;
     }
     else // missing closing bracket, treat `{` as part of the content
     {
-      i=startLang-1;
+      i=startAttributes-1;
       lang="";
     }
   }
@@ -3239,7 +3275,7 @@ size_t Markdown::Private::findEndOfLine(std::string_view data,size_t offset)
 }
 
 void Markdown::Private::writeFencedCodeBlock(std::string_view data,std::string_view lang,
-                size_t blockStart,size_t blockEnd)
+                std::string_view anchor,std::string_view caption,size_t blockStart,size_t blockEnd)
 {
   AUTO_TRACE("data='{}' lang={} blockStart={} blockEnd={}",Trace::trunc(data),lang,blockStart,blockEnd);
   if (!lang.empty() && lang[0]=='.') lang=lang.substr(1);
@@ -3251,10 +3287,23 @@ void Markdown::Private::writeFencedCodeBlock(std::string_view data,std::string_v
     blockStart--;
     blockEnd--;
   }
-  out+="@icode";
-  if (!lang.empty())
+  if (!anchor.empty())
   {
-    out+="{"+lang+"}";
+    out += "@anchor ";
+    out += anchor;
+    out += " ";
+  }
+  out+="@icode";
+  if (!lang.empty() || !caption.empty())
+  {
+    out+="{"+lang;
+    if (!caption.empty())
+    {
+      out += "\x1f";
+      out += "\x1f";
+      out += caption;
+    }
+    out+="}";
   }
   out+=" ";
   addStrEscapeUtf8Nbsp(data.substr(blockStart+i,blockEnd-blockStart));
@@ -3319,7 +3368,8 @@ DString Markdown::Private::processQuotations(std::string_view data,size_t refInd
     if (pi!=std::string::npos)
     {
       size_t blockStart=0, blockEnd=0, blockOffset=0;
-      if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,blockStart,blockEnd,blockOffset,fileName,lineNr))
+      DString anchor,caption;
+      if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,anchor,caption,blockStart,blockEnd,blockOffset,fileName,lineNr))
       {
         auto addSpecialCommand = [&](const DString &startCmd,const DString &endCmd)
         {
@@ -3384,7 +3434,7 @@ DString Markdown::Private::processQuotations(std::string_view data,size_t refInd
         }
         else // normal code block
         {
-          writeFencedCodeBlock(data.substr(pi),lang.view(),blockStart,blockEnd);
+          writeFencedCodeBlock(data.substr(pi),lang.view(),anchor.view(),caption.view(),blockStart,blockEnd);
         }
         i=pi+blockOffset;
         pi=std::string::npos;
@@ -3506,6 +3556,7 @@ DString Markdown::Private::processBlocks(std::string_view data,const size_t inde
     {
       size_t blockStart=0, blockEnd=0, blockOffset=0;
       DString lang;
+      DString anchor,caption;
       size_t blockIndent = currentIndent;
       size_t ref = 0;
       //printf("isHeaderLine(%s)=%d\n",DString(data+i).left(size-i).data(),level);
@@ -3583,11 +3634,11 @@ DString Markdown::Private::processBlocks(std::string_view data,const size_t inde
         i=ref+pi;
         end=i+1;
       }
-      else if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,blockStart,blockEnd,blockOffset,fileName,lineNr))
+      else if (isFencedCodeBlock(data.substr(pi),currentIndent,lang,anchor,caption,blockStart,blockEnd,blockOffset,fileName,lineNr))
       {
         //printf("Found FencedCodeBlock lang='%s' start=%d end=%d code={%s}\n",
         //       qPrint(lang),blockStart,blockEnd,DString(data+pi+blockStart).left(blockEnd-blockStart).data());
-        writeFencedCodeBlock(data.substr(pi),lang.view(),blockStart,blockEnd);
+        writeFencedCodeBlock(data.substr(pi),lang.view(),anchor.view(),caption.view(),blockStart,blockEnd);
         i=pi+blockOffset;
         pi=std::string::npos;
         end=i+1;

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -20,6 +20,10 @@
 
 \ifDoxyUseListings
   \RequirePackage{listings}
+  \RequirePackage{accsupp}
+  \newcommand{\DoxyListingNumber}[1]{%
+    \BeginAccSupp{method=escape,ActualText={}}#1\EndAccSupp{}%
+  }
   \lstdefinestyle{DoxyCode}{%
     basicstyle=\ttfamily\footnotesize,
     keywordstyle=\color{blue!70!black}\bfseries,
@@ -30,6 +34,7 @@
     rulecolor=\color{black!20},
     breaklines=true,
     columns=fullflexible,
+    numberstyle=\tiny\DoxyListingNumber,
     keepspaces=true,
     showstringspaces=false,
     tabsize=2

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -10,6 +10,31 @@
 \RequirePackage{verbatim}
 \RequirePackage{varwidth}
 \RequirePackage[table]{xcolor}
+
+% Optional listings backend, enabled by the generated LaTeX header.
+\newif\ifDoxyUseListings
+\DoxyUseListingsfalse
+\ifdefined\DoxyUseListingsEnabled
+  \DoxyUseListingstrue
+\fi
+
+\ifDoxyUseListings
+  \RequirePackage{listings}
+  \lstdefinestyle{DoxyCode}{%
+    basicstyle=\ttfamily\footnotesize,
+    keywordstyle=\color{blue!70!black}\bfseries,
+    commentstyle=\color{green!40!black}\itshape,
+    stringstyle=\color{red!60!black},
+    backgroundcolor=\color{black!3},
+    frame=single,
+    rulecolor=\color{black!20},
+    breaklines=true,
+    columns=fullflexible,
+    keepspaces=true,
+    showstringspaces=false,
+    tabsize=2
+  }
+\fi
 \RequirePackage{longtable}
 \RequirePackage{xltabular}
 \RequirePackage{tabularray}

--- a/templates/latex/doxygen.sty
+++ b/templates/latex/doxygen.sty
@@ -173,6 +173,9 @@
 }
 
 % Used by @code ... @endcode
+% Shared caption type for ordinary code blocks, independent of their renderer.
+\newfloat{DoxyListing}{tbp}{lol}[chapter]
+\floatname{DoxyListing}{Listing}
 \newenvironment{DoxyCode}[1]{%
   \par%
   \vspace{2pt}%

--- a/testing/1000_latex_default_code.dox
+++ b/testing/1000_latex_default_code.dox
@@ -2,9 +2,12 @@
 // config: GENERATE_LATEX = YES
 // config: LATEX_OUTPUT = $TESTOUTDIR/latex
 // latexcheck: index.tex:\begin{DoxyCode}{0}\n\DoxyCodeLine{\textcolor{keywordtype}{int}\ foo;}\n\n\end{DoxyCode}
+// latexcheck: index.tex:\Hypertarget{index_default-code-example}%
+// latexcheck: index.tex:\captionof*{DoxyListing}{Default code example}
+// config: LATEX_LISTINGS_NUMBERED = NO
 /** \mainpage Default LaTeX code backend
 
-```c
+```{.c #default-code-example caption="Default code example"}
 int foo;
 ```
 */

--- a/testing/1000_latex_default_code.dox
+++ b/testing/1000_latex_default_code.dox
@@ -1,0 +1,10 @@
+// objective: test that the default LaTeX code backend remains DoxyCode when LATEX_USE_LISTINGS is unset
+// config: GENERATE_LATEX = YES
+// config: LATEX_OUTPUT = $TESTOUTDIR/latex
+// latexcheck: index.tex:\begin{DoxyCode}{0}\n\DoxyCodeLine{\textcolor{keywordtype}{int}\ foo;}\n\n\end{DoxyCode}
+/** \mainpage Default LaTeX code backend
+
+```c
+int foo;
+```
+*/

--- a/testing/1001_latex_listings_default_style.dox
+++ b/testing/1001_latex_listings_default_style.dox
@@ -1,0 +1,16 @@
+// objective: test LaTeX listings output without LATEX_LISTINGS_STYLE
+// config: GENERATE_LATEX = YES
+// config: LATEX_OUTPUT = $TESTOUTDIR/latex
+// config: LATEX_USE_LISTINGS = YES
+// latexcheck: index.tex:\begin{lstlisting}[language=c]\nint foo = 1;\n\end{lstlisting}
+// latexcheck: index.tex:\begin{lstlisting}\nplain text\n\end{lstlisting}
+/** \mainpage LaTeX listings default style
+
+```c
+int foo = 1;
+```
+
+```none
+plain text
+```
+*/

--- a/testing/1001_latex_listings_default_style.dox
+++ b/testing/1001_latex_listings_default_style.dox
@@ -7,6 +7,9 @@
 // latexcheck: doxygen.sty:\def\DoxyUseListingsEnabled{}
 // latexcheck: doxygen.sty:\RequirePackage{listings}
 // latexcheck: doxygen.sty:\lstdefinestyle{DoxyCode}{
+// latexcheck: doxygen.sty:\RequirePackage{accsupp}
+// latexcheck: doxygen.sty:DoxyListingNumber}[1]{
+// latexcheck: doxygen.sty:numberstyle=\tiny\DoxyListingNumber,
 /** \mainpage LaTeX listings default style
 
 ```c

--- a/testing/1001_latex_listings_default_style.dox
+++ b/testing/1001_latex_listings_default_style.dox
@@ -1,9 +1,12 @@
-// objective: test LaTeX listings output without LATEX_LISTINGS_STYLE
+// objective: test the bundled default LaTeX listings style
 // config: GENERATE_LATEX = YES
 // config: LATEX_OUTPUT = $TESTOUTDIR/latex
 // config: LATEX_USE_LISTINGS = YES
-// latexcheck: index.tex:\begin{lstlisting}[language=c]\nint foo = 1;\n\end{lstlisting}
-// latexcheck: index.tex:\begin{lstlisting}\nplain text\n\end{lstlisting}
+// latexcheck: index.tex:\begin{lstlisting}[style=DoxyCode,language=c]\nint foo = 1;\n\end{lstlisting}
+// latexcheck: index.tex:\begin{lstlisting}[style=DoxyCode]\nplain text\n\end{lstlisting}
+// latexcheck: doxygen.sty:\def\DoxyUseListingsEnabled{}
+// latexcheck: doxygen.sty:\RequirePackage{listings}
+// latexcheck: doxygen.sty:\lstdefinestyle{DoxyCode}{
 /** \mainpage LaTeX listings default style
 
 ```c

--- a/testing/999_latex_listings.dox
+++ b/testing/999_latex_listings.dox
@@ -1,0 +1,23 @@
+// objective: test exact Markdown code block output with the optional LaTeX listings backend
+// config: GENERATE_LATEX = YES
+// config: LATEX_OUTPUT = $TESTOUTDIR/latex
+// config: LATEX_USE_LISTINGS = YES
+// config: LATEX_LISTINGS_STYLE = MyStyle
+// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=c]\nint foo = 1;\n\end{lstlisting}
+// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=yaml]\nname: example\n\end{lstlisting}
+// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle]\n-option1 -option2-foo\nraw _ % # $ & { } ~ ^ \\\n\end{lstlisting}
+/** \mainpage LaTeX listings
+
+```c
+int foo = 1;
+```
+
+```yaml
+name: example
+```
+
+```none
+-option1 -option2-foo
+raw _ % # $ & { } ~ ^ \\
+```
+*/

--- a/testing/999_latex_listings.dox
+++ b/testing/999_latex_listings.dox
@@ -3,8 +3,11 @@
 // config: LATEX_OUTPUT = $TESTOUTDIR/latex
 // config: LATEX_USE_LISTINGS = YES
 // config: LATEX_LISTINGS_STYLE = MyStyle
-// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=c]\nint foo = 1;\n\end{lstlisting}\nC example
+// config: LATEX_LISTINGS_NUMBERED = YES
+// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=c]\nint foo = 1;\n\end{lstlisting}\n\captionof{DoxyListing}{C example}
 // latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=yaml]\nname: example\n\end{lstlisting}
+// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle]\nenabled = true\n\end{lstlisting}\n\captionof{DoxyListing}{Caption only example}
+// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=c,numbers=none]\nint unnumbered;\n\end{lstlisting}
 // latexcheck: index.tex:\begin{lstlisting}[style=MyStyle]\n-option1 -option2-foo\nraw _ % # $ & { } ~ ^ \\\n\end{lstlisting}
 /** \mainpage LaTeX listings
 
@@ -14,6 +17,14 @@ int foo = 1;
 
 ```yaml
 name: example
+```
+
+```{caption="Caption only example"}
+enabled = true
+```
+
+```{.c numbers=none}
+int unnumbered;
 ```
 
 ```none

--- a/testing/999_latex_listings.dox
+++ b/testing/999_latex_listings.dox
@@ -1,14 +1,14 @@
-// objective: test exact Markdown code block output with the optional LaTeX listings backend
+// objective: test exact Markdown code block output and Pandoc-style attributes with the optional LaTeX listings backend
 // config: GENERATE_LATEX = YES
 // config: LATEX_OUTPUT = $TESTOUTDIR/latex
 // config: LATEX_USE_LISTINGS = YES
 // config: LATEX_LISTINGS_STYLE = MyStyle
-// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=c]\nint foo = 1;\n\end{lstlisting}
+// latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=c]\nint foo = 1;\n\end{lstlisting}\nC example
 // latexcheck: index.tex:\begin{lstlisting}[style=MyStyle,language=yaml]\nname: example\n\end{lstlisting}
 // latexcheck: index.tex:\begin{lstlisting}[style=MyStyle]\n-option1 -option2-foo\nraw _ % # $ & { } ~ ^ \\\n\end{lstlisting}
 /** \mainpage LaTeX listings
 
-```c
+```{.c #listings-example caption="C example"}
 int foo = 1;
 ```
 

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -227,7 +227,8 @@ class Tester:
                         sys.exit(1)
                     print(cfg[0], file=f)
 
-        if 'check' not in self.config or not self.config['check']:
+        if (('check' not in self.config or not self.config['check']) and
+            ('latexcheck' not in self.config or not self.config['latexcheck'])):
             print('Test doesn\'t specify any files to check')
             sys.exit(1)
 
@@ -530,6 +531,23 @@ class Tester:
                     failed_qhp=True
             if not failed_html and not failed_qhp and not self.args.keep:
                 shutil.rmtree(html_output,ignore_errors=True)
+
+        if 'latexcheck' in self.config:
+            latex_output='%s/%slatex' % (self.test_out,
+                                          'out/' if (self.args.xml or self.args.xmlxsd) else '')
+            for check in self.config['latexcheck']:
+                filename, expected = check.split(':', 1)
+                expected = expected.replace(r'\n', '\n')
+                check_file='%s/%s' % (latex_output,filename)
+                if not os.path.isfile(check_file):
+                    msg += ('Non-existing LaTeX file %s after \'latexcheck:\' statement' % check_file,)
+                    failed_latex=True
+                    break
+                with xopen(check_file, 'r') as f:
+                    if expected not in f.read():
+                        msg += ('Expected LaTeX output not found in %s: %s' % (check_file, expected),)
+                        failed_latex=True
+                        break
         if (self.args.pdf):
             failed_latex=False
             latex_output='%s/latex' % self.test_out

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -451,7 +451,8 @@ class Tester:
                     msg += (xmllint_out,)
                     failed_xmlxsd=True
 
-            if not failed_xml and not failed_xmlxsd and not self.args.keep:
+            if (not failed_xml and not failed_xmlxsd and not self.args.keep and
+                'latexcheck' not in self.config):
                 xml_output='%s/out' % self.test_out
                 shutil.rmtree(xml_output,ignore_errors=True)
 


### PR DESCRIPTION
## Summary

Adds an opt-in LaTeX backend for ordinary Markdown fenced code blocks using the LaTeX `listings` package.

- Adds `LATEX_USE_LISTINGS`, `LATEX_LISTINGS_STYLE`, and `LATEX_LISTINGS_NUMBERED`.
- Supports fence language, `#id`, `caption=`, and `numbers=left|right|none` attributes.
- Provides the bundled `DoxyCode` listings style, chapter-based listing captions, and copy-safe line numbers using `accsupp`.
- Documents custom listings languages and preserves existing handling for tables, diagrams, snippets, and generated source listings.
- Adds regression coverage for the opt-in backend, default backend behavior, and bundled style.

## Why

The standard `DoxyCode` backend remains the default. The optional backend lets users use native `listings` styling and language support for Markdown fences while keeping Doxygen captions and cross-references consistent.

## Example

[playground.md](https://github.com/user-attachments/files/31890837/playground.md)

Enable the feature with:

```text
LATEX_USE_LISTINGS   = YES
LATEX_LISTINGS_STYLE = DoxyCode
```

Example fence:

````markdown
```{.cpp #parser caption="Parser entry point" numbers=none}
int parse();
```
````

## Validation

- Focused tests: `999_latex_listings`, `1000_latex_default_code`, and `1001_latex_listings_default_style` all pass.
- Full CTest suite: 122/123 pass. The unrelated existing `058_strong_enum` test differs only in XML source-column values (`1` versus `5`).

## Attribution

This change was implemented with assistance from an AI coding agent and reviewed interactively by the contributor.
