### PR TITLE
Prevent compiler warning for c files

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -118,7 +118,7 @@ function(set_project_warnings project_name)
       )
     endif()
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "8.0.0")
-      set(GCC_EXTRA_WARNINGS ${GCC_EXTRA_WARNINGS}
+      set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}
         -Wextra-semi
       )
     endif()


### PR DESCRIPTION
When compiling a c file one can get the warning like (`portable_c.c`):
```
cc1: warning: command-line option ‘-Wextra-semi’ is valid for C++/ObjC++ but not for C
```