### PR TITLE
issue #12328  `signed char` versus  `unsigned char` versus `int`

### DIFF
--- a/src/dstring.h
+++ b/src/dstring.h
@@ -894,7 +894,7 @@ inline void swap(DString &s1, DString &s2)
  */
 inline bool isId(char c)
 {
-  return c=='_' || c>=128 || static_cast<signed char>(c)<0 || isalnum(c) || c=='$';
+  return c=='_' || static_cast<signed char>(c)<0 || isalnum(c) || c=='$';
 }
 
 /*! Returns a place holder for a position in a list. Used for


### PR DESCRIPTION
On systems with signed characters we can get a warning like:
```
/home/runner/work/doxygen/doxygen/src/dstring.h: In function ‘bool isId(char)’:
/home/runner/work/doxygen/doxygen/src/dstring.h:897:21: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  897 |   return c=='_' || c>=128 || static_cast<signed char>(c)<0 || isalnum(c) || c=='$';
      |                    ~^~~~~
```
as now the range for signed characters is: `-128 ... 127 `
On systems with unsigned characters this situation is caught through: `static_cast<signed char>(c)<0`