### PR TITLE
issue #12339 Broken `@todo` styling in HTML output

### DIFF
--- a/src/commentscan.l
+++ b/src/commentscan.l
@@ -4452,7 +4452,7 @@ static void addXRefItemToEntry(Entry *current, const DString &docs,
   std::unique_lock<std::mutex> lock(g_sectionMutex);
 
   DString listName=baseName;
-  if (Config_getEnum(MARKDOWN_ID_STYLE) == MARKDOWN_ID_STYLE_t::GITHUB) listName = "Doxygen_List_" + listName;
+  if (Config_getEnum(MARKDOWN_ID_STYLE) == MARKDOWN_ID_STYLE_t::GITHUB) listName = doxygenList + listName;
   RefList *refList = RefListManager::instance().add(listName,listTitle,itemTitle);
   RefItem *item = nullptr;
   for (auto it = current->sli.rbegin(); it != current->sli.rend(); ++it)

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -2073,17 +2073,19 @@ void HtmlDocVisitor::operator()(const DocXRefItem &x)
 
   forceEndParagraph(x);
   bool anonymousEnum = x.file()=="@";
+  DString key = x.key();
+  if (key.startsWith("Doxygen_List_")) key=key.mid(13);
   if (!anonymousEnum)
   {
     DString fn = x.file();
     addHtmlExtensionIfMissing(fn);
-    m_t << "<dl class=\"" << x.key() << "\"><dt><b><a class=\"el\" href=\""
+    m_t << "<dl class=\"" << key << "\"><dt><b><a class=\"el\" href=\""
         << x.relPath() << fn
         << "#" << x.anchor() << "\">";
   }
   else
   {
-    m_t << "<dl class=\"" << x.key() << "\"><dt><b>";
+    m_t << "<dl class=\"" << key << "\"><dt><b>";
   }
   filter(x.title());
   if (!anonymousEnum) m_t << "</a>";

--- a/src/htmldocvisitor.cpp
+++ b/src/htmldocvisitor.cpp
@@ -38,6 +38,7 @@
 #include "parserintf.h"
 #include "plantuml.h"
 #include "portable.h"
+#include "reflist.h"
 #include "util.h"
 #include "vhdldocgen.h"
 
@@ -2074,7 +2075,7 @@ void HtmlDocVisitor::operator()(const DocXRefItem &x)
   forceEndParagraph(x);
   bool anonymousEnum = x.file()=="@";
   DString key = x.key();
-  if (key.startsWith("Doxygen_List_")) key=key.mid(13);
+  key.stripPrefix(doxygenList);
   if (!anonymousEnum)
   {
     DString fn = x.file();

--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -50,10 +50,10 @@ RefItem *RefList::find(int itemId)
 
 bool RefList::isEnabled() const
 {
-  if      ((m_listName=="todo"       || m_listName=="Doxygen_List_todo")       && !Config_getBool(GENERATE_TODOLIST))       return false;
-  else if ((m_listName=="test"       || m_listName=="Doxygen_List_test")       && !Config_getBool(GENERATE_TESTLIST))       return false;
-  else if ((m_listName=="bug"        || m_listName=="Doxygen_List_bug")        && !Config_getBool(GENERATE_BUGLIST))        return false;
-  else if ((m_listName=="deprecated" || m_listName=="Doxygen_List_deprecated") && !Config_getBool(GENERATE_DEPRECATEDLIST)) return false;
+  if      ((m_listName=="todo"       || m_listName==doxygenList+"todo")       && !Config_getBool(GENERATE_TODOLIST))       return false;
+  else if ((m_listName=="test"       || m_listName==doxygenList+"test")       && !Config_getBool(GENERATE_TESTLIST))       return false;
+  else if ((m_listName=="bug"        || m_listName==doxygenList+"bug")        && !Config_getBool(GENERATE_BUGLIST))        return false;
+  else if ((m_listName=="deprecated" || m_listName==doxygenList+"deprecated") && !Config_getBool(GENERATE_DEPRECATEDLIST)) return false;
   return true;
 }
 

--- a/src/reflist.cpp
+++ b/src/reflist.cpp
@@ -50,10 +50,10 @@ RefItem *RefList::find(int itemId)
 
 bool RefList::isEnabled() const
 {
-  if      (m_listName=="todo"       && !Config_getBool(GENERATE_TODOLIST))       return false;
-  else if (m_listName=="test"       && !Config_getBool(GENERATE_TESTLIST))       return false;
-  else if (m_listName=="bug"        && !Config_getBool(GENERATE_BUGLIST))        return false;
-  else if (m_listName=="deprecated" && !Config_getBool(GENERATE_DEPRECATEDLIST)) return false;
+  if      ((m_listName=="todo"       || m_listName=="Doxygen_List_todo")       && !Config_getBool(GENERATE_TODOLIST))       return false;
+  else if ((m_listName=="test"       || m_listName=="Doxygen_List_test")       && !Config_getBool(GENERATE_TESTLIST))       return false;
+  else if ((m_listName=="bug"        || m_listName=="Doxygen_List_bug")        && !Config_getBool(GENERATE_BUGLIST))        return false;
+  else if ((m_listName=="deprecated" || m_listName=="Doxygen_List_deprecated") && !Config_getBool(GENERATE_DEPRECATEDLIST)) return false;
   return true;
 }
 

--- a/src/reflist.h
+++ b/src/reflist.h
@@ -26,6 +26,8 @@
 class Definition;
 class RefList;
 
+static inline const DString doxygenList = "Doxygen_List_";
+
 /** This struct represents an item in the list of references. */
 class RefItem
 {


### PR DESCRIPTION
In #12329 a problem was noted with pre defined list names and sections, this was fixed by #12334 though a small part had been forgotten.