### PR TITLE
Spurious white space in column 1 of man page

### DIFF
--- a/src/mandocvisitor.cpp
+++ b/src/mandocvisitor.cpp
@@ -68,9 +68,12 @@ void ManDocVisitor::operator()(const DocWhiteSpace &w)
     m_t << w.chars();
     m_firstCol=w.chars().at(w.chars().length()-1)=='\n';
   }
-  else
+  else if (!m_firstCol)
   {
     m_t << " ";
+  }
+  else
+  {
     m_firstCol=false;
   }
 }


### PR DESCRIPTION
In running text there should not be a white space, so test on first column is necessary.
(based on a remark in #12340)